### PR TITLE
typecheck: warn on a blocking syscall in a cooperative-pool run()

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -806,7 +806,10 @@ fn run_check(target: &Path) -> ExitCode {
         for d in &diags {
             eprintln!("{}", d.render(any_source));
         }
-        return ExitCode::from(1);
+        // Warnings print but don't fail the build; only errors do.
+        if diags.iter().any(|d| d.is_error()) {
+            return ExitCode::from(1);
+        }
     }
     eprintln!("ok: {} file(s) typechecked", files.len());
     ExitCode::SUCCESS
@@ -845,7 +848,10 @@ fn run_program(target: &Path) -> ExitCode {
             for d in &diags {
                 eprintln!("{}", d.render(any_source));
             }
-            return ExitCode::from(1);
+            // Warnings print but don't fail the build; only errors do.
+            if diags.iter().any(|d| d.is_error()) {
+                return ExitCode::from(1);
+            }
         }
         let prog_refs: Vec<&Program> = vec![&program];
         return match hale_runtime::run_bundle(&prog_refs) {
@@ -884,7 +890,10 @@ fn run_program(target: &Path) -> ExitCode {
         for d in &diags {
             eprintln!("{}", d.render(any_source));
         }
-        return ExitCode::from(1);
+        // Warnings print but don't fail the build; only errors do.
+        if diags.iter().any(|d| d.is_error()) {
+            return ExitCode::from(1);
+        }
     }
 
     let prog_refs: Vec<&Program> = programs.values().collect();
@@ -1074,7 +1083,10 @@ fn run_build(target: &Path) -> ExitCode {
         for d in &diags {
             eprintln!("{}", d.render(any_source));
         }
-        return ExitCode::from(1);
+        // Warnings print but don't fail the build; only errors do.
+        if diags.iter().any(|d| d.is_error()) {
+            return ExitCode::from(1);
+        }
     }
     let mut options = match parse_build_options() {
         Ok(o) => o,

--- a/crates/hale-syntax/src/error.rs
+++ b/crates/hale-syntax/src/error.rs
@@ -17,6 +17,12 @@ pub enum DiagKind {
     Parse,
     /// Type-checker errors.
     Type,
+    /// Non-fatal advisories — the program still compiles. The first
+    /// is the blocking-syscall-on-a-cooperative-pool smell: legal,
+    /// but it stalls co-scheduled loci, so it's surfaced rather than
+    /// rejected (cf. the hard `Type` errors for genuinely-broken
+    /// shapes). Build gates fail only on `is_error()` diagnostics.
+    Warn,
 }
 
 impl Diag {
@@ -44,12 +50,29 @@ impl Diag {
         }
     }
 
+    /// A non-fatal advisory (see `DiagKind::Warn`). Surfaced to the
+    /// user but does NOT fail the build.
+    pub fn warn(span: Span, msg: impl Into<String>) -> Self {
+        Diag {
+            kind: DiagKind::Warn,
+            span,
+            message: msg.into(),
+        }
+    }
+
+    /// True for diagnostics that should fail a build. Warnings are
+    /// printed but non-fatal; everything else is an error.
+    pub fn is_error(&self) -> bool {
+        !matches!(self.kind, DiagKind::Warn)
+    }
+
     pub fn render(&self, source: &str) -> String {
         let (line, col) = self.span.line_col(source);
         let kind = match self.kind {
             DiagKind::Lex => "lex error",
             DiagKind::Parse => "parse error",
             DiagKind::Type => "type error",
+            DiagKind::Warn => "warning",
         };
         format!("{}:{}: {}: {}", line, col, kind, self.message)
     }

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -197,6 +197,7 @@ pub fn check_bundle(
     // sibling-in-main + placement fix. See `spec/runtime.md §
     // Long-running cooperative children`.
     check_nested_long_running_child(bundle, &mut diags);
+    check_blocking_on_cooperative_pool(bundle, &mut diags);
     // 2026-05-29: a bus-subscribing locus instantiated non-owned
     // inside another locus's method/handler body dissolves at that
     // method's scope exit, so its subscription can never fire.
@@ -483,6 +484,240 @@ fn locus_has_nontrivial_run(l: &LocusDecl) -> bool {
         }) => !body.stmts.is_empty(),
         _ => false,
     })
