### PR TITLE
codegen+runtime: foreign-ring read-only consumer (Proposal B, PR3)

### DIFF
--- a/crates/hale-codegen/runtime/lotus_shm_ring.c
+++ b/crates/hale-codegen/runtime/lotus_shm_ring.c
@@ -227,6 +227,142 @@ void lotus_shm_ring_close(lotus_shm_ring_t *ring) {
     free(ring);
 }
 
+/* === Proposal B (2026-06-06) — foreign-layout read-only consumer =======
+ *
+ * A `ring_layout` declaration lets a Hale program read an
+ * EXTERNALLY-defined binary broadcast ring (concretely magus2's
+ * `RingPrefix`) without forking the runtime. The native ring above
+ * (LRSRNG1) is one fixed shape; a layout parameterizes the parts
+ * that vary: the magic, a version field, a buffer_size field, the
+ * first-record offset, the published byte cursor, and the record
+ * framing.
+ *
+ * v1 scope is READ-ONLY, `byte_records` framing, single broadcast
+ * cursor. The producer side for foreign layouts (writing magus2's
+ * ring from Hale) is out of scope (Proposal B M3).
+ *
+ * Endianness: fields are read host-native. magus2 and Hale both
+ * target little-endian x86-64; a cross-endian attach is rejected
+ * upstream (there is no byte-swap path at v1).
+ */
+
+/* Descriptor built by codegen from the resolved `ring_layout` and
+ * passed as a flat uint64 word array (see the desc[] contract in
+ * `lotus_bus_register_subscriber_shm_ring_layout`). Mirrored into
+ * this struct at registration time. */
+typedef struct {
+    uint64_t magic;            /* expected header magic at offset 0 */
+    int      has_magic;
+    uint64_t version_off;      /* header offset of the version field */
+    uint64_t version_width;    /* version field width in bytes */
+    uint64_t version_expect;
+    int      has_version;
+    uint64_t buffer_size_off;  /* header offset of the capacity field */
+    uint64_t buffer_size_width;
+    int      has_buffer_size;
+    uint64_t data_at;          /* first-record byte offset */
+    uint64_t cursor_off;       /* offset of the published byte cursor */
+    uint64_t len_prefix_width; /* record length-prefix width in bytes */
+    uint64_t align;            /* record stride alignment (>=1) */
+    uint64_t pad_sentinel;     /* len value meaning "pad to wrap" */
+    int      has_pad_sentinel;
+} lotus_shm_layout_t;
+
+/* Per-process handle for a layout-described ring. Distinct from
+ * lotus_shm_ring_t: a foreign ring has no Lotus header, so none of
+ * the slot_size/slot_count/consumer_seqno machinery applies. */
+typedef struct {
+    void   *base;          /* mmap base (header at offset 0) */
+    size_t  mapped_size;
+    int     fd;
+    char    shm_name[96];
+    lotus_shm_layout_t desc;
+    uint64_t capacity;     /* ring data-region size in bytes */
+} lotus_shm_layout_ring_t;
+
+/* Read an unsigned little-endian field of `width` (1..8) bytes.
+ * Host is assumed little-endian (see the endianness note above). */
+static uint64_t shm_layout_read_uint(const void *p, uint64_t width) {
+    uint64_t v = 0;
+    if (width > 8) width = 8;
+    memcpy(&v, p, (size_t)width);
+    return v;
+}
+
+/* Attach (read-only) to a foreign ring described by `desc`.
+ *
+ * Unlike lotus_shm_ring_open, this NEVER creates the segment — the
+ * foreign producer owns it. The segment must already exist and be
+ * sized; the consumer fstat()s it for the mapping length, then
+ * validates magic + version and reads buffer_size from the header.
+ *
+ * Returns NULL on error (errno set): segment missing, too small,
+ * magic/version mismatch, or a buffer_size that overruns the map. */
+static lotus_shm_layout_ring_t *
+lotus_shm_ring_open_layout(const char *name, const lotus_shm_layout_t *desc) {
+    if (!name || !desc) { errno = EINVAL; return NULL; }
+    if (strlen(name) + 1 > sizeof(((lotus_shm_layout_ring_t *)0)->shm_name)) {
+        errno = ENAMETOOLONG;
+        return NULL;
+    }
+    int fd = shm_open(name, O_RDONLY, 0600);
+    if (fd < 0) return NULL;
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        int save = errno; close(fd); errno = save; return NULL;
+    }
+    size_t total = (size_t)st.st_size;
+    if (total < desc->data_at) {
+        close(fd); errno = EBADF; return NULL;
+    }
+    void *map = mmap(NULL, total, PROT_READ, MAP_SHARED, fd, 0);
+    if (map == MAP_FAILED) {
+        int save = errno; close(fd); errno = save; return NULL;
+    }
+    if (desc->has_magic) {
+        uint64_t got = shm_layout_read_uint(map, 8);
+        if (got != desc->magic) {
+            munmap(map, total); close(fd); errno = EBADF; return NULL;
+        }
+    }
+    if (desc->has_version) {
+        uint64_t got = shm_layout_read_uint(
+            (char *)map + desc->version_off, desc->version_width);
+        if (got != desc->version_expect) {
+            munmap(map, total); close(fd); errno = EBADF; return NULL;
+        }
+    }
+    uint64_t capacity;
+    if (desc->has_buffer_size) {
+        capacity = shm_layout_read_uint(
+            (char *)map + desc->buffer_size_off, desc->buffer_size_width);
+    } else {
+        capacity = total - desc->data_at;
+    }
+    if (capacity == 0 || desc->data_at + capacity > total) {
+        munmap(map, total); close(fd); errno = EBADF; return NULL;
+    }
+    lotus_shm_layout_ring_t *r =
+        (lotus_shm_layout_ring_t *)calloc(1, sizeof(*r));
+    if (!r) {
+        munmap(map, total); close(fd); errno = ENOMEM; return NULL;
+    }
+    r->base = map;
+    r->mapped_size = total;
+    r->fd = fd;
+    r->desc = *desc;
+    r->capacity = capacity;
+    strncpy(r->shm_name, name, sizeof(r->shm_name) - 1);
+    return r;
+}
+
+static void lotus_shm_ring_close_layout(lotus_shm_layout_ring_t *r) {
+    if (!r) return;
+    if (r->base) munmap(r->base, r->mapped_size);
+    if (r->fd >= 0) close(r->fd);
+    free(r);
+}
+
 /* Publisher: claim the next slot.
  *
  * Form K7 (2026-05-20): back-pressure semantics determined by
@@ -535,6 +671,12 @@ int lotus_bus_publish_shm_ring(const char *subject,
 
 struct shm_ring_subscriber_t {
     lotus_shm_ring_t *ring;
+    /* Proposal B (2026-06-06): a foreign-layout subscriber sets
+     * is_layout=1 and reads through `lring` instead of `ring`. The
+     * native and layout paths share one registry + atexit teardown;
+     * the reader-thread fn and close fn branch on is_layout. */
+    int is_layout;
+    lotus_shm_layout_ring_t *lring;
     void (*handler_fn)(void *self, void *slot);
     void *self_ptr;
     pthread_t thread;
