### PR TITLE
feat(reclaim): unify per-child teardown spine + cascade + handler-terminate

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -1355,6 +1355,33 @@ void lotus_children_free(void **buf) {
     free(buf);
 }
 
+/* 2026-06-01: remove `child` from the parent's children tracker
+ * when the child is reclaimed (terminate / run-completion flow /
+ * parent-dissolve cascade) so a subsequent `for child in
+ * self.children` on an iterating parent never dereferences a
+ * freed child. Swap-remove: find the slot holding `child`, move
+ * the last live entry into it, and decrement the count. This
+ * SHRINKS the live set (vs. NUL-tombstoning, which would let
+ * dead slots accumulate unboundedly on a daemon that churns
+ * connections). Children are unordered (F.11), so the reorder is
+ * unobservable. O(live-count) scan; no-op if `buf` is NULL (the
+ * parent never tracked children) or `child` isn't present (already
+ * removed — the reclaim spine is idempotent). Single-threaded by
+ * the same construction as the rest of the teardown: a parent and
+ * its accept'd children share one pool worker, so iteration and
+ * removal never race. */
+void lotus_children_remove(void **buf, int64_t *count, void *child) {
+    if (!buf || !count) return;
+    for (int64_t i = 0; i < *count; i++) {
+        if (buf[i] == child) {
+            buf[i] = buf[*count - 1];
+            buf[*count - 1] = NULL;
+            *count -= 1;
+            return;
+        }
+    }
+}
+
 /* Carve a sub-region of `parent`. The sub-region holds its own
  * chunk list (independent allocation lifetime is *bounded* by
  * the parent's, but the chunks themselves are separate from the

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -400,6 +400,8 @@ pub fn build_executable_with_options(
         current_cooperative_pool: None,
         coop_pool_locus_types: BTreeSet::new(),
         coop_pool_run_wrappers: BTreeMap::new(),
+        reclaim_fns: BTreeMap::new(),
+        handler_reclaim_wrappers: BTreeMap::new(),
         vtables: BTreeMap::new(),
     };
 
@@ -1462,6 +1464,25 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// the pool-handler signature and calls the locus's run()
     /// method. Indexed by locus type name.
     pub(crate) coop_pool_run_wrappers: BTreeMap<String, FunctionValue<'ctx>>,
+    /// 2026-06-01: synthesized `__reclaim_<L>(self_ptr)` fns — the
+    /// single per-child teardown spine. Idempotent (gated on the
+    /// `__arena`-null latch at entry), so the three callers that can
+    /// collide on the same locus all converge here and the spine
+    /// runs exactly once: the run-wrapper (run-completion / flow /
+    /// `terminate;` in run()), the bus-handler wrapper (`terminate;`
+    /// in a handler), and the parent-dissolve children cascade.
+    /// Indexed by locus type name. Absent for arena-elidable loci
+    /// (nothing to reclaim).
+    pub(crate) reclaim_fns: BTreeMap<String, FunctionValue<'ctx>>,
+    /// 2026-06-01: per-(locus, handler) bus-handler wrappers that run
+    /// the user handler then, if `terminate;` set `__drain_requested`
+    /// during dispatch, call `__reclaim_<L>` — so a locus can end its
+    /// own life from inside a bus handler (`on_data` decides it's
+    /// done), not only from `run()` completion. Registered in place of
+    /// the raw handler for cooperative subscribers. Keyed by
+    /// (locus_name, handler_name).
+    pub(crate) handler_reclaim_wrappers:
+        BTreeMap<(String, String), FunctionValue<'ctx>>,
     /// F.20 Phase B: per-(locus, interface) vtable globals.
     /// Synthesized lazily by `ensure_vtable` the first time a
     /// given locus is coerced to a given interface. Layout is
@@ -3267,7 +3288,10 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             // Arena released at scope exit, after the pinned thread
             // is joined or after the cooperative drain/dissolve has
             // run. Symmetric with the ephemeral path in
-            // lower_locus_instantiation.
+            // lower_locus_instantiation. (The accept'd-children
+            // reclaim cascade now runs INSIDE emit_locus_arena_destroy
+            // — the single teardown chokepoint — so every dissolve
+            // path picks it up, not just this one.)
             self.emit_locus_arena_destroy(&info, self_ptr, &locus_name)?;
             // m52: drain again after each dissolve. The dissolve
             // method may publish — those cells enqueue for
@@ -3324,6 +3348,579 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// Saves and restores the builder position so this can run
     /// between passes that use the builder (notably between A2
     /// and the body-lowering passes C/D).
+    /// 2026-06-01: synthesize `__reclaim_<L>(self_ptr)` — the single
+    /// per-child teardown spine. Idempotent: the `__arena`-null latch
+    /// at entry makes a second reclaim of the same locus a full no-op
+    /// (a flow child reclaimed at run-completion, then walked again by
+    /// the parent's dissolve cascade, runs the spine exactly once).
+    /// The spine: drain (children-first) → `release(owner, self)` for
+    /// a flow → dissolve closures → dissolve → field dissolves →
+    /// remove self from the owner's children tracker → arena reclaim.
+    /// Called by the run-wrapper, the bus-handler wrapper, and the
+    /// parent-dissolve cascade.
+    fn synthesize_reclaim_fns(&mut self) -> Result<(), CodegenError> {
+        let saved_block = self.builder.get_insert_block();
+        let void_t = self.context.void_type();
+        let ptr_t = self.context.ptr_type(AddressSpace::default());
+        let i64_t = self.context.i64_type();
+        let types: Vec<String> = self.user_loci.keys().cloned().collect();
+        for locus_name in &types {
+            let info = match self.user_loci.get(locus_name) {
+                Some(i) => i.clone(),
+                None => continue,
+            };
+            // Synthesized for every locus (mirrors the run-wrappers;
+            // DCE drops unused). Arena-elidable loci borrow the
+            // caller's arena: emit_locus_arena_destroy bails on them,
+            // so the spine is harmless (and they're never in a
+            // double-reclaim path, so the __arena-null latch being a
+            // no-op for them doesn't matter).
+            let fn_name = format!("__reclaim_{}", locus_name);
+            let fn_ty = void_t.fn_type(&[ptr_t.into()], false);
+            let reclaim = self.module.add_function(&fn_name, fn_ty, None);
+            let entry = self.context.append_basic_block(reclaim, "entry");
+            let do_bb = self.context.append_basic_block(reclaim, "reclaim.do");
+            let ret_bb = self.context.append_basic_block(reclaim, "reclaim.ret");
+            self.builder.position_at_end(entry);
+            let self_arg = reclaim
+                .get_nth_param(0)
+                .expect("reclaim self_ptr param")
+                .into_pointer_value();
+            // Full-spine idempotency latch (2026-06-01). `__arena` is
+            // NULL'd by emit_locus_arena_destroy on the FIRST reclaim,
+            // so a second entry here loads NULL and skips the entire
+            // spine — not just the arena destroy (which had its own
+            // inner latch), but drain / release / dissolve too, which
+            // would otherwise double-run their user bodies. Single-
+            // threaded by construction at the colliding call sites
+            // (pool workers are joined before the dissolve cascade;
+            // a parent and its accept'd children share one worker), so
+            // a plain load/compare suffices — no atomic.
+            let arena_ptr = self
+                .builder
+                .build_struct_gep(
+                    info.struct_ty,
+                    self_arg,
+                    info.arena_field_idx,
+                    &format!("{}.reclaim.arena.ptr", locus_name),
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let arena = self
+                .builder
+                .build_load(ptr_t, arena_ptr, &format!("{}.reclaim.arena", locus_name))
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                .into_pointer_value();
+            let already = self
+                .builder
+                .build_is_null(arena, &format!("{}.reclaim.done", locus_name))
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder
+                .build_conditional_branch(already, ret_bb, do_bb)
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+
+            self.builder.position_at_end(do_bb);
+            let prev_fn = self.current_fn.take();
+            let prev_self = self.current_self.take();
+            self.current_fn = Some(reclaim);
+            self.current_self = Some(SelfCx {
+                locus_name: locus_name.clone(),
+                struct_ty: info.struct_ty,
+                self_ptr: self_arg,
+                fields: info.fields.clone(),
+            });
+            // A locus is a flow iff some declared locus has a
+            // `release(c: T)` whose child type T is this locus.
+            let release_fn = self.user_loci.values().find_map(|p| {
+                match &p.release_param {
+                    Some((_, child)) if child == locus_name => {
+                        p.methods.get("release").copied()
+                    }
+                    _ => None,
+                }
+            });
+            // drain (children first, then self).
+            self.emit_locus_field_drains(&info, self_arg, locus_name)?;
+            if let Some(drain_fn) = info.methods.get("drain") {
+                if !info.empty_lifecycle.contains("drain") {
+                    self.builder
+                        .build_call(
+                            *drain_fn,
+                            &[self_arg.into()],
+                            &format!("{}.reclaim.drain", locus_name),
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                }
+            }
+            // `release(c)` parent bookend — after drain, before
+            // dissolve — for a flow with a non-null owner.
+            if let Some(rfn) = release_fn {
+                let owner_ptr = self
+                    .builder
+                    .build_struct_gep(
+                        info.struct_ty,
+                        self_arg,
+                        info.owner_self_field_idx,
+                        &format!("{}.reclaim.owner.ptr", locus_name),
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                let owner = self
+                    .builder
+                    .build_load(ptr_t, owner_ptr, &format!("{}.reclaim.owner", locus_name))
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                    .into_pointer_value();
+                let owner_null = self
+                    .builder
+                    .build_is_null(owner, &format!("{}.reclaim.owner.null", locus_name))
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                let fire_bb =
+                    self.context.append_basic_block(reclaim, "release.fire");
+                let after_rel_bb =
+                    self.context.append_basic_block(reclaim, "release.after");
+                self.builder
+                    .build_conditional_branch(owner_null, after_rel_bb, fire_bb)
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                self.builder.position_at_end(fire_bb);
+                self.builder
+                    .build_call(
+                        rfn,
+                        &[owner.into(), self_arg.into()],
+                        &format!("{}.reclaim.release.call", locus_name),
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                self.builder
+                    .build_unconditional_branch(after_rel_bb)
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                self.builder.position_at_end(after_rel_bb);
+            }
+            if let Some(closures_fn) = info.dissolve_closures_fn {
+                let (parent_self, handler_ptr) =
+                    self.resolve_failure_route(locus_name);
+                self.builder
+                    .build_call(
+                        closures_fn,
+                        &[self_arg.into(), parent_self.into(), handler_ptr.into()],
+                        &format!("{}.reclaim.closures", locus_name),
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            }
+            if let Some(dissolve_fn) = info.methods.get("dissolve") {
+                if !info.empty_lifecycle.contains("dissolve") {
+                    self.builder
+                        .build_call(
+                            *dissolve_fn,
+                            &[self_arg.into()],
+                            &format!("{}.reclaim.dissolve", locus_name),
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                }
+            }
+            self.emit_locus_field_dissolves(&info, self_arg, locus_name)?;
+            // NB: removal of self from the owner's children tracker is
+            // NOT done here — it belongs to the *self-reclaim* callers
+            // (run-wrapper, handler-wrapper), which call
+            // `emit_remove_self_from_owner` after this. The
+            // parent-dissolve cascade must NOT have the tracker mutated
+            // mid-iteration (it frees the whole buffer wholesale), so
+            // it skips removal.
+            self.emit_locus_arena_destroy(&info, self_arg, locus_name)?;
+            self.current_fn = prev_fn;
+            self.current_self = prev_self;
+            self.builder
+                .build_unconditional_branch(ret_bb)
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+
+            self.builder.position_at_end(ret_bb);
+            self.builder
+                .build_return(None)
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let _ = i64_t;
+            self.reclaim_fns.insert(locus_name.clone(), reclaim);
+        }
+        if let Some(bb) = saved_block {
+            self.builder.position_at_end(bb);
+        }
+        Ok(())
+    }
+
+    /// 2026-06-01: synthesize `__hwrap_<L>_<handler>(self, payload)`
+    /// for each subscribed handler. The wrapper calls the user handler
+    /// then, if the handler set `__drain_requested` via `terminate;`,
+    /// runs `__reclaim_<L>(self)` + removes self from its owner's
+    /// tracker. Registered in place of the raw handler for cooperative
+    /// subscribers (instantiation.rs), so a locus can end its own life
+    /// from inside a bus handler — the dispatch loop has no per-locus
+    /// teardown hook, so the check rides on the handler itself. The
+    /// cost when nothing terminates is one i64 load + branch per
+    /// dispatch. Handler/locus run on one worker serially, so reading
+    /// the latch needs no atomic.
+    fn synthesize_handler_reclaim_wrappers(
+        &mut self,
+    ) -> Result<(), CodegenError> {
+        let saved_block = self.builder.get_insert_block();
+        let void_t = self.context.void_type();
+        let ptr_t = self.context.ptr_type(AddressSpace::default());
+        let i64_t = self.context.i64_type();
+        let types: Vec<String> = self.user_loci.keys().cloned().collect();
+        for locus_name in &types {
+            let info = match self.user_loci.get(locus_name) {
+                Some(i) => i.clone(),
+                None => continue,
+            };
+            let reclaim_fn = match self.reclaim_fns.get(locus_name).copied() {
+                Some(f) => f,
+                None => continue,
+            };
+            // Distinct handler names (a handler may serve several
+            // subjects; one wrapper per handler suffices).
+            let mut handlers: Vec<String> = info
+                .subscriptions
+                .iter()
+                .map(|(_, h, _, _)| h.clone())
+                .collect();
+            handlers.sort();
+            handlers.dedup();
+            for handler_name in handlers {
+                let handler_fn = match info.user_methods.get(&handler_name) {
+                    Some(f) => *f,
+                    None => continue,
+                };
+                let wname = format!("__hwrap_{}_{}", locus_name, handler_name);
+                let wty = void_t.fn_type(&[ptr_t.into(), ptr_t.into()], false);
+                let wrap = self.module.add_function(&wname, wty, None);
+                let entry = self.context.append_basic_block(wrap, "entry");
+                self.builder.position_at_end(entry);
+                let self_arg = wrap
+                    .get_nth_param(0)
+                    .expect("hwrap self")
+                    .into_pointer_value();
+                let payload_arg = wrap.get_nth_param(1).expect("hwrap payload");
+                // Run the user handler.
+                self.builder
+                    .build_call(
+                        handler_fn,
+                        &[self_arg.into(), payload_arg.into()],
+                        &format!("{}.hwrap.call", handler_name),
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                // if __drain_requested != 0 → reclaim
+                let dr_ptr = self
+                    .builder
+                    .build_struct_gep(
+                        info.struct_ty,
+                        self_arg,
+                        info.drain_requested_field_idx,
+                        &format!("{}.hwrap.dr.ptr", handler_name),
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                let dr = self
+                    .builder
+                    .build_load(i64_t, dr_ptr, &format!("{}.hwrap.dr", handler_name))
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                    .into_int_value();
+                let set = self
+                    .builder
+                    .build_int_compare(
+                        inkwell::IntPredicate::NE,
+                        dr,
+                        i64_t.const_int(0, false),
+                        &format!("{}.hwrap.set", handler_name),
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                let do_bb = self.context.append_basic_block(wrap, "hwrap.reclaim");
+                let ret_bb = self.context.append_basic_block(wrap, "hwrap.ret");
+                self.builder
+                    .build_conditional_branch(set, do_bb, ret_bb)
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                self.builder.position_at_end(do_bb);
+                let prev_self = self.current_self.replace(SelfCx {
+                    locus_name: locus_name.clone(),
+                    struct_ty: info.struct_ty,
+                    self_ptr: self_arg,
+                    fields: info.fields.clone(),
+                });
+                let prev_fn = self.current_fn.replace(wrap);
+                self.builder
+                    .build_call(
+                        reclaim_fn,
+                        &[self_arg.into()],
+                        &format!("{}.hwrap.reclaim", handler_name),
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                self.emit_remove_self_from_owner(&info, self_arg, locus_name)?;
+                self.current_self = prev_self;
+                self.current_fn = prev_fn;
+                self.builder
+                    .build_unconditional_branch(ret_bb)
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                self.builder.position_at_end(ret_bb);
+                self.builder
+                    .build_return(None)
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                self.handler_reclaim_wrappers
+                    .insert((locus_name.clone(), handler_name.clone()), wrap);
+            }
+        }
+        if let Some(bb) = saved_block {
+            self.builder.position_at_end(bb);
+        }
+        Ok(())
+    }
+
+    /// Helper for `synthesize_reclaim_fns` / the dissolve cascade:
+    /// emit `lotus_children_remove(owner.__children, &owner.__child_count,
+    /// self)` when `locus_name` is accept'd by exactly one parent locus
+    /// that iterates its children (has a children buffer). The owner is
+    /// loaded from `self.__owner_self` and null-guarded. No-op (emits
+    /// nothing) when there is no such unique iterating accepter — there
+    /// is then no tracker slot to free, or the owner type can't be
+    /// resolved statically.
+    fn emit_remove_self_from_owner(
+        &mut self,
+        info: &LocusInfo<'ctx>,
+        self_ptr: PointerValue<'ctx>,
+        locus_name: &str,
+    ) -> Result<(), CodegenError> {
+        let ptr_t = self.context.ptr_type(AddressSpace::default());
+        // Find the parent locus type(s) that accept this locus AND
+        // track children in a buffer.
+        let mut accepters = self.user_loci.values().filter(|p| {
+            p.accept_param.as_ref().map(|(_, c)| c == locus_name).unwrap_or(false)
+                && p.children_field_idx.is_some()
+        });
+        let owner_info = match accepters.next() {
+            Some(p) => p.clone(),
+            None => return Ok(()),
+        };
+        if accepters.next().is_some() {
+            // Ambiguous owner type — can't statically pick the
+            // tracker to update. Skip (rare: two parent types
+            // accepting the same child type and both iterating).
+            return Ok(());
+        }
+        let children_idx = owner_info
+            .children_field_idx
+            .expect("filtered to Some");
+        let count_idx = owner_info
+            .child_count_field_idx
+            .expect("paired with children_field_idx");
+        let fn_for_blocks = self.current_fn.expect("reclaim current fn");
+        // owner = self.__owner_self
+        let owner_field = self
+            .builder
+            .build_struct_gep(
+                info.struct_ty,
+                self_ptr,
+                info.owner_self_field_idx,
+                &format!("{}.remove.owner.ptr", locus_name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let owner = self
+            .builder
+            .build_load(ptr_t, owner_field, &format!("{}.remove.owner", locus_name))
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .into_pointer_value();
+        let owner_null = self
+            .builder
+            .build_is_null(owner, &format!("{}.remove.owner.null", locus_name))
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let do_bb = self.context.append_basic_block(fn_for_blocks, "remove.do");
+        let after_bb = self.context.append_basic_block(fn_for_blocks, "remove.after");
+        self.builder
+            .build_conditional_branch(owner_null, after_bb, do_bb)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder.position_at_end(do_bb);
+        // buf = owner.__children (loaded value, void**)
+        let buf_field = self
+            .builder
+            .build_struct_gep(
+                owner_info.struct_ty,
+                owner,
+                children_idx,
+                &format!("{}.remove.buf.ptr", locus_name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let buf = self
+            .builder
+            .build_load(ptr_t, buf_field, &format!("{}.remove.buf", locus_name))
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        // count_ptr = &owner.__child_count
+        let count_ptr = self
+            .builder
+            .build_struct_gep(
+                owner_info.struct_ty,
+                owner,
+                count_idx,
+                &format!("{}.remove.count.ptr", locus_name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let remove_fn = self
+            .module
+            .get_function("lotus_children_remove")
+            .expect("lotus_children_remove declared");
+        self.builder
+            .build_call(
+                remove_fn,
+                &[buf.into(), count_ptr.into(), self_ptr.into()],
+                &format!("{}.remove.call", locus_name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_unconditional_branch(after_bb)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder.position_at_end(after_bb);
+        Ok(())
+    }
+
+    /// 2026-06-01 (graceful-shutdown resident reclaim): when a parent
+    /// that `accept`s children dissolves, reclaim each live accept'd
+    /// child it still tracks — running each child's `__reclaim_<C>`
+    /// (drain → dissolve → arena), so a bounded program's shutdown
+    /// runs residents' dissolve bodies (fd close, flush) and frees
+    /// their arenas, instead of leaking them until process exit.
+    ///
+    /// Flow children that already reclaimed themselves mid-life were
+    /// swap-removed from the tracker by `emit_remove_self_from_owner`,
+    /// so they aren't in the buffer here; residents (no parent
+    /// `release`) and not-yet-completed flows are. `__reclaim` is
+    /// idempotent regardless. The buffer is NOT mutated here (removal
+    /// is a self-reclaim concern), so the counted loop is stable; the
+    /// parent's own `emit_locus_arena_destroy` frees the buffer
+    /// wholesale afterward via `lotus_children_free`.
+    ///
+    /// No-op unless the parent both declares `accept` and tracks a
+    /// children buffer (`children_field_idx` / `accept_param` set).
+    pub(crate) fn emit_accepted_children_reclaim(
+        &mut self,
+        info: &LocusInfo<'ctx>,
+        self_ptr: PointerValue<'ctx>,
+        locus_name: &str,
+    ) -> Result<(), CodegenError> {
+        let (children_idx, count_idx) =
+            match (info.children_field_idx, info.child_count_field_idx) {
+                (Some(a), Some(b)) => (a, b),
+                _ => return Ok(()),
+            };
+        let child_type = match &info.accept_param {
+            Some((_, c)) => c.clone(),
+            None => return Ok(()),
+        };
+        let reclaim_fn = match self.reclaim_fns.get(&child_type).copied() {
+            Some(f) => f,
+            None => return Ok(()),
+        };
+        let ptr_t = self.context.ptr_type(AddressSpace::default());
+        let i64_t = self.context.i64_type();
+        let func = self.current_fn.expect("dissolve frame current fn");
+        // count = self.__child_count
+        let count_ptr = self
+            .builder
+            .build_struct_gep(
+                info.struct_ty,
+                self_ptr,
+                count_idx,
+                &format!("{}.cascade.count.ptr", locus_name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let count = self
+            .builder
+            .build_load(i64_t, count_ptr, &format!("{}.cascade.count", locus_name))
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .into_int_value();
+        // buf = self.__children
+        let buf_field = self
+            .builder
+            .build_struct_gep(
+                info.struct_ty,
+                self_ptr,
+                children_idx,
+                &format!("{}.cascade.buf.ptr", locus_name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let buf = self
+            .builder
+            .build_load(ptr_t, buf_field, &format!("{}.cascade.buf", locus_name))
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .into_pointer_value();
+        let i_slot = self
+            .builder
+            .build_alloca(i64_t, &format!("{}.cascade.i", locus_name))
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_store(i_slot, i64_t.const_int(0, false))
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let header = self.context.append_basic_block(func, "cascade.header");
+        let body = self.context.append_basic_block(func, "cascade.body");
+        let cont = self.context.append_basic_block(func, "cascade.cont");
+        self.builder
+            .build_unconditional_branch(header)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder.position_at_end(header);
+        let i_cur = self
+            .builder
+            .build_load(i64_t, i_slot, &format!("{}.cascade.i.cur", locus_name))
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .into_int_value();
+        let more = self
+            .builder
+            .build_int_compare(
+                inkwell::IntPredicate::ULT,
+                i_cur,
+                count,
+                &format!("{}.cascade.more", locus_name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_conditional_branch(more, body, cont)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder.position_at_end(body);
+        // child = buf[i]
+        let slot_ptr = unsafe {
+            self.builder
+                .build_in_bounds_gep(ptr_t, buf, &[i_cur], &format!("{}.cascade.slot", locus_name))
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+        };
+        let child = self
+            .builder
+            .build_load(ptr_t, slot_ptr, &format!("{}.cascade.child", locus_name))
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .into_pointer_value();
+        // Defensive null-skip (swap-remove never leaves holes, but a
+        // never-accepted slot or a future change shouldn't crash).
+        let child_null = self
+            .builder
+            .build_is_null(child, &format!("{}.cascade.child.null", locus_name))
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let do_reclaim = self.context.append_basic_block(func, "cascade.reclaim");
+        let next = self.context.append_basic_block(func, "cascade.next");
+        self.builder
+            .build_conditional_branch(child_null, next, do_reclaim)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder.position_at_end(do_reclaim);
+        self.builder
+            .build_call(
+                reclaim_fn,
+                &[child.into()],
+                &format!("{}.cascade.reclaim.call", locus_name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_unconditional_branch(next)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder.position_at_end(next);
+        let i_next = self
+            .builder
+            .build_int_add(i_cur, i64_t.const_int(1, false), &format!("{}.cascade.i.next", locus_name))
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_store(i_slot, i_next)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_unconditional_branch(header)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder.position_at_end(cont);
+        Ok(())
+    }
+
     /// F.31 Phase 4b: synthesize `__coop_pool_run_<L>(self,
     /// payload)` wrappers. One per locus type in
     /// `coop_pool_locus_types`. The body calls
@@ -3447,100 +4044,37 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
 
             self.builder.position_at_end(reclaim_bb);
-            let prev_fn = self.current_fn.take();
-            let prev_self = self.current_self.take();
-            self.current_fn = Some(wrapper);
-            self.current_self = Some(SelfCx {
-                locus_name: locus_name.clone(),
-                struct_ty: info.struct_ty,
-                self_ptr: self_arg,
-                fields: info.fields.clone(),
-            });
-            // drain (children first, then self) → __dissolve_closures
-            // → dissolve → field dissolves → arena reclaim.
-            self.emit_locus_field_drains(&info, self_arg, locus_name)?;
-            if let Some(drain_fn) = info.methods.get("drain") {
-                if !info.empty_lifecycle.contains("drain") {
-                    self.builder
-                        .build_call(
-                            *drain_fn,
-                            &[self_arg.into()],
-                            &format!("{}.terminate.drain", locus_name),
-                        )
-                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                }
-            }
-            // The `release(c)` parent bookend fires HERE — after the
-            // child drains, before it dissolves — so the parent reads
-            // the child's final settled state (mirror of accept(c),
-            // which reads it fresh). owner = __owner_self (the
-            // accept'ing parent); guarded against null for a flow-typed
-            // locus instantiated outside an accept context.
-            if let Some(rfn) = release_fn {
-                let owner_ptr = self
-                    .builder
-                    .build_struct_gep(
-                        info.struct_ty,
-                        self_arg,
-                        info.owner_self_field_idx,
-                        &format!("{}.release.owner.ptr", locus_name),
-                    )
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                let owner = self
-                    .builder
-                    .build_load(ptr_t, owner_ptr, &format!("{}.release.owner", locus_name))
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
-                    .into_pointer_value();
-                let owner_null = self
-                    .builder
-                    .build_is_null(owner, &format!("{}.release.owner.null", locus_name))
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                let fire_bb =
-                    self.context.append_basic_block(wrapper, "release.fire");
-                let after_rel_bb =
-                    self.context.append_basic_block(wrapper, "release.after");
-                self.builder
-                    .build_conditional_branch(owner_null, after_rel_bb, fire_bb)
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                self.builder.position_at_end(fire_bb);
+            // 2026-06-01: the teardown spine moved to the shared,
+            // idempotent `__reclaim_<L>` (drain → release → dissolve →
+            // field dissolves → remove-from-owner → arena reclaim).
+            // The run-wrapper just decides WHETHER to reclaim (flow, or
+            // `__drain_requested` set by `terminate;`) and calls it;
+            // the same fn is reused by the handler wrapper and the
+            // parent-dissolve cascade, so a locus reclaimed twice (e.g.
+            // run-completion then parent cascade) runs the spine once.
+            if let Some(reclaim_fn) = self.reclaim_fns.get(locus_name).copied() {
+                let prev_self = self.current_self.replace(SelfCx {
+                    locus_name: locus_name.clone(),
+                    struct_ty: info.struct_ty,
+                    self_ptr: self_arg,
+                    fields: info.fields.clone(),
+                });
+                let prev_fn = self.current_fn.replace(wrapper);
                 self.builder
                     .build_call(
-                        rfn,
-                        &[owner.into(), self_arg.into()],
-                        &format!("{}.release.call", locus_name),
+                        reclaim_fn,
+                        &[self_arg.into()],
+                        &format!("{}.run.reclaim", locus_name),
                     )
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                self.builder
-                    .build_unconditional_branch(after_rel_bb)
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                self.builder.position_at_end(after_rel_bb);
+                // Self-reclaim: drop this child out of its owner's
+                // children tracker so an iterating parent never derefs
+                // the freed child. (pointer-identity scan; safe after
+                // the arena free.)
+                self.emit_remove_self_from_owner(&info, self_arg, locus_name)?;
+                self.current_self = prev_self;
+                self.current_fn = prev_fn;
             }
-            if let Some(closures_fn) = info.dissolve_closures_fn {
-                let (parent_self, handler_ptr) =
-                    self.resolve_failure_route(locus_name);
-                self.builder
-                    .build_call(
-                        closures_fn,
-                        &[self_arg.into(), parent_self.into(), handler_ptr.into()],
-                        &format!("{}.terminate.closures", locus_name),
-                    )
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-            }
-            if let Some(dissolve_fn) = info.methods.get("dissolve") {
-                if !info.empty_lifecycle.contains("dissolve") {
-                    self.builder
-                        .build_call(
-                            *dissolve_fn,
-                            &[self_arg.into()],
-                            &format!("{}.terminate.dissolve", locus_name),
-                        )
-                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                }
-            }
-            self.emit_locus_field_dissolves(&info, self_arg, locus_name)?;
-            self.emit_locus_arena_destroy(&info, self_arg, locus_name)?;
-            self.current_fn = prev_fn;
-            self.current_self = prev_self;
             self.builder
                 .build_unconditional_branch(ret_bb)
                 .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
@@ -4095,6 +4629,11 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // the locus's run() body executes on the pool's worker
         // thread (single-threaded-method invariant) rather than
         // blocking the parent's params-init flow on main.
+        // 2026-06-01: synthesize the per-child reclaim spine BEFORE
+        // the run-wrappers + handler-wrappers, which call
+        // `__reclaim_<L>` on run-completion / terminate.
+        self.synthesize_reclaim_fns()?;
+        self.synthesize_handler_reclaim_wrappers()?;
         self.synthesize_coop_pool_run_wrappers()?;
 
         // Pass B: declare every user-defined function so call sites

--- a/crates/hale-codegen/src/locus/dissolve.rs
+++ b/crates/hale-codegen/src/locus/dissolve.rs
@@ -877,6 +877,19 @@ impl<'ctx, 'p> LocusDissolve<'ctx> for Cx<'ctx, 'p> {
         if info.arena_elidable {
             return Ok(());
         }
+        // 2026-06-01: reclaim this locus's accept'd children BEFORE
+        // tearing down its arena (their subregions live inside it).
+        // This is the single teardown chokepoint every dissolve path
+        // funnels through — graceful-shutdown frame, parent
+        // field-dissolve, a reclaimed flow/terminated child, and the
+        // ephemeral scope-exit — so the cascade is uniform and
+        // recursive (a reclaimed child reclaims its own grandchildren)
+        // without duplicating the walk at each site. No-op unless this
+        // locus both `accept`s and tracks a children buffer; idempotent
+        // (each child's __reclaim is latched), and flow children that
+        // self-reclaimed mid-life already removed themselves from the
+        // tracker, so they aren't re-touched here.
+        self.emit_accepted_children_reclaim(info, self_ptr, locus_name)?;
         let ptr_t = self.context.ptr_type(AddressSpace::default());
         // Deregister from the bus router BEFORE freeing the arena.
         // Without this step, a stale entry in the C-runtime entries

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -2027,10 +2027,21 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                         handler_fn,
                     )?;
                 } else {
+                    // 2026-06-01: register the handler-reclaim wrapper
+                    // (handler + post-dispatch `terminate;` check) in
+                    // place of the raw handler, so a cooperative
+                    // subscriber can end its own life from a bus
+                    // handler. Falls back to the raw handler if no
+                    // wrapper was synthesized.
+                    let reg_handler = self
+                        .handler_reclaim_wrappers
+                        .get(&(locus_name.to_string(), handler_name.clone()))
+                        .copied()
+                        .unwrap_or(handler_fn);
                     self.emit_bus_register(
                         subject,
                         self_ptr,
-                        handler_fn,
+                        reg_handler,
                         None,
                         payload_type,
                         key_filter.as_ref(),

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1227,6 +1227,20 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             children_free_ty,
             None,
         );
+        // 2026-06-01: declare void @lotus_children_remove(ptr buf,
+        // ptr count, ptr child) — swap-removes a reclaimed accept'd
+        // child from its parent's tracker so iterating parents don't
+        // deref a freed child. buf is the LOADED __children value
+        // (void**), count is the ADDRESS of __child_count.
+        let children_remove_ty = void_t.fn_type(
+            &[ptr_t.into(), ptr_t.into(), ptr_t.into()],
+            false,
+        );
+        self.module.add_function(
+            "lotus_children_remove",
+            children_remove_ty,
+            None,
+        );
 
         // m70: lazy global payload arena for cross-process String
         // byte storage. The synthesized __deserialize_T body calls

--- a/crates/hale-codegen/tests/reclamation_spine.rs
+++ b/crates/hale-codegen/tests/reclamation_spine.rs
@@ -1,0 +1,150 @@
+//! 2026-06-01 — the unified per-child reclamation spine
+//! (`__reclaim_<L>`) and its three callers:
+//!
+//!  - graceful-shutdown cascade (a parent reclaims its accept'd
+//!    residents when it dissolves) — Task #5,
+//!  - handler-body `terminate;` (a subscriber ends itself from a bus
+//!    handler, not just run()) — Task #4,
+//!  - the full-spine idempotency latch (`__arena`-null) so a flow
+//!    reclaimed at run-completion isn't dissolved a second time by the
+//!    parent cascade — Task #2,
+//!  - children-tracker removal so an iterating parent never derefs a
+//!    reclaimed child — Task #3.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+fn build_run(tag: &str, src: &str) -> (bool, String) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale_test_reclaim_spine_{}", tag));
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), combined)
+}
+
+/// Task #5: an iterating parent holding N *resident* accept'd children
+/// (no `release`, no `terminate`) runs each child's dissolve at
+/// graceful shutdown. Before this spine, residents skipped dissolve
+/// entirely (reclaimed only by the parent's wholesale arena free at
+/// process exit) — so the token count was 0.
+#[test]
+fn cascade_reclaims_residents_at_shutdown() {
+    const N: usize = 12;
+    let src = format!(
+        r#"
+        locus Worker {{
+            params {{ id: Int = 0; }}
+            dissolve() {{ println("RES"); }}
+        }}
+        locus Manager {{
+            params {{ total: Int = 0; }}
+            accept(c: Worker) {{ }}
+            birth() {{
+                let mut i: Int = 0;
+                while i < {N} {{ Worker {{ id: i }}; i = i + 1; }}
+            }}
+            fn tally() {{
+                for child in self.children {{ self.total = self.total + child.id; }}
+            }}
+        }}
+        main locus App {{
+            params {{ mgr: Manager = Manager {{ }}; }}
+            run() {{ self.mgr.tally(); println("DONE"); }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#
+    );
+    let (ok, out) = build_run("cascade_residents", &src);
+    assert!(ok, "non-zero exit; out: {out}");
+    assert!(out.contains("DONE"), "didn't reach DONE; out: {out}");
+    let reclaimed = out.matches("RES").count();
+    assert_eq!(
+        reclaimed, N,
+        "expected {N} resident dissolves at shutdown, got {reclaimed}; out: {out}"
+    );
+}
+
+/// Task #4: a subscriber that calls `terminate;` from inside a bus
+/// handler (not run()) is reclaimed when the handler returns — the
+/// handler-wrapper runs the reclaim spine post-dispatch.
+#[test]
+fn handler_body_terminate_reclaims() {
+    let src = r#"
+        type Kill { n: Int = 0; }
+        topic KillT { payload: Kill; subject: "rs.kill"; }
+        locus Sub {
+            bus { subscribe KillT as on_kill; }
+            fn on_kill(k: Kill) { terminate; }
+            dissolve() { println("KILLED"); }
+        }
+        main locus App {
+            params { s: Sub = Sub { }; }
+            bus { publish KillT; }
+            run() {
+                KillT <- Kill { n: 1 };
+                std::time::sleep(150ms);
+                println("DONE");
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let (ok, out) = build_run("handler_terminate", src);
+    assert!(ok, "non-zero exit; out: {out}");
+    assert!(out.contains("DONE"), "didn't reach DONE; out: {out}");
+    let killed = out.matches("KILLED").count();
+    assert_eq!(
+        killed, 1,
+        "expected exactly one handler-terminate reclaim, got {killed}; out: {out}"
+    );
+}
+
+/// Task #2 + #3: flow children reclaimed at run-completion remove
+/// themselves from the parent's tracker, so the parent-dissolve
+/// cascade doesn't dissolve them a second time. Each child dissolves
+/// exactly once (not 0, not 2N).
+#[test]
+fn flow_reclaim_then_cascade_no_double() {
+    const N: usize = 10;
+    let src = format!(
+        r#"
+        locus Worker {{
+            params {{ id: Int = 0; }}
+            run() {{ }}
+            dissolve() {{ println("ONCE"); }}
+        }}
+        locus Manager {{
+            params {{ total: Int = 0; }}
+            accept(c: Worker) {{ }}
+            release(c: Worker) {{ }}
+            birth() {{
+                let mut i: Int = 0;
+                while i < {N} {{ Worker {{ id: i }}; i = i + 1; }}
+            }}
+            fn tally() {{
+                for child in self.children {{ self.total = self.total + child.id; }}
+            }}
+        }}
+        main locus App {{
+            params {{ mgr: Manager = Manager {{ }}; }}
+            run() {{ self.mgr.tally(); println("DONE"); }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#
+    );
+    let (ok, out) = build_run("flow_no_double", &src);
+    assert!(ok, "non-zero exit; out: {out}");
+    assert!(out.contains("DONE"), "didn't reach DONE; out: {out}");
+    let once = out.matches("ONCE").count();
+    assert_eq!(
+        once, N,
+        "expected {N} dissolves (each flow once), got {once}; out: {out}"
+    );
+}

--- a/docs/src/concepts/lifecycle-time.md
+++ b/docs/src/concepts/lifecycle-time.md
@@ -350,6 +350,21 @@ locus Worker {
 }
 ```
 
+`terminate;` also works from a **bus handler**, not just `run()`:
+a subscriber that receives a shutdown message can end itself from
+the handler, and it's reclaimed when the handler returns.
+
+```hale
+locus Session {
+    bus { subscribe CloseT as on_close; }
+    fn on_close(c: Close) { terminate; }   // reclaimed after this handler
+    dissolve() { /* flush, close fd */ }
+}
+```
+
+(`terminate;` is only valid inside a locus method — a free
+function has no locus lifecycle to end.)
+
 **Flow children** make this automatic. A child whose parent
 declares `release(c: Child)` is a *flow*: its `run()` **is** its
 lifetime, and when `run()` returns the runtime reclaims it — no

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -201,6 +201,15 @@ function is a typecheck error — there is no enclosing locus whose
 lifecycle to end. It is accepted in any locus method body
 (lifecycle method or member `fn`).
 
+**From a bus handler (2026-06-01).** `terminate;` is no longer
+limited to `run()`. A subscriber can end its own life from inside
+a bus handler (e.g. `on_close` receives a shutdown message and
+calls `terminate;`). The reclaim runs when the handler returns —
+the dispatch path checks the `__drain_requested` latch after each
+handler and runs the spine on the handler's own worker. This is
+the resident-subscriber analogue of the connection child that
+`terminate`s from its `run()` recv loop.
+
 ### `release(c)` and flow children
 
 `release(c: Child) { ... }` (2026-05-30) is the death-side
@@ -238,6 +247,25 @@ matching `accept(c: T)` on the same locus is a typecheck error: a
 locus that never accepts a `T` child can never release one, so
 the declaration is dead (almost always a wrong child type or a
 forgotten `accept`).
+
+**Parent-dissolve reclaim (2026-06-01).** When a parent that
+`accept`s children dissolves, it reclaims each accept'd child it
+still tracks — running the child's full teardown (drain →
+dissolve → arena reclaim) before the parent's own arena (which
+backs the children's subregions) is freed. This is what makes the
+"resident reclaimed only when the parent dissolves" rule above
+*observable*: a resident's `dissolve()` body (fd close, flush)
+runs at the parent's graceful shutdown, rather than the child
+being silently swallowed by the parent's wholesale arena free.
+Flow children that already self-reclaimed mid-life are no longer
+tracked, so they are not torn down twice; the per-child teardown
+is idempotent regardless (an `__arena`-null latch). The cascade is
+single-threaded-safe: cooperative pool workers are joined before
+the dissolve cascade runs at program exit, so no worker can be
+mid-dispatch to a child being reclaimed. (A parent reclaims only
+children it *tracks* — i.e. one whose body iterates
+`self.children`; a dispatcher that accepts but never iterates
+holds no per-child handle and relies on flow/`terminate` reclaim.)
 
 ### Locus method dispatch
 


### PR DESCRIPTION
Closes the remaining per-child reclamation tails (the daemon-leak fix's edges) by funneling all teardown through one idempotent function, `__reclaim_<L>(self)`:

```
drain (children-first) → release(owner,self) [flow] → dissolve closures → dissolve → field dissolves → arena reclaim
```

reached from three callers — the run-wrapper (run-completion / flow / `terminate;` in run()), a new bus-handler wrapper, and the parent-dissolve cascade — so a locus reclaimed by more than one path is torn down **exactly once**.

## What's in it

- **Full-spine idempotency latch (#2)** — the `__arena`-null check moves to the reclaim entry, so a flow reclaimed at run-completion and then walked by the parent cascade runs drain/dissolve/release once, not twice (previously only arena-destroy was latched).
- **Children-tracker removal (#3)** — `lotus_children_remove` swap-removes a self-reclaimed child from its owner's `__children`, so an iterating parent (`for child in self.children`) never derefs a freed child. Removal is a self-reclaim concern; the cascade never mutates the buffer mid-iteration.
- **Handler-body `terminate` (#4)** — `terminate;` now works from a bus handler, not just `run()`. Each cooperative subscriber is registered through a `__hwrap_<L>_<handler>` that runs the handler then reclaims if the latch was set. Cost when nothing terminates: one i64 load + branch per dispatch.
- **Graceful-shutdown resident reclaim (#5)** — the accept'd-children cascade runs inside `emit_locus_arena_destroy` (the single teardown chokepoint every dissolve path funnels through), so a parent that tracks children runs their `dissolve()` bodies at shutdown instead of leaking them to process exit. Safe: pool workers are joined before the cascade (`shutdown_all` precedes the dissolve flush at main-exit).

## Tests

`crates/hale-codegen/tests/reclamation_spine.rs`:
- cascade reclaims N residents at graceful shutdown (was 0 — residents skipped dissolve),
- handler-body `terminate` reclaims exactly once,
- flow reclaim + cascade dissolves each child exactly once (latch + removal).

Existing `terminate_reclaims_child`, `release_reclaims_flow`, `children_growable`, `recpool`, `async_io_*`, `coop_pool_*`, `build_hello` (38) all green locally. The tsan job is the load-bearing CI check (cascade runs at shutdown after worker join).

## Spec + docs

`spec/semantics.md` (handler-body terminate + parent-dissolve reclaim), `docs/src/concepts/lifecycle-time.md` (handler-terminate example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)