### PR TITLE
Bus backpressure check (GH #18 #4)

### DIFF
--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -214,6 +214,10 @@ pub fn check_bundle(
     // an intra-locus loop is devirtualized synchronous self-dispatch
     // that recurses without bound (error).
     check_bus_cycles(bundle, &mut diags);
+    // GH #18 #4: backpressure. An unbounded publish loop with no
+    // yield/throttle floods the bus — the producer has no
+    // backpressure. Structural heuristic (warning).
+    check_bus_backpressure(bundle, &mut diags);
     diags
 }
 
@@ -3449,6 +3453,228 @@ fn check_bus_cycles(bundle: &Bundle<'_>, diags: &mut Vec<Diag>) {
                 ),
             ));
         }
+    }
+}
+
+// === Bus backpressure (GH #18 #4) ==================================
+//
+// A producer with no flow control floods the bus without bound. A
+// full "consumer can't sustain the rate" analysis is undecidable, so
+// this is a deliberately narrow structural heuristic for the clearest
+// case: an UNBOUNDED loop (`while true`) that publishes on some
+// iteration but contains no flow-control or exit point — no
+// cooperative `yield` (which lets a co-scheduled consumer drain), no
+// `time::sleep`/`tick` throttle, no input-pacing blocking `recv`, and
+// no `break`/`return` that could exit. Such a loop posts cells faster
+// than anything can drain them — the queue and the payload arena grow
+// without bound. A warning (the heuristic can't prove the OOM, only
+// flag the missing backpressure). Bounded loops (`for`, `while
+// cond`) are never flagged — only literal `while true`.
+
+/// Flow-control / exit primitives whose presence anywhere in an
+/// unbounded loop body rules out the flood: the loop either paces
+/// itself or can leave.
+fn block_has_flow_control(b: &Block) -> bool {
+    b.stmts.iter().any(stmt_has_flow_control)
+}
+
+fn stmt_has_flow_control(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Yield(_) | Stmt::Break(_) | Stmt::Return(..) => true,
+        Stmt::Let { value, .. } | Stmt::LetTuple { value, .. } => {
+            expr_has_flow_control_call(value)
+        }
+        Stmt::Assign { value, .. } => expr_has_flow_control_call(value),
+        Stmt::Expr(e) => expr_has_flow_control_call(e),
+        Stmt::Send { subject, value, .. } => {
+            expr_has_flow_control_call(subject)
+                || expr_has_flow_control_call(value)
+        }
+        Stmt::If(i) => if_has_flow_control(i),
+        Stmt::Match(m) => m.arms.iter().any(|arm| match &arm.body {
+            MatchArmBody::Block(b) => block_has_flow_control(b),
+            MatchArmBody::Expr(e) => expr_has_flow_control_call(e),
+        }),
+        Stmt::For { body, .. } | Stmt::While { body, .. } => {
+            block_has_flow_control(body)
+        }
+        Stmt::Block(b) => block_has_flow_control(b),
+        _ => false,
+    }
+}
+
+fn if_has_flow_control(i: &IfStmt) -> bool {
+    block_has_flow_control(&i.then_block)
+        || match i.else_block.as_deref() {
+            Some(ElseBranch::Else(b)) => block_has_flow_control(b),
+            Some(ElseBranch::ElseIf(n)) => if_has_flow_control(n),
+            None => false,
+        }
+}
+
+/// A call to a throttle (`time::sleep`/`tick`) or an input-pacing
+/// blocking op (`recv`/`accept`/`wait`) — both bound the publish rate.
+fn expr_has_flow_control_call(expr: &Expr) -> bool {
+    match expr {
+        Expr::Call { callee, args, .. } => {
+            if let Expr::Path(qn) = callee.as_ref() {
+                let segs: Vec<&str> =
+                    qn.segments.iter().map(|s| s.name.as_str()).collect();
+                if blocking_path_match(&segs).is_some()
+                    || segs == ["std", "time", "sleep"]
+                    || segs == ["std", "time", "tick"]
+                {
+                    return true;
+                }
+            }
+            expr_has_flow_control_call(callee)
+                || args.iter().any(expr_has_flow_control_call)
+        }
+        Expr::Binary { left, right, .. } => {
+            expr_has_flow_control_call(left)
+                || expr_has_flow_control_call(right)
+        }
+        Expr::Unary { operand, .. } => expr_has_flow_control_call(operand),
+        Expr::Field { receiver, .. } | Expr::Path2 { receiver, .. } => {
+            expr_has_flow_control_call(receiver)
+        }
+        Expr::Index { receiver, index, .. } => {
+            expr_has_flow_control_call(receiver)
+                || expr_has_flow_control_call(index)
+        }
+        Expr::Tuple(es, _) | Expr::Array(es, _) => {
+            es.iter().any(expr_has_flow_control_call)
+        }
+        Expr::Struct { inits, .. } => {
+            inits.iter().any(|i| expr_has_flow_control_call(&i.value))
+        }
+        Expr::Block(b) => block_has_flow_control(b),
+        Expr::If(i) => {
+            block_has_flow_control(&i.then_block)
+                || matches!(i.else_block.as_deref(), Some(ElseBranch::Else(b)) if block_has_flow_control(b))
+        }
+        Expr::Match(m) => m.arms.iter().any(|arm| match &arm.body {
+            MatchArmBody::Block(b) => block_has_flow_control(b),
+            MatchArmBody::Expr(e) => expr_has_flow_control_call(e),
+        }),
+        Expr::Sum(e, _) | Expr::Prod(e, _) => expr_has_flow_control_call(e),
+        Expr::Or { inner, .. } => expr_has_flow_control_call(inner),
+        _ => false,
+    }
+}
+
+/// Whether a block subtree contains a bus `Topic <- value` send.
+fn block_has_send(b: &Block) -> bool {
+    b.stmts.iter().any(stmt_has_send)
+}
+
+fn stmt_has_send(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Send { .. } => true,
+        Stmt::If(i) => if_has_send(i),
+        Stmt::Match(m) => m.arms.iter().any(|arm| {
+            matches!(&arm.body, MatchArmBody::Block(b) if block_has_send(b))
+        }),
+        Stmt::For { body, .. } | Stmt::While { body, .. } => block_has_send(body),
+        Stmt::Block(b) => block_has_send(b),
+        _ => false,
+    }
+}
+
+fn if_has_send(i: &IfStmt) -> bool {
+    block_has_send(&i.then_block)
+        || match i.else_block.as_deref() {
+            Some(ElseBranch::Else(b)) => block_has_send(b),
+            Some(ElseBranch::ElseIf(n)) => if_has_send(n),
+            None => false,
+        }
+}
+
+fn is_literal_true(e: &Expr) -> bool {
+    matches!(e, Expr::Literal(Literal::Bool(true), _))
+}
+
+/// Walk a method/lifecycle body for unbounded publish-flood loops.
+fn scan_flood_in_block(b: &Block, locus: &str, diags: &mut Vec<Diag>) {
+    for s in &b.stmts {
+        scan_flood_in_stmt(s, locus, diags);
+    }
+}
+
+fn scan_flood_in_stmt(stmt: &Stmt, locus: &str, diags: &mut Vec<Diag>) {
+    match stmt {
+        Stmt::While { cond, body, span } if is_literal_true(cond) => {
+            if block_has_send(body) && !block_has_flow_control(body) {
+                diags.push(Diag::warn(
+                    *span,
+                    format!(
+                        "locus `{}` publishes to the bus inside an unbounded \
+                         `while true` loop with no flow control — no `yield`, \
+                         `time::sleep`/`tick`, input-pacing `recv`, or \
+                         `break`/`return`. The producer has no backpressure, \
+                         so cells pile up in the queue (and the payload arena) \
+                         without bound. Pace the loop (a `time::sleep`/`tick`), \
+                         drive it from an input (a blocking `recv` so the \
+                         publish rate follows the input rate), or `yield` to \
+                         let a co-scheduled subscriber drain.",
+                        locus
+                    ),
+                ));
+                // Reported the outermost flood; don't descend further.
+            } else {
+                scan_flood_in_block(body, locus, diags);
+            }
+        }
+        Stmt::While { body, .. } | Stmt::For { body, .. } => {
+            scan_flood_in_block(body, locus, diags)
+        }
+        Stmt::If(i) => scan_flood_in_if(i, locus, diags),
+        Stmt::Match(m) => {
+            for arm in &m.arms {
+                if let MatchArmBody::Block(b) = &arm.body {
+                    scan_flood_in_block(b, locus, diags);
+                }
+            }
+        }
+        Stmt::Block(b) => scan_flood_in_block(b, locus, diags),
+        _ => {}
+    }
+}
+
+fn scan_flood_in_if(i: &IfStmt, locus: &str, diags: &mut Vec<Diag>) {
+    scan_flood_in_block(&i.then_block, locus, diags);
+    match i.else_block.as_deref() {
+        Some(ElseBranch::Else(b)) => scan_flood_in_block(b, locus, diags),
+        Some(ElseBranch::ElseIf(n)) => scan_flood_in_if(n, locus, diags),
+        None => {}
+    }
+}
+
+fn check_bus_backpressure(bundle: &Bundle<'_>, diags: &mut Vec<Diag>) {
+    fn walk(items: &[TopDecl], diags: &mut Vec<Diag>) {
+        for item in items {
+            match item {
+                TopDecl::Locus(l) => {
+                    let lname = l.name.name.as_str();
+                    for m in &l.members {
+                        match m {
+                            LocusMember::Lifecycle(LifecycleDecl {
+                                body, ..
+                            }) => scan_flood_in_block(body, lname, diags),
+                            LocusMember::Fn(f) => {
+                                scan_flood_in_block(&f.body, lname, diags)
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                TopDecl::Module(md) => walk(&md.items, diags),
+                _ => {}
+            }
+        }
+    }
+    for program in bundle.programs.values() {
+        walk(&program.items, diags);
     }
 }
 

--- a/crates/hale-types/tests/bus_graph.rs
+++ b/crates/hale-types/tests/bus_graph.rs
@@ -434,6 +434,110 @@ fn main() { App { }; }
     );
 }
 
+// --- backpressure (PR C) -------------------------------------------
+
+const BACKPRESSURE: &str = "no backpressure";
+
+fn flood_src(run_body: &str) -> String {
+    format!(
+        r#"
+type Tick {{ n: Int; }}
+topic Beat {{ payload: Tick; subject: "beat"; }}
+
+locus Flooder {{
+    bus {{ publish Beat; subscribe Beat as on_beat; }}
+    fn on_beat(t: Tick) {{ }}
+    run() {{ {run_body} }}
+}}
+
+main locus App {{
+    params {{ f: Flooder = Flooder {{ }}; }}
+}}
+
+fn main() {{ App {{ }}; }}
+"#
+    )
+}
+
+#[test]
+fn unbounded_publish_loop_with_no_flow_control_warns() {
+    let msgs = check(&flood_src("while true { Beat <- Tick { n: 1 }; }"));
+    assert!(
+        msgs.iter().any(|m| m.contains(BACKPRESSURE) && m.contains("`Flooder`")),
+        "an unthrottled publish loop must warn; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn throttled_publish_loop_is_ok() {
+    let msgs = check(&flood_src(
+        "while true { Beat <- Tick { n: 1 }; std::time::sleep(1s); }",
+    ));
+    assert!(
+        !msgs.iter().any(|m| m.contains(BACKPRESSURE)),
+        "a sleep-paced publish loop has backpressure; must not warn; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn yielding_publish_loop_is_ok() {
+    let msgs = check(&flood_src("while true { Beat <- Tick { n: 1 }; yield; }"));
+    assert!(
+        !msgs.iter().any(|m| m.contains(BACKPRESSURE)),
+        "a yielding publish loop lets the subscriber drain; must not warn; \
+         got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn input_driven_publish_loop_is_ok() {
+    // A blocking recv paces the loop — publish rate follows input.
+    let msgs = check(&flood_src(
+        "while true { let n = std::io::tcp::recv_into(0, 0, 64); Beat <- Tick { n: 1 }; }",
+    ));
+    assert!(
+        !msgs.iter().any(|m| m.contains(BACKPRESSURE)),
+        "an input-paced publish loop must not warn; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn bounded_for_loop_publish_is_ok() {
+    let msgs = check(&flood_src("for i in 0..10 { Beat <- Tick { n: i }; }"));
+    assert!(
+        !msgs.iter().any(|m| m.contains(BACKPRESSURE)),
+        "a bounded loop posts a bounded number of cells; must not warn; \
+         got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn breakable_publish_loop_is_ok() {
+    let msgs = check(&flood_src(
+        "let mut i = 0; while true { Beat <- Tick { n: i }; i = i + 1; if i > 5 { break; } }",
+    ));
+    assert!(
+        !msgs.iter().any(|m| m.contains(BACKPRESSURE)),
+        "a loop that can `break` is bounded; must not warn; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn unbounded_loop_without_publish_is_ok() {
+    let msgs = check(&flood_src("while true { let x = 1 + 1; }"));
+    assert!(
+        !msgs.iter().any(|m| m.contains(BACKPRESSURE)),
+        "an unbounded loop that doesn't publish isn't a bus flood; got: {:?}",
+        msgs
+    );
+}
+
 #[test]
 fn library_without_main_is_not_checked() {
     // No `main` locus: the publishers/subscribers may live in

--- a/docs/src/services/concurrency.md
+++ b/docs/src/services/concurrency.md
@@ -197,6 +197,12 @@ placement and the locus's shape are known at compile time:
   until the stack overflows — an error. (Only an *unconditional*
   self-republish errors; one guarded by an `if` is a terminating
   state machine and is left alone.)
+- **An unthrottled publish loop is a warning.** A `while true` loop
+  that publishes with no `yield`, `time::sleep`/`tick`, input-pacing
+  `recv`, or `break`/`return` floods the bus — the producer has no
+  backpressure, so cells pile up without bound. Pace the loop, drive
+  it from an input, or `yield` to let the subscriber drain. (Bounded
+  loops are never flagged; any flow-control point clears it.)
 
 It also enforces the **single-threaded-method invariant**: a locus's
 methods may only be called on the thread that owns its pool, so a

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1459,6 +1459,17 @@ main locus App {
       self-republish guarded by an `if`/`match`/loop is a terminating
       state machine, not unbounded recursion, and is not flagged.
       (GH #18 #4.)
+11. **Bus backpressure (warning).** A locus that publishes to the bus
+    inside an **unbounded** `while true` loop carrying no flow-control
+    or exit point — no cooperative `yield`, no `time::sleep`/`tick`
+    throttle, no input-pacing blocking `recv`, no `break`/`return` —
+    has no backpressure: it posts cells faster than any subscriber can
+    drain, so the queue and the payload arena grow without bound. A
+    full producer-vs-consumer rate analysis is undecidable, so this is
+    a deliberately narrow structural heuristic (warning): only literal
+    `while true` loops are considered (bounded `for`/`while cond`
+    loops never are), and any flow-control point anywhere in the loop
+    body clears it. (GH #18 #4.)
 
 ### Single-threaded-method invariant
 

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -47,6 +47,7 @@ it. (GitHub issue #18 item 4.)
 | **Orphan topic / subject** | a declared `topic` or literal subject wired to only one end — published with no subscriber, subscribed with no publisher, or used by neither | warning | `check_bus_graph` |
 | **Cross-locus bus cycle** | a publish→subscribe→publish loop spanning ≥2 loci — the cell hops via the cooperative queue and can spin / livelock | warning | `check_bus_cycles` |
 | **Intra-locus re-entrant cycle** | an *unconditional* self-republish loop within one locus — intra-locus self-dispatch is a direct synchronous call, so it recurses on one thread without bound (stack overflow) | error | `check_bus_cycles` |
+| **Bus backpressure** | a publish inside an unbounded `while true` loop with no flow-control or exit point (`yield` / `sleep`/`tick` / input-pacing `recv` / `break`/`return`) — floods the bus without bound | warning | `check_bus_backpressure` |
 | **Routing-key fallback rules** | an `on_unmatched: fallback` topic with no `where key == _` subscriber, or a `where key == _` filter on a non-fallback topic | error | `check_phase3_fallback_subscribers` |
 | **Topic parent-chain cycle** | a topic hierarchy that loops (`topic A : B; topic B : A`) | error | `finalize_topic_chain` (resolve) |
 
@@ -77,7 +78,8 @@ diagnostic. See `spec/semantics.md § Locus method dispatch`.
 The remaining GitHub issue #18 candidates are **not** implemented and
 must not be assumed: memory-bound proofs (item 1), model-checked
 race-completeness for substrate primitives (item 2), closure-assertion
-lifting (item 3), backpressure-unboundedness and explicit subject
-type-mismatch diagnostics (the rest of item 4), and resource-budget
-tracking (item 5). Closures still verify their invariants at *runtime*;
-nothing here proves allocation, fd, or thread bounds statically.
+lifting (item 3), an explicit subject type-mismatch diagnostic (the
+last of item 4 — today it's an implicit guarantee of path-mangling),
+and resource-budget tracking (item 5). Closures still verify their
+invariants at *runtime*; nothing here proves allocation, fd, or thread
+bounds statically.


### PR DESCRIPTION
## What

The last of the **#4 bus-graph property checks**. Flags a producer with no backpressure:

```hale
run() { while true { Beat <- Tick { n: 1 }; } }   // WARNING: no backpressure
```

A full producer-vs-consumer rate analysis is undecidable, so this is a deliberately **narrow structural heuristic** for the clearest unbounded-producer pattern: a publish inside an unbounded `while true` loop with **no** flow-control or exit point — no cooperative `yield`, no `time::sleep`/`tick`, no input-pacing blocking `recv`, no `break`/`return`. Such a loop posts cells faster than anything can drain them; the queue and payload arena grow without bound.

## Low false-positive by design

Warning, not error (it flags the missing backpressure, can't prove the OOM). Kept conservative:

- Only **literal `while true`** counts as unbounded — a `for` or `while cond` is bounded and never flagged.
- **Any** flow-control point *anywhere* in the loop body clears it.

So the idioms that *have* backpressure don't fire:

```hale
while true { Beat <- t; std::time::sleep(1s); }                  // throttled — ok
while true { Beat <- t; yield; }                                 // yields, subscriber drains — ok
while true { let n = recv_into(0,0,64); Beat <- t; }             // input-paced — ok
for i in 0..10 { Beat <- t; }                                    // bounded — ok
```

## Verification

- **Whole fixture corpus swept**: no backpressure warnings (the `while true { … sleep }` heartbeats are correctly exempt).
- `tests/bus_graph.rs` +7: the flood warns; throttled / yielding / input-driven / bounded-`for` / breakable / publish-free loops do not. (Suite now 21: 9 orphan + 5 cycle + 7 backpressure.)

`spec/semantics.md` rule 11 + `docs/src/services/concurrency.md` + the `spec/verification.md` catalog (new row; removed from "Not yet offered") updated in-commit.

This lands the last of the three remaining #4 items I flagged; only the explicit subject **type-mismatch** diagnostic remains (today an implicit path-mangling guarantee).

🤖 Generated with [Claude Code](https://claude.com/claude-code)