@@ -578,6 +720,171 @@ static void *shm_ring_reader_thread(void *arg) {
         }
     }
     return NULL;
+}
+
+/* Proposal B (2026-06-06) — reader loop for a foreign `byte_records`
+ * ring. `local` is a monotonic byte cursor (the same units the
+ * producer publishes); the physical read offset is
+ * `data_at + local % capacity`. Each record is `[len_prefix][payload]`;
+ * `len == pad_sentinel` is a tail-pad that fills to the wrap.
+ *
+ * v1 simplifications (matching the native reader):
+ *   - First poll starts `local` at the producer's current cursor, so
+ *     a subscriber reads records published AFTER it attaches (no
+ *     historical replay).
+ *   - Lap handling is lossy + safe: if the producer ran more than
+ *     `capacity` bytes ahead of us, the bytes we missed have been
+ *     overwritten, so we resync to the producer's cursor (a commit
+ *     boundary, hence record-aligned) and resume. Records are never
+ *     read torn — a suspected straddle/corruption also resyncs.
+ *   - Handler runs on this reader thread, like the native path.
+ */
+static void *shm_ring_layout_reader_thread(void *arg) {
+    shm_ring_subscriber_t *sub = (shm_ring_subscriber_t *)arg;
+    lotus_shm_layout_ring_t *r = sub->lring;
+    const lotus_shm_layout_t *d = &r->desc;
+    char *base = (char *)r->base;
+    uint64_t cap = r->capacity;
+    uint64_t local = 0;
+    int initialized = 0;
+    while (!atomic_load_explicit(&sub->should_stop,
+                                  memory_order_acquire)) {
+        uint64_t committed = atomic_load_explicit(
+            (const _Atomic uint64_t *)(base + d->cursor_off),
+            memory_order_acquire);
+        if (!initialized) {
+            local = committed;
+            initialized = 1;
+        }
+        if (committed <= local) {
+            struct timespec ts = {0, 100 * 1000};  /* 100us */
+            nanosleep(&ts, NULL);
+            continue;
+        }
+        /* Lapped: missed bytes are gone — resync to a commit
+         * boundary and drop the gap. */
+        if (committed - local > cap) {
+            local = committed;
+            continue;
+        }
+        while (local < committed) {
+            uint64_t phys = d->data_at + (local % cap);
+            uint64_t len = shm_layout_read_uint(base + phys,
+                                                d->len_prefix_width);
+            if (d->has_pad_sentinel && len == d->pad_sentinel) {
+                /* Tail pad — jump to the next wrap boundary. */
+                local += cap - (local % cap);
+                continue;
+            }
+            uint64_t rec = d->len_prefix_width + len;
+            if (len == 0 || (local % cap) + rec > cap) {
+                /* Malformed or straddles the wrap without a pad —
+                 * treat as desync and resync to the cursor. */
+                local = committed;
+                break;
+            }
+            sub->handler_fn(sub->self_ptr,
+                            base + phys + d->len_prefix_width);
+            uint64_t step = rec;
+            if (d->align > 1) {
+                step = (step + d->align - 1) & ~(d->align - 1);
+            }
+            local += step;
+        }
+    }
+    return NULL;
+}
+
+/* Proposal B (2026-06-06) — register a foreign-layout subscriber.
+ *
+ * `desc_words` is a flat 16-entry uint64 array built by codegen from
+ * the resolved `ring_layout`. The slot contract (keep in sync with
+ * codegen's `emit_bus_register_shm_ring`):
+ *
+ *   [0]  magic              [8]  has_buffer_size
+ *   [1]  has_magic          [9]  data_at
+ *   [2]  version_off        [10] cursor_off
+ *   [3]  version_width      [11] len_prefix_width
+ *   [4]  version_expect     [12] align
+ *   [5]  has_version        [13] pad_sentinel
+ *   [6]  buffer_size_off    [14] has_pad_sentinel
+ *   [7]  buffer_size_width  [15] reserved
+ *
+ * Spawns a reader thread sharing the native subscriber registry +
+ * atexit teardown. _exit(1) on open failure (a misdeclared layout
+ * or an absent producer ring is a hard configuration error). */
+void lotus_bus_register_subscriber_shm_ring_layout(
+        const char *subject,
+        const char *shm_name,
+        const uint64_t *desc_words,
+        void *self_ptr,
+        void (*handler_fn)(void *self, void *slot)) {
+    ensure_shm_ring_atexit_registered();
+
+    lotus_shm_layout_t d;
+    memset(&d, 0, sizeof(d));
+    d.magic             = desc_words[0];
+    d.has_magic         = (int)desc_words[1];
+    d.version_off       = desc_words[2];
+    d.version_width     = desc_words[3];
+    d.version_expect    = desc_words[4];
+    d.has_version       = (int)desc_words[5];
+    d.buffer_size_off   = desc_words[6];
+    d.buffer_size_width = desc_words[7];
+    d.has_buffer_size   = (int)desc_words[8];
+    d.data_at           = desc_words[9];
+    d.cursor_off        = desc_words[10];
+    d.len_prefix_width  = desc_words[11];
+    d.align             = desc_words[12];
+    d.pad_sentinel      = desc_words[13];
+    d.has_pad_sentinel  = (int)desc_words[14];
+
+    lotus_shm_layout_ring_t *r = lotus_shm_ring_open_layout(shm_name, &d);
+    if (!r) {
+        fprintf(stderr,
+                "lotus_bus_register_subscriber_shm_ring_layout(`%s`, `%s`): "
+                "open failed: %s\n",
+                subject, shm_name, strerror(errno));
+        _exit(1);
+    }
+
+    shm_ring_subscriber_t *sub =
+        (shm_ring_subscriber_t *)calloc(1, sizeof(*sub));
+    if (!sub) {
+        fprintf(stderr,
+                "lotus_bus_register_subscriber_shm_ring_layout(`%s`): calloc "
+                "failed\n",
+                subject);
+        _exit(1);
+    }
+    sub->is_layout = 1;
+    sub->lring = r;
+    sub->handler_fn = handler_fn;
+    sub->self_ptr = self_ptr;
+    atomic_store_explicit(&sub->should_stop, 0, memory_order_relaxed);
+
+    lotus_mark_multithreaded();
+    int rc = pthread_create(&sub->thread, NULL,
+                            shm_ring_layout_reader_thread, sub);
+    if (rc != 0) {
+        fprintf(stderr,
+                "lotus_bus_register_subscriber_shm_ring_layout(`%s`): "
+                "pthread_create failed: %d\n",
+                subject, rc);
+        lotus_shm_ring_close_layout(r);
+        free(sub);
+        _exit(1);
+    }
+    int idx = atomic_fetch_add_explicit(
+        &g_shm_ring_subscriber_count, 1, memory_order_acq_rel);
+    if (idx >= LOTUS_SHM_RING_MAX_SUBSCRIBERS) {
+        fprintf(stderr,
+                "lotus_bus_register_subscriber_shm_ring_layout(`%s`): exceeded "
+                "LOTUS_SHM_RING_MAX_SUBSCRIBERS (%d)\n",
+                subject, LOTUS_SHM_RING_MAX_SUBSCRIBERS);
+        _exit(1);
+    }
+    g_shm_ring_subscribers[idx] = sub;
 }
 
 /* Codegen emits one call per shm_ring subscriber registration at
@@ -675,7 +982,11 @@ static void shm_ring_atexit_cleanup(void) {
         shm_ring_subscriber_t *sub = g_shm_ring_subscribers[i];
         if (sub) {
             pthread_join(sub->thread, NULL);
-            if (sub->ring) {
+            if (sub->is_layout) {
+                if (sub->lring) {
+                    lotus_shm_ring_close_layout(sub->lring);
+                }
+            } else if (sub->ring) {
                 lotus_shm_ring_close(sub->ring);
             }
             free(sub);

--- a/crates/hale-codegen/src/bus/runtime.rs
+++ b/crates/hale-codegen/src/bus/runtime.rs
@@ -151,6 +151,15 @@ impl<'ctx, 'p> BusRuntime<'ctx> for Cx<'ctx, 'p> {
                     subject
                 ))
             })?;
+        // Proposal B (2026-06-06): a `layout:`-bound subscriber reads
+        // a foreign ring. Build the descriptor from the resolved
+        // `ring_layout` and register through the layout-aware path;
+        // the native LRSRNG1 path below is left untouched.
+        if let Some(layout) = info.layout.clone() {
+            return self.emit_bus_register_shm_ring_layout(
+                subject, &info.shm_name, &layout, self_ptr, handler_fn,
+            );
+        }
         let payload_info = self
             .user_types
             .get(&info.payload_type_name)
@@ -330,4 +339,169 @@ impl<'ctx, 'p> BusRuntime<'ctx> for Cx<'ctx, 'p> {
         Ok(())
     }
 
+}
+
+/// Width in bytes of a `ring_layout` scalar/len repr token. The
+/// repr set is validated at typecheck (hale-types::check_ring_layout);
+/// an unrecognized token here defaults to 8 (the widest), which is
+/// harmless — the layout would already have been rejected upstream.
+fn ring_repr_width(repr: &str) -> u64 {
+    match repr {
+        "u8" | "i8" => 1,
+        "u16" | "i16" => 2,
+        "u32" | "i32" | "f32" => 4,
+        "u64" | "i64" | "f64" | "atomic_u64" => 8,
+        _ => 8,
+    }
+}
+
+/// Build the flat 16-entry descriptor (the slot contract documented
+/// on `lotus_bus_register_subscriber_shm_ring_layout` in
+/// `lotus_shm_ring.c`) from a resolved `ring_layout`.
+///
+/// Field roles are read by convention from the declared layout:
+///   - `magic N;` → expected header magic at offset 0.
+///   - a scalar named `version` with an `expect` → version check.
+///   - a scalar named `buffer_size` → ring capacity source.
+///   - the first `cursor`'s `at` → the published byte cursor offset.
+///   - the `byte_records` framing's `len_prefix`/`align`/
+///     `pad_sentinel` → record framing.
+fn ring_layout_descriptor_words(
+    decl: &hale_syntax::ast::RingLayoutDecl,
+) -> [u64; 16] {
+    use hale_syntax::ast::RingAttrValue;
+    let mut w = [0u64; 16];
+
+    // [0..2] magic
+    if let Some(m) = decl.magic {
+        w[0] = m as u64;
+        w[1] = 1;
+    }
+
+    // [2..6] version: scalar named "version" carrying an expect.
+    if let Some(v) = decl
+        .scalars
+        .iter()
+        .find(|s| s.name.name == "version" && s.expect.is_some())
+    {
+        w[2] = v.at as u64;
+        w[3] = ring_repr_width(&v.repr.name);
+        w[4] = v.expect.unwrap_or(0) as u64;
+        w[5] = 1;
+    }
+
+    // [6..9] buffer_size: scalar named "buffer_size".
+    if let Some(b) = decl.scalars.iter().find(|s| s.name.name == "buffer_size") {
+        w[6] = b.at as u64;
+        w[7] = ring_repr_width(&b.repr.name);
+        w[8] = 1;
+    }
+
+    // [9] data_at
+    w[9] = decl.data_at.unwrap_or(0) as u64;
+
+    // [10] cursor offset (first cursor's `at` attr)
+    if let Some(c) = decl.cursors.first() {
+        for a in &c.attrs {
+            if a.key.name == "at" {
+                if let RingAttrValue::Int(n) = &a.value {
+                    w[10] = *n as u64;
+                }
+            }
+        }
+    }
+
+    // [11..15] framing: len_prefix width, align, pad_sentinel.
+    w[12] = 1; // align default (no sub-record padding)
+    if let Some(f) = &decl.framing {
+        for a in &f.attrs {
+            match (a.key.name.as_str(), &a.value) {
+                ("len_prefix", RingAttrValue::Ident(id)) => {
+                    w[11] = ring_repr_width(&id.name);
+                }
+                ("len_prefix", RingAttrValue::Int(n)) => {
+                    w[11] = *n as u64;
+                }
+                ("align", RingAttrValue::Int(n)) => {
+                    w[12] = *n as u64;
+                }
+                ("pad_sentinel", RingAttrValue::Int(n)) => {
+                    w[13] = *n as u64;
+                    w[14] = 1;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    w
+}
+
+impl<'ctx, 'p> Cx<'ctx, 'p> {
+    /// Proposal B (2026-06-06): register a subscriber on a
+    /// `layout:`-bound shm_ring topic. Emits a private global holding
+    /// the 16-entry descriptor built from the resolved `ring_layout`
+    /// and calls `lotus_bus_register_subscriber_shm_ring_layout`,
+    /// which attaches the foreign ring read-only and spawns the
+    /// `byte_records` reader thread.
+    fn emit_bus_register_shm_ring_layout(
+        &mut self,
+        subject: &str,
+        shm_name: &str,
+        layout: &hale_syntax::ast::RingLayoutDecl,
+        self_ptr: PointerValue<'ctx>,
+        handler_fn: FunctionValue<'ctx>,
+    ) -> Result<(), CodegenError> {
+        let i64_t = self.context.i64_type();
+        let words = ring_layout_descriptor_words(layout);
+        let const_vals: Vec<inkwell::values::IntValue<'ctx>> =
+            words.iter().map(|wrd| i64_t.const_int(*wrd, false)).collect();
+        let arr = i64_t.const_array(&const_vals);
+        let arr_ty = i64_t.array_type(words.len() as u32);
+        let desc_g = self.module.add_global(
+            arr_ty,
+            None,
+            &format!("lotus.shm_ring.layout.desc.{}", subject),
+        );
+        desc_g.set_initializer(&arr);
+        desc_g.set_constant(true);
+        desc_g.set_linkage(inkwell::module::Linkage::Private);
+        let desc_ptr = desc_g.as_pointer_value();
+
+        let subj_ptr = self
+            .builder
+            .build_global_string_ptr(
+                subject,
+                &format!("lotus.shm_ring.layout.subject.{}", subject),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .as_pointer_value();
+        let name_ptr = self
+            .builder
+            .build_global_string_ptr(
+                shm_name,
+                &format!("lotus.shm_ring.layout.name.{}", subject),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .as_pointer_value();
+        let handler_ptr = handler_fn.as_global_value().as_pointer_value();
+        let reg_fn = self
+            .module
+            .get_function("lotus_bus_register_subscriber_shm_ring_layout")
+            .expect("lotus_bus_register_subscriber_shm_ring_layout declared");
+        self.builder
+            .build_call(
+                reg_fn,
+                &[
+                    subj_ptr.into(),
+                    name_ptr.into(),
+                    desc_ptr.into(),
+                    self_ptr.into(),
+                    handler_ptr.into(),
+                ],
+                "shm_ring.sub.register_layout",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        Ok(())
+    }
 }

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1715,6 +1715,11 @@ pub(crate) struct ShmRingBindingInfo {
     /// (publish sites on a `fail`-policy topic will need to
     /// require a `or raise|substitute|hand-off` disposition).
     pub(crate) overflow: ShmRingOverflow,
+    /// Proposal B (2026-06-06): the resolved `ring_layout` decl when
+    /// the binding carries `layout: Name`, else None (native ring).
+    /// A subscriber on a layout-bound topic registers through the
+    /// layout-aware runtime path; the publish side is out of scope.
+    pub(crate) layout: Option<hale_syntax::ast::RingLayoutDecl>,
 }
 
 /// m47 (enums): per-enum metadata. Variants in declaration order;
@@ -5271,7 +5276,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             if let LocusMember::Bindings(b) = m {
                 for entry in &b.entries {
                     if let TransportSpec::ShmRing {
-                        name, slot_count, overflow, ..
+                        name, slot_count, overflow, layout, ..
                     } = &entry.transport
                     {
                         let subj = wire_subjects
@@ -5282,6 +5287,18 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                             .get(&entry.topic.name)
                             .cloned()
                             .unwrap_or_default();
+                        // Proposal B: resolve `layout: Name` to its
+                        // decl (validated upstream in hale-types) so
+                        // the subscriber register can build the
+                        // descriptor. None → native ring.
+                        let layout_decl = layout.as_ref().and_then(|lid| {
+                            self.program.items.iter().find_map(|it| match it {
+                                TopDecl::RingLayout(r) if r.name.name == lid.name => {
+                                    Some(r.clone())
+                                }
+                                _ => None,
+                            })
+                        });
                         self.shm_ring_subjects.insert(
                             subj,
                             ShmRingBindingInfo {
@@ -5289,6 +5306,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                                 slot_count: *slot_count,
                                 shm_name: name.clone(),
                                 overflow: *overflow,
+                                layout: layout_decl,
                             },
                         );
                     }

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1170,6 +1170,31 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             None,
         );
 
+        // Proposal B (2026-06-06): foreign-layout subscriber. Like
+        // the native register above, but the ring shape is described
+        // by a `ring_layout` rather than the LRSRNG1 header — so it
+        // takes a flat 16-entry uint64 descriptor (built from the
+        // resolved layout in `emit_bus_register_shm_ring`) instead of
+        // slot_size/slot_count, and attaches read-only.
+        // declare void @lotus_bus_register_subscriber_shm_ring_layout(
+        //   ptr subject, ptr shm_name, ptr desc_words,
+        //   ptr self_ptr, ptr handler_fn)
+        let bus_register_sub_shm_ring_layout_ty = void_t.fn_type(
+            &[
+                ptr_t.into(),
+                ptr_t.into(),
+                ptr_t.into(),
+                ptr_t.into(),
+                ptr_t.into(),
+            ],
+            false,
+        );
+        self.module.add_function(
+            "lotus_bus_register_subscriber_shm_ring_layout",
+            bus_register_sub_shm_ring_layout_ty,
+            None,
+        );
+
         // m105: adapter-driven inbound dispatch. Hands wire bytes
         // through the subject's registered deserialize fn into the
         // local handler set. Backs the `std::bus::__local_dispatch`

--- a/crates/hale-codegen/tests/shm_ring_layout.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout.rs
@@ -1,0 +1,83 @@
+//! Proposal B (2026-06-06) — foreign-layout SHM ring consumer test.
+//!
+//! Compiles `runtime/lotus_shm_ring.c` plus the
+//! `shm_ring_layout_driver.c` harness into a one-off binary and
+//! runs it in two modes (see the driver header):
+//!
+//!   1. `roundtrip` — capacity holds all records; deterministic
+//!      exact in-order delivery through the `byte_records` reader.
+//!   2. `wrap` — small capacity + a paced producer forces the
+//!      pad-at-wrap branch; still asserts exact delivery.
+//!
+//! Exercises the C-ABI runtime
+//! (lotus_bus_register_subscriber_shm_ring_layout + the layout
+//! reader thread). The codegen side (a `layout:` binding emitting
+//! this call) is covered in `shm_ring_layout_codegen.rs`.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn build_driver(tag: &str) -> PathBuf {
+    let mut driver_c = manifest_dir();
+    driver_c.push("tests");
+    driver_c.push("shm_ring_layout_driver.c");
+    let mut ring_c = manifest_dir();
+    ring_c.push("runtime");
+    ring_c.push("lotus_shm_ring.c");
+
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("lotus_shm_ring_layout_driver_{}", tag));
+    let status = Command::new("clang")
+        .arg(driver_c)
+        .arg(ring_c)
+        .arg("-O2")
+        .arg("-lrt")
+        .arg("-lpthread")
+        .arg("-o")
+        .arg(&bin)
+        .status()
+        .expect("clang invocation");
+    assert!(status.success(), "clang failed building shm_ring layout driver");
+    bin
+}
+
+fn unique_shm_name(tag: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("/hale-shmlayout-{}-{}-{}", tag, std::process::id(), nanos)
+}
+
+fn run_mode(mode: &str) {
+    let driver = build_driver(mode);
+    let name = unique_shm_name(mode);
+    let out = Command::new(&driver)
+        .arg(mode)
+        .arg(&name)
+        .output()
+        .expect("run driver");
+    let _ = std::fs::remove_file(&driver);
+    assert!(
+        out.status.success(),
+        "{} driver failed: status={:?}\nstderr: {}",
+        mode,
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn layout_byte_records_roundtrip() {
+    run_mode("roundtrip");
+}
+
+#[test]
+fn layout_byte_records_wrap() {
+    run_mode("wrap");
+}

--- a/crates/hale-codegen/tests/shm_ring_layout_codegen.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_codegen.rs
@@ -1,0 +1,100 @@
+//! Proposal B (2026-06-06) — codegen wiring for a `layout:`-bound
+//! shm_ring subscriber.
+//!
+//! Compiles a Hale program with a `ring_layout` declaration and a
+//! subscriber whose binding carries `layout: MagusRing`, dumps the
+//! LLVM IR via `LOTUS_DUMP_IR`, and asserts codegen took the
+//! foreign-layout path: it emits the descriptor global and a call
+//! to `lotus_bus_register_subscriber_shm_ring_layout` (NOT the
+//! native `lotus_bus_register_subscriber_shm_ring`).
+//!
+//! The runtime `byte_records` reader the descriptor drives is
+//! validated separately by the C driver in `shm_ring_layout.rs`;
+//! this test guards the codegen-side marshalling so the two halves
+//! stay connected.
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::build_executable;
+
+fn unique_path(tag: &str, ext: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "lt-pr0b-{}-{}-{}.{}",
+        tag,
+        std::process::id(),
+        nanos,
+        ext,
+    ));
+    p
+}
+
+#[test]
+fn layout_binding_emits_layout_register_call() {
+    let src = r#"
+        ring_layout MagusRing {
+            magic 0x4D475348514D4B54;
+            version 1 at 8 : u32;
+            buffer_size at 12 : u32;
+            data_at 128;
+            cursor published { at 64; repr atomic_u64; load acquire; unit bytes; }
+            framing byte_records { len_prefix u32; align 8; }
+            overflow lap_detect;
+        }
+
+        type Tick {
+            px: Int;
+            sz: Int;
+        }
+        topic Ticks { payload: Tick; }
+
+        locus Sub {
+            bus { subscribe Ticks as on_tick of type Tick; }
+            fn on_tick(t: Tick) {
+                println("tick px=", t.px, " sz=", t.sz);
+            }
+        }
+
+        main locus App {
+            bindings {
+                Ticks: shm_ring("/magus.ticks", on_overflow: drop, layout: MagusRing) where zero_copy;
+            }
+        }
+
+        fn main() {
+            App { };
+            Sub { };
+        }
+    "#;
+
+    let bin = unique_path("layout", "bin");
+    let ir = bin.with_extension("ll");
+    let program = hale_syntax::parse_source(src).expect("parse");
+
+    std::env::set_var("LOTUS_DUMP_IR", "1");
+    let result = build_executable(&program, &bin);
+    std::env::remove_var("LOTUS_DUMP_IR");
+    result.expect("build");
+
+    let ir_text = std::fs::read_to_string(&ir).expect("read IR");
+
+    let _ = std::fs::remove_file(&bin);
+    let _ = std::fs::remove_file(&ir);
+
+    assert!(
+        ir_text.contains("lotus_bus_register_subscriber_shm_ring_layout"),
+        "layout-bound subscriber must register via the layout-aware \
+         runtime path; IR did not reference \
+         lotus_bus_register_subscriber_shm_ring_layout"
+    );
+    assert!(
+        ir_text.contains("lotus.shm_ring.layout.desc"),
+        "codegen must emit the descriptor global for the layout \
+         binding; IR did not contain lotus.shm_ring.layout.desc"
+    );
+}

--- a/crates/hale-codegen/tests/shm_ring_layout_driver.c
+++ b/crates/hale-codegen/tests/shm_ring_layout_driver.c
@@ -1,0 +1,218 @@
+/*
+ * Proposal B (2026-06-06) — foreign-layout SHM ring C driver test.
+ *
+ * Exercises the read-only `byte_records` consumer path
+ * (lotus_bus_register_subscriber_shm_ring_layout + the layout
+ * reader thread) against a magus2-shaped producer that this driver
+ * plays itself.
+ *
+ * The driver is BOTH sides over one POSIX SHM segment:
+ *   - Producer: shm_open(O_CREAT|O_EXCL), writes the header
+ *     (magic @0, version @8:u32, buffer_size @12:u32), then writes
+ *     `[u32 len][payload]` records 8-aligned with a pad_sentinel
+ *     tail-pad at the wrap, release-publishing a monotonic byte
+ *     cursor @64 after each record.
+ *   - Consumer: lotus_bus_register_subscriber_shm_ring_layout
+ *     attaches read-only, spawns the reader thread, and the handler
+ *     records each delivered payload into a global array.
+ *
+ * Modes (argv[1]):
+ *   roundtrip : capacity holds all N records — no wrap, no lap;
+ *               asserts exact in-order delivery (deterministic).
+ *   wrap      : small capacity forces pad-at-wrap; producer paces
+ *               (1ms/record vs the reader's 100us poll, a 10x
+ *               margin) so the consumer never laps; asserts exact
+ *               in-order delivery of all N (exercises the pad
+ *               branch + modular stepping).
+ *
+ * Exits 0 on success, non-zero with a one-line stderr diagnostic.
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+extern void lotus_bus_register_subscriber_shm_ring_layout(
+    const char *subject,
+    const char *shm_name,
+    const uint64_t *desc_words,
+    void *self_ptr,
+    void (*handler_fn)(void *self, void *slot));
+
+/* Layout constants — mirror the `MagusRing` ring_layout used in the
+ * Rust-side tests. */
+#define MAGIC          0x4D475348514D4B54ULL
+#define VERSION_OFF    8
+#define VERSION_WIDTH  4
+#define VERSION_VAL    1
+#define BUFSZ_OFF      12
+#define BUFSZ_WIDTH    4
+#define DATA_AT        128
+#define CURSOR_OFF     64
+#define LEN_WIDTH      4
+#define ALIGN          8
+#define PAD_SENTINEL   0xFFFFFFFFULL
+
+typedef struct {
+    int64_t seq_id;
+    int64_t value;
+} Payload;
+
+static uint64_t align_up(uint64_t v, uint64_t a) {
+    return (v + a - 1) & ~(a - 1);
+}
+
+/* ---- consumer side ---- */
+#define MAX_RECV 256
+static _Atomic int g_recv_count = 0;
+static Payload g_recv[MAX_RECV];
+
+static void on_record(void *self, void *slot) {
+    (void)self;
+    int i = atomic_fetch_add_explicit(&g_recv_count, 1, memory_order_acq_rel);
+    if (i < MAX_RECV) {
+        memcpy(&g_recv[i], slot, sizeof(Payload));
+    }
+}
+
+static void build_desc(uint64_t desc[16]) {
+    memset(desc, 0, 16 * sizeof(uint64_t));
+    desc[0]  = MAGIC;        desc[1]  = 1;            /* magic, has_magic */
+    desc[2]  = VERSION_OFF;  desc[3]  = VERSION_WIDTH;
+    desc[4]  = VERSION_VAL;  desc[5]  = 1;            /* version_expect, has_version */
+    desc[6]  = BUFSZ_OFF;    desc[7]  = BUFSZ_WIDTH;  desc[8] = 1; /* has_buffer_size */
+    desc[9]  = DATA_AT;
+    desc[10] = CURSOR_OFF;
+    desc[11] = LEN_WIDTH;
+    desc[12] = ALIGN;
+    desc[13] = PAD_SENTINEL; desc[14] = 1;            /* has_pad_sentinel */
+}
+
+/* ---- producer side ---- */
+static int run(const char *name, uint64_t capacity, int n, int pace_us) {
+    size_t total = DATA_AT + (size_t)capacity;
+    int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
+    if (fd < 0) {
+        fprintf(stderr, "producer shm_open: %s\n", strerror(errno));
+        return 2;
+    }
+    if (ftruncate(fd, (off_t)total) != 0) {
+        fprintf(stderr, "ftruncate: %s\n", strerror(errno));
+        shm_unlink(name);
+        return 2;
+    }
+    void *map = mmap(NULL, total, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (map == MAP_FAILED) {
+        fprintf(stderr, "producer mmap: %s\n", strerror(errno));
+        shm_unlink(name);
+        return 2;
+    }
+    char *base = (char *)map;
+
+    /* Header. */
+    *(uint64_t *)(base + 0) = MAGIC;
+    *(uint32_t *)(base + VERSION_OFF) = (uint32_t)VERSION_VAL;
+    *(uint32_t *)(base + BUFSZ_OFF) = (uint32_t)capacity;
+    _Atomic uint64_t *cursor = (_Atomic uint64_t *)(base + CURSOR_OFF);
+    atomic_store_explicit(cursor, 0, memory_order_release);
+
+    /* Consumer attaches after the header is valid; it starts reading
+     * from the current cursor (0), so it sees every record below. */
+    uint64_t desc[16];
+    build_desc(desc);
+    lotus_bus_register_subscriber_shm_ring_layout(
+        "magus.ticks", name, desc, NULL, on_record);
+    /* Give the reader a moment to attach + park at cursor 0. */
+    struct timespec warmup = {0, 5 * 1000 * 1000};  /* 5ms */
+    nanosleep(&warmup, NULL);
+
+    uint64_t local = 0;
+    uint64_t rec = LEN_WIDTH + sizeof(Payload);
+    uint64_t step = align_up(rec, ALIGN);
+    for (int i = 0; i < n; i++) {
+        /* Tail pad if this record would straddle the wrap. */
+        if ((local % capacity) + step > capacity) {
+            uint64_t off = DATA_AT + (local % capacity);
+            *(uint32_t *)(base + off) = (uint32_t)PAD_SENTINEL;
+            uint64_t rem = capacity - (local % capacity);
+            local += rem;
+            atomic_store_explicit(cursor, local, memory_order_release);
+            if (pace_us > 0) {
+                struct timespec ts = {0, (long)pace_us * 1000};
+                nanosleep(&ts, NULL);
+            }
+        }
+        uint64_t off = DATA_AT + (local % capacity);
+        *(uint32_t *)(base + off) = (uint32_t)sizeof(Payload);
+        Payload p = { .seq_id = i + 1, .value = (int64_t)(i + 1) * 7 };
+        memcpy(base + off + LEN_WIDTH, &p, sizeof(Payload));
+        local += step;
+        atomic_store_explicit(cursor, local, memory_order_release);
+        if (pace_us > 0) {
+            struct timespec ts = {0, (long)pace_us * 1000};
+            nanosleep(&ts, NULL);
+        }
+    }
+
+    /* Wait for the consumer to drain (bounded). */
+    for (int spins = 0; spins < 2000; spins++) {
+        if (atomic_load_explicit(&g_recv_count, memory_order_acquire) >= n) {
+            break;
+        }
+        struct timespec ts = {0, 1000 * 1000};  /* 1ms */
+        nanosleep(&ts, NULL);
+    }
+
+    int got = atomic_load_explicit(&g_recv_count, memory_order_acquire);
+    int rc = 0;
+    if (got != n) {
+        fprintf(stderr, "expected %d records, got %d\n", n, got);
+        rc = 3;
+    } else {
+        for (int i = 0; i < n; i++) {
+            if (g_recv[i].seq_id != i + 1 ||
+                g_recv[i].value != (int64_t)(i + 1) * 7) {
+                fprintf(stderr,
+                        "record %d mismatch: seq_id=%lld value=%lld\n",
+                        i, (long long)g_recv[i].seq_id,
+                        (long long)g_recv[i].value);
+                rc = 3;
+                break;
+            }
+        }
+    }
+
+    /* atexit teardown (in lotus_shm_ring.c) joins the reader + closes
+     * the consumer attach. The producer owns the segment: unlink it. */
+    munmap(map, total);
+    close(fd);
+    shm_unlink(name);
+    return rc;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s <roundtrip|wrap> <shm_name>\n", argv[0]);
+        return 1;
+    }
+    if (strcmp(argv[1], "roundtrip") == 0) {
+        /* capacity 4096 holds 64 * 24 = 1536 bytes — no wrap. */
+        return run(argv[2], 4096, 64, 0);
+    }
+    if (strcmp(argv[1], "wrap") == 0) {
+        /* capacity 256 wraps every ~10 records; pace 1ms (10x the
+         * reader's 100us poll) so the consumer never laps. */
+        return run(argv[2], 256, 40, 1000);
+    }
+    fprintf(stderr, "unknown mode `%s`\n", argv[1]);
+    return 1;
+}

