### PR TITLE
tests: fix bytes_pack_read parallel-build-path flake (#67 follow-up)

### DIFF
--- a/crates/hale-codegen/tests/bytes_pack_read.rs
+++ b/crates/hale-codegen/tests/bytes_pack_read.rs
@@ -15,7 +15,20 @@ use hale_codegen::build_executable;
 fn build_and_run(name: &str, src: &str) -> String {
     let program = hale_syntax::parse_source(src).expect("parse");
     let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_bytes_pack_{}_{}", name, std::process::id()));
+    // Salt the temp path with a process-wide counter in addition to
+    // name + pid: pid disambiguates across test *binaries*, but nextest
+    // runs tests within one binary in parallel threads, so two tests
+    // sharing a `name` would otherwise compile/exec the same path and
+    // clobber each other (a nondeterministic flake — same class as the
+    // #64 runtime-object race). The counter makes every call unique.
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    bin.push(format!(
+        "hale_bytes_pack_{}_{}_{}",
+        name,
+        std::process::id(),
+        seq
+    ));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -109,7 +122,7 @@ fn main() {
     println("ok=", to_string(std::bytes::read_u16_le(b, 4) or raise));
 }
 "#;
-    let out = build_and_run("oob", src);
+    let out = build_and_run("oob_fields", src);
     assert!(
         out.contains("kind=out_of_bounds") && out.contains("index=4") && out.contains("len=6"),
         "expected IndexError fields on OOB; got {:?}",
@@ -144,7 +157,7 @@ fn main() {
     println("boundok=", to_string(std::bytes::read_u16_le(b, 4) or -1));
 }
 "#;
-    let out = build_and_run("oob", src);
+    let out = build_and_run("oob_overflow", src);
     let lines: Vec<&str> = out.lines().collect();
     assert!(lines.contains(&"max=-1"),
         "off==i64::MAX must hit IndexError (the overflow case), not OOB-read; got {:?}", out);

--- a/crates/hale-codegen/tests/fstring_interpolation.rs
+++ b/crates/hale-codegen/tests/fstring_interpolation.rs
@@ -14,7 +14,17 @@ use hale_codegen::build_executable;
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
     let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_fstring_{}", name));
+    // Salt with pid + a process-wide counter so two tests can never
+    // share a temp-build path under nextest's parallel execution
+    // (the bytes_pack_read flake class).
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    bin.push(format!(
+        "hale_test_fstring_{}_{}_{}",
+        name,
+        std::process::id(),
+        seq
+    ));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/math_nan_inf.rs
+++ b/crates/hale-codegen/tests/math_nan_inf.rs
@@ -18,7 +18,17 @@ use hale_codegen::build_executable;
 fn build_and_run(name: &str, source: &str) -> std::process::Output {
     let program = hale_syntax::parse_source(source).expect("parse");
     let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_math_nan_inf_{}", name));
+    // Salt with pid + a process-wide counter so two tests can never
+    // share a temp-build path under nextest's parallel execution
+    // (the bytes_pack_read flake class).
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    bin.push(format!(
+        "lotus_test_math_nan_inf_{}_{}_{}",
+        name,
+        std::process::id(),
+        seq
+    ));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/shm_ring_layout.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout.rs
@@ -31,7 +31,18 @@ fn build_driver(tag: &str) -> PathBuf {
     ring_c.push("lotus_shm_ring.c");
 
     let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_shm_ring_layout_driver_{}", tag));
+    // Salt with pid + a process-wide counter so two tests can never
+    // share a driver-binary path under nextest's parallel execution
+    // (the bytes_pack_read flake class). The SHM object names are
+    // already unique via unique_shm_name.
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    bin.push(format!(
+        "lotus_shm_ring_layout_driver_{}_{}_{}",
+        tag,
+        std::process::id(),
+        seq
+    ));
     let mut cmd = Command::new("clang");
     cmd.arg(&driver_c).arg(&ring_c);
     // Honor the same sanitizer env flags as the codegen build, so the

--- a/crates/hale-codegen/tests/stdlib_tagged.rs
+++ b/crates/hale-codegen/tests/stdlib_tagged.rs
@@ -12,7 +12,17 @@ use hale_codegen::build_executable;
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
     let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stdlib_tagged_{}", name));
+    // Salt with pid + a process-wide counter so two tests can never
+    // share a temp-build path under nextest's parallel execution
+    // (the bytes_pack_read flake class).
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    bin.push(format!(
+        "hale_test_stdlib_tagged_{}_{}_{}",
+        name,
+        std::process::id(),
+        seq
+    ));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);


### PR DESCRIPTION
`cargo test -p hale-codegen --test bytes_pack_read` failed nondeterministically under nextest's parallel execution (a different OOB test failed each run — 2/2, then 3/1, …), while `--test-threads=1` was clean 4/4. This would flake the #68 UBSan/asan gate, which runs exactly these suites.

## Root cause — shared temp-build path, not a logic bug
The two OOB tests both called `build_and_run("oob", ...)` with the same constant tag, and `build_and_run` derived its temp binary path as `hale_bytes_pack_{name}_{pid}`. `pid` disambiguates across test *binaries* but not across tests within one binary, so both `"oob"` tests compiled / overwrote / exec'd the identical file concurrently and clobbered each other. Same class as the #64 runtime-object race. The OOB fixes from #67 are correct — they pass serially and the source guards are right; this was purely a fixture race.

## Fix
1. **Distinct tags**: `"oob_fields"` (the IndexError-fields test) and `"oob_overflow"` (the INT64_MAX-offset test).
2. **Belt-and-suspenders**: salt every `build_and_run` temp path with a process-wide `AtomicU64` counter (+ `pid`), so two tests sharing a tag can never collide. Applied the same salt to the other per-test build helpers flagged in the audit — `math_nan_inf`, `stdlib_tagged`, `fstring_interpolation` (all had unique tags but **no pid**), and `shm_ring_layout`'s `build_driver` — so the class can't recur. (`shm_ring_layout_producer` / `shm_ring_layout_codegen` already salted with pid+nanos.)

## Verified
- `bytes_pack_read` **10/10 green in parallel** (no `--test-threads=1`).
- The #68 UBSan command (`bytes_pack_read` + `shm_ring_layout` + `shm_ring_layout_producer` under `LOTUS_UBSAN`) **3/3 green in parallel**.
- All five touched test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)