### PR TITLE
CI: GenMC race-completeness gate (GH #18 #2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -356,3 +356,50 @@ jobs:
           cargo test --release -p hale-codegen \
             --test corpus_oracle \
             -- --ignored --test-threads=1 --nocapture
+
+  # GH issue #18 item 2: model-check the substrate's concurrent
+  # primitives under ALL C11 interleavings (not just the schedules a
+  # test happens to hit). GenMC runs the actual C; a race / UAF /
+  # assertion violation in any verification/*_model.c gates the merge.
+  # No Rust/cargo — this job only needs LLVM 18 + cmake to build GenMC
+  # and clang to run the models.
+  genmc:
+    name: genmc (substrate race-completeness)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+                      /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
+          df -h /
+
+      - name: Install LLVM 18 + clang + cmake
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y \
+            llvm-18-dev libpolly-18-dev libzstd-dev \
+            clang-18 libclang-18-dev zlib1g-dev cmake
+
+      # GenMC builds against LLVM 18 in a few minutes; cache the built
+      # tree keyed on build_genmc.sh (which pins the GenMC commit), so
+      # it only rebuilds when the pin / build recipe changes.
+      - name: Cache GenMC build
+        uses: actions/cache@v4
+        with:
+          path: ~/genmc
+          key: genmc-llvm18-${{ hashFiles('verification/build_genmc.sh') }}
+
+      # Build only if the cache missed OR restored a binary that no
+      # longer runs (e.g. libLLVM patch bump under a stale cache).
+      - name: Build GenMC if needed
+        run: |
+          set -eux
+          if ! "$HOME/genmc/build/bin/genmc" --version >/dev/null 2>&1; then
+            verification/build_genmc.sh "$HOME/genmc"
+          fi
+
+      - name: Run substrate model checks
+        run: GENMC="$HOME/genmc/build/bin/genmc" verification/run_genmc.sh

--- a/verification/build_genmc.sh
+++ b/verification/build_genmc.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 
 dest="${1:-/tmp/genmc}"
 llvm_config="${LLVM_CONFIG:-llvm-config-18}"
+# Pinned to the verified commit (GenMC v0.17.0) for reproducible
+# builds + a stable CI cache key. Override with $GENMC_REF.
+genmc_ref="${GENMC_REF:-29b03a66402c4453fc77901ef3be90bb55707cd4}"
 
 command -v cmake >/dev/null 2>&1 || {
     echo "error: cmake required (pip install --user cmake, or apt-get install cmake)" >&2
@@ -18,9 +21,10 @@ command -v "$llvm_config" >/dev/null 2>&1 || {
     exit 1
 }
 
-if [ ! -d "$dest" ]; then
-    git clone --depth 1 https://github.com/MPI-SWS/genmc.git "$dest"
+if [ ! -d "$dest/.git" ]; then
+    git clone https://github.com/MPI-SWS/genmc.git "$dest"
 fi
+( cd "$dest" && git checkout --quiet "$genmc_ref" )
 mkdir -p "$dest/build"
 ( cd "$dest/build"
   cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_CONFIG="$(command -v "$llvm_config")" ..


### PR DESCRIPTION
## What

Turns the substrate race-completeness track from a validated PoC into a **standing CI gate**. A new `genmc` job model-checks every `verification/*_model.c` under all C11 interleavings on each push/PR — a race / UAF / assertion violation now fails the build.

## How

- Installs LLVM 18 + clang + cmake (no Rust/cargo — the job builds GenMC and runs the C models directly).
- **Caches** the GenMC build keyed on `build_genmc.sh` (which now pins `GENMC_REF` to the verified commit / v0.17.0), so it only rebuilds when the pin or recipe changes.
- A guard rebuilds GenMC if a restored cache holds a binary that no longer runs (e.g. a libLLVM patch bump under a stale cache).
- Runs `verification/run_genmc.sh`, which picks up any new model automatically.

## Why a real gate now

The track had two verified models — lockfree hashmap (#50) and mailbox (#51) — but they only ran on demand. This makes them guard every PR, which is the payoff: a regression in the lockfree protocol's atomics or the mailbox monitor is caught at exhaustive-interleaving strength, not just along the schedules TSan happens to hit.

## Validation

This PR's own CI run exercises the new job end-to-end (fresh GenMC build + both models). Locally: YAML validates (5 jobs), and `run_genmc.sh` passes both models (`✓ verified` ×2). Workflow + `build_genmc.sh` only; no production or test-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)