+}
+
+/// Stdlib path calls that block the calling OS thread until the I/O
+/// completes. A cooperative (non-`async_io`) locus that runs one in
+/// its `run()` loop holds the pool's thread for the call's whole
+/// duration — stalling every other locus scheduled on that pool and
+/// the pool's bus drain. (`async_io` parks instead of blocking;
+/// `pinned` owns its own thread.) Best-effort, direct-path-call form
+/// only: blocking via a method on a stdlib handle (`stream.recv(...)`)
+/// or through a helper fn isn't traced — this is a warning, so the
+/// incompleteness is acceptable.
+const BLOCKING_STDLIB_PATHS: &[&[&str]] = &[
+    &["std", "io", "tcp", "recv_into"],
+    &["std", "io", "tcp", "__recv"],
+    &["std", "io", "tcp", "__recv_bytes"],
+    &["std", "io", "tcp", "__accept_one"],
+    &["std", "io", "tls", "recv_into"],
+    &["std", "io", "tls", "recv_bytes"],
+    &["std", "process", "run"],
+    &["std", "process", "wait"],
+    &["std", "process", "__wait_pid"],
+];
+
+fn blocking_path_match(segs: &[&str]) -> Option<String> {
+    BLOCKING_STDLIB_PATHS
+        .iter()
+        .find(|p| **p == segs)
+        .map(|p| p.join("::"))
+}
+
+fn find_blocking_in_block(block: &Block) -> Option<(String, Span)> {
+    block.stmts.iter().find_map(find_blocking_in_stmt)
+}
+
+fn find_blocking_in_stmt(stmt: &Stmt) -> Option<(String, Span)> {
+    match stmt {
+        Stmt::Let { value, .. } | Stmt::LetTuple { value, .. } => {
+            find_blocking_in_expr(value)
+        }
+        Stmt::Assign { value, .. } => find_blocking_in_expr(value),
+        Stmt::Send { subject, value, .. } => {
+            find_blocking_in_expr(subject).or_else(|| find_blocking_in_expr(value))
+        }
+        Stmt::Return(Some(e), _) => find_blocking_in_expr(e),
+        Stmt::Fail { value, .. } => find_blocking_in_expr(value),
+        Stmt::Violate { payload: Some(e), .. } => find_blocking_in_expr(e),
+        Stmt::Recovery { args, .. } => args.iter().find_map(find_blocking_in_expr),
+        Stmt::Expr(e) => find_blocking_in_expr(e),
+        Stmt::If(i) => find_blocking_in_if(i),
+        Stmt::Match(m) => find_blocking_in_match(m),
+        Stmt::For { iter, body, .. } => {
+            find_blocking_in_expr(iter).or_else(|| find_blocking_in_block(body))
+        }
+        Stmt::While { cond, body, .. } => {
+            find_blocking_in_expr(cond).or_else(|| find_blocking_in_block(body))
+        }
+        Stmt::Block(b) => find_blocking_in_block(b),
+        _ => None,
+    }
+}
+
+fn find_blocking_in_if(i: &IfStmt) -> Option<(String, Span)> {
+    find_blocking_in_expr(&i.cond)
+        .or_else(|| find_blocking_in_block(&i.then_block))
+        .or_else(|| match i.else_block.as_deref() {
+            Some(ElseBranch::Else(b)) => find_blocking_in_block(b),
+            Some(ElseBranch::ElseIf(n)) => find_blocking_in_if(n),
+            None => None,
+        })
+}
+
+fn find_blocking_in_match(m: &MatchStmt) -> Option<(String, Span)> {
+    find_blocking_in_expr(&m.scrutinee).or_else(|| {
+        m.arms.iter().find_map(|arm| {
+            arm.guard
+                .as_ref()
+                .and_then(find_blocking_in_expr)
+                .or_else(|| match &arm.body {
+                    MatchArmBody::Expr(e) => find_blocking_in_expr(e),
+                    MatchArmBody::Block(b) => find_blocking_in_block(b),
+                })
+        })
+    })
+}
+
+fn find_blocking_in_expr(expr: &Expr) -> Option<(String, Span)> {
+    match expr {
+        Expr::Call { callee, args, span } => {
+            if let Expr::Path(qn) = callee.as_ref() {
+                let segs: Vec<&str> =
+                    qn.segments.iter().map(|s| s.name.as_str()).collect();
+                if let Some(name) = blocking_path_match(&segs) {
+                    return Some((name, *span));
+                }
+            }
+            find_blocking_in_expr(callee)
+                .or_else(|| args.iter().find_map(find_blocking_in_expr))
+        }
+        Expr::Binary { left, right, .. } => {
+            find_blocking_in_expr(left).or_else(|| find_blocking_in_expr(right))
+        }
+        Expr::Unary { operand, .. } => find_blocking_in_expr(operand),
+        Expr::Field { receiver, .. } | Expr::Path2 { receiver, .. } => {
+            find_blocking_in_expr(receiver)
+        }
+        Expr::Index { receiver, index, .. } => {
+            find_blocking_in_expr(receiver).or_else(|| find_blocking_in_expr(index))
+        }
+        Expr::Tuple(es, _) | Expr::Array(es, _) => {
+            es.iter().find_map(find_blocking_in_expr)
+        }
+        Expr::Struct { inits, .. } => {
+            inits.iter().find_map(|i| find_blocking_in_expr(&i.value))
+        }
+        Expr::Block(b) => find_blocking_in_block(b),
+        Expr::If(i) => find_blocking_in_if(i),
+        Expr::Match(m) => find_blocking_in_match(m),
+        Expr::Sum(e, _) | Expr::Prod(e, _) => find_blocking_in_expr(e),
+        Expr::Or { inner, disposition, .. } => find_blocking_in_expr(inner)
+            .or_else(|| match disposition {
+                OrDisposition::Substitute(e) | OrDisposition::Fail(e, _) => {
+                    find_blocking_in_expr(e)
+                }
+                _ => None,
+            }),
+        _ => None,
+    }
+}
+
+/// Warn when a locus placed `cooperative(pool = X)` without
+/// `where async_io` calls a known-blocking stdlib op in its `run()`.
+/// Such a call holds the pool's OS thread, starving co-scheduled loci
+/// (this silently bricked a downstream team's metrics server when a
+/// blocking gateway was moved onto a shared pool). A warning, not an
+/// error — a single-purpose blocking server with nothing co-scheduled
+/// is legitimate; the smell is real but situational.
+fn check_blocking_on_cooperative_pool(
+    bundle: &Bundle<'_>,
+    diags: &mut Vec<Diag>,
+) {
+    let mut local_loci: BTreeMap<&str, &LocusDecl> = BTreeMap::new();
+    for program in bundle.programs.values() {
+        for item in &program.items {
+            if let TopDecl::Locus(l) = item {
+                local_loci.insert(l.name.name.as_str(), l);
+            }
+        }
+    }
+
+    for program in bundle.programs.values() {
+        for item in &program.items {
+            let TopDecl::Locus(main) = item else { continue };
+            if !main.is_main {
+                continue;
+            }
+            let Some(pb) = main.members.iter().find_map(|m| match m {
+                LocusMember::Placement(pb) => Some(pb),
+                _ => None,
+            }) else {
+                continue;
+            };
+            // field name -> single-segment locus type name.
+            let mut field_locus: BTreeMap<&str, &str> = BTreeMap::new();
+            for m in &main.members {
+                let LocusMember::Params(params) = m else { continue };
+                for pd in &params.params {
+                    if let Some(TypeExpr::Named { path, .. }) = &pd.ty {
+                        if path.segments.len() == 1 {
+                            field_locus.insert(
+                                pd.name.name.as_str(),
+                                path.segments[0].name.as_str(),
+                            );
+                        }
+                    }
+                }
+            }
+
+            for entry in &pb.entries {
+                let PlacementSpec::Cooperative { pool } = &entry.spec else {
+                    continue;
+                };
+                // `where async_io` parks blocking I/O — not a stall.
+                if entry
+                    .constraints
+                    .iter()
+                    .any(|c| matches!(c.kind, PlacementConstraint::AsyncIo))
+                {
+                    continue;
+                }
+                let Some(locus_name) = field_locus.get(entry.field.name.as_str())
+                else {
+                    continue;
+                };
+                let Some(decl) = local_loci.get(locus_name) else {
+                    continue;
+                };
+                let Some(run_body) = decl.members.iter().find_map(|m| match m {
+                    LocusMember::Lifecycle(LifecycleDecl {
+                        kind: LifecycleKind::Run,
+                        body,
+                        ..
+                    }) => Some(body),
+                    _ => None,
+                }) else {
+                    continue;
+                };
+                if let Some((call, span)) = find_blocking_in_block(run_body) {
+                    let pool_name = pool
+                        .as_ref()
+                        .map(|i| i.name.as_str())
+                        .unwrap_or("main");
+                    diags.push(Diag::warn(
+                        span,
+                        format!(
+                            "locus `{}` (field `{}`) is placed `cooperative(pool \
+                             = {})` and calls the blocking `{}` in its `run()`. A \
+                             blocking call holds the pool's OS thread for its whole \
+                             duration, stalling every other locus scheduled on `{}` \
+                             (and the pool's bus drain). Use `pinned` (its own \
+                             thread — the prescribed shape for blocking I/O), or \
+                             `cooperative(pool = {}) where async_io` (which parks on \
+                             I/O readiness instead of blocking the thread).",
+                            locus_name,
+                            entry.field.name,
+                            pool_name,
+                            call,
+                            pool_name,
+                            pool_name,
+                        ),
+                    ));
+                }
+            }
+        }
+    }
 }
 
 fn check_nested_long_running_child(

--- a/crates/hale-types/tests/examples.rs
+++ b/crates/hale-types/tests/examples.rs
@@ -162,14 +162,19 @@ fn all_examples_parse_and_check() {
                 programs: bundle_programs,
             };
             let diags = check_bundle(&bundle);
-            if !diags.is_empty() {
+            // Warnings (e.g. blocking-syscall-on-cooperative-pool) are
+            // advisory and don't fail the corpus typecheck — only
+            // errors do.
+            let errs: Vec<_> =
+                diags.iter().filter(|d| d.is_error()).cloned().collect();
+            if !errs.is_empty() {
                 let source_refs: BTreeMap<String, &str> =
                     sources.iter().map(|(k, v)| (k.clone(), v.as_str())).collect();
                 failures.push(format!(
                     "[{}] bundle {} type errors:\n  {}",
                     project_label,
                     label,
-                    render_diags(&diags, &source_refs)
+                    render_diags(&errs, &source_refs)
                 ));
             }
         }

--- a/crates/hale-types/tests/placement.rs
+++ b/crates/hale-types/tests/placement.rs
@@ -687,3 +687,94 @@ fn main() { App { }; }
         msgs
     );
 }
