### PR TITLE
syntax: single source for the keyword list; generate the highlighters

### DIFF
--- a/crates/hale-syntax/src/keywords.rs
+++ b/crates/hale-syntax/src/keywords.rs
@@ -1,0 +1,71 @@
+//! Canonical Hale keyword lists — the single source of truth for tooling
+//! that needs to know "what's a keyword": syntax highlighters (the docs
+//! site `docs/hale-highlight.js`, the README SVG generator
+//! `tools/hale_svg.py`) and the `pond/heron` tree-sitter grammar.
+//!
+//! Hale has two kinds of keyword, stored differently in the compiler:
+//!
+//!   - **hard** — reserved in the lexer ([`crate::lexer`]); each lexes to
+//!     its own `TokenKind`, never `Ident`.
+//!   - **contextual** — lexed as an identifier and recognized by the
+//!     parser only in position, which frees the word for ordinary
+//!     identifier use elsewhere (e.g. `topic`, `shm_ring`, `mode`).
+//!
+//! Highlighters want the union ([`all`]). Literals (`true`/`false`/`nil`)
+//! and primitive type names are coloured separately and aren't listed.
+//!
+//! `tests/keyword_sync.rs` keeps this honest: it verifies every
+//! [`HARD_KEYWORDS`] entry really lexes to a non-`Ident` token and every
+//! [`CONTEXTUAL_KEYWORDS`] entry lexes to `Ident`, and it regenerates the
+//! highlighter keyword blocks from [`all`] (run with `UPDATE_KEYWORDS=1`
+//! to bless). Add a keyword here and the test points at what's stale.
+
+/// Reserved keywords — each lexes to its own `TokenKind` (never `Ident`).
+/// Mirrors the match in `lexer.rs` (minus the `true`/`false`/`nil`
+/// literals, which highlighters colour as literals, not keywords).
+pub const HARD_KEYWORDS: &[&str] = &[
+    "locus", "perspective", "type", "const", "fn", "import", "export", "module",
+    "params", "contract", "bus", "capacity", "as_parent_for", "indexed_by",
+    "birth", "accept", "run", "drain", "dissolve", "on_failure",
+    "bulk", "harmonic", "resolution",
+    "projection", "rich", "chunked", "recognition",
+    "closure", "epoch", "persists_through", "resets_on", "resets_per_epoch",
+    "restart", "restart_in_place", "quarantine", "reorganize", "bubble",
+    "expose", "consume", "inferred",
+    "subscribe", "publish", "on", "of",
+    "stable_when", "serialize_as",
+    "let", "mut", "if", "else", "match", "for", "in", "while",
+    "return", "break", "continue", "tier", "self",
+    "trait", "impl", "interface", "async", "await", "yield",
+    "terminate", "release", "macro", "where",
+];
+
+/// Contextual keywords — lexed as `Ident`, coloured as keywords (matching
+/// `pond/heron`). Recognized by the parser in position; the parser still
+/// matches the strings inline, so this list is for tooling, not parsing.
+pub const CONTEXTUAL_KEYWORDS: &[&str] = &[
+    "topic", "ring_layout", "as", "main",
+    "mode", "bindings", "birth_check", "placement",
+    "cooperative", "pinned", "pool", "core", "heap",
+    "schedule", "fixed_cell", "shared_slab", "spillover", "summary_only", "cap",
+    "payload", "subject",
+    "captures", "inline", "tick", "duration", "explicit", "approx", "within",
+    "with", "violate", "fail", "until",
+    "sum", "prod", "or", "fallible",
+    "unix", "shm_ring", "role", "listen", "connect", "slot_count",
+    "on_overflow", "block", "drop",
+    "intra_process", "intra_machine", "cross_machine", "zero_copy",
+];
+
+/// The union of [`HARD_KEYWORDS`] and [`CONTEXTUAL_KEYWORDS`], sorted and
+/// deduped — exactly what a syntax highlighter colours as a keyword.
+pub fn all() -> Vec<&'static str> {
+    let mut v: Vec<&'static str> = HARD_KEYWORDS
+        .iter()
+        .chain(CONTEXTUAL_KEYWORDS.iter())
+        .copied()
+        .collect();
+    v.sort_unstable();
+    v.dedup();
+    v
+}

