### PR TITLE
cli+syntax: name the right file + line in multi-file diagnostics

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -379,6 +379,10 @@ fn resolve_imports(
     workspace_root: Option<&Path>,
     visited: &mut std::collections::BTreeSet<PathBuf>,
     sources: &mut BTreeMap<PathBuf, String>,
+    // Per-file (virtual base offset, canonical path, byte length). Each
+    // file is parsed at a distinct base so merged spans are globally
+    // unique and a diagnostic can be demultiplexed back to its file.
+    file_bases: &mut Vec<(u32, PathBuf, u32)>,
     errors: &mut Vec<(PathBuf, hale_syntax::Diag, String)>,
     merged_items: &mut Vec<hale_syntax::ast::TopDecl>,
     renames: &mut ImportRenames,
@@ -492,7 +496,12 @@ fn resolve_imports(
             if trace {
                 eprintln!("[import]     parse start: {}", file.display());
             }
-            let program = match hale_syntax::parse_source(&source) {
+            let base = file_bases
+                .last()
+                .map(|(b, _, l)| b + l + 1)
+                .unwrap_or(0);
+            file_bases.push((base, canon.clone(), source.len() as u32));
+            let program = match hale_syntax::parse_source_at(&source, base) {
                 Ok(p) => p,
                 Err(diags) => {
                     for d in diags {
@@ -604,6 +613,7 @@ fn resolve_imports(
                 workspace_root,
                 visited,
                 sources,
+                file_bases,
                 errors,
                 merged_items,
                 renames,
@@ -642,7 +652,13 @@ pub struct EntryCtx {
 fn parse_with_imports(
     entry: &Path,
 ) -> Result<
-    (Program, ImportRenames, BTreeMap<PathBuf, String>, EntryCtx),
+    (
+        Program,
+        ImportRenames,
+        BTreeMap<PathBuf, String>,
+        Vec<(u32, PathBuf, u32)>,
+        EntryCtx,
+    ),
     Vec<(PathBuf, hale_syntax::Diag, String)>,
 > {
     let mut sources: BTreeMap<PathBuf, String> = BTreeMap::new();
@@ -674,6 +690,10 @@ fn parse_with_imports(
         }
     };
     visited.insert(entry_canon.clone());
+    // The entry file occupies base 0 (parse_source above = no shift);
+    // imported files get subsequent virtual bases in resolve_imports.
+    let mut file_bases: Vec<(u32, PathBuf, u32)> =
+        vec![(0, entry_canon.clone(), entry_source.len() as u32)];
     sources.insert(entry_canon, entry_source);
 
     let entry_imports = entry_program.imports.clone();
@@ -686,6 +706,7 @@ fn parse_with_imports(
         workspace_root.as_deref(),
         &mut visited,
         &mut sources,
+        &mut file_bases,
         &mut errors,
         &mut merged_items,
         &mut renames,
@@ -718,15 +739,47 @@ fn parse_with_imports(
         workspace_root,
         imports: entry_imports,
     };
-    Ok((merged, renames, sources, ctx))
+    Ok((merged, renames, sources, file_bases, ctx))
 }
 
 
+/// Render a post-merge diagnostic, demultiplexing its (globally-unique,
+/// `parse_source_at`-shifted) span back to the file it came from via
+/// `file_bases`, so the output reads `path:line:col` against that file's
+/// own source instead of an arbitrary file. Falls back to the entry
+/// source if the span isn't in any known file range.
+fn render_located(
+    d: &hale_syntax::Diag,
+    file_bases: &[(u32, PathBuf, u32)],
+    sources: &BTreeMap<PathBuf, String>,
+) -> String {
+    let off = d.span.start.as_usize() as u32;
+    for (base, path, len) in file_bases {
+        if off >= *base && off < base.saturating_add(*len) {
+            if let Some(src) = sources.get(path) {
+                return d.render_located(&path.display().to_string(), src, *base);
+            }
+        }
+    }
+    let any = sources.values().next().map(|s| s.as_str()).unwrap_or("");
+    d.render(any)
+}
+
 fn parse_files(
     files: &[PathBuf],
-) -> Result<(BTreeMap<PathBuf, Program>, BTreeMap<PathBuf, String>), ExitCode> {
+) -> Result<
+    (
+        BTreeMap<PathBuf, Program>,
+        BTreeMap<PathBuf, String>,
+        Vec<(u32, PathBuf, u32)>,
+    ),
+    ExitCode,
+> {
     let mut programs: BTreeMap<PathBuf, Program> = BTreeMap::new();
     let mut sources: BTreeMap<PathBuf, String> = BTreeMap::new();
+    // (virtual base, path, len) — each file parsed at a distinct base so
+    // merged spans demultiplex back to their file (see parse_source_at).
+    let mut file_bases: Vec<(u32, PathBuf, u32)> = Vec::new();
     let mut had_error = false;
     for f in files {
         let source = match fs::read_to_string(f) {
@@ -737,15 +790,16 @@ fn parse_files(
                 continue;
             }
         };
-        match hale_syntax::parse_source(&source) {
+        let base = file_bases.last().map(|(b, _, l)| b + l + 1).unwrap_or(0);
+        file_bases.push((base, f.clone(), source.len() as u32));
+        match hale_syntax::parse_source_at(&source, base) {
             Ok(p) => {
                 programs.insert(f.clone(), p);
                 sources.insert(f.clone(), source);
             }
             Err(diags) => {
-                eprintln!("{}:", f.display());
                 for d in &diags {
-                    eprintln!("  {}", d.render(&source));
+                    eprintln!("{}", d.render_located(&f.display().to_string(), &source, base));
                 }
                 had_error = true;
             }
@@ -754,7 +808,7 @@ fn parse_files(
     if had_error {
         return Err(ExitCode::from(1));
     }
-    Ok((programs, sources))
+    Ok((programs, sources, file_bases))
 }
 
 fn run_check(target: &Path) -> ExitCode {
@@ -765,7 +819,7 @@ fn run_check(target: &Path) -> ExitCode {
             return ExitCode::from(1);
         }
     };
-    let (mut programs, sources) = match parse_files(&files) {
+    let (mut programs, sources, file_bases) = match parse_files(&files) {
         Ok(x) => x,
         Err(code) => return code,
     };
@@ -797,9 +851,8 @@ fn run_check(target: &Path) -> ExitCode {
         std::env::args().any(|a| a == "--allow-unowned-subscriber");
     let diags = hale_types::check_bundle_opts(&bundle, allow_unowned);
     if !diags.is_empty() {
-        let any_source = sources.values().next().map(|s| s.as_str()).unwrap_or("");
         for d in &diags {
-            eprintln!("{}", d.render(any_source));
+            eprintln!("{}", render_located(d, &file_bases, &sources));
         }
         // Warnings print but don't fail the build; only errors do.
         if diags.iter().any(|d| d.is_error()) {
@@ -855,7 +908,7 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         // per the known limitation). Cross-seed imports through
         // `hale run` will likewise fail on `alias::Name` paths;
         // use `hale build` for programs with imports.
-        let (program, renames, sources, _ctx) = match parse_with_imports(target) {
+        let (program, renames, sources, file_bases, _ctx) = match parse_with_imports(target) {
             Ok(x) => x,
             Err(errors) => {
                 for (path, d, src) in &errors {
@@ -872,9 +925,8 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
             std::env::args().any(|a| a == "--allow-unowned-subscriber");
         let diags = hale_types::check_bundle_opts(&bundle, allow_unowned);
         if !diags.is_empty() {
-            let any_source = sources.values().next().map(|s| s.as_str()).unwrap_or("");
             for d in &diags {
-                eprintln!("{}", d.render(any_source));
+                eprintln!("{}", render_located(d, &file_bases, &sources));
             }
             // Warnings print but don't fail the build; only errors do.
             if diags.iter().any(|d| d.is_error()) {
@@ -891,7 +943,7 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
             return ExitCode::from(1);
         }
     };
-    let (programs, sources) = match parse_files(&files) {
+    let (programs, sources, file_bases) = match parse_files(&files) {
         Ok(x) => x,
         Err(code) => return code,
     };
@@ -907,9 +959,8 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         std::env::args().any(|a| a == "--allow-unowned-subscriber");
     let diags = hale_types::check_bundle_opts(&bundle, allow_unowned);
     if !diags.is_empty() {
-        let any_source = sources.values().next().map(|s| s.as_str()).unwrap_or("");
         for d in &diags {
-            eprintln!("{}", d.render(any_source));
+            eprintln!("{}", render_located(d, &file_bases, &sources));
         }
         // Warnings print but don't fail the build; only errors do.
         if diags.iter().any(|d| d.is_error()) {
@@ -948,8 +999,8 @@ fn run_build(target: &Path) -> ExitCode {
     // directory shape is the user-facing answer to the
     // single-file-app-monolith friction; the file shape stays for
     // backwards compatibility and for one-off scripts.
-    let (mut program, renames, sources, output, entry_ctx) = if target.is_file() {
-        let (program, renames, sources, ctx) = match parse_with_imports(target) {
+    let (mut program, renames, sources, file_bases, output, entry_ctx) = if target.is_file() {
+        let (program, renames, sources, file_bases, ctx) = match parse_with_imports(target) {
             Ok(x) => x,
             Err(errors) => {
                 for (path, d, src) in &errors {
@@ -961,7 +1012,7 @@ fn run_build(target: &Path) -> ExitCode {
         };
         // hello-world.hl → hello-world
         let output = target.with_extension("");
-        (program, renames, sources, output, ctx)
+        (program, renames, sources, file_bases, output, ctx)
     } else if target.is_dir() {
         let files = match collect_ap_files(target) {
             Ok(f) => f,
@@ -970,7 +1021,7 @@ fn run_build(target: &Path) -> ExitCode {
                 return ExitCode::from(1);
             }
         };
-        let (programs, sources) = match parse_files(&files) {
+        let (programs, sources, mut dir_file_bases) = match parse_files(&files) {
             Ok(x) => x,
             Err(code) => return code,
         };
@@ -1015,6 +1066,7 @@ fn run_build(target: &Path) -> ExitCode {
             workspace_root.as_deref(),
             &mut visited,
             &mut path_sources,
+            &mut dir_file_bases,
             &mut import_errors,
             &mut merged_items,
             &mut renames,
@@ -1067,7 +1119,7 @@ fn run_build(target: &Path) -> ExitCode {
             workspace_root,
             imports: union_imports,
         };
-        (with_imports, renames, path_sources, output, ctx)
+        (with_imports, renames, path_sources, dir_file_bases, output, ctx)
     } else {
         eprintln!("not a file or directory: {}", target.display());
         return ExitCode::from(1);
@@ -1083,9 +1135,8 @@ fn run_build(target: &Path) -> ExitCode {
     // single-pool use are left alone.
     let pre_diags = hale_types::apply_sync_inference(&mut program);
     if !pre_diags.is_empty() {
-        let any_source = sources.values().next().map(|s| s.as_str()).unwrap_or("");
         for d in &pre_diags {
-            eprintln!("{}", d.render(any_source));
+            eprintln!("{}", render_located(d, &file_bases, &sources));
         }
         return ExitCode::from(1);
     }
@@ -1103,9 +1154,8 @@ fn run_build(target: &Path) -> ExitCode {
         std::env::args().any(|a| a == "--allow-unowned-subscriber");
     let diags = hale_types::check_bundle_opts(&bundle, allow_unowned);
     if !diags.is_empty() {
-        let any_source = sources.values().next().map(|s| s.as_str()).unwrap_or("");
         for d in &diags {
-            eprintln!("{}", d.render(any_source));
+            eprintln!("{}", render_located(d, &file_bases, &sources));
         }
         // Warnings print but don't fail the build; only errors do.
         if diags.iter().any(|d| d.is_error()) {

--- a/crates/hale-syntax/src/error.rs
+++ b/crates/hale-syntax/src/error.rs
@@ -60,20 +60,38 @@ impl Diag {
         }
     }
 
+    /// Offset this diagnostic's span by `delta` bytes (see
+    /// `Span::shifted` / `parse_source_at`).
+    pub fn shifted(mut self, delta: u32) -> Self {
+        self.span = self.span.shifted(delta);
+        self
+    }
+
     /// True for diagnostics that should fail a build. Warnings are
     /// printed but non-fatal; everything else is an error.
     pub fn is_error(&self) -> bool {
         !matches!(self.kind, DiagKind::Warn)
     }
 
-    pub fn render(&self, source: &str) -> String {
-        let (line, col) = self.span.line_col(source);
-        let kind = match self.kind {
+    pub fn kind_str(&self) -> &'static str {
+        match self.kind {
             DiagKind::Lex => "lex error",
             DiagKind::Parse => "parse error",
             DiagKind::Type => "type error",
             DiagKind::Warn => "warning",
-        };
-        format!("{}:{}: {}: {}", line, col, kind, self.message)
+        }
+    }
+
+    pub fn render(&self, source: &str) -> String {
+        let (line, col) = self.span.line_col(source);
+        format!("{}:{}: {}: {}", line, col, self.kind_str(), self.message)
+    }
+
+    /// Render as `path:line:col: kind: message`, un-shifting the span by
+    /// the file's virtual `base` (from `parse_source_at`) so the line/col
+    /// are relative to the file's own source — for multi-file builds.
+    pub fn render_located(&self, path: &str, source: &str, base: u32) -> String {
+        let (line, col) = self.span.shifted(base.wrapping_neg()).line_col(source);
+        format!("{}:{}:{}: {}: {}", path, line, col, self.kind_str(), self.message)
     }
 }

--- a/crates/hale-syntax/src/lib.rs
+++ b/crates/hale-syntax/src/lib.rs
@@ -26,3 +26,20 @@ pub fn parse_source(source: &str) -> Result<ast::Program, Vec<Diag>> {
     let tokens = lex(source)?;
     parse(tokens, source)
 }
+
+/// Lex + parse like [`parse_source`], but offset every span (and any
+/// diagnostic span) by `base` bytes. A multi-file build parses each file
+/// at a distinct `base` so the merged program's spans are globally
+/// unique — a diagnostic span can then be demultiplexed back to its
+/// originating file (its `base..base+len` range), giving the right
+/// filename + line instead of rendering an imported span against the
+/// entry file. `base` is a virtual coordinate; no combined source string
+/// is built.
+pub fn parse_source_at(source: &str, base: u32) -> Result<ast::Program, Vec<Diag>> {
+    let mut tokens =
+        lex(source).map_err(|ds| ds.into_iter().map(|d| d.shifted(base)).collect::<Vec<_>>())?;
+    for t in &mut tokens {
+        t.span = t.span.shifted(base);
+    }
+    parse(tokens, source).map_err(|ds| ds.into_iter().map(|d| d.shifted(base)).collect())
+}

--- a/crates/hale-syntax/src/span.rs
+++ b/crates/hale-syntax/src/span.rs
@@ -11,6 +11,13 @@ impl Pos {
     pub fn as_usize(self) -> usize {
         self.0 as usize
     }
+    /// Offset this position by `delta` bytes. Used to relocate a single
+    /// file's spans into a process-wide coordinate space so multi-file
+    /// builds can demultiplex a span back to its originating file (see
+    /// `parse_source_at`).
+    pub fn shifted(self, delta: u32) -> Self {
+        Pos(self.0.wrapping_add(delta))
+    }
 }
 
 /// A half-open byte range [start, end) into the source.
@@ -25,6 +32,14 @@ impl Span {
         Span {
             start: Pos::new(start),
             end: Pos::new(end),
+        }
+    }
+
+    /// Offset both ends by `delta` bytes (see `Pos::shifted`).
+    pub fn shifted(self, delta: u32) -> Span {
+        Span {
+            start: self.start.shifted(delta),
+            end: self.end.shifted(delta),
         }
     }
 

--- a/crates/hale-syntax/tests/parse_source_at.rs
+++ b/crates/hale-syntax/tests/parse_source_at.rs
@@ -1,0 +1,35 @@
+//! Multi-file diagnostic locations: `parse_source_at` shifts a file's
+//! spans into a process-wide coordinate space so a merged build can
+//! demultiplex a diagnostic back to its originating file, and
+//! `Diag::render_located` un-shifts it to the file's own line/col.
+//! Regression for the "317:1, no filename" mislocation that mis-reported
+//! errors from imported files against the entry file.
+
+use hale_syntax::{parse_source, parse_source_at, Diag};
+
+#[test]
+fn parse_source_at_shifts_spans_by_base() {
+    let src = "fn main() {\n    foo();\n}\n";
+    let base = 5000u32;
+    let p0 = parse_source(src).expect("parse");
+    let pb = parse_source_at(src, base).expect("parse at base");
+    assert_eq!(p0.items.len(), pb.items.len());
+    let s0 = p0.items[0].span();
+    let sb = pb.items[0].span();
+    // Identical structure, every span offset by exactly `base`.
+    assert_eq!(sb.start.as_usize(), s0.start.as_usize() + base as usize);
+    assert_eq!(sb.end.as_usize(), s0.end.as_usize() + base as usize);
+}
+
+#[test]
+fn render_located_unshifts_to_file_line_col() {
+    let src = "fn main() {\n    foo();\n}\n";
+    let base = 5000u32;
+    let pb = parse_source_at(src, base).expect("parse at base");
+    let span = pb.items[0].span(); // shifted span, as it'd appear post-merge
+    let d = Diag::ty(span, "boom");
+    // Demux: rendering against the file's own source + base recovers the
+    // real location (line 1 — `fn main` is the first line).
+    let out = d.render_located("lib/foo.hl", src, base);
+    assert_eq!(out, "lib/foo.hl:1:1: type error: boom");
+}


### PR DESCRIPTION
## The bug (reported by the fathom session)
A `hale build <dir>` (or file-with-imports) merges every file's items into one program, but each file's spans are byte offsets into its **own** source. Diagnostics were rendered against an arbitrary `sources.values().next()` source, so an error in an **imported** file printed a bogus line with **no filename** — fathom saw `317:1` for an error that was really at `apps/mdgw/bybit/main.hl:322`, and lost hours localizing it by diffing gateways and grepping shared imports by line count.

## The fix
Parse each file at a distinct **virtual `base` offset** so merged spans are globally unique, then **demultiplex** a diagnostic's span back to its file at render time. No combined source string is built — `base` is virtual.

- **hale-syntax**: `parse_source_at(source, base)` lexes, shifts every token (and diagnostic) span by `base`, then parses, so AST spans land in a process-wide coordinate space. Adds `Pos/Span/Diag::shifted` + `Diag::render_located(path, source, base)` (un-shifts + prefixes the path).
- **hale-cli**: `parse_files` / `parse_with_imports` assign each file a base (running total) and return a `(base, path, len)` table; both build paths thread it. `render_located(diag, file_bases, sources)` finds the file whose range contains the span and prints `path:line:col: kind: message`.

## Result
Before: `317:1: type error: error not addressed: …` (wrong line, no file).
After: `apps/mdgw/bybit/main.hl:322:17: type error: error not addressed: …` — and `/tmp/bug2test/lib.hl:7:9` for an error in an imported file (verified). Single-file builds are unchanged (base 0 = no shift) but now also show the filename.

## Tests
`crates/hale-syntax/tests/parse_source_at.rs` — shift + un-shift round-trip. Full hale-syntax suite (82 span-sensitive tests) + hale-types/codegen suites stay green.

## Context
This is **bug #2** of a fathom gateway report. Bug #1 ("error not addressed" on the gateways) was **not** a compiler regression — the gateways called `() fallible(WsError)` WS methods without an `or` disposition (alpaca, same lib, built fine because it addressed them); the fathom session has since cleaned up their code with `or discard`. This PR only fixes the diagnostic-quality bug that made it hard to find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)