### PR TITLE
typecheck: reject a dead bus receiver (non-main cooperative subscriber)

### DIFF
--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -2730,6 +2730,84 @@ impl<'a> Checker<'a> {
                     ));
                 }
             }
+            // Dead bus receiver (fathom handoff 2026-06-02): a locus
+            // that subscribes to the bus but is placed
+            // `cooperative(pool = X)` with X != main never receives a
+            // cell. Inbound dispatch reaches a locus only if it is
+            // cooperative on `main` (its cell lands on the global
+            // queue that main's sliced keep-alive sleep drains) or
+            // `pinned` (its subscribe registration carries a per-locus
+            // mailbox the pinned thread drains at sleep/yield). A
+            // non-main cooperative locus is in neither bucket, so its
+            // handlers silently never fire. Placement and
+            // subscriptions are both static, so reject this at compile
+            // time rather than letting it compile clean and do
+            // nothing (this cost a downstream team most of a day).
+            //
+            // Spared: a subscription to a topic this locus ALSO
+            // publishes — an intra-locus self-publish→self-subscribe
+            // is devirtualized to a direct `self.handler(...)` call
+            // (same instance, same thread), which delivers on any
+            // pool. Rejecting it would be a false positive.
+            if let PlacementSpec::Cooperative { pool } = &entry.spec {
+                let pool_name = pool
+                    .as_ref()
+                    .map(|i| i.name.clone())
+                    .unwrap_or_else(|| "main".to_string());
+                if pool_name != "main" {
+                    let dead: Option<Vec<String>> = match &param.ty {
+                        Ty::Named(lname) => match self.top.lookup(lname) {
+                            Some(TopSymbol::Locus(li)) => {
+                                let published: BTreeSet<&str> = li
+                                    .bus_publishes
+                                    .iter()
+                                    .map(|p| p.subject.as_str())
+                                    .collect();
+                                let handlers: Vec<String> = li
+                                    .bus_subscribes
+                                    .iter()
+                                    .filter(|s| {
+                                        !published.contains(s.subject.as_str())
+                                    })
+                                    .map(|s| s.handler.clone())
+                                    .collect();
+                                if handlers.is_empty() {
+                                    None
+                                } else {
+                                    Some(handlers)
+                                }
+                            }
+                            _ => None,
+                        },
+                        _ => None,
+                    };
+                    if let Some(handlers) = dead {
+                        let plural = handlers.len() > 1;
+                        self.diags.push(Diag::ty(
+                            entry.span,
+                            format!(
+                                "locus `{}` (field `{}`) subscribes to bus \
+                                 topics but is placed `cooperative(pool = \
+                                 {})`. Only main-pool-cooperative or pinned \
+                                 loci receive bus cells, so {} ({}) will \
+                                 never fire. Use `pinned` (recommended for \
+                                 blocking I/O) or place the field on the \
+                                 `main` pool.",
+                                param.ty.display(),
+                                entry.field.name,
+                                pool_name,
+                                if plural {
+                                    "these handlers"
+                                } else {
+                                    "this handler"
+                                },
+                                handlers.join(", "),
+                            ),
+                        ));
+                    }
+                }
+            }
+
             // F.35: per-entry constraint validity.
             for c in &entry.constraints {
                 match c.kind {

--- a/crates/hale-types/tests/placement.rs
+++ b/crates/hale-types/tests/placement.rs
@@ -558,3 +558,132 @@ fn main() { App { }; }
         combined
     );
 }
