### PR TITLE
types: ring_layout↔payload conformance checks (Proposal B)

### DIFF
--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -2829,7 +2829,41 @@ fn check_main_and_bindings(
                             } = &entry.transport
                             {
                                 match top.lookup(&lid.name) {
-                                    Some(TopSymbol::RingLayout(_)) => {}
+                                    Some(TopSymbol::RingLayout(_)) => {
+                                        // Conformance (2026-06-06): a
+                                        // layout-bound topic is read by
+                                        // direct pointer-cast and written
+                                        // by memcpy of the payload struct
+                                        // (the bindgen-style contract — the
+                                        // foreign format is fixed, so the
+                                        // Hale struct must *be* the record
+                                        // bytes). That's only sound if the
+                                        // payload is flat-shapeable, and it
+                                        // holds whether or not the binding
+                                        // also asserts `where zero_copy`.
+                                        if let Some(TopSymbol::Topic(topic)) =
+                                            top.lookup(&entry.topic.name)
+                                        {
+                                            if !is_flat_shapeable(&topic.payload, top) {
+                                                diags.push(Diag::ty(
+                                                    entry.span,
+                                                    format!(
+                                                        "shm_ring binding for topic \
+                                                         `{}` with `layout: {}` requires \
+                                                         a flat-shapeable payload, but \
+                                                         `{}` contains String, Bytes, or \
+                                                         other variable-size fields — a \
+                                                         foreign ring record is read by \
+                                                         direct cast, which needs a \
+                                                         fixed byte layout",
+                                                        entry.topic.name,
+                                                        lid.name,
+                                                        topic.payload.display()
+                                                    ),
+                                                ));
+                                            }
+                                        }
+                                    }
                                     Some(_) => diags.push(Diag::ty(
                                         lid.span,
                                         format!(
@@ -4339,6 +4373,144 @@ impl<'a> Checker<'a> {
                                 ));
                             }
                         }
+                    }
+                }
+            }
+        }
+
+        // shm-ring-interop conformance (2026-06-06): cross-field
+        // geometric consistency. magus2's binary format is fixed and
+        // unchangeable, so a `ring_layout` that mis-transcribes it is
+        // purely *our* bug — and several of these fields silently
+        // corrupt PR3's already-shipped reader if they're wrong (a
+        // cursor past `data_at`, an overlapping field, a non-power-of-
+        // two `align` the reader masks with, a `pad_sentinel` too wide
+        // for the `len_prefix` to hold). Catch them at compile time.
+        fn repr_bytes(name: &str) -> Option<i64> {
+            Some(match name {
+                "u8" | "i8" => 1,
+                "u16" | "i16" => 2,
+                "u32" | "i32" | "f32" => 4,
+                "u64" | "i64" | "f64" | "atomic_u64" => 8,
+                _ => return None,
+            })
+        }
+
+        // Occupied header intervals [start, end) with a label + span.
+        let mut intervals: Vec<(i64, i64, String, Span)> = Vec::new();
+        for f in &r.scalars {
+            if f.at >= 0 {
+                if let Some(w) = repr_bytes(&f.repr.name) {
+                    intervals.push((
+                        f.at,
+                        f.at + w,
+                        format!("field `{}`", f.name.name),
+                        f.span,
+                    ));
+                }
+            }
+        }
+        for c in &r.cursors {
+            let at = c.attrs.iter().find_map(|a| match (a.key.name.as_str(), &a.value) {
+                ("at", RingAttrValue::Int(n)) if *n >= 0 => Some(*n),
+                _ => None,
+            });
+            if let Some(at) = at {
+                let label = c
+                    .name
+                    .as_ref()
+                    .map(|n| format!("cursor `{}`", n.name))
+                    .unwrap_or_else(|| "cursor".to_string());
+                // A cursor is an atomic u64 — 8 bytes.
+                intervals.push((at, at + 8, label, c.span));
+            }
+        }
+
+        // (1) every header field + cursor must lie before `data_at`.
+        if let Some(data_at) = r.data_at {
+            for (start, end, label, span) in &intervals {
+                if *end > data_at {
+                    self.diags.push(Diag::ty(
+                        *span,
+                        format!(
+                            "ring_layout `{}`: {} occupies bytes [{}, {}) which \
+                             overruns `data_at {}` — header fields and the cursor \
+                             must lie before the data region",
+                            r.name.name, label, start, end, data_at
+                        ),
+                    ));
+                }
+            }
+        }
+
+        // (2) no two header fields / cursor may overlap.
+        for i in 0..intervals.len() {
+            for j in (i + 1)..intervals.len() {
+                let (a0, a1) = (intervals[i].0, intervals[i].1);
+                let (b0, b1) = (intervals[j].0, intervals[j].1);
+                if a0 < b1 && b0 < a1 {
+                    self.diags.push(Diag::ty(
+                        intervals[i].3,
+                        format!(
+                            "ring_layout `{}`: {} (bytes [{}, {})) overlaps {} \
+                             (bytes [{}, {}))",
+                            r.name.name, intervals[i].2, a0, a1, intervals[j].2, b0, b1
+                        ),
+                    ));
+                }
+            }
+        }
+
+        // (3) byte_records framing: `align` must be a power of two
+        //     (the reader does `& ~(align-1)`); `pad_sentinel` must
+        //     fit in the `len_prefix` width or wrap-detection reads a
+        //     truncated sentinel and never fires.
+        if let Some(fr) = &r.framing {
+            if fr.kind.name == "byte_records" {
+                if let Some((align, span)) =
+                    fr.attrs.iter().find_map(|a| match (a.key.name.as_str(), &a.value) {
+                        ("align", RingAttrValue::Int(n)) => Some((*n, a.span)),
+                        _ => None,
+                    })
+                {
+                    if align < 1 || (align & (align - 1)) != 0 {
+                        self.diags.push(Diag::ty(
+                            span,
+                            format!(
+                                "ring_layout `{}`: framing `align {}` must be a power \
+                                 of two — it's the record-stride alignment the reader \
+                                 masks with",
+                                r.name.name, align
+                            ),
+                        ));
+                    }
+                }
+                let len_width =
+                    fr.attrs.iter().find_map(|a| match (a.key.name.as_str(), &a.value) {
+                        ("len_prefix", RingAttrValue::Ident(id)) => repr_bytes(&id.name),
+                        _ => None,
+                    });
+                let pad =
+                    fr.attrs.iter().find_map(|a| match (a.key.name.as_str(), &a.value) {
+                        ("pad_sentinel", RingAttrValue::Int(n)) => Some((*n, a.span)),
+                        _ => None,
+                    });
+                if let (Some(w), Some((pad, span))) = (len_width, pad) {
+                    let max: u64 = if w >= 8 { u64::MAX } else { (1u64 << (w * 8)) - 1 };
+                    if pad < 0 || (pad as u64) > max {
+                        self.diags.push(Diag::ty(
+                            span,
+                            format!(
+                                "ring_layout `{}`: `pad_sentinel {:#x}` does not fit \
+                                 in the `len_prefix` width ({} byte{}) — wrap \
+                                 detection would read a truncated value and never \
+                                 trigger",
+                                r.name.name,
+                                pad,
+                                w,
+                                if w == 1 { "" } else { "s" }
+                            ),
+                        ));
                     }
                 }
             }

--- a/crates/hale-types/tests/ring_layout.rs
+++ b/crates/hale-types/tests/ring_layout.rs
@@ -151,3 +151,84 @@ fn main() {
         msgs
     );
 }
