### PR TITLE
json_gen: generated Type::to_json (JSON Tier 2 emit)

### DIFF
--- a/crates/hale-codegen/tests/json_from_json.rs
+++ b/crates/hale-codegen/tests/json_from_json.rs
@@ -90,3 +90,35 @@ fn from_json_recurses_into_nested_json_structs() {
     assert!(out.contains("name=Ada city=London zip=1234"), "nested parse wrong:\n{}", out);
     assert!(out.contains("bad=ERR"), "missing nested field should propagate:\n{}", out);
 }
+
+#[test]
+fn to_json_emits_valid_json_and_round_trips() {
+    // Emit covers numbers (unquoted), bools, strings (quoted + escaped),
+    // and nested structs (recursed); then parse the emitted text back.
+    let src = r#"
+        type Addr { city: String `json:"city"`; zip: Int `json:"zip"`; }
+        type Order {
+            id: Int      `json:"id"`;
+            price: Float `json:"px"`;
+            active: Bool `json:"on"`;
+            side: String `json:"side"`;
+            home: Addr   `json:"home"`;
+        }
+        fn main() {
+            let o = Order { id: 7, price: 2.5, active: true, side: "buy\"x",
+                            home: Addr { city: "London", zip: 1234 } };
+            let j = Order::to_json(o);
+            println("json=", j);
+            let back = Order::from_json(j) or raise;
+            println("rt=", to_string(back.id), " ", back.home.city, " ", back.side);
+        }
+    "#;
+    let (out, status) = build_and_run("tojson", src);
+    assert!(status.success(), "run failed: {}", out);
+    assert!(
+        out.contains(r#"json={"id":7,"px":2.5,"on":true,"side":"buy\"x","home":{"city":"London","zip":1234}}"#),
+        "emit wrong:\n{}", out
+    );
+    // round-trip preserves nested + escaped values
+    assert!(out.contains(r#"rt=7 London buy"x"#), "round-trip wrong:\n{}", out);
+}

--- a/crates/hale-syntax/src/json_gen.rs
+++ b/crates/hale-syntax/src/json_gen.rs
@@ -282,8 +282,44 @@ fn generate_parser_src(t: &JsonType) -> String {
     b
 }
 
-/// Synthesize `__json_parse_<T>` + `JsonError`, inject them, then rewrite
-/// every `T::from_json(s)` call to `__json_parse_T(s)`.
+/// The Hale string-literal `"<sep>\"<key>\":"` — the member prefix for the
+/// emitted object (sep is "" for the first field, "," after).
+fn prefix_lit(sep: &str, key: &str) -> String {
+    format!("\"{}\\\"{}\\\":\"", sep, key)
+}
+
+/// Emit-side: `__json_to_json_<T>(v: T) -> String`, building the object by
+/// string concat. Numbers/bools via `to_string`, strings quoted +
+/// escaped, nested structs recurse. Not fallible — serialization always
+/// succeeds.
+fn generate_emit_src(t: &JsonType) -> String {
+    let mut b = String::new();
+    b.push_str(&format!(
+        "fn __json_to_json_{}(__v: {}) -> String {{\n",
+        t.name, t.name
+    ));
+    b.push_str("    let mut __b: String = \"{\";\n");
+    for (i, f) in t.fields.iter().enumerate() {
+        let sep = if i == 0 { "" } else { "," };
+        let prefix = prefix_lit(sep, &f.key);
+        let value = match &f.kind {
+            FieldKind::Scalar(ScalarTy::Str) => format!(
+                "\"\\\"\" + std::json::escape_string(__v.{}) + \"\\\"\"",
+                f.name
+            ),
+            FieldKind::Scalar(_) => format!("to_string(__v.{})", f.name),
+            FieldKind::Nested(tn) => format!("__json_to_json_{}(__v.{})", tn, f.name),
+        };
+        b.push_str(&format!("    __b = __b + {} + {};\n", prefix, value));
+    }
+    b.push_str("    __b = __b + \"}\";\n");
+    b.push_str("    return __b;\n}\n");
+    b
+}
+
+/// Synthesize `__json_parse_<T>` / `__json_to_json_<T>` / `JsonError`,
+/// inject them, then rewrite every `T::from_json(s)` and `T::to_json(o)`
+/// call to the generated function.
 pub fn generate_json_parsers(program: &mut Program) {
     let mut names = HashSet::new();
     collect_json_type_names(&program.items, &mut names);
@@ -312,6 +348,9 @@ pub fn generate_json_parsers(program: &mut Program) {
     for t in &types {
         if !existing_fns.contains(&format!("__json_parse_{}", t.name)) {
             src.push_str(&generate_parser_src(t));
+        }
+        if !existing_fns.contains(&format!("__json_to_json_{}", t.name)) {
+            src.push_str(&generate_emit_src(t));
         }
     }
     if !src.trim().is_empty() {
@@ -438,18 +477,23 @@ fn rewrite_expr(e: &mut Expr, names: &HashSet<String>) {
             for a in args.iter_mut() {
                 rewrite_expr(a, names);
             }
-            // `T::from_json(s)` with T a generated type -> `__json_parse_T(s)`.
+            // `T::from_json(s)` / `T::to_json(o)` with T a generated type
+            // -> `__json_parse_T(s)` / `__json_to_json_T(o)`.
             if args.len() == 1 {
                 if let Expr::Path(qn) = callee.as_ref() {
-                    if qn.segments.len() == 2
-                        && qn.segments[1].name == "from_json"
-                        && names.contains(&qn.segments[0].name)
-                    {
-                        let fname = format!("__json_parse_{}", qn.segments[0].name);
-                        *callee = Box::new(Expr::Ident(Ident {
-                            name: fname,
-                            span: *span,
-                        }));
+                    if qn.segments.len() == 2 && names.contains(&qn.segments[0].name) {
+                        let prefix = match qn.segments[1].name.as_str() {
+                            "from_json" => Some("__json_parse_"),
+                            "to_json" => Some("__json_to_json_"),
+                            _ => None,
+                        };
+                        if let Some(prefix) = prefix {
+                            let fname = format!("{}{}", prefix, qn.segments[0].name);
+                            *callee = Box::new(Expr::Ident(Ident {
+                                name: fname,
+                                span: *span,
+                            }));
+                        }
                     }
                 }
             }

--- a/docs/src/everyday/json.md
+++ b/docs/src/everyday/json.md
@@ -74,6 +74,17 @@ let p = Person::from_json(body) or raise;
 println(p.home.city);
 ```
 
+The same tags drive the reverse direction — `Type::to_json(value)`
+serializes back to a JSON string (numbers and bools bare, strings escaped,
+nested structs recursed), so `from_json` / `to_json` round-trip:
+
+```hale
+let body = Order::to_json(o);          // -> {"id":7,"px":...}
+let o2   = Order::from_json(body) or raise;
+```
+
+`to_json` is not fallible — serialization always succeeds.
+
 The tag is general `key:"value"` metadata — `json:` is one consumer;
 other keys are free for future tools.
 

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1052,7 +1052,10 @@ payload picks the consumer mode:
   the field name; unmatched keys (and nested objects/arrays under them)
   are skipped. A missing field raises `JsonError { kind, field }` unless
   the field declares a literal default (`= "USD"`), which fills it.
-  `from_json` is `fallible`, so callers must address it. A field whose
+  `from_json` is `fallible`, so callers must address it. The same tags
+  drive emit: `Type::to_json(v) -> String` serializes a value back (bare
+  numbers/bools, escaped strings, nested structs recursed), round-tripping
+  with `from_json`; it is not fallible. A field whose
   type is another generated JSON struct is parsed recursively (the nested
   object's raw text is handed to that type's parser; a nested failure
   propagates). Array fields are **not** supported by design — Hale


### PR DESCRIPTION
The emit side of the generated JSON codec, symmetric with `from_json`. A `json:`-tagged struct now also gets `Type::to_json(v) -> String`:

```hale
let body = Order::to_json(o);          // {"id":7,"px":2.5,"on":true,"side":"buy\"x",...}
let o2   = Order::from_json(body) or raise;
```

The generated `__json_to_json_<T>` builds the object by string concat from the same `json:` keys: numbers and bools bare (`to_string`), strings quoted + escaped (`std::json::escape_string`), nested generated structs recursed. **Not fallible** — serialization always succeeds. Field order = declaration order.

Reuses the existing `json_gen` pass: same type collection, now emitting both `__json_parse_<T>` and `__json_to_json_<T>`, and the call rewrite handles both `T::from_json(s)` and `T::to_json(o)`.

## Tests
Emit produces valid JSON (unquoted numbers/bools, escaped strings, nested recursion) and **round-trips** (emit → parse-back preserves nested + escaped values). json / cursor / check suites stay green. Docs + spec updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)