### PR TITLE
codegen+runtime: foreign-ring producer (Proposal B, M3a)

### DIFF
--- a/crates/hale-codegen/runtime/lotus_shm_ring.c
+++ b/crates/hale-codegen/runtime/lotus_shm_ring.c
@@ -278,7 +278,11 @@ typedef struct {
     char    shm_name[96];
     lotus_shm_layout_t desc;
     uint64_t capacity;     /* ring data-region size in bytes */
+    int     owns_unlink;   /* 1 if this handle created the segment */
 } lotus_shm_layout_ring_t;
+
+/* Read/write an unsigned little-endian field of `width` (1..8)
+ * bytes. Host is assumed little-endian (see the endianness note). */
 
 /* Read an unsigned little-endian field of `width` (1..8) bytes.
  * Host is assumed little-endian (see the endianness note above). */
@@ -287,6 +291,34 @@ static uint64_t shm_layout_read_uint(const void *p, uint64_t width) {
     if (width > 8) width = 8;
     memcpy(&v, p, (size_t)width);
     return v;
+}
+
+/* Write the low `width` (1..8) bytes of `val` little-endian. */
+static void shm_layout_write_uint(void *p, uint64_t width, uint64_t val) {
+    if (width > 8) width = 8;
+    memcpy(p, &val, (size_t)width);
+}
+
+/* Populate a descriptor from the flat 16-word array codegen emits.
+ * The slot contract is documented on
+ * `lotus_bus_register_subscriber_shm_ring_layout`. */
+static void shm_layout_from_words(const uint64_t *w, lotus_shm_layout_t *d) {
+    memset(d, 0, sizeof(*d));
+    d->magic             = w[0];
+    d->has_magic         = (int)w[1];
+    d->version_off       = w[2];
+    d->version_width     = w[3];
+    d->version_expect    = w[4];
+    d->has_version       = (int)w[5];
+    d->buffer_size_off   = w[6];
+    d->buffer_size_width = w[7];
+    d->has_buffer_size   = (int)w[8];
+    d->data_at           = w[9];
+    d->cursor_off        = w[10];
+    d->len_prefix_width  = w[11];
+    d->align             = w[12];
+    d->pad_sentinel      = w[13];
+    d->has_pad_sentinel  = (int)w[14];
 }
 
 /* Attach (read-only) to a foreign ring described by `desc`.
@@ -360,7 +392,76 @@ static void lotus_shm_ring_close_layout(lotus_shm_layout_ring_t *r) {
     if (!r) return;
     if (r->base) munmap(r->base, r->mapped_size);
     if (r->fd >= 0) close(r->fd);
+    if (r->owns_unlink) shm_unlink(r->shm_name);
     free(r);
+}
+
+/* Proposal B M3a (2026-06-06) — producer side: CREATE a foreign-
+ * layout ring this process owns. Unlike the read-only attach above,
+ * this sizes the segment (`data_at + capacity`), writes the header
+ * the declared layout describes (magic, version, buffer_size =
+ * capacity), and zeroes the published cursor. The Hale producer is
+ * THE single producer (SPMC), so it owns + unlinks the segment.
+ *
+ * If the segment already exists, attach read-write without
+ * re-initializing (a peer created it) — but does NOT own the unlink.
+ * Returns NULL on error (errno set). */
+static lotus_shm_layout_ring_t *
+lotus_shm_ring_create_layout(const char *name,
+                             const lotus_shm_layout_t *desc,
+                             uint64_t capacity) {
+    if (!name || !desc || capacity == 0) { errno = EINVAL; return NULL; }
+    if (strlen(name) + 1 > sizeof(((lotus_shm_layout_ring_t *)0)->shm_name)) {
+        errno = ENAMETOOLONG;
+        return NULL;
+    }
+    size_t total = (size_t)desc->data_at + (size_t)capacity;
+    int owns = 1;
+    int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
+    if (fd < 0 && errno == EEXIST) {
+        owns = 0;
+        fd = shm_open(name, O_RDWR, 0600);
+    }
+    if (fd < 0) return NULL;
+    if (owns && ftruncate(fd, (off_t)total) != 0) {
+        int save = errno; close(fd); shm_unlink(name); errno = save; return NULL;
+    }
+    void *map = mmap(NULL, total, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (map == MAP_FAILED) {
+        int save = errno; close(fd); if (owns) shm_unlink(name); errno = save;
+        return NULL;
+    }
+    if (owns) {
+        char *base = (char *)map;
+        if (desc->has_magic) {
+            shm_layout_write_uint(base, 8, desc->magic);
+        }
+        if (desc->has_version) {
+            shm_layout_write_uint(base + desc->version_off,
+                                  desc->version_width, desc->version_expect);
+        }
+        if (desc->has_buffer_size) {
+            shm_layout_write_uint(base + desc->buffer_size_off,
+                                  desc->buffer_size_width, capacity);
+        }
+        atomic_store_explicit(
+            (_Atomic uint64_t *)(base + desc->cursor_off), 0,
+            memory_order_release);
+    }
+    lotus_shm_layout_ring_t *r =
+        (lotus_shm_layout_ring_t *)calloc(1, sizeof(*r));
+    if (!r) {
+        munmap(map, total); close(fd); if (owns) shm_unlink(name);
+        errno = ENOMEM; return NULL;
+    }
+    r->base = map;
+    r->mapped_size = total;
+    r->fd = fd;
+    r->desc = *desc;
+    r->capacity = capacity;
+    r->owns_unlink = owns;
+    strncpy(r->shm_name, name, sizeof(r->shm_name) - 1);
+    return r;
 }
 
 /* Publisher: claim the next slot.
@@ -644,6 +745,128 @@ int lotus_bus_publish_shm_ring(const char *subject,
     return -1;
 }
 
+/* === Proposal B M3a (2026-06-06) — foreign-layout PRODUCER ============
+ *
+ * The mirror of the read-only consumer: a Hale locus that publishes a
+ * `layout:`-bound topic writes `byte_records` into a ring it created
+ * (`lotus_shm_ring_create_layout`). One producer per subject (SPMC,
+ * single producer). The framing is the exact inverse of the reader:
+ * reserve `align_up(len_prefix + payload, align)` bytes; if the record
+ * won't fit before the wrap, write the `pad_sentinel` length and
+ * advance to the wrap boundary; write the length prefix + payload;
+ * then release-store the monotonic byte cursor so a consumer's
+ * acquire-load sees the bytes.
+ *
+ * Endianness is host-native (LE), matching the consumer + magus2.
+ */
+typedef struct {
+    char subject[64];
+    lotus_shm_layout_ring_t *ring;
+    uint64_t local;   /* the producer's own monotonic byte cursor */
+} shm_ring_layout_producer_t;
+
+static shm_ring_layout_producer_t
+    g_shm_ring_layout_producers[LOTUS_SHM_RING_MAX_BINDINGS];
+static int g_shm_ring_layout_producer_count = 0;
+
+/* Codegen emits one call per layout-bound topic that this bundle
+ * PUBLISHES, into main's prelude. Creates the ring (this process is
+ * the owner). `desc_words` is the same 16-word descriptor the
+ * subscriber path uses; `capacity` is the ring data-region size in
+ * bytes (from the binding's `buffer_size:` kwarg, with a default). */
+void lotus_bus_register_shm_ring_layout(const char *subject,
+                                        const char *shm_name,
+                                        const uint64_t *desc_words,
+                                        uint64_t capacity) {
+    ensure_shm_ring_atexit_registered();
+    if (g_shm_ring_layout_producer_count >= LOTUS_SHM_RING_MAX_BINDINGS) {
+        fprintf(stderr,
+                "lotus_bus_register_shm_ring_layout: exceeded "
+                "LOTUS_SHM_RING_MAX_BINDINGS (%d)\n",
+                LOTUS_SHM_RING_MAX_BINDINGS);
+        _exit(1);
+    }
+    for (int i = 0; i < g_shm_ring_layout_producer_count; i++) {
+        if (strcmp(g_shm_ring_layout_producers[i].subject, subject) == 0) {
+            fprintf(stderr,
+                    "lotus_bus_register_shm_ring_layout: duplicate "
+                    "registration for subject `%s`\n",
+                    subject);
+            _exit(1);
+        }
+    }
+    lotus_shm_layout_t d;
+    shm_layout_from_words(desc_words, &d);
+    lotus_shm_layout_ring_t *r =
+        lotus_shm_ring_create_layout(shm_name, &d, capacity);
+    if (!r) {
+        fprintf(stderr,
+                "lotus_bus_register_shm_ring_layout(`%s`, `%s`): create "
+                "failed: %s\n",
+                subject, shm_name, strerror(errno));
+        _exit(1);
+    }
+    shm_ring_layout_producer_t *p =
+        &g_shm_ring_layout_producers[g_shm_ring_layout_producer_count++];
+    strncpy(p->subject, subject, sizeof(p->subject) - 1);
+    p->subject[sizeof(p->subject) - 1] = '\0';
+    p->ring = r;
+    p->local = 0;
+}
+
+/* Publish-side dispatch for a layout-bound topic. Frames `value`
+ * (`value_size` bytes) as one `byte_records` record and publishes the
+ * cursor. Returns 0 on success, -1 if the subject isn't registered. */
+int lotus_bus_publish_shm_ring_layout(const char *subject,
+                                      const void *value,
+                                      uint64_t value_size) {
+    for (int i = 0; i < g_shm_ring_layout_producer_count; i++) {
+        shm_ring_layout_producer_t *p = &g_shm_ring_layout_producers[i];
+        if (strcmp(p->subject, subject) != 0) continue;
+        const lotus_shm_layout_t *d = &p->ring->desc;
+        char *base = (char *)p->ring->base;
+        uint64_t cap = p->ring->capacity;
+        _Atomic uint64_t *cursor =
+            (_Atomic uint64_t *)(base + d->cursor_off);
+
+        uint64_t rec = d->len_prefix_width + value_size;
+        uint64_t step = rec;
+        if (d->align > 1) {
+            step = (step + d->align - 1) & ~(d->align - 1);
+        }
+        if (step > cap) {
+            fprintf(stderr,
+                    "lotus_bus_publish_shm_ring_layout(`%s`): record (%llu "
+                    "bytes framed) exceeds ring capacity (%llu) — raise the "
+                    "binding's `buffer_size:`\n",
+                    subject, (unsigned long long)step,
+                    (unsigned long long)cap);
+            _exit(1);
+        }
+        /* Tail-pad if the record would straddle the wrap. */
+        if ((p->local % cap) + step > cap) {
+            uint64_t off = d->data_at + (p->local % cap);
+            if (d->has_pad_sentinel) {
+                shm_layout_write_uint(base + off, d->len_prefix_width,
+                                      d->pad_sentinel);
+            }
+            p->local += cap - (p->local % cap);
+            atomic_store_explicit(cursor, p->local, memory_order_release);
+        }
+        uint64_t off = d->data_at + (p->local % cap);
+        shm_layout_write_uint(base + off, d->len_prefix_width, value_size);
+        memcpy(base + off + d->len_prefix_width, value, value_size);
+        p->local += step;
+        atomic_store_explicit(cursor, p->local, memory_order_release);
+        return 0;
+    }
+    fprintf(stderr,
+            "lotus_bus_publish_shm_ring_layout(`%s`): no registration for "
+            "this subject\n",
+            subject);
+    return -1;
+}
+
 /* === Form K6b (2026-05-20) — subscriber-side reader thread ============
  *
  * Each subscriber locus that has a `bus { subscribe Foo as on_foo; }`
@@ -822,22 +1045,7 @@ void lotus_bus_register_subscriber_shm_ring_layout(
     ensure_shm_ring_atexit_registered();
 
     lotus_shm_layout_t d;
-    memset(&d, 0, sizeof(d));
-    d.magic             = desc_words[0];
-    d.has_magic         = (int)desc_words[1];
-    d.version_off       = desc_words[2];
-    d.version_width     = desc_words[3];
-    d.version_expect    = desc_words[4];
-    d.has_version       = (int)desc_words[5];
-    d.buffer_size_off   = desc_words[6];
-    d.buffer_size_width = desc_words[7];
-    d.has_buffer_size   = (int)desc_words[8];
-    d.data_at           = desc_words[9];
-    d.cursor_off        = desc_words[10];
-    d.len_prefix_width  = desc_words[11];
-    d.align             = desc_words[12];
-    d.pad_sentinel      = desc_words[13];
-    d.has_pad_sentinel  = (int)desc_words[14];
+    shm_layout_from_words(desc_words, &d);
 
     lotus_shm_layout_ring_t *r = lotus_shm_ring_open_layout(shm_name, &d);
     if (!r) {
@@ -999,6 +1207,14 @@ static void shm_ring_atexit_cleanup(void) {
         if (g_shm_ring_bindings[i].ring) {
             lotus_shm_ring_close(g_shm_ring_bindings[i].ring);
             g_shm_ring_bindings[i].ring = NULL;
+        }
+    }
+    /* Proposal B M3a: layout-producer rings — close + unlink the
+     * segments this process created. */
+    for (int i = 0; i < g_shm_ring_layout_producer_count; i++) {
+        if (g_shm_ring_layout_producers[i].ring) {
+            lotus_shm_ring_close_layout(g_shm_ring_layout_producers[i].ring);
+            g_shm_ring_layout_producers[i].ring = NULL;
         }
     }
 }