+
+// ---- conformance: cross-field geometric consistency (2026-06-06) ----
+// magus2's format is fixed, so a mis-transcribed layout is our bug and
+// several of these fields silently corrupt the reader. Caught at
+// compile time.
+
+#[test]
+fn cursor_past_data_at_errors() {
+    let src = r#"
+ring_layout R {
+    magic 0x1;
+    data_at 64;
+    cursor published { at 64; repr atomic_u64; load acquire; unit bytes; }
+    framing byte_records { len_prefix u32; align 8; }
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("overruns `data_at")),
+        "a cursor at/after data_at must error; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn overlapping_header_fields_error() {
+    // version@8:u64 occupies [8,16); buffer_size@12 overlaps it.
+    let src = r#"
+ring_layout R {
+    magic 0x1;
+    version 1 at 8 : u64;
+    buffer_size at 12 : u32;
+    data_at 128;
+    cursor published { at 64; repr atomic_u64; load acquire; unit bytes; }
+    framing byte_records { len_prefix u32; align 8; }
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("overlaps")),
+        "overlapping header fields must error; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn non_power_of_two_align_errors() {
+    let src = r#"
+ring_layout R {
+    magic 0x1;
+    data_at 128;
+    cursor published { at 64; repr atomic_u64; load acquire; unit bytes; }
+    framing byte_records { len_prefix u32; align 6; }
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("must be a power")),
+        "a non-power-of-two align must error; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn pad_sentinel_too_wide_for_len_prefix_errors() {
+    // len_prefix is u16 (max 0xFFFF) but pad_sentinel is 0xFFFFFFFF.
+    let src = r#"
+ring_layout R {
+    magic 0x1;
+    data_at 128;
+    cursor published { at 64; repr atomic_u64; load acquire; unit bytes; }
+    framing byte_records { len_prefix u16; align 8; pad_sentinel 0xFFFFFFFF; }
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("does not fit in the `len_prefix` width")),
+        "a pad_sentinel wider than len_prefix must error; got: {:?}",
+        msgs
+    );
+}

