### PR TITLE
spec: add verification.md — canonical static-check catalog

### DIFF
--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1361,6 +1361,10 @@ main locus App {
 
 ### Type-check rules
 
+> These placement/bus rules are part of the broader compile-time
+> verification surface; `spec/verification.md` is the canonical
+> catalog of every static check (with severities and enforcing passes).
+
 1. **`placement { }` is `main locus` only.** Any other locus
    declaring `placement { }` is a parse error (same shape as
    `bindings { }`).

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -1,0 +1,83 @@
+# Static verification surface
+
+This page is the canonical catalog of the compile-time **checks** the
+toolchain runs beyond ordinary type-checking — the structural and
+semantic guarantees a program earns at `hale build` / `hale check`
+time. It describes shipped behavior; the roadmap of *candidate* future
+checks lives in GitHub issue #18, not here.
+
+Two severity levels exist:
+
+- **error** — fails the build (`Diag::is_error()` is true).
+- **warning** — surfaced but non-fatal; the only non-error diagnostic
+  Hale emits. Used where the flagged shape is a real smell but can be
+  legitimate, so the call is left to the author.
+
+Most checks run in the bundle-level passes of
+`crates/hale-types/src/check.rs` (`check_bundle`); a few resolve-time
+ones run in `crates/hale-types/src/resolve.rs`; cell slot-of-origin is
+a codegen-time check. Each entry names the enforcing pass.
+
+## Concurrency & placement safety
+
+The bus + cooperative-pool model is the substrate; these checks keep a
+program's placement coherent with how the runtime dispatches.
+
+| Check | Catches | Severity | Enforced by |
+|---|---|---|---|
+| **Single-threaded-method invariant** | a *direct* cross-pool method call (`self.field.method()` where `field` is placed on a different pool) — it would run the callee's method on the wrong thread | error | `check_placement_single_thread` |
+| **Dead bus receiver** | a non-`main` cooperative locus that subscribes to the bus *and* makes a blocking call in `run()` — the blocking call monopolizes the pool thread so the dispatch never delivers and its handlers never fire | error | `check_cooperative_pool_blocking` |
+| **Blocking call on a cooperative pool** | a blocking `run()` (`recv`/`accept`, `process::run`) on a pool that isn't `where async_io` — it holds the pool's OS thread and stalls co-scheduled loci. Follows the call graph: blocking reached through a helper fn or `self.method` is flagged too | warning | `check_cooperative_pool_blocking` |
+| **Nested long-running child** | a non-`main` locus holding a params field of a locus type whose `run()` doesn't return — the canonical fix is hoisting it to a `main` sibling with its own placement | error | `check_nested_long_running_child` |
+| **Unowned subscriber locus** | a bus-subscribing locus instantiated *non-owned* inside another locus's method/handler body — it dissolves at that scope's exit, so its subscription can never fire (overridable with `--allow-unowned-subscriber`) | error | `check_unowned_subscriber_locus` |
+
+The dead-receiver error is deliberately **direct-call-only** (its
+call-graph surface is not widened), while the blocking *warning* is
+interprocedural — the high-stakes diagnostic stays precise. See
+`spec/semantics.md` type-check rules 7–8 and
+`docs/src/services/concurrency.md`.
+
+## Bus-graph property checks
+
+The bus topology is a typed directed graph in the source; these walk
+it. (GitHub issue #18 item 4.)
+
+| Check | Catches | Severity | Enforced by |
+|---|---|---|---|
+| **Orphan topic / subject** | a declared `topic` or literal subject wired to only one end — published with no subscriber, subscribed with no publisher, or used by neither | warning | `check_bus_graph` |
+| **Cross-locus bus cycle** | a publish→subscribe→publish loop spanning ≥2 loci — the cell hops via the cooperative queue and can spin / livelock | warning | `check_bus_cycles` |
+| **Intra-locus re-entrant cycle** | an *unconditional* self-republish loop within one locus — intra-locus self-dispatch is a direct synchronous call, so it recurses on one thread without bound (stack overflow) | error | `check_bus_cycles` |
+| **Routing-key fallback rules** | an `on_unmatched: fallback` topic with no `where key == _` subscriber, or a `where key == _` filter on a non-fallback topic | error | `check_phase3_fallback_subscribers` |
+| **Topic parent-chain cycle** | a topic hierarchy that loops (`topic A : B; topic B : A`) | error | `finalize_topic_chain` (resolve) |
+
+Orphan detection is **closed-world gated** (it runs only when a `main`
+locus is present), and suppressed by transport bindings, `**` wildcard
+coverage, cross-seed (`alias::Topic`) references, and self-pub/sub —
+so library seeds and external peers aren't falsely flagged. The
+intra-locus cycle error counts only *unconditional* sends as edges: a
+self-republish guarded by `if`/`match`/loop is a terminating state
+machine, not unbounded recursion, and is left alone. See
+`spec/semantics.md` type-check rules 9–10.
+
+## Structural & design rules
+
+| Check | Catches | Severity | Enforced by |
+|---|---|---|---|
+| **CQRS / no-locus-return** | a locus `fn` member whose return type (or `fallible(T)` payload) names a user-declared locus type — returning a managed entity from a method is a Law-of-Demeter / CQRS / Dependency-Inversion violation that also leaks via payload-arena routing | error | `check_no_locus_return` |
+| **Stdlib error-type shadow** | a user-declared `type IoError` / `ParseError` / `CryptoError` / `IndexError` / `KeyError` / `EmptyError` whose shape doesn't match the stdlib's, when that error type is reached by a fallible stdlib call | error | `check_stdlib_error_shadowing` (resolve) |
+| **Codec purity** | a bus codec whose `encode` / `decode` method isn't pure (codecs may be dispatched off-thread) | error | `check_main_and_bindings` + `purity::infer_purity_for_bundle` |
+| **Cell slot-of-origin** | releasing a `Cell<T>` into a different `(locus, slot)` than it was acquired from | error | codegen |
+
+CQRS is GitHub issue #18 item 6; its three sanctioned remedies
+(parent-child + contract, bus mediator, delegation) are named in the
+diagnostic. See `spec/semantics.md § Locus method dispatch`.
+
+## Not yet offered
+
+The remaining GitHub issue #18 candidates are **not** implemented and
+must not be assumed: memory-bound proofs (item 1), model-checked
+race-completeness for substrate primitives (item 2), closure-assertion
+lifting (item 3), backpressure-unboundedness and explicit subject
+type-mismatch diagnostics (the rest of item 4), and resource-budget
+tracking (item 5). Closures still verify their invariants at *runtime*;
+nothing here proves allocation, fd, or thread bounds statically.


### PR DESCRIPTION
## What

Adds `spec/verification.md`: a single canonical page cataloging every **compile-time check** the toolchain runs beyond ordinary type-checking, in three groups —

- **Concurrency & placement safety** (single-threaded-method, dead-receiver, blocking warning, nested long-running child, unowned subscriber)
- **Bus-graph property checks** (orphans, cross-locus cycle, intra-locus re-entrant, routing-key fallback, topic parent cycle)
- **Structural & design rules** (CQRS/no-locus-return, stdlib error-shadow, codec purity, cell slot-of-origin)

Each entry lists what it catches, its **severity** (error vs warning), and the **enforcing pass** in `check.rs`/`resolve.rs`, so the verification surface is discoverable in one place instead of scattered across `semantics.md` rules and the source.

## Why

Prompted by "I'm not sure what actual verifs we offer now." The page also has an explicit **"Not yet offered"** section listing the unimplemented GH #18 candidates (memory bounds, model-checked races, closure lifting, resource budgets, backpressure) so it can't be misread as promising guarantees we don't ship.

Cross-linked from `semantics.md`'s type-check-rules section. Companion to the GH #18 body annotation marking #4's landed sub-checks.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)