### PR TITLE
Race-completeness PoC: GenMC model of the lockfree hashmap (GH #18 #2)

### DIFF
--- a/spec/verification.md
+++ b/spec/verification.md
@@ -77,9 +77,15 @@ diagnostic. See `spec/semantics.md § Locus method dispatch`.
 ## Not yet offered
 
 The remaining GitHub issue #18 candidates are **not** implemented and
-must not be assumed: memory-bound proofs (item 1), model-checked
-race-completeness for substrate primitives (item 2), closure-assertion
+must not be assumed: memory-bound proofs (item 1), closure-assertion
 lifting (item 3), and resource-budget tracking (item 5). Item 4
 (bus-graph property checks) is fully landed. Closures still verify
 their invariants at *runtime*; nothing here proves allocation, fd, or
 thread bounds statically.
+
+Item 2 (race-completeness for substrate primitives) is a *substrate*
+quality bar, not a user-facing check: it model-checks the runtime's own
+concurrent primitives under all C11 interleavings. A proof-of-concept
+has landed (the lockfree hashmap's enter/drain/grow protocol, verified
+exhaustively with GenMC) — see `verification/`. It is not yet a CI gate
+across every primitive.

--- a/verification/README.md
+++ b/verification/README.md
@@ -1,0 +1,97 @@
+# Substrate race-completeness (GH issue #18 item 2)
+
+Model-check the lotus runtime's concurrent primitives under **every**
+thread interleaving the C11 memory model permits — to catch races and
+use-after-frees that TSan only hits along paths a test happens to
+exercise. This directory holds the proof-of-concept that settles the
+tooling question and validates the approach on the first primitive.
+
+## Tool: GenMC (decided)
+
+The issue's open question was *TLA+ vs Loom vs hand-rolled*. The
+substrate is **C** (pthreads + C11 atomics), which decides it:
+
+- **GenMC** — a stateless model checker that runs the *actual C* under
+  all interleavings of the C11 model, catching data races and
+  use-after-free automatically. **Chosen.** The primitives are written
+  in clean C11 atomics with no syscalls on the hot path, so they model
+  directly.
+- **Loom** — Rust-only. Would require porting each primitive to Rust
+  and keeping two implementations in sync. **Rejected** (the substrate
+  is C; we want to check the code that ships).
+- **TLA+** — an *abstract* spec, not the C; smaller state space, good
+  as documentation, but the spec-to-code mapping is unverified.
+  **Complementary, not primary** — write it later if a primitive wants
+  a formal design record.
+
+GenMC v0.17.0 builds against the project's LLVM 18. See
+`build_genmc.sh`.
+
+## What's here
+
+| Model | Mirrors | Status |
+|-------|---------|--------|
+| `lockfree_hashmap_model.c` | `lotus_hashmap_*_lockfree` in `crates/hale-codegen/runtime/lotus_arena.c` — the enter/exit writer-counter protocol, single-grower grow phase, writers-in-flight drain, and EMPTY→CLAIMED→COMMITTED set state machine | ✅ verified: **42 executions, no errors** |
+
+## How to run
+
+```sh
+verification/build_genmc.sh            # one-time: build GenMC (LLVM 18 + cmake)
+GENMC=/tmp/genmc/build/bin/genmc verification/run_genmc.sh
+```
+
+`run_genmc.sh` exits non-zero if any model reports a race / UAF /
+assertion violation, so it works as a CI gate (see "CI" below).
+
+## Why trust a passing model: the negative control
+
+A model that passes only matters if it would *fail* on a real bug. The
+PoC confirms GenMC has teeth: deleting the grower's drain-wait (the
+`while (writers_in_flight > 0)` spin) — so a writer can still touch
+`old_slots` while grow frees it — makes GenMC report a **safety
+violation (use-after-free)** within the first executions. The protocol
+is exactly what prevents that, and the checker proves it does, across
+all interleavings.
+
+The verified property set, all automatic under GenMC:
+
+- **no data race** — no conflicting non-atomic accesses;
+- **no use-after-free** — no op reads/writes `slots` after grow frees
+  the old table (the reason the enter/drain protocol exists);
+- **no lost insert / corruption** — hand-written invariants in the
+  harness `main()` (both distinct keys survive, `len` agrees).
+
+## Crucial caveat: the model is a transcription
+
+Each `*_model.c` is a **hand-written transcription** of the
+synchronization core, not the production code — it strips payloads,
+hashing, tombstones, and the striped/serialized modes, keeping exactly
+the atomics and orderings that decide thread-safety. **If the
+production atomics or memory orderings change, the model must change
+with them**, or the proof is about stale code. Treat a model edit as
+mandatory whenever you touch the corresponding `lotus_*` atomics. The
+top of each model names the functions it mirrors.
+
+State space is kept small on purpose (2 writers, `cap=2` forcing one
+grow) — exhaustive checking is exponential in threads/operations, and
+the grow-during-write interleaving is the whole race surface. Larger
+configurations are for a deeper sweep, not the gate.
+
+## Roadmap
+
+PoC done (lockfree hashmap). Remaining substrate primitives, by
+model-checking value (see the inventory in the issue thread):
+
+1. **Mailbox** (`lotus_arena.c`, pinned-locus bus) — mutex + condvar; a
+   canonical pattern, good second model to validate the methodology on
+   lock-based code.
+2. **Bus queue** (cooperative pool) — `g_bus_has_pinned`-gated mutex;
+   producers + drainer.
+3. **Chunk pool / arena locks** — lower interleaving risk; model if a
+   regression appears.
+
+**CI wiring** (follow-up): GenMC takes a few minutes to build, so a CI
+gate should build it once (cached on the LLVM-18 toolchain image) in a
+dedicated job, then run `run_genmc.sh`. Until that lands, the PoC is
+run locally / on demand. The `build_genmc.sh` + `run_genmc.sh` pair is
+the CI recipe.

