### PR TITLE
runtime: reserve/commit split for zero-copy ring writes (A1, stage 1)

### DIFF
--- a/crates/hale-codegen/runtime/lotus_shm_ring.c
+++ b/crates/hale-codegen/runtime/lotus_shm_ring.c
@@ -836,6 +836,13 @@ typedef struct {
                        * required power-of-two). Records never straddle the
                        * wrap (the pad guarantees it), so a compare-subtract
                        * suffices. See experiments/foreign-ring-throughput. */
+    /* A1 zero-copy write: an open reservation made by
+     * lotus_bus_reserve_shm_ring_layout, closed by ..._commit_.... The
+     * record starts at `pos`; the producer wrote directly into the slot.
+     * `reserved_max` is the capacity the reservation guaranteed; commit
+     * rejects a length beyond it. */
+    uint64_t reserved_max;
+    int      has_reservation;
 } shm_ring_layout_producer_t;
 
 static shm_ring_layout_producer_t
@@ -942,6 +949,110 @@ int lotus_bus_publish_shm_ring_layout(const char *subject,
     }
     fprintf(stderr,
             "lotus_bus_publish_shm_ring_layout(`%s`): no registration for "
+            "this subject\n",
+            subject);
+    return -1;
+}
+
+/* A1 zero-copy write — reserve side. Claims room for a record of up to
+ * `max` payload bytes and returns a pointer to its DATA region (just past
+ * the len prefix) so the producer can write fields directly into the
+ * mapped ring, with no intermediate buffer + copy. Pads + wraps eagerly
+ * if a max-sized record wouldn't fit before end-of-buffer (the pad
+ * advances the cursor, which the consumer skips — the not-yet-committed
+ * record stays beyond `committed` until commit writes its len prefix).
+ * Returns NULL if the subject isn't a registered producer; _exit(1) on a
+ * record that can't ever fit. The reservation is closed by
+ * lotus_bus_commit_shm_ring_layout. */
+void *lotus_bus_reserve_shm_ring_layout(const char *subject, uint64_t max) {
+    for (int i = 0; i < g_shm_ring_layout_producer_count; i++) {
+        shm_ring_layout_producer_t *p = &g_shm_ring_layout_producers[i];
+        if (strcmp(p->subject, subject) != 0) continue;
+        const lotus_shm_layout_t *d = &p->ring->desc;
+        char *base = (char *)p->ring->base;
+        uint64_t cap = p->ring->capacity;
+        _Atomic uint64_t *cursor =
+            (_Atomic uint64_t *)(base + d->cursor_off);
+
+        uint64_t max_step = d->len_prefix_width + max;
+        if (d->align > 1) {
+            max_step = (max_step + d->align - 1) & ~(d->align - 1);
+        }
+        if (max_step > cap) {
+            fprintf(stderr,
+                    "lotus_bus_reserve_shm_ring_layout(`%s`): record (%llu "
+                    "bytes framed for max=%llu) exceeds ring capacity (%llu)\n",
+                    subject, (unsigned long long)max_step,
+                    (unsigned long long)max, (unsigned long long)cap);
+            _exit(1);
+        }
+        uint64_t pos = p->pos;
+        if (pos + max_step > cap) {
+            uint64_t off = d->data_at + pos;
+            if (d->has_pad_sentinel) {
+                shm_layout_write_uint(base + off, d->len_prefix_width,
+                                      d->pad_sentinel);
+            }
+            p->local += cap - pos;
+            pos = 0;
+            p->pos = pos;
+            atomic_store_explicit(cursor, p->local, memory_order_release);
+        }
+        p->reserved_max = max;
+        p->has_reservation = 1;
+        return base + d->data_at + pos + d->len_prefix_width;
+    }
+    fprintf(stderr,
+            "lotus_bus_reserve_shm_ring_layout(`%s`): no registration for "
+            "this subject\n",
+            subject);
+    return NULL;
+}
+
+/* A1 zero-copy write — commit side. Finalizes the open reservation: writes
+ * the record's len prefix (`len`, the actual bytes written, which must not
+ * exceed the reserved `max`) and release-publishes the cursor, making the
+ * record visible to consumers. Returns 0 on success, -1 if the subject
+ * isn't registered or has no open reservation. */
+int lotus_bus_commit_shm_ring_layout(const char *subject, uint64_t len) {
+    for (int i = 0; i < g_shm_ring_layout_producer_count; i++) {
+        shm_ring_layout_producer_t *p = &g_shm_ring_layout_producers[i];
+        if (strcmp(p->subject, subject) != 0) continue;
+        if (!p->has_reservation) {
+            fprintf(stderr,
+                    "lotus_bus_commit_shm_ring_layout(`%s`): commit with no "
+                    "open reservation\n",
+                    subject);
+            return -1;
+        }
+        if (len > p->reserved_max) {
+            fprintf(stderr,
+                    "lotus_bus_commit_shm_ring_layout(`%s`): committed %llu "
+                    "bytes but only %llu were reserved\n",
+                    subject, (unsigned long long)len,
+                    (unsigned long long)p->reserved_max);
+            _exit(1);
+        }
+        const lotus_shm_layout_t *d = &p->ring->desc;
+        char *base = (char *)p->ring->base;
+        uint64_t cap = p->ring->capacity;
+        _Atomic uint64_t *cursor =
+            (_Atomic uint64_t *)(base + d->cursor_off);
+        uint64_t off = d->data_at + p->pos;
+        shm_layout_write_uint(base + off, d->len_prefix_width, len);
+        uint64_t step = d->len_prefix_width + len;
+        if (d->align > 1) {
+            step = (step + d->align - 1) & ~(d->align - 1);
+        }
+        p->local += step;
+        p->pos += step;
+        if (p->pos >= cap) p->pos -= cap;
+        p->has_reservation = 0;
+        atomic_store_explicit(cursor, p->local, memory_order_release);
+        return 0;
+    }
+    fprintf(stderr,
+            "lotus_bus_commit_shm_ring_layout(`%s`): no registration for "
             "this subject\n",
             subject);
     return -1;

--- a/crates/hale-codegen/tests/shm_ring_layout.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout.rs
@@ -205,3 +205,12 @@ fn layout_heterogeneous_raw_view() {
 fn layout_slots_reads_native_lotus_ring() {
     run_mode("lotus_dogfood");
 }
+
+/// A1 zero-copy write (runtime): a producer reserves a max-sized slot,
+/// writes differently-sized records DIRECTLY into the mapped ring (no
+/// intermediate buffer + copy), and commits the actual length; a raw
+/// consumer reads them back. Validates the reserve/commit framing split.
+#[test]
+fn layout_reserve_commit_zero_copy_write() {
+    run_mode("reserve_commit");
+}

--- a/crates/hale-codegen/tests/shm_ring_layout_driver.c
+++ b/crates/hale-codegen/tests/shm_ring_layout_driver.c
@@ -58,6 +58,9 @@ extern int lotus_bus_publish_shm_ring_layout(
     const char *subject,
     const void *value,
     uint64_t value_size);
+/* A1 zero-copy write: reserve a slot, write directly, commit the length. */
+extern void *lotus_bus_reserve_shm_ring_layout(const char *subject, uint64_t max);
+extern int lotus_bus_commit_shm_ring_layout(const char *subject, uint64_t len);
 
 /* Native LotusRing (LRSRNG1) producer API — the dogfood test has a
  * layout-`slots` consumer read the very ring this native producer writes. */
@@ -683,15 +686,76 @@ static int run_produce_native_external(const char *name) {
     return 0;
 }
 
+/* A1 zero-copy write: reserve a max-sized slot, write differently-sized
+ * records DIRECTLY into the mapped ring (no intermediate buffer), commit
+ * the actual length. A raw (value_size == 0) consumer reads them back —
+ * proving reserve/commit frames variable-length records correctly. */
+static int run_reserve_commit(const char *name) {
+    uint64_t desc[21] = {0};
+    build_desc(desc);
+    desc[15] = 0;  /* value_size = 0 → raw consumer (variable records) */
+    lotus_bus_register_shm_ring_layout("foreign.ticks", name, desc, 4096);
+    lotus_bus_register_subscriber_shm_ring_layout(
+        "foreign.ticks", name, desc, NULL, (void (*)(void *, void *))on_raw);
+    struct timespec warmup = {0, 5 * 1000 * 1000};
+    nanosleep(&warmup, NULL);
+
+    int n = 6;
+    for (int i = 0; i < n; i++) {
+        int64_t kind = (i % 2) + 1;
+        uint64_t plen = (kind == 1) ? 16 : 24;
+        /* Reserve room for the largest record (24), write only `plen`. */
+        char *slot = (char *)lotus_bus_reserve_shm_ring_layout("foreign.ticks", 24);
+        if (!slot) {
+            fprintf(stderr, "reserve %d failed\n", i);
+            return 2;
+        }
+        int64_t a = (int64_t)(100 + i), b = (int64_t)(200 + i);
+        memcpy(slot + 0, &kind, sizeof(int64_t));
+        memcpy(slot + 8, &a, sizeof(int64_t));
+        if (kind == 2) memcpy(slot + 16, &b, sizeof(int64_t));
+        if (lotus_bus_commit_shm_ring_layout("foreign.ticks", plen) != 0) {
+            fprintf(stderr, "commit %d failed\n", i);
+            return 2;
+        }
+        struct timespec pace = {0, 5 * 1000 * 1000};
+        nanosleep(&pace, NULL);
+    }
+    for (int s = 0; s < 2000; s++) {
+        if (atomic_load_explicit(&g_raw_count, memory_order_acquire) >= n) break;
+        struct timespec ts = {0, 1000 * 1000};
+        nanosleep(&ts, NULL);
+    }
+    int got = atomic_load_explicit(&g_raw_count, memory_order_acquire);
+    if (got != n) {
+        fprintf(stderr, "reserve_commit: expected %d records, got %d\n", n, got);
+        return 3;
+    }
+    for (int i = 0; i < n; i++) {
+        int64_t exp_kind = (i % 2) + 1;
+        int64_t exp_len = (exp_kind == 1) ? 16 : 24;
+        if (g_raw_kind[i] != exp_kind || g_raw_len[i] != exp_len ||
+            g_raw_a[i] != 100 + i ||
+            (exp_kind == 2 && g_raw_b[i] != 200 + i)) {
+            fprintf(stderr, "reserve_commit record %d mismatch\n", i);
+            return 3;
+        }
+    }
+    return 0;
+}
+
 int main(int argc, char **argv) {
     if (argc < 3) {
         fprintf(stderr,
                 "usage: %s <roundtrip|wrap|producer|producer_wrap|"
                 "bad_bufsize|short_record|u64_lenprefix|heterogeneous|"
-                "produce_external|lotus_dogfood|produce_native_external> "
-                "<shm_name>\n",
+                "produce_external|lotus_dogfood|produce_native_external|"
+                "reserve_commit> <shm_name>\n",
                 argv[0]);
         return 1;
+    }
+    if (strcmp(argv[1], "reserve_commit") == 0) {
+        return run_reserve_commit(argv[2]);
     }
     if (strcmp(argv[1], "lotus_dogfood") == 0) {
         return run_lotus_dogfood(argv[2]);


### PR DESCRIPTION
**Stage 1 of the A1 zero-copy producer write path** (the closure-scoped `Topic.write(max) { w => ... }` surface you picked). This is the runtime/ABI foundation; the Hale surface lands on top in later stages.

Splits the layout publish into a **reserve + commit** pair so a producer can write fields **directly into the mapped ring slot** — no intermediate buffer + memcpy:

- `lotus_bus_reserve_shm_ring_layout(subject, max) -> void*` — claims room for a record of up to `max` payload bytes (pad + wrap eagerly if a max-sized record wouldn't fit before end-of-buffer) and returns a pointer to the record's **data region** for the producer to write into. The pad-on-wrap advances the cursor (which the consumer skips); the not-yet-committed record stays beyond `committed` until commit.
- `lotus_bus_commit_shm_ring_layout(subject, len)` — writes the record's len prefix (the actual bytes written, rejected if `> max`) and release-publishes the cursor, making the record visible.

The atomic publish path (`<- value`) is untouched.

## Test
C-driver `reserve_commit` mode: reserve a max-24 slot, write **differently-sized** records (16 and 24 bytes) directly into the ring, commit the actual length; a raw consumer reads them back. ASan + UBSan clean; all byte_records / native regressions stay green.

## Remaining stages
- **Stage 2:** a `BytesMut` writable view + `std::bytes::write_*` primitives (mirror the readers).
- **Stage 3:** the `Topic.write(max) { w => ...; len }` construct (a bespoke parser form — Hale has no value-closures/keyword-args — wiring reserve → write → commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)