### PR TITLE
bus udp: array-of-pointers for remote entries (fix listen+connect SIGSEGV)

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -8366,7 +8366,29 @@ typedef struct lotus_bus_remote_entry {
     int                udp_is_multicast;
 } lotus_bus_remote_entry_t;
 
-static lotus_bus_remote_entry_t *g_bus_remote_entries = NULL;
+/* 2026-05-27 — array-of-pointers shape (was array-of-structs).
+ * Each entry is its own malloc'd allocation; the global array
+ * holds pointers to them and may realloc freely without
+ * invalidating the per-entry addresses.
+ *
+ * Why this shape: the udp listen-side reader threads hold a
+ * stable `entry` pointer captured at spawn time (see
+ * lotus_bus_udp_reader_args_t.entry). With the array-of-structs
+ * shape, a subsequent register_remote call that grew the array
+ * could realloc-move the storage and dangle every previously-
+ * spawned reader thread's `entry` pointer. Fathom hit this when
+ * priceview's LOTUS_BUS_CONFIG mixed 4 listens + 2 connects:
+ * the 5th entry's realloc invalidated the first 4 reader
+ * threads' entry pointers, segfaulting silently on the first
+ * inbound datagram. Single-role configs (listen-only or
+ * connect-only) that fit in the initial cap (=4) never tripped
+ * the realloc, which is why the crash matrix appeared
+ * "listen+connect specific" rather than "more than 4 entries."
+ *
+ * Cost: one extra pointer dereference per fanout step; one
+ * extra malloc per registration. Both are noise in the
+ * shapes that touch this code (startup + low-rate publishes). */
+static lotus_bus_remote_entry_t **g_bus_remote_entries = NULL;
 static size_t g_bus_remote_count = 0;
 static size_t g_bus_remote_cap   = 0;
 
@@ -8762,16 +8784,19 @@ void lotus_bus_register_remote(const char *subject,
         return;
     }
 
-    /* Grow the table BEFORE doing any side effects so the
-     * realloc-relocation can't invalidate a pointer we already
-     * handed out (e.g., to a reader thread via reader_args). */
+    /* Grow the slot-array (of pointers, post-2026-05-27) so we
+     * have room to stash the new entry's pointer. The
+     * realloc here can move the array of pointers, but the
+     * individual entries it points to are stable malloc'd
+     * allocations — no dangling reader-thread `args->entry`
+     * pointers from prior registrations. */
     if (g_bus_remote_count == g_bus_remote_cap) {
         size_t new_cap = g_bus_remote_cap == 0
             ? LOTUS_BUS_REMOTE_INITIAL_CAP
             : g_bus_remote_cap * 2;
-        lotus_bus_remote_entry_t *grown = (lotus_bus_remote_entry_t *)
+        lotus_bus_remote_entry_t **grown = (lotus_bus_remote_entry_t **)
             realloc(g_bus_remote_entries,
-                    new_cap * sizeof(lotus_bus_remote_entry_t));
+                    new_cap * sizeof(lotus_bus_remote_entry_t *));
         if (!grown) return;
         g_bus_remote_entries = grown;
         g_bus_remote_cap     = new_cap;
@@ -8780,8 +8805,10 @@ void lotus_bus_register_remote(const char *subject,
     char *subject_copy = strdup(subject);
     if (!subject_copy) return;
 
-    lotus_bus_remote_entry_t *e =
-        &g_bus_remote_entries[g_bus_remote_count++];
+    lotus_bus_remote_entry_t *e = (lotus_bus_remote_entry_t *)
+        malloc(sizeof(lotus_bus_remote_entry_t));
+    if (!e) { free(subject_copy); return; }
+    g_bus_remote_entries[g_bus_remote_count++] = e;
     e->subject           = subject_copy;
     e->kind              = is_udp
         ? LOTUS_BUS_REMOTE_KIND_UDP
@@ -8916,17 +8943,19 @@ void lotus_bus_register_remote_adapter(
         size_t new_cap = g_bus_remote_cap == 0
             ? LOTUS_BUS_REMOTE_INITIAL_CAP
             : g_bus_remote_cap * 2;
-        lotus_bus_remote_entry_t *grown = (lotus_bus_remote_entry_t *)
+        lotus_bus_remote_entry_t **grown = (lotus_bus_remote_entry_t **)
             realloc(g_bus_remote_entries,
-                    new_cap * sizeof(lotus_bus_remote_entry_t));
+                    new_cap * sizeof(lotus_bus_remote_entry_t *));
         if (!grown) return;
         g_bus_remote_entries = grown;
         g_bus_remote_cap     = new_cap;
     }
     char *subject_copy = strdup(subject);
     if (!subject_copy) return;
