### PR TITLE
hale run compiles + execs (no interpreter) — retire slice 1

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -65,20 +65,15 @@ fn main() -> ExitCode {
         "parse" => run_parse_file(&target),
         "check" => run_check(&target),
         "run" => {
-            // Plumb the script's argv into the interpreter so
-            // `std::env::args_count` / `std::env::arg(i)` work.
-            // Convention mirrors compiled binaries: argv[0] is
-            // the script path; argv[1..] are the trailing CLI
-            // args. `hale run script.hl foo bar` → script
-            // sees ["script.hl", "foo", "bar"].
-            let mut user_args: Vec<String> =
-                Vec::with_capacity(args.len().saturating_sub(2));
-            user_args.push(args[2].clone());
-            for a in args.iter().skip(3) {
-                user_args.push(a.clone());
-            }
-            hale_runtime::set_user_args(user_args);
-            run_program(&target)
+            // `hale run` compiles the program to a temporary binary
+            // (the same codegen backend as `hale build`) and executes
+            // it — there is no separate interpreter. The program's
+            // trailing argv is forwarded to the exec'd process, so
+            // `hale run script.hl foo bar` makes the program's
+            // `std::env::arg(1..)` see ["foo", "bar"] exactly as a
+            // built binary run directly would.
+            let user_args: Vec<String> = args.iter().skip(3).cloned().collect();
+            run_program(&target, &user_args)
         }
         "build" => run_build(&target),
         other => {
@@ -815,7 +810,40 @@ fn run_check(target: &Path) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-fn run_program(target: &Path) -> ExitCode {
+/// Compile `program` to a temporary native binary and execute it,
+/// forwarding `user_args` as the program's trailing argv. This is
+/// the whole of `hale run` — the same codegen backend as `hale
+/// build`, so there is no `run`-vs-`build` behavioral divergence.
+fn compile_and_exec(
+    program: &Program,
+    renames: &[(Vec<String>, String)],
+    user_args: &[String],
+) -> ExitCode {
+    let mut bin = std::env::temp_dir();
+    let mut h = DefaultHasher::new();
+    h.write_usize(program.items.len());
+    h.write_u32(std::process::id());
+    bin.push(format!("hale_run_{:016x}", h.finish()));
+    if let Err(e) =
+        hale_codegen::build_executable_with_imports(program, &bin, renames)
+    {
+        eprintln!("build error: {:?}", e);
+        return ExitCode::from(1);
+    }
+    let status = std::process::Command::new(&bin).args(user_args).status();
+    let _ = std::fs::remove_file(&bin);
+    match status {
+        Ok(s) => {
+            ExitCode::from(s.code().unwrap_or(1).clamp(0, 255) as u8)
+        }
+        Err(e) => {
+            eprintln!("could not execute compiled program: {}", e);
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
     // Single-file targets follow imports starting from the entry
     // file's directory. Directory targets bundle every .lt under
     // them as today (multi-file projects without import wiring
@@ -827,7 +855,7 @@ fn run_program(target: &Path) -> ExitCode {
         // per the known limitation). Cross-seed imports through
         // `hale run` will likewise fail on `alias::Name` paths;
         // use `hale build` for programs with imports.
-        let (program, _renames, sources, _ctx) = match parse_with_imports(target) {
+        let (program, renames, sources, _ctx) = match parse_with_imports(target) {
             Ok(x) => x,
             Err(errors) => {
                 for (path, d, src) in &errors {
@@ -853,14 +881,7 @@ fn run_program(target: &Path) -> ExitCode {
                 return ExitCode::from(1);
             }
         }
-        let prog_refs: Vec<&Program> = vec![&program];
-        return match hale_runtime::run_bundle(&prog_refs) {
-            Ok(code) => ExitCode::from(code as u8),
-            Err(e) => {
-                eprintln!("runtime error: {}", e);
-                ExitCode::from(1)
-            }
-        };
+        return compile_and_exec(&program, &renames, user_args);
     }
 
     let files = match collect_ap_files(target) {
@@ -896,14 +917,17 @@ fn run_program(target: &Path) -> ExitCode {
         }
     }
 
-    let prog_refs: Vec<&Program> = programs.values().collect();
-    match hale_runtime::run_bundle(&prog_refs) {
-        Ok(code) => ExitCode::from(code as u8),
-        Err(e) => {
-            eprintln!("runtime error: {}", e);
-            ExitCode::from(1)
+    let merged = match merge_programs(programs.values()) {
+        Some(m) => m,
+        None => {
+            eprintln!("no .hl files in {}", target.display());
+            return ExitCode::from(1);
         }
-    }
+    };
+    // Directory `hale run` is the ad-hoc multi-file path; like the
+    // pre-retirement interpreter behavior, it doesn't resolve
+    // cross-seed imports (use `hale build <dir>` for those).
+    compile_and_exec(&merged, &[], user_args)
 }
 
 fn run_build(target: &Path) -> ExitCode {

--- a/docs/src/getting-started/first-run.md
+++ b/docs/src/getting-started/first-run.md
@@ -1,6 +1,6 @@
 # Your first run
 
-> Put something on screen, and see the two run modes.
+> Put something on screen.
 
 Create a file `hello.hl`:
 
@@ -10,7 +10,7 @@ fn main() {
 }
 ```
 
-Run it through the interpreter:
+Run it:
 
 ```sh
 hale run hello.hl
@@ -20,15 +20,20 @@ hale run hello.hl
 Hello from Hale.
 ```
 
-Compile it to a native binary and run that:
+`hale run` compiles your program and runs it in one step — it's
+the same native code `hale build` produces, just executed
+immediately and not left on disk. When you want the artifact to
+keep and ship, build it:
 
 ```sh
 hale build hello.hl
 ./hello
 ```
 
-Same output. The interpreter is for fast feedback; `build`
-produces the artifact you ship.
+Same compiler, same output: `run` is the fast inner-loop shape,
+`build` is for the binary you deploy. There's no separate
+interpreter, so anything that runs under `build` runs identically
+under `run`.
 
 ## What's here
 
@@ -60,7 +65,9 @@ That's the whole surface you need to start. The next chapter
 introduces variables and the value types — the vocabulary every
 Hale program is built from.
 
-> **A note on `hale run` vs files with imports.** The
-> interpreter doesn't resolve cross-file library imports yet; for
-> any program that uses `import "..." as ...;` use `hale build`.
-> Single-file programs and whole-directory builds work in both.
+> **`hale run` and imports.** A single file's `import "..." as
+> ...;` directives are resolved by `hale run` just as `hale build`
+> resolves them. The one gap is the ad-hoc *directory* form (`hale
+> run ./dir`), which bundles the directory's files without
+> cross-seed import resolution — use `hale build ./dir` for a
+> multi-file project that imports libraries.

--- a/docs/src/getting-started/install.md
+++ b/docs/src/getting-started/install.md
@@ -63,16 +63,17 @@ cargo test --release --workspace -- --test-threads=1
 
 ## The two ways to run a program
 
-Hale ships two execution paths, and you'll use both:
+Both go through the **same LLVM-native compiler** — there's no
+separate interpreter, so they never disagree:
 
-- **Interpreter** — `hale run prog.hl`. A tree-walking
-  interpreter for fast feedback while you write.
-- **Native** — `hale build prog.hl` produces a native ELF binary
-  via LLVM. This is what you ship.
+- **`hale run prog.hl`** — compiles and runs in one step (the
+  binary is temporary). The fast inner loop while you write.
+- **`hale build prog.hl`** — compiles to a native ELF binary on
+  disk via LLVM. This is the artifact you ship.
 
 ```sh
-cargo run -p hale-cli --bin hale -- run  prog.hl   # interpret
-cargo run -p hale-cli --bin hale -- build prog.hl  # compile
+cargo run -p hale-cli --bin hale -- run  prog.hl   # compile + run
+cargo run -p hale-cli --bin hale -- build prog.hl  # compile to ./prog
 ./prog
 ```
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -41,7 +41,7 @@ diagnostic's meaning, go there.
 
 | Command | Does |
 |---|---|
-| `hale run <file/dir>` | interpret (fast feedback) |
+| `hale run <file/dir>` | compile + run (fast feedback) |
 | `hale build <file/dir>` | compile to a native binary |
 | `hale check` | parse + typecheck only |
 | `hale test` | run `*_test.hl` |

--- a/spec/styleguide.md
+++ b/spec/styleguide.md
@@ -346,9 +346,9 @@ locus DbPool {
   via the child handle: `c.last_error`, `c.conn_fd`, etc. Since
   `violate` is divergent, the child's locus state is frozen at
   the violate moment — every captured field is readable through
-  the handle. This is the portable access pattern; it works
-  identically under `hale run` (interpreted) and `hale build`
-  (native).
+  the handle. This is the portable access pattern; `hale run`
+  and `hale build` share the same native codegen, so it behaves
+  identically under both.
 
 **Why this shape.** Three forces meet:
 


### PR DESCRIPTION
## What

Repoint `hale run` from the tree-walking interpreter (`hale-runtime`) to the **same LLVM codegen backend `hale build` uses**: compile the program to a temporary native binary via `build_executable_with_imports`, exec it (forwarding the program's trailing argv), then delete the binary.

## Why

Two execution paths meant `run` and `build` could diverge — and did. Codegen-only features (e.g. `base64url`) printed correctly under `build` but produced wrong/missing output under `run`. Collapsing to one backend kills that whole class of bug: anything that runs under `build` runs identically under `run`.

This is **slice 1** of "retire the interpreter":
- **Slice 1 (this PR):** repoint `hale run`; update user-facing docs/spec describing it as an interpreter.
- **Slice 2 (next):** delete the now-unused `hale-runtime` crate, its `hale-cli` dependency, and the interpreter-parity spec sections.

## Behavior notes

- Single-file `hale run x.hl` resolves `import "..." as ...;` exactly as `hale build` does.
- Directory `hale run ./dir` bundles files without cross-seed import resolution (unchanged from prior interpreter behavior) — use `hale build ./dir` for multi-file projects with library imports.
- Exit code is the compiled program's exit code; argv forwarding matches a directly-run binary (`argv[0]`=path, `argv[1..]`=user args).

## Docs/spec updated in-commit (user-visible change)

`docs/src/getting-started/{install,first-run}.md`, `docs/src/reference.md`, `spec/styleguide.md` — all stop describing `hale run` as a separate interpreter.

## Verification

- `hale run x.hl`, `hale run ./dir`, and arg forwarding (`hale run x.hl foo bar` → `argc=3`, `arg(1)=foo`) all smoke-tested ✅
- Relies on full CI for the workspace + corpus oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)