### PR TITLE
codegen+syntax: generated Type::from_json from json: tags (JSON Tier 2)

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -830,6 +830,10 @@ fn run_check(target: &Path) -> ExitCode {
     // auto-inferable cross-pool calls while `build` silently
     // applies — same source, divergent answers.
     for prog in programs.values_mut() {
+        // JSON Tier 2: synthesize `__json_parse_<T>` + rewrite
+        // `T::from_json` before typecheck, so the generated parser is
+        // checked and callers must address its `fallible(JsonError)`.
+        hale_syntax::json_gen::generate_json_parsers(prog);
         let pre_diags = hale_types::apply_sync_inference(prog);
         if !pre_diags.is_empty() {
             let any_source = sources.values().next().map(|s| s.as_str()).unwrap_or("");
@@ -1133,6 +1137,7 @@ fn run_build(target: &Path) -> ExitCode {
     // F.32-0 cross-pool diagnostic stays quiet for auto-
     // inferable cases. Loci with existing sync kwarg or
     // single-pool use are left alone.
+    hale_syntax::json_gen::generate_json_parsers(&mut program);
     let pre_diags = hale_types::apply_sync_inference(&mut program);
     if !pre_diags.is_empty() {
         for d in &pre_diags {

--- a/crates/hale-codegen/runtime/stdlib/json.hl
+++ b/crates/hale-codegen/runtime/stdlib/json.hl
@@ -933,6 +933,11 @@ fn __json_obj_value_bool(it: std::json::ObjectIterSpan, json: String) -> Bool {
     return std::str::range_eq(json, it.val_start, it.val_end, "true");
 }
 
+fn __json_obj_value_float(it: std::json::ObjectIterSpan, json: String) -> Float {
+    if it.done { return 0.0; }
+    return std::str::parse_float(json[it.val_start..it.val_end]) or 0.0;
+}
+
 fn __json_obj_value_string(it: std::json::ObjectIterSpan, json: String) -> String {
     if it.done { return ""; }
     let raw = json[it.val_start..it.val_end];

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -402,6 +402,9 @@ pub fn build_executable_with_options(
     // optimizable Send statements into direct `self.handler(...)`
     // method calls. desugar_topics then handles whatever bus refs
     // remain.
+    // JSON Tier 2: synthesize `__json_parse_<T>` + rewrite `T::from_json`.
+    // Idempotent — a no-op if the CLI already generated them pre-typecheck.
+    hale_syntax::json_gen::generate_json_parsers(&mut program_owned);
     hale_syntax::desugar::desugar_intra_locus_topics(&mut program_owned);
     hale_syntax::desugar::desugar_topics(&mut program_owned);
     // Proposal A′: rewrite repr-tagged field accessors (`L2::price(v)` /
@@ -17097,6 +17100,11 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 let result = self.lower_user_fn_call("__json_obj_value_bool", args, scope)?;
                 result.ok_or_else(|| CodegenError::Unsupported(
                     "std::json::obj_value_bool returns Bool but called in a position that expects no value".to_string()))
+            }
+            ["std", "json", "obj_value_float"] => {
+                let result = self.lower_user_fn_call("__json_obj_value_float", args, scope)?;
+                result.ok_or_else(|| CodegenError::Unsupported(
+                    "std::json::obj_value_float returns Float but called in a position that expects no value".to_string()))
             }
             ["std", "json", "obj_value_string"] => {
                 let result = self.lower_user_fn_call("__json_obj_value_string", args, scope)?;

--- a/crates/hale-codegen/tests/json_from_json.rs
+++ b/crates/hale-codegen/tests/json_from_json.rs
@@ -1,0 +1,67 @@
+//! JSON Tier 2 (2026-06-09): compiler-generated `Type::from_json`. A struct
+//! with `json:` field tags gets a single-pass schema-specialized parser
+//! generated from the tags (driving the object cursor). End-to-end: all
+//! scalar types, key remapping, missing-required raises, declared default
+//! fills a missing field, nested objects skipped.
+
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::build_executable;
+
+fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
+    let n = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("lt-fromjson-{}-{}-{}.bin", name, std::process::id(), n));
+    let program = hale_syntax::parse_source(src).expect("parse");
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (String::from_utf8_lossy(&out.stdout).to_string(), out.status)
+}
+
+const TYPE: &str = r#"
+    type Order {
+        id: Int      `json:"id"`;
+        price: Int   `json:"px"`;
+        qty: Float   `json:"sz"`;
+        active: Bool `json:"on"`;
+        side: String `json:"side"`;
+        note: String = "none";
+    }
+"#;
+
+#[test]
+fn from_json_parses_all_scalar_types_and_remaps_keys() {
+    let src = format!(
+        r#"{TYPE}
+        fn main() {{
+            let o = Order::from_json("{{\"id\": 7, \"px\": 250, \"sz\": 1.5, \"on\": true, \"side\": \"buy\", \"meta\": {{\"x\": 1}}}}") or raise;
+            println("id=", to_string(o.id), " px=", to_string(o.price), " sz=", to_string(o.qty),
+                    " on=", to_string(o.active), " side=", o.side, " note=", o.note);
+        }}
+    "#
+    );
+    let (out, status) = build_and_run("ok", &src);
+    assert!(status.success(), "run failed: {}", out);
+    assert!(out.contains("id=7 px=250 sz=1.5 on=true side=buy note=none"),
+        "wrong parse (note should default):\n{}", out);
+}
+
+#[test]
+fn from_json_raises_on_missing_required_and_defaults_optional() {
+    // `px` required + absent -> raise -> fallback branch. `note` has a
+    // declared default so its absence is fine.
+    let src = format!(
+        r#"{TYPE}
+        fn main() {{
+            let bad = Order::from_json("{{\"id\": 1, \"sz\": 0.0, \"on\": false, \"side\": \"x\"}}")
+                or Order {{ id: -1, price: -1, qty: 0.0, active: false, side: "ERR", note: "ERR" }};
+            println("side=", bad.side);
+        }}
+    "#
+    );
+    let (out, status) = build_and_run("missing", &src);
+    assert!(status.success(), "run failed: {}", out);
+    assert!(out.contains("side=ERR"), "missing required px should have raised:\n{}", out);
+}

--- a/crates/hale-syntax/src/json_gen.rs
+++ b/crates/hale-syntax/src/json_gen.rs
@@ -1,0 +1,416 @@
+//! JSON Tier 2: compiler-generated, schema-specialized parsers.
+//!
+//! A struct that carries at least one `json:"<key>"` field tag opts into a
+//! generated `Type::from_json(s) -> Type fallible(JsonError)`. For each such
+//! type we synthesize a `__json_parse_<Type>` function that drives the
+//! single-pass `std::json` object cursor (see `runtime/stdlib/json.hl`),
+//! dispatching each key (length-gated) and reading the value by the field's
+//! declared type — one pass, no per-field rescan, unknown keys skipped.
+//! `Type::from_json(s)` calls are rewritten to the generated function.
+//!
+//! Semantics (v1, scalar fields):
+//!   - key = the `json:` tag value, else the field name.
+//!   - a missing field raises `JsonError { kind: "missing_field", field }`,
+//!     UNLESS the field declares a literal `= default`, in which case the
+//!     default is kept (optional-with-default for free).
+//!   - field types: Int / Float / Bool / String. A type with any non-scalar
+//!     field is left ungenerated (nested types + arrays are a follow-up).
+//!
+//! The pass runs BEFORE typecheck (so the generated parser is itself
+//! checked and `from_json` resolves to a real fallible function the caller
+//! must address) and is idempotent.
+
+use std::collections::HashSet;
+
+use crate::ast::{
+    Block, ElseBranch, Expr, Ident, IfStmt, Literal, LocusMember, MatchArmBody,
+    MatchStmt, OrDisposition, PrimType, Program, Stmt, TopDecl, TypeDeclBody,
+    TypeExpr,
+};
+use crate::parse_source;
+
+#[derive(Clone, Copy)]
+enum ScalarTy {
+    Int,
+    Float,
+    Bool,
+    Str,
+}
+
+impl ScalarTy {
+    fn type_name(self) -> &'static str {
+        match self {
+            ScalarTy::Int => "Int",
+            ScalarTy::Float => "Float",
+            ScalarTy::Bool => "Bool",
+            ScalarTy::Str => "String",
+        }
+    }
+    fn zero(self) -> &'static str {
+        match self {
+            ScalarTy::Int => "0",
+            ScalarTy::Float => "0.0",
+            ScalarTy::Bool => "false",
+            ScalarTy::Str => "\"\"",
+        }
+    }
+    fn reader(self) -> &'static str {
+        match self {
+            ScalarTy::Int => "obj_value_int",
+            ScalarTy::Float => "obj_value_float",
+            ScalarTy::Bool => "obj_value_bool",
+            ScalarTy::Str => "obj_value_string",
+        }
+    }
+}
+
+struct JsonField {
+    name: String,           // struct field name
+    key: String,            // JSON key (tag value or field name)
+    ty: ScalarTy,
+    default_src: Option<String>, // literal default source, if declared
+}
+
+struct JsonType {
+    name: String,
+    fields: Vec<JsonField>,
+}
+
+fn scalar_of(te: &TypeExpr) -> Option<ScalarTy> {
+    match te {
+        TypeExpr::Primitive(PrimType::Int, _) => Some(ScalarTy::Int),
+        TypeExpr::Primitive(PrimType::Float, _) => Some(ScalarTy::Float),
+        TypeExpr::Primitive(PrimType::Bool, _) => Some(ScalarTy::Bool),
+        TypeExpr::Primitive(PrimType::String, _) => Some(ScalarTy::Str),
+        _ => None,
+    }
+}
+
+/// Render a literal default expression to Hale source. Only literals are
+/// supported (covers `= 0`, `= 1.5`, `= true`, `= "USD"`); anything else
+/// disqualifies the field's default (treated as required).
+fn literal_src(e: &Expr) -> Option<String> {
+    match e {
+        Expr::Literal(Literal::Int(n), _) => Some(n.to_string()),
+        Expr::Literal(Literal::Bool(b), _) => Some(b.to_string()),
+        Expr::Literal(Literal::Float(f), _) => Some(format!("{:?}", f)),
+        Expr::Literal(Literal::String(s), _) => {
+            Some(format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\"")))
+        }
+        _ => None,
+    }
+}
+
+fn tag_json_key(tag: &Option<String>) -> Option<String> {
+    tag.as_deref().and_then(|t| crate::desugar::tag_value(t, "json"))
+}
+
+/// Collect every struct type that opts into JSON parsing (≥1 `json:` tag)
+/// and whose fields are all scalar. A type with a non-scalar field is
+/// skipped (left to a future nested/array pass).
+fn collect_json_types(items: &[TopDecl], out: &mut Vec<JsonType>) {
+    for item in items {
+        match item {
+            TopDecl::Type(td) => {
+                if let TypeDeclBody::Struct(fields) = &td.body {
+                    let opts_in = fields.iter().any(|f| tag_json_key(&f.tag).is_some());
+                    if !opts_in {
+                        continue;
+                    }
+                    let mut jfields = Vec::new();
+                    let mut all_scalar = true;
+                    for f in fields {
+                        let Some(ty) = scalar_of(&f.ty) else {
+                            all_scalar = false;
+                            break;
+                        };
+                        jfields.push(JsonField {
+                            name: f.name.name.clone(),
+                            key: tag_json_key(&f.tag).unwrap_or_else(|| f.name.name.clone()),
+                            ty,
+                            default_src: f.default.as_ref().and_then(literal_src),
+                        });
+                    }
+                    if all_scalar && !jfields.is_empty() {
+                        out.push(JsonType { name: td.name.name.clone(), fields: jfields });
+                    }
+                }
+            }
+            TopDecl::Module(m) => collect_json_types(&m.items, out),
+            _ => {}
+        }
+    }
+}
+
+fn generate_parser_src(t: &JsonType) -> String {
+    let mut b = String::new();
+    b.push_str(&format!(
+        "fn __json_parse_{}(__s: String) -> {} fallible(JsonError) {{\n",
+        t.name, t.name
+    ));
+    for f in &t.fields {
+        let init = f.default_src.as_deref().unwrap_or_else(|| f.ty.zero());
+        b.push_str(&format!(
+            "    let mut __f_{}: {} = {};\n",
+            f.name,
+            f.ty.type_name(),
+            init
+        ));
+        if f.default_src.is_none() {
+            b.push_str(&format!("    let mut __seen_{}: Bool = false;\n", f.name));
+        }
+    }
+    b.push_str("    let mut __it = std::json::object_first(__s);\n");
+    b.push_str("    while !__it.done {\n");
+    let mut first = true;
+    for f in &t.fields {
+        let kw = if first { "if" } else { "} else if" };
+        first = false;
+        b.push_str(&format!(
+            "        {} std::json::obj_key_len(__it) == {} && std::json::obj_key_eq(__it, __s, \"{}\") {{\n",
+            kw,
+            f.key.len(),
+            f.key
+        ));
+        b.push_str(&format!(
+            "            __f_{} = std::json::{}(__it, __s);\n",
+            f.name,
+            f.ty.reader()
+        ));
+        if f.default_src.is_none() {
+            b.push_str(&format!("            __seen_{} = true;\n", f.name));
+        }
+    }
+    if !first {
+        b.push_str("        }\n");
+    }
+    b.push_str("        __it = std::json::object_next(__it, __s);\n");
+    b.push_str("    }\n");
+    for f in &t.fields {
+        if f.default_src.is_none() {
+            b.push_str(&format!(
+                "    if !__seen_{} {{ fail JsonError {{ kind: \"missing_field\", field: \"{}\" }}; }}\n",
+                f.name, f.key
+            ));
+        }
+    }
+    let inits: Vec<String> =
+        t.fields.iter().map(|f| format!("{}: __f_{}", f.name, f.name)).collect();
+    b.push_str(&format!("    return {} {{ {} }};\n}}\n", t.name, inits.join(", ")));
+    b
+}
+
+/// Synthesize `__json_parse_<T>` + `JsonError`, inject them, then rewrite
+/// every `T::from_json(s)` call to `__json_parse_T(s)`.
+pub fn generate_json_parsers(program: &mut Program) {
+    let mut types = Vec::new();
+    collect_json_types(&program.items, &mut types);
+    if types.is_empty() {
+        return;
+    }
+
+    let existing_fns: HashSet<String> = program
+        .items
+        .iter()
+        .filter_map(|i| match i {
+            TopDecl::Fn(f) => Some(f.name.name.clone()),
+            _ => None,
+        })
+        .collect();
+    let have_jsonerror = program.items.iter().any(
+        |i| matches!(i, TopDecl::Type(t) if t.name.name == "JsonError"),
+    );
+
+    let mut src = String::new();
+    if !have_jsonerror {
+        src.push_str("type JsonError { kind: String; field: String; }\n");
+    }
+    for t in &types {
+        if !existing_fns.contains(&format!("__json_parse_{}", t.name)) {
+            src.push_str(&generate_parser_src(t));
+        }
+    }
+    if !src.trim().is_empty() {
+        match parse_source(&src) {
+            Ok(generated) => program.items.extend(generated.items),
+            // The generator emits well-formed source; a parse failure is a
+            // generator bug, not user error. Leave the program unchanged so
+            // the (un-rewritten) call surfaces a normal diagnostic.
+            Err(_) => return,
+        }
+    }
+
+    let names: HashSet<String> = types.iter().map(|t| t.name.clone()).collect();
+    rewrite_items(&mut program.items, &names);
+}
+
+// ---- `T::from_json(s)` -> `__json_parse_T(s)` rewrite (full expr walk) ----
+
+fn rewrite_items(items: &mut [TopDecl], names: &HashSet<String>) {
+    for item in items {
+        match item {
+            TopDecl::Fn(f) => rewrite_block(&mut f.body, names),
+            TopDecl::Locus(l) => {
+                for m in &mut l.members {
+                    match m {
+                        LocusMember::Lifecycle(lc) => rewrite_block(&mut lc.body, names),
+                        LocusMember::Mode(md) => rewrite_block(&mut md.body, names),
+                        LocusMember::Fn(fd) => rewrite_block(&mut fd.body, names),
+                        _ => {}
+                    }
+                }
+            }
+            TopDecl::Module(m) => rewrite_items(&mut m.items, names),
+            _ => {}
+        }
+    }
+}
+
+fn rewrite_block(b: &mut Block, names: &HashSet<String>) {
+    for s in &mut b.stmts {
+        rewrite_stmt(s, names);
+    }
+    if let Some(t) = &mut b.tail {
+        rewrite_expr(t, names);
+    }
+}
+
+fn rewrite_stmt(s: &mut Stmt, names: &HashSet<String>) {
+    match s {
+        Stmt::Let { value, .. } | Stmt::LetTuple { value, .. } => rewrite_expr(value, names),
+        Stmt::Assign { target, value, .. } => {
+            rewrite_expr(value, names);
+            for seg in &mut target.tail {
+                if let crate::ast::LValueSeg::Index(e) = seg {
+                    rewrite_expr(e, names);
+                }
+            }
+        }
+        Stmt::If(if_stmt) => rewrite_if(if_stmt, names),
+        Stmt::Match(m) => rewrite_match(m, names),
+        Stmt::For { iter, body, .. } => {
+            rewrite_expr(iter, names);
+            rewrite_block(body, names);
+        }
+        Stmt::While { cond, body, .. } => {
+            rewrite_expr(cond, names);
+            rewrite_block(body, names);
+        }
+        Stmt::Return(Some(e), _) => rewrite_expr(e, names),
+        Stmt::Fail { value, .. } => rewrite_expr(value, names),
+        Stmt::Send { subject, value, .. } => {
+            rewrite_expr(subject, names);
+            rewrite_expr(value, names);
+        }
+        Stmt::Block(b) => rewrite_block(b, names),
+        Stmt::Recovery { args, .. } => {
+            for a in args {
+                rewrite_expr(a, names);
+            }
+        }
+        Stmt::Violate { payload, .. } => {
+            if let Some(p) = payload {
+                rewrite_expr(p, names);
+            }
+        }
+        Stmt::ShmWrite { max, body, .. } => {
+            rewrite_expr(max, names);
+            rewrite_block(body, names);
+        }
+        Stmt::Expr(e) => rewrite_expr(e, names),
+        Stmt::Return(None, _)
+        | Stmt::Break(_)
+        | Stmt::Continue(_)
+        | Stmt::Yield(_)
+        | Stmt::Terminate(_) => {}
+    }
+}
+
+fn rewrite_if(if_stmt: &mut IfStmt, names: &HashSet<String>) {
+    rewrite_expr(&mut if_stmt.cond, names);
+    rewrite_block(&mut if_stmt.then_block, names);
+    if let Some(eb) = &mut if_stmt.else_block {
+        match eb.as_mut() {
+            ElseBranch::Else(b) => rewrite_block(b, names),
+            ElseBranch::ElseIf(inner) => rewrite_if(inner, names),
+        }
+    }
+}
+
+fn rewrite_match(m: &mut MatchStmt, names: &HashSet<String>) {
+    rewrite_expr(&mut m.scrutinee, names);
+    for arm in &mut m.arms {
+        match &mut arm.body {
+            MatchArmBody::Block(b) => rewrite_block(b, names),
+            MatchArmBody::Expr(e) => rewrite_expr(e, names),
+        }
+    }
+}
+
+fn rewrite_expr(e: &mut Expr, names: &HashSet<String>) {
+    match e {
+        Expr::Call { callee, args, span } => {
+            rewrite_expr(callee, names);
+            for a in args.iter_mut() {
+                rewrite_expr(a, names);
+            }
+            // `T::from_json(s)` with T a generated type -> `__json_parse_T(s)`.
+            if args.len() == 1 {
+                if let Expr::Path(qn) = callee.as_ref() {
+                    if qn.segments.len() == 2
+                        && qn.segments[1].name == "from_json"
+                        && names.contains(&qn.segments[0].name)
+                    {
+                        let fname = format!("__json_parse_{}", qn.segments[0].name);
+                        *callee = Box::new(Expr::Ident(Ident {
+                            name: fname,
+                            span: *span,
+                        }));
+                    }
+                }
+            }
+        }
+        Expr::Binary { left, right, .. } => {
+            rewrite_expr(left, names);
+            rewrite_expr(right, names);
+        }
+        Expr::Unary { operand, .. } => rewrite_expr(operand, names),
+        Expr::Field { receiver, .. } => rewrite_expr(receiver, names),
+        Expr::Index { receiver, index, .. } => {
+            rewrite_expr(receiver, names);
+            rewrite_expr(index, names);
+        }
+        Expr::Path2 { receiver, .. } => rewrite_expr(receiver, names),
+        Expr::Tuple(es, _) | Expr::Array(es, _) => {
+            for x in es {
+                rewrite_expr(x, names);
+            }
+        }
+        Expr::Struct { inits, .. } => {
+            for i in inits {
+                rewrite_expr(&mut i.value, names);
+            }
+        }
+        Expr::Block(b) => rewrite_block(b, names),
+        Expr::If(if_stmt) => rewrite_if(if_stmt, names),
+        Expr::Match(m) => rewrite_match(m, names),
+        Expr::Sum(inner, _) | Expr::Prod(inner, _) => rewrite_expr(inner, names),
+        Expr::Approx { left, right, tolerance, .. } => {
+            rewrite_expr(left, names);
+            rewrite_expr(right, names);
+            rewrite_expr(tolerance, names);
+        }
+        Expr::Range { lo, hi, .. } => {
+            rewrite_expr(lo, names);
+            rewrite_expr(hi, names);
+        }
+        Expr::ArrayRepeat { val, .. } => rewrite_expr(val, names),
+        Expr::Or { inner, disposition, .. } => {
+            rewrite_expr(inner, names);
+            if let OrDisposition::Substitute(s) = disposition {
+                rewrite_expr(s, names);
+            }
+        }
+        Expr::Literal(..) | Expr::Ident(_) | Expr::Path(_) | Expr::KwSelf(_) => {}
+    }
+}

--- a/crates/hale-syntax/src/lib.rs
+++ b/crates/hale-syntax/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod ast;
 pub mod desugar;
 pub mod error;
+pub mod json_gen;
 pub mod keywords;
 pub mod lexer;
 pub mod parser;

--- a/crates/hale-types/tests/json_from_json_check.rs
+++ b/crates/hale-types/tests/json_from_json_check.rs
@@ -1,0 +1,43 @@
+//! JSON Tier 2 typecheck (2026-06-09): after the generator runs,
+//! `Type::from_json` resolves to a `fallible(JsonError)` function, so an
+//! unaddressed call is flagged by the two-channel rule (and an addressed
+//! one is clean). Mirrors the CLI pipeline: generate parsers, then check.
+
+use hale_syntax::json_gen::generate_json_parsers;
+use hale_syntax::parse_source;
+
+fn check(src: &str) -> Vec<String> {
+    let mut prog = parse_source(src).expect("parse failed");
+    generate_json_parsers(&mut prog);
+    hale_types::check_program(&prog).into_iter().map(|d| d.message).collect()
+}
+
+#[test]
+fn unaddressed_from_json_is_flagged() {
+    let msgs = check(
+        r#"
+        type Order { id: Int `json:"id"`; }
+        fn f() { let o = Order::from_json("{}"); let _ = o.id; }
+    "#,
+    );
+    assert!(
+        msgs.iter().any(|m| m.contains("error not addressed")),
+        "unaddressed from_json must be flagged; got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn addressed_from_json_is_clean() {
+    let msgs = check(
+        r#"
+        type Order { id: Int `json:"id"`; }
+        fn f() -> Int { let o = Order::from_json("{}") or raise; return o.id; }
+    "#,
+    );
+    assert!(
+        !msgs.iter().any(|m| m.contains("error not addressed")),
+        "addressed from_json must be clean; got: {:?}",
+        msgs
+    );
+}

--- a/docs/src/everyday/json.md
+++ b/docs/src/everyday/json.md
@@ -31,6 +31,42 @@ let inner = std::json::find_field_raw(doc, "address");
 let city  = std::json::find_string_field(inner, "city");
 ```
 
+## Parsing into a type
+
+Pulling fields one by one rescans the document per field. When you have
+a fixed shape, tag the fields with their JSON keys and the compiler
+generates a single-pass parser for you:
+
+```hale
+type Order {
+    id: Int      `json:"id"`;
+    price: Int   `json:"px"`;     // JSON key differs from the field name
+    qty: Float   `json:"sz"`;
+    active: Bool `json:"on"`;
+    side: String `json:"side"`;
+    currency: String = "USD";     // optional: default fills a missing key
+}
+
+let o = Order::from_json(body) or raise;
+println(o.price);
+```
+
+`Type::from_json(s) -> Type fallible(JsonError)` walks the object once,
+dispatches each key to the matching field, and reads the value by the
+field's declared type — no per-field rescan, and unmatched keys (and
+nested objects/arrays under them) are skipped. The `json:"<key>"` tag
+sets the JSON key; without it the field name is the key.
+
+A **missing field raises** `JsonError`, naming the field — *unless* the
+field declares a default (`currency: String = "USD"`), in which case the
+default fills it. Because `from_json` is `fallible`, you must address it
+(`or raise`, `or <fallback>`, …) like any other fallible call.
+
+The tag is general `key:"value"` metadata — `json:` is one consumer;
+other keys are free for future tools. (Fields must be scalar — `Int` /
+`Float` / `Bool` / `String` — for now; nested types and arrays are a
+follow-up.)
+
 ## Arrays
 
 Walk a JSON array with the iterator pair:

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1042,8 +1042,19 @@ payload picks the consumer mode:
   the field's offset (computed in declaration order over the tagged
   fields, or pinned with `,at=N`). These desugar to the matching
   `std::bytes::read_*` / `write_*` call, so they share the primitives'
-  bounds-checking and cost. Other tag keys are reserved for future
-  consumers (serialization, validation).
+  bounds-checking and cost.
+- A `json:"<key>"` tag is the second tag consumer: a struct with at least
+  one `json:` tag gets a generated `Type::from_json(s) -> Type
+  fallible(JsonError)` that parses the object in a single pass (driving
+  the `std::json` object cursor), dispatching each key to the matching
+  field and reading the value by the field's declared scalar type
+  (`Int` / `Float` / `Bool` / `String`). The key is the tag value, else
+  the field name; unmatched keys (and nested objects/arrays under them)
+  are skipped. A missing field raises `JsonError { kind, field }` unless
+  the field declares a literal default (`= "USD"`), which fills it.
+  `from_json` is `fallible`, so callers must address it. Nested-struct
+  and array fields are a follow-up. Further tag keys remain reserved for
+  future consumers (validation, db mapping).
 
 Any other payload (with `String`, `Bytes`, or variable-size fields and
 not itself `BytesView`) is rejected.


### PR DESCRIPTION
The Tier-2 payoff on top of the object cursor (#84): a struct that tags its fields with `json:"<key>"` gets a **compiler-generated, single-pass, schema-specialized parser** — the part a hand-roll can't practically match (length+key dispatch, parse straight into the struct, skip unwanted fields).

```hale
type Order {
    id: Int      `json:"id"`;
    price: Int   `json:"px"`;
    qty: Float   `json:"sz"`;
    active: Bool `json:"on"`;
    side: String `json:"side"`;
    currency: String = "USD";   // default fills a missing key
}

let o = Order::from_json(body) or raise;
```

`Type::from_json(s) -> Type fallible(JsonError)` walks the object **once** (the #84 cursor), dispatches each key length-gated to the matching field, reads the value by the field's declared type, and skips unmatched keys (and nested objects/arrays under them) — no O(N·K) rescan. Missing field → `JsonError { kind, field }` naming it; **unless** the field declares a literal default. `from_json` is fallible, so the two-channel rule forces callers to address it.

## How
`json_gen::generate_json_parsers` collects `json:`-tagged scalar structs, synthesizes a `__json_parse_<T>` function **as Hale source** (parsed + injected) plus a `JsonError` type, and rewrites `T::from_json` → `__json_parse_T`. Runs **before typecheck** (so the generated parser is checked and the call is seen as fallible) and again in `build_executable` (idempotent) for the codegen-only test path. **No new type/codegen logic** — the generated parser is ordinary Hale over the public cursor API.

## Design decisions (from the conversation)
- Missing required field → **raise** (your call). A literal `= default` makes it optional-with-default for free.
- Ergonomics weren't the point — this is the perf/specialization tier; the cursor seam (#84) keeps Tier 3 (SIMD substrate) a drop-in under the *same* generated code.

## Scope
Scalar fields (Int/Float/Bool/String). Nested types (recursive generation) + arrays are the next PR; a non-scalar field leaves the type ungenerated for now. Adds `std::json::obj_value_float`.

## Tests
e2e (all scalar types, key remap, default-for-missing, missing-required-raises, nested skip) + typecheck enforcement (unaddressed `from_json` flagged, addressed clean). Corpus / json / repr-accessor / syntax / types suites stay green. Docs + spec updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)