### PR TITLE
harden: compiled-corpus ASAN oracle + the three leaks it found

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,3 +248,63 @@ jobs:
           cargo test --release -p hale-codegen \
             --test form_hashmap_lockfree_tsan \
             -- --ignored --test-threads=1 --nocapture
+
+  # 2026-06-02 — AddressSanitizer + LeakSanitizer coverage for the
+  # compiled example corpus. The broad corpus is otherwise only
+  # parse-tested + type-checked + interpreter-run (exit-0); the
+  # interpreter has no arenas/pools/coros, so it can't surface the
+  # teardown leaks, shutdown use-after-free, and buffer overflows
+  # that keep appearing at feature intersections in real apps.
+  # `corpus_oracle` compiles every runnable fixture to native and
+  # runs it under the oracle battery; this job adds the sanitizer
+  # arm. Three closure epoch-fire leaks are quarantined in the test
+  # (KNOWN_CLOSURE_LEAKS) so the gate is green on the known state —
+  # any NEW leak/UAF/overflow in any other fixture fails here.
+  #
+  # Separate job like tsan: ASAN-instrumented builds are slower and
+  # need the wrap-malloc shim disabled, so they don't belong in the
+  # normal partitions. The plain exit+deadline arm of corpus_oracle
+  # DOES run in those partitions (no extra toolchain needed).
+  asan:
+    name: asan (example corpus)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-asan-x86_64-linux-llvm18-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-asan-x86_64-linux-llvm18-
+
+      - name: Install LLVM 18 + clang
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y \
+            llvm-18-dev libpolly-18-dev libzstd-dev \
+            clang-18 libclang-18-dev zlib1g-dev
+
+      - name: cargo build --release --workspace
+        run: cargo build --release --workspace
+
+      - name: LOTUS_ASAN=1 cargo test (corpus_oracle under ASAN)
+        # #[ignore]'d like the tsan suite; --ignored opts in.
+        # LOTUS_ASAN=1 tells build_executable to pass
+        # -fsanitize=address to clang for the runtime C compile +
+        # binary link. A new leak outside KNOWN_CLOSURE_LEAKS, or
+        # any UAF/overflow, gates the merge.
+        env:
+          LOTUS_ASAN: "1"
+        run: |
+          cargo test --release -p hale-codegen \
+            --test corpus_oracle \
+            -- --ignored --test-threads=1 --nocapture

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -413,15 +413,62 @@ static void lotus_chunk_pool_stats_thread_dtor(void *unused) {
     lotus_chunk_pool_stats_emit("thread-exit");
 }
 
