### PR TITLE
fix(runtime): poke async pool wake_fd on cross-pool enqueue (on_out starvation)

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -4701,6 +4701,25 @@ void lotus_coop_pool_post(lotus_coop_pool_t *p,
 #endif
     pthread_cond_broadcast(&p->not_empty);
     pthread_mutex_unlock(&p->lock);
+    /* 2026-05-31: if this is an async_io pool, its worker may be
+     * blocked in `epoll_wait(-1)` with a parked coro and no cells
+     * pending (the `timeout_ms = cell_pending ? 0 : -1` path in
+     * drain_one_async). The condvar broadcast above does NOT wake a
+     * worker sitting in epoll_wait — so a cross-pool cell enqueued
+     * here would sit undelivered until some fd event happens to wake
+     * the worker. That starves fanout to a per-connection handler
+     * whose `run()` is parked on recv (a silent client → the push
+     * cell never fires). Poke the wake eventfd — the same one
+     * shutdown_all uses — so the worker returns from epoll_wait,
+     * falls through to the cell-drain step, and dispatches this cell.
+     * Gated on `wake_fd >= 0` (async_io pools only): a classic
+     * blocking pool has wake_fd == -1 and is woken by the condvar,
+     * so it pays nothing. (wake_fd is set once at async-enable and
+     * stable thereafter, so this unlocked read is race-free.) */
+    if (p->wake_fd >= 0) {
+        uint64_t one = 1;
+        (void)write(p->wake_fd, &one, sizeof(one));
+    }
 }
 
 /* Drain a single cell on the pool's worker thread. Blocks on


### PR DESCRIPTION
## What

A cell enqueued to a cooperative `async_io` pool via `lotus_coop_pool_post` broadcasts the `not_empty` condvar — but a worker blocked in `epoll_wait(-1)` with a parked coro and no pending cells (the `timeout_ms = cell_pending ? 0 : -1` path in `drain_one_async`) is **not** woken by a condvar. So a cross-pool cell sat undelivered until some unrelated fd event happened to wake the worker.

This starves bus fanout to a per-connection handler whose `run()` is parked on recv: a silent client means the worker never leaves `epoll_wait`, so the push (`on_out`) cell never fires — **0 dispatches while parked**, confirmed downstream (fathom) against the dashboard FLOW-child shape.

## Fix

After the condvar broadcast in `lotus_coop_pool_post`, poke the pool's wake eventfd — the same one `shutdown_all` already uses to unblock `epoll_wait`. The worker returns from `epoll_wait`, drains the wake event (`data.ptr == p`), returns 1, re-enters `drain_one_async` with `cell_pending` now true, and dispatches the cell.

Gated on `wake_fd >= 0` so it fires only for `async_io` pools; a classic blocking pool (`wake_fd == -1`) is woken by the condvar as before and pays nothing. `wake_fd` is set once at async-enable and stable thereafter, so the unlocked read is race-free.

Restores intended cross-pool delivery (a defect, not a behavior change); no spec surface changes.

## Testing

- Traced the full wake path end-to-end against `drain_one_async`: enqueue → poke → `epoll_wait` returns → wake event drained (no busy-loop) → `return 1` → re-enter → `cell_pending` → drain + dispatch.
- No regression: `async_io_park_resume`, `async_io_shutdown_parked`, `coop_pool_basic`, `coop_pool_run_dispatch`, `terminate_reclaims_child`, `release_reclaims_flow`, `qualified_locus_type_coop_pool` all green locally.
- A minimal synthetic repro could not isolate the starvation — routing a subscription *onto* an async pool requires the `subscribe` to run on that pool's worker (the accept-loop-`run()`-on-async shape), which the synthetic repros couldn't reach (their subscriptions landed on the global queue via the orthogonal method-body-pool-context limitation). The tsan CI job is the load-bearing check here for the concurrency change; fathom's dashboard FLOW case is the authoritative end-to-end reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)