--- a/crates/hale-codegen/src/bus/dispatch.rs
+++ b/crates/hale-codegen/src/bus/dispatch.rs
@@ -852,10 +852,24 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
             )
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
             .as_pointer_value();
+        // Proposal B M3a: a `layout:`-bound topic frames a foreign
+        // `byte_records` record via the layout publish path; the
+        // native ring uses claim + memcpy + commit. Both take the
+        // same (subject, value, size) arguments.
+        let is_layout = self
+            .shm_ring_subjects
+            .get(subject)
+            .map(|info| info.layout.is_some())
+            .unwrap_or(false);
+        let publish_fn_name = if is_layout {
+            "lotus_bus_publish_shm_ring_layout"
+        } else {
+            "lotus_bus_publish_shm_ring"
+        };
         let publish_fn = self
             .module
-            .get_function("lotus_bus_publish_shm_ring")
-            .expect("lotus_bus_publish_shm_ring declared");
+            .get_function(publish_fn_name)
+            .unwrap_or_else(|| panic!("{} declared", publish_fn_name));
         self.builder
             .build_call(
                 publish_fn,

--- a/crates/hale-codegen/src/bus/runtime.rs
+++ b/crates/hale-codegen/src/bus/runtime.rs
@@ -444,14 +444,15 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// and calls `lotus_bus_register_subscriber_shm_ring_layout`,
     /// which attaches the foreign ring read-only and spawns the
     /// `byte_records` reader thread.
-    fn emit_bus_register_shm_ring_layout(
+    /// Emit a private global holding the 16-entry descriptor built
+    /// from a resolved `ring_layout`, returning a pointer to it. Both
+    /// the subscriber (attach) and producer (create) register paths
+    /// hand this pointer to the runtime.
+    pub(crate) fn ring_layout_desc_global(
         &mut self,
         subject: &str,
-        shm_name: &str,
         layout: &hale_syntax::ast::RingLayoutDecl,
-        self_ptr: PointerValue<'ctx>,
-        handler_fn: FunctionValue<'ctx>,
-    ) -> Result<(), CodegenError> {
+    ) -> PointerValue<'ctx> {
         let i64_t = self.context.i64_type();
         let words = ring_layout_descriptor_words(layout);
         let const_vals: Vec<inkwell::values::IntValue<'ctx>> =
@@ -466,7 +467,18 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         desc_g.set_initializer(&arr);
         desc_g.set_constant(true);
         desc_g.set_linkage(inkwell::module::Linkage::Private);
-        let desc_ptr = desc_g.as_pointer_value();
+        desc_g.as_pointer_value()
+    }
+
+    fn emit_bus_register_shm_ring_layout(
+        &mut self,
+        subject: &str,
+        shm_name: &str,
+        layout: &hale_syntax::ast::RingLayoutDecl,
+        self_ptr: PointerValue<'ctx>,
+        handler_fn: FunctionValue<'ctx>,
+    ) -> Result<(), CodegenError> {
+        let desc_ptr = self.ring_layout_desc_global(subject, layout);
 
         let subj_ptr = self
             .builder
@@ -500,6 +512,55 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     handler_ptr.into(),
                 ],
                 "shm_ring.sub.register_layout",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Proposal B M3a (2026-06-06): register a PRODUCER for a
+    /// `layout:`-bound topic the bundle publishes. Emits the
+    /// descriptor global + a `lotus_bus_register_shm_ring_layout`
+    /// call, which CREATES the foreign ring (this process owns it).
+    /// `capacity` is the data-region size in bytes.
+    pub(crate) fn emit_bus_register_shm_ring_layout_producer(
+        &mut self,
+        subject: &str,
+        shm_name: &str,
+        layout: &hale_syntax::ast::RingLayoutDecl,
+        capacity: u64,
+    ) -> Result<(), CodegenError> {
+        let desc_ptr = self.ring_layout_desc_global(subject, layout);
+        let subj_ptr = self
+            .builder
+            .build_global_string_ptr(
+                subject,
+                &format!("lotus.shm_ring.layout.psubject.{}", subject),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .as_pointer_value();
+        let name_ptr = self
+            .builder
+            .build_global_string_ptr(
+                shm_name,
+                &format!("lotus.shm_ring.layout.pname.{}", subject),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .as_pointer_value();
+        let cap_val = self.context.i64_type().const_int(capacity, false);
+        let reg_fn = self
+            .module
+            .get_function("lotus_bus_register_shm_ring_layout")
+            .expect("lotus_bus_register_shm_ring_layout declared");
+        self.builder
+            .build_call(
+                reg_fn,
+                &[
+                    subj_ptr.into(),
+                    name_ptr.into(),
+                    desc_ptr.into(),
+                    cap_val.into(),
+                ],
+                "shm_ring.register_layout_producer",
             )
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         Ok(())

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -5315,6 +5315,32 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         }
     }
 
+    /// Proposal B M3a (2026-06-06): does any locus in this bundle
+    /// `publish` the topic on the given wire subject? Drives whether a
+    /// `layout:`-bound binding creates the foreign ring (producer) in
+    /// the prelude or merely attaches it read-only at a subscriber's
+    /// birth. `desugar` has already rewritten `publish Foo;` to a
+    /// `BusSubject::Literal` carrying the topic's wire subject, so we
+    /// match that (and the pre-desugar `Topic` form defensively).
+    fn bundle_publishes_topic(&self, wire_subject: &str) -> bool {
+        use hale_syntax::ast::{BusMember, BusSubject, LocusMember};
+        self.program.items.iter().any(|item| {
+            let TopDecl::Locus(l) = item else { return false };
+            l.members.iter().any(|m| {
+                let LocusMember::Bus(bus) = m else { return false };
+                bus.members.iter().any(|bm| match bm {
+                    BusMember::Publish { subject: BusSubject::Literal { subject, .. }, .. } => {
+                        subject == wire_subject
+                    }
+                    BusMember::Publish { subject: BusSubject::Topic(i), .. } => {
+                        i.name == wire_subject
+                    }
+                    _ => false,
+                })
+            })
+        })
+    }
+
     /// Phase 3 (2026-05-25): walk top-level topic decls and
     /// record each KEYED topic's (wire subject → payload type +
     /// keyed_by field) for the codegen-side publish lookup.
@@ -5589,7 +5615,44 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         )?;
                         continue;
                     }