--- a/verification/build_genmc.sh
+++ b/verification/build_genmc.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Build GenMC (the C11 stateless model checker) from source against
+# the LLVM 18 the project already uses. One-time setup for
+# verification/run_genmc.sh. Prints the resulting binary path.
+#
+#   verification/build_genmc.sh [install-dir]   # default: /tmp/genmc
+set -euo pipefail
+
+dest="${1:-/tmp/genmc}"
+llvm_config="${LLVM_CONFIG:-llvm-config-18}"
+
+command -v cmake >/dev/null 2>&1 || {
+    echo "error: cmake required (pip install --user cmake, or apt-get install cmake)" >&2
+    exit 1
+}
+command -v "$llvm_config" >/dev/null 2>&1 || {
+    echo "error: $llvm_config not found (set \$LLVM_CONFIG)" >&2
+    exit 1
+}
+
+if [ ! -d "$dest" ]; then
+    git clone --depth 1 https://github.com/MPI-SWS/genmc.git "$dest"
+fi
+mkdir -p "$dest/build"
+( cd "$dest/build"
+  cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_CONFIG="$(command -v "$llvm_config")" ..
+  make -j"$(nproc)" )
+
+bin="$(find "$dest" -name genmc -type f -executable | head -1)"
+echo "GenMC built: $bin"
+echo "Run:  GENMC=$bin verification/run_genmc.sh"

