### PR TITLE
docs(runtime): resolve Item B (coop→pinned mailbox) — sequencing, not a lost wakeup

### DIFF
--- a/crates/hale-codegen/tests/coop_to_pinned_mid_program.rs
+++ b/crates/hale-codegen/tests/coop_to_pinned_mid_program.rs
@@ -159,3 +159,52 @@ fn pinned_run_loop_drains_mailbox_via_sleep() {
         );
     }
 }
+
+#[test]
+fn pinned_returning_run_drains_mailbox() {
+    // The other half of the coop→pinned story (2026-06-01): a
+    // pinned subscriber whose run() RETURNS (rather than looping)
+    // proceeds into the blocking mailbox drain, where a cooperative
+    // publisher's `<-` wakes it via the not_empty condvar. This is
+    // the well-behaved case — it confirms the mailbox wake path
+    // itself is correct, so the only residual coop→pinned gap is a
+    // *long-running* pinned run() that never returns/yields (it
+    // can't drain mid-run because the single pinned thread is busy),
+    // which is documented as a constraint, not a bug.
+    let src = r#"
+        type Tick { n: Int = 0; }
+        topic TickT { payload: Tick; subject: "cp.tick"; }
+        locus Sub {
+            bus { subscribe TickT as on_tick; }
+            fn on_tick(t: Tick) { println("PINNED GOT ", t.n); }
+            run() { }
+        }
+        main locus App {
+            params { s: Sub = Sub { }; }
+            placement { s: pinned; }
+            bus { publish TickT; }
+            run() {
+                std::time::sleep(100ms);
+                let mut i: Int = 0;
+                while i < 3 { i = i + 1; TickT <- Tick { n: i }; std::time::sleep(80ms); }
+                std::time::sleep(150ms);
+                println("app done");
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = unique_path("pinned-returning-run");
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success(), "non-zero exit; stdout: {stdout}");
+    for tag in ["PINNED GOT 1", "PINNED GOT 2", "PINNED GOT 3", "app done"] {
+        assert!(
+            stdout.contains(tag),
+            "expected `{tag}` (a returning-run pinned subscriber should drain \
+             cross-pool publishes via the mailbox condvar); stdout: {stdout}"
+        );
+    }
+}

--- a/spec/design-rationale.md
+++ b/spec/design-rationale.md
@@ -2953,13 +2953,16 @@ were previously `: schedule` annotations.
 - The "sibling-in-main pattern" workaround becomes the
   canonical shape rather than a friction routing.
 
-**Still open.**
+**Resolved (2026-06-01).**
 
-- Cross-pool mailbox drain for the cooperative-publisher →
-  pinned-subscriber path (`spec/runtime.md` Item B) is
-  orthogonal. The placement substrate doesn't fix
-  the missing condvar drain on that path; that's its own
-  runtime bug.
+- The cooperative-publisher → pinned-subscriber path
+  (`spec/runtime.md` Item B) works: the mailbox condvar wakes a
+  pinned subscriber blocked in `lotus_mailbox_drain_one`. The
+  earlier "missing condvar drain" was a sequencing effect — a
+  *long-running* pinned `run()` never reaches the blocking drain,
+  so it must yield (`time::sleep`/`yield`) or return for its
+  mailbox to be serviced. That's a property of the single pinned
+  thread, not a bug. See `spec/runtime.md` Item B.
 
 **Adapter placement interaction.** Adapter loci instantiated
 inline in a `bindings { Topic: AdapterLocus { ... }; }` entry

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -365,21 +365,30 @@ The pinned-mailbox path is unchanged: pinned subscribers wake
 on `lotus_mailbox_post`'s condvar broadcast regardless of what
 the cooperative scheduler is doing.
 
-**Item B from the 2026-05-21 friction log** is a separate,
-still-open shape: a cooperative publisher's `<-` cell to a
-pinned subscriber. The publish enqueues on the pinned
-subscriber's mailbox via `lotus_mailbox_post` (correct), and
-the condvar broadcast SHOULD wake the pinned thread blocked
-in `lotus_mailbox_drain_one`. Empirically the cell drains
-only at dissolve in some configurations — root cause not yet
-isolated; the `time::sleep` fix here doesn't address it
-because the mailbox path doesn't touch `g_bus_queue`. The
-documented workaround is direct method invocation on the
-receiver (`self.on_subscribe(req)`) inside the publisher's
-loop, bypassing the bus for the in-binary case. Cross-binary
-flows (unix / shm_ring transport with their own reader
-threads) work fine because their dispatch path lands in
-`g_bus_queue` and benefits from the sleep-folded drain above.
+**Item B from the 2026-05-21 friction log** (a cooperative
+publisher's `<-` to a pinned subscriber) is **resolved as of
+2026-06-01** — the earlier "drains only at dissolve in some
+configurations" was a *sequencing* effect, not a lost wakeup.
+The mailbox condvar path is correct: a pinned subscriber whose
+`run()` **returns** proceeds into the blocking
+`lotus_mailbox_drain_one`, and a cooperative publisher's `<-`
+wakes it via the `not_empty` broadcast — confirmed by
+`coop_to_pinned_mid_program::pinned_returning_run_drains_mailbox`.
+
+The residual constraint is inherent to a single pinned thread:
+a pinned subscriber with a **long-running `run()`** that never
+returns or yields cannot drain its mailbox *during* `run()` —
+the one thread is busy in the loop. Such a `run()` must reach a
+cooperative yield point (`time::sleep` / `yield`) for the
+TLS-cached `lotus_mailbox_drain_pending` to service the mailbox
+(the `coop_to_pinned_mid_program` sleep-loop test), or let
+`run()` return so the post-run blocking drain takes over. This
+is a property of the bimodal model — "pinned owns its thread,
+no yielding between cells" — not a bug; a pinned subscriber that
+must receive bus traffic while busy should yield in its loop.
+Cross-binary flows (unix / shm_ring with their own reader
+threads) land in `g_bus_queue` and benefit from the sleep-folded
+drain above.
 
 #### Long-running cooperative children: placement closes Item D
 


### PR DESCRIPTION
## What

Item B (a cooperative publisher's `<-` to a pinned subscriber) was logged as "the cell drains only at dissolve in some configurations — root cause not isolated." **Root cause found: a sequencing effect, not a lost condvar wakeup.**

The mailbox path is correct. A pinned subscriber whose `run()` **returns** proceeds into the blocking `lotus_mailbox_drain_one`, and a cooperative publisher's `<-` wakes it via the `not_empty` broadcast.

The residual is inherent to a single pinned thread: a **long-running `run()`** that never returns/yields can't drain its mailbox *during* `run()` (the thread is busy in the loop). It must reach a yield point (`time::sleep`/`yield`) for the TLS-cached `drain_pending` to service it (the existing sleep-loop test covers this), or return. That's a property of the bimodal model ("pinned owns its thread, no yielding"), documented as a constraint rather than chased as a phantom bug.

## Testing

- New `coop_to_pinned_mid_program::pinned_returning_run_drains_mailbox` — a returning-`run()` pinned subscriber receives 3 cross-pool publishes (PINNED GOT 1/2/3) + clean exit.
- Existing `pinned_run_loop_drains_mailbox_via_sleep` (the sleep-loop case) still green.

## Docs

No runtime change. `spec/runtime.md` Item B and `spec/design-rationale.md` "Still open → Resolved".

🤖 Generated with [Claude Code](https://claude.com/claude-code)