### PR TITLE
mangle: import-mangle the Topic.write construct's topic ref (A1 follow-up)

### DIFF
--- a/crates/hale-codegen/src/mangle.rs
+++ b/crates/hale-codegen/src/mangle.rs
@@ -778,7 +778,11 @@ impl<'a> Mangler<'a> {
                 self.walk_expr(subject);
                 self.walk_expr(value);
             }
-            Stmt::ShmWrite { max, body, .. } => {
+            Stmt::ShmWrite { topic, max, body, .. } => {
+                // Mangle the topic ref like a bus publish/subscribe
+                // subject, so `Topic.write(...)` resolves to the same
+                // (possibly import-renamed) subject the binding registers.
+                self.rewrite_ident(&mut topic.name);
                 self.walk_expr(max);
                 self.walk_block(body);
             }

--- a/crates/hale-codegen/tests/shm_write_topic_mangle.rs
+++ b/crates/hale-codegen/tests/shm_write_topic_mangle.rs
@@ -1,0 +1,65 @@
+//! A1 follow-up (2026-06-09): the `Topic.write(max) { ... }` construct's
+//! topic reference must be import-mangled like a bus publish/subscribe
+//! subject, so a producer writing to an imported topic resolves to the
+//! same (renamed) subject the binding registers. Before the fix the
+//! mangle pass walked the construct's body but skipped its topic ident.
+
+use std::collections::HashMap;
+
+use hale_codegen::mangle::mangle_with_renames;
+use hale_syntax::ast::{LocusMember, Stmt, TopDecl};
+use hale_syntax::parse_source;
+
+#[test]
+fn shm_write_topic_ref_is_import_mangled() {
+    let src = r#"
+        topic Recs { payload: BytesView; }
+        locus Producer {
+            bus { publish Recs; }
+            birth() {
+                Recs.write(8) { w =>
+                    std::bytes::write_i64_le(w, 0, 1) or raise;
+                    8
+                };
+            }
+        }
+    "#;
+    let mut prog = parse_source(src).expect("parse");
+    let mut renames = HashMap::new();
+    renames.insert("Recs".to_string(), "lib_x_Recs".to_string());
+    mangle_with_renames(&mut prog, &renames);
+
+    let mut topic_ref = None;
+    let mut publish_subj = None;
+    for item in &prog.items {
+        if let TopDecl::Locus(l) = item {
+            for m in &l.members {
+                match m {
+                    LocusMember::Lifecycle(lc) => {
+                        for s in &lc.body.stmts {
+                            if let Stmt::ShmWrite { topic, .. } = s {
+                                topic_ref = Some(topic.name.clone());
+                            }
+                        }
+                    }
+                    LocusMember::Bus(bb) => {
+                        for bm in &bb.members {
+                            if let hale_syntax::ast::BusMember::Publish {
+                                subject: hale_syntax::ast::BusSubject::Topic(id),
+                                ..
+                            } = bm
+                            {
+                                publish_subj = Some(id.name.clone());
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    // The construct's topic ref is mangled to the same name as the
+    // publish subject — both follow the binding.
+    assert_eq!(topic_ref.as_deref(), Some("lib_x_Recs"));
+    assert_eq!(publish_subj.as_deref(), Some("lib_x_Recs"));
+}


### PR DESCRIPTION
The `Topic.write(max) { w => ... }` construct's topic reference now goes through the seed-rename mangler like a bus publish/subscribe subject, so a producer that writes to an **imported** topic resolves to the same renamed subject its binding registers.

The #79 mangle arm walked the construct's `max` + body but skipped the topic ident, so an imported-topic producer could reserve/commit on the wrong (unmangled) subject. (Flagged as a known limitation in #79.)

## Fix
One line — `self.rewrite_ident(&mut topic.name)` in the `ShmWrite` arm of the mangler's `walk_stmt`, mirroring exactly what bus publish/subscribe subjects do. No effect on a local topic (not in the rename map → no-op), so the single-file zero-copy / accessor e2e tests are unchanged.

## Test
`mangle_with_renames` over a `Topic.write` producer rewrites the construct's topic ref to the same name as the publish subject. cross_seed_imports + the zero-copy/accessor e2e suites stay green.

Closes the known limitation from #79. With this, the foreign-ring interop work is fully closed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)