--- a/docs/src/systems/zero-copy-bus.md
+++ b/docs/src/systems/zero-copy-bus.md
@@ -77,6 +77,51 @@ exhaustion needs a policy the substrate can't guess:
 - **`fail`** — panic with a clear diagnostic. Process-level
   visibility into back-pressure.
 
+## Reading someone else's ring
+
+A `shm_ring` binding speaks Hale's *own* ring format. But sometimes
+the ring already exists — written by another program in another
+language, with its own binary layout. Instead of hand-writing FFI
+or forking the runtime, you *declare* that layout and point a
+binding at it:
+
+```hale
+ring_layout MagusRing {
+    magic 0x4D475348514D4B54;        // expected header magic at offset 0
+    version 1 at 8 : u32;            // header field `version`, must equal 1
+    buffer_size at 12 : u32;         // ring capacity, read from the header
+    data_at 128;                     // first record starts here
+    cursor published {               // the producer's published byte cursor
+        at 64; repr atomic_u64; load acquire; unit bytes;
+    }
+    framing byte_records {           // records are [u32 length][payload]
+        len_prefix u32; align 8; pad_sentinel 0xFFFFFFFF;
+    }
+    overflow lap_detect;
+}
+
+main locus App {
+    bindings {
+        Ticks: shm_ring("/magus.ticks", on_overflow: drop,
+                        layout: MagusRing) where zero_copy;
+    }
+}
+```
+
+A subscriber on `Ticks` now reads that foreign ring directly: the
+runtime attaches it read-only, checks the magic and version, and
+walks the length-prefixed records, handing each payload to your
+`on_tick` handler with no copy. Your handler code is identical to
+any other `shm_ring` subscriber — the layout only changes how the
+substrate finds and frames the bytes.
+
+A binding with no `layout:` keeps Hale's native ring, so nothing
+you wrote before changes. This is read-only at this version: you
+can *consume* a foreign ring, not yet *produce* into one. A
+subscriber sees records published after it attaches, and if it
+falls more than a full buffer behind it resyncs rather than
+reading a torn record.
+
 ## The same shape, one tier down
 
 Notice this is the same move as everything else at this level: an