+
+// ---------------------------------------------------------------
+// Blocking-syscall-on-a-cooperative-pool (fathom handoff #2). A
+// cooperative (non-async_io) locus that calls a known-blocking
+// stdlib op in run() stalls co-scheduled loci. hale's first
+// WARNING (non-fatal) — a single-purpose blocking server is
+// legitimate, so it's surfaced, not rejected.
+// ---------------------------------------------------------------
+
+const BLOCKS_WARN: &str = "holds the pool's OS thread";
+
+fn blocking_src(placement_spec: &str, run_body: &str) -> String {
+    format!(
+        r#"
+locus Gateway {{
+    run() {{ {run_body} }}
+}}
+
+main locus App {{
+    params {{ gw: Gateway = Gateway {{ }}; }}
+    placement {{ gw: {placement_spec}; }}
+}}
+
+fn main() {{ App {{ }}; }}
+"#
+    )
+}
+
+#[test]
+fn cooperative_blocking_run_warns() {
+    let msgs = check(&blocking_src(
+        "cooperative(pool = ws)",
+        "let n = std::io::tls::recv_into(0, 0, 64);",
+    ));
+    assert!(
+        msgs.iter().any(|m| m.contains(BLOCKS_WARN)),
+        "expected a blocking-on-cooperative-pool warning; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn pinned_blocking_run_not_warned() {
+    let msgs = check(&blocking_src(
+        "pinned",
+        "let n = std::io::tls::recv_into(0, 0, 64);",
+    ));
+    assert!(
+        !msgs.iter().any(|m| m.contains(BLOCKS_WARN)),
+        "pinned owns its own thread; blocking is fine: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn async_io_blocking_run_not_warned() {
+    let msgs = check(&blocking_src(
+        "cooperative(pool = ws) where async_io",
+        "let n = std::io::tls::recv_into(0, 0, 64);",
+    ));
+    assert!(
+        !msgs.iter().any(|m| m.contains(BLOCKS_WARN)),
+        "async_io parks on I/O readiness; must not warn: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn cooperative_nonblocking_run_not_warned() {
+    let msgs = check(&blocking_src("cooperative(pool = ws)", "let x = 1 + 1;"));
+    assert!(
+        !msgs.iter().any(|m| m.contains(BLOCKS_WARN)),
+        "no blocking call in run(); must not warn: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn blocking_inside_while_loop_warns() {
+    // The blocking call is nested in `while true { ... }` — exercises
+    // the full-recursion walk into loop bodies.
+    let msgs = check(&blocking_src(
+        "cooperative(pool = ws)",
+        "while true { let n = std::io::tls::recv_into(0, 0, 64); }",
+    ));
+    assert!(
+        msgs.iter().any(|m| m.contains(BLOCKS_WARN)),
+        "a blocking call inside a loop in run() must warn: {:?}",
+        msgs
+    );
+}

--- a/docs/src/services/concurrency.md
+++ b/docs/src/services/concurrency.md
@@ -128,5 +128,24 @@ same call either way; the substrate picks the parking lowering at
 the syscall boundary. This is how you get async-style throughput
 without async-style function coloring.
 
+## The compiler checks your placement
+
+Two placement mistakes are caught for you, because both the
+placement and the locus's shape are known at compile time:
+
+- **A subscriber that can never be delivered to is an error.** A
+  locus with a `bus { subscribe ... }` placed `cooperative(pool =
+  X)` on a non-`main` pool would silently never receive a cell
+  (only main-cooperative and pinned loci get bus delivery). The
+  compiler rejects it and points you at `pinned` or the `main`
+  pool.
+- **A blocking call on a cooperative pool is a warning.** If a
+  cooperative locus's `run()` makes a blocking I/O call (a
+  blocking `recv`/`accept`, a subprocess `run`) and the pool
+  isn't `where async_io`, it would hold the pool's thread and
+  stall everything else scheduled there. The compiler warns and
+  suggests `pinned` (own thread) or `where async_io` (parks). For
+  blocking I/O gateways, `pinned` is the prescribed shape.
+
 Next: how loci nest and own each other — [Parents &
 children](./parents-children.md).

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1386,6 +1386,31 @@ main locus App {
    the named locus type. A locus that uses neither feature can
    be placed either cooperative or pinned at the deployment's
    discretion.
+7. **Dead bus receiver (error).** A locus that declares
+   `bus { subscribe ... }` but is placed `cooperative(pool = X)`
+   with `X != main` is rejected: inbound bus dispatch reaches a
+   locus only if it is cooperative on `main` (its cell lands on
+   the global queue that `main`'s sliced keep-alive sleep drains)
+   or `pinned` (its subscribe registration carries a per-locus
+   mailbox the pinned thread drains). A non-main cooperative
+   subscriber is in neither bucket — its handlers would silently
+   never fire. A subscription to a topic the locus also
+   *publishes* is spared (an intra-locus self-publish→subscribe
+   is devirtualized to a direct call, which delivers on any pool).
+8. **Blocking syscall on a cooperative pool (warning).** A locus
+   placed `cooperative(pool = X)` *without* `where async_io`
+   whose `run()` calls a known-blocking stdlib op (tcp/tls recv,
+   accept, `process::run`/`wait`) gets a **warning** (not an
+   error — hale's only non-fatal diagnostic). A blocking call
+   holds the pool's OS thread for its whole duration, stalling
+   every other locus scheduled on that pool and the pool's bus
+   drain. The fix is `pinned` (its own thread — the prescribed
+   shape for blocking I/O) or `cooperative(pool = X) where
+   async_io` (parks on I/O readiness). It is a warning rather
+   than an error because a single-purpose blocking server with
+   nothing co-scheduled is legitimate; detection is best-effort
+   (direct path-call form only — blocking via a handle method or
+   a helper fn isn't traced).
 
 ### Single-threaded-method invariant
 


### PR DESCRIPTION
Second of fathom's bus-receipt-handoff asks (after the dead-receiver error, #35), and **hale's first warning**.

## Problem

A locus placed `cooperative(pool = X)` whose `run()` calls a known-blocking stdlib op holds the pool's OS thread for the call's whole duration — stalling every other locus scheduled on that pool, plus the pool's bus drain. This silently bricked fathom's metrics server when a blocking gateway was moved onto a shared pool, with no diagnostic at the point of failure.

## Why a warning (not an error)

Unlike the dead-receiver (*always* a bug → error), blocking-on-cooperative is **situational** — a single-purpose blocking server with nothing co-scheduled is legitimate (e.g. the `http-hello` fixture's blocking accept on the default pool). So it's *surfaced*, not rejected. That required introducing hale's first non-fatal diagnostic.

## Warning infrastructure

`DiagKind::Warn` + `Diag::warn` + `Diag::is_error()` (hale-syntax). The build gates — the CLI typecheck paths and the corpus typecheck test — now fail only on `is_error()` diagnostics; warnings print but exit 0. Verified end-to-end:

```
$ hale check blocking.hl
2:21: warning: locus `Gateway` (field `gw`) is placed `cooperative(pool = ws)` and calls
the blocking `std::io::tls::recv_into` in its `run()`. ... Use `pinned` ... or
`cooperative(pool = ws) where async_io` ...
ok: 1 file(s) typechecked          # exit 0

$ hale check dead-receiver.hl
6:17: type error: ... will never fire ...   # exit 1
```

## The check

A sibling of `check_nested_long_running_child` (hale-types): for each main-locus `cooperative` placement entry **without** `where async_io`, resolve the field's locus and walk its `run()` body — full recursion into loops / `if` / `match` — for a direct call to a known-blocking stdlib path (`tcp`/`tls` recv, accept, `process::run`/`wait`). Gated precisely:
- **pinned** → no warning (owns its thread)
- **`where async_io`** → no warning (parks on I/O readiness)
- **non-blocking `run()`** → no warning

Best-effort by design: direct path-call form only — blocking via a handle method (`stream.recv(...)`) or through a helper fn isn't traced. Acceptable for a warning; the common direct forms (the fathom shape) are caught.

## Tests

`placement.rs`: warns for cooperative+blocking (including *inside a `while` loop* — exercises the recursive walk); spared for pinned / async_io / non-blocking. Full hale-types suite green; workspace builds (no `DiagKind` exhaustiveness breaks); corpus typecheck unaffected (warnings non-fatal there too).

Closes ask #2 of `handoff-compiler-pinned-mdgw-bus-receipt-2026-06-02.md`. (#3–6 — doc clarifications, `where async_io` message polish — remain.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)