### PR TITLE
codegen: fix runtime-object temp-path race in parallel builds

### DIFF
--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -280,15 +280,26 @@ fn compile_cached_runtime_object(
     if obj.exists() {
         return Ok(obj);
     }
-    // Compile to per-process temp paths, then atomically rename the
-    // object into place — so concurrent `hale build`s (the corpus
-    // oracle runs fixtures in parallel) never see a half-written .o.
+    // Compile to a UNIQUE temp path, then atomically rename the object
+    // into place — so concurrent builds never see a half-written .o
+    // and never clobber each other's in-flight source. The corpus
+    // oracle runs fixtures in parallel *threads of one process*, so a
+    // `{pid}` suffix is not enough: two threads compiling the same
+    // runtime object (same source+flags → same `key`) would share the
+    // temp path, and one thread's post-compile `remove_file` could
+    // delete the source out from under another thread's clang (-> a
+    // "no such file / no input files" build failure). A per-call
+    // process-wide nonce disambiguates concurrent same-process builds;
+    // `{pid}` still disambiguates across processes.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static RT_TMP_NONCE: AtomicU64 = AtomicU64::new(0);
     let pid = std::process::id();
-    let src_tmp = dir.join(format!("lotus-rt-{stem}-{key:016x}.{pid}.c"));
+    let nonce = RT_TMP_NONCE.fetch_add(1, Ordering::Relaxed);
+    let src_tmp = dir.join(format!("lotus-rt-{stem}-{key:016x}.{pid}.{nonce}.c"));
     std::fs::write(&src_tmp, source).map_err(|e| {
         CodegenError::Link(format!("write runtime {stem} C: {e}"))
     })?;
-    let obj_tmp = dir.join(format!("lotus-rt-{stem}-{key:016x}.{pid}.o"));
+    let obj_tmp = dir.join(format!("lotus-rt-{stem}-{key:016x}.{pid}.{nonce}.o"));
     let status = Command::new("clang")
         .arg("-c")
         .args(cflags)


### PR DESCRIPTION
## What
The cached runtime-object compile (`compile_cached_runtime_object`) wrote its temp source/object to a `{pid}`-suffixed path. That disambiguates across **processes** but not across **threads of one process** — and the corpus oracle compiles fixtures in parallel threads.

Two threads building the same runtime object (same source+flags → same content-hash `key`, e.g. the `tls` shim that every fixture links) shared the temp `.c` path. One thread's post-compile `remove_file(&src_tmp)` could delete the source while another thread's `clang` was still reading it:

```
clang: error: no such file or directory: 'lotus-rt-tls-<key>.<pid>.c'
clang: error: no input files
build: Link("clang failed compiling runtime tls: exit status: 1")
```

This is the intermittent flake that just failed the `asan (example corpus)` job on an unrelated PR (#63). It can hit any PR.

## Fix
Add a process-wide `AtomicU64` nonce to the temp source/object filenames so concurrent same-process builds get distinct in-flight paths; `{pid}` still separates across processes. The **final cached object** stays content-addressed (`lotus-rt-{stem}-{key}.o`, shared via atomic rename) — only the temp paths become per-call unique, so the dedup/caching behavior is unchanged.

## Validation
3 cold-cache `LOTUS_ASAN=1 cargo test -p hale-codegen --test corpus_oracle` runs (cold cache forces the concurrent runtime-object compiles that trigger the race) — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)