### PR TITLE
syntax: Go-style struct field tags (parse + store)

### DIFF
--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -8037,6 +8037,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         name: f.name.clone(),
                         ty: Self::substitute_type_expr(&f.ty, &subst),
                         default: f.default.clone(),
+                        tag: f.tag.clone(),
                         span: f.span.clone(),
                     })
                     .collect();

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -1174,6 +1174,14 @@ pub struct StructField {
     pub name: Ident,
     pub ty: TypeExpr,
     pub default: Option<Expr>,
+    /// Go-style metadata tag: the raw text of a backtick string written
+    /// after the field (`price: Int `wire:"u32_le"`;`). Free-form
+    /// `key:"value"` metadata that downstream features parse — the
+    /// binary-pack layer (Proposal A′) reads a `wire:` key; ignored
+    /// otherwise. The backtick lexer is shared with time literals, which
+    /// only occur in expression position; in field-declaration position
+    /// it's a tag.
+    pub tag: Option<String>,
     pub span: Span,
 }
 

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -2770,12 +2770,25 @@ impl Parser {
         } else {
             None
         };
+        // Optional Go-style metadata tag: a backtick string after the
+        // field. The backtick lexer is shared with time literals (which
+        // only appear in expression position); in field-declaration
+        // position it's a tag, and we keep its raw body verbatim.
+        let tag = if matches!(self.peek(), TokenKind::TimeLit(_)) {
+            match self.bump().kind {
+                TokenKind::TimeLit(body) => Some(body),
+                _ => unreachable!("peeked TimeLit"),
+            }
+        } else {
+            None
+        };
         let semi = self.expect(TokenKind::Semi, ";")?;
         Ok(StructField {
             span: name.span.merge(semi.span),
             name,
             ty,
             default,
+            tag,
         })
     }
 

--- a/crates/hale-syntax/tests/field_tags.rs
+++ b/crates/hale-syntax/tests/field_tags.rs
@@ -1,0 +1,60 @@
+//! Go-style struct field tags (2026-06-09): a backtick metadata string
+//! after a field is parsed and stored verbatim on the `StructField`, and
+//! ignored by everything that doesn't read it. The backtick lexer is
+//! shared with time literals (expression position); in field-declaration
+//! position it's a tag. General-purpose metadata — the binary-pack layer
+//! (Proposal A′) is the first consumer.
+
+use hale_syntax::ast::{TopDecl, TypeDeclBody};
+use hale_syntax::parse_source;
+
+fn fields(src: &str) -> Vec<(String, Option<String>)> {
+    let prog = parse_source(src).expect("parse");
+    for item in &prog.items {
+        if let TopDecl::Type(td) = item {
+            if let TypeDeclBody::Struct(fs) = &td.body {
+                return fs
+                    .iter()
+                    .map(|f| (f.name.name.clone(), f.tag.clone()))
+                    .collect();
+            }
+        }
+    }
+    panic!("no struct type in source");
+}
+
+#[test]
+fn field_tags_are_parsed_and_stored() {
+    let got = fields(
+        r#"
+        type L2 {
+            kind:  Int `wire:"u8"`;
+            price: Int `wire:"u32_le"`;
+            qty:   Int `wire:"u32_le" json:"quantity"`;
+            note:  Int;
+        }
+    "#,
+    );
+    assert_eq!(
+        got,
+        vec![
+            ("kind".to_string(), Some("wire:\"u8\"".to_string())),
+            ("price".to_string(), Some("wire:\"u32_le\"".to_string())),
+            (
+                "qty".to_string(),
+                Some("wire:\"u32_le\" json:\"quantity\"".to_string())
+            ),
+            ("note".to_string(), None),
+        ]
+    );
+}
+
+#[test]
+fn tag_coexists_with_a_default() {
+    let got = fields(
+        r#"
+        type T { count: Int = 0 `json:"n"`; }
+    "#,
+    );
+    assert_eq!(got, vec![("count".to_string(), Some("json:\"n\"".to_string()))]);
+}

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -553,7 +553,14 @@ type_decl         = "type" , IDENTIFIER , [ generic_params ] , "=" ,
                     "enum" , "{" , enum_variant , { "," , enum_variant } , "}" , ";"
                   ;
 
-struct_field      = IDENTIFIER , ":" , type_expr , [ "=" , expression ] , ";" ;
+struct_field      = IDENTIFIER , ":" , type_expr , [ "=" , expression ] ,
+                    [ field_tag ] , ";" ;
+(* Go-style metadata tag: a backtick raw string of free-form `key:"value"`
+   pairs that downstream features parse (the binary-pack layer reads a
+   `wire:` key; ignored otherwise). Shares the backtick lexing with time
+   literals — a time literal only appears in expression position, a tag
+   only in field-declaration position. *)
+field_tag         = "`" , { ? any char except backtick ? } , "`" ;
 
 enum_variant      = IDENTIFIER , [ "(" , type_expr , { "," , type_expr } , ")" ] ;
 


### PR DESCRIPTION
A struct field may carry a backtick metadata tag after its type:

```hale
type L2 {
    kind:  Int `wire:"u8"`;
    price: Int `wire:"u32_le"`;
    qty:   Int `wire:"u32_le" json:"quantity"`;
}
```

The tag is free-form `key:"value"` metadata, stored verbatim on `StructField` (`tag: Option<String>`) and **ignored by everything that doesn't read it** — a general mechanism (json, db, validation, …) whose first consumer will be the binary-pack layer (Proposal A′, reading a `wire:` key), landing on top of this.

## No lexer change
The backtick lexing is **shared with time literals**. A time literal only occurs in expression position; a field tag only in field-declaration position. So the parser disambiguates by position — it consumes the backtick `TimeLit` token as the tag after a field's type/default. Time literals are unaffected (verified).

## Why split from A′
This is a general language addition (field metadata) that's worth reviewing on its own; A′ is a second PR that consumes the `wire:` tag and generates field accessors. Per the conversation: field tags first, A′ on top.

## Tests
Parser round-trip — tags stored verbatim, multi-key, coexists with a default, untagged fields stay `None`. Spec grammar updated; `pond/heron` gains the tag rule + an `@attribute` highlight (29/29 corpus green). Full hale-syntax/hale-types suites stay green; time literals still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)