### PR TITLE
ci: run the foreign-ring UBSan suite in the asan job (no extra build)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -302,7 +302,7 @@ jobs:
   # normal partitions. The plain exit+deadline arm of corpus_oracle
   # DOES run in those partitions (no extra toolchain needed).
   asan:
-    name: asan (example corpus)
+    name: sanitizers (asan corpus + ubsan foreign-ring)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -356,6 +356,35 @@ jobs:
           cargo test --release -p hale-codegen \
             --test corpus_oracle \
             -- --ignored --test-threads=1 --nocapture
+
+      # 2026-06-08 — UBSan (+ASan) coverage for the foreign-ring
+      # (`ring_layout`) boundary, folded into THIS job to reuse the
+      # workspace build above (a separate job would redo the expensive
+      # LLVM-linked release build for no benefit). `ring_layout` reads
+      # rings written by another program, so the interesting failures
+      # are at the non-conforming / hostile foreign-producer edge: a
+      # record `len` that disagrees with the bound payload size, a
+      # `buffer_size` that isn't an `align` multiple, a pack-read offset
+      # near INT64_MAX. A review found three OOB holes there the normal
+      # corpus never hit (it stays inside the safe invariants); this step
+      # runs the suites that DO exercise those edges with LOTUS_UBSAN=1
+      # (clang -fsanitize=address,undefined -fno-sanitize-recover), so a
+      # signed-overflow / OOB / wrongful-dispatch regression aborts and
+      # gates the merge. Scoped to the foreign-ring + pack tests on
+      # purpose: a full-corpus UBSan run could surface unrelated latent
+      # UB elsewhere (a separate effort). Leaks stay the ASan step's
+      # remit (detect_leaks=0 here) so this stays focused on UB / OOB.
+      - name: LOTUS_UBSAN=1 foreign-ring + pack suite (under ASan+UBSan)
+        env:
+          LOTUS_UBSAN: "1"
+          UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
+          ASAN_OPTIONS: "detect_leaks=0"
+        run: |
+          cargo test --release -p hale-codegen \
+            --test bytes_pack_read \
+            --test shm_ring_layout \
+            --test shm_ring_layout_producer \
+            -- --test-threads=1 --nocapture
 
   # GH issue #18 item 2: model-check the substrate's concurrent
   # primitives under ALL C11 interleavings (not just the schedules a


### PR DESCRIPTION
Wires the `LOTUS_UBSAN=1` flag (added in #67) into CI to guard the foreign-ring boundary — but as an **extra step of the existing sanitizer job**, not a standalone job.

A separate job would redo the expensive LLVM-linked `cargo build --release --workspace` for no benefit (CI is already long enough). Instead the renamed **`sanitizers (asan corpus + ubsan foreign-ring)`** job builds once, then:
1. runs `corpus_oracle` under `LOTUS_ASAN` (unchanged), and
2. runs the suites that exercise the non-conforming / hostile foreign-producer edge under `LOTUS_UBSAN` (`-fsanitize=address,undefined -fno-sanitize-recover=all`):
   - `bytes_pack_read` (the `INT64_MAX` offset regression)
   - `shm_ring_layout` (the `short_record` / `bad_bufsize` / `u64_lenprefix` modes)
   - `shm_ring_layout_producer`

A signed-overflow, OOB, or wrongful short-record dispatch aborts and gates the merge — so #67's three closed holes can't silently regress.

**Scoped** to the foreign-ring + pack tests (a full-corpus UBSan run could surface unrelated latent UB — a separate effort); leak detection stays the ASan step's remit (`ASAN_OPTIONS=detect_leaks=0`). No new job, no extra workspace build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