+
+// ---------------------------------------------------------------
+// Dead bus receiver (fathom handoff 2026-06-02): a locus that
+// subscribes to the bus but is placed cooperative on a non-main
+// pool never receives a cell — only main-cooperative or pinned
+// loci get delivery. The toolchain used to accept it silently.
+// These lock in the diagnostic and its precision (no false
+// positives on pinned / main / non-subscribing / intra-locus).
+// ---------------------------------------------------------------
+
+const DEAD_RX: &str = "will never fire";
+
+fn dead_receiver_src(placement_spec: &str) -> String {
+    format!(
+        r#"
+type Tick {{ n: Int; }}
+
+locus Gateway {{
+    bus {{ subscribe "tick" as on_tick of type Tick; }}
+    fn on_tick(t: Tick) {{ }}
+    run() {{ }}
+}}
+
+locus Feed {{
+    bus {{ publish "tick" of type Tick; }}
+    run() {{ "tick" <- Tick {{ n: 1 }}; }}
+}}
+
+main locus App {{
+    params {{
+        gw: Gateway = Gateway {{ }};
+        feed: Feed  = Feed {{ }};
+    }}
+    placement {{
+        gw: {placement_spec};
+    }}
+}}
+
+fn main() {{ App {{ }}; }}
+"#
+    )
+}
+
+#[test]
+fn cooperative_nonmain_subscriber_rejected() {
+    let msgs = check(&dead_receiver_src("cooperative(pool = ws)"));
+    assert!(
+        msgs.iter().any(|m| m.contains(DEAD_RX)),
+        "expected dead-bus-receiver diagnostic for a non-main cooperative \
+         subscriber; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn pinned_subscriber_not_rejected() {
+    let msgs = check(&dead_receiver_src("pinned"));
+    assert!(
+        !msgs.iter().any(|m| m.contains(DEAD_RX)),
+        "pinned subscribers receive bus cells (per-locus mailbox); must not \
+         be flagged: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn main_cooperative_subscriber_not_rejected() {
+    let msgs = check(&dead_receiver_src("cooperative(pool = main)"));
+    assert!(
+        !msgs.iter().any(|m| m.contains(DEAD_RX)),
+        "main-pool cooperative subscribers receive bus cells; must not be \
+         flagged: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn cooperative_nonmain_nonsubscriber_not_rejected() {
+    // A non-main cooperative locus that does NOT subscribe is fine.
+    let src = r#"
+locus Worker { run() { } }
+
+main locus App {
+    params { w: Worker = Worker { }; }
+    placement { w: cooperative(pool = compute); }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        !msgs.iter().any(|m| m.contains(DEAD_RX)),
+        "a non-subscribing locus must not be flagged regardless of pool: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn intra_locus_self_pub_sub_not_rejected() {
+    // Publishes AND subscribes the same topic itself → the intra-locus
+    // optimization devirtualizes it to a direct self.handler() call,
+    // which delivers on any pool. Flagging it would be a false positive.
+    let src = r#"
+type Ev { n: Int; }
+
+locus SelfLoop {
+    bus {
+        publish   "ev" of type Ev;
+        subscribe "ev" as on_ev of type Ev;
+    }
+    fn on_ev(e: Ev) { }
+    run() { "ev" <- Ev { n: 1 }; }
+}
+
+main locus App {
+    params { s: SelfLoop = SelfLoop { }; }
+    placement { s: cooperative(pool = ws); }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        !msgs.iter().any(|m| m.contains(DEAD_RX)),
+        "intra-locus self-publish→self-subscribe is devirtualized and \
+         delivers on any pool; must not be flagged: {:?}",
+        msgs
+    );
+}


### PR DESCRIPTION
Closes the headline ask in fathom's `handoff-compiler-pinned-mdgw-bus-receipt-2026-06-02.md`.

## Problem

A locus that declares `bus { subscribe ... }` but is placed `cooperative(pool = X)` with `X != main` **compiled cleanly and silently never received a single cell** — handlers never fired, no diagnostic at compile or run time. Fathom lost ~a day bisecting this.

## The delivery model (for the record)

Inbound bus dispatch reaches a locus **iff** it is:
- **cooperative on `main`** — its cell lands on the global queue that `main`'s sliced keep-alive `sleep` drains, or
- **`pinned`** — its subscribe registration carries a per-locus mailbox the pinned thread drains at `sleep`/`yield`.

A `cooperative(pool = X != main)` subscriber is in neither bucket → dead receiver.

## Fix

Placement and subscriptions are both statically known, so `check_placement_block` (hale-types) now rejects it with an actionable message:

> locus `Gateway` (field `gw`) subscribes to bus topics but is placed `cooperative(pool = ws)`. Only main-pool-cooperative or pinned loci receive bus cells, so this handler (on_tick) will never fire. Use `pinned` (recommended for blocking I/O) or place the field on the `main` pool.

`pinned` is the shape the spec already prescribes for blocking-I/O gateways.

## Precision (no false positives)

A subscription to a topic the locus **also publishes** is spared — an intra-locus self-publish→self-subscribe is devirtualized to a direct `self.handler()` call (same instance, same thread), which delivers on any pool. Pinned subscribers, main-pool subscribers, and non-subscribing loci are likewise untouched. Verified by dedicated tests + the full corpus typecheck.

## Tests

`hale-types/tests/placement.rs`: rejection fires for a non-main cooperative subscriber; **pinned / main / non-subscriber / intra-locus self-loop all spared**. Full hale-types suite green (208 tests, incl. `examples.rs` typechecking the whole corpus — confirms no over-firing). The runnable positive case (pinned subscriber receives) is already the `19-pinned-bus` corpus fixture.

## Scope note

This is the diagnostic ask (reject early). The deeper alternative — making non-main cooperative pools actually *deliver* bus cells — is a much larger runtime change and unnecessary given `pinned` is the prescribed shape; deferred unless the restriction proves limiting. The other 5 asks in the handoff (blocking-syscall warning, doc clarifications, async_io guidance) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)