+/* Per-thread chunk-pool reclamation (2026-06-02). The chunk pool
+ * (`g_chunk_pool`, __thread) is prefilled with
+ * LOTUS_CHUNK_POOL_PREFILL_DEFAULT (32) malloc'd 64KiB chunks on a
+ * thread's first chunk allocation, and accumulates recycled chunks
+ * over the thread's life. Those chunks are never freed when a
+ * SPAWNED worker thread (pinned locus thread, cooperative pool
+ * worker) exits — its __thread storage is torn down with the
+ * pointers still live, so the 32×64KiB prefill (2MiB) plus any
+ * recycled chunks leak per exited worker. (The main thread never
+ * runs pthread_key destructors — it exits via return-from-main /
+ * exit() — and its still-live TLS keeps the pool reachable, so
+ * LeakSanitizer only ever flags the worker-thread case.) This
+ * destructor, armed for any thread that touches the pool, frees
+ * the pool on thread exit. Independent of the stats diagnostic
+ * above — it must run on every build, not only when
+ * LOTUS_CHUNK_POOL_STATS is set. */
+static pthread_key_t g_chunk_pool_free_key;
+static int g_chunk_pool_free_key_init = 0;
+
+static void lotus_chunk_pool_free_thread_dtor(void *unused) {
+    (void)unused;
+    /* The pool only ever holds malloc'd, default-size chunks:
+     * lotus_arena_release_chunk munmaps `via_mmap` chunks before
+     * they could be pooled, and only chunks with
+     * cap == LOTUS_ARENA_CHUNK_BYTES are admitted. So free() is the
+     * correct reclaim for every entry. Runs on the exiting thread,
+     * so __thread g_chunk_pool refers to that thread's own pool. */
+    while (g_chunk_pool_count > 0) {
+        free(g_chunk_pool[--g_chunk_pool_count]);
+    }
+}
+
 static inline void lotus_mark_thread_for_pool_dtor(void) {
     if (g_thread_marked_for_pool_dtor) return;
-    if (!g_chunk_pool_stats_key_init) return;
-    pthread_setspecific(g_chunk_pool_stats_thread_key, (void *)1);
     g_thread_marked_for_pool_dtor = 1;
+    /* Always arm the pool-free dtor (a non-NULL value is required
+     * for a pthread_key destructor to fire at thread exit). */
+    if (g_chunk_pool_free_key_init) {
+        pthread_setspecific(g_chunk_pool_free_key, (void *)1);
+    }
+    /* The stats-dump dtor is only meaningful when the diagnostic
+     * is enabled (its key is created only in that case). */
+    if (g_chunk_pool_stats_key_init) {
+        pthread_setspecific(g_chunk_pool_stats_thread_key, (void *)1);
+    }
 }
 
 __attribute__((constructor))
 static void lotus_chunk_pool_stats_install(void) {
+    /* The pool-free key is created unconditionally — chunk-pool
+     * reclamation at worker-thread exit is a correctness property,
+     * not a diagnostic. */
+    if (pthread_key_create(&g_chunk_pool_free_key,
+                           lotus_chunk_pool_free_thread_dtor) == 0) {
+        g_chunk_pool_free_key_init = 1;
+    }
     if (lotus_chunk_pool_stats_enabled()) {
         atexit(lotus_chunk_pool_stats_dump_main);
         if (pthread_key_create(&g_chunk_pool_stats_thread_key,
@@ -903,6 +950,17 @@ static void lotus_chunk_pool_prefill_if_needed(void) {
         c->next = NULL;
         c->used = 0;
         c->cap = LOTUS_ARENA_CHUNK_BYTES;
+        /* via_mmap / mmap_size MUST be initialized: prefill chunks
+         * are malloc'd, and a pooled chunk later handed out and then
+         * passed to lotus_arena_release_chunk is dispatched on
+         * `via_mmap`. Left uninitialized (malloc, not calloc), a
+         * garbage non-zero value sends the chunk down the munmap
+         * path with a garbage size — the munmap fails and the chunk
+         * is neither freed nor re-pooled, leaking it. The other two
+         * chunk-creation paths (mmap + malloc-fallback in
+         * new_chunk_for) already set these; prefill was the gap. */
+        c->via_mmap = 0;
+        c->mmap_size = 0;
         g_chunk_pool[g_chunk_pool_count++] = c;
     }
 }

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -434,10 +434,22 @@ pub fn build_executable_with_options(
     // through pointer-typed parameters. `default<O2>` runs the
     // canonical pass set (mem2reg, SROA, LICM, InstCombine,
     // SimplifyCFG, GVN, etc.) — same as Clang -O2.
-    let pb_opts = inkwell::passes::PassBuilderOptions::create();
-    cx.module
-        .run_passes("default<O2>", &machine, pb_opts)
-        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+    // LOTUS_ASAN diagnostic builds skip the O2 module pipeline so
+    // AddressSanitizer leak/UAF reports carry ACCURATE frames: O2's
+    // inliner collapses an allocation into whatever fn it's inlined
+    // into, so a leak's "allocated from" frame points at the wrong
+    // function (e.g. an inlined alloc symbolized as
+    // `__duration_closures`). Naive IR keeps every call in its true
+    // function. Speed doesn't matter for the dedicated ASAN job.
+    let asan_diag = std::env::var("LOTUS_ASAN")
+        .map(|v| v == "1" || v == "true" || v == "TRUE")
+        .unwrap_or(false);
+    if !asan_diag {
+        let pb_opts = inkwell::passes::PassBuilderOptions::create();
+        cx.module
+            .run_passes("default<O2>", &machine, pb_opts)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+    }
 
     machine
         .write_to_file(&cx.module, FileType::Object, &obj_path)
@@ -548,6 +560,21 @@ pub fn build_executable_with_options(
     let lotus_tsan = std::env::var("LOTUS_TSAN")
         .map(|v| v == "1" || v == "true" || v == "TRUE")
         .unwrap_or(false);
+    // 2026-06-02: AddressSanitizer validation build, symmetric to
+    // the TSAN hook above. Set `LOTUS_ASAN=1` to compile the
+    // runtime C + emitted binary with `-fsanitize=address`. Used
+    // by the compiled-corpus oracle harness
+    // (`crates/hale-codegen/tests/corpus_oracle.rs`) under
+    // `--ignored` to catch the bug classes that keep surfacing at
+    // feature intersections — heap-buffer-overflow (e.g. the >16
+    // accept'd-children overflow), use-after-free (e.g. the
+    // classic-pool shutdown UAF), and leaks (LeakSanitizer ships
+    // inside ASAN and reports at exit). Like TSAN, ASAN's malloc
+    // interceptor collides with the `-Wl,--wrap=malloc` shim, so
+    // the wrap surface is disabled when either sanitizer is on.
+    let lotus_asan = std::env::var("LOTUS_ASAN")
+        .map(|v| v == "1" || v == "true" || v == "TRUE")
+        .unwrap_or(false);
     if lotus_tsan {
         clang.arg("-fsanitize=thread");
         // Conservative: -O1 keeps TSAN reports readable while
@@ -556,6 +583,16 @@ pub fn build_executable_with_options(
         // (Existing -O2 above stacks with this; clang accepts
         // the last `-O` on the command line.)
         clang.arg("-O1");
+    } else if lotus_asan {
+        // -fsanitize=address instruments both the runtime C and
+        // the emitted object. -O1 + frame-pointers keep the
+        // reports legible (symbolized frames) without the O0
+        // slowdown. LeakSanitizer is on by default under ASAN on
+        // Linux; the harness sets ASAN_OPTIONS at runtime.
+        clang
+            .arg("-fsanitize=address")
+            .arg("-fno-omit-frame-pointer")
+            .arg("-O1");
     } else {
         clang
             .arg("-DLOTUS_ENABLE_WRAP_MALLOC")
@@ -20881,6 +20918,27 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// reads fall through to the self-arena path (matches the
     /// invariant outside method bodies).
     pub(crate) fn close_method_scratch(&mut self) -> Result<(), CodegenError> {
+        self.emit_method_scratch_destroy()?;
+        self.current_method_scratch = None;
+        self.current_method_caller_arena = None;
+        Ok(())
+    }
+
+    /// Emit a `lotus_arena_destroy` of the current method-scratch
+    /// subregion at the builder's current position WITHOUT clearing
+    /// the codegen-time scratch state. For early-exit paths that
+    /// diverge before the body's normal `close_method_scratch` while
+    /// the fall-through path still needs the slot live — e.g. the
+    /// quarantine entry-gate's `skip_bb` return: it bails out of an
+    /// already-quarantined handler after the entry created the
+    /// scratch (open_method_scratch), so without this the scratch
+    /// subregion leaks once per post-quarantine delivery. The two
+    /// runtime paths (skip vs body) are mutually exclusive, so the
+    /// single subregion is destroyed exactly once at run time even
+    /// though both emit a destroy. No-op when no scratch is open.
+    pub(crate) fn emit_method_scratch_destroy(
+        &mut self,
+    ) -> Result<(), CodegenError> {
         let Some(slot) = self.current_method_scratch else {
             return Ok(());
         };
@@ -20901,8 +20959,6 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 "method.scratch.destroy",
             )
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-        self.current_method_scratch = None;
-        self.current_method_caller_arena = None;
         Ok(())
     }
 

--- a/crates/hale-codegen/src/locus/method.rs
+++ b/crates/hale-codegen/src/locus/method.rs
@@ -717,6 +717,15 @@ impl<'ctx, 'p> LocusMethodBodies<'ctx> for Cx<'ctx, 'p> {
                         .build_conditional_branch(is_q, skip_bb, body_bb)
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                     self.builder.position_at_end(skip_bb);
+                    // The entry (open_method_scratch) created this
+                    // handler's scratch subregion before the
+                    // quarantine gate; bailing out here without
+                    // destroying it leaks one subregion per delivery
+                    // to an already-quarantined subscriber. Destroy
+                    // it (state stays live for the body path, which
+                    // is mutually exclusive at run time and closes
+                    // it normally at its own exit).
+                    self.emit_method_scratch_destroy()?;
                     self.builder
                         .build_return(None)
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;

--- a/crates/hale-codegen/tests/corpus_oracle.rs
+++ b/crates/hale-codegen/tests/corpus_oracle.rs
@@ -1,0 +1,446 @@
+//! Compiled-corpus oracle harness.
+//!
+//! The broad example corpus is parse-tested (`hale-syntax`) and
+//! type-checked (`hale-types`) across the whole set, but the only
+//! systematic *run* coverage goes through the interpreter
+//! (`hale-runtime/tests/examples.rs`, exit-code-0 only). The
+//! interpreter has no arenas, pools, wake_fds, or coroutine
+//! parking — so it structurally cannot reproduce the bug classes
+//! that keep surfacing at feature *intersections* on the compiled
+//! substrate: teardown-time leaks, shutdown use-after-free,
+//! cross-pool starvation/hangs, and buffer overflows.
+//!
+//! This harness closes that blind spot. It compiles every
+//! runnable fixture to a NATIVE binary and runs it under an oracle
+//! battery:
+//!
+//!   * exit oracle      — the process exits with its expected code
+//!                        (0, except the deliberately-bubbled
+//!                        closure violation). A SIGSEGV/SIGABRT
+//!                        shutdown crash fails here.
+//!   * deadline oracle  — the process terminates within a wall
+//!                        clock budget. A cross-pool starvation /
+//!                        missed-wakeup hang fails here.
+//!   * sanitizer oracle — built with `LOTUS_ASAN=1` (the
+//!                        `*_under_asan` test, opt-in like the TSAN
+//!                        job), AddressSanitizer + LeakSanitizer
+//!                        catch heap-overflow, use-after-free, and
+//!                        leaks at exit.
+//!
+//! Fixtures are discovered at runtime, so a new example under
+//! `tests/fixtures/examples/` is covered automatically — no
+//! manifest to keep in sync.
+
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use hale_codegen::build_executable;
+
+fn examples_dir() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("examples");
+    p
+}
+
+/// Fixtures excluded from the run oracles, with the reason:
+///   * network servers — they `accept()` connections and never
+///     self-terminate, so they need a start/probe/shutdown driver
+///     (a separate harness, out of scope here).
+///   * none currently need explicit listing beyond servers; the
+///     multi-file/import projects are filtered structurally below
+///     (plain `build_executable` can't resolve cross-file imports;
+///     that's the CLI's directory-build path).
+const SKIP_SERVERS: &[&str] = &["http-hello", "io-demo", "docs-server"];
+
+/// The one fixture whose correct exit is non-zero: it deliberately
+/// bubbles a ClosureViolation to the root, which the runtime
+/// surfaces as a non-zero process exit.
+fn expects_nonzero_exit(name: &str) -> bool {
+    name == "03c-closure-bubbled"
+}
+
+/// Fixtures that terminate abnormally by design — they `bubble` a
+/// violation to the root and exit via root-panic, which
+/// intentionally skips the drain/dissolve cleanup cascade. Their
+/// "leaks" under LeakSanitizer are the un-run cleanup, not a bug,
+/// so the leak oracle doesn't apply.
+fn leak_exempt(name: &str) -> bool {
+    name == "03c-closure-bubbled"
+}
+
+/// KNOWN, TRACKED leak the ASAN oracle still flags. Quarantined so
+/// the gate is green on the KNOWN state — but a leak in ANY fixture
+/// outside this set is a hard failure, and a fixture that stops
+/// leaking just stops being reported. Shrink this set as leaks are
+/// fixed; the goal is to empty it.
+///
+/// Fixed and removed 2026-06-02: `35-tick-closures` and
+/// `41-closure-accumulator` — the method-scratch subregion leaked
+/// once per delivery to an already-quarantined subscribed handler
+/// (the quarantine entry-gate's early `return` bypassed
+/// `close_method_scratch`). Fixed in `locus/method.rs` by destroying
+/// the scratch on the skip path.
+///
+/// Also fixed 2026-06-02 (the big one): the per-thread chunk POOL
+/// was never freed when a spawned worker thread (pinned locus
+/// thread / cooperative pool worker) exited. `new_chunk_for`
+/// prefills 32×64KiB chunks into a `__thread` pool on a thread's
+/// first allocation; the pthread_key dtor only dumped stats, never
+/// reclaimed. So EVERY exited worker leaked ~2MiB (main thread
+/// excepted — its TLS stays reachable). Fixed in
+/// `runtime/lotus_arena.c` with a pool-freeing thread dtor armed
+/// for any thread that touches the pool.
+///
+/// Also fixed 2026-06-02: `40-pinned-duration`'s 64KiB residual —
+/// the SAME file, a sibling bug. The chunk-pool prefill path
+/// malloc'd chunks but left `via_mmap` uninitialized; the other two
+/// chunk-creation paths set it. A pooled prefill chunk later handed
+/// out and then passed to `lotus_arena_release_chunk` is dispatched
+/// on `via_mmap` — a garbage non-zero value took the `munmap` path
+/// with a garbage size, so the chunk was neither freed nor
+/// re-pooled. (Latent until something released a pooled chunk; the
+/// pinned locus's lifetime-arena teardown was the trigger here.)
+/// Fixed by zero-initializing `via_mmap`/`mmap_size` in prefill.
+///
+/// Empty == the goal reached. Any leak/UAF/overflow now hard-fails.
+const KNOWN_CLOSURE_LEAKS: &[&str] = &[];
+
+/// Per-fixture wall-clock budget. Demos finish in well under a
+/// second; the budget is generous so a slow CI box doesn't flake,
+/// while a genuine hang (missed wakeup, starvation) still trips it.
+const DEADLINE: Duration = Duration::from_secs(15);
+/// ASAN instrumentation runs ~2-5x slower; give it more room.
+const DEADLINE_ASAN: Duration = Duration::from_secs(90);
+
+/// Discover every runnable single-file binary fixture: a directory
+/// holding exactly one `.hl` file, named `main.hl`, that declares
+/// `fn main()`, and isn't a known never-terminating server.
+/// The single-`.hl` rule structurally excludes multi-file import
+/// projects (25-imports, multi-file-seed, fitter-applier-pair),
+/// which need the CLI's directory-build import resolution.
+fn runnable_fixtures() -> Vec<(String, PathBuf)> {
+    let dir = examples_dir();
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(&dir).expect("read examples dir") {
+        let entry = entry.expect("dir entry");
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if SKIP_SERVERS.contains(&name.as_str()) {
+            continue;
+        }
+        let hl_files: Vec<PathBuf> = std::fs::read_dir(entry.path())
+            .expect("read fixture dir")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().map(|x| x == "hl").unwrap_or(false))
+            .collect();
+        if hl_files.len() != 1 {
+            continue; // multi-file project — needs import bundling
+        }
+        let main_hl = entry.path().join("main.hl");
+        if !main_hl.exists() {
+            continue;
+        }
+        let src = std::fs::read_to_string(&main_hl).expect("read main.hl");
+        if !src.contains("fn main()") {
+            continue; // library-only fixture, not a binary
+        }
+        out.push((name, main_hl));
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+enum RunResult {
+    /// Completed within the deadline; carries exit code (None if
+    /// killed by a signal), the signal number if any, and stderr.
+    Exited {
+        code: Option<i32>,
+        signal: Option<i32>,
+        stderr: String,
+    },
+    /// Did not terminate within the deadline (killed by us).
+    TimedOut,
+}
+
+/// Run `bin` with output redirected to temp files (so a large
+/// sanitizer report on stderr can never deadlock a pipe), polling
+/// for completion until `deadline`, then SIGKILLing on timeout.
+fn run_with_deadline(bin: &Path, deadline: Duration) -> RunResult {
+    let out_path = bin.with_extension("stdout");
+    let err_path = bin.with_extension("stderr");
+    let out_file = File::create(&out_path).expect("create stdout file");
+    let err_file = File::create(&err_path).expect("create stderr file");
+
+    let mut child = Command::new(bin)
+        .stdin(Stdio::null())
+        .stdout(out_file)
+        .stderr(err_file)
+        // LeakSanitizer detects leaks at exit (no-op on a non-ASAN
+        // build). Leave abort_on_error off so ASAN/LSAN exit
+        // non-zero *with* their stderr banner rather than raising
+        // SIGABRT — the banner lets the sanitizer oracle classify
+        // (and the abnormal-exit fixture stays exempt by exit code).
+        .env("ASAN_OPTIONS", "detect_leaks=1")
+        .spawn()
+        .expect("spawn fixture binary");
+
+    let start = Instant::now();
+    let result = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                #[cfg(unix)]
+                let signal = {
+                    use std::os::unix::process::ExitStatusExt;
+                    status.signal()
+                };
+                #[cfg(not(unix))]
+                let signal = None;
+                let mut stderr = String::new();
+                let _ = File::open(&err_path)
+                    .and_then(|mut f| f.read_to_string(&mut stderr));
+                break RunResult::Exited {
+                    code: status.code(),
+                    signal,
+                    stderr,
+                };
+            }
+            Ok(None) => {
+                if start.elapsed() > deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break RunResult::TimedOut;
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(e) => panic!("try_wait failed: {e}"),
+        }
+    };
+    let _ = std::fs::remove_file(&out_path);
+    let _ = std::fs::remove_file(&err_path);
+    result
+}
+
+/// stderr markers that mean a *sanitizer* (ASAN/LSAN/TSAN) fired,
+/// regardless of exit code — needed so a sanitizer failure on the
+/// one deliberately-non-zero fixture isn't masked by its expected
+/// non-zero exit. Deliberately narrow: Hale's own root-panic
+/// formatter prints "runtime error: ..." for a bubbled
+/// ClosureViolation, which is correct program behavior, NOT a
+/// sanitizer hit — so we match only the sanitizers' own banners.
+fn stderr_has_sanitizer_error(stderr: &str) -> bool {
+    stderr.contains("AddressSanitizer")
+        || stderr.contains("LeakSanitizer")
+        || stderr.contains("ThreadSanitizer")
+        || stderr.contains("detected memory leaks")
+}
+
+enum Outcome {
+    Pass,
+    /// Codegen can't lower this fixture yet (interpreter-only
+    /// feature). Reported as a skip, not an oracle failure — out
+    /// of scope for the run oracles, but surfaced so the
+    /// interpreter/codegen divergence stays visible.
+    Uncompilable(String),
+    /// A known, tracked leak (see `KNOWN_CLOSURE_LEAKS`). Reported
+    /// loudly but doesn't fail the gate.
+    Quarantined(String),
+    /// A run oracle (exit / deadline / sanitizer) failed.
+    Fail(String),
+}
+
+/// Build one fixture to a unique temp binary and run it under the
+/// oracles.
+fn check_fixture(name: &str, main_hl: &Path, deadline: Duration) -> Outcome {
+    let src = match std::fs::read_to_string(main_hl) {
+        Ok(s) => s,
+        Err(e) => return Outcome::Fail(format!("read: {e}")),
+    };
+    let program = match hale_syntax::parse_source(&src) {
+        Ok(p) => p,
+        Err(d) => return Outcome::Fail(format!("parse: {d:?}")),
+    };
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("lotus_corpus_{}_{}", name.replace(['/', '-'], "_"), std::process::id()));
+    if let Err(e) = build_executable(&program, &bin) {
+        let msg = format!("{e:?}");
+        // A codegen feature gap (interpreter-only fixture) is a
+        // skip; any other build error is a real regression.
+        if msg.contains("Unsupported(") {
+            return Outcome::Uncompilable(msg);
+        }
+        return Outcome::Fail(format!("build: {msg}"));
+    }
+
+    let result = run_with_deadline(&bin, deadline);
+    let _ = std::fs::remove_file(&bin);
+
+    match result {
+        RunResult::TimedOut => Outcome::Fail(format!(
+            "HANG: did not terminate within {}s (starvation / missed wakeup?)",
+            deadline.as_secs()
+        )),
+        RunResult::Exited { code, signal, stderr } => {
+            if stderr_has_sanitizer_error(&stderr) && !leak_exempt(name) {
+                let snippet: String = stderr
+                    .lines()
+                    .filter(|l| l.contains("leak") || l.contains("SUMMARY") || l.contains("ERROR"))
+                    .take(3)
+                    .collect::<Vec<_>>()
+                    .join(" | ");
+                if KNOWN_CLOSURE_LEAKS.contains(&name) {
+                    return Outcome::Quarantined(snippet);
+                }
+                let full: String = stderr.lines().take(12).collect::<Vec<_>>().join("\n");
+                return Outcome::Fail(format!("SANITIZER:\n{full}"));
+            }
+            if let Some(sig) = signal {
+                return Outcome::Fail(format!("CRASH: killed by signal {sig} (UAF / overflow?)"));
+            }
+            let nonzero_ok = expects_nonzero_exit(name);
+            match code {
+                Some(0) if !nonzero_ok => Outcome::Pass,
+                Some(0) => Outcome::Fail(
+                    "expected non-zero exit (bubbled violation) but got 0".to_string(),
+                ),
+                Some(_) if nonzero_ok => Outcome::Pass,
+                Some(c) => Outcome::Fail(format!("BAD EXIT: expected 0, got {c}")),
+                None => Outcome::Fail("no exit code and no signal".to_string()),
+            }
+        }
+    }
+}
+
+/// Build + run every runnable fixture concurrently under the
+/// oracles, collecting all results (don't bail on the first, so
+/// one run surfaces the whole picture). Returns
+/// `(failures, uncompilable)`. Shared by the plain and ASAN
+/// entry points.
+fn run_corpus(
+    deadline: Duration,
+) -> (
+    Vec<(String, String)>,
+    Vec<(String, String)>,
+    Vec<(String, String)>,
+) {
+    let fixtures = runnable_fixtures();
+    assert!(!fixtures.is_empty(), "no runnable fixtures discovered");
+    eprintln!("corpus oracle: {} runnable fixtures", fixtures.len());
+
+    let queue = Arc::new(Mutex::new(fixtures.into_iter()));
+    let failures = Arc::new(Mutex::new(Vec::<(String, String)>::new()));
+    let uncompilable = Arc::new(Mutex::new(Vec::<(String, String)>::new()));
+    let quarantined = Arc::new(Mutex::new(Vec::<(String, String)>::new()));
+    let n_threads = std::thread::available_parallelism()
+        .map(|n| n.get().min(8))
+        .unwrap_or(4);
+
+    let mut handles = Vec::new();
+    for _ in 0..n_threads {
+        let queue = Arc::clone(&queue);
+        let failures = Arc::clone(&failures);
+        let uncompilable = Arc::clone(&uncompilable);
+        let quarantined = Arc::clone(&quarantined);
+        handles.push(std::thread::spawn(move || loop {
+            let next = queue.lock().unwrap().next();
+            let Some((name, path)) = next else { break };
+            match check_fixture(&name, &path, deadline) {
+                Outcome::Pass => {}
+                Outcome::Fail(reason) => failures.lock().unwrap().push((name, reason)),
+                Outcome::Uncompilable(reason) => {
+                    uncompilable.lock().unwrap().push((name, reason))
+                }
+                Outcome::Quarantined(reason) => {
+                    quarantined.lock().unwrap().push((name, reason))
+                }
+            }
+        }));
+    }
+    for h in handles {
+        h.join().expect("worker thread");
+    }
+
+    let mut fails = Arc::try_unwrap(failures).unwrap().into_inner().unwrap();
+    fails.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut uncomp = Arc::try_unwrap(uncompilable).unwrap().into_inner().unwrap();
+    uncomp.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut quar = Arc::try_unwrap(quarantined).unwrap().into_inner().unwrap();
+    quar.sort_by(|a, b| a.0.cmp(&b.0));
+    (fails, uncomp, quar)
+}
+
+fn report(
+    (failures, uncompilable, quarantined): (
+        Vec<(String, String)>,
+        Vec<(String, String)>,
+        Vec<(String, String)>,
+    ),
+) {
+    // Surface the interpreter/codegen divergence as a warning —
+    // not a hard failure (the run oracles are this gate's job),
+    // but loud enough that the gap doesn't stay hidden.
+    if !uncompilable.is_empty() {
+        eprintln!(
+            "\n⚠ {} fixture(s) compile under the interpreter but NOT codegen \
+             (excluded from run oracles):",
+            uncompilable.len()
+        );
+        for (name, reason) in &uncompilable {
+            let cause = reason.lines().next().unwrap_or(reason);
+            eprintln!("    · {name}: {cause}");
+        }
+    }
+    // Known, tracked leaks — loud, but not a gate failure (see
+    // KNOWN_CLOSURE_LEAKS). The point is to keep them visible until
+    // the closure epoch-fire reclaim is fixed and the set is empty.
+    if !quarantined.is_empty() {
+        eprintln!(
+            "\n⚠ {} KNOWN leak(s) quarantined (closure epoch-fire reclaim — fix pending):",
+            quarantined.len()
+        );
+        for (name, reason) in &quarantined {
+            eprintln!("    · {name}: {reason}");
+        }
+    }
+    if failures.is_empty() {
+        return;
+    }
+    let mut msg = format!("\n{} fixture(s) failed the run oracles:\n", failures.len());
+    for (name, reason) in &failures {
+        msg.push_str(&format!("\n  ● {name}\n    {}\n", reason.replace('\n', "\n    ")));
+    }
+    panic!("{msg}");
+}
+
+/// Exit + deadline oracles on a normal (non-instrumented) build.
+/// Runs in the standard CI partitions — no extra toolchain needed.
+#[test]
+fn corpus_terminates_and_exits_clean() {
+    report(run_corpus(DEADLINE));
+}
+
+/// Full oracle battery including AddressSanitizer + LeakSanitizer.
+/// Ignored by default (ASAN slows builds + runs and needs the
+/// instrumented runtime); opted into by the dedicated CI job with
+/// `LOTUS_ASAN=1 cargo nextest run --run-ignored ...`, mirroring
+/// the TSAN job. A no-op pass if LOTUS_ASAN isn't set, so an
+/// accidental `--run-ignored` locally doesn't give false comfort.
+#[test]
+#[ignore = "ASAN build: opt in with LOTUS_ASAN=1 (dedicated CI job)"]
+fn corpus_clean_under_asan() {
+    let on = std::env::var("LOTUS_ASAN")
+        .map(|v| v == "1" || v == "true" || v == "TRUE")
+        .unwrap_or(false);
+    if !on {
+        eprintln!("skipping: set LOTUS_ASAN=1 to build the corpus under AddressSanitizer");
+        return;
+    }
+    report(run_corpus(DEADLINE_ASAN));
+}

--- a/docs/src/services/bus.md
+++ b/docs/src/services/bus.md
@@ -94,5 +94,76 @@ dispatch cost; if the topic later grows a second subscriber or a
 deployment binding, the real bus path comes back automatically,
 and your code doesn't change.
 
+## Routing keys: one topic, sharded by a field
+
+By default every subscriber to a topic sees every message. When
+you have many subscribers that each care about *one slice* of the
+traffic — one connection, one symbol, one tenant — fanning every
+message to all of them and filtering in each handler is wasteful.
+A **routing key** moves that filter into the bus: a subscriber
+declares which key it wants, and the runtime only delivers
+matching messages.
+
+Name a payload field as the key on the topic, then filter on it
+at the subscribe site:
+
+```hale
+type Tick { symbol_id: Int; price: Decimal; }
+
+topic Quote { payload: Tick; keyed_by symbol_id; }
+
+locus Feed {
+    params { symbol_id: Int = 0; }
+
+    bus {
+        subscribe Quote as on_quote where key == self.symbol_id;
+    }
+
+    fn on_quote(t: Tick) {
+        // only ticks whose symbol_id matches this Feed arrive
+    }
+}
+```
+
+A publish carries its key in the payload, so the send is
+unchanged — `Quote <- Tick { symbol_id: 7, price: 100.0d };`
+reaches only the `Feed` instances that subscribed with
+`where key == 7`.
+
+- **`keyed_by FIELD`** on the topic picks the routing field. It
+  must be a field of the payload, and its type must be one the bus
+  can hash to a fixed-width key: `Int`, `Bool`, `Time`,
+  `Duration`, a no-payload enum, or `Decimal`. (Need a compound
+  key like `(symbol, venue)`? Pack it into one `Decimal` field
+  yourself.)
+- **`where key == EXPR`** on a subscribe filters that subscriber.
+  `EXPR` can be a literal, a `const`, or `self.<field>` — the
+  common case, one instance per shard.
+- The key is **captured by value when the locus is constructed.**
+  Reassigning `self.symbol_id` later does *not* re-route the
+  subscription; to change shards, dissolve the locus and
+  instantiate a fresh one.
+
+### When nothing matches
+
+A keyed publish whose key matches no subscriber is governed by the
+topic's `on_unmatched:` policy:
+
+```hale
+topic Quote { payload: Tick; keyed_by symbol_id; on_unmatched: fallback; }
+```
+
+- **`swallow`** *(the default)* — the message is dropped silently.
+  Run with `LOTUS_BUS_LOG_UNMATCHED=1` to log drops while
+  debugging.
+- **`fail`** — the publish becomes fallible; every send site must
+  dispose of it: `Quote <- t or raise;` panics on an unmatched
+  key, `Quote <- t or discard;` swallows it. Use this when an
+  unrouted message is a bug, not an expected case.
+- **`fallback`** — an unmatched message is delivered to a
+  catch-all subscriber that opts in with `where key == _`. At
+  least one such subscriber must exist program-wide, or the topic
+  is rejected at compile time.
+
 Next: where loci actually run — [Concurrency &
 placement](./concurrency.md).

--- a/docs/src/services/concurrency.md
+++ b/docs/src/services/concurrency.md
@@ -24,6 +24,32 @@ third:
   to neighbors. For latency-critical or CPU-bound work that
   shouldn't share.
 
+## Long sleeps don't freeze the pool
+
+A cooperative pool runs one locus at a time, so a locus that sits
+in a long `time::sleep` could, in principle, starve every other
+locus sharing its pool — a 30-second keep-alive timer on the
+`main` pool would block bus handlers for 30 seconds. It doesn't.
+`std::time::sleep` slices any sleep into short intervals (≤100ms)
+and drains the pool's pending bus work between slices, so
+neighbors keep getting dispatched while one locus naps:
+
+```hale
+run() {
+    while true {
+        self.send_heartbeat();
+        std::time::sleep(30s);   // sliced — co-resident handlers
+                                 // still fire every ≤100ms
+    }
+}
+```
+
+The sleeping locus still wakes after the full duration; it just
+doesn't hold the thread hostage in the meantime. You write
+`sleep(30s)` and the slicing is invisible — there's nothing to
+opt into. (A `pinned` locus owns its thread, so its sleeps affect
+no one and aren't sliced.)
+
 ## Placement lives on `main`
 
 You declare placement once, against the top-level loci, in


### PR DESCRIPTION
## Why

App teams keep hitting embarrassing-but-simple runtime bugs — leaks, missed wakeups — at *feature intersections*. The root cause is a coverage gap: the broad example corpus is parse-tested, type-checked, and **interpreter**-run (exit-0 only), but the interpreter has no arenas/pools/coros, so it structurally can't reproduce the substrate bugs. The compiled native path had only bespoke one-off tests, none under leak/UAF/hang oracles.

This closes that gap and fixes everything the new oracle found on its first run.

## The harness — `crates/hale-codegen/tests/corpus_oracle.rs`

Compiles **every** runnable fixture to a native binary and runs it under:
- **exit oracle** — expected exit code (SIGSEGV/SIGABRT shutdown crash fails here)
- **deadline oracle** — terminates within budget (cross-pool starvation / missed wakeup fails here)
- **sanitizer oracle** — AddressSanitizer + LeakSanitizer (leak/UAF/overflow)

Fixtures are auto-discovered (new examples covered for free). The plain exit+deadline arm runs in the normal CI partitions; the ASAN arm is opt-in (`LOTUS_ASAN=1`, `#[ignore]`) with a dedicated `asan` CI job mirroring the existing `tsan` job. `KNOWN_CLOSURE_LEAKS` is **empty** — any new leak/UAF/overflow hard-fails. It also surfaces (as a non-failing warning) 3 fixtures that the interpreter runs but codegen can't compile yet (`43-enums`, `45-enum-payloads`, `47-fn-arenas-extras`).

## Plumbing
- `codegen.rs`: `LOTUS_ASAN=1` → `-fsanitize=address` on the runtime C + emitted binary (symmetric to the existing `LOTUS_TSAN` hook); skips the O2 module pipeline under ASAN so sanitizer frames are accurate.
- `.github/workflows/tests.yml`: new `asan (example corpus)` job.

## Leaks fixed (all found by the oracle)

1. **Quarantine-skip method-scratch leak** (`method.rs`, `codegen.rs`). A subscribed handler opens a method-scratch subregion at entry, but the quarantine entry-gate's early `return` bypassed `close_method_scratch` — leaking one subregion per delivery to an already-quarantined subscriber. Fixed by destroying the scratch on the skip path (`close_method_scratch` split into a state-clearing close + an emit-only destroy for diverging paths).

2. **Per-thread chunk-pool leak** (`lotus_arena.c`) — *the big one, general*. The `__thread` chunk pool (32×64KiB prefill) was never freed when a spawned worker thread (pinned locus thread / cooperative pool worker) exited; the pthread_key destructor only dumped stats. **Every exited worker leaked ~2MiB.** Fixed with a pool-freeing thread destructor armed for any thread that touches the pool. (Main thread excepted — its TLS stays reachable, so LSan only ever flagged workers.)

3. **Uninitialized `via_mmap` on prefill chunks** (`lotus_arena.c`) — *latent corruption*. Prefill malloc'd chunks but didn't initialize `via_mmap`/`mmap_size` (both other chunk-creation paths do). A pooled prefill chunk later released took `release_chunk`'s `munmap` branch on a garbage flag → neither freed nor re-pooled. Fixed by zero-initializing in prefill.

## Docs (same session, bundled per request)
- `concurrency.md`: restored the `time::sleep` ≤100ms slicing note dropped in the docs restructure.
- `bus.md`: added the routing-keys teaching section (`keyed_by` / `where key ==` / `on_unmatched`).

## Verification
- ASAN corpus: **fully green, empty quarantine** — all runnable fixtures clean under ASan+LSan.
- Plain corpus + `method_scratch_reclaim`, `reclamation_spine`, `release_reclaims_flow`, `terminate_reclaims_child`, `coop_pool_multi_locus`, and the runtime examples: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)