--- a/verification/lockfree_hashmap_model.c
+++ b/verification/lockfree_hashmap_model.c
@@ -1,0 +1,250 @@
+/* GenMC model of the lotus lockfree hashmap concurrency protocol.
+ * GH issue #18 item 2 (race-completeness), proof-of-concept.
+ *
+ * This is a FAITHFUL TRANSCRIPTION of the synchronization core of
+ * `lotus_hashmap_*_lockfree` in
+ * crates/hale-codegen/runtime/lotus_arena.c — the enter/exit
+ * writer-counter protocol, the single-grower grow phase, the
+ * writers-in-flight drain, and the EMPTY→CLAIMED→COMMITTED set state
+ * machine. It is NOT the production code; it strips the payload
+ * (key/value are ints), the hash (identity), tombstones, and the
+ * striped/serialized modes, keeping exactly the atomics and orderings
+ * that decide thread-safety. If the production atomics or orderings
+ * change, this model must change with them.
+ *
+ * GenMC explores EVERY thread interleaving permitted by the C11
+ * memory model and checks, automatically:
+ *   - no data race (non-atomic conflicting access),
+ *   - no use-after-free (a reader/writer touching old `slots` after
+ *     grow frees it — the property the enter/drain protocol exists to
+ *     guarantee),
+ *   - no assertion failure (our hand-written invariants below).
+ *
+ * Run:  genmc -- verification/lockfree_hashmap_model.c
+ * (or:  verification/run_genmc.sh)
+ */
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdatomic.h>
+#include <assert.h>
+
+/* Cell occupancy states — mirror lotus_arena.c. */
+#define CELL_EMPTY     0
+#define CELL_CLAIMED   1
+#define CELL_COMMITTED 2
+/* TOMBSTONE (3) omitted: the remove path is a separate, simpler CAS;
+ * the grow/drain race surface this PoC targets lives in set+grow. */
+
+/* Load factor: grow when len*10 > cap*6 (LOTUS_HASHMAP_LF_LOAD_NUM/
+ * LOAD_DEN). Kept identical so the grow trigger fires at the same
+ * point the production map grows. */
+#define LOAD_NUM 6
+#define LOAD_DEN 10
+
+typedef struct {
+    _Atomic(unsigned char) state;
+    int key;
+    int val;
+} slot_t;
+
+typedef struct {
+    _Atomic(slot_t *) slots;
+    _Atomic(size_t)   cap;
+    _Atomic(int)      grow_phase;        /* 0 = open, 1 = growing */
+    _Atomic(int)      writers_in_flight;
+    _Atomic(size_t)   len;
+} map_t;
+
+
+/* GenMC's runtime models malloc/free but not calloc; allocate + zero
+ * explicitly. Single-threaded at every call site (init / mid-grow). */
+static slot_t *alloc_slots(size_t n) {
+    slot_t *p = (slot_t *)malloc(n * sizeof(slot_t));
+    for (size_t i = 0; i < n; i++) { p[i].state = CELL_EMPTY; p[i].key = 0; p[i].val = 0; }
+    return p;
+}
+
+/* --- enter / exit (lotus_hashmap_lf_enter / _exit) ----------------- */
+
+static void lf_enter(map_t *m) {
+    for (;;) {
+        int phase = atomic_load_explicit(&m->grow_phase, memory_order_acquire);
+        if (phase != 0) { continue; }          /* spin: grow in progress */
+        atomic_fetch_add_explicit(&m->writers_in_flight, 1,
+                                   memory_order_acquire);
+        /* Re-check: a grower could have CAS'd 0→1 between our load and
+         * our fetch_add. If so, back out so the grower's drain can
+         * reach 0. */
+        phase = atomic_load_explicit(&m->grow_phase, memory_order_acquire);
+        if (phase != 0) {
+            atomic_fetch_sub_explicit(&m->writers_in_flight, 1,
+                                       memory_order_release);
+            continue;
+        }
+        return;
+    }
+}
+
+static void lf_exit(map_t *m) {
+    atomic_fetch_sub_explicit(&m->writers_in_flight, 1, memory_order_release);
+}
+
+/* --- grow (lotus_hashmap_grow_lockfree + _lf_migrate) -------------- */
+
+static void grow(map_t *m) {
+    int expected = 0;
+    if (!atomic_compare_exchange_strong_explicit(
+            &m->grow_phase, &expected, 1,
+            memory_order_acq_rel, memory_order_relaxed)) {
+        return;                                 /* another grower won */
+    }
+    /* Drain: wait for every in-flight writer to exit. New writers
+     * back off via the enter re-check. */
+    while (atomic_load_explicit(&m->writers_in_flight,
+                                memory_order_acquire) > 0) {
+        /* spin */
+    }
+    slot_t *old_slots = atomic_load_explicit(&m->slots, memory_order_relaxed);
+    size_t  old_cap   = atomic_load_explicit(&m->cap, memory_order_relaxed);
+    size_t  new_cap   = old_cap * 2;
+    slot_t *new_slots = alloc_slots(new_cap);
+    if (!new_slots) { atomic_store_explicit(&m->grow_phase, 0,
+                                             memory_order_release); return; }
+    /* Single-threaded migration — drain guarantees no concurrent op
+     * touches old_slots. Rehash live (COMMITTED) cells. */
+    size_t live = 0;
+    for (size_t s = 0; s < old_cap; s++) {
+        if (atomic_load_explicit(&old_slots[s].state, memory_order_relaxed)
+            != CELL_COMMITTED) continue;
+        int k = old_slots[s].key, v = old_slots[s].val;
+        size_t i = (size_t)k & (new_cap - 1);
+        for (;;) {
+            if (new_slots[i].state == CELL_EMPTY) {
+                new_slots[i].key = k;
+                new_slots[i].val = v;
+                new_slots[i].state = CELL_COMMITTED;
+                live++;
+                break;
+            }
+            i = (i + 1) & (new_cap - 1);
+        }
+    }
+    atomic_store_explicit(&m->len, live, memory_order_relaxed);
+    atomic_store_explicit(&m->slots, new_slots, memory_order_release);
+    atomic_store_explicit(&m->cap, new_cap, memory_order_release);
+    free(old_slots);                            /* the UAF cliff edge */
+    atomic_store_explicit(&m->grow_phase, 0, memory_order_release);
+}
+
+/* --- set (lotus_hashmap_set_lockfree) ------------------------------ */
+
+static void set(map_t *m, int key, int val) {
+    int did_grow_check = 0;
+set_retry:
+    lf_enter(m);
+    size_t cap  = atomic_load_explicit(&m->cap, memory_order_relaxed);
+    slot_t *slots = atomic_load_explicit(&m->slots, memory_order_relaxed);
+    size_t mask = cap - 1;
+    size_t i = (size_t)key & mask;
+    size_t probes = 0;
+    for (;;) {
+        if (probes >= cap) {                    /* probe exhausted → grow */
+            lf_exit(m);
+            grow(m);
+            did_grow_check = 1;
+            goto set_retry;
+        }
+        unsigned char st = atomic_load_explicit(&slots[i].state,
+                                                 memory_order_acquire);
+        if (st == CELL_EMPTY) {
+            unsigned char exp = CELL_EMPTY;
+            if (atomic_compare_exchange_strong_explicit(
+                    &slots[i].state, &exp, CELL_CLAIMED,
+                    memory_order_acquire, memory_order_relaxed)) {
+                slots[i].key = key;
+                slots[i].val = val;
+                atomic_store_explicit(&slots[i].state, CELL_COMMITTED,
+                                      memory_order_release);
+                atomic_fetch_add_explicit(&m->len, 1, memory_order_relaxed);
+                goto set_done;
+            }
+            continue;                           /* CAS lost; re-read */
+        }
+        if (st == CELL_CLAIMED) continue;       /* spin */
+        if (slots[i].key == key) {              /* COMMITTED, same key */
+            unsigned char exp = CELL_COMMITTED;
+            if (atomic_compare_exchange_strong_explicit(
+                    &slots[i].state, &exp, CELL_CLAIMED,
+                    memory_order_acquire, memory_order_relaxed)) {
+                slots[i].val = val;
+                atomic_store_explicit(&slots[i].state, CELL_COMMITTED,
+                                      memory_order_release);
+                lf_exit(m);
+                return;                         /* update: no grow */
+            }
+            continue;
+        }
+        i = (i + 1) & mask;
+        probes++;
+    }
+set_done:
+    {
+        size_t cap_now = atomic_load_explicit(&m->cap, memory_order_relaxed);
+        size_t live    = atomic_load_explicit(&m->len, memory_order_relaxed);
+        lf_exit(m);
+        if (!did_grow_check && live * LOAD_DEN > cap_now * LOAD_NUM) {
+            grow(m);
+        }
+    }
+}
+
+/* --- harness ------------------------------------------------------- */
+/* Two writers insert distinct keys into a cap-2 map. The second
+ * insert pushes the load factor over the threshold, forcing exactly
+ * one grow that races against the other in-flight writer — the
+ * grow-during-write interleaving TSan can only sometimes hit and that
+ * GenMC explores exhaustively. */
+
+#define INIT_CAP 2
+
+static map_t M;
+
+static void *writer_a(void *_) { (void)_; set(&M, 0, 100); return NULL; }
+static void *writer_b(void *_) { (void)_; set(&M, 1, 200); return NULL; }
+
+int main(void) {
+    M.slots = alloc_slots(INIT_CAP);
+    M.cap = INIT_CAP;
+    M.grow_phase = 0;
+    M.writers_in_flight = 0;
+    M.len = 0;
+
+    pthread_t a, b;
+    pthread_create(&a, NULL, writer_a, NULL);
+    pthread_create(&b, NULL, writer_b, NULL);
+    pthread_join(a, NULL);
+    pthread_join(b, NULL);
+
+    /* Invariant: both distinct keys survived every interleaving
+     * (no lost insert, no corruption), and the live count agrees. */
+    slot_t *s = atomic_load_explicit(&M.slots, memory_order_relaxed);
+    size_t  c = atomic_load_explicit(&M.cap, memory_order_relaxed);
+    int seen0 = 0, seen1 = 0;
+    size_t committed = 0;
+    for (size_t i = 0; i < c; i++) {
+        if (s[i].state == CELL_COMMITTED) {
+            committed++;
+            if (s[i].key == 0 && s[i].val == 100) seen0 = 1;
+            if (s[i].key == 1 && s[i].val == 200) seen1 = 1;
+        }
+    }
+    assert(seen0 && seen1);
+    assert(committed == 2);
+    assert(atomic_load_explicit(&M.len, memory_order_relaxed) == 2);
+
+    free(s);
+    return 0;
+}

