### PR TITLE
bus: bound-check deserialize length prefixes (closes fathom priceview crash)

### DIFF
--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -5890,17 +5890,38 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             None,
         );
         let de_entry = self.context.append_basic_block(de_fn, "entry");
+        // 2026-05-27 — error block for length-prefix bound-check
+        // failures inside variable-length field paths
+        // (`String` / `Bytes`). The reader-thread caller
+        // observes the -1 return as "drop this datagram" via the
+        // existing `if (struct_size <= 0) continue;` guard. The
+        // String/Bytes paths in `emit_per_field_deserialize{,_size}`
+        // branch here when a decoded length is negative or
+        // exceeds the remaining wire bytes — closes a real fault
+        // mode (corrupt or cross-routed datagram) that would
+        // otherwise hand a giant `size` straight to
+        // `lotus_bus_payload_arena_alloc`, triggering the arena
+        // cap-hit / NULL-deref symptom fathom reported.
+        let de_fail = self.context.append_basic_block(de_fn, "wire.fail");
+        self.builder.position_at_end(de_fail);
+        let neg_one = i64_t.const_int((-1i64) as u64, true);
+        self.builder
+            .build_return(Some(&neg_one))
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         self.builder.position_at_end(de_entry);
         let de_src = de_fn
             .get_nth_param(0)
             .expect("de src arg")
             .into_pointer_value();
-        let _ = de_fn.get_nth_param(1); // n, ignored
+        let de_n = de_fn
+            .get_nth_param(1)
+            .expect("de n arg")
+            .into_int_value();
         let de_dst = de_fn
             .get_nth_param(2)
             .expect("de dst arg")
             .into_pointer_value();
-        let _ = de_fn.get_nth_param(3); // cap, ignored
+        let _ = de_fn.get_nth_param(3); // cap, reserved
 
         let de_struct_size: inkwell::values::IntValue<'ctx> =
             if let Some((struct_ty, field_order, fields)) = &struct_layout
@@ -5911,6 +5932,8 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     *struct_ty,
                     field_order,
                     fields,
+                    de_n,
+                    de_fail,
                 )?
             } else {
                 let size_iv = enum_size.expect("enum size present");
@@ -6126,6 +6149,8 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         elem_ty: &CodegenTy,
         n: u64,
         fname: &str,
+        wire_n: inkwell::values::IntValue<'ctx>,
+        fail_block: inkwell::basic_block::BasicBlock<'ctx>,
     ) -> Result<(), CodegenError> {
         let i64_t = self.context.i64_type();
         let i8_t = self.context.i8_type();
@@ -6276,6 +6301,8 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         nested_info.struct_ty,
                         &nested_info.field_order,
                         &nested_info.fields,
+                        wire_n,
+                        fail_block,
                     )?;
                     let after = self
                         .builder
@@ -6585,6 +6612,8 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         struct_ty: StructType<'ctx>,
         field_order: &[String],
         fields: &BTreeMap<String, (u32, CodegenTy)>,
+        wire_n: inkwell::values::IntValue<'ctx>,
+        fail_block: inkwell::basic_block::BasicBlock<'ctx>,
     ) -> Result<inkwell::values::IntValue<'ctx>, CodegenError> {
         let i64_t = self.context.i64_type();
         let i8_t = self.context.i8_type();
@@ -6634,6 +6663,35 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         .build_load(i64_t, len_alloca, "de.str.len")
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
                         .into_int_value();
