### PR TITLE
docs: highlight Hale code blocks (register `hale` with highlight.js)

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -12,6 +12,9 @@ no-section-label = false
 site-url = "/hale/"
 git-repository-url = "https://github.com/hale-lang/hale"
 edit-url-template = "https://github.com/hale-lang/hale/edit/main/docs/{path}"
+# Registers the `hale` language with highlight.js (mdbook's bundled
+# build doesn't know it) so ```hale code blocks are highlighted.
+additional-js = ["hale-highlight.js"]
 
 [output.html.fold]
 enable = true

--- a/docs/hale-highlight.js
+++ b/docs/hale-highlight.js
@@ -1,0 +1,90 @@
+// Hale syntax highlighting for the mdbook docs.
+//
+// mdbook ships a fixed highlight.js build that doesn't know `hale`, so
+// the ```hale code blocks rendered as plain text. This registers a
+// `hale` language with the global `hljs` (loaded by mdbook before this
+// additional-js) and re-highlights any already-rendered hale blocks.
+//
+// Keyword set tracks crates/hale-syntax/src/lexer.rs (hard keywords) +
+// the contextual keywords the parser recognizes (topic, ring_layout,
+// bindings, placement, mode, cooperative, pinned, pool, core, approx,
+// within, inline, captures, with, violate, fail). The tree-sitter
+// grammar in pond/heron is the editor-side counterpart.
+(function () {
+  if (typeof hljs === "undefined") return;
+
+  function haleLanguage(hljs) {
+    const KEYWORDS = {
+      keyword:
+        "locus perspective type const fn import export module topic ring_layout " +
+        "params contract bus capacity as_parent_for indexed_by bindings placement mode " +
+        "birth accept run drain dissolve on_failure " +
+        "bulk harmonic resolution projection rich chunked recognition " +
+        "cooperative pinned pool core " +
+        "closure epoch persists_through resets_on resets_per_epoch approx within inline captures " +
+        "restart restart_in_place quarantine reorganize bubble " +
+        "expose consume inferred " +
+        "subscribe publish on of stable_when serialize_as " +
+        "let mut if else match for in while return break continue tier self " +
+        "trait impl interface async await yield terminate release macro where with violate fail",
+      literal: "true false nil",
+      built_in:
+        "Int Float Bool String Bytes BytesView StringView Unit",
+    };
+
+    return {
+      name: "Hale",
+      aliases: ["hl"],
+      keywords: KEYWORDS,
+      contains: [
+        hljs.C_LINE_COMMENT_MODE,
+        hljs.C_BLOCK_COMMENT_MODE,
+        hljs.QUOTE_STRING_MODE,
+        // `@form`, `@locality`, `@ffi` … annotations.
+        { className: "meta", begin: "@\\w+" },
+        // Prefixed-radix + duration literals before the generic number.
+        { className: "number", begin: "\\b0[xXoObB][0-9a-fA-F_]+\\b" },
+        { className: "number", begin: "\\b\\d[\\d_]*(\\.[\\d_]+)?(ns|us|ms|s|m|h)?\\b" },
+        // Capitalized identifiers read as type / locus / topic names.
+        { className: "type", begin: "\\b[A-Z][A-Za-z0-9_]*\\b", relevance: 0 },
+      ],
+    };
+  }
+
+  try {
+    hljs.registerLanguage("hale", haleLanguage);
+  } catch (e) {
+    return;
+  }
+
+  // mdbook's book.js highlights all blocks on DOMContentLoaded. With
+  // `hale` registered synchronously above, that pass highlights hale
+  // blocks natively in most cases. This is the fallback for the case
+  // where book.js's highlight ran *before* this script (so hale blocks
+  // were left plain): re-highlight only blocks that aren't already
+  // highlighted, so we never double-process one book.js handled
+  // (double-highlighting mangles output under hljs 10.x).
+  //
+  // API-agnostic: highlightElement (11.x / 10.7+) or highlightBlock
+  // (10.1, mdbook's current bundle) — so this survives an mdbook bump.
+  var highlightOne = hljs.highlightElement
+    ? function (el) { hljs.highlightElement(el); }
+    : function (el) { hljs.highlightBlock(el); };
+
+  function rehighlight() {
+    document.querySelectorAll("code.language-hale").forEach(function (el) {
+      // Already highlighted (by book.js, after our registration)?
+      // hljs emits child spans with `hljs-*` classes — leave it alone.
+      if (el.querySelector("[class^='hljs-'], [class*=' hljs-']")) return;
+      el.classList.remove("hljs");
+      if (el.dataset) delete el.dataset.highlighted;
+      highlightOne(el);
+    });
+  }
+  if (document.readyState === "loading") {
+    // Registered after book.js's listener, so this runs after its pass.
+    document.addEventListener("DOMContentLoaded", rehighlight);
+  } else {
+    rehighlight();
+  }
+})();


### PR DESCRIPTION
The docs site rendered all ```hale code blocks as plain text: mdbook's bundled highlight.js has no `hale` language. This adds one (`docs/hale-highlight.js`, wired via `book.toml` `additional-js`) and registers it with the global `hljs`.

## Coverage
Keyword set tracks `crates/hale-syntax/src/lexer.rs` (hard keywords) + the contextual keywords the parser recognizes (`topic`, `ring_layout`, `bindings`, `placement`, `mode`, `cooperative`/`pinned`/`pool`/`core`, `approx`/`within`/`inline`/`captures`, `with`, `violate`, `fail`). Comments, strings, prefixed-radix + duration numbers, `@`-annotations, and Capitalized type/locus names also highlight. The editor-side counterpart is the tree-sitter grammar in `pond/heron` (updated in lockstep for `ring_layout` + the new kwargs).

## Robustness
- **Registers synchronously**, so mdbook's `book.js` DOMContentLoaded highlight pass picks up `hale` natively.
- **Fallback re-highlight** only touches blocks not already processed (a span-guard) — so it can't double-highlight, which mangles output under hljs 10.x (mdbook's current bundle).
- **Feature-detects** `highlightElement` (11.x) vs `highlightBlock` (10.x), so it survives an mdbook/hljs bump (CI installs latest mdbook).

## Validation
Loaded mdbook's actual `highlight.js` bundle + this registration in Node: `locus` / `let` / `ring_layout` → `hljs-keyword` spans, numbers → `hljs-number`, Capitalized names → `hljs-type`. mdbook build is clean; the asset is copied + loaded after highlight.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)