### PR TITLE
codegen+syntax: repr-tagged field accessors (Proposal A′)

### DIFF
--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -404,6 +404,9 @@ pub fn build_executable_with_options(
     // remain.
     hale_syntax::desugar::desugar_intra_locus_topics(&mut program_owned);
     hale_syntax::desugar::desugar_topics(&mut program_owned);
+    // Proposal A′: rewrite repr-tagged field accessors (`L2::price(v)` /
+    // `L2::set_price(w, x)`) into the equivalent `std::bytes::*` calls.
+    hale_syntax::desugar::desugar_repr_accessors(&mut program_owned);
     let program = &program_owned;
 
     Target::initialize_native(&InitializationConfig::default())

--- a/crates/hale-codegen/tests/repr_field_accessors.rs
+++ b/crates/hale-codegen/tests/repr_field_accessors.rs
@@ -1,0 +1,99 @@
+//! Proposal A′ (2026-06-09): repr-tagged field accessors. A struct whose
+//! fields carry `repr:"<wire-type>"` tags is a binary layout; `L2::price(v)`
+//! reads the field at its computed offset from a BytesView, and
+//! `L2::set_price(w, x)` writes it into a Topic.write block's BytesMut.
+//! Desugars to `std::bytes::read_*`/`write_*`, so it composes with the
+//! foreign-ring consumer and the zero-copy producer. End-to-end: a producer
+//! writes records field-by-field via accessors, a subscriber reads them
+//! back via accessors.
+
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::build_executable;
+
+fn tag(label: &str) -> String {
+    let n = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
+    format!("rfa-{}-{}-{}", label, std::process::id(), n)
+}
+
+#[test]
+fn repr_accessors_round_trip_through_a_foreign_ring() {
+    let shm = format!("/hale-{}", tag("e2e"));
+    let src = format!(
+        r#"
+        ring_layout ForeignRing {{
+            magic 0x52494E47464D5431;
+            version 1 at 8 : u32;
+            buffer_size at 12 : u32;
+            data_at 128;
+            cursor published {{ at 64; repr atomic_u64; load acquire; unit bytes; }}
+            framing byte_records {{ len_prefix u32; align 8; pad_sentinel 0xFFFFFFFF; }}
+            overflow lap_detect;
+        }}
+
+        // A 12-byte wire record: u8 kind @0, u32_le price @4 (padded),
+        // u32_le qty @8. Offsets pinned to exercise the `at=` override.
+        type L2 {{
+            kind:  Int `repr:"u8,at=0"`;
+            price: Int `repr:"u32_le,at=4"`;
+            qty:   Int `repr:"u32_le,at=8"`;
+        }}
+
+        topic Recs {{ payload: BytesView; }}
+
+        locus Sub {{
+            bus {{ subscribe Recs as on_rec; }}
+            fn on_rec(v: BytesView) {{
+                let k = L2::kind(v)  or -1;
+                let p = L2::price(v) or -1;
+                let q = L2::qty(v)   or -1;
+                println("rec kind=", to_string(k), " price=", to_string(p), " qty=", to_string(q));
+            }}
+        }}
+
+        locus Producer {{
+            bus {{ publish Recs; }}
+            birth() {{
+                Recs.write(12) {{ w =>
+                    L2::set_kind(w, 1)     or raise;
+                    L2::set_price(w, 250)  or raise;
+                    L2::set_qty(w, 9)      or raise;
+                    12
+                }};
+                Recs.write(12) {{ w =>
+                    L2::set_kind(w, 2)     or raise;
+                    L2::set_price(w, 999)  or raise;
+                    L2::set_qty(w, 3)      or raise;
+                    12
+                }};
+            }}
+        }}
+
+        main locus App {{
+            bindings {{
+                Recs: shm_ring("{shm}", on_overflow: drop, layout: ForeignRing, buffer_size: 4096);
+            }}
+        }}
+
+        fn main() {{
+            App {{ }};
+            Sub {{ }};
+            time::sleep(50ms);
+            Producer {{ }};
+            time::sleep(500ms);
+        }}
+    "#,
+        shm = shm,
+    );
+    let program = hale_syntax::parse_source(&src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("lotus_{}.bin", tag("bin")));
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(out.status.success(), "failed: {:?}\nstderr: {}", out.status, String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("rec kind=1 price=250 qty=9"), "missing record 1:\n{}", stdout);
+    assert!(stdout.contains("rec kind=2 price=999 qty=3"), "missing record 2:\n{}", stdout);
+}

--- a/crates/hale-syntax/src/desugar.rs
+++ b/crates/hale-syntax/src/desugar.rs
@@ -361,6 +361,329 @@ fn rewrite_match(m: &mut MatchStmt, topics: &BTreeMap<String, TopicEntry>) {
     }
 }
 
