### PR TITLE
codegen: BytesView producer path for foreign ring_layout

### DIFF
--- a/crates/hale-codegen/src/bus/dispatch.rs
+++ b/crates/hale-codegen/src/bus/dispatch.rs
@@ -807,43 +807,90 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
             }
             _ => None,
         };
-        let (payload_val, payload_struct_name): (PointerValue<'ctx>, String) =
+        // Compute the (data pointer, byte size) the runtime frames as one
+        // record. Two shapes:
+        //   - a flat struct payload (the typed path): pointer to the
+        //     struct + its fixed `size_of`.
+        //   - a Bytes / BytesView payload (the raw / variable-length path,
+        //     the producer mirror of the BytesView consumer): the value's
+        //     data pointer + its actual byte length, so a heterogeneous /
+        //     variable-width record can be published.
+        let (value_ptr, size_iv): (PointerValue<'ctx>, inkwell::values::IntValue<'ctx>) =
             if let Some((slot, mname)) = stack_payload {
-                (slot, mname)
+                let info = self
+                    .user_types
+                    .get(&mname)
+                    .cloned()
+                    .expect("checked above");
+                let size = info
+                    .struct_ty
+                    .size_of()
+                    .expect("flat struct has compile-time size");
+                (slot, size)
             } else {
-                // Non-literal expressions: lower normally,
-                // require a struct-typed result whose pointer we
-                // can pass to memcpy.
                 let (v, ty) = self.lower_expr(value, scope)?;
-                match (&v, &ty) {
-                    (BasicValueEnum::PointerValue(p), CodegenTy::TypeRef(n)) => {
-                        (*p, n.clone())
+                match ty {
+                    CodegenTy::Bytes | CodegenTy::BytesView => {
+                        let blob = self.unpack_view_if_needed(v, &ty)?;
+                        let len_fn = self
+                            .module
+                            .get_function("lotus_bytes_len")
+                            .expect("lotus_bytes_len declared");
+                        let len = self
+                            .builder
+                            .build_call(len_fn, &[blob.into()], "shm.send.bytes.len")
+                            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                            .try_as_basic_value()
+                            .left()
+                            .expect("lotus_bytes_len returns i64")
+                            .into_int_value();
+                        let data_fn = self
+                            .module
+                            .get_function("lotus_bytes_data")
+                            .expect("lotus_bytes_data declared");
+                        let data = self
+                            .builder
+                            .build_call(data_fn, &[blob.into()], "shm.send.bytes.data")
+                            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                            .try_as_basic_value()
+                            .left()
+                            .expect("lotus_bytes_data returns ptr")
+                            .into_pointer_value();
+                        (data, len)
+                    }
+                    CodegenTy::TypeRef(n) => {
+                        let p = match v {
+                            BasicValueEnum::PointerValue(p) => p,
+                            _ => {
+                                return Err(CodegenError::Unsupported(format!(
+                                    "shm_ring send for subject `{}`: struct payload \
+                                     `{}` must lower to a pointer",
+                                    subject, n
+                                )));
+                            }
+                        };
+                        let info = self.user_types.get(&n).cloned().ok_or_else(|| {
+                            CodegenError::Unsupported(format!(
+                                "shm_ring send for subject `{}`: payload type `{}` \
+                                 not registered in user_types",
+                                subject, n
+                            ))
+                        })?;
+                        let size = info
+                            .struct_ty
+                            .size_of()
+                            .expect("flat struct has compile-time size");
+                        (p, size)
                     }
                     _ => {
                         return Err(CodegenError::Unsupported(format!(
-                            "shm_ring send for subject `{}`: payload must be \
-                             a struct-typed value (struct literal or \
-                             struct-shaped expression); got {:?}",
+                            "shm_ring send for subject `{}`: payload must be a \
+                             struct, Bytes, or BytesView value; got {:?}",
                             subject, ty
                         )));
                     }
                 }
             };
-        let info = self
-            .user_types
-            .get(&payload_struct_name)
-            .cloned()
-            .ok_or_else(|| {
-                CodegenError::Unsupported(format!(
-                    "shm_ring send for subject `{}`: payload type `{}` not \
-                     registered in user_types",
-                    subject, payload_struct_name
-                ))
-            })?;
-        let payload_size_iv = info
-            .struct_ty
-            .size_of()
-            .expect("flat struct has compile-time size");
         let subj_ptr = self
             .builder
             .build_global_string_ptr(
@@ -875,8 +922,8 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
                 publish_fn,
                 &[
                     subj_ptr.into(),
-                    payload_val.into(),
-                    payload_size_iv.into(),
+                    value_ptr.into(),
+                    size_iv.into(),
                 ],
                 "bus.shm_ring.publish.call",
             )

--- a/crates/hale-codegen/tests/shm_ring_layout_bytesview_producer.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_bytesview_producer.rs
@@ -1,0 +1,123 @@
+//! BytesView producer over a foreign `ring_layout` (2026-06-08) — the
+//! producer mirror of the BytesView consumer (#72).
+//!
+//! A Hale program publishes variable-length / heterogeneous records to a
+//! `byte_records` ring by sending a `BytesView` value: `Recs <- b.view()`
+//! frames `[len_prefix len][bytes]` where `len` is the value's actual
+//! byte length (not a fixed struct size). Single binary (App creates the
+//! ring, Sub attaches, Producer publishes) to avoid the cross-process
+//! attach-ordering race; the Sub decodes each record with
+//! `std::bytes::read_*`, proving the producer's variable-length framing
+//! round-trips.
+
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::build_executable;
+
+fn unique_tag(label: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("bvp-{}-{}-{}", label, std::process::id(), nanos)
+}
+
+#[test]
+fn hale_bytesview_producer_frames_variable_length_records() {
+    let shm_name = format!("/hale-{}", unique_tag("e2e"));
+
+    // Producer sends two records of DIFFERENT sizes (a 16-byte kind-1 and
+    // a 24-byte kind-2), tagged by an i64 discriminator at offset 0. The
+    // BytesView consumer decodes both — only possible if the producer
+    // framed each record at its own length.
+    let src = format!(
+        r#"
+        ring_layout ForeignRing {{
+            magic 0x52494E47464D5431;
+            version 1 at 8 : u32;
+            buffer_size at 12 : u32;
+            data_at 128;
+            cursor published {{ at 64; repr atomic_u64; load acquire; unit bytes; }}
+            framing byte_records {{ len_prefix u32; align 8; pad_sentinel 0xFFFFFFFF; }}
+            overflow lap_detect;
+        }}
+
+        topic Recs {{ payload: BytesView; }}
+
+        locus Sub {{
+            bus {{ subscribe Recs as on_rec; }}
+            fn on_rec(v: BytesView) {{
+                let kind = std::bytes::read_i64_le(v, 0) or -1;
+                let a = std::bytes::read_i64_le(v, 8) or -1;
+                if kind == 2 {{
+                    let b = std::bytes::read_i64_le(v, 16) or -1;
+                    println("rec kind=2 a=", to_string(a), " b=", to_string(b));
+                }} else {{
+                    println("rec kind=1 a=", to_string(a));
+                }}
+            }}
+        }}
+
+        locus Producer {{
+            bus {{ publish Recs; }}
+            birth() {{
+                let r1 = std::bytes::BytesBuilder {{ initial_cap: 64 }};
+                r1.append_i64_le(1);     // kind
+                r1.append_i64_le(100);   // a            -> 16-byte record
+                Recs <- r1.view();
+                let r2 = std::bytes::BytesBuilder {{ initial_cap: 64 }};
+                r2.append_i64_le(2);     // kind
+                r2.append_i64_le(200);   // a
+                r2.append_i64_le(201);   // b            -> 24-byte record
+                Recs <- r2.view();
+            }}
+        }}
+
+        main locus App {{
+            bindings {{
+                Recs: shm_ring("{shm_name}", on_overflow: drop,
+                               layout: ForeignRing, buffer_size: 4096);
+            }}
+        }}
+
+        fn main() {{
+            App {{ }};
+            Sub {{ }};
+            // Let the reader's first poll initialize its cursor to 0 before
+            // the in-process producer publishes (no historical replay).
+            time::sleep(50ms);
+            Producer {{ }};
+            time::sleep(500ms);
+        }}
+    "#,
+        shm_name = shm_name,
+    );
+
+    let program = hale_syntax::parse_source(&src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("lotus_{}.bin", unique_tag("bin")));
+    build_executable(&program, &bin).expect("build");
+
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+
+    assert!(
+        out.status.success(),
+        "producer/consumer binary failed: status={:?}\nstdout: {}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("rec kind=1 a=100"),
+        "missing the 16-byte record. stdout:\n{}",
+        stdout
+    );
+    assert!(
+        stdout.contains("rec kind=2 a=200 b=201"),
+        "missing the 24-byte record. stdout:\n{}",
+        stdout
+    );
+}

--- a/docs/src/systems/zero-copy-bus.md
+++ b/docs/src/systems/zero-copy-bus.md
@@ -167,6 +167,22 @@ a discriminator branch. This is the path for reading real external
 mixed-record rings; the typed-struct binding stays the fast path for a
 homogeneous ring.
 
+Producing such a ring is symmetric — build a record with a
+`BytesBuilder` and send the bytes:
+
+```hale
+fn emit_l2(level: L2) {
+    let b = std::bytes::BytesBuilder { initial_cap: 64 };
+    b.append_u8(2);                // discriminator
+    b.append_u32_le(level.price);
+    b.append_u32_le(level.qty);
+    Recs <- b.view();              // framed at its own length
+}
+```
+
+`Recs <- bytes` frames `[len_prefix len][bytes]` where `len` is the
+value's actual byte length, so each record carries its own size.
+
 ## The same shape, one tier down
 
 Notice this is the same move as everything else at this level: an

--- a/notes/binary-shm-ring-interop.md
+++ b/notes/binary-shm-ring-interop.md
@@ -447,6 +447,18 @@ a loopback against a faithful mock before any live wiring):**
    First real target: read `ForeignRing`.
 3. **Proposal B, producer path** + Proposal A writable view (A1) for
    zero-copy writes.
+   - ✅ **Typed producer LANDED** (M3a, #61): `Topic <- Struct { ... }`
+     frames a fixed-size `byte_records` record.
+   - ✅ **BytesView/raw producer LANDED** (2026-06-08): `Topic <- bytes`
+     (a `Bytes` or `BytesView` value) frames `[len_prefix len][bytes]`
+     with `len` = the value's actual byte length, so a Hale program can
+     emit heterogeneous / variable-width records — the producer mirror of
+     the BytesView consumer (#72). Codegen-only (`lower_send_shm_ring`
+     extracts data+len via `lotus_bytes_data`/`lotus_bytes_len`); the
+     runtime publish was already size-generic. End-to-end test
+     (`shm_ring_layout_bytesview_producer.rs`). The A1 zero-copy writable
+     view (write directly into the slot, no build-then-copy) is still
+     future.
 4. **Dogfood:** re-express `LRSRNG1` as the built-in `LotusRing`
    declaration; delete the hardcoded constants in favor of the default
    instantiation.

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1021,8 +1021,12 @@ payload picks the consumer mode:
   discriminator branch. The framed-size bounds checks against the ring
   still apply; the record payload is copied into a Bytes-shaped scratch
   blob (the pack readers need that prefix, and the mapping is
-  read-only), so raw-frame mode is not zero-copy. Producing a
-  `BytesView` topic (the raw producer path) is not yet supported.
+  read-only), so raw-frame mode is not zero-copy. The producer side is
+  symmetric: `Recs <- bytes` (a `Bytes` or `BytesView` value, e.g. built
+  with a `BytesBuilder`) frames `[len_prefix len][bytes]` where `len` is
+  the value's actual byte length, so a producer can emit
+  heterogeneous / variable-width records — the runtime publish path is
+  size-generic.
 
 Any other payload (with `String`, `Bytes`, or variable-size fields and
 not itself `BytesView`) is rejected.


### PR DESCRIPTION
The **producer mirror** of the BytesView consumer (#72): a Hale program can now publish **heterogeneous / variable-length** records to a foreign `byte_records` ring by sending a `Bytes` or `BytesView` value.

```hale
fn emit(level: L2) {
    let b = std::bytes::BytesBuilder { initial_cap: 64 };
    b.append_u8(2);
    b.append_u32_le(level.price);
    b.append_u32_le(level.qty);
    Recs <- b.view();   // framed at its own length
}
```

`Recs <- bytes` frames `[len_prefix len][bytes]` where `len` is the value's **actual byte length** — each record carries its own size, no fixed struct width.

## How
**Codegen-only.** `lower_send_shm_ring` previously required a struct payload (pointer + `size_of`); it now also accepts a Bytes/BytesView value, extracting `(data_ptr, len)` via `lotus_bytes_data`/`lotus_bytes_len` and handing them to the publish path. The runtime publish (`lotus_bus_publish_shm_ring_layout`) was **already size-generic** (writes the passed size as the len prefix, memcpys that many bytes) — no runtime change. The frontend already accepts a BytesView layout topic + the `BytesView → BytesView` send (from #72).

## Tests
End-to-end (`shm_ring_layout_bytesview_producer.rs`): a single Hale binary publishes a **16-byte and a 24-byte** record; a BytesView subscriber decodes both, proving the variable-length framing round-trips. The typed producer (M3a) + all ring suites stay green **under UBSan**.

Spec (`semantics.md`), docs (`zero-copy-bus.md`), and the interop notes updated. The **A1 zero-copy writable view** (write directly into the slot, no build-then-copy) remains the explicit future item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)