-    lotus_bus_remote_entry_t *e =
-        &g_bus_remote_entries[g_bus_remote_count++];
+    lotus_bus_remote_entry_t *e = (lotus_bus_remote_entry_t *)
+        malloc(sizeof(lotus_bus_remote_entry_t));
+    if (!e) { free(subject_copy); return; }
+    g_bus_remote_entries[g_bus_remote_count++] = e;
     e->subject           = subject_copy;
     e->kind              = LOTUS_BUS_REMOTE_KIND_ADAPTER;
     e->transport         = NULL;
@@ -9024,7 +9053,7 @@ void lotus_bus_remote_fanout(const char *subject,
                              size_t payload_size) {
     if (!subject) return;
     for (size_t i = 0; i < g_bus_remote_count; i++) {
-        lotus_bus_remote_entry_t *e = &g_bus_remote_entries[i];
+        lotus_bus_remote_entry_t *e = g_bus_remote_entries[i];
         if (!e->subject) continue;
         if (strcmp(e->subject, subject) != 0) continue;
         if (e->kind == LOTUS_BUS_REMOTE_KIND_ADAPTER) {
@@ -10982,7 +11011,7 @@ const char *lotus_fs_mktemp(const char *prefix, const char *suffix) {
 
 void lotus_bus_remote_destroy_all(void) {
     for (size_t i = 0; i < g_bus_remote_count; i++) {
-        lotus_bus_remote_entry_t *e = &g_bus_remote_entries[i];
+        lotus_bus_remote_entry_t *e = g_bus_remote_entries[i];
 
         /* Wave B: adapter entries own their protocol lifecycle
          * through the adapter locus's own dissolve method, which
@@ -10991,6 +11020,7 @@ void lotus_bus_remote_destroy_all(void) {
          * here — only the strdup'd subject string to free. */
         if (e->kind == LOTUS_BUS_REMOTE_KIND_ADAPTER) {
             if (e->subject) free(e->subject);
+            free(e);
             continue;
         }
 
@@ -11017,6 +11047,7 @@ void lotus_bus_remote_destroy_all(void) {
                 e->udp_fd = -1;
             }
             if (e->subject) free(e->subject);
+            free(e);
             continue;
         }
 
@@ -11046,6 +11077,7 @@ void lotus_bus_remote_destroy_all(void) {
         if (e->subject) {
             free(e->subject);
         }
+        free(e);
     }
     if (g_bus_remote_entries) free(g_bus_remote_entries);
     g_bus_remote_entries = NULL;

--- a/crates/hale-codegen/tests/bus_udp_transport.rs
+++ b/crates/hale-codegen/tests/bus_udp_transport.rs
@@ -531,6 +531,108 @@ fn udp_multi_listener_same_port_different_groups() {
 }
 
 #[test]
+fn udp_mixed_listen_connect_survives_realloc() {
+    // 2026-05-27 — fathom priceview hit a silent SIGSEGV when
+    // LOTUS_BUS_CONFIG mixed udp:// listen and udp:// connect
+    // roles. Root cause: `g_bus_remote_entries` was an
+    // array-of-structs with initial cap = 4. The udp listen
+    // reader threads each captured `args->entry = &entries[N]`
+    // at spawn time. When a subsequent register_remote call
+    // grew the array (>4 entries), realloc could move the
+    // storage, and the previously-spawned reader threads'
+    // entry pointers became dangling. Matrix: 4 listens alone
+    // = stable (fits in cap); 2 connects alone = stable;
+    // 4 listens + 2 connects (6 → realloc) = silent SIGSEGV.
+    //
+    // Fix shipped 2026-05-27: g_bus_remote_entries is an
+    // array of POINTERS to individually-malloc'd entries.
+    // The array can realloc freely; per-entry addresses stay
+    // stable.
+    //
+    // This test reproduces the priceview shape: more than 4
+    // total entries with at least one listen and at least one
+    // connect. Without the fix, the subscriber binary
+    // segfaults on the first inbound datagram. With the fix,
+    // the listen handlers fire normally.
+    let sub_bin = compile("mixed_sub", r#"
+        type Evt { sym: String = ""; }
+        locus Sub {
+            bus {
+                subscribe "evt.a" as on_a of type Evt;
+                subscribe "evt.b" as on_b of type Evt;
+                subscribe "evt.c" as on_c of type Evt;
+                subscribe "evt.d" as on_d of type Evt;
+            }
+            fn on_a(e: Evt) { println("a sym=", e.sym); }
+            fn on_b(e: Evt) { println("b sym=", e.sym); }
+            fn on_c(e: Evt) { println("c sym=", e.sym); }
+            fn on_d(e: Evt) { println("d sym=", e.sym); }
+        }
+        fn main() {
+            Sub { };
+            println("READY");
+            std::time::sleep(800ms);
+            println("SURVIVED");
+        }
+    "#);
+    let pub_bin = compile("mixed_pub", r#"
+        type Evt { sym: String = ""; }
+        locus Pub {
+            bus {
+                publish "evt.a" of type Evt;
+            }
+            birth() {
+                "evt.a" <- Evt { sym: "FROM-A" };
+            }
+        }
+        fn main() {
+            Pub { };
+        }
+    "#);
+
+    // Subscriber config: 4 udp listens + 2 udp connects = 6
+    // remote entries, which forces a realloc past the initial
+    // cap of 4. The connects don't actually need to be
+    // reachable — just registered, to provoke the realloc.
+    let port_a   = 57870;
+    let port_b   = 57871;
+    let port_c   = 57872;
+    let port_d   = 57873;
+    let port_out = 57874;
+    let sub_cfg = unique_path("mixed_sub", "conf");
+    let pub_cfg = unique_path("mixed_pub", "conf");
+    std::fs::write(&sub_cfg, format!(
+        "evt.a   = udp://127.0.0.1:{}:listen\n\
+         evt.b   = udp://127.0.0.1:{}:listen\n\
+         evt.c   = udp://127.0.0.1:{}:listen\n\
+         evt.d   = udp://127.0.0.1:{}:listen\n\
+         out.x   = udp://127.0.0.1:{}:connect\n\
+         out.y   = udp://127.0.0.1:{}:connect\n",
+        port_a, port_b, port_c, port_d, port_out, port_out + 1,
+    )).expect("write sub cfg");
+    std::fs::write(&pub_cfg, format!(
+        "evt.a = udp://127.0.0.1:{}:connect\n",
+        port_a,
+    )).expect("write pub cfg");
+
+    let out = run_pair(&sub_bin, &pub_bin, &sub_cfg, &pub_cfg);
+
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+    let _ = std::fs::remove_file(&sub_cfg);
+    let _ = std::fs::remove_file(&pub_cfg);
+
+    assert!(out.contains("READY"),    "stdout: {}", out);
+    assert!(out.contains("a sym=FROM-A"),
+        "the kraken-shaped listen handler must fire — \
+         entry-pointer should survive the realloc that the \
+         2 connect entries trigger; stdout:\n{}", out);
+    assert!(out.contains("SURVIVED"),
+        "subscriber must not segfault after dispatch; \
+         stdout:\n{}", out);
+}
+
+#[test]
 fn udp_corrupt_length_prefix_rejected_cleanly() {
     // 2026-05-27 — proves the deserialize bound-check (added
     // alongside the fathom priceview crash report) actually


### PR DESCRIPTION
Third in the session's udp:// bug-fix series. Closes the silent-SIGSEGV reported in fathom's \`handoff-compiler-udp-listen-plus-connect-2026-05-27.md\`.

## Root cause

\`g_bus_remote_entries\` was an array of structs with \`LOTUS_BUS_REMOTE_INITIAL_CAP = 4\`. Reader threads captured \`args->entry = &g_bus_remote_entries[N]\` — a pointer **into** the array. The 5th \`register_remote\` call hit the cap boundary, \`realloc\` could move the storage, and previously-spawned reader threads' entry pointers became dangling.

Crash matrix from the handoff:

| LOTUS_BUS_CONFIG | Result |
|---|---|
| 4 udp listens | stable (fits in initial cap) |
| 2 udp connects | stable (fits) |
| 4 listens + 2 connects (6 total) | **SIGSEGV** |
| 4 listens + commented-out connect | stable |

## Fix

Switch to an array of **pointers** to individually-malloc'd entries. The pointer-array can realloc freely; per-entry addresses stay stable.

Touched sites:
- declaration: \`lotus_bus_remote_entry_t **g_bus_remote_entries\`
- both \`register_remote\` paths (udp+unix and adapter)
- both fanout loops (one level less of dereference)
- \`destroy_all\` frees each entry before freeing the pointer-array

Cost: one extra pointer dereference per fanout step + one malloc per registration. Negligible.

## Test plan
- [x] New \`udp_mixed_listen_connect_survives_realloc\` test mirrors the priceview shape (4 listens + 2 connects); listen handler fires, subscriber doesn't segfault
- [x] All 29 existing bus_* tests still pass
- [ ] CI green