### PR TITLE
docs+diag: close fathom bus-receipt handoff asks #3-6

### DIFF
--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -3128,7 +3128,14 @@ impl<'a> Checker<'a> {
                              none must; the pool's worker drain loop is \
                              one-or-the-other. (The pool first appeared at \
                              the entry whose I/O mode is the other; pick \
-                             one and apply consistently.)",
+                             one and apply consistently.)\n\nNote: \
+                             `where async_io` governs non-blocking I/O \
+                             readiness — it makes blocking `recv`/`accept`/\
+                             `send` park-and-resume instead of holding the \
+                             thread. It does NOT affect bus delivery or \
+                             handler dispatch; if a `subscribe` handler \
+                             isn't firing, `async_io` is not the fix (check \
+                             the locus's placement instead).",
                             entry.field.name, pool_name
                         ),
                     ));

--- a/docs/src/services/concurrency.md
+++ b/docs/src/services/concurrency.md
@@ -97,6 +97,31 @@ sibling in `main` and give it a placement entry. (This is the
 canonical fix for "my long-running child starved its parent" —
 make it a sibling, not a nested child.)
 
+This inheritance is also how you **co-locate work on a `pinned`
+thread**. There's no `pinned(pool = X)` for sharing a pinned
+thread — `pinned` owns its thread exclusively. So when a pinned
+locus needs helpers on its thread (counters, a metrics registry, a
+signal store — anything it calls directly), you *nest* them: make
+them `params` of the pinned locus, and they inherit its thread.
+Param defaults make this ergonomic — a default can itself
+instantiate the helper:
+
+```hale
+locus Gateway {              // placed pinned in main
+    params {
+        reg:   Registry = Registry { };
+        ticks: metrics::Counter = metrics::counter(self.reg, "ticks");
+    }
+    // run() calls self.ticks.inc() etc. — all on the pinned thread
+}
+```
+
+Hoisting them to siblings instead would put them on a *different*
+thread, and the gateway calling them directly would then be a
+cross-pool method call — which the compiler rejects (see below).
+Nesting is the supported pattern for "many loci, one pinned
+thread."
+
 ## The bus crosses threads for you
 
 When a cooperative locus on one pool publishes to a subscriber on
@@ -146,6 +171,22 @@ placement and the locus's shape are known at compile time:
   stall everything else scheduled there. The compiler warns and
   suggests `pinned` (own thread) or `where async_io` (parks). For
   blocking I/O gateways, `pinned` is the prescribed shape.
+
+It also enforces the **single-threaded-method invariant**: a locus's
+methods may only be called on the thread that owns its pool, so a
+*direct* method call across pools (`self.other.foo()` where `other`
+is placed on a different pool) is a compile error — it would run
+`other`'s method on the wrong thread.
+
+One escape is deliberately **not** traced: a call made through a
+*handler function pointer* rather than a direct method reference —
+the canonical case being a `std::http::Server` handler that reads a
+locus living on another pool. The static call-graph walk can't see
+through the pointer, so it's allowed. That's load-bearing (it's how
+a `/metrics` endpoint on the `io` pool reads a registry nested on a
+pinned gateway), but it's on *you* to keep that access safe —
+typically a read of stable, append-only state, not a mutation that
+would race the owning thread.
 
 Next: how loci nest and own each other — [Parents &
 children](./parents-children.md).

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -341,6 +341,17 @@ threads, pinned publishers via `lotus_bus_local_dispatch`, etc.
 The drain is idempotent, so existing code with `sleep; yield;`
 stays correct.
 
+**Scope: this delivery is `main`-pool only.** The queue drained
+here is the program-wide *cooperative* queue, drained on the `main`
+thread — so a cooperative subscriber receives cells via its sleep
+loop only when placed on the `main` pool. A subscriber placed
+`cooperative(pool = X)` with `X != main` is **not** reached by this
+drain (its handlers would silently never fire), which is why that
+placement is rejected at compile time — see the dead-bus-receiver
+rule under "Type-check rules" in `spec/semantics.md`. Pinned loci
+are a separate path: they drain their own per-locus mailbox at each
+`sleep`/`yield`, independent of the cooperative queue.
+
 **Long sleeps no longer starve main-pool handlers (2026-05-29).**
 Before the slicing, the drain happened only *after the whole sleep
 returned*, so the natural keep-alive idiom


### PR DESCRIPTION
The small follow-up cleanups after the dead-receiver error (#35) and the blocking-syscall warning (#38). Closes asks #3–6 of `handoff-compiler-pinned-mdgw-bus-receipt-2026-06-02.md` — doc + one diagnostic-message touch-up.

### #3 — sleep-drains-bus is `main`-only (`spec/runtime.md`)
The `time::sleep` drain section implied *any* cooperative subscriber that sleeps receives cells. Clarified: the queue drained is the program-wide *cooperative* queue, drained on `main`, so only **main-pool** cooperative loci get delivery this way — a non-main cooperative subscriber isn't reached (and is rejected by the dead-receiver rule). Pinned loci drain their own mailbox separately. (A non-main author read the old text and reasonably expected delivery — ~an hour lost.)

### #4 — `where async_io` is not a delivery fix (diagnostic message)
The mixed-I/O-modes diagnostic now spells out that `async_io` governs **non-blocking I/O readiness** (parking `recv`/`accept`/`send`), **not** bus delivery or handler dispatch — so a non-firing handler isn't an async_io problem. (The old message led to mechanically tagging ~30 entries chasing a non-issue.)

### #5 — pinned co-location pattern (`docs/services/concurrency.md`)
"Nested loci inherit their pool" now documents the supported way to put many loci on one pinned thread: **nest them as params** (pinned owns its thread; there's no `pinned(pool = X)` to share), with the `metrics::counter(self.reg, ...)` param-default idiom shown.

### #6 — the untraced handler-pointer escape (`docs/services/concurrency.md`)
The compiler-checks section now states the single-threaded-method invariant **and its one deliberate hole**: a cross-pool access through a handler function pointer (e.g. an http `Server` handler reading a locus on another pool) isn't statically traced — load-bearing, but the caller owns keeping that access safe.

## Verified
hale-types builds; placement suite (24) green; the codegen `placement_where_async_io` test still passes (it asserts the `mixed I/O modes` substring, which the appended note preserves); the mdBook builds.

This closes fathom handoff-1 end to end (#1 #35, #2 #38, #3–6 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)