### PR TITLE
fix(codegen): resolve enum names to Enum, not TypeRef

### DIFF
--- a/crates/hale-codegen/src/types/mod.rs
+++ b/crates/hale-codegen/src/types/mod.rs
@@ -59,6 +59,21 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     // own `declare_locus_struct` runs later in the
                     // same pass.
                     Ok(CodegenTy::LocusRef(name.clone()))
+                } else if self.user_enums.contains_key(name) {
+                    // Enums resolve to Enum(name) — BEFORE the
+                    // user_types/pending_type_names branch. An enum
+                    // name is also inserted into `pending_type_names`
+                    // by the forward-ref pre-pass, so if that branch
+                    // ran first a declared enum used in a type
+                    // annotation / param / return / match-scrutinee
+                    // would mis-resolve to TypeRef (generic
+                    // record-by-pointer), while enum *construction*
+                    // yields Enum — the representation mismatch made
+                    // the enum machinery unreachable from annotated
+                    // values (no-payload print, payload match, etc.).
+                    // user_enums is populated by the time lowering
+                    // resolves these, so checking it first is the fix.
+                    Ok(CodegenTy::Enum(name.clone()))
                 } else if self.user_types.contains_key(name)
                     || self.pending_type_names.contains(name)
                 {
@@ -78,8 +93,6 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     // that points at a not-yet-registered
                     // imported-lib type decl.
                     Ok(CodegenTy::TypeRef(name.clone()))
-                } else if self.user_enums.contains_key(name) {
-                    Ok(CodegenTy::Enum(name.clone()))
                 } else if self.user_interfaces.contains(name) {
                     // F.20 Phase B: interface type in signature
                     // position. Lowered as a fat pointer (data +
@@ -134,6 +147,15 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     || self.pending_locus_names.contains(mangled)
                 {
                     Ok(CodegenTy::LocusRef(mangled.to_string()))
+                } else if self.user_enums.contains_key(mangled) {
+                    // Path-qualified enum (e.g. a cross-seed
+                    // `lib::Result`). Checked before the
+                    // user_types/pending_type_names branch for the
+                    // same reason as the single-segment case — enum
+                    // names also land in pending_type_names, and an
+                    // enum must resolve to Enum(name) so its value
+                    // representation matches construction.
+                    Ok(CodegenTy::Enum(mangled.to_string()))
                 } else if self.user_types.contains_key(mangled)
                     || self.pending_type_names.contains(mangled)
                 {

--- a/crates/hale-codegen/tests/corpus_oracle.rs
+++ b/crates/hale-codegen/tests/corpus_oracle.rs
@@ -74,6 +74,29 @@ fn leak_exempt(name: &str) -> bool {
     name == "03c-closure-bubbled"
 }
 
+/// Fixtures that the interpreter runs but codegen can't compile YET,
+/// acknowledged as interpreter-only rather than treated as a gap to
+/// chase right now. This is regression protection in both
+/// directions:
+///   * an uncompilable fixture NOT in this set is a hard failure —
+///     something that used to compile regressed, or a new fixture
+///     uses an unsupported feature without a decision being made;
+///   * a fixture IN this set that now COMPILES is also a hard
+///     failure — the list is stale and must shrink. So when the
+///     codegen gap is closed, the gate tells you to remove it here.
+///
+/// Empty — codegen compiles the whole runnable corpus. The three
+/// former entries (`43-enums`, `45-enum-payloads`,
+/// `47-fn-arenas-extras`) were fixed 2026-06-02 by a one-branch
+/// reorder in `type_expr_to_codegen_ty`: enum names now resolve to
+/// `CodegenTy::Enum` before the `pending_type_names` forward-ref
+/// branch, so annotated enum values get the same representation as
+/// constructed ones and the already-built enum machinery (no-payload
+/// print, payload construction/match/deep-copy) became reachable.
+/// The guard remains: any uncompilable fixture is now a hard
+/// failure unless deliberately listed here.
+const EXPECTED_INTERPRETER_ONLY: &[&str] = &[];
+
 /// KNOWN, TRACKED leak the ASAN oracle still flags. Quarantined so
 /// the gate is green on the KNOWN state — but a leak in ANY fixture
 /// outside this set is a hard failure, and a fixture that stops
@@ -271,12 +294,31 @@ fn check_fixture(name: &str, main_hl: &Path, deadline: Duration) -> Outcome {
     bin.push(format!("lotus_corpus_{}_{}", name.replace(['/', '-'], "_"), std::process::id()));
     if let Err(e) = build_executable(&program, &bin) {
         let msg = format!("{e:?}");
-        // A codegen feature gap (interpreter-only fixture) is a
-        // skip; any other build error is a real regression.
+        // A codegen feature gap is ACKNOWLEDGED only when the fixture
+        // is on the interpreter-only list; otherwise it's a
+        // regression (something stopped compiling, or a new fixture
+        // hit an unsupported feature with no decision made).
         if msg.contains("Unsupported(") {
-            return Outcome::Uncompilable(msg);
+            if EXPECTED_INTERPRETER_ONLY.contains(&name) {
+                return Outcome::Uncompilable(msg);
+            }
+            return Outcome::Fail(format!(
+                "UNEXPECTED uncompilable: {msg}\n    (implement the codegen, or \
+                 add to EXPECTED_INTERPRETER_ONLY if interpreter-only is intended)"
+            ));
         }
         return Outcome::Fail(format!("build: {msg}"));
+    }
+
+    // It compiled. If it's still on the interpreter-only list, the
+    // list is stale — fail so the entry gets removed now the gap is
+    // closed (keeps the list honest as codegen catches up).
+    if EXPECTED_INTERPRETER_ONLY.contains(&name) {
+        let _ = std::fs::remove_file(&bin);
+        return Outcome::Fail(format!(
+            "`{name}` is in EXPECTED_INTERPRETER_ONLY but now COMPILES — \
+             remove it from that list (the codegen gap is closed)"
+        ));
     }
 
     let result = run_with_deadline(&bin, deadline);
@@ -383,13 +425,14 @@ fn report(
         Vec<(String, String)>,
     ),
 ) {
-    // Surface the interpreter/codegen divergence as a warning —
-    // not a hard failure (the run oracles are this gate's job),
-    // but loud enough that the gap doesn't stay hidden.
+    // Acknowledged interpreter-only fixtures (EXPECTED_INTERPRETER_ONLY).
+    // Not a failure — the divergence is a known, tracked codegen gap —
+    // but surfaced so it stays visible. (An UNEXPECTED uncompilable
+    // is a hard failure in check_fixture, and a listed fixture that
+    // starts compiling also fails, so this list can't silently drift.)
     if !uncompilable.is_empty() {
         eprintln!(
-            "\n⚠ {} fixture(s) compile under the interpreter but NOT codegen \
-             (excluded from run oracles):",
+            "\nℹ {} fixture(s) acknowledged interpreter-only (codegen gap, tracked):",
             uncompilable.len()
         );
         for (name, reason) in &uncompilable {


### PR DESCRIPTION
## What

Enum names in a **type-annotation / param / return / `match`-scrutinee** position resolved to `CodegenTy::TypeRef(name)` (the generic record-by-pointer kind) instead of `CodegenTy::Enum(name)` — while enum **construction** (`Light::Red`, `Result::Ok(42)`) produced `Enum`. That representation mismatch left annotated enum values physically wrong for the enum machinery, which was **already fully built** (no-payload tag print, payload construction / match-unpack / return deep-copy / equality) but unreachable.

## Root cause

In `type_expr_to_codegen_ty`, the `user_types || pending_type_names → TypeRef` branch ran **before** the `user_enums → Enum` branch. The forward-ref pre-pass inserts every type-decl name — enums included — into `pending_type_names`, so that branch always won for enums.

**Fix:** check `user_enums` first (it's populated by the time lowering resolves these). Applied to both the single-segment branch and the path-qualified branch (the latter had no enum case at all, so a cross-seed `lib::Enum` would error). One-branch reorder; no new codegen.

## Effect

The three fixtures the compiled-corpus oracle flagged as interpreter-only now compile and produce **byte-identical output to the interpreter**:
- `43-enums` — `println` of a no-payload enum
- `45-enum-payloads` — payload construction + `match` unpack + equality + print
- `47-fn-arenas-extras` — payload-enum return deep-copy

This also advances the larger goal: with codegen reaching parity, `EXPECTED_INTERPRETER_ONLY` in the corpus oracle is now **empty**, and its guard is bidirectional — any uncompilable fixture is a hard failure unless explicitly listed, and a listed fixture that *starts* compiling also fails (the list can't silently drift). That's the parity meter for eventually retiring the interpreter.

## Verification
- `43`/`45`/`47`: compiled output `diff`-clean against the interpreter.
- Full corpus: compiles + runs under both the plain (exit/deadline) and ASAN (leak/UAF) oracles — empty uncompilable, no leaks.
- `hale-codegen` + `hale-types` + `hale-runtime` suites: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)