--- a/notes/binary-shm-ring-interop.md
+++ b/notes/binary-shm-ring-interop.md
@@ -212,9 +212,27 @@ runtime already does for `LRSRNG1`; this just parameterizes it.
 > `shm_ring(..., layout: Name)` parses and resolves to a declared
 > `ring_layout` (unknown / non-layout names diagnose); absent
 > `layout:` keeps the native ring, so existing bindings are unchanged.
-> No codegen behavior yet — PR3 adds the descriptor-parameterized
-> read-only consumer. Grammar: `spec/grammar.ebnf` (`ring_layout_decl`,
-> `shm_ring_kwarg`).
+> Grammar: `spec/grammar.ebnf` (`ring_layout_decl`, `shm_ring_kwarg`).
+>
+> **PR3 (LANDED): the read-only `byte_records` consumer.**
+> A subscriber on a `layout:`-bound topic now actually reads the
+> foreign ring. Runtime (`lotus_shm_ring.c`):
+> `lotus_shm_ring_open_layout` (attach read-only, validate
+> magic/version, read buffer_size) +
+> `lotus_bus_register_subscriber_shm_ring_layout` + a `byte_records`
+> reader thread (modular `[len_prefix][payload]` walk, `pad_sentinel`
+> tail-pad skip, `align_up` stride; lossy-but-safe lap resync).
+> Codegen (`emit_bus_register_shm_ring`) branches on the resolved
+> layout, emitting a flat 16-entry descriptor global + the
+> layout-aware register call; the native LRSRNG1 path is untouched
+> (back-compat verified). Field roles read by convention from the
+> layout (`version`/`buffer_size` scalars). Validated by a C
+> mock-producer ↔ consumer round-trip (`shm_ring_layout.rs`,
+> roundtrip + wrap, clean under ASan/UBSan) and a codegen IR-shape
+> test (`shm_ring_layout_codegen.rs`). Spec: `semantics.md`
+> § "Foreign rings", `runtime.md`. **Read path complete.**
+> Still out of scope: the producer path for foreign layouts (M3),
+> `slots` framing, historical replay, multi-cursor back-pressure.
 
 magus2's ring becomes a declaration:
 

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -834,6 +834,28 @@ atomic seqno) followed by N slots of `slot_size` bytes each.
 Header magic + sizes are validated on attach to catch ABI
 mismatches across binaries pinned to the same ring name.
 
