### PR TITLE
shm_ring layout: binding kwarg (shm-ring-interop Proposal B, PR2)

### DIFF
--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -741,6 +741,11 @@ pub enum TransportSpec {
         name: String,
         slot_count: u64,
         overflow: ShmRingOverflow,
+        /// shm-ring-interop Proposal B: `layout: <Ident>` names a
+        /// `ring_layout` declaration describing a foreign ring's byte
+        /// layout. `None` = the native `LotusRing` shape (the only
+        /// behavior today; back-compat).
+        layout: Option<Ident>,
         span: Span,
     },
 }

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -1814,10 +1814,16 @@ impl Parser {
                 let name = self.expect_string_literal("shm_ring name")?;
                 let mut slot_count: u64 = 128;
                 let mut overflow: Option<ShmRingOverflow> = None;
+                let mut layout: Option<Ident> = None;
                 while self.eat(&TokenKind::Comma) {
                     let key = self.expect_ident("shm_ring kwarg name")?;
                     self.expect(TokenKind::Colon, ":")?;
                     match key.name.as_str() {
+                        "layout" => {
+                            layout = Some(self.expect_ident(
+                                "ring_layout name for `layout:`",
+                            )?);
+                        }
                         "slot_count" => {
                             let tok = self.peek_token().clone();
                             match tok.kind {
@@ -1881,7 +1887,7 @@ impl Parser {
                                 key.span,
                                 format!(
                                     "unknown `shm_ring` kwarg `{}` (recognized: \
-                                     `slot_count`, `on_overflow`)",
+                                     `slot_count`, `on_overflow`, `layout`)",
                                     other
                                 ),
                             ));
@@ -1904,6 +1910,7 @@ impl Parser {
                     name,
                     slot_count,
                     overflow,
+                    layout,
                     span: head_tok.span.merge(close.span),
                 })
             }

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -2819,6 +2819,37 @@ fn check_main_and_bindings(
                                 }
                             }
 
+                            // shm-ring-interop Proposal B: a
+                            // `shm_ring(..., layout: Name)` binding's
+                            // layout reference must resolve to a
+                            // declared `ring_layout`. Absent layout =
+                            // the native shape (back-compat).
+                            if let TransportSpec::ShmRing {
+                                layout: Some(lid), ..
+                            } = &entry.transport
+                            {
+                                match top.lookup(&lid.name) {
+                                    Some(TopSymbol::RingLayout(_)) => {}
+                                    Some(_) => diags.push(Diag::ty(
+                                        lid.span,
+                                        format!(
+                                            "shm_ring binding for topic `{}`: \
+                                             `layout: {}` is not a `ring_layout` \
+                                             declaration",
+                                            entry.topic.name, lid.name
+                                        ),
+                                    )),
+                                    None => diags.push(Diag::ty(
+                                        lid.span,
+                                        format!(
+                                            "shm_ring binding for topic `{}`: \
+                                             unknown ring_layout `{}`",
+                                            entry.topic.name, lid.name
+                                        ),
+                                    )),
+                                }
+                            }
+
                             // Form K4a (2026-05-20): operational-
                             // constraint validity. The `where ...`
                             // clause asserts properties of the