-                    TransportSpec::ShmRing { name, slot_count, overflow, .. } => {
+                    TransportSpec::ShmRing {
+                        name, slot_count, overflow, layout, buffer_size, ..
+                    } => {
+                        // Proposal B M3a (2026-06-06): a foreign-layout
+                        // binding does NOT create the native LRSRNG1
+                        // ring. If this bundle PUBLISHES the topic, it
+                        // is the ring's producer and creates it here;
+                        // otherwise a subscriber attaches it read-only
+                        // at locus birth (PR3) and the prelude emits
+                        // nothing. (Without this branch the native
+                        // register below would stamp an LRSRNG1 header
+                        // onto a foreign ring name — wrong either way.)
+                        if let Some(lid) = layout {
+                            if self.bundle_publishes_topic(&subject) {
+                                let decl = self.program.items.iter().find_map(
+                                    |it| match it {
+                                        TopDecl::RingLayout(r)
+                                            if r.name.name == lid.name =>
+                                        {
+                                            Some(r.clone())
+                                        }
+                                        _ => None,
+                                    },
+                                );
+                                if let Some(decl) = decl {
+                                    // Default capacity when the binding
+                                    // omits `buffer_size:` — 1 MiB data
+                                    // region. A consumer reads the
+                                    // actual size from the header.
+                                    const DEFAULT_CAP: u64 = 1 << 20;
+                                    let cap = buffer_size.unwrap_or(DEFAULT_CAP);
+                                    self.emit_bus_register_shm_ring_layout_producer(
+                                        &subject, name, &decl, cap,
+                                    )?;
+                                }
+                            }
+                            continue;
+                        }
                         // Form K4c (2026-05-20): emit the
                         // shm_ring registration + record the
                         // subject for lower_send's publish-side

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1195,6 +1195,34 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             None,
         );
 
+        // Proposal B M3a (2026-06-06): foreign-layout PRODUCER. The
+        // prelude emits a register for each layout-bound topic the
+        // bundle publishes (creates the ring); publish sites route
+        // through publish_shm_ring_layout (frames one byte_records
+        // record + advances the cursor).
+        // declare void @lotus_bus_register_shm_ring_layout(
+        //   ptr subject, ptr shm_name, ptr desc_words, i64 capacity)
+        let bus_register_shm_ring_layout_ty = void_t.fn_type(
+            &[ptr_t.into(), ptr_t.into(), ptr_t.into(), i64_t.into()],
+            false,
+        );
+        self.module.add_function(
+            "lotus_bus_register_shm_ring_layout",
+            bus_register_shm_ring_layout_ty,
+            None,
+        );
+        // declare i32 @lotus_bus_publish_shm_ring_layout(
+        //   ptr subject, ptr value, i64 value_size)
+        let bus_publish_shm_ring_layout_ty = i32_t.fn_type(
+            &[ptr_t.into(), ptr_t.into(), i64_t.into()],
+            false,
+        );
+        self.module.add_function(
+            "lotus_bus_publish_shm_ring_layout",
+            bus_publish_shm_ring_layout_ty,
+            None,
+        );
+
         // m105: adapter-driven inbound dispatch. Hands wire bytes
         // through the subject's registered deserialize fn into the
         // local handler set. Backs the `std::bus::__local_dispatch`

--- a/crates/hale-codegen/tests/shm_ring_layout.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout.rs
@@ -81,3 +81,19 @@ fn layout_byte_records_roundtrip() {
 fn layout_byte_records_wrap() {
     run_mode("wrap");
 }
+
+// Proposal B M3a — the PRODUCER C ABI
+// (lotus_bus_register_shm_ring_layout + publish_shm_ring_layout):
+// register a producer that creates the ring, publish records, and
+// confirm a consumer reads them back in order. Validates that the
+// producer's framing is the exact inverse of the reader's.
+
+#[test]
+fn layout_producer_roundtrip() {
+    run_mode("producer");
+}
+
+#[test]
+fn layout_producer_wrap() {
+    run_mode("producer_wrap");
+}

--- a/crates/hale-codegen/tests/shm_ring_layout_codegen.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_codegen.rs
@@ -98,3 +98,69 @@ fn layout_binding_emits_layout_register_call() {
          binding; IR did not contain lotus.shm_ring.layout.desc"
     );
 }
+
+#[test]
+fn layout_publisher_emits_producer_register_and_publish() {
+    // Proposal B M3a: a bundle that *publishes* a layout-bound topic
+    // creates the foreign ring in the prelude
+    // (lotus_bus_register_shm_ring_layout) and frames each `<-`
+    // through lotus_bus_publish_shm_ring_layout — NOT the native
+    // register/publish.
+    let src = r#"
+        ring_layout MagusRing {
+            magic 0x4D475348514D4B54;
+            version 1 at 8 : u32;
+            buffer_size at 12 : u32;
+            data_at 128;
+            cursor published { at 64; repr atomic_u64; load acquire; unit bytes; }
+            framing byte_records { len_prefix u32; align 8; pad_sentinel 0xFFFFFFFF; }
+            overflow lap_detect;
+        }
+
+        type Tick { px: Int; sz: Int; }
+        topic Ticks { payload: Tick; }
+
+        locus Producer {
+            bus { publish Ticks; }
+            birth() { Ticks <- Tick { px: 1, sz: 7 }; }
+        }
+
+        main locus App {
+            bindings {
+                Ticks: shm_ring("/magus.ticks", on_overflow: drop,
+                                layout: MagusRing, buffer_size: 4096) where zero_copy;
+            }
+        }
+
+        fn main() { App { }; Producer { }; }
+    "#;
+
+    let bin = unique_path("producer", "bin");
+    let ir = bin.with_extension("ll");
+    let program = hale_syntax::parse_source(src).expect("parse");
+
+    std::env::set_var("LOTUS_DUMP_IR", "1");
+    let result = build_executable(&program, &bin);
+    std::env::remove_var("LOTUS_DUMP_IR");
+    result.expect("build");
+
+    let ir_text = std::fs::read_to_string(&ir).expect("read IR");
+    let _ = std::fs::remove_file(&bin);
+    let _ = std::fs::remove_file(&ir);
+
+    assert!(
+        ir_text.contains("lotus_bus_register_shm_ring_layout"),
+        "a publishing layout binding must create the ring via the \
+         producer register; IR missing lotus_bus_register_shm_ring_layout"
+    );
+    assert!(
+        ir_text.contains("lotus_bus_publish_shm_ring_layout"),
+        "a `<-` on a layout topic must route through the layout publish \
+         path; IR missing lotus_bus_publish_shm_ring_layout"
+    );
+    // The native register/publish must NOT appear for this binding.
+    assert!(
+        !ir_text.contains("call void @lotus_bus_register_shm_ring("),
+        "a layout binding must not emit the native LRSRNG1 register"
+    );
+}

--- a/crates/hale-codegen/tests/shm_ring_layout_driver.c
+++ b/crates/hale-codegen/tests/shm_ring_layout_driver.c
@@ -48,6 +48,17 @@ extern void lotus_bus_register_subscriber_shm_ring_layout(
     void *self_ptr,
     void (*handler_fn)(void *self, void *slot));
 
+/* Proposal B M3a — producer-side C ABI. */
+extern void lotus_bus_register_shm_ring_layout(
+    const char *subject,
+    const char *shm_name,
+    const uint64_t *desc_words,
+    uint64_t capacity);
+extern int lotus_bus_publish_shm_ring_layout(
+    const char *subject,
+    const void *value,
+    uint64_t value_size);
+
 /* Layout constants — mirror the `MagusRing` ring_layout used in the
  * Rust-side tests. */
 #define MAGIC          0x4D475348514D4B54ULL
@@ -199,9 +210,67 @@ static int run(const char *name, uint64_t capacity, int n, int pace_us) {
     return rc;
 }
 
+/* Proposal B M3a — round-trip through the PRODUCER C ABI: register a
+ * producer (creates the ring), register a consumer (attaches), publish
+ * N records via lotus_bus_publish_shm_ring_layout, validate the
+ * consumer reads them back in order. Exercises producer + consumer
+ * framing symmetry end to end. `pace_us > 0` (with a small capacity)
+ * forces the pad-at-wrap path on the producer side too. */
+static int run_producer(const char *name, uint64_t capacity, int n, int pace_us) {
+    uint64_t desc[16];
+    build_desc(desc);
+
+    /* Producer creates + owns the ring. */
+    lotus_bus_register_shm_ring_layout("magus.ticks", name, desc, capacity);
+    /* Consumer attaches read-only and parks at cursor 0. */
+    lotus_bus_register_subscriber_shm_ring_layout(
+        "magus.ticks", name, desc, NULL, on_record);
+    struct timespec warmup = {0, 5 * 1000 * 1000};  /* 5ms */
+    nanosleep(&warmup, NULL);
+
+    for (int i = 0; i < n; i++) {
+        Payload p = { .seq_id = i + 1, .value = (int64_t)(i + 1) * 7 };
+        if (lotus_bus_publish_shm_ring_layout(
+                "magus.ticks", &p, sizeof(p)) != 0) {
+            fprintf(stderr, "publish %d failed\n", i);
+            return 2;
+        }
+        if (pace_us > 0) {
+            struct timespec ts = {0, (long)pace_us * 1000};
+            nanosleep(&ts, NULL);
+        }
+    }
+
+    for (int spins = 0; spins < 2000; spins++) {
+        if (atomic_load_explicit(&g_recv_count, memory_order_acquire) >= n) {
+            break;
+        }
+        struct timespec ts = {0, 1000 * 1000};
+        nanosleep(&ts, NULL);
+    }
+    int got = atomic_load_explicit(&g_recv_count, memory_order_acquire);
+    if (got != n) {
+        fprintf(stderr, "expected %d records, got %d\n", n, got);
+        return 3;
+    }
+    for (int i = 0; i < n; i++) {
+        if (g_recv[i].seq_id != i + 1 ||
+            g_recv[i].value != (int64_t)(i + 1) * 7) {
+            fprintf(stderr, "record %d mismatch: seq_id=%lld value=%lld\n",
+                    i, (long long)g_recv[i].seq_id,
+                    (long long)g_recv[i].value);
+            return 3;
+        }
+    }
+    /* atexit teardown joins the reader + closes/unlinks both handles. */
+    return 0;
+}
+
 int main(int argc, char **argv) {
     if (argc < 3) {
-        fprintf(stderr, "usage: %s <roundtrip|wrap> <shm_name>\n", argv[0]);
+        fprintf(stderr,
+                "usage: %s <roundtrip|wrap|producer|producer_wrap> <shm_name>\n",
+                argv[0]);
         return 1;
     }
     if (strcmp(argv[1], "roundtrip") == 0) {
@@ -212,6 +281,12 @@ int main(int argc, char **argv) {
         /* capacity 256 wraps every ~10 records; pace 1ms (10x the
          * reader's 100us poll) so the consumer never laps. */
         return run(argv[2], 256, 40, 1000);
+    }
+    if (strcmp(argv[1], "producer") == 0) {
+        return run_producer(argv[2], 4096, 64, 0);
+    }
+    if (strcmp(argv[1], "producer_wrap") == 0) {
+        return run_producer(argv[2], 256, 40, 1000);
     }
     fprintf(stderr, "unknown mode `%s`\n", argv[1]);
     return 1;

--- a/crates/hale-codegen/tests/shm_ring_layout_producer.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_producer.rs
@@ -1,0 +1,132 @@
+//! Proposal B M3a (2026-06-06) — end-to-end Hale producer over a
+//! foreign `ring_layout`.
+//!
+//! A single Hale binary both produces and consumes its own foreign
+//! ring, which avoids the cross-process attach-ordering race (a
+//! broadcast consumer reads only records published after it
+//! attaches, and cannot create the ring):
+//!
+//!   1. `App {}` birth → the prelude CREATES the ring (the bundle
+//!      publishes `Ticks`, so it's the producer).
+//!   2. `Sub {}` birth → attaches the ring read-only and spawns the
+//!      byte_records reader thread.
+//!   3. `Producer {}` birth → publishes N ticks via
+//!      `lotus_bus_publish_shm_ring_layout`.
+//!
+//! The subscriber prints each received tick; we assert all N arrive
+//! in order, proving the producer's framing is read back correctly
+//! by the consumer (and, by construction, by any magus2-shaped
+//! reader).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::build_executable;
+
+fn unique_tag(label: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("m3a-{}-{}-{}", label, std::process::id(), nanos)
+}
+
+#[test]
+fn hale_producer_roundtrips_through_foreign_layout() {
+    let shm_name = format!("/hale-{}", unique_tag("e2e"));
+    let n_msgs: i64 = 6;
+
+    let src = format!(
+        r#"
+        ring_layout MagusRing {{
+            magic 0x4D475348514D4B54;
+            version 1 at 8 : u32;
+            buffer_size at 12 : u32;
+            data_at 128;
+            cursor published {{ at 64; repr atomic_u64; load acquire; unit bytes; }}
+            framing byte_records {{ len_prefix u32; align 8; pad_sentinel 0xFFFFFFFF; }}
+            overflow lap_detect;
+        }}
+
+        type Tick {{ px: Int; sz: Int; }}
+        topic Ticks {{ payload: Tick; }}
+
+        locus Sub {{
+            bus {{ subscribe Ticks as on_tick; }}
+            fn on_tick(t: Tick) {{
+                println("tick px=", t.px, " sz=", t.sz);
+            }}
+        }}
+
+        locus Producer {{
+            bus {{ publish Ticks; }}
+            birth() {{
+                Ticks <- Tick {{ px: 1, sz: 7 }};
+                Ticks <- Tick {{ px: 2, sz: 14 }};
+                Ticks <- Tick {{ px: 3, sz: 21 }};
+                Ticks <- Tick {{ px: 4, sz: 28 }};
+                Ticks <- Tick {{ px: 5, sz: 35 }};
+                Ticks <- Tick {{ px: 6, sz: 42 }};
+            }}
+        }}
+
+        main locus App {{
+            bindings {{
+                Ticks: shm_ring("{shm_name}", on_overflow: drop,
+                                layout: MagusRing, buffer_size: 4096) where zero_copy;
+            }}
+        }}
+
+        fn main() {{
+            App {{ }};
+            Sub {{ }};
+            // Let the reader thread do its first poll (initializing its
+            // byte cursor to the ring's current 0) BEFORE the producer
+            // publishes — the byte_records reader starts at the live
+            // cursor (no historical replay), so an in-process producer
+            // that ran first would advance the cursor past records the
+            // just-attached reader never saw. A real external producer
+            // (magus2) is long-running, so this is a test-only barrier.
+            time::sleep(50ms);
+            Producer {{ }};
+            time::sleep(500ms);
+        }}
+    "#,
+        shm_name = shm_name,
+    );
+
+    let program = hale_syntax::parse_source(&src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("lotus_{}.bin", unique_tag("bin")));
+    build_executable(&program, &bin).expect("build");
+
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+
+    assert!(
+        out.status.success(),
+        "producer/consumer binary failed: status={:?}\nstdout: {}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for i in 1..=n_msgs {
+        let want = format!("tick px={} sz={}", i, i * 7);
+        assert!(
+            stdout.contains(&want),
+            "subscriber missing `{}`. Full stdout:\n{}",
+            want,
+            stdout
+        );
+    }
+
+    // The producer owns + unlinks the ring at exit.
+    let stripped = shm_name.trim_start_matches('/');
+    assert!(
+        !PathBuf::from(format!("/dev/shm/{}", stripped)).exists(),
+        "atexit cleanup failed: `{}` persists in /dev/shm/",
+        shm_name
+    );
+}

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -746,6 +746,12 @@ pub enum TransportSpec {
         /// layout. `None` = the native `LotusRing` shape (the only
         /// behavior today; back-compat).
         layout: Option<Ident>,
+        /// Proposal B M3a: producer ring capacity in bytes (the data
+        /// region size). Only meaningful with `layout:` (a foreign
+        /// `byte_records` ring has no fixed slots); `None` = the
+        /// per-transport default. Ignored for the native ring, which
+        /// sizes from `slot_count` × payload size.
+        buffer_size: Option<u64>,
         span: Span,
     },
 }

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -1815,6 +1815,7 @@ impl Parser {
                 let mut slot_count: u64 = 128;
                 let mut overflow: Option<ShmRingOverflow> = None;
                 let mut layout: Option<Ident> = None;
+                let mut buffer_size: Option<u64> = None;
                 while self.eat(&TokenKind::Comma) {
                     let key = self.expect_ident("shm_ring kwarg name")?;
                     self.expect(TokenKind::Colon, ":")?;
@@ -1823,6 +1824,33 @@ impl Parser {
                             layout = Some(self.expect_ident(
                                 "ring_layout name for `layout:`",
                             )?);
+                        }
+                        "buffer_size" => {
+                            let tok = self.peek_token().clone();
+                            match tok.kind {
+                                TokenKind::IntLit(n) if n > 0 => {
+                                    self.bump();
+                                    buffer_size = Some(n as u64);
+                                }
+                                TokenKind::IntLit(_) => {
+                                    return Err(Diag::parse(
+                                        tok.span,
+                                        "shm_ring `buffer_size:` must be a positive \
+                                         byte count"
+                                            .to_string(),
+                                    ));
+                                }
+                                other => {
+                                    return Err(Diag::parse(
+                                        tok.span,
+                                        format!(
+                                            "expected positive integer for shm_ring \
+                                             `buffer_size:`, got {:?}",
+                                            other
+                                        ),
+                                    ));
+                                }
+                            }
                         }
                         "slot_count" => {
                             let tok = self.peek_token().clone();
@@ -1887,7 +1915,8 @@ impl Parser {
                                 key.span,
                                 format!(
                                     "unknown `shm_ring` kwarg `{}` (recognized: \
-                                     `slot_count`, `on_overflow`, `layout`)",
+                                     `slot_count`, `on_overflow`, `layout`, \
+                                     `buffer_size`)",
                                     other
                                 ),
                             ));
@@ -1911,6 +1940,7 @@ impl Parser {
                     slot_count,
                     overflow,
                     layout,
+                    buffer_size,
                     span: head_tok.span.merge(close.span),
                 })
             }

--- a/docs/src/systems/zero-copy-bus.md
+++ b/docs/src/systems/zero-copy-bus.md
@@ -116,11 +116,26 @@ any other `shm_ring` subscriber — the layout only changes how the
 substrate finds and frames the bytes.
 
 A binding with no `layout:` keeps Hale's native ring, so nothing
-you wrote before changes. This is read-only at this version: you
-can *consume* a foreign ring, not yet *produce* into one. A
-subscriber sees records published after it attaches, and if it
-falls more than a full buffer behind it resyncs rather than
-reading a torn record.
+you wrote before changes.
+
+The same binding works the other way too. If a locus in your
+program *publishes* the topic, it becomes the ring's producer: Hale
+creates the segment, writes the header the layout describes, and
+frames each `Ticks <- Tick { ... }` as a length-prefixed record
+another program (or another language) can read. Give the binding a
+`buffer_size:` to size the ring:
+
+```hale
+Ticks: shm_ring("/magus.ticks", on_overflow: drop,
+                layout: MagusRing, buffer_size: 65536) where zero_copy;
+```
+
+So the same declared layout lets Hale sit on either side of a
+foreign ring — consume what another process writes, or produce what
+another process reads — with the locus body unchanged. Two caveats
+at this version: a subscriber sees records published after it
+attaches (no replay of history), and if it falls more than a full
+buffer behind it resyncs rather than read a torn record.
 
 ## The same shape, one tier down
 

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -270,7 +270,8 @@ shm_ring_transport = "shm_ring" , "(" , STRING_LIT ,
                      { "," , shm_ring_kwarg } , ")" ;
 shm_ring_kwarg    = ( "slot_count" , ":" , INT_LIT )
                   | ( "on_overflow" , ":" , overflow_policy )
-                  | ( "layout" , ":" , IDENTIFIER ) ;
+                  | ( "layout" , ":" , IDENTIFIER )
+                  | ( "buffer_size" , ":" , INT_LIT ) ;
 overflow_policy    = "block" | "drop" | "fail" ;
 
 (* Form K (2026-05-20): operational constraints the dev team

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -852,9 +852,23 @@ the native LRSRNG1 shape:
   subscriber registry + `atexit` teardown; a layout subscriber is
   marked `is_layout` and torn down via `lotus_shm_ring_close_layout`.
 
-Field reads are host-native endianness (magus2 and Hale are both
-little-endian x86-64). v1 is read-only `byte_records`; the
-producer side and `slots` framing are post-v1.
+The producer side (Proposal B M3a) mirrors these:
+
+- `lotus_shm_ring_create_layout(name, desc, capacity)` — CREATE +
+  own the segment (size `data_at + capacity`, write the
+  magic/`version`/`buffer_size` header, zero the cursor). Attaches
+  read-write without re-init if it already exists.
+- `lotus_bus_register_shm_ring_layout(subject, name, desc_words,
+  capacity)` — create via the above + register a producer (one per
+  subject). `lotus_bus_publish_shm_ring_layout(subject, value,
+  size)` frames one `byte_records` record (the inverse of the
+  reader: reserve `align_up`, `pad_sentinel` at the wrap, write the
+  length prefix + payload, release-store the cursor). The producer
+  rings are closed + `shm_unlink`'d at `atexit`.
+
+Field reads/writes are host-native endianness (magus2 and Hale are
+both little-endian x86-64). v1 is `byte_records` only; the `slots`
+framing kind and a zero-copy writable producer view are post-v1.
 
 v1 scope: single-producer, multi-consumer; in-memory delivery is
 in scope (POSIX shm_open works intra-machine cross-process).

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -982,9 +982,8 @@ words that collide with keywords like `release`) are layout
 keyword-spelled words) checked against the sets above, never
 resolved as types.
 