+**Foreign-layout consumer (Proposal B, 2026-06-06).** Two more
+primitives read an *externally*-defined ring described by a
+`ring_layout` (see semantics.md § "Foreign rings"), rather than
+the native LRSRNG1 shape:
+
+- `lotus_shm_ring_open_layout(name, desc)` — attach an existing
+  foreign segment READ-ONLY (never creates), `fstat` for the map
+  length, validate `magic`/`version`, read `buffer_size` for the
+  data-region capacity. `desc` is a `lotus_shm_layout_t` built
+  from a flat 16-entry uint64 descriptor codegen emits.
+- `lotus_bus_register_subscriber_shm_ring_layout(subject, name,
+  desc_words, self, handler)` — open via the above and spawn a
+  `byte_records` reader thread that walks `[len_prefix][payload]`
+  records (modular over `capacity`, skipping `pad_sentinel`
+  tail-pads, advancing by `align_up`). Shares the native
+  subscriber registry + `atexit` teardown; a layout subscriber is
+  marked `is_layout` and torn down via `lotus_shm_ring_close_layout`.
+
+Field reads are host-native endianness (magus2 and Hale are both
+little-endian x86-64). v1 is read-only `byte_records`; the
+producer side and `slots` framing are post-v1.
+
 v1 scope: single-producer, multi-consumer; in-memory delivery is
 in scope (POSIX shm_open works intra-machine cross-process).
 Multi-producer (CAS-based claim), back-pressure / timeout

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -903,6 +903,89 @@ Transport surface:
   different process and exists before the publisher
   process starts.)
 