--- a/crates/hale-types/tests/ring_layout_binding.rs
+++ b/crates/hale-types/tests/ring_layout_binding.rs
@@ -1,0 +1,94 @@
+//! `shm_ring(..., layout: Name)` binding kwarg (shm-ring-interop
+//! Proposal B, PR2): the layout reference must resolve to a declared
+//! `ring_layout`. Absent layout = the native ring (back-compat).
+
+use hale_syntax::parse_source;
+use hale_types::check_program;
+
+fn check(src: &str) -> Vec<String> {
+    let prog = parse_source(src).expect("parse failed");
+    check_program(&prog).into_iter().map(|d| d.message).collect()
+}
+
+const LAYOUT: &str = r#"
+ring_layout MagusRing {
+    magic 0x4D475348514D4B54;
+    version 1 at 8 : u32;
+    buffer_size at 12 : u32;
+    data_at 128;
+    cursor published { at 64; repr atomic_u64; load acquire; unit bytes; }
+    framing byte_records { len_prefix u32; align 8; }
+    overflow lap_detect;
+}
+"#;
+
+fn program(binding: &str) -> String {
+    format!(
+        r#"
+{LAYOUT}
+type T {{ x: Int; }}
+topic Foo {{ payload: T; }}
+locus Producer {{
+    bus {{ publish Foo; }}
+    birth() {{ Foo <- T {{ x: 1 }}; }}
+}}
+main locus App {{
+    bindings {{
+        {binding}
+    }}
+}}
+fn main() {{ App {{ }}; Producer {{ }}; }}
+"#
+    )
+}
+
+#[test]
+fn layout_binding_resolves_clean() {
+    let msgs = check(&program(
+        r#"Foo: shm_ring("/magus.ticks", on_overflow: drop, layout: MagusRing) where zero_copy;"#,
+    ));
+    assert!(
+        !msgs.iter().any(|m| m.contains("ring_layout")),
+        "a binding to a declared ring_layout must resolve clean; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn unknown_layout_errors() {
+    let msgs = check(&program(
+        r#"Foo: shm_ring("/magus.ticks", on_overflow: drop, layout: Nonexistent) where zero_copy;"#,
+    ));
+    assert!(
+        msgs.iter().any(|m| m.contains("unknown ring_layout `Nonexistent`")),
+        "got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn layout_naming_a_non_layout_errors() {
+    // `Foo` is a topic, not a ring_layout.
+    let msgs = check(&program(
+        r#"Foo: shm_ring("/magus.ticks", on_overflow: drop, layout: Foo) where zero_copy;"#,
+    ));
+    assert!(
+        msgs.iter().any(|m| m.contains("is not a `ring_layout`")),
+        "got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn layout_less_binding_is_back_compat() {
+    // No `layout:` → native ring; must typecheck without any
+    // ring_layout diagnostic.
+    let msgs = check(&program(
+        r#"Foo: shm_ring("/lotus.ticks", slot_count: 4, on_overflow: drop) where zero_copy;"#,
+    ));
+    assert!(
+        !msgs.iter().any(|m| m.contains("ring_layout")),
+        "a layout-less shm_ring binding must stay valid; got: {:?}",
+        msgs
+    );
+}

--- a/notes/binary-shm-ring-interop.md
+++ b/notes/binary-shm-ring-interop.md
@@ -206,10 +206,15 @@ runtime already does for `LRSRNG1`; this just parameterizes it.
 > ints) parses, resolves, and typechecks — the layout *contract*
 > (known width reprs, recognized framing kind with `len_prefix` for
 > `byte_records`, ≥1 cursor with an offset, known cursor
-> reprs/orderings/unit) is enforced in `hale-types::check`. Codegen
-> consumption is **not** wired yet — PR2 adds the `layout:` binding
-> kwarg, PR3 the descriptor-parameterized read-only consumer. Grammar:
-> `spec/grammar.ebnf` (`ring_layout_decl`).
+> reprs/orderings/unit) is enforced in `hale-types::check`.
+>
+> **PR2 (LANDED): the `layout:` binding kwarg.**
+> `shm_ring(..., layout: Name)` parses and resolves to a declared
+> `ring_layout` (unknown / non-layout names diagnose); absent
+> `layout:` keeps the native ring, so existing bindings are unchanged.
+> No codegen behavior yet — PR3 adds the descriptor-parameterized
+> read-only consumer. Grammar: `spec/grammar.ebnf` (`ring_layout_decl`,
+> `shm_ring_kwarg`).
 
 magus2's ring becomes a declaration:
 

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -269,7 +269,8 @@ adapter_transport = LOCUS_IDENTIFIER , "{" , [ struct_init , { "," , struct_init
 shm_ring_transport = "shm_ring" , "(" , STRING_LIT ,
                      { "," , shm_ring_kwarg } , ")" ;
 shm_ring_kwarg    = ( "slot_count" , ":" , INT_LIT )
-                  | ( "on_overflow" , ":" , overflow_policy ) ;
+                  | ( "on_overflow" , ":" , overflow_policy )
+                  | ( "layout" , ":" , IDENTIFIER ) ;
 overflow_policy    = "block" | "drop" | "fail" ;
 
 (* Form K (2026-05-20): operational constraints the dev team


### PR DESCRIPTION
## What

Second slice of **Proposal B** (after the `ring_layout` decl, #57). Threads a `layout: <Ident>` kwarg onto the `shm_ring(...)` binding, resolving to a declared `ring_layout`:

```hale
bindings {
    ForeignTick: shm_ring("/foreign.ticks", on_overflow: drop, layout: ForeignRing) where zero_copy;
}
```

**Typed binding surface only** — no codegen behavior yet (PR3 adds the descriptor-parameterized read-only consumer). An absent `layout:` keeps the native ring, so **every existing binding is unchanged**.

## How

- **AST**: `layout: Option<Ident>` on `TransportSpec::ShmRing`. All existing destructures use `..`, so only the parser's construction site changes.
- **Parser**: a `layout` kwarg arm beside `slot_count`/`on_overflow`; unknown-kwarg message updated.
- **Typecheck** (`check_main_and_bindings`): `Some(layout)` must resolve to a `TopSymbol::RingLayout` — an unknown name or a non-layout symbol (e.g. a topic) diagnoses.
- **Grammar**: `shm_ring_kwarg` gains `( "layout" , ":" , IDENTIFIER )`.

## Tests

`ring_layout_binding.rs` (4): binding to a declared layout resolves clean; unknown layout / non-layout-name error; layout-less binding stays valid (back-compat). The existing `shm_ring` codegen suite (8) passes unchanged. Proposal doc marks PR2 landed.

PR3 (next) wires the runtime descriptor + `byte_records` consumer iterate — the capability that actually reads a foreign ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