--- a/crates/hale-syntax/src/lib.rs
+++ b/crates/hale-syntax/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod ast;
 pub mod desugar;
 pub mod error;
+pub mod keywords;
 pub mod lexer;
 pub mod parser;
 pub mod span;

--- a/crates/hale-syntax/tests/keyword_sync.rs
+++ b/crates/hale-syntax/tests/keyword_sync.rs
@@ -1,0 +1,103 @@
+//! Keeps the canonical keyword list (`hale_syntax::keywords`) honest and
+//! the downstream syntax highlighters generated from it.
+//!
+//!   1. `keyword_lists_match_the_lexer` — every `HARD_KEYWORDS` entry
+//!      really lexes to its own token (never `Ident`), and every
+//!      `CONTEXTUAL_KEYWORDS` entry lexes to `Ident` (so it's free as an
+//!      identifier and recognized by the parser in position). This ties
+//!      the list to the real lexer; misclassify one and this fails.
+//!
+//!   2. `highlighter_keyword_blocks_are_in_sync` — the `keyword` block in
+//!      `docs/hale-highlight.js` and the `KEYWORDS` set in
+//!      `tools/hale_svg.py` are generated from `keywords::all()`. Run with
+//!      `UPDATE_KEYWORDS=1` to regenerate (bless); otherwise it asserts
+//!      they're current, so a new keyword can't silently drift the docs
+//!      site or the README SVGs out of date.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use hale_syntax::keywords;
+use hale_syntax::lexer::{lex, TokenKind};
+
+#[test]
+fn keyword_lists_match_the_lexer() {
+    for kw in keywords::HARD_KEYWORDS {
+        let toks = lex(kw).unwrap_or_else(|e| panic!("lex `{kw}`: {e:?}"));
+        assert!(
+            !matches!(toks[0].kind, TokenKind::Ident(_)),
+            "HARD keyword `{kw}` lexes to an identifier — it isn't reserved \
+             in the lexer. Move it to CONTEXTUAL_KEYWORDS (or add it to the \
+             lexer)."
+        );
+    }
+    for kw in keywords::CONTEXTUAL_KEYWORDS {
+        let toks = lex(kw).unwrap_or_else(|e| panic!("lex `{kw}`: {e:?}"));
+        assert!(
+            matches!(toks[0].kind, TokenKind::Ident(_)),
+            "CONTEXTUAL keyword `{kw}` lexes to {:?}, not Ident — it's \
+             reserved in the lexer, so move it to HARD_KEYWORDS.",
+            toks[0].kind
+        );
+    }
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/hale-syntax -> repo root")
+        .to_path_buf()
+}
+
+/// The text strictly between the begin-marker line and the end-marker line.
+fn region_body<'a>(content: &'a str, begin: &str, end: &str) -> &'a str {
+    let bp = content
+        .find(begin)
+        .unwrap_or_else(|| panic!("begin marker not found: {begin}"));
+    let after = bp + content[bp..].find('\n').expect("newline after begin") + 1;
+    let ep = after
+        + content[after..]
+            .find(end)
+            .unwrap_or_else(|| panic!("end marker not found: {end}"));
+    &content[after..ep]
+}
+
+#[test]
+fn highlighter_keyword_blocks_are_in_sync() {
+    let kw = keywords::all().join(" ");
+    let root = repo_root();
+    let bless = std::env::var_os("UPDATE_KEYWORDS").is_some();
+
+    let targets = [
+        (
+            root.join("docs/hale-highlight.js"),
+            "      // BEGIN GENERATED KEYWORDS",
+            "      // END GENERATED KEYWORDS",
+            format!("      keyword:\n        \"{kw}\",\n"),
+        ),
+        (
+            root.join("tools/hale_svg.py"),
+            "# BEGIN GENERATED KEYWORDS",
+            "# END GENERATED KEYWORDS",
+            format!("KEYWORDS = set(\n    \"{kw}\".split()\n)\n"),
+        ),
+    ];
+
+    for (path, begin, end, want) in targets {
+        let content = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        let have = region_body(&content, begin, end);
+        if have == want {
+            continue;
+        }
+        assert!(
+            bless,
+            "{} keyword block is stale.\n--- generated ---\n{want}\n--- in file ---\n{have}\n\
+             Run `UPDATE_KEYWORDS=1 cargo test -p hale-syntax --test keyword_sync` to regenerate.",
+            path.display()
+        );
+        let updated = content.replacen(have, &want, 1);
+        fs::write(&path, updated).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+    }
+}

