### PR TITLE
feat(typecheck): gate terminate (locus-only) and release (needs accept)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,11 @@ present in this repo — use the fixture corpus instead.
 - The spec under `spec/` is the canonical contract. It describes
   shipped behavior, not aspirations. If the impl changes
   user-visible behavior, the spec changes in the same commit.
+- The `docs/` mdBook is the pedagogical companion to `spec/`. When
+  a spec change alters user-facing surface or behavior (a new
+  keyword, lifecycle method, sugar, diagnostic, or semantic
+  rule), update the relevant `docs/src/` chapter in the same
+  change — the book is easy to forget and drifts silently.
 - The user owns commit cadence — never commit without an
   explicit ask.
 - Don't generate planning / status / progress markdown files in

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -2592,6 +2592,43 @@ impl<'a> Checker<'a> {
             self.check_placement_block(info, pb);
         }
 
+        // 2026-06-01: `release(c: T)` is the death-side bookend of
+        // `accept(c: T)` — it fires when an accept'd child of type
+        // T completes, and declaring it marks T a "flow". Without a
+        // matching `accept(c: T)` the locus never owns a T child, so
+        // the release can never fire: it's a dead declaration and
+        // almost always a mistake (wrong child type, or the author
+        // forgot the `accept`). Reject it with a focused diagnostic.
+        for member in &decl.members {
+            if let LocusMember::Lifecycle(lc) = member {
+                if lc.kind == LifecycleKind::Release {
+                    let child_name = lc.params.first().and_then(|p| {
+                        match &p.ty {
+                            TypeExpr::Named { path, .. } => path
+                                .segments
+                                .last()
+                                .map(|s| s.name.clone()),
+                            _ => None,
+                        }
+                    });
+                    match child_name {
+                        Some(name) if locus_accepts(decl, &name) => {}
+                        Some(name) => self.diags.push(Diag::ty(
+                            lc.span,
+                            format!(
+                                "locus `{}` declares `release(c: {})` but has \
+                                 no matching `accept(c: {})` — release is the \
+                                 death-side bookend of accept and can only \
+                                 fire for an accept'd child type",
+                                info.name, name, name
+                            ),
+                        )),
+                        None => {}
+                    }
+                }
+            }
+        }
+
         for member in &decl.members {
             self.check_locus_member(member);
         }
@@ -4192,7 +4229,26 @@ impl<'a> Checker<'a> {
                     }
                 }
             }
-            Stmt::Break(_) | Stmt::Continue(_) | Stmt::Yield(_) | Stmt::Terminate(_) => {}
+            Stmt::Break(_) | Stmt::Continue(_) | Stmt::Yield(_) => {}
+            Stmt::Terminate(span) => {
+                // `terminate;` ends the *current locus's* own
+                // lifecycle (the locus analogue of `return`), so it
+                // only has meaning inside a locus method body —
+                // there must be a `self` whose lifecycle to end. In
+                // a free function there is no locus to terminate;
+                // previously this fell through to a codegen
+                // "no self" error with no source location. Gate it
+                // here with a focused diagnostic.
+                if self.current_locus.is_none() {
+                    self.diags.push(Diag::ty(
+                        *span,
+                        "`terminate` is only valid inside a locus method \
+                         — it ends the enclosing locus's own lifecycle, so \
+                         there is nothing to terminate in a free function"
+                            .to_string(),
+                    ));
+                }
+            }
             Stmt::Fail { value, span } => {
                 // v1.x-FORM-1: `fail <expr>;` must appear inside
                 // a fallible fn body, and its payload type must

--- a/crates/hale-types/tests/terminate_release_gate.rs
+++ b/crates/hale-types/tests/terminate_release_gate.rs
@@ -1,0 +1,92 @@
+//! Typecheck gates for `terminate;` and `release(c: T)`.
+//!
+//! - `terminate;` ends the *enclosing locus's* own lifecycle, so it
+//!   only has meaning inside a locus method body. In a free function
+//!   there is no `self`/locus to terminate — rejected.
+//! - `release(c: T)` is the death-side bookend of `accept(c: T)`. A
+//!   `release` with no matching `accept` of the same child type can
+//!   never fire — rejected.
+
+use hale_syntax::parse_source;
+use hale_types::check_program;
+
+fn check(src: &str) -> Vec<String> {
+    let prog = parse_source(src).expect("parse failed");
+    check_program(&prog)
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+#[test]
+fn terminate_in_free_fn_rejected() {
+    let src = r#"
+fn helper() {
+    terminate;
+}
+fn main() { }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter()
+            .any(|m| m.contains("`terminate` is only valid inside a locus method")),
+        "expected free-fn terminate rejection, got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn terminate_in_locus_method_ok() {
+    let src = r#"
+locus L {
+    params { done: Bool = false; }
+    fn step() {
+        if self.done {
+            terminate;
+        }
+    }
+}
+fn main() { L { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().all(|m| !m.contains("terminate")),
+        "expected terminate-in-method to typecheck, got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn release_without_accept_rejected() {
+    let src = r#"
+locus Child { params { v: Int = 0; } }
+locus Parent {
+    release(c: Child) { }
+}
+fn main() { Parent { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("no matching `accept(c: Child)`")),
+        "expected release-without-accept rejection, got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn release_with_matching_accept_ok() {
+    let src = r#"
+locus Child { params { v: Int = 0; } }
+locus Parent {
+    accept(c: Child) { }
+    release(c: Child) { }
+}
+fn main() { Parent { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().all(|m| !m.contains("release")),
+        "expected release-with-accept to typecheck, got: {:?}",
+        msgs
+    );
+}

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -196,6 +196,11 @@ a still-executing frame. (A child that `terminate`s mid-`run()`
 exits `run()` immediately, like `return`; code after `terminate`
 in the same method does not execute.)
 
+**Validity (typecheck, 2026-06-01).** `terminate;` in a free
+function is a typecheck error — there is no enclosing locus whose
+lifecycle to end. It is accepted in any locus method body
+(lifecycle method or member `fn`).
+
 ### `release(c)` and flow children
 
 `release(c: Child) { ... }` (2026-05-30) is the death-side
@@ -227,6 +232,12 @@ parent has two effects:
 
 `release` has the same shape as `accept` — one typed child
 param — and the same fn signature `(parent_self, child_self)`.
+
+**Validity (typecheck, 2026-06-01).** A `release(c: T)` with no
+matching `accept(c: T)` on the same locus is a typecheck error: a
+locus that never accepts a `T` child can never release one, so
+the declaration is dead (almost always a wrong child type or a
+forgotten `accept`).
 
 ### Locus method dispatch
 


### PR DESCRIPTION
## What

Two typecheck diagnostics that previously only surfaced as a codegen "no self" error (or not at all):

- **`terminate;` in a free function** → typecheck error. `terminate` ends the *enclosing locus's* own lifecycle (the locus analogue of `return`), so it has no meaning where there is no `self`/locus. Accepted in any locus method body.
- **`release(c: T)` with no matching `accept(c: T)`** on the same locus → typecheck error. A locus that never accepts a `T` child can never release one, so the declaration is dead — almost always a wrong child type or a forgotten `accept`.

## Tests

`crates/hale-types/tests/terminate_release_gate.rs` — 4 cases: free-fn `terminate` rejected / in-method ok; `release` without `accept` rejected / with `accept` ok. Full hale-types suite green (168+).

## Spec + docs

- `spec/semantics.md`: validity notes added to the existing `terminate` and `release(c)` sections.
- `CLAUDE.md`: new convention line — spec changes that alter user-facing surface should update the `docs/` mdBook in the same change (the book drifts silently otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)