### PR TITLE
Bus subject type-mismatch check (GH #18 #4 — completes item 4)

### DIFF
--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -218,6 +218,12 @@ pub fn check_bundle(
     // yield/throttle floods the bus — the producer has no
     // backpressure. Structural heuristic (warning).
     check_bus_backpressure(bundle, &mut diags);
+    // GH #18 #4: subject type-mismatch. Two literal-subject sites
+    // addressing the same wire subject must agree on the payload
+    // type — otherwise a subscriber decodes the publisher's bytes as
+    // the wrong type. Declared `topic`s are already unified by their
+    // declaration; this closes the literal-subject gap.
+    check_bus_subject_types(bundle, &mut diags);
     diags
 }
 
@@ -3647,6 +3653,144 @@ fn scan_flood_in_if(i: &IfStmt, locus: &str, diags: &mut Vec<Diag>) {
         Some(ElseBranch::Else(b)) => scan_flood_in_block(b, locus, diags),
         Some(ElseBranch::ElseIf(n)) => scan_flood_in_if(n, locus, diags),
         None => {}
+    }
+}
+
+// === Bus subject type-mismatch (GH #18 #4) ========================
+//
+// A *declared* `topic` fixes its payload type once, so every `publish
+// Foo` / `subscribe Foo` site is unified by the declaration — no
+// mismatch possible (and `of type` is forbidden on topic refs). The
+// hole is *literal* subjects (`publish "wire.sig" of type Tick`):
+// nothing ties the `of type` annotations at two sites on the same
+// wire string together, so a publisher's `Tick` and a subscriber's
+// `Pulse` both compile — and at runtime the subscriber decodes the
+// publisher's bytes as the wrong type. That is a hard correctness
+// bug, so this is an **error**.
+//
+// Grouping is by EXACT subject string, which deliberately sidesteps
+// wildcards (`log.**` is a different string than `log.app`, so the
+// two are never cross-compared — wildcard-subscriber type
+// compatibility is a separate, fuzzier question).
+
+/// A canonical, comparable rendering of a `TypeExpr` — equal strings
+/// mean the same type at this layer. Also used in the diagnostic.
+fn type_expr_key(t: &TypeExpr) -> String {
+    match t {
+        TypeExpr::Primitive(p, _) => format!("{:?}", p),
+        TypeExpr::Named { path, generic_args, .. } => {
+            let base = path
+                .segments
+                .iter()
+                .map(|s| s.name.as_str())
+                .collect::<Vec<_>>()
+                .join("::");
+            if generic_args.is_empty() {
+                base
+            } else {
+                let args = generic_args
+                    .iter()
+                    .map(type_expr_key)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{}<{}>", base, args)
+            }
+        }
+        TypeExpr::Projection { class, inner, .. } => {
+            format!("{:?}({})", class, type_expr_key(inner))
+        }
+        TypeExpr::Array { elem, .. } => format!("[{}]", type_expr_key(elem)),
+        TypeExpr::Tuple(tys, _) => format!(
+            "({})",
+            tys.iter().map(type_expr_key).collect::<Vec<_>>().join(", ")
+        ),
+        TypeExpr::Function { params, ret, .. } => format!(
+            "fn({}){}",
+            params.iter().map(type_expr_key).collect::<Vec<_>>().join(", "),
+            ret.as_ref()
+                .map(|r| format!(" -> {}", type_expr_key(r)))
+                .unwrap_or_default()
+        ),
+    }
+}
+
+fn check_bus_subject_types(bundle: &Bundle<'_>, diags: &mut Vec<Diag>) {
+    // subject string -> the distinct payload types seen, each with a
+    // representative site span. Insertion order preserved so the
+    // first-declared type is the "expected" one in the message.
+    let mut subjects: BTreeMap<String, Vec<(String, Span)>> = BTreeMap::new();
+
+    fn record(
+        subject: &BusSubject,
+        ty: &Option<TypeExpr>,
+        span: Span,
+        subjects: &mut BTreeMap<String, Vec<(String, Span)>>,
+    ) {
+        // Only literal subjects carry an independent `of type`; topic
+        // refs are unified by their declaration, qualified refs live
+        // in another seed.
+        let BusSubject::Literal { subject: subj, .. } = subject else {
+            return;
+        };
+        let Some(ty) = ty else { return };
+        let key = type_expr_key(ty);
+        let entry = subjects.entry(subj.clone()).or_default();
+        if !entry.iter().any(|(k, _)| k == &key) {
+            entry.push((key, span));
+        }
+    }
+
+    fn walk(
+        items: &[TopDecl],
+        subjects: &mut BTreeMap<String, Vec<(String, Span)>>,
+    ) {
+        for item in items {
+            match item {
+                TopDecl::Locus(l) => {
+                    for m in &l.members {
+                        if let LocusMember::Bus(bb) = m {
+                            for bm in &bb.members {
+                                match bm {
+                                    BusMember::Publish { subject, ty, span, .. } => {
+                                        record(subject, ty, *span, subjects)
+                                    }
+                                    BusMember::Subscribe { subject, ty, span, .. } => {
+                                        record(subject, ty, *span, subjects)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                TopDecl::Module(md) => walk(&md.items, subjects),
+                _ => {}
+            }
+        }
+    }
+    for program in bundle.programs.values() {
+        walk(&program.items, &mut subjects);
+    }
+
+    for (subj, types) in &subjects {
+        if types.len() < 2 {
+            continue;
+        }
+        let (expected, _) = &types[0];
+        // Report each divergent type once, at its site.
+        for (got, span) in types.iter().skip(1) {
+            diags.push(Diag::ty(
+                *span,
+                format!(
+                    "bus subject `\"{}\"` is used with conflicting payload \
+                     types: `{}` here vs `{}` at another site. Every \
+                     publish/subscribe on the same subject must carry the \
+                     same payload type — a mismatch decodes the wire bytes as \
+                     the wrong type at runtime. Declare a `topic` to fix the \
+                     type in one place, or align the `of type` annotations.",
+                    subj, got, expected,
+                ),
+            ));
+        }
     }
 }
 

--- a/crates/hale-types/tests/bus_graph.rs
+++ b/crates/hale-types/tests/bus_graph.rs
@@ -538,6 +538,137 @@ fn unbounded_loop_without_publish_is_ok() {
     );
 }
 
+// --- subject type-mismatch (PR D) ----------------------------------
+
+const CONFLICT: &str = "conflicting payload types";
+
+#[test]
+fn literal_subject_with_conflicting_payload_types_errors() {
+    let src = r#"
+type Tick { n: Int; }
+type Pulse { hz: Int; }
+
+locus Pub {
+    bus { publish "wire.sig" of type Tick; }
+    birth() { "wire.sig" <- Tick { n: 1 }; }
+}
+
+locus Sub {
+    bus { subscribe "wire.sig" as on_sig of type Pulse; }
+    fn on_sig(p: Pulse) { }
+}
+
+main locus App {
+    params { p: Pub = Pub { }; s: Sub = Sub { }; }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains(CONFLICT)
+            && m.contains("wire.sig")
+            && m.contains("Tick")
+            && m.contains("Pulse")),
+        "mismatched payload types on the same literal subject must error; \
+         got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn literal_subject_with_matching_payload_types_is_clean() {
+    let src = r#"
+type Tick { n: Int; }
+
+locus Pub {
+    bus { publish "wire.sig" of type Tick; }
+    birth() { "wire.sig" <- Tick { n: 1 }; }
+}
+
+locus Sub {
+    bus { subscribe "wire.sig" as on_sig of type Tick; }
+    fn on_sig(t: Tick) { }
+}
+
+main locus App {
+    params { p: Pub = Pub { }; s: Sub = Sub { }; }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        !msgs.iter().any(|m| m.contains(CONFLICT)),
+        "agreeing payload types must not error; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn different_subjects_with_different_types_is_clean() {
+    // Two different subjects, each with its own type — no conflict.
+    let src = r#"
+type Tick { n: Int; }
+type Pulse { hz: Int; }
+
+locus L {
+    bus {
+        publish "a" of type Tick;
+        publish "b" of type Pulse;
+        subscribe "a" as on_a of type Tick;
+        subscribe "b" as on_b of type Pulse;
+    }
+    fn on_a(t: Tick) { }
+    fn on_b(p: Pulse) { }
+}
+
+main locus App {
+    params { l: L = L { }; }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        !msgs.iter().any(|m| m.contains(CONFLICT)),
+        "distinct subjects with distinct types must not error; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn declared_topic_is_not_subject_to_mismatch() {
+    // A declared topic unifies its payload at the declaration, so two
+    // sites referencing it can't disagree — and carry no `of type`.
+    let src = r#"
+type Tick { n: Int; }
+topic Beat { payload: Tick; subject: "beat"; }
+
+locus Pub {
+    bus { publish Beat; }
+    birth() { Beat <- Tick { n: 1 }; }
+}
+
+locus Sub {
+    bus { subscribe Beat as on_beat; }
+    fn on_beat(t: Tick) { }
+}
+
+main locus App {
+    params { p: Pub = Pub { }; s: Sub = Sub { }; }
+}
+
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        !msgs.iter().any(|m| m.contains(CONFLICT)),
+        "declared topics are unified by their declaration; got: {:?}",
+        msgs
+    );
+}
+
 #[test]
 fn library_without_main_is_not_checked() {
     // No `main` locus: the publishers/subscribers may live in

--- a/docs/src/services/concurrency.md
+++ b/docs/src/services/concurrency.md
@@ -203,6 +203,11 @@ placement and the locus's shape are known at compile time:
   backpressure, so cells pile up without bound. Pace the loop, drive
   it from an input, or `yield` to let the subscriber drain. (Bounded
   loops are never flagged; any flow-control point clears it.)
+- **A subject payload type-mismatch is an error.** If two sites
+  publish/subscribe the same literal subject string with different
+  `of type` payloads, a subscriber would decode the wrong type at
+  runtime — rejected. (Declared `topic`s are already unified by their
+  declaration, so this only affects ad-hoc literal subjects.)
 
 It also enforces the **single-threaded-method invariant**: a locus's
 methods may only be called on the thread that owns its pool, so a

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1470,6 +1470,17 @@ main locus App {
     `while true` loops are considered (bounded `for`/`while cond`
     loops never are), and any flow-control point anywhere in the loop
     body clears it. (GH #18 #4.)
+12. **Bus subject type-mismatch (error).** Every publish/subscribe
+    site addressing the same **literal** subject string must declare
+    the same `of type` payload — otherwise a subscriber decodes the
+    publisher's bytes as the wrong type at runtime. A declared `topic`
+    is already unified by its declaration (and `of type` is forbidden
+    on topic refs), so this closes the literal-subject gap.
+    Grouping is by *exact* subject string, which excludes wildcards
+    (`log.**` and `log.app` are different strings, never
+    cross-compared). The fix is to declare a `topic` (one payload
+    type, fixed in one place) or align the `of type` annotations.
+    (GH #18 #4.)
 
 ### Single-threaded-method invariant
 

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -48,6 +48,7 @@ it. (GitHub issue #18 item 4.)
 | **Cross-locus bus cycle** | a publish→subscribe→publish loop spanning ≥2 loci — the cell hops via the cooperative queue and can spin / livelock | warning | `check_bus_cycles` |
 | **Intra-locus re-entrant cycle** | an *unconditional* self-republish loop within one locus — intra-locus self-dispatch is a direct synchronous call, so it recurses on one thread without bound (stack overflow) | error | `check_bus_cycles` |
 | **Bus backpressure** | a publish inside an unbounded `while true` loop with no flow-control or exit point (`yield` / `sleep`/`tick` / input-pacing `recv` / `break`/`return`) — floods the bus without bound | warning | `check_bus_backpressure` |
+| **Subject type-mismatch** | two sites on the same literal subject string declaring different `of type` payloads — a subscriber would decode the wrong type | error | `check_bus_subject_types` |
 | **Routing-key fallback rules** | an `on_unmatched: fallback` topic with no `where key == _` subscriber, or a `where key == _` filter on a non-fallback topic | error | `check_phase3_fallback_subscribers` |
 | **Topic parent-chain cycle** | a topic hierarchy that loops (`topic A : B; topic B : A`) | error | `finalize_topic_chain` (resolve) |
 
@@ -78,8 +79,7 @@ diagnostic. See `spec/semantics.md § Locus method dispatch`.
 The remaining GitHub issue #18 candidates are **not** implemented and
 must not be assumed: memory-bound proofs (item 1), model-checked
 race-completeness for substrate primitives (item 2), closure-assertion
-lifting (item 3), an explicit subject type-mismatch diagnostic (the
-last of item 4 — today it's an implicit guarantee of path-mangling),
-and resource-budget tracking (item 5). Closures still verify their
-invariants at *runtime*; nothing here proves allocation, fd, or thread
-bounds statically.
+lifting (item 3), and resource-budget tracking (item 5). Item 4
+(bus-graph property checks) is fully landed. Closures still verify
+their invariants at *runtime*; nothing here proves allocation, fd, or
+thread bounds statically.


### PR DESCRIPTION
## What

Closes the last #4 bus-graph gap. A subscriber decoding the wrong payload type:

```hale
locus Pub { bus { publish   "wire.sig" of type Tick;  } ... }
locus Sub { bus { subscribe "wire.sig" of type Pulse; } ... }   // ERROR
```

A declared `topic` fixes its payload type once, so every `publish Foo`/`subscribe Foo` site is unified by the declaration (and `of type` is forbidden on topic refs). But **literal** subjects carry an independent `of type` at each site with nothing tying them together — the repro above compiled **and built** cleanly, and at runtime the subscriber decodes the publisher's `Tick` bytes as `Pulse`. A hard correctness bug → **error**.

## How

`check_bus_subject_types`: group publish/subscribe sites by **exact** literal subject string; within a group, all `of type` payloads must share a canonical `type_expr_key`. Exact-string grouping deliberately **excludes wildcards** (`log.**` ≠ `log.app`, never cross-compared — wildcard type compatibility is a separate, fuzzier question). Declared topics and qualified cross-seed refs carry no literal `of type` and are skipped.

## Verification

- The `Tick`-vs-`Pulse` repro now fails the build (was clean before).
- **Whole fixture corpus stays clean** — no false conflicts (critical, since this is a fatal error).
- `tests/bus_graph.rs` +4: conflict errors, agreeing types clean, distinct-subjects clean, declared-topic exempt. Suite now **25** (9 orphan + 5 cycle + 7 backpressure + 4 type-mismatch).

`spec/semantics.md` rule 12 + `docs/src/services/concurrency.md` + the `spec/verification.md` catalog (new row; **item 4 now marked fully landed**) updated in-commit.

**This completes all five #4 sub-checks.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)