+**Foreign rings via `ring_layout` (Proposal B, 2026-06-06).**
+The shm_ring transport above reads/writes the *native* Lotus
+ring (the `LRSRNG1` header + equal-sized slots). To read a ring
+defined by *another* program — concretely a magus2-style binary
+broadcast ring — a `ring_layout` declaration describes that
+ring's binary shape, and a binding references it with the
+`layout:` kwarg:
+
+```hale
+ring_layout MagusRing {
+    magic 0x4D475348514D4B54;        // expected header magic at offset 0
+    version 1 at 8 : u32;            // header field `version`: expect 1
+    buffer_size at 12 : u32;         // ring data capacity, read from header
+    data_at 128;                     // first-record byte offset
+    cursor published {               // the published byte cursor
+        at 64; repr atomic_u64; load acquire; unit bytes;
+    }
+    framing byte_records {           // records are [u32 len][payload]
+        len_prefix u32; align 8; pad_sentinel 0xFFFFFFFF;
+    }
+    overflow lap_detect;
+}
+
+main locus App {
+    bindings {
+        Ticks: shm_ring("/magus.ticks", on_overflow: drop,
+                        layout: MagusRing) where zero_copy;
+    }
+}
+```
+
+The `layout:` reference must resolve to a declared `ring_layout`
+(else a typecheck diagnostic). A binding with no `layout:` is the
+native ring, unchanged.
+
+*The layout contract.* A `ring_layout` is validated at typecheck
+(`hale-types::check`), so a malformed layout fails the build, not
+the read. The rules:
+
+- Each scalar `repr` must be a known fixed width — `u8`/`u16`/
+  `u32`/`u64`, `i8`/`i16`/`i32`/`i64`, `f32`/`f64`.
+- A `cursor` block needs an `at` offset, a known `repr`
+  (`atomic_u64`), a known `load` memory ordering (`relaxed`/
+  `acquire`/`release`/`acq_rel`/`seq_cst`), and a `unit` of
+  `bytes` or `slots`. At least one cursor is required.
+- `framing` kind is `byte_records` or `slots`; `byte_records`
+  requires a `len_prefix`.
+- All offsets are non-negative.
+- A `ring_layout` is a declaration, not a value — referencing its
+  name in expression position is an error.
+
+The member token positions (`acquire`, `atomic_u64`, `bytes`, and
+words that collide with keywords like `release`) are layout
+*words*, not Hale type expressions — bare identifiers (or
+keyword-spelled words) checked against the sets above, never
+resolved as types.
+
+*Scope (v1): read-only `byte_records` consumer.* A subscriber on
+a layout-bound topic registers via
+`lotus_bus_register_subscriber_shm_ring_layout(subject, name,
+desc, self, handler)`, where `desc` is a flat 16-entry descriptor
+codegen builds from the resolved layout. The runtime attaches the
+foreign segment read-only (it never creates it — the foreign
+producer owns the ring), validates the magic and `version`, reads
+`buffer_size` for the data-region capacity, then runs a
+`byte_records` reader thread: acquire-load the published byte
+cursor, and for each record walk `data_at + local % capacity`,
+read the `len_prefix`, skip a `pad_sentinel` tail-pad to the wrap,
+hand the payload view to the handler, and advance by
+`align_up(len_prefix + len, align)`. Field *roles* are read by
+convention from the layout — a scalar named `version` (with an
+expected value) is the version check; one named `buffer_size` is
+the capacity source.
+
+*Limitations (v1).* A subscriber reads records published *after*
+it attaches (no historical replay). Lap handling is lossy + safe:
+if the producer runs more than `capacity` bytes ahead, the missed
+bytes are gone, so the reader resyncs to the producer's cursor (a
+commit boundary) and resumes rather than reading a torn record.
+The handler runs on the reader thread (same constraint as the
+native subscriber). The producer side for foreign layouts, the
+`slots` framing kind, and multi-cursor back-pressure are post-v1.
+
 **In-memory delivery is absence-of-entry.** A topic with no
 binding entry is delivered same-process via the cooperative
 queue. There is no `in_memory` variant — the runtime default