+// ---------------------------------------------------------------
+// Proposal A′: repr-tagged field accessors.
+// ---------------------------------------------------------------
+//
+// A struct whose fields carry `repr:"<wire-type>"` tags is a binary
+// (wire) layout. For such a type `L2`, a call `L2::price(v)` reads the
+// `price` field at its computed byte offset from `v` (a Bytes/BytesView),
+// and `L2::set_price(w, x)` writes it into `w` (a BytesMut). This pass
+// rewrites those accessor calls into the equivalent `std::bytes::read_*` /
+// `write_*` calls so the rest of the pipeline (typecheck, codegen) needs
+// no accessor-specific logic — they ride the existing pack primitives,
+// including the `fallible(IndexError)` typing. Runs before typecheck (so
+// the checker sees the desugared calls) and is idempotent.
+
+/// A field's wire placement, parsed from its `repr:"…"` tag.
+#[derive(Debug, Clone)]
+struct WireField {
+    offset: u64,
+    /// The pack-primitive type token, e.g. `"u32_le"` — `read_`/`write_`
+    /// prefix it to name the runtime call.
+    repr: String,
+}
+
+type WireLayouts = BTreeMap<String, BTreeMap<String, WireField>>;
+
+/// Extract a Go-style `key:"value"` from a tag string.
+fn tag_value(tag: &str, key: &str) -> Option<String> {
+    let needle = format!("{}:\"", key);
+    let start = tag.find(&needle)? + needle.len();
+    let rest = &tag[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// Byte width of a pack-primitive type token (endianness suffix ignored).
+fn repr_width(repr: &str) -> u64 {
+    let base = repr
+        .strip_suffix("_le")
+        .or_else(|| repr.strip_suffix("_be"))
+        .unwrap_or(repr);
+    match base {
+        "u8" | "i8" => 1,
+        "u16" | "i16" => 2,
+        "u32" | "i32" | "f32" => 4,
+        _ => 8,
+    }
+}
+
+/// Compute a struct's wire layout from its fields' `repr:` tags. Offsets
+/// run in declaration order over the tagged fields (each advances the
+/// cursor by its width); an explicit `,at=N` in the tag pins an offset
+/// for a foreign format with padding. Returns `None` if no field is
+/// repr-tagged (an ordinary struct).
+fn wire_layout(fields: &[StructField]) -> Option<BTreeMap<String, WireField>> {
+    let mut layout = BTreeMap::new();
+    let mut cursor = 0u64;
+    for f in fields {
+        let Some(repr_val) = f.tag.as_deref().and_then(|t| tag_value(t, "repr")) else {
+            continue;
+        };
+        let mut parts = repr_val.split(',');
+        let repr = parts.next().unwrap_or("").trim().to_string();
+        let mut at: Option<u64> = None;
+        for p in parts {
+            if let Some(n) = p.trim().strip_prefix("at=") {
+                at = n.trim().parse().ok();
+            }
+        }
+        let width = repr_width(&repr);
+        let offset = at.unwrap_or(cursor);
+        cursor = offset + width;
+        layout.insert(f.name.name.clone(), WireField { offset, repr });
+    }
+    if layout.is_empty() {
+        None
+    } else {
+        Some(layout)
+    }
+}
+
+fn collect_wire_layouts(items: &[TopDecl], out: &mut WireLayouts) {
+    for item in items {
+        match item {
+            TopDecl::Type(td) => {
+                if let TypeDeclBody::Struct(fields) = &td.body {
+                    if let Some(layout) = wire_layout(fields) {
+                        out.insert(td.name.name.clone(), layout);
+                    }
+                }
+            }
+            TopDecl::Module(m) => collect_wire_layouts(&m.items, out),
+            _ => {}
+        }
+    }
+}
+
+/// Rewrite repr-tagged field accessors into `std::bytes::*` calls.
+pub fn desugar_repr_accessors(program: &mut Program) {
+    let mut layouts = WireLayouts::new();
+    collect_wire_layouts(&program.items, &mut layouts);
+    if layouts.is_empty() {
+        return;
+    }
+    acc_items(&mut program.items, &layouts);
+}
+
+fn std_bytes_call(name: &str, args: Vec<Expr>, span: Span) -> Expr {
+    let seg = |s: &str| Ident {
+        name: s.to_string(),
+        span,
+    };
+    Expr::Call {
+        callee: Box::new(Expr::Path(QualifiedName {
+            segments: vec![seg("std"), seg("bytes"), seg(name)],
+            span,
+        })),
+        args,
+        span,
+    }
+}
+
+/// If `callee(args)` is an accessor of a wire-tagged type, return its
+/// `std::bytes::*` replacement.
+fn try_accessor(
+    callee: &Expr,
+    args: &[Expr],
+    span: Span,
+    w: &WireLayouts,
+) -> Option<Expr> {
+    let Expr::Path(qn) = callee else { return None };
+    if qn.segments.len() != 2 {
+        return None;
+    }
+    let layout = w.get(&qn.segments[0].name)?;
+    let member = &qn.segments[1].name;
+    // Read: `T::field(v)` → `std::bytes::read_<repr>(v, off)`.
+    if let Some(wf) = layout.get(member) {
+        if args.len() != 1 {
+            return None;
+        }
+        return Some(std_bytes_call(
+            &format!("read_{}", wf.repr),
+            vec![args[0].clone(), Expr::Literal(Literal::Int(wf.offset as i64), span)],
+            span,
+        ));
+    }
+    // Write: `T::set_field(w, x)` → `std::bytes::write_<repr>(w, off, x)`.
+    if let Some(field) = member.strip_prefix("set_") {
+        if let Some(wf) = layout.get(field) {
+            if args.len() != 2 {
+                return None;
+            }
+            return Some(std_bytes_call(
+                &format!("write_{}", wf.repr),
+                vec![
+                    args[0].clone(),
+                    Expr::Literal(Literal::Int(wf.offset as i64), span),
+                    args[1].clone(),
+                ],
+                span,
+            ));
+        }
+    }
+    None
+}
+
+fn acc_items(items: &mut [TopDecl], w: &WireLayouts) {
+    for item in items {
+        match item {
+            TopDecl::Fn(f) => acc_block(&mut f.body, w),
+            TopDecl::Locus(l) => {
+                for member in &mut l.members {
+                    match member {
+                        LocusMember::Lifecycle(lc) => acc_block(&mut lc.body, w),
+                        LocusMember::Mode(md) => acc_block(&mut md.body, w),
+                        LocusMember::Fn(fd) => acc_block(&mut fd.body, w),
+                        _ => {}
+                    }
+                }
+            }
+            TopDecl::Module(m) => acc_items(&mut m.items, w),
+            _ => {}
+        }
+    }
+}
+
+fn acc_block(b: &mut Block, w: &WireLayouts) {
+    for s in &mut b.stmts {
+        acc_stmt(s, w);
+    }
+    if let Some(t) = &mut b.tail {
+        acc_expr(t, w);
+    }
+}
+
+fn acc_stmt(s: &mut Stmt, w: &WireLayouts) {
+    match s {
+        Stmt::Let { value, .. } | Stmt::LetTuple { value, .. } => acc_expr(value, w),
+        Stmt::Assign { target, value, .. } => {
+            acc_expr(value, w);
+            for seg in &mut target.tail {
+                if let LValueSeg::Index(e) = seg {
+                    acc_expr(e, w);
+                }
+            }
+        }
+        Stmt::If(if_stmt) => acc_if(if_stmt, w),
+        Stmt::Match(m) => acc_match(m, w),
+        Stmt::For { iter, body, .. } => {
+            acc_expr(iter, w);
+            acc_block(body, w);
+        }
+        Stmt::While { cond, body, .. } => {
+            acc_expr(cond, w);
+            acc_block(body, w);
+        }
+        Stmt::Return(Some(e), _) => acc_expr(e, w),
+        Stmt::Fail { value, .. } => acc_expr(value, w),
+        Stmt::Send { subject, value, .. } => {
+            acc_expr(subject, w);
+            acc_expr(value, w);
+        }
+        Stmt::Block(b) => acc_block(b, w),
+        Stmt::Recovery { args, .. } => {
+            for a in args {
+                acc_expr(a, w);
+            }
+        }
+        Stmt::Violate { payload, .. } => {
+            if let Some(p) = payload {
+                acc_expr(p, w);
+            }
+        }
+        Stmt::ShmWrite { max, body, .. } => {
+            acc_expr(max, w);
+            acc_block(body, w);
+        }
+        Stmt::Expr(e) => acc_expr(e, w),
+        Stmt::Return(None, _)
+        | Stmt::Break(_)
+        | Stmt::Continue(_)
+        | Stmt::Yield(_)
+        | Stmt::Terminate(_) => {}
+    }
+}
+
+fn acc_if(if_stmt: &mut IfStmt, w: &WireLayouts) {
+    acc_expr(&mut if_stmt.cond, w);
+    acc_block(&mut if_stmt.then_block, w);
+    if let Some(eb) = &mut if_stmt.else_block {
+        match eb.as_mut() {
+            ElseBranch::Else(b) => acc_block(b, w),
+            ElseBranch::ElseIf(inner) => acc_if(inner, w),
+        }
+    }
+}
+
+fn acc_match(m: &mut MatchStmt, w: &WireLayouts) {
+    acc_expr(&mut m.scrutinee, w);
+    for arm in &mut m.arms {
+        match &mut arm.body {
+            MatchArmBody::Block(b) => acc_block(b, w),
+            MatchArmBody::Expr(e) => acc_expr(e, w),
+        }
+    }
+}
+
+fn acc_expr(e: &mut Expr, w: &WireLayouts) {
+    match e {
+        Expr::Call { callee, args, span } => {
+            acc_expr(callee, w);
+            for a in args.iter_mut() {
+                acc_expr(a, w);
+            }
+            if let Some(rewritten) = try_accessor(callee, args, *span, w) {
+                *e = rewritten;
+            }
+        }
+        Expr::Binary { left, right, .. } => {
+            acc_expr(left, w);
+            acc_expr(right, w);
+        }
+        Expr::Unary { operand, .. } => acc_expr(operand, w),
+        Expr::Field { receiver, .. } => acc_expr(receiver, w),
+        Expr::Index { receiver, index, .. } => {
+            acc_expr(receiver, w);
+            acc_expr(index, w);
+        }
+        Expr::Path2 { receiver, .. } => acc_expr(receiver, w),
+        Expr::Tuple(es, _) | Expr::Array(es, _) => {
+            for x in es {
+                acc_expr(x, w);
+            }
+        }
+        Expr::Struct { inits, .. } => {
+            for i in inits {
+                acc_expr(&mut i.value, w);
+            }
+        }
+        Expr::Block(b) => acc_block(b, w),
+        Expr::If(if_stmt) => acc_if(if_stmt, w),
+        Expr::Match(m) => acc_match(m, w),
+        Expr::Sum(inner, _) | Expr::Prod(inner, _) => acc_expr(inner, w),
+        Expr::Approx { left, right, tolerance, .. } => {
+            acc_expr(left, w);
+            acc_expr(right, w);
+            acc_expr(tolerance, w);
+        }
+        Expr::Range { lo, hi, .. } => {
+            acc_expr(lo, w);
+            acc_expr(hi, w);
+        }
+        Expr::ArrayRepeat { val, .. } => acc_expr(val, w),
+        Expr::Or { inner, disposition, .. } => {
+            acc_expr(inner, w);
+            if let OrDisposition::Substitute(s) = disposition {
+                acc_expr(s, w);
+            }
+        }
+        Expr::Literal(..) | Expr::Ident(_) | Expr::Path(_) | Expr::KwSelf(_) => {}
+    }
+}
+
 fn rewrite_expr(e: &mut Expr, topics: &BTreeMap<String, TopicEntry>) {
     match e {
         Expr::Block(b) => rewrite_block(b, topics),

--- a/docs/src/systems/zero-copy-bus.md
+++ b/docs/src/systems/zero-copy-bus.md
@@ -207,6 +207,48 @@ body's tail yields. The `std::bytes::write_*` family mirrors the readers
 scoped to the block, so the view can't escape and the commit can't be
 forgotten.
 
+### Naming the fields (`repr:` tags)
+
+Hand-writing `read_u32_le(b, 12)` per field is error-prone — the offsets
+are implicit and drift as the record changes. Tag a struct's fields with
+their wire representation and the offsets are computed for you, with typed
+accessors generated from the layout:
+
+```hale
+type L2 {
+    kind:  Int `repr:"u8"`;       // 1 byte  @ 0
+    price: Int `repr:"u32_le"`;   // 4 bytes @ 1
+    qty:   Int `repr:"u32_le"`;   // 4 bytes @ 5
+}
+```
+
+Now the consumer reads fields by name and the producer writes them by
+name — both compose with everything above:
+
+```hale
+fn on_rec(v: BytesView) {
+    let p = L2::price(v) or raise;       // read u32_le @ 1
+    ...
+}
+
+fn emit(level: L2) {
+    Recs.write(9) { w =>
+        L2::set_kind(w, 2)            or raise;
+        L2::set_price(w, level.price) or raise;
+        L2::set_qty(w, level.qty)     or raise;
+        9
+    };
+}
+```
+
+`Type::field(v)` and `Type::set_field(w, x)` desugar to the matching
+`std::bytes::read_*` / `write_*` call at the field's computed offset — so
+they're exactly as cheap (and as bounds-checked) as writing the primitive
+by hand. Offsets run in declaration order over the tagged fields; pin one
+for a padded foreign format with `repr:"u32_le,at=4"`. The tag itself is
+general `key:"value"` metadata — `repr:` is the binary-pack consumer;
+other keys (e.g. `json:`) are free for later tools.
+
 ## The same shape, one tier down
 
 Notice this is the same move as everything else at this level: an

--- a/notes/binary-shm-ring-interop.md
+++ b/notes/binary-shm-ring-interop.md
@@ -181,13 +181,37 @@ Recommend shipping the readers + builder-append first (A2 is enough for a
 working producer), and adding the writable view (A1) when the zero-copy
 write path matters.
 
-### Optional follow-on — layout-declared payload structs
+### Proposal A′ — typed field accessors (LANDED 2026-06-09)
 
-The payload analog of `ring_layout` below: declare a POD struct layout
-(`@repr(c)` / field offsets) once and get generated typed field
-accessors, instead of hand-writing `read_u32_le(b, 12)` per field. This
-is the `bindgen`/`zerocopy`/SBE-codegen layer. Strictly additive on top
-of the pack primitives — call it out as a future Proposal A′, not v1.
+The payload analog of `ring_layout`: declare a struct's binary layout
+once and get generated typed field accessors, instead of hand-writing
+`read_u32_le(b, 12)` per field. The `bindgen`/`zerocopy`/SBE-codegen
+layer, strictly additive on the pack primitives.
+
+Design pivoted during implementation away from a dedicated `payload`
+block / `@repr(c)` annotation toward **Go-style struct field tags** — a
+general field-metadata mechanism (a backtick `key:"value"` string after a
+field), so a plain `type` carries its wire layout and the door is open to
+`json:`/`db:`/validation consumers later:
+
+```hale
+type L2 {
+    kind:  Int `repr:"u8"`;
+    price: Int `repr:"u32_le"`;   // offsets computed; pin with ,at=N
+    qty:   Int `repr:"u32_le"`;
+}
+```
+
+Generated accessors `L2::price(v)` (read a `Bytes`/`BytesView`) and
+`L2::set_price(w, x)` (write a `BytesMut`) desugar to the matching
+`std::bytes::read_*`/`write_*` call at the field's offset — so they reuse
+the primitives' typing (incl. `fallible(IndexError)`), bounds-checking,
+and cost, and compose with the BytesView consumer + the `Topic.write`
+zero-copy block. Two PRs: the general field-tag mechanism (#80, parse +
+store), then the `repr:` consumer (desugar). Known follow-up: a typo'd
+field name (`L2::pirce`) currently errors at codegen rather than
+typecheck (the path call is permissively typed, same as a raw
+`std::bytes::` call).
 
 ---
 

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1034,6 +1034,16 @@ payload picks the consumer mode:
   the mapped ring with no intermediate buffer. The reserve and commit are
   scoped to the block, so the view can't escape and the commit can't be
   forgotten.
+- A struct field may carry a Go-style backtick metadata tag after its
+  type (`price: Int `repr:"u32_le"`;`) — free-form `key:"value"` metadata
+  stored on the field. A `repr:"<wire-type>"` key makes the struct a
+  binary layout: `Type::field(v)` reads that field from a `Bytes` /
+  `BytesView` and `Type::set_field(w, x)` writes it into a `BytesMut`, at
+  the field's offset (computed in declaration order over the tagged
+  fields, or pinned with `,at=N`). These desugar to the matching
+  `std::bytes::read_*` / `write_*` call, so they share the primitives'
+  bounds-checking and cost. Other tag keys are reserved for future
+  consumers (serialization, validation).
 
 Any other payload (with `String`, `Bytes`, or variable-size fields and
 not itself `BytesView`) is rejected.


### PR DESCRIPTION
Generated typed field access for binary records, on top of the field-tag mechanism (#80). A struct whose fields carry a `repr:"<wire-type>"` tag is a binary layout:

```hale
type L2 {
    kind:  Int `repr:"u8"`;
    price: Int `repr:"u32_le"`;   // offsets computed in field order
    qty:   Int `repr:"u32_le"`;   // pin a padded format with ,at=N
}
```

`L2::price(v)` reads the field from a `Bytes`/`BytesView` and `L2::set_price(w, x)` writes it into a `BytesMut` — so the consumer **and** the zero-copy `Topic.write` producer both work by field name instead of hand-written `read_u32_le(b, 12)`:

```hale
let p = L2::price(v) or raise;            // consumer
Recs.write(9) { w =>                      // producer
    L2::set_kind(w, 2)            or raise;
    L2::set_price(w, level.price) or raise;
    9
};
```

## How
A single pre-codegen desugar pass (`desugar_repr_accessors`): parse each struct's `repr:` tags into a field→(offset, wire-type) layout (offsets in declaration order, honoring `,at=N`), then rewrite `Type::field(v)` / `Type::set_field(w, x)` calls into the matching `std::bytes::read_*` / `write_*` call at the computed offset. **No accessor-specific type or codegen logic** — everything rides the existing pack primitives (typing, `fallible(IndexError)`, bounds-checking). No-op for programs with no repr-tagged types.

## Design note
This is the `payload`-block idea from the conversation, pivoted (at your prompting) onto Go-style field tags + `repr:` as the key — a general metadata mechanism, not a binary-only construct.

## Tests
End-to-end (`repr_field_accessors.rs`): a producer writes two records field-by-field via `set_*` accessors inside `Topic.write` blocks, a subscriber reads them back via read accessors, both round-trip through a foreign `byte_records` ring. Foreign-ring / zero-copy / bytes / corpus / syntax / types suites stay green. Spec + docs + notes updated.

## Known follow-up
A typo'd field (`L2::pirce`) errors at **codegen** rather than typecheck — the path call is permissively typed, same as a raw `std::bytes::` call. A typecheck-stage guard could front-run it (would need accessor recognition in the checker, which this PR deliberately avoids to keep the type/codegen layers untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)