+                    // Bound-check (2026-05-27): decoded length must
+                    // be in [0, wire_n]. An unsigned > catches both
+                    // negative-as-i64 (would be huge unsigned) and
+                    // larger-than-the-wire-buffer cases — either
+                    // implies a corrupt or cross-routed datagram.
+                    // Fail-block returns -1; reader-thread drops
+                    // the packet via the existing
+                    // `if (struct_size <= 0) continue;` guard.
+                    let str_too_big = self
+                        .builder
+                        .build_int_compare(
+                            inkwell::IntPredicate::UGT,
+                            str_len,
+                            wire_n,
+                            "de.str.len.bad",
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    let ok_block = self.context.append_basic_block(
+                        self.builder
+                            .get_insert_block()
+                            .expect("insert block set")
+                            .get_parent()
+                            .expect("block has parent fn"),
+                        "de.str.len.ok",
+                    );
+                    self.builder
+                        .build_conditional_branch(str_too_big, fail_block, ok_block)
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    self.builder.position_at_end(ok_block);
                     let after_len = self
                         .builder
                         .build_int_add(
@@ -6771,6 +6829,33 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         .build_load(i64_t, len_alloca, "de.bytes.len")
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
                         .into_int_value();
+                    // Bound-check (2026-05-27): see matching note
+                    // on the String path.
+                    let bytes_too_big = self
+                        .builder
+                        .build_int_compare(
+                            inkwell::IntPredicate::UGT,
+                            bytes_len,
+                            wire_n,
+                            "de.bytes.len.bad",
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    let ok_block = self.context.append_basic_block(
+                        self.builder
+                            .get_insert_block()
+                            .expect("insert block set")
+                            .get_parent()
+                            .expect("block has parent fn"),
+                        "de.bytes.len.ok",
+                    );
+                    self.builder
+                        .build_conditional_branch(
+                            bytes_too_big,
+                            fail_block,
+                            ok_block,
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    self.builder.position_at_end(ok_block);
                     let total = self
                         .builder
                         .build_int_add(
@@ -6864,6 +6949,8 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         nested_info.struct_ty,
                         &nested_info.field_order,
                         &nested_info.fields,
+                        wire_n,
+                        fail_block,
                     )?;
                     self.builder
                         .build_store(dst_field_ptr, nested_dst)
@@ -6890,6 +6977,8 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         elem_ty,
                         *n,
                         fname,
+                        wire_n,
+                        fail_block,
                     )?;
                 }
                 other => {
@@ -6923,6 +7012,8 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         struct_ty: StructType<'ctx>,
         field_order: &[String],
         fields: &BTreeMap<String, (u32, CodegenTy)>,
+        wire_n: inkwell::values::IntValue<'ctx>,
+        fail_block: inkwell::basic_block::BasicBlock<'ctx>,
     ) -> Result<inkwell::values::IntValue<'ctx>, CodegenError> {
         let i64_t = self.context.i64_type();
         let i8_t = self.context.i8_type();
@@ -6971,6 +7062,29 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         .build_load(i64_t, len_alloca, "de.nested.str.len")
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
                         .into_int_value();
+                    // Bound-check (2026-05-27): see matching note on
+                    // emit_per_field_deserialize's String path.
+                    let str_too_big = self
+                        .builder
+                        .build_int_compare(
+                            inkwell::IntPredicate::UGT,
+                            str_len,
+                            wire_n,
+                            "de.nested.str.len.bad",
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    let ok_block = self.context.append_basic_block(
+                        self.builder
+                            .get_insert_block()
+                            .expect("insert block set")
+                            .get_parent()
+                            .expect("block has parent fn"),
+                        "de.nested.str.len.ok",
+                    );
+                    self.builder
+                        .build_conditional_branch(str_too_big, fail_block, ok_block)
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    self.builder.position_at_end(ok_block);
                     let after_len = self
                         .builder
                         .build_int_add(
@@ -7096,6 +7210,33 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         .build_load(i64_t, len_alloca, "de.nested.bytes.len")
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
                         .into_int_value();
+                    // Bound-check (2026-05-27): see matching note on
+                    // the top-level Bytes path.
+                    let bytes_too_big = self
+                        .builder
+                        .build_int_compare(
+                            inkwell::IntPredicate::UGT,
+                            bytes_len,
+                            wire_n,
+                            "de.nested.bytes.len.bad",
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    let ok_block = self.context.append_basic_block(
+                        self.builder
+                            .get_insert_block()
+                            .expect("insert block set")
+                            .get_parent()
+                            .expect("block has parent fn"),
+                        "de.nested.bytes.len.ok",
+                    );
+                    self.builder
+                        .build_conditional_branch(
+                            bytes_too_big,
+                            fail_block,
+                            ok_block,
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    self.builder.position_at_end(ok_block);
                     let total = self
                         .builder
                         .build_int_add(
@@ -7185,6 +7326,8 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         nested_info.struct_ty,
                         &nested_info.field_order,
                         &nested_info.fields,
+                        wire_n,
+                        fail_block,
                     )?;
                     self.builder
                         .build_store(dst_field_ptr, nested_dst)
@@ -7211,6 +7354,8 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         elem_ty,
                         *n,
                         fname,
+                        wire_n,
+                        fail_block,
                     )?;
                 }
                 other => {

--- a/crates/hale-codegen/tests/bus_udp_transport.rs
+++ b/crates/hale-codegen/tests/bus_udp_transport.rs
@@ -11,6 +11,7 @@
 //! local handler), then run a publisher binary that fires once
 //! and exits. The subscriber's stdout is checked for the payload.
 
+use std::net::UdpSocket;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -227,6 +228,132 @@ fn large_publisher_src() -> &'static str {
     "#
 }
 
+fn book_snapshot_subscriber_src() -> &'static str {
+    // BookSignalSnapshot-shaped: two Strings (variable-length
+    // length-prefixed on the wire) ahead of a long tail of
+    // fixed-size Decimals and Decimal arrays. The fathom
+    // priceview crash report (2026-05-27) said inbound udp
+    // datagrams trigger `g_bus_payload_arena` cap-hit on the
+    // first message, with the diagnostic numbers matching a
+    // single ~64 MB alloc from inside the deserializer.
+    // Theory A in the handoff: a length-prefix misread
+    // (decoded length taken as garbage from the wire) handed
+    // unchecked to `lotus_bus_payload_arena_alloc`.
+    //
+    // This shape exercises the multi-variable-length-field
+    // case that the existing single-Int / single-array UDP
+    // tests don't cover.
+    r#"
+        type Book {
+            symbol:        String  = "";
+            venue_ts:      String  = "";
+            best_bid:      Decimal = 0.0d;
+            best_ask:      Decimal = 0.0d;
+            bid_qty:       Decimal = 0.0d;
+            ask_qty:       Decimal = 0.0d;
+            mid:           Decimal = 0.0d;
+            spread:        Decimal = 0.0d;
+            probe_sizes:   [Decimal; 4] = [0.0d, 0.0d, 0.0d, 0.0d];
+            buy_costs:     [Decimal; 4] = [0.0d, 0.0d, 0.0d, 0.0d];
+            buy_filled:    [Decimal; 4] = [0.0d, 0.0d, 0.0d, 0.0d];
+            sell_proceeds: [Decimal; 4] = [0.0d, 0.0d, 0.0d, 0.0d];
+            sell_filled:   [Decimal; 4] = [0.0d, 0.0d, 0.0d, 0.0d];
+            vol_proxy:     Int = 0;
+            snap_count:    Int = 0;
+            delta_count:   Int = 0;
+            checksum_ok:   Int = 1;
+        }
+        locus Sub {
+            bus {
+                subscribe "book" as on_book of type Book;
+            }
+            fn on_book(b: Book) {
+                println("sym=", b.symbol);
+                println("ts=", b.venue_ts);
+                println("bid=", b.best_bid);
+                println("ask=", b.best_ask);
+                println("checksum_ok=", b.checksum_ok);
+            }
+        }
+        fn main() {
+            Sub { };
+            std::time::sleep(800ms);
+        }
+    "#
+}
+
+fn book_snapshot_publisher_src() -> &'static str {
+    r#"
+        type Book {
+            symbol:        String  = "";
+            venue_ts:      String  = "";
+            best_bid:      Decimal = 0.0d;
+            best_ask:      Decimal = 0.0d;
+            bid_qty:       Decimal = 0.0d;
+            ask_qty:       Decimal = 0.0d;
+            mid:           Decimal = 0.0d;
+            spread:        Decimal = 0.0d;
+            probe_sizes:   [Decimal; 4] = [0.0d, 0.0d, 0.0d, 0.0d];
+            buy_costs:     [Decimal; 4] = [0.0d, 0.0d, 0.0d, 0.0d];
+            buy_filled:    [Decimal; 4] = [0.0d, 0.0d, 0.0d, 0.0d];
+            sell_proceeds: [Decimal; 4] = [0.0d, 0.0d, 0.0d, 0.0d];
+            sell_filled:   [Decimal; 4] = [0.0d, 0.0d, 0.0d, 0.0d];
+            vol_proxy:     Int = 0;
+            snap_count:    Int = 0;
+            delta_count:   Int = 0;
+            checksum_ok:   Int = 1;
+        }
+        locus Pub {
+            bus {
+                publish "book" of type Book;
+            }
+            birth() {
+                "book" <- Book {
+                    symbol:   "BTC-USD",
+                    venue_ts: "2026-05-27T10:00:00Z",
+                    best_bid: 42000.5d,
+                    best_ask: 42001.0d,
+                    mid:      42000.75d,
+                    spread:   0.5d,
+                    checksum_ok: 1,
+                };
+            }
+        }
+        fn main() {
+            Pub { };
+        }
+    "#
+}
+
+#[test]
+fn udp_unicast_delivers_multi_string_payload() {
+    // Reproduces the fathom priceview crash shape: a payload
+    // with two variable-length Strings followed by a tail of
+    // fixed-size fields. Without the deserializer length
+    // bound-check, the first udp datagram would trigger the
+    // g_bus_payload_arena cap-hit and SIGSEGV.
+    let sub_bin = compile("book_sub", book_snapshot_subscriber_src());
+    let pub_bin = compile("book_pub", book_snapshot_publisher_src());
+    let port = 57787;
+    let sub_cfg = unique_path("book_sub", "conf");
+    let pub_cfg = unique_path("book_pub", "conf");
+    std::fs::write(&sub_cfg, format!("book = udp://127.0.0.1:{}:listen\n", port))
+        .expect("write sub cfg");
+    std::fs::write(&pub_cfg, format!("book = udp://127.0.0.1:{}:connect\n", port))
+        .expect("write pub cfg");
+
+    let out = run_pair(&sub_bin, &pub_bin, &sub_cfg, &pub_cfg);
+
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+    let _ = std::fs::remove_file(&sub_cfg);
+    let _ = std::fs::remove_file(&pub_cfg);
+
+    assert!(out.contains("sym=BTC-USD"),  "got: {:?}", out);
+    assert!(out.contains("ts=2026-05-27T10:00:00Z"), "got: {:?}", out);
+    assert!(out.contains("checksum_ok=1"), "got: {:?}", out);
+}
+
 #[test]
 fn udp_unicast_delivers_payload_over_inline_threshold() {
     // [Int; 100] + Int = 808 bytes, well above
@@ -255,4 +382,219 @@ fn udp_unicast_delivers_payload_over_inline_threshold() {
     assert!(out.contains("big_tag=77"),     "got: {:?}", out);
     assert!(out.contains("big_first=1234567"), "got: {:?}", out);
     assert!(out.contains("big_last=7654321"),  "got: {:?}", out);
+}
+
+fn multi_listener_subscriber_src() -> &'static str {
+    // 2026-05-27 — mirrors the fathom priceview shape: a
+    // single subscriber binary with FOUR multicast listeners
+    // on the same port, different groups, different payload
+    // types. The reader threads each call into a different
+    // deserialize_fn looked up by subject. If SO_REUSEPORT
+    // cross-routes (a multicast packet for group A arrives
+    // on the socket that joined group B), the lookup picks
+    // the wrong deserializer and tries to interpret the
+    // arriving bytes as the wrong type. With multi-String
+    // payloads, this manifests as a giant decoded length
+    // prefix → the 2026-05-27 deserialize bound-check now
+    // rejects this cleanly via the `wire.fail` block.
+    r#"
+        type BookSnap {
+            symbol:   String  = "";
+            venue_ts: String  = "";
+            mid:      Decimal = 0.0d;
+        }
+        type TickMsg {
+            symbol:   String  = "";
+            qty:      Decimal = 0.0d;
+        }
+        locus Sub {
+            bus {
+                subscribe "md.book.kraken"   as on_kraken_book   of type BookSnap;
+                subscribe "md.book.coinbase" as on_coinbase_book of type BookSnap;
+                subscribe "md.tick.kraken"   as on_kraken_tick   of type TickMsg;
+                subscribe "md.tick.coinbase" as on_coinbase_tick of type TickMsg;
+            }
+            fn on_kraken_book(b: BookSnap) {
+                println("kraken_book sym=", b.symbol);
+            }
+            fn on_coinbase_book(b: BookSnap) {
+                println("coinbase_book sym=", b.symbol);
+            }
+            fn on_kraken_tick(t: TickMsg) {
+                println("kraken_tick sym=", t.symbol);
+            }
+            fn on_coinbase_tick(t: TickMsg) {
+                println("coinbase_tick sym=", t.symbol);
+            }
+        }
+        fn main() {
+            Sub { };
+            std::time::sleep(1200ms);
+        }
+    "#
+}
+
+fn multi_listener_publisher_src() -> &'static str {
+    r#"
+        type BookSnap {
+            symbol:   String  = "";
+            venue_ts: String  = "";
+            mid:      Decimal = 0.0d;
+        }
+        locus Pub {
+            bus {
+                publish "md.book.kraken" of type BookSnap;
+            }
+            birth() {
+                "md.book.kraken" <- BookSnap {
+                    symbol:   "BTC-USD",
+                    venue_ts: "2026-05-27T10:00:00Z",
+                    mid:      42000.5d,
+                };
+            }
+        }
+        fn main() {
+            Pub { };
+        }
+    "#
+}
+
+#[test]
+fn udp_multi_listener_same_port_different_groups() {
+    // Stress the SO_REUSEPORT + multicast-group-membership
+    // case that priceview uses in production. Four reader
+    // threads, each bound to the same port and joined to a
+    // distinct multicast group. A single publisher fires one
+    // payload at the kraken-book group; the subscriber should
+    // dispatch exactly one handler (on_kraken_book) and not
+    // crash even if SO_REUSEPORT delivers the packet to a
+    // socket that hadn't joined that group (which would mean
+    // the deserialize lookup picks a deserialize_fn for a
+    // different payload type and the bound-check is the only
+    // thing standing between us and the 64 MB alloc).
+    let sub_bin = compile("multi_sub", multi_listener_subscriber_src());
+    let pub_bin = compile("multi_pub", multi_listener_publisher_src());
+    let port = 57795;
+    let sub_cfg = unique_path("multi_sub", "conf");
+    let pub_cfg = unique_path("multi_pub", "conf");
+    std::fs::write(&sub_cfg, format!(
+        "md.book.kraken   = udp://239.42.1.1:{}:listen\n\
+         md.book.coinbase = udp://239.42.1.2:{}:listen\n\
+         md.tick.kraken   = udp://239.42.2.1:{}:listen\n\
+         md.tick.coinbase = udp://239.42.2.2:{}:listen\n",
+        port, port, port, port,
+    )).expect("write sub cfg");
+    std::fs::write(&pub_cfg, format!(
+        "md.book.kraken = udp://239.42.1.1:{}:connect\n",
+        port,
+    )).expect("write pub cfg");
+
+    let out = run_pair(&sub_bin, &pub_bin, &sub_cfg, &pub_cfg);
+
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+    let _ = std::fs::remove_file(&sub_cfg);
+    let _ = std::fs::remove_file(&pub_cfg);
+
+    // Only the kraken_book handler should fire; the other 3
+    // listeners didn't join group 239.42.1.1, so they
+    // shouldn't receive this datagram. Critically: the
+    // subscriber MUST NOT crash, even if SO_REUSEPORT cross-
+    // routes.
+    assert!(
+        out.contains("kraken_book sym=BTC-USD"),
+        "kraken_book handler should fire; stdout:\n{}",
+        out
+    );
+}
+
+#[test]
+fn udp_corrupt_length_prefix_rejected_cleanly() {
+    // 2026-05-27 — proves the deserialize bound-check (added
+    // alongside the fathom priceview crash report) actually
+    // engages. We bypass the publisher binary entirely and
+    // send a malformed datagram straight from the test
+    // harness: 8 bytes encoding length-prefix = 0x04000000
+    // (= 64 MB, exactly the value that triggered priceview's
+    // `g_bus_payload_arena` cap-hit symptom).
+    //
+    // Without the bound-check, the subscriber's deserialize
+    // would hand 64 MB to `lotus_bus_payload_arena_alloc`,
+    // hit the arena cap, return NULL, then dereference NULL
+    // in the subsequent memcpy → SIGSEGV in seconds.
+    //
+    // With the check, the deserialize compares the decoded
+    // length against the wire size (8 bytes), the UGT
+    // comparison fires (67108864 > 8), and the deserialize
+    // returns -1. The reader thread's `if (struct_size <= 0)
+    // continue;` drops the datagram silently. Subscriber
+    // stays alive.
+    let sub_bin = compile("corrupt_sub", r#"
+        type Msg {
+            symbol: String  = "";
+            mid:    Decimal = 0.0d;
+        }
+        locus Sub {
+            bus {
+                subscribe "corrupt" as on_msg of type Msg;
+            }
+            fn on_msg(m: Msg) {
+                // Should NEVER fire — the malformed wire bytes
+                // are rejected at deserialize time, before any
+                // dispatch happens.
+                println("FIRED sym=", m.symbol);
+            }
+        }
+        fn main() {
+            Sub { };
+            println("READY");
+            std::time::sleep(800ms);
+            println("SURVIVED");
+        }
+    "#);
+
+    let port = 57799;
+    let sub_cfg = unique_path("corrupt_sub", "conf");
+    std::fs::write(&sub_cfg, format!("corrupt = udp://127.0.0.1:{}:listen\n", port))
+        .expect("write sub cfg");
+
+    let sub = Command::new(&sub_bin)
+        .env("LOTUS_BUS_CONFIG", &sub_cfg)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn subscriber");
+
+    // Give the reader thread time to bind.
+    std::thread::sleep(Duration::from_millis(200));
+
+    // Send the malformed datagram. The 8 bytes are the LE
+    // encoding of i64=67108864 — what priceview observed in
+    // the wild.
+    let sock = UdpSocket::bind("127.0.0.1:0").expect("test sock");
+    let bad = [0x00u8, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00];
+    sock.send_to(&bad, format!("127.0.0.1:{}", port))
+        .expect("send corrupt datagram");
+
+    let sub_out = sub.wait_with_output().expect("wait subscriber");
+
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&sub_cfg);
+
+    assert!(
+        sub_out.status.success(),
+        "subscriber should survive the malformed datagram; \
+         status: {:?}\nstdout: {}\nstderr: {}",
+        sub_out.status,
+        String::from_utf8_lossy(&sub_out.stdout),
+        String::from_utf8_lossy(&sub_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&sub_out.stdout);
+    assert!(stdout.contains("READY"),    "stdout: {}", stdout);
+    assert!(stdout.contains("SURVIVED"), "stdout: {}", stdout);
+    assert!(
+        !stdout.contains("FIRED"),
+        "handler must not fire on a malformed payload; stdout: {}",
+        stdout,
+    );
 }


### PR DESCRIPTION
Closes a real production crash reported by fathom's priceview (2026-05-27 handoff). First inbound \`udp://\` datagram → \`g_bus_payload_arena\` cap-hit at \`65536 / 67108864 bytes\` → NULL alloc → SIGSEGV in seconds.

## Root cause

The codegen-synthesized \`__deserialize_T\` reads an 8-byte length prefix for String / Bytes fields, then hands it straight to \`lotus_bus_payload_arena_alloc\` with zero bound check. A corrupt or cross-routed datagram (any 8 wire bytes whose LE decoding lands above ~64 MB) triggers the arena's hard cap, the NULL return is dereferenced by the trailing memcpy, segfault.

## Fix

Unsigned \`> wire_n\` guard on every decoded length. Branches to a shared \`wire.fail\` block that returns -1 from the deserialize fn. Reader threads already drop the message on \`-1\` via the existing \`if (struct_size <= 0) continue;\`. Plumbing threads two new params through the deserialize emit helpers; bound-check IR lives at four sites (top-level + nested-struct × String + Bytes).

## Tests

Three new regression tests in \`bus_udp_transport.rs\`:

1. **\`udp_unicast_delivers_multi_string_payload\`** — replays the exact BookSignalSnapshot shape end-to-end through UDP. Existing tests only covered single-Int payloads.
2. **\`udp_multi_listener_same_port_different_groups\`** — mirrors priceview's 4-listener-same-port deployment shape.
3. **\`udp_corrupt_length_prefix_rejected_cleanly\`** — the load-bearing test for the fix: sends a malformed datagram from the test harness with the exact \`0x04000000\` length-prefix priceview saw. Without the check → SIGSEGV; with it → silent drop, subscriber survives.

## Root cause separate

The \`bus_udp_transport\` multi-listener test passes on loopback, so the trigger for fathom's wire corruption isn't reproducible locally. Likely candidates: docker host-network multicast routing quirks, or something specific to the mdgw publisher serialize path. Diagnosing that needs the binaries to stay up first — this PR unblocks that.

## Test plan
- [x] All bus_* tests pass (36 tests, 0 failures) on this branch
- [x] Corrupt-wire test proves the bound-check engages and the subscriber survives
- [ ] CI green
- [ ] Fathom pulls the patched compiler, confirms priceview no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)