--- a/verification/run_genmc.sh
+++ b/verification/run_genmc.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Run every GenMC model in this directory under exhaustive
+# interleaving. GH issue #18 item 2 (race-completeness).
+#
+# GenMC must be on PATH, or pointed at via $GENMC. Build it once with
+# verification/build_genmc.sh (needs LLVM 18 + cmake). Exits non-zero
+# if any model reports a race / UAF / assertion violation, so this is
+# usable as a CI gate.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GENMC="${GENMC:-genmc}"
+
+if ! command -v "$GENMC" >/dev/null 2>&1; then
+    echo "error: genmc not found (set \$GENMC or build with verification/build_genmc.sh)" >&2
+    exit 127
+fi
+
+echo "Using $("$GENMC" --version 2>&1 | head -2 | tail -1)"
+fail=0
+for model in "$here"/*_model.c; do
+    [ -e "$model" ] || continue
+    echo "── $(basename "$model") ───────────────────────────────"
+    if "$GENMC" -- "$model"; then
+        echo "  ✓ verified (no races / UAF / assertion violations)"
+    else
+        echo "  ✗ GenMC reported a violation in $(basename "$model")" >&2
+        fail=1
+    fi
+done
+exit "$fail"


### PR DESCRIPTION
## What

First step on **#18 item 2 — race-completeness for substrate primitives**: model-check the runtime's concurrent primitives under *every* C11 interleaving, catching races/UAF that TSan only hits along the paths a test happens to exercise.

## Settles the tooling question

The issue's open question was *TLA+ vs Loom vs hand-rolled*. The substrate is **C** (pthreads + C11 atomics), which decides it:

- **GenMC** — runs the *actual C* under all interleavings of the C11 model, catching data races + use-after-free automatically. **Chosen.**
- **Loom** — Rust-only → would need a parallel Rust port. Rejected.
- **TLA+** — abstract spec, not the code. Complementary documentation, not primary.

GenMC v0.17.0 builds cleanly against the project's LLVM 18.

## Result

`verification/lockfree_hashmap_model.c` faithfully transcribes the `lotus_hashmap_*_lockfree` synchronization core — the enter/exit writer counter, single-grower grow phase, writers-in-flight drain, and EMPTY→CLAIMED→COMMITTED set machine. GenMC verifies it:

```
*** Verification complete.
No errors were detected.
Number of complete executions explored: 42
```

**Negative control (proves the check has teeth):** delete the grower's drain-wait so a writer can touch `old_slots` while grow frees it → GenMC reports a **safety violation (use-after-free)**. The protocol is exactly what prevents that; the checker proves it does, exhaustively.

## Contents

- `lockfree_hashmap_model.c` — the model (mirrors `lotus_arena.c`).
- `build_genmc.sh` — one-time GenMC build (LLVM 18 + cmake).
- `run_genmc.sh` — runs every model, non-zero on any violation (CI-gate shaped).
- `README.md` — tool decision, methodology, negative-control evidence, the **model-tracks-the-C caveat** (a hand-transcription — must be updated whenever the production atomics change), and the roadmap.

## Scope / honesty

This is a **PoC**, not yet a CI gate across all primitives. Next models: the mailbox (mutex+condvar) and the bus queue. CI wiring (build GenMC once, cached, then `run_genmc.sh`) is a documented follow-up. `spec/verification.md` records #2's PoC status. No production code changes — `verification/` is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)