### PR DESCRIPTION
The capstone of Proposal B (`notes/binary-shm-ring-interop.md`): a subscriber on a `layout:`-bound `shm_ring` topic now actually **reads an externally-defined binary broadcast ring** described by a `ring_layout` declaration — no hand-written FFI, no runtime fork.

Builds on PR1 (#57, the `ring_layout` declaration) and PR2 (#58, the `layout:` binding kwarg).

## Runtime (`lotus_shm_ring.c`)
- `lotus_shm_layout_t` descriptor + `lotus_shm_ring_open_layout`: attach an existing foreign segment **read-only** (never creates — the foreign producer owns it), `fstat` for the map length, validate magic + version, read `buffer_size` for the data-region capacity.
- `lotus_bus_register_subscriber_shm_ring_layout` + a `byte_records` reader thread: acquire-load the published byte cursor and walk `[len_prefix][payload]` records modular over `capacity`, skipping `pad_sentinel` tail-pads, advancing by `align_up(len_prefix + len, align)`. Lap handling is **lossy-but-safe** — if the producer runs more than a buffer ahead, resync to its commit boundary rather than read a torn record. Shares the native subscriber registry + `atexit` teardown.

## Codegen (`emit_bus_register_shm_ring`)
Branches on the resolved `ring_layout`: emits a flat 16-entry descriptor global built from the layout and calls the layout-aware register fn. Field roles are read by convention (`version` scalar w/ expect → version check; `buffer_size` scalar → capacity). **The native LRSRNG1 path is untouched** — existing `shm_ring` bindings are back-compat.

## Validation
- `shm_ring_layout.rs` — C mock-producer ↔ consumer round-trip over POSIX SHM: `roundtrip` (deterministic, no wrap) + `wrap` (paced, exercises the pad-at-wrap branch). Clean under ASan/UBSan.
- `shm_ring_layout_codegen.rs` — IR-shape test: a `layout:` binding emits the descriptor global + the layout register call.
- Existing `shm_ring` / `shm_ring_hale_subscriber` tests still pass (native path).

## Scope
Completes Proposal B's **read path**. Out of scope (follow-ons named in the doc): the producer side for foreign layouts (M3), `slots` framing, historical replay, multi-cursor back-pressure.

Spec: `semantics.md` § "Foreign rings", `runtime.md`. Docs: `zero-copy-bus.md` "Reading someone else's ring".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
