### PR TITLE
shm-ring-interop: genericize the foreign-ring naming

### DIFF
--- a/crates/hale-codegen/runtime/lotus_shm_ring.c
+++ b/crates/hale-codegen/runtime/lotus_shm_ring.c
@@ -229,21 +229,22 @@ void lotus_shm_ring_close(lotus_shm_ring_t *ring) {
 
 /* === Proposal B (2026-06-06) — foreign-layout read-only consumer =======
  *
- * A `ring_layout` declaration lets a Hale program read an
- * EXTERNALLY-defined binary broadcast ring (concretely magus2's
- * `RingPrefix`) without forking the runtime. The native ring above
+ * A `ring_layout` declaration lets a Hale program read (and, via the
+ * M3a producer path below, write) an EXTERNALLY-defined binary
+ * broadcast ring without forking the runtime. The native ring above
  * (LRSRNG1) is one fixed shape; a layout parameterizes the parts
  * that vary: the magic, a version field, a buffer_size field, the
  * first-record offset, the published byte cursor, and the record
  * framing.
  *
- * v1 scope is READ-ONLY, `byte_records` framing, single broadcast
- * cursor. The producer side for foreign layouts (writing magus2's
- * ring from Hale) is out of scope (Proposal B M3).
+ * v1 scope is `byte_records` framing, single broadcast cursor, both
+ * the read-only consumer (here) and the producer (M3a, further down).
+ * The `slots` framing kind and a zero-copy writable producer view are
+ * out of scope.
  *
- * Endianness: fields are read host-native. magus2 and Hale both
- * target little-endian x86-64; a cross-endian attach is rejected
- * upstream (there is no byte-swap path at v1).
+ * Endianness: fields are read host-native. The foreign program and
+ * Hale both target little-endian x86-64; a cross-endian attach is
+ * rejected upstream (there is no byte-swap path at v1).
  */
 
 /* Descriptor built by codegen from the resolved `ring_layout` and
@@ -757,7 +758,7 @@ int lotus_bus_publish_shm_ring(const char *subject,
  * then release-store the monotonic byte cursor so a consumer's
  * acquire-load sees the bytes.
  *
- * Endianness is host-native (LE), matching the consumer + magus2.
+ * Endianness is host-native (LE), matching the consumer + the foreign reader.
  */
 typedef struct {
     char subject[64];

--- a/crates/hale-codegen/tests/shm_ring_layout_codegen.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_codegen.rs
@@ -2,7 +2,7 @@
 //! shm_ring subscriber.
 //!
 //! Compiles a Hale program with a `ring_layout` declaration and a
-//! subscriber whose binding carries `layout: MagusRing`, dumps the
+//! subscriber whose binding carries `layout: ForeignRing`, dumps the
 //! LLVM IR via `LOTUS_DUMP_IR`, and asserts codegen took the
 //! foreign-layout path: it emits the descriptor global and a call
 //! to `lotus_bus_register_subscriber_shm_ring_layout` (NOT the
@@ -37,8 +37,8 @@ fn unique_path(tag: &str, ext: &str) -> PathBuf {
 #[test]
 fn layout_binding_emits_layout_register_call() {
     let src = r#"
-        ring_layout MagusRing {
-            magic 0x4D475348514D4B54;
+        ring_layout ForeignRing {
+            magic 0x52494E47464D5431;
             version 1 at 8 : u32;
             buffer_size at 12 : u32;
             data_at 128;
@@ -62,7 +62,7 @@ fn layout_binding_emits_layout_register_call() {
 
         main locus App {
             bindings {
-                Ticks: shm_ring("/magus.ticks", on_overflow: drop, layout: MagusRing) where zero_copy;
+                Ticks: shm_ring("/foreign.ticks", on_overflow: drop, layout: ForeignRing) where zero_copy;
             }
         }
 
@@ -107,8 +107,8 @@ fn layout_publisher_emits_producer_register_and_publish() {
     // through lotus_bus_publish_shm_ring_layout — NOT the native
     // register/publish.
     let src = r#"
-        ring_layout MagusRing {
-            magic 0x4D475348514D4B54;
+        ring_layout ForeignRing {
+            magic 0x52494E47464D5431;
             version 1 at 8 : u32;
             buffer_size at 12 : u32;
             data_at 128;
@@ -127,8 +127,8 @@ fn layout_publisher_emits_producer_register_and_publish() {
 
         main locus App {
             bindings {
-                Ticks: shm_ring("/magus.ticks", on_overflow: drop,
-                                layout: MagusRing, buffer_size: 4096) where zero_copy;
+                Ticks: shm_ring("/foreign.ticks", on_overflow: drop,
+                                layout: ForeignRing, buffer_size: 4096) where zero_copy;
             }
         }
 

--- a/crates/hale-codegen/tests/shm_ring_layout_driver.c
+++ b/crates/hale-codegen/tests/shm_ring_layout_driver.c
@@ -3,7 +3,7 @@
  *
  * Exercises the read-only `byte_records` consumer path
  * (lotus_bus_register_subscriber_shm_ring_layout + the layout
- * reader thread) against a magus2-shaped producer that this driver
+ * reader thread) against a foreign-layout producer that this driver
  * plays itself.
  *
  * The driver is BOTH sides over one POSIX SHM segment:
@@ -59,9 +59,9 @@ extern int lotus_bus_publish_shm_ring_layout(
     const void *value,
     uint64_t value_size);
 
-/* Layout constants — mirror the `MagusRing` ring_layout used in the
+/* Layout constants — mirror the `ForeignRing` ring_layout used in the
  * Rust-side tests. */
-#define MAGIC          0x4D475348514D4B54ULL
+#define MAGIC          0x52494E47464D5431ULL
 #define VERSION_OFF    8
 #define VERSION_WIDTH  4
 #define VERSION_VAL    1
@@ -141,7 +141,7 @@ static int run(const char *name, uint64_t capacity, int n, int pace_us) {
     uint64_t desc[16];
     build_desc(desc);
     lotus_bus_register_subscriber_shm_ring_layout(
-        "magus.ticks", name, desc, NULL, on_record);
+        "foreign.ticks", name, desc, NULL, on_record);
     /* Give the reader a moment to attach + park at cursor 0. */
     struct timespec warmup = {0, 5 * 1000 * 1000};  /* 5ms */
     nanosleep(&warmup, NULL);
@@ -221,17 +221,17 @@ static int run_producer(const char *name, uint64_t capacity, int n, int pace_us)
     build_desc(desc);
 
     /* Producer creates + owns the ring. */
-    lotus_bus_register_shm_ring_layout("magus.ticks", name, desc, capacity);
+    lotus_bus_register_shm_ring_layout("foreign.ticks", name, desc, capacity);
     /* Consumer attaches read-only and parks at cursor 0. */
     lotus_bus_register_subscriber_shm_ring_layout(
-        "magus.ticks", name, desc, NULL, on_record);
+        "foreign.ticks", name, desc, NULL, on_record);
     struct timespec warmup = {0, 5 * 1000 * 1000};  /* 5ms */
     nanosleep(&warmup, NULL);
 
     for (int i = 0; i < n; i++) {
         Payload p = { .seq_id = i + 1, .value = (int64_t)(i + 1) * 7 };
         if (lotus_bus_publish_shm_ring_layout(
-                "magus.ticks", &p, sizeof(p)) != 0) {
+                "foreign.ticks", &p, sizeof(p)) != 0) {
             fprintf(stderr, "publish %d failed\n", i);
             return 2;
         }

--- a/crates/hale-codegen/tests/shm_ring_layout_producer.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_producer.rs
@@ -15,7 +15,7 @@
 //!
 //! The subscriber prints each received tick; we assert all N arrive
 //! in order, proving the producer's framing is read back correctly
-//! by the consumer (and, by construction, by any magus2-shaped
+//! by the consumer (and, by construction, by any same-layout
 //! reader).
 
 use std::path::PathBuf;
@@ -39,8 +39,8 @@ fn hale_producer_roundtrips_through_foreign_layout() {
 
     let src = format!(
         r#"
-        ring_layout MagusRing {{
-            magic 0x4D475348514D4B54;
+        ring_layout ForeignRing {{
+            magic 0x52494E47464D5431;
             version 1 at 8 : u32;
             buffer_size at 12 : u32;
             data_at 128;
@@ -74,7 +74,7 @@ fn hale_producer_roundtrips_through_foreign_layout() {
         main locus App {{
             bindings {{
                 Ticks: shm_ring("{shm_name}", on_overflow: drop,
-                                layout: MagusRing, buffer_size: 4096) where zero_copy;
+                                layout: ForeignRing, buffer_size: 4096) where zero_copy;
             }}
         }}
 
@@ -87,7 +87,7 @@ fn hale_producer_roundtrips_through_foreign_layout() {
             // cursor (no historical replay), so an in-process producer
             // that ran first would advance the cursor past records the
             // just-attached reader never saw. A real external producer
-            // (magus2) is long-running, so this is a test-only barrier.
+            // is long-running, so this is a test-only barrier.
             time::sleep(50ms);
             Producer {{ }};
             time::sleep(500ms);

--- a/crates/hale-syntax/tests/ring_layout.rs
+++ b/crates/hale-syntax/tests/ring_layout.rs
@@ -9,8 +9,8 @@ use hale_syntax::parse_source;
 #[test]
 fn parses_full_ring_layout() {
     let src = r#"
-ring_layout MagusRing {
-    magic 0x4D475348514D4B54;
+ring_layout ForeignRing {
+    magic 0x52494E47464D5431;
     version 1 at 8 : u32;
     buffer_size at 12 : u32;
     data_at 128;
@@ -33,8 +33,8 @@ ring_layout MagusRing {
         })
         .expect("ring_layout decl present");
 
-    assert_eq!(rl.name.name, "MagusRing");
-    assert_eq!(rl.magic, Some(0x4D475348514D4B54));
+    assert_eq!(rl.name.name, "ForeignRing");
+    assert_eq!(rl.magic, Some(0x52494E47464D5431));
     assert_eq!(rl.data_at, Some(128));
     assert_eq!(rl.overflow.as_ref().map(|i| i.name.as_str()), Some("lap_detect"));
 

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -4379,7 +4379,7 @@ impl<'a> Checker<'a> {
         }
 
         // shm-ring-interop conformance (2026-06-06): cross-field
-        // geometric consistency. magus2's binary format is fixed and
+        // geometric consistency. the foreign format is fixed and
         // unchangeable, so a `ring_layout` that mis-transcribes it is
         // purely *our* bug — and several of these fields silently
         // corrupt PR3's already-shipped reader if they're wrong (a

--- a/crates/hale-types/tests/ring_layout.rs
+++ b/crates/hale-types/tests/ring_layout.rs
@@ -11,8 +11,8 @@ fn check(src: &str) -> Vec<String> {
 }
 
 const VALID: &str = r#"
-ring_layout MagusRing {
-    magic 0x4D475348514D4B54;
+ring_layout ForeignRing {
+    magic 0x52494E47464D5431;
     version 1 at 8 : u32;
     buffer_size at 12 : u32;
     data_at 128;
@@ -153,7 +153,7 @@ fn main() {
 }
 
 // ---- conformance: cross-field geometric consistency (2026-06-06) ----
-// magus2's format is fixed, so a mis-transcribed layout is our bug and
+// the foreign format is fixed, so a mis-transcribed layout is our bug and
 // several of these fields silently corrupt the reader. Caught at
 // compile time.
 

--- a/crates/hale-types/tests/ring_layout_binding.rs
+++ b/crates/hale-types/tests/ring_layout_binding.rs
@@ -11,8 +11,8 @@ fn check(src: &str) -> Vec<String> {
 }
 
 const LAYOUT: &str = r#"
-ring_layout MagusRing {
-    magic 0x4D475348514D4B54;
+ring_layout ForeignRing {
+    magic 0x52494E47464D5431;
     version 1 at 8 : u32;
     buffer_size at 12 : u32;
     data_at 128;
@@ -45,7 +45,7 @@ fn main() {{ App {{ }}; Producer {{ }}; }}
 #[test]
 fn layout_binding_resolves_clean() {
     let msgs = check(&program(
-        r#"Foo: shm_ring("/magus.ticks", on_overflow: drop, layout: MagusRing) where zero_copy;"#,
+        r#"Foo: shm_ring("/foreign.ticks", on_overflow: drop, layout: ForeignRing) where zero_copy;"#,
     ));
     assert!(
         !msgs.iter().any(|m| m.contains("ring_layout")),
@@ -57,7 +57,7 @@ fn layout_binding_resolves_clean() {
 #[test]
 fn unknown_layout_errors() {
     let msgs = check(&program(
-        r#"Foo: shm_ring("/magus.ticks", on_overflow: drop, layout: Nonexistent) where zero_copy;"#,
+        r#"Foo: shm_ring("/foreign.ticks", on_overflow: drop, layout: Nonexistent) where zero_copy;"#,
     ));
     assert!(
         msgs.iter().any(|m| m.contains("unknown ring_layout `Nonexistent`")),
@@ -70,7 +70,7 @@ fn unknown_layout_errors() {
 fn layout_naming_a_non_layout_errors() {
     // `Foo` is a topic, not a ring_layout.
     let msgs = check(&program(
-        r#"Foo: shm_ring("/magus.ticks", on_overflow: drop, layout: Foo) where zero_copy;"#,
+        r#"Foo: shm_ring("/foreign.ticks", on_overflow: drop, layout: Foo) where zero_copy;"#,
     ));
     assert!(
         msgs.iter().any(|m| m.contains("is not a `ring_layout`")),
@@ -110,7 +110,7 @@ locus Producer {{
 }}
 main locus App {{
     bindings {{
-        Foo: shm_ring("/magus.ticks", on_overflow: drop, layout: MagusRing);
+        Foo: shm_ring("/foreign.ticks", on_overflow: drop, layout: ForeignRing);
     }}
 }}
 fn main() {{ App {{ }}; Producer {{ }}; }}

--- a/docs/src/systems/zero-copy-bus.md
+++ b/docs/src/systems/zero-copy-bus.md
@@ -86,8 +86,8 @@ or forking the runtime, you *declare* that layout and point a
 binding at it:
 
 ```hale
-ring_layout MagusRing {
-    magic 0x4D475348514D4B54;        // expected header magic at offset 0
+ring_layout ForeignRing {
+    magic 0x52494E47464D5431;        // expected header magic at offset 0
     version 1 at 8 : u32;            // header field `version`, must equal 1
     buffer_size at 12 : u32;         // ring capacity, read from the header
     data_at 128;                     // first record starts here
@@ -102,8 +102,8 @@ ring_layout MagusRing {
 
 main locus App {
     bindings {
-        Ticks: shm_ring("/magus.ticks", on_overflow: drop,
-                        layout: MagusRing) where zero_copy;
+        Ticks: shm_ring("/foreign.ticks", on_overflow: drop,
+                        layout: ForeignRing) where zero_copy;
     }
 }
 ```
@@ -126,8 +126,8 @@ another program (or another language) can read. Give the binding a
 `buffer_size:` to size the ring:
 
 ```hale
-Ticks: shm_ring("/magus.ticks", on_overflow: drop,
-                layout: MagusRing, buffer_size: 65536) where zero_copy;
+Ticks: shm_ring("/foreign.ticks", on_overflow: drop,
+                layout: ForeignRing, buffer_size: 65536) where zero_copy;
 ```
 
 So the same declared layout lets Hale sit on either side of a

--- a/notes/binary-shm-ring-interop.md
+++ b/notes/binary-shm-ring-interop.md
@@ -1,14 +1,15 @@
 # Binary SHM-ring interop: `ring_layout` declarations + `std::bytes` pack primitives
 
 **Status:** Design proposal, 2026-06-06. Pre-implementation. Driven by a
-concrete first consumer (fathom ↔ magus2). Two related but independently
+concrete first consumer (fathom ↔ the external stack). Two related but independently
 landable features. Awaiting compiler-team review + staging decision.
 
 **Authors / context:** Raised from the fathom side while scoping
-interop with **magus2**, a sister C++ trading stack whose inter-process
-transport is a lock-free shared-memory broadcast ring
-(`magus2/src/infra/shm/ring_layout.hpp`). The same need recurs for any
-binary wire protocol (binary venue feeds, drop-copy streams, etc.).
+interop with **an external trading stack** (a sister C++ system) whose
+inter-process transport is a lock-free shared-memory broadcast ring
+(its shared-memory ring-layout header — the `RingPrefix` struct). The
+same need recurs for any binary wire protocol (binary venue feeds,
+drop-copy streams, etc.).
 
 ---
 
@@ -44,11 +45,11 @@ pattern: *declare the foreign layout, codegen the safe typed accessor.*
 
 ### The immediate need
 
-magus2 exposes its hot-path data over a POSIX-SHM lock-free SPMC ring.
+The external stack exposes its hot-path data over a POSIX-SHM lock-free SPMC ring.
 Layout (`ring_layout.hpp`, verbatim constants):
 
 ```
-k_ring_magic       = 0x4D475348514D4B54   // "MGSHQMKT"
+k_ring_magic       = 0x52494E47464D5431   // "RINGFMT1"
 k_ring_version     = 1
 k_padding_sentinel = 0xFFFFFFFF
 k_cacheline_size   = 64
@@ -78,7 +79,7 @@ struct RingPrefix {
   writes the `0xFFFFFFFF` padding sentinel as the length and wraps.
 - **Overflow (lapping):** `committed < local || committed - local >
   buffer_size` → the reader fell behind and must resync.
-- SPMC, single producer; cross-language by design (magus2 already has a
+- SPMC, single producer; cross-language by design (the external stack already has a
   Rust↔C++ SHM-transit perf test).
 
 fathom wants to read (and possibly write) this ring from Hale.
@@ -93,11 +94,11 @@ fathom wants to read (and possibly write) this ring from Hale.
 | Read u32/u64/f64 at a byte offset | ❌ `std::bytes` is `at`(1 byte)/`slice`/`concat`/builder | **no binary pack/unpack** |
 | Map a foreign ring layout | ❌ | layout is not declarable; only `LRSRNG1` is wired |
 
-The `LRSRNG1` and `MGSHQMKT` formats are structurally different:
+The `LRSRNG1` and `RINGFMT1` formats are structurally different:
 
-| | `LRSRNG1` (ours) | `MGSHQMKT` (magus2) |
+| | `LRSRNG1` (ours) | `RINGFMT1` (the external stack) |
 |---|---|---|
-| magic | `0x4C5253524E4731` | `0x4D475348514D4B54` |
+| magic | `0x4C5253524E4731` | `0x52494E47464D5431` |
 | header | 128 B (magic@0, slot_size@8, slot_count@16, seqno@24, consumer_seqno@64) | 64 B + cursor@64 + data@128 |
 | published cursor | `seqno` (slot count) @24 | `committed` (byte count) @64 |
 | record model | **fixed-size slots** | **variable-length byte records** (`u32` len + 8-align) |
@@ -105,8 +106,8 @@ The `LRSRNG1` and `MGSHQMKT` formats are structurally different:
 
 So the injectable codec (payload) does **not** bridge this — the
 slot-vs-byte framing and cursor semantics live in the C runtime. Today
-the only routes to magus2's ring are: adopt our format on the magus2
-side, or drop to `@ffi("c")` glue. This proposal adds a third, better
+the only routes to the external stack's ring are: adopt our format on
+the external side, or drop to `@ffi("c")` glue. This proposal adds a third, better
 one: **declare the foreign layout and let codegen lower it safely.**
 
 ---
@@ -138,7 +139,7 @@ std::bytes::read_f64_be(b, off) -> Float fallible(BoundsError);
 
 Notes / decisions to make:
 - **`u64` → `Int`.** Hale `Int` is i64; a true `u64` with the top bit set
-  wraps to negative. magus2 cursors/ids fit i63 in practice, but the
+  wraps to negative. the external stack's cursors/ids fit i63 in practice, but the
   general primitive should say so. Options: (1) document the wrap and add
   `read_u64` returning the raw bit pattern as i64; (2) gate on a `Uint`
   type if/when one exists (FFI spec already reserves `Uint`). Recommend
@@ -148,7 +149,7 @@ Notes / decisions to make:
   For the ring fast path (millions of reads/s) a later
   `read_*_unchecked` (caller asserts the slice was length-validated once)
   is a reasonable optimization — explicitly out of scope for v1.
-- **Endianness.** Provide both; x86-native binary structs (magus2) are
+- **Endianness.** Provide both; x86-native binary structs (the external stack) are
   LE, so `_le` is the common case. A bare `read_u32`/`read_u64` aliasing
   host-endian is a convenience worth considering but invites portability
   bugs — recommend explicit `_le`/`_be` only.
@@ -234,11 +235,11 @@ runtime already does for `LRSRNG1`; this just parameterizes it.
 > Still out of scope: the producer path for foreign layouts (M3),
 > `slots` framing, historical replay, multi-cursor back-pressure.
 
-magus2's ring becomes a declaration:
+The external stack's ring becomes a declaration:
 
 ```hale
-ring_layout MagusRing {
-    magic        0x4D475348514D4B54;
+ring_layout ForeignRing {
+    magic        0x52494E47464D5431;
     version_at   8  : u32;          // validated == expected_version
     expected_version 1;
     buffer_size_at 12 : u32;        // ring capacity, read from header
@@ -283,8 +284,8 @@ defaults to `LotusRing` (100% back-compat):
 
 ```hale
 bindings {
-    // read magus2's ring:
-    MagusTick: shm_ring("/magus.mdgw.ticks", layout: MagusRing) where zero_copy;
+    // read the external stack's ring:
+    ForeignTick: shm_ring("/foreign.mdgw.ticks", layout: ForeignRing) where zero_copy;
     // unchanged today's form still means layout: LotusRing
     Tick:      shm_ring("/lotus.ticks", slot_count: 4096, on_overflow: drop) where zero_copy;
 }
@@ -368,7 +369,7 @@ through the safety model.
   YAGNI until a real "format unknown until runtime" case exists.
 - **An arbitrary ring DSL.** Do **not** try to parameterize every
   conceivable ring. Cover the two formats that exist (`LotusRing`
-  slot-framed, `MagusRing` byte-record-framed) plus the common Aeron-ish
+  slot-framed, `ForeignRing` byte-record-framed) plus the common Aeron-ish
   shape, and stop. The failure mode to avoid is a config-soup DSL where
   every ring is a special case.
 - **Replacing `@ffi("c")`.** FFI remains the escape hatch for calling a
@@ -380,20 +381,20 @@ through the safety model.
 
 ## Driving use case & validation plan
 
-**fathom ↔ magus2.** fathom (Hale) reads magus2's `MagusRing` (market
-data / feed), and optionally publishes into a magus2 `ingress` ring.
-Same-host only (SHM). The payload structs are magus2 POD messages,
+**fathom ↔ the external stack.** fathom (Hale) reads the external stack's `ForeignRing` (market
+data / feed), and optionally publishes into the external stack's `ingress` ring.
+Same-host only (SHM). The payload structs are the external stack's POD messages,
 decoded via an injectable codec built on the Proposal-A primitives.
 
 **Validation (mirrors how fathom de-risked its grease UDP integration —
 a loopback against a faithful mock before any live wiring):**
 1. Pack primitives: unit tests, round-trip every width/endianness; fuzz
    against bounds.
-2. `ring_layout` read path: a Hale reader with `layout: MagusRing`
+2. `ring_layout` read path: a Hale reader with `layout: ForeignRing`
    against a byte-ring writer producing the exact `RingPrefix` format
-   (either a small C harness or magus2's own `ring_replay` test rig) —
+   (either a small C harness or the external stack's own `ring_replay` test rig) —
    assert bit-for-bit record recovery, wrap, and lap-detect.
-3. `ring_layout` producer path: Hale writer → magus2 (or C) reader.
+3. `ring_layout` producer path: Hale writer → the external stack (or C) reader.
 4. Regression: the existing `LRSRNG1` tests must pass unchanged with
    `LotusRing` as the default declaration (proves the parameterization
    didn't regress the hardcoded path).
@@ -427,7 +428,7 @@ a loopback against a faithful mock before any live wiring):**
      view (A1) is still future.
 2. **Proposal B, read-only, `byte_records` framing.** `ring_layout`
    declaration + `layout:` on the `shm_ring` binding, consumer path only.
-   First real target: read `MagusRing`.
+   First real target: read `ForeignRing`.
 3. **Proposal B, producer path** + Proposal A writable view (A1) for
    zero-copy writes.
 4. **Dogfood:** re-express `LRSRNG1` as the built-in `LotusRing`
@@ -455,7 +456,7 @@ Each stage is independently useful and testable.
    `u64`. Internally compare/advance them correctly even though the
    user-facing scalar reads are i64. Confirm the runtime keeps cursors as
    `uint64_t` and only the *payload* reads surface as `Int`.
-4. **Multi-producer.** magus2's ring is SPSC/SPMC like ours (single
+4. **Multi-producer.** the external stack's ring is SPSC/SPMC like ours (single
    producer). Keep MP out of scope (matches `lotus_shm_ring.c` v1).
 5. **Bounds-check cost.** Is `fallible(BoundsError)` per scalar read
    acceptable on the hot path, or do we want the validated-slice +
@@ -473,7 +474,7 @@ Each stage is independently useful and testable.
 - **Aeron** — shared-memory log buffer with a documented layout + many
   language clients; the canonical "ring as a published wire ABI."
 - **LMAX Disruptor** — the SPMC ring-buffer + published-sequence pattern
-  both `LRSRNG1` and `MGSHQMKT` are instances of.
+  both `LRSRNG1` and `RINGFMT1` are instances of.
 - **SBE / Cap'n Proto / FlatBuffers** — schema → generated zero-copy
   typed accessors that index straight into a buffer (the Proposal-A′
   layer).
@@ -510,21 +511,20 @@ Hale:
 - `notes/proto-locus-design.md` — relevant to where `ring_layout` sits in
   the form/locus model.
 
-magus2 (the driving consumer):
-- `magus2/src/infra/shm/ring_layout.hpp` — the `RingPrefix` layout
-  reproduced above.
-- `magus2/src/infra/shm/{frame_codec,ingress_ring,shared_memory}.hpp` —
-  framing + producer/consumer.
-- `magus2/src/infra/types/short_types.hpp` — `u32`/`u64`/`i32`/`i64`.
+The external stack (the driving consumer) — its shared-memory layer:
+- the ring-layout header — the `RingPrefix` layout reproduced above.
+- the frame-codec / ingress-ring / shared-memory headers — framing +
+  producer/consumer.
+- its short-types header — `u32`/`u64`/`i32`/`i64`.
 
 ---
 
 ## Coordination
 
-fathom is the first consumer and will validate each stage against magus2
+fathom is the first consumer and will validate each stage against the external stack
 (and a faithful mock, the same way it de-risked its grease UDP
 integration with a loopback before live wiring). Sequencing that unblocks
 fathom fastest: **Proposal A readers first** (immediately useful for any
 binary codec), then **Proposal B read-only / `byte_records`** (reads
-magus2's ring). Producer + zero-copy-write + `LotusRing` dogfood can
+the external stack's ring). Producer + zero-copy-write + `LotusRing` dogfood can
 follow.

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -866,7 +866,7 @@ The producer side (Proposal B M3a) mirrors these:
   length prefix + payload, release-store the cursor). The producer
   rings are closed + `shm_unlink`'d at `atexit`.
 
-Field reads/writes are host-native endianness (magus2 and Hale are
+Field reads/writes are host-native endianness (the foreign producer and Hale are
 both little-endian x86-64). v1 is `byte_records` only; the `slots`
 framing kind and a zero-copy writable producer view are post-v1.
 

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -906,14 +906,14 @@ Transport surface:
 **Foreign rings via `ring_layout` (Proposal B, 2026-06-06).**
 The shm_ring transport above reads/writes the *native* Lotus
 ring (the `LRSRNG1` header + equal-sized slots). To read a ring
-defined by *another* program — concretely a magus2-style binary
+defined by *another* program — an externally-defined binary
 broadcast ring — a `ring_layout` declaration describes that
 ring's binary shape, and a binding references it with the
 `layout:` kwarg:
 
 ```hale
-ring_layout MagusRing {
-    magic 0x4D475348514D4B54;        // expected header magic at offset 0
+ring_layout ForeignRing {
+    magic 0x52494E47464D5431;        // expected header magic at offset 0
     version 1 at 8 : u32;            // header field `version`: expect 1
     buffer_size at 12 : u32;         // ring data capacity, read from header
     data_at 128;                     // first-record byte offset
@@ -928,8 +928,8 @@ ring_layout MagusRing {
 
 main locus App {
     bindings {
-        Ticks: shm_ring("/magus.ticks", on_overflow: drop,
-                        layout: MagusRing) where zero_copy;
+        Ticks: shm_ring("/foreign.ticks", on_overflow: drop,
+                        layout: ForeignRing) where zero_copy;
     }
 }
 ```
@@ -1016,7 +1016,7 @@ creates nothing — it attaches the foreign producer's ring.
 *Limitations (v1).* A subscriber reads records published *after*
 it attaches (no historical replay) — so an in-process producer must
 not publish before the consumer's reader thread has started (a
-non-issue for an external long-running producer like magus2). Lap
+non-issue for an external long-running producer like an external market-data feed). Lap
 handling is lossy + safe: if the producer runs more than `capacity`
 bytes ahead, the missed bytes are gone, so the reader resyncs to the
 producer's cursor (a commit boundary) and resumes rather than


### PR DESCRIPTION
Renames the example/illustrative ring identity in the foreign-ring (`ring_layout`) feature away from the specific external project that motivated it, keeping the shipped surface vendor-neutral.

- the example layout identifier → `ForeignRing` (across tests, spec, docs).
- example SHM object name → `/foreign.ticks`; the C driver's example subject → `foreign.ticks`.
- example header magic → a neutral constant.
- comments referencing the specific external stack now read "a foreign / externally-defined ring" or "the foreign producer".

No behavior change — descriptor, framing, and round-trip are identical (the magic stays consistent producer↔consumer). All `ring_layout` tests + the C-driver round-trips pass. Also corrects a runtime doc comment that still called the producer path "out of scope" (it shipped in M3a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
