### PR TITLE
typecheck: correct the dead-receiver check — require a blocking run()

### DIFF
--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -197,7 +197,7 @@ pub fn check_bundle(
     // sibling-in-main + placement fix. See `spec/runtime.md §
     // Long-running cooperative children`.
     check_nested_long_running_child(bundle, &mut diags);
-    check_blocking_on_cooperative_pool(bundle, &mut diags);
+    check_cooperative_pool_blocking(bundle, &mut diags);
     // 2026-05-29: a bus-subscribing locus instantiated non-owned
     // inside another locus's method/handler body dissolves at that
     // method's scope exit, so its subscription can never fire.
@@ -620,7 +620,59 @@ fn find_blocking_in_expr(expr: &Expr) -> Option<(String, Span)> {
 /// blocking gateway was moved onto a shared pool). A warning, not an
 /// error — a single-purpose blocking server with nothing co-scheduled
 /// is legitimate; the smell is real but situational.
-fn check_blocking_on_cooperative_pool(
+/// A comparable key for a bus subject (topic name / literal /
+/// qualified path) — used to tell whether a subscription is to a
+/// topic the locus also publishes.
+fn bus_subject_key(s: &BusSubject) -> String {
+    match s {
+        BusSubject::Literal { subject, .. } => subject.clone(),
+        BusSubject::Topic(id) => id.name.clone(),
+        BusSubject::QualifiedTopic(qn) => qn
+            .segments
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect::<Vec<_>>()
+            .join("::"),
+    }
+}
+
+/// Handler names for the locus's `subscribe` entries on topics it
+/// does NOT itself publish — i.e. genuine cross-context receives. A
+/// self-publish→self-subscribe is devirtualized to a direct
+/// `self.handler(...)` call (same instance, same thread), not a bus
+/// receive, so it's excluded.
+fn external_subscription_handlers(decl: &LocusDecl) -> Vec<String> {
+    let mut published: BTreeSet<String> = BTreeSet::new();
+    let mut handlers: Vec<(String, String)> = Vec::new(); // (subject_key, handler)
+    for m in &decl.members {
+        let LocusMember::Bus(b) = m else { continue };
+        for bm in &b.members {
+            match bm {
+                BusMember::Publish { subject, .. } => {
+                    published.insert(bus_subject_key(subject));
+                }
+                BusMember::Subscribe { subject, handler, .. } => {
+                    handlers.push((bus_subject_key(subject), handler.name.clone()));
+                }
+            }
+        }
+    }
+    handlers
+        .into_iter()
+        .filter(|(subj, _)| !published.contains(subj))
+        .map(|(_, h)| h)
+        .collect()
+}
+
+/// Flag blocking calls on cooperative pools. Two outcomes:
+///   * a non-main cooperative SUBSCRIBER whose `run()` blocks is a
+///     **dead receiver** (error) — the blocking call starves the
+///     dispatch that would deliver to its handlers;
+///   * any other cooperative locus whose `run()` blocks gets a
+///     **warning** — it stalls co-scheduled loci on the pool.
+/// An event-driven subscriber (no blocking call — handlers + a sleep
+/// loop, or `where async_io`) is flagged by neither: it receives fine.
+fn check_cooperative_pool_blocking(
     bundle: &Bundle<'_>,
     diags: &mut Vec<Diag>,
 ) {
@@ -690,11 +742,56 @@ fn check_blocking_on_cooperative_pool(
                 }) else {
                     continue;
                 };
-                if let Some((call, span)) = find_blocking_in_block(run_body) {
-                    let pool_name = pool
-                        .as_ref()
-                        .map(|i| i.name.as_str())
-                        .unwrap_or("main");
+                let Some((call, span)) = find_blocking_in_block(run_body)
+                else {
+                    // Event-driven (no blocking call in run()): the pool
+                    // thread stays free, the bus dispatch runs, cells
+                    // arrive. Nothing to flag — even a non-main
+                    // cooperative subscriber receives fine this way.
+                    continue;
+                };
+                let pool_name =
+                    pool.as_ref().map(|i| i.name.as_str()).unwrap_or("main");
+                // Handlers for topics this locus does NOT itself publish
+                // (a self-publish→subscribe is a devirtualized direct
+                // call, not a bus receive).
+                let dead = external_subscription_handlers(decl);
+                if pool_name != "main" && !dead.is_empty() {
+                    // DEAD RECEIVER (error). A non-main cooperative
+                    // subscriber whose run() blocks: cross-process
+                    // dispatch reaches a cooperative locus only when its
+                    // pool thread is free to run the dispatch, and a
+                    // blocking call monopolizes it, so these handlers
+                    // never fire. (Corrected 2026-06-03 from the
+                    // placement-only rule, which over-fired on
+                    // event-driven subscribers — `PriceView`/`WsDispatcher`
+                    // received fine for 16h+ in production.)
+                    diags.push(Diag::ty(
+                        span,
+                        format!(
+                            "locus `{}` (field `{}`) subscribes to bus topics \
+                             ({}) but its `run()` makes the blocking call `{}` \
+                             while placed `cooperative(pool = {})`. The \
+                             blocking call monopolizes the pool's thread, so \
+                             the dispatch that would deliver those cells never \
+                             runs — the handlers can't fire. (An event-driven \
+                             subscriber that yields — handlers plus a \
+                             `time::sleep` loop, or `where async_io` — receives \
+                             fine; the problem is the blocking call, not the \
+                             placement.) Use `pinned` (its own thread + a \
+                             mailbox drained at sleep/yield), or keep `run()` \
+                             non-blocking.",
+                            locus_name,
+                            entry.field.name,
+                            dead.join(", "),
+                            call,
+                            pool_name,
+                        ),
+                    ));
+                } else {
+                    // Blocking on a cooperative pool stalls co-scheduled
+                    // loci (and the pool's bus drain), even when this
+                    // locus isn't itself a subscriber.
                     diags.push(Diag::warn(
                         span,
                         format!(
@@ -2965,83 +3062,12 @@ impl<'a> Checker<'a> {
                     ));
                 }
             }
-            // Dead bus receiver (fathom handoff 2026-06-02): a locus
-            // that subscribes to the bus but is placed
-            // `cooperative(pool = X)` with X != main never receives a
-            // cell. Inbound dispatch reaches a locus only if it is
-            // cooperative on `main` (its cell lands on the global
-            // queue that main's sliced keep-alive sleep drains) or
-            // `pinned` (its subscribe registration carries a per-locus
-            // mailbox the pinned thread drains at sleep/yield). A
-            // non-main cooperative locus is in neither bucket, so its
-            // handlers silently never fire. Placement and
-            // subscriptions are both static, so reject this at compile
-            // time rather than letting it compile clean and do
-            // nothing (this cost a downstream team most of a day).
-            //
-            // Spared: a subscription to a topic this locus ALSO
-            // publishes — an intra-locus self-publish→self-subscribe
-            // is devirtualized to a direct `self.handler(...)` call
-            // (same instance, same thread), which delivers on any
-            // pool. Rejecting it would be a false positive.
-            if let PlacementSpec::Cooperative { pool } = &entry.spec {
-                let pool_name = pool
-                    .as_ref()
-                    .map(|i| i.name.clone())
-                    .unwrap_or_else(|| "main".to_string());
-                if pool_name != "main" {
-                    let dead: Option<Vec<String>> = match &param.ty {
-                        Ty::Named(lname) => match self.top.lookup(lname) {
-                            Some(TopSymbol::Locus(li)) => {
-                                let published: BTreeSet<&str> = li
-                                    .bus_publishes
-                                    .iter()
-                                    .map(|p| p.subject.as_str())
-                                    .collect();
-                                let handlers: Vec<String> = li
-                                    .bus_subscribes
-                                    .iter()
-                                    .filter(|s| {
-                                        !published.contains(s.subject.as_str())
-                                    })
-                                    .map(|s| s.handler.clone())
-                                    .collect();
-                                if handlers.is_empty() {
-                                    None
-                                } else {
-                                    Some(handlers)
-                                }
-                            }
-                            _ => None,
-                        },
-                        _ => None,
-                    };
-                    if let Some(handlers) = dead {
-                        let plural = handlers.len() > 1;
-                        self.diags.push(Diag::ty(
-                            entry.span,
-                            format!(
-                                "locus `{}` (field `{}`) subscribes to bus \
-                                 topics but is placed `cooperative(pool = \
-                                 {})`. Only main-pool-cooperative or pinned \
-                                 loci receive bus cells, so {} ({}) will \
-                                 never fire. Use `pinned` (recommended for \
-                                 blocking I/O) or place the field on the \
-                                 `main` pool.",
-                                param.ty.display(),
-                                entry.field.name,
-                                pool_name,
-                                if plural {
-                                    "these handlers"
-                                } else {
-                                    "this handler"
-                                },
-                                handlers.join(", "),
-                            ),
-                        ));
-                    }
-                }
-            }
+            // (The dead-bus-receiver check moved to
+            // `check_cooperative_pool_blocking` and was corrected: a
+            // non-main cooperative subscriber is dead only when its
+            // `run()` ALSO makes a blocking call that starves the pool
+            // thread — placement alone over-fires on event-driven
+            // subscribers, which receive fine. See that fn.)
 
             // F.35: per-entry constraint validity.
             for c in &entry.constraints {

--- a/crates/hale-types/tests/placement.rs
+++ b/crates/hale-types/tests/placement.rs
@@ -568,9 +568,15 @@ fn main() { App { }; }
 // positives on pinned / main / non-subscribing / intra-locus).
 // ---------------------------------------------------------------
 
-const DEAD_RX: &str = "will never fire";
+// Corrected 2026-06-03 (fathom over-fire handoff): a non-main
+// cooperative subscriber is a dead receiver only when its run() ALSO
+// makes a blocking call that starves the pool thread. Placement alone
+// over-fired on event-driven subscribers (PriceView/WsDispatcher),
+// which receive fine. The error message no longer claims "will never
+// fire" flatly.
+const DEAD_RX: &str = "monopolizes the pool's thread";
 
-fn dead_receiver_src(placement_spec: &str) -> String {
+fn dead_receiver_src(placement_spec: &str, run_body: &str) -> String {
     format!(
         r#"
 type Tick {{ n: Int; }}
@@ -578,7 +584,7 @@ type Tick {{ n: Int; }}
 locus Gateway {{
     bus {{ subscribe "tick" as on_tick of type Tick; }}
     fn on_tick(t: Tick) {{ }}
-    run() {{ }}
+    run() {{ {run_body} }}
 }}
 
 locus Feed {{
@@ -601,20 +607,43 @@ fn main() {{ App {{ }}; }}
     )
 }
 
+const BLOCKING_RUN: &str = "let n = std::io::tls::recv_into(0, 0, 64);";
+
 #[test]
-fn cooperative_nonmain_subscriber_rejected() {
-    let msgs = check(&dead_receiver_src("cooperative(pool = ws)"));
+fn cooperative_nonmain_subscriber_blocking_rejected() {
+    // The gateway shape: non-main cooperative subscriber whose run()
+    // blocks — still rejected (its blocking call starves the dispatch).
+    let msgs = check(&dead_receiver_src("cooperative(pool = ws)", BLOCKING_RUN));
     assert!(
         msgs.iter().any(|m| m.contains(DEAD_RX)),
-        "expected dead-bus-receiver diagnostic for a non-main cooperative \
-         subscriber; got: {:?}",
+        "a non-main cooperative subscriber with a blocking run() is a dead \
+         receiver and must be rejected; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn cooperative_nonmain_subscriber_event_driven_compiles() {
+    // The PriceView shape: non-main cooperative subscriber that does
+    // NOT block (handlers + a sleep loop) — receives fine, must NOT be
+    // rejected. This is the over-fire the correction fixes.
+    let msgs = check(&dead_receiver_src(
+        "cooperative(pool = prices)",
+        "std::time::sleep(60s);",
+    ));
+    assert!(
+        !msgs.iter().any(|m| m.contains(DEAD_RX)),
+        "an event-driven (non-blocking) non-main cooperative subscriber \
+         receives fine and must not be rejected; got: {:?}",
         msgs
     );
 }
 
 #[test]
 fn pinned_subscriber_not_rejected() {
-    let msgs = check(&dead_receiver_src("pinned"));
+    // Pinned owns its thread (+ mailbox) — never a dead receiver, even
+    // with a blocking run().
+    let msgs = check(&dead_receiver_src("pinned", BLOCKING_RUN));
     assert!(
         !msgs.iter().any(|m| m.contains(DEAD_RX)),
         "pinned subscribers receive bus cells (per-locus mailbox); must not \
@@ -625,11 +654,13 @@ fn pinned_subscriber_not_rejected() {
 
 #[test]
 fn main_cooperative_subscriber_not_rejected() {
-    let msgs = check(&dead_receiver_src("cooperative(pool = main)"));
+    // main-pool cooperative subscriber, even blocking, is not the
+    // dead-receiver error (main's sliced sleep drains; at most a
+    // blocking warning).
+    let msgs = check(&dead_receiver_src("cooperative(pool = main)", BLOCKING_RUN));
     assert!(
         !msgs.iter().any(|m| m.contains(DEAD_RX)),
-        "main-pool cooperative subscribers receive bus cells; must not be \
-         flagged: {:?}",
+        "main-pool cooperative subscribers are not the dead-receiver error: {:?}",
         msgs
     );
 }

--- a/docs/src/services/concurrency.md
+++ b/docs/src/services/concurrency.md
@@ -158,19 +158,24 @@ without async-style function coloring.
 Two placement mistakes are caught for you, because both the
 placement and the locus's shape are known at compile time:
 
-- **A subscriber that can never be delivered to is an error.** A
-  locus with a `bus { subscribe ... }` placed `cooperative(pool =
-  X)` on a non-`main` pool would silently never receive a cell
-  (only main-cooperative and pinned loci get bus delivery). The
-  compiler rejects it and points you at `pinned` or the `main`
-  pool.
-- **A blocking call on a cooperative pool is a warning.** If a
-  cooperative locus's `run()` makes a blocking I/O call (a
-  blocking `recv`/`accept`, a subprocess `run`) and the pool
-  isn't `where async_io`, it would hold the pool's thread and
-  stall everything else scheduled there. The compiler warns and
-  suggests `pinned` (own thread) or `where async_io` (parks). For
-  blocking I/O gateways, `pinned` is the prescribed shape.
+- **A subscriber that blocks its own delivery is an error.** A
+  cooperative locus on a non-`main` pool *receives bus cells fine*
+  as long as its pool thread is free to run the dispatch — an
+  event-driven subscriber (handlers plus a `sleep` loop, or `where
+  async_io`) works. But if such a subscriber's `run()` makes a
+  **blocking** call, it monopolizes the pool thread, the dispatch
+  never runs, and its handlers never fire. *That* combination —
+  non-`main` cooperative subscriber **with a blocking `run()`** —
+  is the error; the compiler points you at `pinned` (own thread +
+  mailbox) or keeping `run()` non-blocking. (Placement alone is
+  fine; it's the blocking call that kills delivery.)
+- **A blocking call on a cooperative pool is a warning.** Even when
+  the locus *isn't* a subscriber, a blocking `run()` (a blocking
+  `recv`/`accept`, a subprocess `run`) on a pool that isn't `where
+  async_io` holds the pool's thread and stalls everything else
+  scheduled there. The compiler warns and suggests `pinned` (own
+  thread) or `where async_io` (parks). For blocking I/O gateways,
+  `pinned` is the prescribed shape.
 
 It also enforces the **single-threaded-method invariant**: a locus's
 methods may only be called on the thread that owns its pool, so a

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -341,16 +341,23 @@ threads, pinned publishers via `lotus_bus_local_dispatch`, etc.
 The drain is idempotent, so existing code with `sleep; yield;`
 stays correct.
 
-**Scope: this delivery is `main`-pool only.** The queue drained
-here is the program-wide *cooperative* queue, drained on the `main`
-thread — so a cooperative subscriber receives cells via its sleep
-loop only when placed on the `main` pool. A subscriber placed
-`cooperative(pool = X)` with `X != main` is **not** reached by this
-drain (its handlers would silently never fire), which is why that
-placement is rejected at compile time — see the dead-bus-receiver
-rule under "Type-check rules" in `spec/semantics.md`. Pinned loci
-are a separate path: they drain their own per-locus mailbox at each
-`sleep`/`yield`, independent of the cooperative queue.
+**Which path delivers to whom.** The queue drained *here* is the
+program-wide *in-process cooperative* queue, drained on the `main`
+thread — so this sleep-loop drain delivers in-process cells to a
+cooperative subscriber on the `main` pool. It is **not** the only
+delivery path: cross-process topics (`udp://` / `unix://` bound via
+`LOTUS_BUS_CONFIG`) are delivered by the transport reader thread,
+which dispatches directly into the subscribed handler set and
+reaches a cooperative locus on *any* pool — **provided that pool's
+thread is free to run the dispatch.** So a non-`main` cooperative
+subscriber receives reliably as long as it doesn't monopolize its
+pool thread with a blocking call. (Pinned loci are a third path: a
+per-locus mailbox drained at each `sleep`/`yield`.) The failure mode
+is a cooperative subscriber whose `run()` *blocks* — the dispatch
+can't run and its handlers never fire; that blocking-and-subscribing
+combination is what the dead-bus-receiver rule rejects (see
+"Type-check rules" in `spec/semantics.md`), **not** non-`main`
+placement on its own.
 
 **Long sleeps no longer starve main-pool handlers (2026-05-29).**
 Before the slicing, the drain happened only *after the whole sleep

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1387,30 +1387,39 @@ main locus App {
    be placed either cooperative or pinned at the deployment's
    discretion.
 7. **Dead bus receiver (error).** A locus that declares
-   `bus { subscribe ... }` but is placed `cooperative(pool = X)`
-   with `X != main` is rejected: inbound bus dispatch reaches a
-   locus only if it is cooperative on `main` (its cell lands on
-   the global queue that `main`'s sliced keep-alive sleep drains)
-   or `pinned` (its subscribe registration carries a per-locus
-   mailbox the pinned thread drains). A non-main cooperative
-   subscriber is in neither bucket — its handlers would silently
-   never fire. A subscription to a topic the locus also
-   *publishes* is spared (an intra-locus self-publish→subscribe
-   is devirtualized to a direct call, which delivers on any pool).
+   `bus { subscribe ... }`, is placed `cooperative(pool = X)` with
+   `X != main` (and not `where async_io`), **and** whose `run()`
+   makes a known-blocking stdlib call is rejected. A cooperative
+   locus receives cells only while its pool thread is free to run
+   the dispatch (the cross-process transport reader dispatches
+   into the handler set; the in-process cooperative queue is
+   drained at yield points). A blocking call monopolizes the pool
+   thread, so the dispatch never runs and the subscriber's handlers
+   never fire. **Placement alone is not the condition** — an
+   event-driven subscriber that yields (handlers plus a
+   `time::sleep` loop, or `where async_io`, which parks) receives
+   fine and is *not* flagged; only the blocking-and-subscribing
+   combination is rejected. A subscription to a topic the locus
+   also *publishes* is also spared (an intra-locus
+   self-publish→subscribe is devirtualized to a direct call). Fix:
+   `pinned` (own thread + a mailbox drained at sleep/yield) or keep
+   `run()` non-blocking. (Corrected 2026-06-03: an earlier form
+   rejected on placement alone and over-fired on event-driven
+   non-main cooperative subscribers, which receive reliably.)
 8. **Blocking syscall on a cooperative pool (warning).** A locus
    placed `cooperative(pool = X)` *without* `where async_io`
    whose `run()` calls a known-blocking stdlib op (tcp/tls recv,
-   accept, `process::run`/`wait`) gets a **warning** (not an
-   error — hale's only non-fatal diagnostic). A blocking call
-   holds the pool's OS thread for its whole duration, stalling
-   every other locus scheduled on that pool and the pool's bus
-   drain. The fix is `pinned` (its own thread — the prescribed
-   shape for blocking I/O) or `cooperative(pool = X) where
-   async_io` (parks on I/O readiness). It is a warning rather
-   than an error because a single-purpose blocking server with
-   nothing co-scheduled is legitimate; detection is best-effort
-   (direct path-call form only — blocking via a handle method or
-   a helper fn isn't traced).
+   accept, `process::run`/`wait`) but is *not* a dead receiver
+   (rule 7) gets a **warning** (not an error — hale's only
+   non-fatal diagnostic). A blocking call holds the pool's OS
+   thread for its whole duration, stalling every other locus
+   scheduled on that pool and the pool's bus drain. The fix is
+   `pinned` (its own thread — the prescribed shape for blocking
+   I/O) or `cooperative(pool = X) where async_io` (parks on I/O
+   readiness). It is a warning rather than an error because a
+   single-purpose blocking server with nothing co-scheduled is
+   legitimate; detection is best-effort (direct path-call form
+   only — blocking via a handle method or a helper fn isn't traced).
 
 ### Single-threaded-method invariant
 


### PR DESCRIPTION
Owns the correction in fathom's `handoff-compiler-dead-receiver-check-overfires-2026-06-03.md`. The dead-receiver check (#35) **over-fires** and now blocks valid production builds.

## The over-fire

#35 rejected **any** non-`main` cooperative subscriber. But two fathom loci are non-`main` cooperative subscribers that **receive correctly and have for 16h+ in production**:

| binary | subscriber placement | builds under #35? | receives at runtime? |
|---|---|---|---|
| `priceview` | `cooperative(pool = prices)` | ❌ rejected | ✅ yes (udp-fed `signal.flow` → flowfit `active=3`) |
| `dashboard` | `cooperative(pool = ws_workers) where async_io` | ❌ rejected | ✅ yes (drives the live SPA) |

And the diagnostic claimed "will never fire" — empirically false.

## Corrected model

A cooperative locus receives bus cells **while its pool thread is free to run the dispatch** (the cross-process transport reader dispatches into the handler set; the in-process cooperative queue drains at yield points). A non-`main` cooperative subscriber is dead **only when its `run()` also makes a blocking call** that monopolizes the pool thread — the gateways' blocking `read_msg`, *not* placement alone. Event-driven subscribers (handlers + a `sleep` loop, or `async_io` parking) yield, so the dispatch runs and cells arrive.

## Fix (the handoff's lead ask)

AND the placement test with the blocking-call analysis from #38. The two placement checks are unified in `check_cooperative_pool_blocking`:
- non-`main` cooperative **subscriber + blocking `run()`** → **error** (dead receiver: blocking starves its own dispatch);
- any other cooperative + blocking `run()` → **warning** (stalls co-scheduled loci);
- **no blocking call → neither** (event-driven receives fine).

The placement-only block is removed from `check_placement_block`. The error message names the blocking call as the cause and notes the event-driven case works — no more flat "will never fire."

## Acceptance criteria (all met)
- `PriceView` / `dashboard` shapes **compile**.
- the gateway shape (non-`main` cooperative subscriber **with a blocking recv in `run()`**) is **still rejected**.
- diagnostic text matches reality.

**Limitation** (best-effort, inherited from #38): blocking is detected for direct stdlib path-calls only (tcp/tls recv, accept, `process::run`/`wait`) — blocking via a handle method or a helper fn isn't traced. Noted in the spec.

## Spec + docs corrected
`#35`/`#39` had documented the placement-only model that production disproves. This fixes `semantics.md` placement rules 7 & 8, the `runtime.md` sleep-drain scope note (it wrongly said non-`main` cooperative subscribers are never reached), and `docs/services/concurrency.md`.

## Tests
`placement.rs`: gateway shape (subscriber + blocking) rejected; `PriceView` shape (subscriber + sleep loop) compiles; pinned / main / async_io / non-blocking spared. Full hale-types suite green; mdBook builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)