-*Scope (v1): read-only `byte_records` consumer.* A subscriber on
-a layout-bound topic registers via
-`lotus_bus_register_subscriber_shm_ring_layout(subject, name,
+*Consumer (read).* A subscriber on a layout-bound topic registers
+via `lotus_bus_register_subscriber_shm_ring_layout(subject, name,
 desc, self, handler)`, where `desc` is a flat 16-entry descriptor
 codegen builds from the resolved layout. The runtime attaches the
 foreign segment read-only (it never creates it — the foreign
@@ -999,14 +998,32 @@ convention from the layout — a scalar named `version` (with an
 expected value) is the version check; one named `buffer_size` is
 the capacity source.
 
+*Producer (write).* If the bundle *publishes* a layout-bound topic,
+it is the ring's single producer (SPMC): the prelude CREATES the
+segment via `lotus_bus_register_shm_ring_layout(subject, name,
+desc, capacity)` — sizing it `data_at + capacity`, writing the
+header (magic, `version`, `buffer_size = capacity`) and zeroing the
+cursor — and each `Topic <- value` routes through
+`lotus_bus_publish_shm_ring_layout`, the exact inverse of the
+reader: reserve `align_up(len_prefix + payload, align)`, write a
+`pad_sentinel` and wrap if the record would straddle the end, write
+the length prefix + a `memcpy` of the (flat) payload, then
+release-store the cursor. Capacity comes from the binding's
+`buffer_size:` kwarg (bytes; a per-transport default applies when
+omitted). A layout binding that is only *subscribed* in this bundle
+creates nothing — it attaches the foreign producer's ring.
+
 *Limitations (v1).* A subscriber reads records published *after*
-it attaches (no historical replay). Lap handling is lossy + safe:
-if the producer runs more than `capacity` bytes ahead, the missed
-bytes are gone, so the reader resyncs to the producer's cursor (a
-commit boundary) and resumes rather than reading a torn record.
-The handler runs on the reader thread (same constraint as the
-native subscriber). The producer side for foreign layouts, the
-`slots` framing kind, and multi-cursor back-pressure are post-v1.
+it attaches (no historical replay) — so an in-process producer must
+not publish before the consumer's reader thread has started (a
+non-issue for an external long-running producer like magus2). Lap
+handling is lossy + safe: if the producer runs more than `capacity`
+bytes ahead, the missed bytes are gone, so the reader resyncs to the
+producer's cursor (a commit boundary) and resumes rather than
+reading a torn record. Handlers run on the reader thread (same
+constraint as the native subscriber). The `slots` framing kind, the
+zero-copy writable producer view (A1 — the producer copies the
+payload once today), and multi-cursor back-pressure are post-v1.
 
 **In-memory delivery is absence-of-entry.** A topic with no
 binding entry is delivered same-process via the cooperative


### PR DESCRIPTION
Makes the foreign-ring interop **symmetric**: Hale can now WRITE a `ring_layout`-described ring, not just read one (PR #59). A locus that *publishes* a `layout:`-bound topic creates the ring and frames `byte_records` into it; a consumer — Hale or another language — reads them back unchanged. This is the producer half the design doc bundled as M3.

## Runtime (`lotus_shm_ring.c`)
- **`lotus_shm_ring_create_layout(name, desc, capacity)`** — create + own the segment: size it `data_at + capacity`, write the header the layout describes (magic, `version`, `buffer_size = capacity`), zero the cursor. Attaches read-write without re-init if it already exists.
- **`lotus_bus_register_shm_ring_layout` + `lotus_bus_publish_shm_ring_layout`** — a one-producer-per-subject registry; publish frames one record as the **exact inverse of the reader**: reserve `align_up(len_prefix + payload, align)`, write a `pad_sentinel` + wrap if the record would straddle the end, write the length prefix + `memcpy` the (flat) payload, release-store the cursor.
- `atexit` closes + `shm_unlink`s producer-owned segments. Descriptor build is now shared with the consumer via `shm_layout_from_words`.

## Codegen
- New **`buffer_size:`** `shm_ring` kwarg (bytes) → the producer ring capacity (default 1 MiB).
- The bindings prelude **branches on `layout`**: if the bundle *publishes* the topic it emits the producer-create; a subscribe-only layout binding emits nothing (the subscriber attaches at birth). **This also fixes a latent PR3 bug** where a layout binding wrongly emitted the native LRSRNG1 register.
- `lower_send` routes `<-` on a layout topic to `publish_shm_ring_layout`. `bundle_publishes_topic` matches the desugared wire-subject `Literal`.

## Tests
- C-driver producer round-trips (`producer` + `producer_wrap`, ASan/UBSan clean) — producer framing read back correctly, including pad-at-wrap.
- **End-to-end single-binary Hale producer ↔ consumer** over the `ForeignRing` layout (`shm_ring_layout_producer.rs`): the prelude creates the ring, a `Sub` attaches, a `Producer` publishes 6 ticks, the subscriber reads all 6 in order.
- IR-shape: producer register + publish emitted; native register **not**.
- Native `shm_ring` path untouched (back-compat verified).

Spec: `semantics.md` / `runtime.md` "Foreign rings" producer half; docs: `zero-copy-bus.md`.

Builds on #60 (conformance) which is already merged. Item #2 of the post-PR3 plan; completes the symmetric read+write interop the user confirmed as the goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