--- a/crates/hale-types/tests/ring_layout_binding.rs
+++ b/crates/hale-types/tests/ring_layout_binding.rs
@@ -92,3 +92,34 @@ fn layout_less_binding_is_back_compat() {
         msgs
     );
 }
+
+#[test]
+fn layout_binding_with_nonflat_payload_errors() {
+    // A foreign ring record is read by direct cast / written by memcpy,
+    // so a layout-bound topic needs a flat-shapeable payload regardless
+    // of whether `where zero_copy` is also asserted. `T` here has a
+    // String field — not flat-shapeable.
+    let src = format!(
+        r#"
+{LAYOUT}
+type T {{ name: String; }}
+topic Foo {{ payload: T; }}
+locus Producer {{
+    bus {{ publish Foo; }}
+    birth() {{ Foo <- T {{ name: "x" }}; }}
+}}
+main locus App {{
+    bindings {{
+        Foo: shm_ring("/magus.ticks", on_overflow: drop, layout: MagusRing);
+    }}
+}}
+fn main() {{ App {{ }}; Producer {{ }}; }}
+"#
+    );
+    let msgs = check(&src);
+    assert!(
+        msgs.iter().any(|m| m.contains("requires a flat-shapeable payload")),
+        "a layout binding with a non-flat payload must error; got: {:?}",
+        msgs
+    );
+}

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -954,6 +954,28 @@ the read. The rules:
 - A `ring_layout` is a declaration, not a value — referencing its
   name in expression position is an error.
 
+*Cross-field conformance.* Because the foreign format is fixed and
+unchangeable, a layout that mis-transcribes it is the program's own
+bug — and several of these fields silently corrupt the reader if
+wrong, so they are caught at compile time:
+
+- Every header scalar and the cursor (an 8-byte atomic) must lie
+  *before* `data_at` — a field whose `[at, at+width)` overruns the
+  data region is rejected.
+- No two header fields (or a field and the cursor) may overlap.
+- `byte_records` `align` must be a power of two — it is the
+  record-stride alignment the reader masks with.
+- `pad_sentinel` must fit in the `len_prefix` width; otherwise wrap
+  detection reads a truncated value and never fires.
+
+*Payload conformance at the binding.* A `layout:`-bound topic is
+read by a direct pointer-cast (and, on the producer side, written
+by a `memcpy` of the payload struct — the foreign record bytes
+*are* the Hale struct, bindgen-style). That requires a
+flat-shapeable payload, enforced whether or not the binding also
+asserts `where zero_copy`; a payload with `String`, `Bytes`, or
+other variable-size fields is rejected.
+
 The member token positions (`acquire`, `atomic_u64`, `bytes`, and
 words that collide with keywords like `release`) are layout
 *words*, not Hale type expressions — bare identifiers (or


### PR DESCRIPTION
Hardens the `ring_layout` interop surface with compile-time conformance checks. The driving constraint: **the foreign format is fixed and unchangeable**, so a layout that mis-transcribes it is purely *our* bug — and several fields silently corrupt the already-shipped `byte_records` reader (PR #59) if wrong. These catch them before they ship.

## Layout self-consistency (`check_ring_layout`)
- Every header scalar + the cursor (an 8-byte atomic) must lie **before `data_at`** — a field whose `[at, at+width)` overruns the data region is rejected.
- **No overlap** between header fields (or a field and the cursor).
- `byte_records` **`align` must be a power of two** — it's the record-stride alignment the reader masks with (`& ~(align-1)`); a non-pow2 value misaligns silently.
- **`pad_sentinel` must fit in the `len_prefix` width** — else wrap detection reads a truncated value and never fires.

## Payload conformance (binding site)
A `layout:`-bound topic is read by a direct pointer-cast and (on the producer side) written by `memcpy` of the payload struct — the bindgen contract: the foreign record bytes *are* the Hale struct. That requires a **flat-shapeable payload**, now enforced intrinsically for layout bindings **whether or not `where zero_copy` is also asserted** (previously flat-shapeable was only checked when `zero_copy` was present).

## Tests
- 4 geometric: cursor-past-`data_at`, overlapping fields, non-pow2 `align`, `pad_sentinel` too wide for `len_prefix`.
- 1 binding: non-flat (`String`) payload rejected.
- The real `ForeignRing` layout stays clean (`valid_layout_is_clean` regression guard — no false positives).

Spec: `semantics.md` § "Foreign rings" — cross-field + payload conformance rules.

This is item #1 of the post-PR3 plan (the highest-leverage correctness item under a fixed-format interop), ahead of the producer path (M3a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
