### PR TITLE
ring_layout declaration (shm-ring-interop Proposal B, PR1)

### DIFF
--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -7587,6 +7587,10 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     // carry no type-bearing positions; nothing
                     // to collect for generic monomorph.
                 }
+                TopDecl::RingLayout(_) => {
+                    // ring_layout members are layout tokens, not
+                    // type-bearing positions; nothing to collect.
+                }
             }
         }
         Ok(())

--- a/crates/hale-codegen/src/mangle.rs
+++ b/crates/hale-codegen/src/mangle.rs
@@ -267,6 +267,9 @@ impl<'a> QualifiedRenameApplier<'a> {
                 }
             }
             TopDecl::Topic(t) => self.rewrite_type_expr(&mut t.payload),
+            // ring_layout members are layout tokens (idents/ints) — no
+            // TypeExpr to path-rewrite for cross-seed imports.
+            TopDecl::RingLayout(_) => {}
             TopDecl::Perspective(p) => {
                 for m in &mut p.members {
                     match m {
@@ -399,6 +402,7 @@ fn top_decl_name(d: &TopDecl) -> Option<&str> {
         TopDecl::Fn(f) => Some(&f.name.name),
         TopDecl::Interface(i) => Some(&i.name.name),
         TopDecl::Topic(t) => Some(&t.name.name),
+        TopDecl::RingLayout(r) => Some(&r.name.name),
         TopDecl::Module(_) => None,
         TopDecl::Target(t) => Some(&t.name.name),
     }
@@ -454,6 +458,11 @@ impl<'a> Mangler<'a> {
             TopDecl::Topic(t) => {
                 self.walk_type_expr(&mut t.payload);
                 self.rewrite_ident(&mut t.name.name);
+            }
+            TopDecl::RingLayout(r) => {
+                // Layout members are tokens, not types; only the
+                // declaration name participates in the rename table.
+                self.rewrite_ident(&mut r.name.name);
             }
             TopDecl::Module(_) => {}
             TopDecl::Target(t) => {

--- a/crates/hale-codegen/tests/cross_seed_imports.rs
+++ b/crates/hale-codegen/tests/cross_seed_imports.rs
@@ -44,6 +44,7 @@ fn top_name(d: &TopDecl) -> Option<&str> {
         TopDecl::Fn(f) => Some(&f.name.name),
         TopDecl::Interface(i) => Some(&i.name.name),
         TopDecl::Topic(t) => Some(&t.name.name),
+        TopDecl::RingLayout(r) => Some(&r.name.name),
         TopDecl::Module(_) => None,
         TopDecl::Target(t) => Some(&t.name.name),
     }

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -31,6 +31,11 @@ pub enum TopDecl {
     Module(ModuleDecl),
     Interface(InterfaceDecl),
     Topic(TopicDecl),
+    /// shm-ring-interop Proposal B (2026-06-06): `ring_layout Name
+    /// { ... }` — declares the byte layout of an externally-defined
+    /// SHM broadcast ring so a `shm_ring(..., layout: Name)` binding
+    /// can read it. Pure declaration; lowers to a bounded accessor.
+    RingLayout(RingLayoutDecl),
     /// FUv0.8.2 #7 (2026-05-25): `target <name> { cap.path,
     /// cap.path, ... }` — names a substrate (e.g.
     /// `browser-js`, `native`) plus its capability profile.
@@ -52,6 +57,7 @@ impl TopDecl {
             TopDecl::Module(m) => m.span,
             TopDecl::Interface(i) => i.span,
             TopDecl::Topic(t) => t.span,
+            TopDecl::RingLayout(r) => r.span,
             TopDecl::Target(t) => t.span,
         }
     }
@@ -102,6 +108,74 @@ pub struct TopicDecl {
     /// topics — typecheck rejects.
     pub on_unmatched: Option<UnmatchedPolicy>,
     pub span: Span,
+}
+
+/// shm-ring-interop Proposal B: a declared byte layout for an
+/// externally-defined SHM broadcast ring. Members are parsed
+/// loosely (idents + ints); the layout *contract* — known reprs /
+/// orderings / framing kinds, sane offsets — is enforced in
+/// `hale-types::check`. See `notes/binary-shm-ring-interop.md`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RingLayoutDecl {
+    pub name: Ident,
+    /// `magic 0x...;` — expected header magic (None = unchecked).
+    pub magic: Option<i64>,
+    /// `data_at OFF;` — first-record byte offset.
+    pub data_at: Option<i64>,
+    /// Header scalar fields: `name [expect] at OFF : repr;`.
+    pub scalars: Vec<RingScalarField>,
+    /// `cursor [name] { attr value; ... }` (one or more).
+    pub cursors: Vec<RingCursorBlock>,
+    /// `framing KIND { attr value; ... }`.
+    pub framing: Option<RingFramingBlock>,
+    /// `overflow KIND;`.
+    pub overflow: Option<Ident>,
+    pub span: Span,
+}
+
+/// A header scalar: `version 1 at 8 : u32;` — name `version`, an
+/// optional validated `expect` value (1), byte offset (8), and a
+/// width/repr token (`u32`). The repr is a layout token, not a Hale
+/// `TypeExpr`, so it's an `Ident` checked against a known set.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RingScalarField {
+    pub name: Ident,
+    pub expect: Option<i64>,
+    pub at: i64,
+    pub repr: Ident,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RingCursorBlock {
+    /// `cursor published { ... }` → Some("published"); bare
+    /// `cursor { ... }` → None.
+    pub name: Option<Ident>,
+    pub attrs: Vec<RingAttr>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RingFramingBlock {
+    /// `byte_records` | `slots`.
+    pub kind: Ident,
+    pub attrs: Vec<RingAttr>,
+    pub span: Span,
+}
+
+/// A `key value;` pair inside a `cursor`/`framing` block, e.g.
+/// `at 64`, `repr atomic_u64`, `len_prefix u32`, `align 8`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RingAttr {
+    pub key: Ident,
+    pub value: RingAttrValue,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RingAttrValue {
+    Ident(Ident),
+    Int(i64),
 }
 
 /// Routing-key `on_unmatched` policy. See `spec/semantics.md`

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -436,6 +436,11 @@ impl Parser {
             TokenKind::Ident(s) if s == "topic" => {
                 self.parse_topic_decl().map(TopDecl::Topic)
             }
+            // `ring_layout Name { ... }` — shm-ring-interop Proposal B.
+            // Contextual keyword, same pattern as `topic`.
+            TokenKind::Ident(s) if s == "ring_layout" => {
+                self.parse_ring_layout_decl().map(TopDecl::RingLayout)
+            }
             // FUv0.8.2 #7 (2026-05-25): `target <name> { ... }` —
             // names the substrate + its capability profile.
             // Contextual keyword recognized only at top-level decl
@@ -658,6 +663,162 @@ impl Parser {
             on_unmatched,
             span: kw.span.merge(close.span),
         })
+    }
+
+    /// shm-ring-interop Proposal B: `ring_layout Name { ... }`. Members
+    /// are keyword-led, `;`-terminated. Parsed loosely (idents + ints);
+    /// the layout contract is enforced in hale-types::check.
+    fn parse_ring_layout_decl(&mut self) -> Result<RingLayoutDecl, Diag> {
+        let kw_tok = self.peek_token().clone();
+        match &kw_tok.kind {
+            TokenKind::Ident(s) if s == "ring_layout" => {
+                self.bump();
+            }
+            _ => return Err(Diag::parse(kw_tok.span, "expected `ring_layout`")),
+        }
+        let name = self.expect_ident("ring_layout name")?;
+        self.expect(TokenKind::LBrace, "{")?;
+
+        let mut magic: Option<i64> = None;
+        let mut data_at: Option<i64> = None;
+        let mut scalars: Vec<RingScalarField> = Vec::new();
+        let mut cursors: Vec<RingCursorBlock> = Vec::new();
+        let mut framing: Option<RingFramingBlock> = None;
+        let mut overflow: Option<Ident> = None;
+
+        while !matches!(self.peek(), TokenKind::RBrace) {
+            let member = self.expect_ring_word("ring_layout member")?;
+            match member.name.as_str() {
+                "magic" => {
+                    magic = Some(self.expect_int_lit("magic")?);
+                    self.expect(TokenKind::Semi, ";")?;
+                }
+                "data_at" => {
+                    data_at = Some(self.expect_int_lit("data_at")?);
+                    self.expect(TokenKind::Semi, ";")?;
+                }
+                "overflow" => {
+                    overflow = Some(self.expect_ring_word("overflow kind")?);
+                    self.expect(TokenKind::Semi, ";")?;
+                }
+                "cursor" => {
+                    // Optional name before the block: `cursor published {`.
+                    let cname = if matches!(self.peek(), TokenKind::Ident(_)) {
+                        Some(self.expect_ident("cursor name")?)
+                    } else {
+                        None
+                    };
+                    let attrs = self.parse_ring_attr_block()?;
+                    cursors.push(RingCursorBlock {
+                        name: cname,
+                        attrs,
+                        span: member.span,
+                    });
+                }
+                "framing" => {
+                    let kind = self.expect_ring_word("framing kind")?;
+                    let attrs = self.parse_ring_attr_block()?;
+                    framing = Some(RingFramingBlock {
+                        kind,
+                        attrs,
+                        span: member.span,
+                    });
+                }
+                _ => {
+                    // Scalar field: `name [expect] at OFF : repr ;`.
+                    let fspan = member.span;
+                    let expect = if matches!(self.peek(), TokenKind::IntLit(_)) {
+                        Some(self.expect_int_lit("expected value")?)
+                    } else {
+                        None
+                    };
+                    let at_kw = self.expect_ident("`at`")?;
+                    if at_kw.name != "at" {
+                        return Err(Diag::parse(
+                            at_kw.span,
+                            "expected `at` in ring_layout scalar field \
+                             (`name [expect] at OFF : repr;`)",
+                        ));
+                    }
+                    let at = self.expect_int_lit("field offset")?;
+                    self.expect(TokenKind::Colon, ":")?;
+                    let repr = self.expect_ring_word("field repr (e.g. `u32`)")?;
+                    self.expect(TokenKind::Semi, ";")?;
+                    scalars.push(RingScalarField {
+                        name: member,
+                        expect,
+                        at,
+                        repr,
+                        span: fspan,
+                    });
+                }
+            }
+        }
+        let close = self.expect(TokenKind::RBrace, "}")?;
+        Ok(RingLayoutDecl {
+            name,
+            magic,
+            data_at,
+            scalars,
+            cursors,
+            framing,
+            overflow,
+            span: kw_tok.span.merge(close.span),
+        })
+    }
+
+    /// Parse a `{ key value; ... }` attribute block for a
+    /// `cursor`/`framing` member. Values are bare idents or ints.
+    fn parse_ring_attr_block(&mut self) -> Result<Vec<RingAttr>, Diag> {
+        self.expect(TokenKind::LBrace, "{")?;
+        let mut attrs: Vec<RingAttr> = Vec::new();
+        while !matches!(self.peek(), TokenKind::RBrace) {
+            let key = self.expect_ring_word("attribute name")?;
+            let kspan = key.span;
+            let value = match self.peek().clone() {
+                TokenKind::IntLit(n) => {
+                    self.bump();
+                    RingAttrValue::Int(n)
+                }
+                _ => {
+                    // ident or keyword-as-word; expect_ring_word
+                    // errors if it's neither.
+                    RingAttrValue::Ident(self.expect_ring_word("attribute value")?)
+                }
+            };
+            self.expect(TokenKind::Semi, ";")?;
+            attrs.push(RingAttr { key, value, span: kspan });
+        }
+        self.expect(TokenKind::RBrace, "}")?;
+        Ok(attrs)
+    }
+
+    /// A bare "word" in a ring_layout — an identifier OR any keyword
+    /// token used as a layout token. Several layout words collide with
+    /// language keywords (`release` ordering, `fail` overflow policy,
+    /// etc.); the layout grammar is unambiguous, so admit them.
+    fn expect_ring_word(&mut self, what: &str) -> Result<Ident, Diag> {
+        if let Some(name) = try_member_keyword_as_name(self.peek()) {
+            let span = self.peek_token().span;
+            self.bump();
+            return Ok(Ident { name: name.to_string(), span });
+        }
+        self.expect_ident(what)
+    }
+
+    fn expect_int_lit(&mut self, what: &str) -> Result<i64, Diag> {
+        let tok = self.peek_token().clone();
+        match self.peek() {
+            TokenKind::IntLit(n) => {
+                let v = *n;
+                self.bump();
+                Ok(v)
+            }
+            other => Err(Diag::parse(
+                tok.span,
+                format!("expected integer literal for {}, got {:?}", what, other),
+            )),
+        }
     }
 
     /// v1.x-FORM-1: `@form(<name>, <args>...)`.

--- a/crates/hale-syntax/tests/ring_layout.rs
+++ b/crates/hale-syntax/tests/ring_layout.rs
@@ -1,0 +1,87 @@
+//! Parser round-trip for the `ring_layout` declaration
+//! (shm-ring-interop Proposal B). Confirms members + nested
+//! cursor/framing blocks land in the AST, including layout words
+//! that collide with language keywords (`release`).
+
+use hale_syntax::ast::{RingAttrValue, TopDecl};
+use hale_syntax::parse_source;
+
+#[test]
+fn parses_full_ring_layout() {
+    let src = r#"
+ring_layout MagusRing {
+    magic 0x4D475348514D4B54;
+    version 1 at 8 : u32;
+    buffer_size at 12 : u32;
+    data_at 128;
+    cursor published {
+        at 64; repr atomic_u64; load acquire; store release; unit bytes;
+    }
+    framing byte_records {
+        len_prefix u32; align 8; pad_sentinel 0xFFFFFFFF;
+    }
+    overflow lap_detect;
+}
+"#;
+    let prog = parse_source(src).expect("parse");
+    let rl = prog
+        .items
+        .iter()
+        .find_map(|i| match i {
+            TopDecl::RingLayout(r) => Some(r),
+            _ => None,
+        })
+        .expect("ring_layout decl present");
+
+    assert_eq!(rl.name.name, "MagusRing");
+    assert_eq!(rl.magic, Some(0x4D475348514D4B54));
+    assert_eq!(rl.data_at, Some(128));
+    assert_eq!(rl.overflow.as_ref().map(|i| i.name.as_str()), Some("lap_detect"));
+
+    // scalars: version (expect 1, at 8, u32), buffer_size (at 12, u32).
+    assert_eq!(rl.scalars.len(), 2);
+    let version = rl.scalars.iter().find(|f| f.name.name == "version").unwrap();
+    assert_eq!(version.expect, Some(1));
+    assert_eq!(version.at, 8);
+    assert_eq!(version.repr.name, "u32");
+    let bsz = rl.scalars.iter().find(|f| f.name.name == "buffer_size").unwrap();
+    assert_eq!(bsz.expect, None);
+    assert_eq!(bsz.at, 12);
+
+    // cursor: one named `published` with at=64, and the keyword
+    // `release` admitted as the `store` value.
+    assert_eq!(rl.cursors.len(), 1);
+    let cur = &rl.cursors[0];
+    assert_eq!(cur.name.as_ref().map(|i| i.name.as_str()), Some("published"));
+    let at = cur.attrs.iter().find(|a| a.key.name == "at").unwrap();
+    assert!(matches!(at.value, RingAttrValue::Int(64)));
+    let store = cur.attrs.iter().find(|a| a.key.name == "store").unwrap();
+    assert!(matches!(&store.value, RingAttrValue::Ident(i) if i.name == "release"));
+    let unit = cur.attrs.iter().find(|a| a.key.name == "unit").unwrap();
+    assert!(matches!(&unit.value, RingAttrValue::Ident(i) if i.name == "bytes"));
+
+    // framing byte_records with len_prefix/align/pad_sentinel.
+    let fr = rl.framing.as_ref().expect("framing");
+    assert_eq!(fr.kind.name, "byte_records");
+    let lp = fr.attrs.iter().find(|a| a.key.name == "len_prefix").unwrap();
+    assert!(matches!(&lp.value, RingAttrValue::Ident(i) if i.name == "u32"));
+    let pad = fr.attrs.iter().find(|a| a.key.name == "pad_sentinel").unwrap();
+    assert!(matches!(pad.value, RingAttrValue::Int(0xFFFFFFFF)));
+}
+
+#[test]
+fn bare_cursor_without_name_parses() {
+    let src = r#"
+ring_layout R {
+    cursor { at 24; repr atomic_u64; }
+    framing slots { }
+}
+"#;
+    let prog = parse_source(src).expect("parse");
+    let TopDecl::RingLayout(rl) = prog.items.iter().find(|i| matches!(i, TopDecl::RingLayout(_))).unwrap() else {
+        unreachable!()
+    };
+    assert_eq!(rl.cursors.len(), 1);
+    assert!(rl.cursors[0].name.is_none());
+    assert_eq!(rl.framing.as_ref().unwrap().kind.name, "slots");
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -4137,6 +4137,180 @@ impl<'a> Checker<'a> {
                 // structural only — the resolver registered
                 // the target name; no use-site checks here yet.
             }
+            TopDecl::RingLayout(r) => self.check_ring_layout(r),
+        }
+    }
+
+    /// shm-ring-interop Proposal B: validate a `ring_layout`'s
+    /// contract — known width reprs, a recognized framing kind (with
+    /// `len_prefix` for byte_records), at least one cursor with an
+    /// `at` offset and a known repr/ordering/unit, and non-negative
+    /// offsets. A wrong-but-well-formed layout still produces wrong
+    /// *values* not OOB (the safety argument), but these catch the
+    /// obvious declaration mistakes at build time.
+    fn check_ring_layout(&mut self, r: &'a hale_syntax::ast::RingLayoutDecl) {
+        use hale_syntax::ast::RingAttrValue;
+        const WIDTHS: &[&str] = &[
+            "u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64", "f32", "f64",
+        ];
+        const ORDERINGS: &[&str] =
+            &["relaxed", "acquire", "release", "acq_rel", "seq_cst"];
+
+        if let Some(off) = r.data_at {
+            if off < 0 {
+                self.diags.push(Diag::ty(
+                    r.span,
+                    format!("ring_layout `{}`: data_at must be >= 0", r.name.name),
+                ));
+            }
+        }
+        for f in &r.scalars {
+            if f.at < 0 {
+                self.diags.push(Diag::ty(
+                    f.span,
+                    format!("ring_layout field `{}`: offset must be >= 0", f.name.name),
+                ));
+            }
+            if !WIDTHS.contains(&f.repr.name.as_str()) {
+                self.diags.push(Diag::ty(
+                    f.repr.span,
+                    format!(
+                        "ring_layout field `{}`: unknown repr `{}` (expected one \
+                         of u8/u16/u32/u64, i8/i16/i32/i64, f32/f64)",
+                        f.name.name, f.repr.name
+                    ),
+                ));
+            }
+        }
+
+        // At least one cursor, each with an `at` offset and known attrs.
+        if r.cursors.is_empty() {
+            self.diags.push(Diag::ty(
+                r.span,
+                format!(
+                    "ring_layout `{}`: needs at least one `cursor {{ ... }}` \
+                     (the published position a consumer reads)",
+                    r.name.name
+                ),
+            ));
+        }
+        for c in &r.cursors {
+            let mut has_at = false;
+            for a in &c.attrs {
+                match a.key.name.as_str() {
+                    "at" => {
+                        has_at = true;
+                        if let RingAttrValue::Int(n) = a.value {
+                            if n < 0 {
+                                self.diags.push(Diag::ty(
+                                    a.span,
+                                    "cursor `at` offset must be >= 0".to_string(),
+                                ));
+                            }
+                        } else {
+                            self.diags.push(Diag::ty(
+                                a.span,
+                                "cursor `at` must be an integer offset".to_string(),
+                            ));
+                        }
+                    }
+                    "load" | "store" => {
+                        if let RingAttrValue::Ident(id) = &a.value {
+                            if !ORDERINGS.contains(&id.name.as_str()) {
+                                self.diags.push(Diag::ty(
+                                    a.span,
+                                    format!(
+                                        "cursor `{}`: unknown memory ordering `{}` \
+                                         (relaxed/acquire/release/acq_rel/seq_cst)",
+                                        a.key.name, id.name
+                                    ),
+                                ));
+                            }
+                        }
+                    }
+                    "unit" => {
+                        if let RingAttrValue::Ident(id) = &a.value {
+                            if id.name != "bytes" && id.name != "slots" {
+                                self.diags.push(Diag::ty(
+                                    a.span,
+                                    format!(
+                                        "cursor `unit`: expected `bytes` or `slots`, \
+                                         got `{}`",
+                                        id.name
+                                    ),
+                                ));
+                            }
+                        }
+                    }
+                    // `kind`, `repr` accepted as free idents (the
+                    // descriptor build in PR3 maps the known ones).
+                    _ => {}
+                }
+            }
+            if !has_at {
+                self.diags.push(Diag::ty(
+                    c.span,
+                    format!(
+                        "ring_layout `{}`: cursor needs an `at OFFSET;`",
+                        r.name.name
+                    ),
+                ));
+            }
+        }
+
+        // Framing: required, recognized kind; byte_records needs a
+        // len_prefix width.
+        match &r.framing {
+            None => self.diags.push(Diag::ty(
+                r.span,
+                format!(
+                    "ring_layout `{}`: needs a `framing byte_records {{ ... }}` \
+                     (or `framing slots {{ ... }}`)",
+                    r.name.name
+                ),
+            )),
+            Some(fr) => {
+                if fr.kind.name != "byte_records" && fr.kind.name != "slots" {
+                    self.diags.push(Diag::ty(
+                        fr.kind.span,
+                        format!(
+                            "ring_layout `{}`: unknown framing `{}` (expected \
+                             `byte_records` or `slots`)",
+                            r.name.name, fr.kind.name
+                        ),
+                    ));
+                }
+                if fr.kind.name == "byte_records" {
+                    let len_prefix = fr.attrs.iter().find(|a| a.key.name == "len_prefix");
+                    match len_prefix {
+                        None => self.diags.push(Diag::ty(
+                            fr.span,
+                            "framing byte_records: needs `len_prefix u32;` (the \
+                             record length-prefix width)".to_string(),
+                        )),
+                        Some(a) => {
+                            if let RingAttrValue::Ident(id) = &a.value {
+                                if !WIDTHS.contains(&id.name.as_str()) {
+                                    self.diags.push(Diag::ty(
+                                        a.span,
+                                        format!(
+                                            "framing byte_records: `len_prefix` repr \
+                                             `{}` is not a known width",
+                                            id.name
+                                        ),
+                                    ));
+                                }
+                            } else {
+                                self.diags.push(Diag::ty(
+                                    a.span,
+                                    "framing byte_records: `len_prefix` must be a \
+                                     width ident (e.g. u32)".to_string(),
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -6617,6 +6791,17 @@ impl<'a> Checker<'a> {
                                 format!(
                                     "topic `{}` is not a value; use `{} <- expr` \
                                      to publish on it",
+                                    id.name, id.name
+                                ),
+                            ));
+                            Ty::Unknown
+                        }
+                        TopSymbol::RingLayout(_) => {
+                            self.diags.push(Diag::ty(
+                                id.span,
+                                format!(
+                                    "ring_layout `{}` is not a value; reference it \
+                                     in a `shm_ring(..., layout: {})` binding",
                                     id.name, id.name
                                 ),
                             ));

--- a/crates/hale-types/src/resolve.rs
+++ b/crates/hale-types/src/resolve.rs
@@ -211,6 +211,7 @@ fn collect_type_names(
             TopDecl::Perspective(p) => insert_name(known, &p.name, diags),
             TopDecl::Interface(i) => insert_name(known, &i.name, diags),
             TopDecl::Topic(t) => insert_name(known, &t.name, diags),
+            TopDecl::RingLayout(r) => insert_name(known, &r.name, diags),
             TopDecl::Module(m) => collect_type_names(&m.items, known, diags),
             _ => {}
         }
@@ -430,6 +431,7 @@ fn register_top_decls(
             }
             TopDecl::Interface(i) => register_interface(i, known, scope, diags),
             TopDecl::Topic(t) => register_topic(t, topics, scope, diags),
+            TopDecl::RingLayout(r) => register_ring_layout(r, scope, diags),
             TopDecl::Target(_) => {
                 // FUv0.8.2 #7 (2026-05-25): target capability
                 // declarations don't introduce a scope entry —
@@ -557,6 +559,29 @@ fn register_topic(
         scope,
         &decl.name.name,
         TopSymbol::Topic(info),
+        decl.span,
+        diags,
+    );
+}
+
+/// shm-ring-interop Proposal B: register a `ring_layout Name` as a
+/// resolvable symbol. The layout contract (offsets, reprs, framing) is
+/// validated separately in `check`; here we just bind the name so a
+/// `shm_ring(..., layout: Name)` reference can find it.
+fn register_ring_layout(
+    decl: &hale_syntax::ast::RingLayoutDecl,
+    scope: &mut TopScope,
+    diags: &mut Vec<Diag>,
+) {
+    let info = crate::symbol::RingLayoutInfo {
+        name: decl.name.name.clone(),
+        decl: decl.clone(),
+        span: decl.span,
+    };
+    register_symbol(
+        scope,
+        &decl.name.name,
+        TopSymbol::RingLayout(info),
         decl.span,
         diags,
     );

--- a/crates/hale-types/src/symbol.rs
+++ b/crates/hale-types/src/symbol.rs
@@ -32,6 +32,7 @@ pub enum TopSymbol {
     Fn(FnSig),
     Interface(InterfaceInfo),
     Topic(TopicInfo),
+    RingLayout(RingLayoutInfo),
 }
 
 impl TopSymbol {
@@ -44,8 +45,20 @@ impl TopSymbol {
             TopSymbol::Fn(f) => f.span,
             TopSymbol::Interface(i) => i.span,
             TopSymbol::Topic(t) => t.span,
+            TopSymbol::RingLayout(r) => r.span,
         }
     }
+}
+
+/// shm-ring-interop Proposal B: a resolved `ring_layout` declaration.
+/// Carries the full AST decl so codegen (PR3) can build the runtime
+/// ring descriptor from its fields; PR1/PR2 only need it to exist as a
+/// resolvable symbol a `shm_ring(..., layout: Name)` binding references.
+#[derive(Debug, Clone)]
+pub struct RingLayoutInfo {
+    pub name: String,
+    pub decl: hale_syntax::ast::RingLayoutDecl,
+    pub span: Span,
 }
 
 /// Resolved `topic Foo { payload: T; }` declaration. The payload

--- a/crates/hale-types/tests/ring_layout.rs
+++ b/crates/hale-types/tests/ring_layout.rs
@@ -1,0 +1,153 @@
+//! Resolve + typecheck for `ring_layout` declarations
+//! (shm-ring-interop Proposal B): a valid layout is clean; the
+//! layout contract (known reprs, framing, cursor) is enforced.
+
+use hale_syntax::parse_source;
+use hale_types::check_program;
+
+fn check(src: &str) -> Vec<String> {
+    let prog = parse_source(src).expect("parse failed");
+    check_program(&prog).into_iter().map(|d| d.message).collect()
+}
+
+const VALID: &str = r#"
+ring_layout MagusRing {
+    magic 0x4D475348514D4B54;
+    version 1 at 8 : u32;
+    buffer_size at 12 : u32;
+    data_at 128;
+    cursor published {
+        at 64; repr atomic_u64; load acquire; store release; unit bytes;
+    }
+    framing byte_records {
+        len_prefix u32; align 8; pad_sentinel 0xFFFFFFFF;
+    }
+    overflow lap_detect;
+}
+"#;
+
+#[test]
+fn valid_layout_is_clean() {
+    let msgs = check(VALID);
+    assert!(
+        msgs.is_empty(),
+        "a well-formed ring_layout must typecheck clean; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn unknown_scalar_repr_errors() {
+    let src = r#"
+ring_layout R {
+    version at 8 : u99;
+    cursor c { at 64; }
+    framing slots { }
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("unknown repr `u99`")),
+        "got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn missing_cursor_errors() {
+    let src = r#"
+ring_layout R {
+    framing slots { }
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("needs at least one `cursor")),
+        "got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn cursor_without_at_errors() {
+    let src = r#"
+ring_layout R {
+    cursor c { repr atomic_u64; }
+    framing slots { }
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("cursor needs an `at OFFSET")),
+        "got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn unknown_framing_errors() {
+    let src = r#"
+ring_layout R {
+    cursor c { at 64; }
+    framing mystery { }
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("unknown framing `mystery`")),
+        "got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn byte_records_without_len_prefix_errors() {
+    let src = r#"
+ring_layout R {
+    cursor c { at 64; }
+    framing byte_records { align 8; }
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("needs `len_prefix")),
+        "got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn bad_memory_ordering_errors() {
+    let src = r#"
+ring_layout R {
+    cursor c { at 64; load sideways; }
+    framing slots { }
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("unknown memory ordering `sideways`")),
+        "got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn ring_layout_used_as_value_errors() {
+    let src = r#"
+ring_layout R {
+    cursor c { at 64; }
+    framing slots { }
+}
+fn main() {
+    let x = R;
+    println(to_string(x));
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("ring_layout `R` is not a value")),
+        "got: {:?}",
+        msgs
+    );
+}

--- a/notes/binary-shm-ring-interop.md
+++ b/notes/binary-shm-ring-interop.md
@@ -198,7 +198,18 @@ Make the SHM ring **layout** a source-level declaration that the existing
 to attach, validate, iterate, and (optionally) publish — all of which the
 runtime already does for `LRSRNG1`; this just parameterizes it.
 
-### Surface (illustrative — exact syntax is the team's call)
+### Surface
+
+> **Status (2026-06-06): the `ring_layout` declaration LANDED (PR1).**
+> The concrete grammar below (members keyword-led + `;`-terminated;
+> `cursor`/`framing` as nested attr blocks; attr values are idents or
+> ints) parses, resolves, and typechecks — the layout *contract*
+> (known width reprs, recognized framing kind with `len_prefix` for
+> `byte_records`, ≥1 cursor with an offset, known cursor
+> reprs/orderings/unit) is enforced in `hale-types::check`. Codegen
+> consumption is **not** wired yet — PR2 adds the `layout:` binding
+> kwarg, PR3 the descriptor-parameterized read-only consumer. Grammar:
+> `spec/grammar.ebnf` (`ring_layout_decl`).
 
 magus2's ring becomes a declaration:
 

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -37,6 +37,7 @@ top_decl          = locus_decl
                   | module_decl
                   | interface_decl
                   | topic_decl
+                  | ring_layout_decl
                   | target_decl
                   ;
 
@@ -80,6 +81,37 @@ topic_field       = "payload" , ":" , type_expr , ";"
                   | "keyed_by" , IDENTIFIER , ";"
                   | "on_unmatched" , ":" , unmatched_policy , ";"
                   ;
+
+(* `ring_layout Name { ... }` — declares the byte layout of an
+   externally-defined SHM broadcast ring so a
+   `shm_ring(..., layout: Name)` binding can read it
+   (shm-ring-interop Proposal B). Contextual keyword like `topic`.
+   Members are keyword-led and `;`-terminated; attribute values are
+   bare identifiers or integer literals. The layout *contract*
+   (known reprs, recognized framing, a cursor with an offset) is
+   enforced at typecheck, not in the grammar. *)
+ring_layout_decl  = "ring_layout" , IDENTIFIER ,
+                    "{" , { ring_layout_member } , "}" ;
+ring_layout_member
+                  = "magic" , INT_LIT , ";"
+                  | "data_at" , INT_LIT , ";"
+                  | "overflow" , ring_word , ";"
+                  | ring_scalar_field
+                  | ring_cursor_block
+                  | ring_framing_block
+                  ;
+(* header scalar: `version 1 at 8 : u32;` — name, optional expected
+   value, byte offset, width repr. *)
+ring_scalar_field = IDENTIFIER , [ INT_LIT ] , "at" , INT_LIT ,
+                    ":" , ring_word , ";" ;
+ring_cursor_block = "cursor" , [ IDENTIFIER ] ,
+                    "{" , { ring_attr } , "}" ;
+ring_framing_block= "framing" , ring_word ,
+                    "{" , { ring_attr } , "}" ;
+ring_attr         = IDENTIFIER , ( ring_word | INT_LIT ) , ";" ;
+(* a layout token — an identifier or a keyword admitted as a word
+   (e.g. the `release` ordering, the `fail` overflow policy). *)
+ring_word         = IDENTIFIER ;
 
 (* Routing-key policy on no-key-match publishes — see
    `spec/semantics.md` § "Topic declarations" / "Phase 3:


### PR DESCRIPTION
## What

First slice of **Proposal B** ([doc](../blob/main/notes/binary-shm-ring-interop.md)): a new `ring_layout Name { ... }` top-level declaration naming the byte layout of an externally-defined SHM broadcast ring. **Parses, resolves, typechecks** — no codegen consumption yet (PR2 = the `layout:` binding kwarg; PR3 = the descriptor-parameterized read-only consumer).

```hale
ring_layout ForeignRing {
    magic 0x4D475348514D4B54;
    version 1 at 8 : u32;
    buffer_size at 12 : u32;
    data_at 128;
    cursor published { at 64; repr atomic_u64; load acquire; store release; unit bytes; }
    framing byte_records { len_prefix u32; align 8; pad_sentinel 0xFFFFFFFF; }
    overflow lap_detect;
}
```

## Concrete grammar (the doc's was "illustrative")

Keyword-led, `;`-terminated members; `cursor`/`framing` as nested attr blocks; attribute values are bare idents or ints. Layout words that collide with language keywords (`release` ordering, `fail` overflow policy) are admitted via an `expect_ring_word` helper (idents *or* keyword tokens). No lexer change — `ring_layout` is contextual like `topic`.

## How

Follows the `topic` decl template end to end: parser dispatch + `parse_ring_layout_decl`, AST `TopDecl::RingLayout(RingLayoutDecl)`, resolve `TopSymbol::RingLayout(RingLayoutInfo)` (carries the full decl so PR3 can build the runtime descriptor). The `TopDecl` exhaustiveness fan-out (ast span, resolve register + name-collision, check, three `mangle.rs` matches, codegen generic-collect) all get arms — layout members carry no `TypeExpr`s, so the rewrite arms are no-ops (only the decl name participates in cross-seed renaming).

**Typecheck enforces the layout contract**: known width reprs, framing kind ∈ {byte_records, slots} (byte_records requires `len_prefix`), ≥1 cursor each with an `at` offset + known orderings/unit, non-negative offsets; a `ring_layout` used as a value is rejected.

## Tests

`hale-syntax/tests/ring_layout.rs` (parser round-trip incl. the `release` keyword-as-value + a bare unnamed cursor) + `hale-types/tests/ring_layout.rs` (8: valid clean; bad repr / missing cursor / cursor-without-at / unknown framing / byte_records-without-len_prefix / bad ordering / used-as-value). Full hale-syntax (82) + hale-types (169) + build_hello (38) regression green.

`spec/grammar.ebnf` gains the `ring_layout_decl` production; the proposal doc marks PR1 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
