### PR TITLE
bus udp: bind multicast receivers to the group address (fix crosstalk)

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -8612,16 +8612,28 @@ static void *lotus_bus_udp_reader_thread_main(void *arg) {
     memset(&bind_addr, 0, sizeof(bind_addr));
     bind_addr.sin_family = AF_INET;
     bind_addr.sin_port   = dest.sin_port;
-    if (lotus_addr_is_multicast(&dest.sin_addr)) {
-        /* Multicast: bind INADDR_ANY so the socket receives
-         * datagrams sent to the group from any source. */
-        bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-    } else {
-        /* Unicast: bind the configured address so we receive
-         * only datagrams addressed to us (and not to other IPs
-         * on this host). */
-        bind_addr.sin_addr = dest.sin_addr;
-    }
+    /* Bind to the configured address regardless of unicast /
+     * multicast. The bind tuple is what Linux uses to filter
+     * which incoming datagrams reach this socket; the
+     * IP_ADD_MEMBERSHIP call below (multicast case) is a
+     * separate concern controlling whether the kernel
+     * forwards the group's traffic up the IP stack at all.
+     *
+     * Pre-2026-05-27 the multicast branch bound INADDR_ANY,
+     * which works for a single receiver but crosstalks with
+     * any other socket bound to the same port: every joined-
+     * group packet on that port lands on every wildcard-bound
+     * socket. Surfaced by fathom's priceview, which subscribes
+     * to four distinct multicast groups sharing port 5000 —
+     * each (group, port) is logically a distinct endpoint
+     * carrying its own payload type, but the wildcard bind
+     * collapsed them into a single delivery set so every
+     * datagram fanned to all four handlers (kraken+coinbase
+     * gauges converged to whichever venue's snapshot arrived
+     * last). Matches the reference multicast-receiver shape
+     * in Boost.Asio's `multicast::join_group` example and
+     * NASDAQ ITCH-Recovery client samples. */
+    bind_addr.sin_addr = dest.sin_addr;
     if (bind(fd, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) < 0) {
         perror("lotus_bus udp reader: bind");
         close(fd);

--- a/crates/hale-codegen/tests/bus_udp_transport.rs
+++ b/crates/hale-codegen/tests/bus_udp_transport.rs
@@ -496,14 +496,36 @@ fn udp_multi_listener_same_port_different_groups() {
     let _ = std::fs::remove_file(&sub_cfg);
     let _ = std::fs::remove_file(&pub_cfg);
 
-    // Only the kraken_book handler should fire; the other 3
-    // listeners didn't join group 239.42.1.1, so they
-    // shouldn't receive this datagram. Critically: the
-    // subscriber MUST NOT crash, even if SO_REUSEPORT cross-
-    // routes.
+    // Only the kraken_book handler should fire. The other 3
+    // listeners are on distinct multicast groups; with the
+    // bind-to-group fix (2026-05-27) per-(group, port)
+    // endpoints are honored and each socket only receives
+    // its own group's datagrams. Pre-fix the
+    // bind-to-INADDR_ANY shape would fan this single
+    // datagram to all 4 handlers — the crosstalk that
+    // fathom's priceview reported.
     assert!(
         out.contains("kraken_book sym=BTC-USD"),
         "kraken_book handler should fire; stdout:\n{}",
+        out
+    );
+    assert!(
+        !out.contains("coinbase_book"),
+        "coinbase_book must NOT fire (different group; \
+         firing would indicate INADDR_ANY-bind crosstalk); \
+         stdout:\n{}",
+        out
+    );
+    assert!(
+        !out.contains("kraken_tick"),
+        "kraken_tick must NOT fire (different group); \
+         stdout:\n{}",
+        out
+    );
+    assert!(
+        !out.contains("coinbase_tick"),
+        "coinbase_tick must NOT fire (different group); \
+         stdout:\n{}",
         out
     );
 }


### PR DESCRIPTION
Closes the second half of the fathom priceview report. #7 stopped the crash; this fixes the multicast crosstalk that was masked behind it.

## Root cause

The UDP reader's multicast branch bound \`INADDR_ANY:port\` and relied on \`IP_ADD_MEMBERSHIP\` to filter. Wrong: on Linux \`IP_ADD_MEMBERSHIP\` only enables IP-stack forwarding for the group, not per-socket dest filtering. Multiple wildcard-bound sockets on the same port all receive every joined-group packet.

Fathom symptom: per-(venue, symbol) gauges identical across kraken/coinbase despite gateways publishing distinct streams.

## Fix

Bind \`dest.sin_addr\` in both unicast and multicast cases. The kernel accepts bind to a multicast IP and uses the bind tuple as the per-socket dest filter; \`IP_ADD_MEMBERSHIP\` still happens for the multicast case to enable IP-stack forwarding for the group. Each \`(group, port)\` endpoint now receives only its own traffic.

Matches the reference shape in Boost.Asio's \`multicast::join_group\` example and NASDAQ ITCH-Recovery client samples. Port reuse across distinct groups (the conventional deployment pattern) still works; what changes is that the substrate honors the per-endpoint identity.

## Test plan
- [x] \`udp_multi_listener_same_port_different_groups\` strengthened: now asserts ONLY the kraken_book handler fires on a packet to that group; the other 3 handlers (on different joined groups) must NOT fire. Pre-fix this fails (crosstalk fanout); post-fix it passes.
- [x] All 6 UDP tests + workspace bus_* tests pass locally
- [ ] CI green
- [ ] Fathom confirms per-venue gauges diverge after pulling the patched compiler

🤖 Generated with [Claude Code](https://claude.com/claude-code)