### PR TITLE
ci: build-and-run per partition (drop the serial build+archive job)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,18 @@ name: tests
 # `--test-threads=1` no longer collide. Workspace-wide test time
 # drops ~2-3x vs libtest.
 #
-# Partition-then-fanout shape: one `build` job compiles + archives
-# the workspace test binaries; N parallel `test` jobs each run a
-# hash-partitioned subset of the archive. Total wall-clock drops
-# from ~7min to ~3min at the cost of ~2-3x CI minutes (separate
-# runner boot per partition). Worth it for branch-iteration
-# velocity.
+# Build-and-run-per-partition shape: N parallel `test` jobs each
+# build the workspace from the shared cargo cache and run a
+# hash-partitioned subset (`cargo nextest run --partition`). There
+# is deliberately NO separate compile-once `build` job + archive
+# handoff: that serialized the run behind a full compile *and* an
+# archive upload/download round-trip (~1.7min upload alone), and
+# each partition still paid its own ~2min setup afterward. Folding
+# the build into each partition overlaps the compile with the
+# (already parallel) partitions and drops the round-trip — ~3-4min
+# of wall-clock — at the cost of compiling ~Nx instead of once (the
+# cargo cache keeps each warm build to ~3min). Wall-clock over CI
+# minutes, for branch-iteration velocity.
 
 on:
   push:
@@ -39,96 +45,8 @@ env:
   LLVM_SYS_180_PREFIX: /usr/lib/llvm-18
 
 jobs:
-  build:
-    name: build + archive
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      # ubuntu-latest ships ~25-30GB of preinstalled toolchains this
-      # build never uses (dotnet, Android SDK, GHC, CodeQL). Reclaim
-      # them up front — the release build + nextest archive of an
-      # LLVM-linked workspace had been intermittently exhausting the
-      # runner disk ("No space left on device" in build+archive).
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
-                      /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
-          sudo docker image prune -af 2>/dev/null || true
-          df -h /
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry + target
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-tests-x86_64-linux-llvm18-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-tests-x86_64-linux-llvm18-
-
-      - name: Install LLVM 18 + clang
-        run: |
-          set -eux
-          sudo apt-get update
-          sudo apt-get install -y \
-            llvm-18-dev libpolly-18-dev libzstd-dev \
-            clang-18 libclang-18-dev zlib1g-dev
-
-      - name: Install cargo-nextest
-        # Prebuilt binary — installs in seconds vs ~2min for
-        # `cargo install`.
-        uses: taiki-e/install-action@nextest
-
-      - name: cargo build --release --workspace
-        # Build ALL workspace members first so `libhale_ts_shim.a`
-        # lands at `target/release/` before any test that links
-        # against it runs. `hale-cli` and `hale-codegen` tests
-        # invoke clang to link compiled .hl fixtures — codegen
-        # appends the staticlib by path-probe (no cargo dep edge
-        # forces it), so a fresh checkout that goes straight to
-        # `cargo test` misses the artifact and fails with
-        # `undefined reference to lotus_ts_*`.
-        run: cargo build --release --workspace
-
-      - name: cargo nextest archive
-        # Bundles all compiled test binaries + workspace metadata
-        # into a zstd-compressed tarball. Test runners unpack and
-        # execute without rebuilding. Fixtures referenced via
-        # CARGO_MANIFEST_DIR are remapped at the test side via
-        # `--workspace-remap` if needed; on Actions runners both
-        # phases check out to the same path so no remap is
-        # required.
-        run: |
-          cargo nextest archive \
-            --archive-file tests.tar.zst \
-            --release --workspace
-
-      - name: Upload nextest archive
-        uses: actions/upload-artifact@v4
-        with:
-          name: nextest-archive
-          path: tests.tar.zst
-          retention-days: 1
-
-      - name: Upload runtime artifacts
-        # `libhale_ts_shim.a` is needed by codegen tests that
-        # invoke clang to link compiled `.hl` programs. nextest
-        # archive doesn't include arbitrary build outputs, so the
-        # staticlib goes as a separate artifact.
-        uses: actions/upload-artifact@v4
-        with:
-          name: runtime-artifacts
-          path: target/release/libhale_ts_shim.a
-          retention-days: 1
-
   test:
     name: test ${{ matrix.partition }}/4
-    needs: build
     runs-on: ubuntu-latest
     strategy:
       # Don't short-circuit other partitions on first failure —
@@ -144,24 +62,40 @@ jobs:
       # them up front — the release build + nextest archive of an
       # LLVM-linked workspace had been intermittently exhausting the
       # runner disk ("No space left on device" in build+archive).
+      # ubuntu-latest ships ~25-30GB of preinstalled toolchains this
+      # build never uses (dotnet, Android SDK, GHC, CodeQL). Reclaim
+      # them up front — the release build of an LLVM-linked workspace
+      # had been intermittently exhausting the runner disk. Fixtures
+      # resolve via CARGO_MANIFEST_DIR against this checkout, so the
+      # build + run happen in-place with no path remap.
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
                       /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
           sudo docker image prune -af 2>/dev/null || true
           df -h /
