### PR TITLE
fix(runtime): clean shutdown of classic-pool blocking-accept servers (refstore SIGSEGV)

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -7126,10 +7126,51 @@ int lotus_tcp_accept_one(int listen_fd) {
     /* F.35 Slice 3: on async_io pools, accept(2) is non-blocking +
      * park on EAGAIN. Classic blocking accept on every other path. */
     int async = lotus_io_on_async_io_pool();
+    /* The worker's own pool (NULL on the main thread). */
+    lotus_coop_pool_t *cpool = g_current_pool_tls;
     if (async) {
         lotus_io_set_nonblock(listen_fd);
     }
     for (;;) {
+        /* 2026-06-01: shutdown-interruptible classic accept. A
+         * blocking accept() on a *classic* (non-async_io) pool worker
+         * can't be woken by shutdown_all — the signal + condvar
+         * broadcast reach a worker parked on the cell queue or in
+         * epoll_wait, but NOT one sitting in the accept(2) syscall.
+         * So at program shutdown the join in shutdown_all would hang
+         * (no client ever arrives to return the accept), or — if the
+         * listen fd gets invalidated mid-teardown — the worker returns
+         * and races main's arena free (use-after-free / SIGSEGV).
+         * This bit the std::http::Server accept loop placed on a plain
+         * `cooperative(pool = io)`: its drain() does shutdown(SHUT_RDWR)
+         * to unblock accept, but the PR#23/#24 shutdown reorder now runs
+         * that drain AFTER the worker join, so it can no longer unblock
+         * this syscall. Fix: on a classic pool worker, poll the listen
+         * fd with a short timeout and check the pool's shutdown flag, so
+         * the worker leaves run() cleanly (accept returns -1, the stdlib
+         * loop exits) and the join completes before arenas are freed.
+         * Main-thread accept (cpool == NULL) keeps blocking — main is
+         * the one driving shutdown; there's nothing to interrupt. */
+        if (!async && cpool) {
+            struct pollfd pfd;
+            pfd.fd     = listen_fd;
+            pfd.events = POLLIN;
+            for (;;) {
+                int sd;
+                pthread_mutex_lock(&cpool->lock);
+                sd = cpool->shutdown;
+                pthread_mutex_unlock(&cpool->lock);
+                if (sd) return -1;        /* shutdown → stdlib loop exits */
+                pfd.revents = 0;
+                int pr = poll(&pfd, 1, 100 /* ms tick */);
+                if (pr < 0) {
+                    if (errno == EINTR) continue;
+                    break;                /* poll error → let accept surface it */
+                }
+                if (pr == 0) continue;    /* timeout → re-check shutdown */
+                break;                    /* readable (or POLLNVAL) → accept */
+            }
+        }
         int conn = accept(listen_fd, NULL, NULL);
         if (conn >= 0) {
             int nodelay = 1;

--- a/crates/hale-codegen/runtime/stdlib/io_tcp.hl
+++ b/crates/hale-codegen/runtime/stdlib/io_tcp.hl
@@ -222,6 +222,17 @@ locus __StdIoTcpListener {
         let mut accepted = 0;
         while self.max_accepts < 0 || accepted < self.max_accepts {
             let conn = std::io::tcp::__accept_one(self.listen_fd);
+            // Graceful exit on accept failure, mirroring
+            // std::http::Server.run(). A -1 return means the listen
+            // fd was closed cross-thread, the kernel errored, or the
+            // pool is shutting down (the classic-pool accept now
+            // returns -1 when its worker's shutdown flag is set, so
+            // the forever loop can be joined at program teardown
+            // instead of spinning on a dead fd — the same 1.6M-lines-
+            // in-seconds EBADF spin the http server already guards).
+            if conn < 0 {
+                break;
+            }
             __handle_one_connection(conn, self.on_connection);
             accepted = accepted + 1;
         }

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -2819,6 +2819,27 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
             || parent_accepts_us
             || parent_owns_via_field;
         if !defer {
+            // 2026-06-01: the MAIN locus dissolves eagerly here, right
+            // after its run() returns — but its `params` fields may be
+            // placed on cooperative pools whose worker threads are
+            // still executing those fields' run() loops (e.g. a
+            // std::http::Server on `cooperative(pool = io)`). Tearing
+            // down a field's arena here while its pool worker is mid-
+            // run() is a use-after-free (the worker's next subregion
+            // op locks the freed parent arena → SIGSEGV; observed in
+            // fathom refstore). Join all pool workers FIRST so no
+            // worker can touch a field arena we're about to free.
+            // This was added then reverted (b35a449) because a classic
+            // pool worker blocked in std::http::Server's accept()
+            // couldn't be woken → the join hung; that's now fixed by
+            // the shutdown-interruptible accept in lotus_tcp_accept_one
+            // (poll + pool-shutdown check). shutdown_all is idempotent
+            // (worker_started gate), so the later main-exit join is a
+            // no-op. Gated to the main locus: a non-main ephemeral
+            // locus dissolving mid-program must not join global pools.
+            if is_main_locus {
+                self.emit_coop_pool_shutdown_all()?;
+            }
             // Phase-2 (3): cascade child-field drains depth-first
             // BEFORE outer's drain, per spec/runtime.md "drain()
             // cascades depth-first; children first, then self."

--- a/crates/hale-codegen/tests/http_server_classic_pool_shutdown.rs
+++ b/crates/hale-codegen/tests/http_server_classic_pool_shutdown.rs
@@ -1,0 +1,67 @@
+//! 2026-06-01 — std::http::Server on a classic (non-async_io)
+//! cooperative pool must shut down cleanly when the main locus's
+//! run() returns.
+//!
+//! Regression for the fathom refstore boot-blocker: the server's
+//! blocking accept() ran on a classic `cooperative(pool = io)`
+//! worker. When App.run() returned, the main locus dissolved its
+//! io-placed server field's arena while the io worker was still in
+//! run() — a use-after-free (the worker's next subregion op locked
+//! the freed parent arena → SIGSEGV), or, depending on timing, the
+//! join hung forever (the blocking accept couldn't be woken).
+//!
+//! Two-part fix: (1) the classic accept polls + checks the pool's
+//! shutdown flag so the worker leaves run() cleanly; (2) the main
+//! locus joins all pool workers before tearing down its fields.
+//! This test asserts the program exits 0 (neither 139/SIGSEGV nor a
+//! timeout/hang) across several runs — it's a timing-sensitive race,
+//! so we repeat it.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[test]
+fn http_server_on_classic_pool_shuts_down_cleanly() {
+    let src = r#"
+        locus Routes {
+            fn handle(req: std::http::Request) -> std::http::Response {
+                return std::http::Response { status: 200, body: "ok" };
+            }
+        }
+        main locus App {
+            params {
+                srv: std::http::Server = std::http::Server {
+                    port: 19137, handler: Routes { }, ready_signal: "READY"
+                };
+            }
+            placement { srv: cooperative(pool = io); }
+            run() {
+                std::time::sleep(120ms);
+                println("APP DONE");
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale_http_classic_shutdown_{}", std::process::id()));
+    build_executable(&program, &bin).expect("build");
+
+    for run in 0..4 {
+        let out = Command::new(&bin).output().expect("run binary");
+        let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+        assert!(
+            out.status.success(),
+            "run {run}: http-server-on-classic-pool did not exit cleanly: \
+             {:?} (139 = SIGSEGV use-after-free; a hang shows as a non-zero \
+             signal once the harness times out)\nstdout: {stdout}",
+            out.status,
+        );
+        assert!(
+            stdout.contains("READY") && stdout.contains("APP DONE"),
+            "run {run}: expected READY + APP DONE; stdout: {stdout}"
+        );
+    }
+    let _ = std::fs::remove_file(&bin);
+}

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -154,6 +154,24 @@ the model: runtime is automatic; stdlib is explicit.
   refinement), and the process is exiting anyway. Per-child
   reclamation proper (terminate / flow run-completion) never
   needs this: there the coro returns from `run()` on its own.
+- **Classic-pool blocking-accept shutdown (2026-06-01).** A
+  *classic* (non-`async_io`) pool worker blocked in a blocking
+  `accept(2)` inside a locus's `run()` (e.g. `std::http::Server`
+  or `std::io::tcp::Listener` placed on a plain
+  `cooperative(pool = X)`) can't be woken by the wake `eventfd`
+  (there is no epoll on a classic pool) — so two rules keep its
+  teardown clean: (a) the classic `accept` polls the listen fd
+  with a short timeout and checks its pool's shutdown flag, so it
+  returns a sentinel `-1` once `shutdown_all` is signalled and the
+  stdlib accept loops (`Server`/`Listener`) break out of their
+  forever loop; and (b) the **main locus joins all pool workers
+  before dissolving its `params` fields**, so a worker still
+  executing a pool-placed field's `run()` can never touch that
+  field's arena after it's freed (the alternative — freeing first
+  — is a use-after-free; the alternative join-without-(a) is a
+  hang). Together these let a program whose `main` run() returns
+  while a classic-pool server child is live shut down cleanly
+  rather than hanging or segfaulting.
 - **Recovery primitives.** `restart`, `restart_in_place`,
   `quarantine`, `reorganize`, `bubble`, `dissolve`, `drain` —
   all language keywords; runtime implements the actual


### PR DESCRIPTION
## What

fathom **refstore boot-blocker** (`handoff-compiler-stdhttpserver-arena-segv-2026-06-01`): a `std::http::Server` (or `std::io::tcp::Listener`) placed on a plain `cooperative(pool = io)` SIGSEGV'd ~200ms after boot in `lotus_arena_create_subregion`/`arena_destroy` — a use-after-free of the server's arena, before any request.

## Root cause (not the metrics graph the handoff suspected)

The main locus dissolves its `params` fields eagerly when `run()` returns, but a **classic (non-`async_io`) pool worker is still executing the server's `run()` accept loop**. The PR#23/#24 shutdown reorder put the worker-join *after* the dissolve flush, and the server's own `drain()` `SHUT_RDWR` (which would unblock `accept`) likewise runs too late — so `main` frees the io-placed server's arena while the io worker is mid-`run()`; the worker's next subregion op locks the freed parent arena → SIGSEGV (or, with no client, the join just hangs). The real differentiator vs the stable dashboard is that **refstore's `App.run()` returns** (triggering teardown), not the metrics loci. Confirmed via valgrind (UAF: `arena_destroy` ← `run()` on a `main`-freed block) + `/proc` wchan (main in `pthread_join`, worker spinning).

## Fix (three parts)

1. **`lotus_tcp_accept_one`** — on a classic pool worker, poll the listen fd with a 100ms timeout and check the pool's shutdown flag, returning `-1` when set, so a blocking `accept` is interruptible at shutdown (the `wake_fd`/epoll path only covers `async_io` pools). Main-thread accept unchanged.
2. **main locus joins all pool workers before dissolving its fields** — so no worker can touch a field arena after it's freed. (Added-then-reverted in `b35a449` because the blocking accept hung the join; part 1 makes it safe. Idempotent — the later main-exit join no-ops.)
3. **`std::io::tcp::Listener.run()` breaks on `conn < 0`** — like `std::http::Server` already does; otherwise the `-1` sentinel spins the forever loop (the same EBADF spin the http server guards against).

## Testing

- `crates/hale-codegen/tests/http_server_classic_pool_shutdown.rs` — main locus + http-server-on-`io`, run() returns, asserts clean exit (not SIGSEGV/hang) over repeated runs.
- fathom `apps/refstore` now exits 0 (was 139) across runs; minimal repro likewise.
- Shutdown-sensitive suite green: `qualified_locus_type_coop_pool` (the historical shutdown-hang sentinel), `async_io_shutdown_parked`, `async_io_park_resume`, `coop_pool_*`, `http_server_bus_logging`, `io_tcp_bus_logging`, `coop_to_pinned_mid_program`. The **tsan** job is load-bearing here.

## Spec

`spec/runtime.md` scheduler shutdown section: classic-pool blocking-accept teardown rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)