### PR TITLE
Bus-graph orphan-topic check (GH #18 #4, PR A)

### DIFF
--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -203,6 +203,12 @@ pub fn check_bundle(
     // method's scope exit, so its subscription can never fire.
     // Hard error unless `--allow-unowned-subscriber` is set.
     check_unowned_subscriber_locus(bundle, allow_unowned_subscriber, &mut diags);
+    // GH #18 #4: bus-graph property checks over the typed topic
+    // topology. v1 (PR A): orphan topics — declared/used subjects
+    // wired to only one end. Gated on a closed-world program (a
+    // `main` locus present), so library seeds whose consumers are
+    // external aren't falsely flagged.
+    check_bus_graph(bundle, top, &mut diags);
     diags
 }
 
@@ -2895,6 +2901,243 @@ fn collect_topic_pub_sub(
         walk(&program.items, &mut pubs, &mut subs);
     }
     (pubs, subs)
+}
+
+// === Bus-graph property checks (GH #18 #4) =========================
+//
+// The bus topology is a typed directed graph already in the AST.
+// PR A walks it for ORPHANs — a subject wired to only one end. Gated
+// on a closed-world program (a `main` locus present): a library seed
+// whose publishers/subscribers live in downstream consumers must not
+// be flagged, since the other half is out of this bundle.
+//
+// Subjects are keyed by `BusSubject::canonical()` (literal string /
+// topic name / qualified last segment), which is exactly the key a
+// declared topic's name matches. False-positive guards: transport
+// bindings (external peer), trailing-`**` wildcard coverage, and
+// cross-seed (`alias::Foo`) references (the other seed owns the other
+// half). A declared topic is matched by both its name and its
+// `wire_subject` (a literal site may address it by the wire form).
+
+/// One end of the bus graph: subject-key → first declaration span,
+/// plus the wildcard patterns seen on that end (matched separately).
+#[derive(Default)]
+struct BusEnd {
+    concrete: BTreeMap<String, Span>,
+    wildcards: Vec<String>,
+}
+
+impl BusEnd {
+    fn record(&mut self, key: String, span: Span) {
+        if key.contains("**") {
+            self.wildcards.push(key);
+        } else {
+            self.concrete.entry(key).or_insert(span);
+        }
+    }
+    /// Does this end carry `subject` — exactly, or via a wildcard?
+    fn covers(&self, subject: &str) -> bool {
+        self.concrete.contains_key(subject)
+            || self.wildcards.iter().any(|p| crate::wildcard_match(p, subject))
+    }
+}
+
+fn check_bus_graph(
+    bundle: &Bundle<'_>,
+    top: &TopScope,
+    diags: &mut Vec<Diag>,
+) {
+    // Closed-world gate: only a complete program (has `main`) has
+    // both ends of every channel in-bundle.
+    let has_main = bundle.programs.values().any(|p| {
+        p.items
+            .iter()
+            .any(|i| matches!(i, TopDecl::Locus(l) if l.is_main))
+    });
+    if !has_main {
+        return;
+    }
+
+    let mut publishers = BusEnd::default();
+    let mut subscribers = BusEnd::default();
+    let mut bound: BTreeSet<String> = BTreeSet::new();
+    // Keys referenced cross-seed (`alias::Foo`) — the other seed owns
+    // the other half; never orphan-flag these.
+    let mut cross_seed: BTreeSet<String> = BTreeSet::new();
+
+    fn walk_bus(
+        items: &[TopDecl],
+        publishers: &mut BusEnd,
+        subscribers: &mut BusEnd,
+        bound: &mut BTreeSet<String>,
+        cross_seed: &mut BTreeSet<String>,
+    ) {
+        for item in items {
+            match item {
+                TopDecl::Locus(l) => {
+                    for m in &l.members {
+                        match m {
+                            LocusMember::Bus(bb) => {
+                                for bm in &bb.members {
+                                    match bm {
+                                        BusMember::Publish { subject, span, .. } => {
+                                            if matches!(subject, BusSubject::QualifiedTopic(_)) {
+                                                cross_seed.insert(subject.canonical().to_string());
+                                            }
+                                            publishers.record(
+                                                subject.canonical().to_string(),
+                                                *span,
+                                            );
+                                        }
+                                        BusMember::Subscribe { subject, span, .. } => {
+                                            if matches!(subject, BusSubject::QualifiedTopic(_)) {
+                                                cross_seed.insert(subject.canonical().to_string());
+                                            }
+                                            subscribers.record(
+                                                subject.canonical().to_string(),
+                                                *span,
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                            LocusMember::Bindings(bbk) => {
+                                for entry in &bbk.entries {
+                                    bound.insert(entry.topic.name.clone());
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                TopDecl::Module(md) => walk_bus(
+                    &md.items, publishers, subscribers, bound, cross_seed,
+                ),
+                _ => {}
+            }
+        }
+    }
+    for program in bundle.programs.values() {
+        walk_bus(
+            &program.items,
+            &mut publishers,
+            &mut subscribers,
+            &mut bound,
+            &mut cross_seed,
+        );
+    }
+
+    // A subject has a publisher if some locus publishes it (exactly
+    // or via wildcard), it is bound to a transport (external peer),
+    // or it's referenced cross-seed. Same for subscriber.
+    let has_pub = |aliases: &[&str]| {
+        aliases.iter().any(|a| {
+            publishers.covers(a) || bound.contains(*a) || cross_seed.contains(*a)
+        })
+    };
+    let has_sub = |aliases: &[&str]| {
+        aliases.iter().any(|a| {
+            subscribers.covers(a) || bound.contains(*a) || cross_seed.contains(*a)
+        })
+    };
+
+    // 1) Declared topics — matched by name and wire_subject.
+    let mut declared_keys: BTreeSet<String> = BTreeSet::new();
+    for (name, sym) in &top.symbols {
+        let TopSymbol::Topic(info) = sym else { continue };
+        // Topics that failed parent resolution carry an empty wire
+        // subject and already have a diagnostic — skip.
+        if info.wire_subject.is_empty() {
+            continue;
+        }
+        declared_keys.insert(name.clone());
+        declared_keys.insert(info.wire_subject.clone());
+        let aliases: Vec<&str> = if info.wire_subject == *name {
+            vec![name.as_str()]
+        } else {
+            vec![name.as_str(), info.wire_subject.as_str()]
+        };
+        let p = has_pub(&aliases);
+        let s = has_sub(&aliases);
+        if p && !s {
+            let span = publishers
+                .concrete
+                .get(name)
+                .or_else(|| publishers.concrete.get(&info.wire_subject))
+                .copied()
+                .unwrap_or(info.span);
+            diags.push(Diag::warn(
+                span,
+                format!(
+                    "bus topic `{}` is published but has no subscriber — \
+                     the cells go nowhere. Add a `subscribe` for it, bind it \
+                     to a transport, or drop the publish.",
+                    name
+                ),
+            ));
+        } else if s && !p {
+            let span = subscribers
+                .concrete
+                .get(name)
+                .or_else(|| subscribers.concrete.get(&info.wire_subject))
+                .copied()
+                .unwrap_or(info.span);
+            diags.push(Diag::warn(
+                span,
+                format!(
+                    "bus topic `{}` is subscribed but never published — its \
+                     handler can't fire. Add a `publish` for it, bind it to a \
+                     transport, or drop the subscription.",
+                    name
+                ),
+            ));
+        } else if !p && !s {
+            diags.push(Diag::warn(
+                info.span,
+                format!(
+                    "bus topic `{}` is declared but neither published nor \
+                     subscribed — it's dead wiring.",
+                    name
+                ),
+            ));
+        }
+    }
+
+    // 2) Literal subjects (not a declared topic's name or wire form).
+    let mut literal_keys: BTreeSet<String> = BTreeSet::new();
+    for k in publishers.concrete.keys().chain(subscribers.concrete.keys()) {
+        if !declared_keys.contains(k) {
+            literal_keys.insert(k.clone());
+        }
+    }
+    for k in literal_keys {
+        let aliases = [k.as_str()];
+        let p = has_pub(&aliases);
+        let s = has_sub(&aliases);
+        if p && !s {
+            let span = publishers.concrete.get(&k).copied().unwrap();
+            diags.push(Diag::warn(
+                span,
+                format!(
+                    "bus subject `\"{}\"` is published but has no subscriber — \
+                     the cells go nowhere. Add a `subscribe`, bind it to a \
+                     transport, or drop the publish.",
+                    k
+                ),
+            ));
+        } else if s && !p {
+            let span = subscribers.concrete.get(&k).copied().unwrap();
+            diags.push(Diag::warn(
+                span,
+                format!(
+                    "bus subject `\"{}\"` is subscribed but never published — \
+                     its handler can't fire. Add a `publish`, bind it to a \
+                     transport, or drop the subscription.",
+                    k
+                ),
+            ));
+        }
+    }
 }
 
 fn collect_known_names(top: &TopScope) -> BTreeMap<String, Span> {

--- a/crates/hale-types/tests/bus_graph.rs
+++ b/crates/hale-types/tests/bus_graph.rs
@@ -1,0 +1,270 @@
+//! GH #18 #4 — bus-graph property checks. PR A: ORPHAN topics.
+//!
+//! A bus subject wired to only one end (published with no subscriber,
+//! or subscribed with no publisher) is dead wiring. These warnings
+//! fire only on a closed-world program (a `main` locus present), and
+//! are suppressed by transport bindings, wildcard coverage, cross-seed
+//! references, and self-publish/subscribe.
+
+use hale_syntax::parse_source;
+use hale_types::check_program;
+
+fn check(src: &str) -> Vec<String> {
+    let prog = parse_source(src).expect("parse failed");
+    check_program(&prog).into_iter().map(|d| d.message).collect()
+}
+
+const NO_SUB: &str = "has no subscriber";
+const NO_PUB: &str = "never published";
+const DEAD: &str = "neither published nor subscribed";
+
+// --- positives -----------------------------------------------------
+
+#[test]
+fn topic_published_but_not_subscribed_warns() {
+    let src = r#"
+type Tick { n: Int; }
+topic Beat { payload: Tick; subject: "beat"; }
+
+locus Producer {
+    bus { publish Beat; }
+    birth() { Beat <- Tick { n: 1 }; }
+}
+
+main locus App {
+    params { p: Producer = Producer { }; }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("`Beat`") && m.contains(NO_SUB)),
+        "a published-but-unsubscribed topic must warn; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn topic_subscribed_but_not_published_warns() {
+    let src = r#"
+type Tick { n: Int; }
+topic Beat { payload: Tick; subject: "beat"; }
+
+locus Consumer {
+    bus { subscribe Beat as on_beat; }
+    fn on_beat(t: Tick) { }
+}
+
+main locus App {
+    params { c: Consumer = Consumer { }; }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("`Beat`") && m.contains(NO_PUB)),
+        "a subscribed-but-unpublished topic must warn; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn literal_subject_published_but_not_subscribed_warns() {
+    let src = r#"
+type Tick { n: Int; }
+
+locus Producer {
+    bus { publish "demo.tick" of type Tick; }
+    birth() { "demo.tick" <- Tick { n: 1 }; }
+}
+
+main locus App {
+    params { p: Producer = Producer { }; }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter()
+            .any(|m| m.contains("demo.tick") && m.contains(NO_SUB)),
+        "a published-but-unsubscribed literal subject must warn; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn topic_declared_but_unused_warns() {
+    let src = r#"
+type Tick { n: Int; }
+topic Beat { payload: Tick; subject: "beat"; }
+
+locus Worker { run() { } }
+
+main locus App {
+    params { w: Worker = Worker { }; }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("`Beat`") && m.contains(DEAD)),
+        "a declared-but-unused topic must warn; got: {:?}",
+        msgs
+    );
+}
+
+// --- guards (no false positives) -----------------------------------
+
+#[test]
+fn both_ends_present_is_clean() {
+    let src = r#"
+type Tick { n: Int; }
+topic Beat { payload: Tick; subject: "beat"; }
+
+locus Producer {
+    bus { publish Beat; }
+    birth() { Beat <- Tick { n: 1 }; }
+}
+
+locus Consumer {
+    bus { subscribe Beat as on_beat; }
+    fn on_beat(t: Tick) { }
+}
+
+main locus App {
+    params {
+        p: Producer = Producer { };
+        c: Consumer = Consumer { };
+    }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        !msgs.iter().any(|m| m.contains("Beat") && (m.contains(NO_SUB) || m.contains(NO_PUB) || m.contains(DEAD))),
+        "a fully-wired topic must not warn; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn bound_topic_is_not_orphan() {
+    // Published + bound to a transport adapter, never locally
+    // subscribed — the binding implies an external consumer.
+    let src = r#"
+type Tick { n: Int; }
+topic Beat { payload: Tick; subject: "beat"; }
+
+locus MyAdapter {
+    params { label: String = "noname"; }
+    fn send(subject: String, bytes: Bytes) { }
+}
+
+locus Producer {
+    bus { publish Beat; }
+    birth() { Beat <- Tick { n: 1 }; }
+}
+
+main locus App {
+    bindings { Beat: MyAdapter { label: "T" }; }
+}
+
+fn main() { App { }; Producer { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        !msgs.iter().any(|m| m.contains("Beat") && m.contains(NO_SUB)),
+        "a bound topic has an external consumer and must not be an \
+         orphan; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn wildcard_subscriber_covers_concrete_publish() {
+    // publish "log.app", subscribe "log.**" — the wildcard covers
+    // the concrete subject, so log.app is not an orphan.
+    let src = r#"
+type Line { msg: String; }
+
+locus Emitter {
+    bus { publish "log.app" of type Line; }
+    birth() { "log.app" <- Line { msg: "hi" }; }
+}
+
+locus Sink {
+    bus { subscribe "log.**" as on_log of type Line; }
+    fn on_log(l: Line) { }
+}
+
+main locus App {
+    params {
+        e: Emitter = Emitter { };
+        s: Sink    = Sink { };
+    }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        !msgs.iter().any(|m| m.contains("log.app") && m.contains(NO_SUB)),
+        "a wildcard subscriber must cover the concrete publish; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn self_publish_subscribe_is_not_orphan() {
+    let src = r#"
+type Tick { n: Int; }
+topic Beat { payload: Tick; subject: "beat"; }
+
+locus Loop {
+    bus {
+        publish Beat;
+        subscribe Beat as on_beat;
+    }
+    fn on_beat(t: Tick) { }
+    birth() { Beat <- Tick { n: 1 }; }
+}
+
+main locus App {
+    params { l: Loop = Loop { }; }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        !msgs.iter().any(|m| m.contains("Beat") && (m.contains(NO_SUB) || m.contains(NO_PUB) || m.contains(DEAD))),
+        "a self-publish/subscribe topic has both ends; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn library_without_main_is_not_checked() {
+    // No `main` locus: the publishers/subscribers may live in
+    // downstream consumers, so orphan detection is suppressed.
+    let src = r#"
+type Tick { n: Int; }
+topic Beat { payload: Tick; subject: "beat"; }
+
+locus Producer {
+    bus { publish Beat; }
+    birth() { Beat <- Tick { n: 1 }; }
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        !msgs.iter().any(|m| m.contains("Beat") && m.contains(NO_SUB)),
+        "a library (no main) must not get orphan warnings; got: {:?}",
+        msgs
+    );
+}

--- a/docs/src/services/concurrency.md
+++ b/docs/src/services/concurrency.md
@@ -180,6 +180,15 @@ placement and the locus's shape are known at compile time:
   `self.method` it calls — is flagged too, naming the offending call.
   (The dead-receiver *error* above stays direct-call-only, so it
   never widens onto an indirect path.)
+- **An orphan bus topic is a warning.** In a complete program (one
+  with a `main` locus), a topic or subject wired to only one end —
+  published with nobody subscribed, or subscribed with nobody
+  publishing — is flagged, as is a declared topic used by neither.
+  It's suppressed when the other end is plausibly external: a
+  transport `binding`, a wildcard (`log.**`) covering the subject, a
+  cross-seed (`alias::Topic`) reference, or the same locus being both
+  ends. Library code (no `main`) isn't checked — its peers live
+  downstream.
 
 It also enforces the **single-threaded-method invariant**: a locus's
 methods may only be called on the thread that owns its pool, so a

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1427,6 +1427,19 @@ main locus App {
    Note rule 7 (the dead-receiver *error*) stays **direct-call-only**
    — it is not widened onto indirect paths, so the higher-stakes
    diagnostic keeps its precision.
+9. **Orphan bus topic (warning).** In a closed-world program (a
+   `main` locus present), a bus subject — a declared `topic` or a
+   literal string — wired to only one end is flagged: *published with
+   no subscriber* (the cells go nowhere) or *subscribed with no
+   publisher* (the handler can't fire), and a declared topic touched
+   by neither is *dead wiring*. Suppressed when the other end is
+   plausibly external: a **transport binding** (`bindings { T: ... }`
+   implies a cross-process peer), a **wildcard** subscriber/publisher
+   covering the subject (`log.**` covers `log.app`), a **cross-seed**
+   reference (`alias::Foo` — the other seed owns the other half), or
+   the same locus being both publisher and subscriber. The closed-
+   world gate is why this is skipped for library seeds (no `main`):
+   their consumers are downstream, out of the bundle. (GH #18 #4.)
 
 ### Single-threaded-method invariant
 


### PR DESCRIPTION
## What

First of the GH #18 **#4 bus-graph property checks**. The bus topology is a typed directed graph already in the AST; this walks it for **orphan** subjects — wired to only one end:

- published with **no subscriber** (cells go nowhere)
- subscribed with **no publisher** (handler can't fire)
- a declared topic touched by **neither** (dead wiring)

All warnings (hale's non-fatal diagnostic). New `check_bus_graph(bundle, top, diags)` pass in `check.rs`. Subjects keyed by `BusSubject::canonical()`; declared topics matched by both name and `wire_subject`.

## Soundness gates (why this isn't just naive)

- **Closed-world**: fires only when a `main` locus is present. A library seed's other end lives downstream, out of the bundle → skipped.
- **Bindings**: a topic in a `bindings { }` block has an external transport peer → counts as both ends.
- **Wildcards**: a `log.**` subscriber/publisher covers `log.app` (reuses `wildcard_match`).
- **Cross-seed**: an `alias::Foo` reference → the other seed owns the other half → never flagged.
- **Self-pub/sub**: same locus on both ends → not an orphan.

## Verification

- Clean on the bus corpus (`05-bus`, `19-pinned-bus`, `39-multi-instance-bus`, `34-quarantine-bus`) and the `topic_phase2_adapter_binding` shape (published+bound, never subscribed — the bindings guard suppresses it; this existing case is exactly why the guard is load-bearing).
- `tests/bus_graph.rs` (9): each positive (topic pub-only / sub-only / unused, literal pub-only) + each guard (both-ends, bound, wildcard-covered, self-pub/sub, no-main library).
- `placement.rs` (30) still green.

`spec/semantics.md` (type-check rule 9) + `docs/src/services/concurrency.md` updated in-commit.

**PR B** (next) adds the cycle warning + intra-locus re-entrant synchronous-deadlock error on the same graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)