### PR TITLE
feat: self.children.count / .is_empty summary sugar (F.11)

### DIFF
--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -3674,6 +3674,66 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// nothing) when there is no such unique iterating accepter — there
     /// is then no tracker slot to free, or the owner type can't be
     /// resolved statically.
+    /// Entity-collection sugar (F.11): lower `self.children.count`
+    /// (→ Int) and `self.children.is_empty` (→ Bool) to a read of the
+    /// current locus's `__child_count` tracker field. Errors if the
+    /// locus has no children tracker (it doesn't `accept` / never
+    /// iterates) — typecheck rejects that case with a friendlier
+    /// message first.
+    fn lower_self_children_count(
+        &mut self,
+        which: &str,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        let cs = self.current_self.clone().ok_or_else(|| {
+            CodegenError::Unsupported(
+                "`self.children` is only valid inside a locus method".into(),
+            )
+        })?;
+        let info = self.user_loci.get(&cs.locus_name).cloned().ok_or_else(|| {
+            CodegenError::Unsupported(format!(
+                "no LocusInfo for `{}`",
+                cs.locus_name
+            ))
+        })?;
+        let cnt_idx = info.child_count_field_idx.ok_or_else(|| {
+            CodegenError::Unsupported(format!(
+                "locus `{}` has no children tracker — `self.children.{}` \
+                 needs the locus to `accept` a child type",
+                cs.locus_name, which
+            ))
+        })?;
+        let i64_t = self.context.i64_type();
+        let ptr = self
+            .builder
+            .build_struct_gep(
+                cs.struct_ty,
+                cs.self_ptr,
+                cnt_idx,
+                "self.children.count.ptr",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let cnt = self
+            .builder
+            .build_load(i64_t, ptr, "self.children.count")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .into_int_value();
+        if which == "is_empty" {
+            let zero = i64_t.const_int(0, false);
+            let z = self
+                .builder
+                .build_int_compare(
+                    inkwell::IntPredicate::EQ,
+                    cnt,
+                    zero,
+                    "self.children.is_empty",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            Ok((z.into(), CodegenTy::Bool))
+        } else {
+            Ok((cnt.into(), CodegenTy::Int))
+        }
+    }
+
     fn emit_remove_self_from_owner(
         &mut self,
         info: &LocusInfo<'ctx>,
@@ -13463,6 +13523,29 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 Ok((val, ty))
             }
             Expr::Field { receiver, name, .. } => {
+                // Entity-collection sugar (F.11): `self.children.count`
+                // and `self.children.is_empty` read the accept'd-child
+                // tracker's live count. `self.children` itself isn't a
+                // value (only a `for` iterand), so intercept the whole
+                // `self.children.<count|is_empty>` shape here before the
+                // generic path tries to lower `self.children`. Lowers to
+                // a load of the `__child_count` i64 (count) or `== 0`
+                // (is_empty) — the buffer is already kept live by
+                // `locus_reads_self_children` (which recurses into this
+                // receiver).
+                if let Expr::Field {
+                    receiver: inner,
+                    name: inner_name,
+                    ..
+                } = receiver.as_ref()
+                {
+                    if matches!(inner.as_ref(), Expr::KwSelf(_))
+                        && inner_name.name == "children"
+                        && (name.name == "count" || name.name == "is_empty")
+                    {
+                        return self.lower_self_children_count(&name.name);
+                    }
+                }
                 // Generalized field access: lower the receiver as
                 // an expression. If it's a LocusRef or TypeRef
                 // pointer, GEP+load. This supports `g.X`, `g.x.y`,

--- a/crates/hale-codegen/tests/children_count_sugar.rs
+++ b/crates/hale-codegen/tests/children_count_sugar.rs
@@ -1,0 +1,58 @@
+//! F.11 entity-collection sugar: `self.children.count` (Int) and
+//! `self.children.is_empty` (Bool) read the accept'd-child tracker's
+//! live count, instead of hand-rolling a `for child in self.children`
+//! counter loop. Lowers to a load of the `__child_count` field.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[test]
+fn children_count_and_is_empty() {
+    let src = r#"
+        locus Worker { params { id: Int = 0; } }
+        locus Mgr {
+            params { n: Int = 0; }
+            accept(c: Worker) { }
+            birth() {
+                let mut i: Int = 0;
+                while i < self.n { Worker { id: i }; i = i + 1; }
+            }
+            fn report() {
+                println("count=", self.children.count);
+                if self.children.is_empty {
+                    println("EMPTY");
+                } else {
+                    println("NONEMPTY");
+                }
+            }
+        }
+        main locus App {
+            params {
+                full:  Mgr = Mgr { n: 7 };
+                empty: Mgr = Mgr { n: 0 };
+            }
+            run() {
+                self.full.report();
+                self.empty.report();
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale_children_count_{}", std::process::id()));
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success(), "non-zero exit; stdout: {stdout}");
+    assert!(
+        stdout.contains("count=7") && stdout.contains("NONEMPTY"),
+        "expected count=7 + NONEMPTY for the 7-child Mgr; stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("count=0") && stdout.contains("EMPTY"),
+        "expected count=0 + EMPTY for the 0-child Mgr; stdout: {stdout}"
+    );
+}

--- a/crates/hale-runtime/src/eval.rs
+++ b/crates/hale-runtime/src/eval.rs
@@ -1692,6 +1692,19 @@ impl Interpreter {
                     handle.name, name
                 )))
             }
+            // F.11 entity-collection sugar: `self.children.count` /
+            // `.is_empty`. self.children evaluates to an Array here;
+            // the typechecker only admits `.count` / `.is_empty` on
+            // the children array, so handling them on any Array is
+            // safe (and keeps interpreter ↔ codegen parity).
+            Value::Array(arr) => match name {
+                "count" => Ok(Value::Int(arr.borrow().len() as i64)),
+                "is_empty" => Ok(Value::Bool(arr.borrow().is_empty())),
+                _ => Err(Signal::Error(format!(
+                    "cannot read field `{}` on Array",
+                    name
+                ))),
+            },
             _ => Err(Signal::Error(format!(
                 "cannot read field on {}",
                 v.type_name()

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -5078,6 +5078,41 @@ impl<'a> Checker<'a> {
                 }
             }
             Expr::Field { receiver, name, span } => {
+                // F.11 entity-collection sugar: `self.children.count`
+                // (Int) and `self.children.is_empty` (Bool) read the
+                // accept'd-child tracker's live count. `self.children`
+                // alone is only a `for` iterand (typed `[Child]`); these
+                // two accessors are the summary surface F.11 commits to.
+                if let Expr::Field {
+                    receiver: inner,
+                    name: inner_name,
+                    ..
+                } = receiver.as_ref()
+                {
+                    if matches!(inner.as_ref(), Expr::KwSelf(_))
+                        && inner_name.name == "children"
+                        && (name.name == "count" || name.name == "is_empty")
+                    {
+                        let accepts = self
+                            .current_locus
+                            .map_or(false, |li| li.accept_param.is_some());
+                        if !accepts {
+                            self.diags.push(Diag::ty(
+                                *span,
+                                format!(
+                                    "`self.children.{}` requires the enclosing \
+                                     locus to `accept` a child type",
+                                    name.name
+                                ),
+                            ));
+                        }
+                        return if name.name == "count" {
+                            Ty::Prim(PrimType::Int)
+                        } else {
+                            Ty::Prim(PrimType::Bool)
+                        };
+                    }
+                }
                 let rt = self.check_expr(receiver);
                 match self.field_ty(&rt, &name.name) {
                     Some(t) => t,

--- a/crates/hale-types/tests/terminate_release_gate.rs
+++ b/crates/hale-types/tests/terminate_release_gate.rs
@@ -90,3 +90,42 @@ fn main() { Parent { }; }
         msgs
     );
 }
+
+#[test]
+fn children_count_typing_and_gate() {
+    // self.children.count : Int, .is_empty : Bool on an accepting
+    // locus → clean. On a non-accepting locus → rejected.
+    let ok = check(
+        r#"
+locus Worker { params { id: Int = 0; } }
+locus Mgr {
+    accept(c: Worker) { }
+    fn n() -> Int { return self.children.count; }
+    fn e() -> Bool { return self.children.is_empty; }
+}
+fn main() { Mgr { }; }
+"#,
+    );
+    assert!(
+        ok.iter().all(|m| !m.contains("children")),
+        "expected self.children.count/is_empty to typecheck on an \
+         accepting locus, got: {:?}",
+        ok
+    );
+
+    let bad = check(
+        r#"
+locus NoAccept {
+    params { x: Int = 0; }
+    fn n() -> Int { return self.children.count; }
+}
+fn main() { NoAccept { }; }
+"#,
+    );
+    assert!(
+        bad.iter().any(|m| m.contains("requires the enclosing locus to `accept`")),
+        "expected self.children.count on a non-accepting locus to be \
+         rejected, got: {:?}",
+        bad
+    );
+}

--- a/docs/src/concepts/recursive-composition.md
+++ b/docs/src/concepts/recursive-composition.md
@@ -129,6 +129,12 @@ locus Matchmaker {
 }
 ```
 
+A parent can iterate its accept'd children with
+`for child in self.children { ... }`, and read two summary
+accessors without a loop: `self.children.count` (an `Int`) and
+`self.children.is_empty` (a `Bool`). Both are valid only inside a
+method of a locus that `accept`s a child type.
+
 If sibling coordination is *common* enough that routing through
 the parent feels like ceremony, the language is telling you the
 parent is missing logic. The `Matchmaker` should be the place

--- a/spec/design-rationale.md
+++ b/spec/design-rationale.md
@@ -1091,6 +1091,16 @@ class loci. The cost reflects the projection class:
   favor of summary access (`self.children.count` vs the
   manual count-loop) once a workload exercises the surface.
 
+**Summary access (2026-06-01).** `self.children.count` (Int) and
+`self.children.is_empty` (Bool) are the shipped summary surface —
+they read the accept'd-child tracker's live count directly (a load
+of `__child_count`) instead of a hand-rolled `for c in
+self.children` counter. Valid only inside a method of a locus that
+`accept`s a child type (typecheck-enforced); `self.children`
+itself remains a `for`-iterand only (not a value). Richer entity-
+collection sugar (filter/map/broadcast, `first_where`) would need
+a closure-value surface Hale doesn't yet have — deferred.
+
 **v0 limitation: single-accept-type only.** A locus with
 `accept(c: ChildType)` for a single ChildType has well-typed
 `self.children`. A locus that accepts multiple types


### PR DESCRIPTION
## What

F.11 long promised `self.children.count` as the summary alternative to a hand-rolled `for c in self.children` counter loop, but it was never shipped. This adds it plus `.is_empty`:

- `self.children.count` → `Int` (a load of the locus's `__child_count`)
- `self.children.is_empty` → `Bool` (`count == 0`)

Valid only inside a method of a locus that `accept`s a child type (typecheck-enforced — non-accepting loci get a focused diagnostic). `self.children` itself stays a `for`-iterand only; these two accessors are the value surface.

Wired in all three evaluators: **codegen** (Field-expr interception → `lower_self_children_count`), **typecheck** (`check.rs` Field arm → Int/Bool + accept gate), **interpreter** (`eval.rs` `read_field` on the children Array — keeps `hale run` ↔ `hale build` parity).

Richer entity sugar (filter / map / broadcast / `first_where`) would need a closure-value surface Hale doesn't have yet — deferred (noted in F.11).

## Tests

- `children_count_sugar.rs` — count + is_empty on a 7-child and a 0-child manager.
- `terminate_release_gate.rs` — typing (Int/Bool on an accepting locus) + the non-accepting-locus rejection.
- No regressions: hale-types full, hale-runtime, `children_growable`, `recpool_codegen`, `reclamation_spine`, accept+iterate fixtures (04-modes, 14-projection-classes).

## Spec + docs

`spec/design-rationale.md` F.11 (summary access, shipped); `docs/src/concepts/recursive-composition.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)