-        # Tests reference fixture files under
-        # `crates/*/tests/fixtures/` via CARGO_MANIFEST_DIR-rooted
-        # paths. Checkout to the same directory the build runner
-        # used so the paths align.
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # Shared cache across the partitions (and reused run-to-run):
+      # all four restore the same key, so each partition's build is
+      # warm (~3min) rather than cold (~6.5min). One partition wins
+      # the save at job end; the others skip with a harmless warning.
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-tests-x86_64-linux-llvm18-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-tests-x86_64-linux-llvm18-
+
       - name: Install LLVM 18 + clang
-        # Test runners need libLLVM.so.18 at runtime (llvm-sys
-        # links dynamically) AND clang-18 for the
-        # compile-Hale-test invocations.
+        # llvm-sys links libLLVM.so.18 dynamically; clang-18 is also
+        # invoked at test time to link compiled `.hl` fixtures.
         run: |
           set -eux
           sudo apt-get update
@@ -170,37 +104,29 @@ jobs:
             clang-18 libclang-18-dev zlib1g-dev
 
       - name: Install cargo-nextest
+        # Prebuilt binary — installs in seconds.
         uses: taiki-e/install-action@nextest
 
-      - name: Download nextest archive
-        uses: actions/download-artifact@v4
-        with:
-          name: nextest-archive
-
-      - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: runtime-artifacts
-          path: target/release
+      - name: cargo build --release --workspace
+        # Build ALL workspace members first so `libhale_ts_shim.a`
+        # lands at `target/release/` before any test links against
+        # it. `hale-cli` / `hale-codegen` tests invoke clang to link
+        # compiled .hl fixtures — codegen appends the staticlib by
+        # path-probe (no cargo dep edge forces it), so going straight
+        # to `cargo test` misses it (`undefined reference to
+        # lotus_ts_*`).
+        run: cargo build --release --workspace
 
       - name: cargo nextest run (partition ${{ matrix.partition }}/4)
-        # `hash:I/N` deterministically partitions by test name —
-        # same test always lands on the same partition across
-        # runs, so a flake is reproducible to its partition.
-        #
-        # `--extract-to .` unpacks the archive into the workspace
-        # root (target/release/ etc.) rather than nextest's default
-        # temp dir, so `CARGO_BIN_EXE_hale` (baked at compile
-        # time to the workspace's target/release/hale path)
-        # resolves on the test runner. `--extract-overwrite`
-        # allows the staticlib downloaded by the previous step at
-        # target/release/ to be replaced or preserved during
-        # extraction without aborting.
+        # Build-and-run in one job (no separate archive job + upload/
+        # download round-trip): nextest compiles the test binaries
+        # reusing the build above + the cache, then runs this
+        # partition's subset. `hash:I/N` partitions by test name — a
+        # test always lands on the same partition, so a flake is
+        # reproducible to its partition.
         run: |
           cargo nextest run \
-            --archive-file tests.tar.zst \
-            --extract-to . \
-            --extract-overwrite \
+            --release --workspace \
             --partition hash:${{ matrix.partition }}/4
 
   # 2026-05-26 — TSAN regression coverage for the lockfree


### PR DESCRIPTION
Cuts test-phase wall-clock by removing the serial `build + archive` → `test` handoff.

## The problem (from the job step timings)
The `build + archive` job's ~6.5min was mostly **not** compile:
- setup (disk/rust/cache/LLVM): ~2 min
- `cargo build --workspace` ~50s + `nextest archive` (compile test bins) ~2 min
- **archive upload: ~1:43** (pure handoff)

…and each `test` partition (`needs: build`) then paid its **own ~2 min setup + archive download** before a single test ran. Critical path: `build-setup → compile → upload → [test-setup → download → run] ≈ 12 min`.

## The change
Fold the build into each partition. Every `test` job now: restores the shared cargo cache → `cargo build --release --workspace` (staticlib in place) → `cargo nextest run --partition hash:I/4` (compiles test bins + runs its subset). No separate job, **no archive upload/download round-trip, no duplicated post-build setup**. The compile overlaps the already-parallel partitions; building in place means `CARGO_BIN_EXE_hale` resolves without the archive's `--extract-to` dance.

Expected: **~3–4 min wall-clock off**, and **fewer concurrent jobs** (the build job is gone: `test×4 + tsan + asan + genmc`).

## Tradeoff
Compiles ~Nx instead of once — the shared cargo cache keeps each warm build ~3 min (all four restore the same key; one wins the save). Wall-clock over CI-minutes, consistent with the existing partition design's stated bias toward branch-iteration velocity.

`asan` / `tsan` / `genmc` are independent and unchanged. This PR's own CI dogfoods the new shape — compare the `test N/4` durations against the prior runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)