### PR TITLE
fix(desugar): keep cross-pool publishes on the bus (intra-locus opt pool-safety)

### DIFF
--- a/crates/hale-syntax/src/desugar.rs
+++ b/crates/hale-syntax/src/desugar.rs
@@ -426,6 +426,26 @@ pub fn desugar_intra_locus_topics(program: &mut Program) {
     let (pubs, subs) = collect_pub_sub(&program.items);
     let locus_types = collect_locus_type_names(&program.items);
     let locus_fields = collect_locus_typed_fields(&program.items, &locus_types);
+    // F.31 pool-safety (2026-05-31): the set of (owner_locus,
+    // field) pairs whose `placement { }` puts the field-child on
+    // a thread OTHER than its owner's (a named cooperative pool
+    // that isn't `main`, or a pinned thread). The intra-locus
+    // rewrite below turns a publish into a *direct, synchronous*
+    // method call on the publisher's own thread — correct only
+    // when publisher and subscriber share an execution context.
+    // For an off-thread subscriber that bypasses the bus's
+    // `lotus_coop_pool_post` routing: the handler would run on the
+    // publisher's thread (e.g. main), violating the
+    // single-threaded-pool invariant AND dropping the pool context
+    // that any locus the handler instantiates needs to inherit
+    // (an accept'd child's run() would then go synchronous + its
+    // subscriptions register on the global queue — observed as a
+    // per-connection handler blocking the main thread in accept()).
+    // Such publishes must stay on the bus dispatch path. Same-locus
+    // (case a) and non-main-owner field-children (placement is a
+    // main-locus-only seam, so those share the owner's pool) are
+    // unaffected.
+    let placed_off_owner_thread = collect_off_owner_thread_fields(&program.items);
     // Phase 3 (2026-05-25): collect the set of topic names that
     // declare `keyed_by` (or `on_unmatched`). The intra-locus
     // optimization rewrites publishes to direct method calls,
@@ -504,6 +524,13 @@ pub fn desugar_intra_locus_topics(program: &mut Program) {
             continue;
         }
         let field = fields_of_s[0].clone();
+        // F.31 pool-safety: if this field-child is placed on a
+        // thread other than its owner's, the publish must route
+        // through the bus (which posts to the child's pool), not a
+        // direct same-thread call. See `placed_off_owner_thread`.
+        if placed_off_owner_thread.contains(&(pub_locus.clone(), field.clone())) {
+            continue;
+        }
         eligible.insert(
             topic.clone(),
             EligibleRewrite {
@@ -525,6 +552,56 @@ pub fn desugar_intra_locus_topics(program: &mut Program) {
             _ => {}
         }
     }
+}
+
+/// Set of (owner_locus, field) pairs whose `placement { }` entry
+/// puts the field-child on a thread other than the owner's: a
+/// named cooperative pool that isn't `main`, or a pinned thread.
+/// `cooperative` with no pool (or `pool = main`) keeps the child
+/// on the owner's (main) thread, so a direct same-thread call is
+/// safe and stays eligible for the intra-locus rewrite.
+///
+/// F.31 scopes `placement { }` to the main locus, so in practice
+/// only main-locus fields appear here — but the walk is
+/// locus-agnostic, so a future non-main placement seam is covered
+/// automatically.
+fn collect_off_owner_thread_fields(
+    items: &[TopDecl],
+) -> std::collections::BTreeSet<(String, String)> {
+    let mut out = std::collections::BTreeSet::new();
+    fn walk(
+        items: &[TopDecl],
+        out: &mut std::collections::BTreeSet<(String, String)>,
+    ) {
+        for item in items {
+            match item {
+                TopDecl::Locus(l) => {
+                    for member in &l.members {
+                        if let LocusMember::Placement(pb) = member {
+                            for e in &pb.entries {
+                                let off_thread = match &e.spec {
+                                    PlacementSpec::Cooperative { pool } => pool
+                                        .as_ref()
+                                        .is_some_and(|p| p.name != "main"),
+                                    PlacementSpec::Pinned { .. } => true,
+                                };
+                                if off_thread {
+                                    out.insert((
+                                        l.name.name.clone(),
+                                        e.field.name.clone(),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+                TopDecl::Module(m) => walk(&m.items, out),
+                _ => {}
+            }
+        }
+    }
+    walk(items, &mut out);
+    out
 }
 
 /// Set of every declared locus type name in the program (across

--- a/crates/hale-syntax/tests/intra_locus_pool_safety.rs
+++ b/crates/hale-syntax/tests/intra_locus_pool_safety.rs
@@ -1,0 +1,138 @@
+//! F.31 pool-safety guard on the intra-locus publish→direct-call
+//! optimization (`desugar_intra_locus_topics`).
+//!
+//! The optimization rewrites a 1-publisher / 1-subscriber publish
+//! into a direct, *synchronous* method call on the publisher's own
+//! thread. That is correct only when publisher and subscriber share
+//! an execution context. When the subscriber field is placed on a
+//! separate cooperative pool (or pinned thread), the direct call
+//! would run the handler on the publisher's thread (e.g. main) —
+//! violating the single-threaded-pool invariant and dropping the
+//! pool context that any locus the handler instantiates needs to
+//! inherit (an accept'd child's run() would go synchronous and its
+//! subscriptions would register on the global queue; observed as a
+//! per-connection handler blocking the main thread in accept()).
+//!
+//! So: an off-thread subscriber must keep its publish on the bus
+//! dispatch path (Send preserved), while an on-thread subscriber
+//! (pool = main / no placement) still gets the optimization
+//! (Send rewritten to a method-call Stmt::Expr).
+
+use hale_syntax::ast::{Block, LifecycleKind, LocusMember, Stmt, TopDecl};
+use hale_syntax::desugar::desugar_intra_locus_topics;
+
+/// Pull the `run()` body of the named locus out of a parsed +
+/// desugared program.
+fn run_body<'a>(program: &'a hale_syntax::ast::Program, locus: &str) -> &'a Block {
+    for item in &program.items {
+        if let TopDecl::Locus(l) = item {
+            if l.name.name != locus {
+                continue;
+            }
+            for m in &l.members {
+                if let LocusMember::Lifecycle(d) = m {
+                    if d.kind == LifecycleKind::Run {
+                        return &d.body;
+                    }
+                }
+            }
+        }
+    }
+    panic!("no run() body found for locus {locus}");
+}
+
+/// `true` if the run body still contains a `Stmt::Send` (publish
+/// left on the bus path); `false` if every Send was rewritten to a
+/// method-call Stmt::Expr by the optimization.
+fn has_send(body: &Block) -> bool {
+    body.stmts.iter().any(|s| matches!(s, Stmt::Send { .. }))
+}
+
+const SRC_TEMPLATE: &str = r#"
+    type Ping { n: Int = 0; }
+    topic PingT { payload: Ping; subject: "p.ping"; }
+
+    locus Worker {
+        bus { subscribe PingT as on_ping; }
+        fn on_ping(p: Ping) { println("ping ", p.n); }
+    }
+
+    main locus App {
+        params { w: Worker = Worker { }; }
+        placement { __PLACEMENT__ }
+        bus { publish PingT; }
+        run() {
+            PingT <- Ping { n: 1 };
+        }
+    }
+
+    fn main() { App { }; }
+"#;
+
+fn desugared_with_placement(placement: &str) -> hale_syntax::ast::Program {
+    let src = SRC_TEMPLATE.replace("__PLACEMENT__", placement);
+    let mut program = hale_syntax::parse_source(&src).expect("parse");
+    desugar_intra_locus_topics(&mut program);
+    program
+}
+
+#[test]
+fn off_thread_pool_subscriber_keeps_publish_on_bus() {
+    // Worker on a named non-main pool → the publish must NOT be
+    // devirtualized to a direct call on main.
+    let program = desugared_with_placement("w: cooperative(pool = io);");
+    assert!(
+        has_send(run_body(&program, "App")),
+        "publish to a pool-placed subscriber was rewritten to a direct \
+         call — it must stay on the bus dispatch path so the handler \
+         runs on the pool's worker"
+    );
+}
+
+#[test]
+fn async_io_pool_subscriber_keeps_publish_on_bus() {
+    // The exact shape that wedged the main thread: an async_io pool.
+    let program =
+        desugared_with_placement("w: cooperative(pool = io) where async_io;");
+    assert!(
+        has_send(run_body(&program, "App")),
+        "publish to an async_io-pool subscriber was rewritten to a \
+         direct call"
+    );
+}
+
+#[test]
+fn pinned_subscriber_keeps_publish_on_bus() {
+    let program = desugared_with_placement("w: pinned;");
+    assert!(
+        has_send(run_body(&program, "App")),
+        "publish to a pinned subscriber was rewritten to a direct call"
+    );
+}
+
+#[test]
+fn pool_main_subscriber_still_optimizes() {
+    // Explicit `pool = main` keeps Worker on the publisher's thread,
+    // so the optimization is safe and must still fire.
+    let program = desugared_with_placement("w: cooperative(pool = main);");
+    assert!(
+        !has_send(run_body(&program, "App")),
+        "publish to a same-thread (pool = main) subscriber should still \
+         be optimized to a direct call"
+    );
+}
+
+#[test]
+fn unplaced_subscriber_still_optimizes() {
+    // No placement block at all → Worker is on main with the
+    // publisher → optimization must still fire. (Drop the
+    // placement line entirely.)
+    let src = SRC_TEMPLATE.replace("placement { __PLACEMENT__ }", "");
+    let mut program = hale_syntax::parse_source(&src).expect("parse");
+    desugar_intra_locus_topics(&mut program);
+    assert!(
+        !has_send(run_body(&program, "App")),
+        "publish to an unplaced (main-thread) subscriber should still be \
+         optimized to a direct call"
+    );
+}

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -976,7 +976,10 @@ to a synchronous method call. The `subscribe` / `publish`
 entries stay declared (still type-check) but the bus runtime
 never sees traffic on the optimized subject. This is a pure-perf
 rewrite — observable behavior is identical modulo timing
-(synchronous instead of cooperative-deferred).
+(synchronous instead of cooperative-deferred) — *provided
+publisher and subscriber share an execution context* (see the
+placement carve-out below; that condition is what keeps the
+rewrite observably transparent).
 
 Out of scope for v1 (fall through to bus dispatch unchanged):
 
@@ -987,6 +990,19 @@ Out of scope for v1 (fall through to bus dispatch unchanged):
   mechanism that doesn't exist in v1.
 - A parent with multiple direct fields of the subscriber type
   (ambiguous receiver).
+- **Off-thread subscribers (F.31 placement).** When the
+  subscriber is a main-locus field placed on a cooperative pool
+  other than `main`, or on a pinned thread, the direct call would
+  run the handler on the *publisher's* thread instead of the
+  subscriber's pool worker — breaking the single-threaded-pool
+  invariant and dropping the pool context that any locus the
+  handler instantiates must inherit (an accept'd child's `run()`
+  would otherwise go synchronous, and its `subscribe`s would
+  register on the global queue rather than the pool). Such
+  publishes stay on the bus dispatch path, which posts to the
+  subscriber's pool via `lotus_coop_pool_post`. `cooperative` with
+  no pool (or `pool = main`) keeps the subscriber on the
+  publisher's thread, so it remains eligible.
 
 A bound topic is never optimized: the binding may publish to
 remote subscribers that aren't visible at compile time.


### PR DESCRIPTION
## What

The closed-world publish optimization (`desugar_intra_locus_topics`) rewrites a 1-publisher / 1-subscriber `Topic <- payload` into a **direct, synchronous method call** on the publisher's thread, bypassing the bus. It never checked the subscriber's F.31 placement.

So for a main locus publishing to a pool-placed field subscriber:

```
SpawnT <- Spawn{}   ⟶   self.mgr.on_spawn(Spawn{})   // direct call, ON MAIN
```

the handler ran on **main** instead of being posted to its `ws` worker. Everything the handler then instantiated saw `lotus_coop_pool_current() == null`: an accept'd child's `run()` took the synchronous **blocking-`accept()`** path (wedging the main thread in `inet_csk_accept`) and its subscriptions registered on the **global queue** instead of the pool.

This is the long-standing "method-body drops pool context → sync `run()` + NULL-pool subscriptions" symptom — root-caused here to the publish devirtualization (confirmed via LLVM IR: `@App.run` calling `@Manager.on_spawn` directly, plus runtime register/dispatch/post traces and `/proc` wchan showing the main thread parked in `inet_csk_accept`).

## Fix

Skip the rewrite when the subscriber field is placed off the publisher's thread (`cooperative(pool != main)` or `pinned`). Those publishes stay on the bus dispatch path, which posts to the subscriber's pool via `lotus_coop_pool_post`. Same-thread subscribers (`pool = main` / unplaced) and same-locus publishes still get the optimization.

## Why it matters

With this + #24 (async-pool `wake_fd` on enqueue), the canonical pattern — an accept'd per-connection child that **both** parks on its socket **and** receives cross-pool fanout — works end-to-end. The repro that previously hung (indefinitely, main wedged in blocking `accept`) now exits cleanly with every push delivered (ON_TICK 1..5).

## Testing

- `tests/intra_locus_pool_safety.rs` — 5 deterministic cases: off-thread pool / async_io pool / pinned → Send **preserved** on the bus; `pool = main` + unplaced → still **optimized** to a direct call (positive controls).
- No regressions: hale-syntax full (82 unit + all parse fixtures), `topic_phase2`, `closed_world_nested_struct`, `http_server_bus_logging`, `io_tcp_bus_logging`, `bus_routing_keys`, `coop_pool_*`, `async_io_park_resume`, `f22_capacity_dispatch`.
- The tsan job is the load-bearing CI check here — it touches the threading model.

## Spec

`spec/semantics.md` closed-world-optimization section gets the placement carve-out: the "observable behavior identical" guarantee holds only when publisher and subscriber share a thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)