--- a/docs/hale-highlight.js
+++ b/docs/hale-highlight.js
@@ -5,33 +5,19 @@
 // `hale` language with the global `hljs` (loaded by mdbook before this
 // additional-js) and re-highlights any already-rendered hale blocks.
 //
-// Keyword set mirrors pond/heron/queries/highlights.scm (the most
-// complete source) — declaration, member, lifecycle, bus, capacity,
-// closure, transport/binding (unix, shm_ring, where, zero_copy,
-// intra_machine, on_overflow, …), statement, and recovery keywords —
-// and tools/hale_svg.py; keep the three in sync.
+// The `keyword` list below is GENERATED from the compiler's canonical
+// keyword set (crates/hale-syntax/src/keywords.rs) — do not edit it by
+// hand. `cargo test -p hale-syntax --test keyword_sync` fails if it
+// drifts; run that with UPDATE_KEYWORDS=1 to regenerate.
 (function () {
   if (typeof hljs === "undefined") return;
 
   function haleLanguage(hljs) {
     const KEYWORDS = {
+      // BEGIN GENERATED KEYWORDS — regen: `cargo test -p hale-syntax --test keyword_sync` (UPDATE_KEYWORDS=1 to bless). Source: crates/hale-syntax/src/keywords.rs.
       keyword:
-        "locus perspective interface module topic ring_layout type const fn import export as main " +
-        "tier projection schedule rich chunked recognition fixed_cell shared_slab spillover " +
-        "summary_only cooperative pinned cap core mode " +
-        "params contract bus capacity bindings placement indexed_by as_parent_for " +
-        "birth accept run drain dissolve on_failure bulk harmonic resolution birth_check " +
-        "expose consume inferred " +
-        "subscribe publish of payload subject stable_when serialize_as " +
-        "pool heap " +
-        "closure epoch persists_through resets_on resets_per_epoch captures inline tick " +
-        "duration explicit approx within " +
-        "unix shm_ring where role listen connect slot_count on_overflow block drop " +
-        "intra_process intra_machine cross_machine zero_copy " +
-        "let mut if else match for in while return break continue self yield sum prod " +
-        "restart restart_in_place quarantine reorganize bubble violate with until " +
-        "fallible fail or terminate release " +
-        "trait impl async await macro",
+        "accept approx as as_parent_for async await bindings birth birth_check block break bubble bulk bus cap capacity captures chunked closure connect const consume continue contract cooperative core cross_machine dissolve drain drop duration else epoch explicit export expose fail fallible fixed_cell fn for harmonic heap if impl import in indexed_by inferred inline interface intra_machine intra_process let listen locus macro main match mode module mut of on on_failure on_overflow or params payload persists_through perspective pinned placement pool prod projection publish quarantine recognition release reorganize resets_on resets_per_epoch resolution restart restart_in_place return rich ring_layout role run schedule self serialize_as shared_slab shm_ring slot_count spillover stable_when subject subscribe sum summary_only terminate tick tier topic trait type unix until violate where while with within yield zero_copy",
+      // END GENERATED KEYWORDS
       literal: "true false nil",
       built_in:
         "Int Float Bool String Bytes BytesView StringView Unit",

--- a/tools/hale_svg.py
+++ b/tools/hale_svg.py
@@ -18,26 +18,13 @@ import html
 import re
 import sys
 
-# Keyword set — mirrors pond/heron/queries/highlights.scm (the most
-# complete source) and docs/hale-highlight.js; keep the three in sync.
+# Keyword set — generated from the compiler's canonical list, not edited
+# by hand. Source: crates/hale-syntax/src/keywords.rs.
+# BEGIN GENERATED KEYWORDS — regen: `cargo test -p hale-syntax --test keyword_sync` (UPDATE_KEYWORDS=1 to bless).
 KEYWORDS = set(
-    "locus perspective interface module topic ring_layout type const fn import export as main "
-    "tier projection schedule rich chunked recognition fixed_cell shared_slab spillover "
-    "summary_only cooperative pinned cap core mode "
-    "params contract bus capacity bindings placement indexed_by as_parent_for "
-    "birth accept run drain dissolve on_failure bulk harmonic resolution birth_check "
-    "expose consume inferred "
-    "subscribe publish of payload subject stable_when serialize_as "
-    "pool heap "
-    "closure epoch persists_through resets_on resets_per_epoch captures inline tick "
-    "duration explicit approx within "
-    "unix shm_ring where role listen connect slot_count on_overflow block drop "
-    "intra_process intra_machine cross_machine zero_copy "
-    "let mut if else match for in while return break continue self yield sum prod "
-    "restart restart_in_place quarantine reorganize bubble violate with until "
-    "fallible fail or terminate release "
-    "trait impl async await macro".split()
+    "accept approx as as_parent_for async await bindings birth birth_check block break bubble bulk bus cap capacity captures chunked closure connect const consume continue contract cooperative core cross_machine dissolve drain drop duration else epoch explicit export expose fail fallible fixed_cell fn for harmonic heap if impl import in indexed_by inferred inline interface intra_machine intra_process let listen locus macro main match mode module mut of on on_failure on_overflow or params payload persists_through perspective pinned placement pool prod projection publish quarantine recognition release reorganize resets_on resets_per_epoch resolution restart restart_in_place return rich ring_layout role run schedule self serialize_as shared_slab shm_ring slot_count spillover stable_when subject subscribe sum summary_only terminate tick tier topic trait type unix until violate where while with within yield zero_copy".split()
 )
+# END GENERATED KEYWORDS
 LITERALS = {"true", "false", "nil"}
 
 # GitHub-dark theme (renders well over the SVG's own dark background on


### PR DESCRIPTION
The Hale keyword list was hand-duplicated across the lexer, the docs highlighter (`docs/hale-highlight.js`), and the README SVG generator (`tools/hale_svg.py`), kept in sync only by comments — and had already drifted (the docs JS was missing `main`/`unix`/`shm_ring`/`zero_copy`/… and carried a bogus bare `on`). This is the single-source follow-up.

## Single source of truth
- **`crates/hale-syntax/src/keywords.rs`** — canonical `HARD_KEYWORDS` (reserved in the lexer) + `CONTEXTUAL_KEYWORDS` (lexed as `Ident`, recognized by the parser in position) + `all()` (the sorted union highlighters colour).

## Generated + guarded
- **`tests/keyword_sync.rs`**:
  1. **Ties the list to the real lexer** — asserts every `HARD` entry lexes to a non-`Ident` token and every `CONTEXTUAL` entry lexes to `Ident`. Misclassify one and it fails.
  2. **Generates** the `keyword` block in `hale-highlight.js` and the `KEYWORDS` set in `hale_svg.py` from `all()`, between `BEGIN/END GENERATED KEYWORDS` markers. Default run asserts they're current; `UPDATE_KEYWORDS=1` regenerates (bless).

It runs in the normal `cargo test`, so **drift fails CI with no new job** — a new keyword can't silently leave the docs site or README SVGs behind.

## Bonus
Grounding in the lexer **auto-corrected my earlier mistake**: `on` and `export` *are* reserved, so they're back in the generated highlighter keyword sets (I'd wrongly dropped `on` two PRs ago).

## Scope
The lexer's `match` (each keyword → its own `TokenKind`) and `pond/heron` (a separate repo) stay as-is; the test guards the two in-repo highlighter copies. Driving the lexer match or heron from this list too would be a larger refactor — noted, not done here. The README SVGs regenerate byte-identical (the snippets don't contain `on`/`export`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)