### PR TITLE
json: SIMD-accelerate the object cursor (Tier 3 Level A)

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -38,6 +38,9 @@
 #include <malloc.h>
 #include <string.h>
 #include <pthread.h>
+#if defined(__SSE2__)
+#include <emmintrin.h>  /* JSON Tier-3 Level-A SIMD scan primitives */
+#endif
 #include <sched.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -11411,6 +11414,97 @@ void lotus_bytes_write_uint(void *base, int64_t cap, int64_t off, int width,
             v >>= 8;
         }
     }
+}
+
+/*
+ * JSON Tier-3 Level-A — SIMD scan primitives.
+ *
+ * Each takes a NUL-terminated String `char*` (the data pointer directly),
+ * a start offset, and the precomputed length, and returns the offset of the next byte matching a small character
+ * class at/after `from`, or `len` if none. The single-pass `std::json`
+ * object/array cursors call these instead of byte-at-a-time inner loops.
+ *
+ * SSE2 (baseline on x86-64) scans 16-byte chunks; a scalar tail handles
+ * the final < 16 bytes so there is never an out-of-bounds read (the
+ * `from + 16 <= len` guard keeps the vector load fully in-bounds —
+ * ASan-safe). On non-SSE2 targets the scalar loop is the whole impl, and
+ * it must stay byte-identical to the SSE2 result (the cursor's existing
+ * test corpus + a differential fuzz enforce that).
+ */
+
+/* First offset >= from whose byte is a JSON structural char or a quote:
+ * `{ } [ ] , "` (no `:` — the value scan doesn't need it). Drives the
+ * outside-string value scan and finds an object key's opening quote. */
+int64_t lotus_json_next_struct_or_quote(const char *s, int64_t from, int64_t len) {
+    const unsigned char *d = (const unsigned char *)s;
+    int64_t i = from < 0 ? 0 : from;
+#if defined(__SSE2__)
+    for (; i + 16 <= len; i += 16) {
+        __m128i v = _mm_loadu_si128((const __m128i *)(d + i));
+        __m128i m = _mm_or_si128(
+            _mm_or_si128(
+                _mm_or_si128(_mm_cmpeq_epi8(v, _mm_set1_epi8('{')),
+                             _mm_cmpeq_epi8(v, _mm_set1_epi8('}'))),
+                _mm_or_si128(_mm_cmpeq_epi8(v, _mm_set1_epi8('[')),
+                             _mm_cmpeq_epi8(v, _mm_set1_epi8(']')))),
+            _mm_or_si128(_mm_cmpeq_epi8(v, _mm_set1_epi8(',')),
+                         _mm_cmpeq_epi8(v, _mm_set1_epi8('"'))));
+        int mask = _mm_movemask_epi8(m);
+        if (mask) return i + __builtin_ctz((unsigned)mask);
+    }
+#endif
+    for (; i < len; i++) {
+        unsigned char c = d[i];
+        if (c == '{' || c == '}' || c == '[' || c == ']' || c == ',' || c == '"')
+            return i;
+    }
+    return len;
+}
+
+/* First offset >= from whose byte is a quote or backslash (`" \`).
+ * Drives the inside-string scan (key + string values): a `\` means skip
+ * the escaped byte, a `"` closes the string. */
+int64_t lotus_json_next_quote_or_bs(const char *s, int64_t from, int64_t len) {
+    const unsigned char *d = (const unsigned char *)s;
+    int64_t i = from < 0 ? 0 : from;
+#if defined(__SSE2__)
+    for (; i + 16 <= len; i += 16) {
+        __m128i v = _mm_loadu_si128((const __m128i *)(d + i));
+        __m128i m = _mm_or_si128(_mm_cmpeq_epi8(v, _mm_set1_epi8('"')),
+                                 _mm_cmpeq_epi8(v, _mm_set1_epi8('\\')));
+        int mask = _mm_movemask_epi8(m);
+        if (mask) return i + __builtin_ctz((unsigned)mask);
+    }
+#endif
+    for (; i < len; i++) {
+        unsigned char c = d[i];
+        if (c == '"' || c == '\\') return i;
+    }
+    return len;
+}
+
+/* First offset >= from whose byte is NOT JSON whitespace (space, tab,
+ * newline, carriage return). Drives the skip-whitespace loops. */
+int64_t lotus_json_next_non_ws(const char *s, int64_t from, int64_t len) {
+    const unsigned char *d = (const unsigned char *)s;
+    int64_t i = from < 0 ? 0 : from;
+#if defined(__SSE2__)
+    for (; i + 16 <= len; i += 16) {
+        __m128i v = _mm_loadu_si128((const __m128i *)(d + i));
+        __m128i ws = _mm_or_si128(
+            _mm_or_si128(_mm_cmpeq_epi8(v, _mm_set1_epi8(' ')),
+                         _mm_cmpeq_epi8(v, _mm_set1_epi8('\t'))),
+            _mm_or_si128(_mm_cmpeq_epi8(v, _mm_set1_epi8('\n')),
+                         _mm_cmpeq_epi8(v, _mm_set1_epi8('\r'))));
+        int nonws = (~_mm_movemask_epi8(ws)) & 0xFFFF;
+        if (nonws) return i + __builtin_ctz((unsigned)nonws);
+    }
+#endif
+    for (; i < len; i++) {
+        unsigned char c = d[i];
+        if (c != ' ' && c != '\t' && c != '\n' && c != '\r') return i;
+    }
+    return len;
 }
 
 /*

--- a/crates/hale-codegen/runtime/stdlib/json.hl
+++ b/crates/hale-codegen/runtime/stdlib/json.hl
@@ -841,10 +841,11 @@ fn __json_obj_step_span(json: String, start: Int)
     let done_iter = std::json::ObjectIterSpan {
         pos: total, key_start: -1, key_end: 0, val_start: -1, val_end: 0, done: true
     };
-    let mut p = start;
-    while p < total {
-        let c = std::str::byte_at_unchecked(json, p);
-        if c == 32 || c == 9 || c == 10 || c == 13 || c == 44 { p = p + 1; } else { break; }
+    // Skip whitespace, then any leading commas (each followed by more
+    // whitespace). SIMD jumps over runs of whitespace.
+    let mut p = std::json::next_non_ws(json, start, total);
+    while p < total && std::str::byte_at_unchecked(json, p) == 44 {
+        p = std::json::next_non_ws(json, p + 1, total);
     }
     if p >= total { return done_iter; }
     let c = std::str::byte_at_unchecked(json, p);
@@ -854,47 +855,45 @@ fn __json_obj_step_span(json: String, start: Int)
         };
     }
     if c != 34 { return done_iter; }  // expected a `"`-quoted key
+    // Key string: jump to the next quote/backslash; a backslash escapes
+    // the next byte, a quote closes the key.
     let key_start = p + 1;
-    let mut kp = key_start;
-    while kp < total {
-        let ch = std::str::byte_at_unchecked(json, kp);
-        if ch == 92 { kp = kp + 2; continue; }  // backslash: skip escaped byte
-        if ch == 34 { break; }
-        kp = kp + 1;
+    let mut kp = std::json::next_quote_or_bs(json, key_start, total);
+    while kp < total && std::str::byte_at_unchecked(json, kp) == 92 {
+        kp = std::json::next_quote_or_bs(json, kp + 2, total);
     }
     let key_end = kp;
-    let mut q = kp + 1;  // past closing quote
-    while q < total {
-        let ch = std::str::byte_at_unchecked(json, q);
-        if ch == 32 || ch == 9 || ch == 10 || ch == 13 { q = q + 1; } else { break; }
-    }
+    // Whitespace, `:`, whitespace.
+    let mut q = std::json::next_non_ws(json, kp + 1, total);
     if q >= total || std::str::byte_at_unchecked(json, q) != 58 { return done_iter; }  // `:`
-    q = q + 1;
-    while q < total {
-        let ch = std::str::byte_at_unchecked(json, q);
-        if ch == 32 || ch == 9 || ch == 10 || ch == 13 { q = q + 1; } else { break; }
-    }
+    q = std::json::next_non_ws(json, q + 1, total);
+    // Value: jump structural-to-structural, tracking nesting depth and
+    // skipping string contents wholesale.
     let val_start = q;
     let mut depth = 0;
-    let mut in_str = false;
-    while q < total {
-        let ch = std::str::byte_at_unchecked(json, q);
-        if in_str {
-            if ch == 92 { q = q + 2; continue; }
-            if ch == 34 { in_str = false; }
-            q = q + 1;
-            continue;
+    let mut scanning = true;
+    while scanning {
+        q = std::json::next_struct_or_quote(json, q, total);
+        if q >= total {
+            q = total;
+            scanning = false;
+        } else {
+            let ch = std::str::byte_at_unchecked(json, q);
+            if ch == 34 {  // string value — skip to its closing quote
+                let mut sp = std::json::next_quote_or_bs(json, q + 1, total);
+                while sp < total && std::str::byte_at_unchecked(json, sp) == 92 {
+                    sp = std::json::next_quote_or_bs(json, sp + 2, total);
+                }
+                if sp >= total { q = total; scanning = false; } else { q = sp + 1; }
+            } else if ch == 123 || ch == 91 {  // { [
+                depth = depth + 1;
+                q = q + 1;
+            } else if ch == 125 || ch == 93 {  // } ]
+                if depth == 0 { scanning = false; } else { depth = depth - 1; q = q + 1; }
+            } else {  // comma
+                if depth == 0 { scanning = false; } else { q = q + 1; }
+            }
         }
-        if ch == 34 { in_str = true; q = q + 1; continue; }
-        if ch == 123 || ch == 91 { depth = depth + 1; q = q + 1; continue; }
-        if ch == 125 || ch == 93 {
-            if depth == 0 { break; }
-            depth = depth - 1;
-            q = q + 1;
-            continue;
-        }
-        if ch == 44 && depth == 0 { break; }
-        q = q + 1;
     }
     // Trim trailing whitespace from the value range.
     let mut ve = q;

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -16187,6 +16187,18 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 let _ = self.lower_std_str_byte_at_unchecked(args, scope)?;
                 Ok(())
             }
+            ["std", "json", "next_struct_or_quote"] => {
+                let _ = self.lower_json_scan("lotus_json_next_struct_or_quote", args, scope)?;
+                Ok(())
+            }
+            ["std", "json", "next_quote_or_bs"] => {
+                let _ = self.lower_json_scan("lotus_json_next_quote_or_bs", args, scope)?;
+                Ok(())
+            }
+            ["std", "json", "next_non_ws"] => {
+                let _ = self.lower_json_scan("lotus_json_next_non_ws", args, scope)?;
+                Ok(())
+            }
             ["std", "io", "sockopt", name]
                 if SOCKOPT_NAMES.contains(name) =>
             {
@@ -16871,6 +16883,15 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             }
             ["std", "str", "byte_at_unchecked"] => {
                 self.lower_std_str_byte_at_unchecked(args, scope)
+            }
+            ["std", "json", "next_struct_or_quote"] => {
+                self.lower_json_scan("lotus_json_next_struct_or_quote", args, scope)
+            }
+            ["std", "json", "next_quote_or_bs"] => {
+                self.lower_json_scan("lotus_json_next_quote_or_bs", args, scope)
+            }
+            ["std", "json", "next_non_ws"] => {
+                self.lower_json_scan("lotus_json_next_non_ws", args, scope)
             }
             // 2026-05-26 — named socket-option constants. Each
             // resolves to a zero-arg call into the matching C

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1802,6 +1802,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             bytes_write_uint_ty,
             None,
         );
+        // JSON Tier-3 Level-A SIMD scan primitives:
+        // i64 @lotus_json_next_*(ptr s, i64 from, i64 len).
+        let json_scan_ty =
+            i64_t.fn_type(&[ptr_t.into(), i64_t.into(), i64_t.into()], false);
+        for name in [
+            "lotus_json_next_struct_or_quote",
+            "lotus_json_next_quote_or_bs",
+            "lotus_json_next_non_ws",
+        ] {
+            self.module.add_function(name, json_scan_ty, None);
+        }
         // A1 zero-copy ring write: reserve a slot, commit a length.
         // declare ptr @lotus_bus_reserve_shm_ring_layout(ptr subject, i64 max)
         let reserve_ty = ptr_t.fn_type(&[ptr_t.into(), i64_t.into()], false);

--- a/crates/hale-codegen/src/stdlib/str.rs
+++ b/crates/hale-codegen/src/stdlib/str.rs
@@ -28,6 +28,12 @@ pub(crate) trait StrStdlib<'ctx> {
         args: &[Expr],
         scope: &Scope<'ctx>,
     ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
+    fn lower_json_scan(
+        &mut self,
+        fn_name: &str,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
     fn lower_std_str_range_parse_int_fallible(
         &mut self,
         args: &[Expr],
@@ -383,6 +389,52 @@ impl<'ctx, 'p> StrStdlib<'ctx> for Cx<'ctx, 'p> {
                 &[s_val.into(), i_val.into()],
                 "str.byte_at_unchecked.ret",
             )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .expect("returns i64");
+        Ok((v, CodegenTy::Int))
+    }
+
+    /// JSON Tier-3 Level-A scan primitive: `(json: String, from: Int) ->
+    /// Int`, dispatched to a `lotus_json_next_*` SIMD runtime fn. Shares
+    /// the `byte_at_unchecked` shape (String blob + offset → offset).
+    fn lower_json_scan(
+        &mut self,
+        fn_name: &str,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        if args.len() != 3 {
+            return Err(CodegenError::Unsupported(format!(
+                "std::json::{} takes 3 args (json, from, len), got {}",
+                fn_name,
+                args.len()
+            )));
+        }
+        let (s_val, s_ty) = self.lower_expr(&args[0], scope)?;
+        if !matches!(s_ty, CodegenTy::String | CodegenTy::StringView) {
+            return Err(CodegenError::Unsupported(format!(
+                "std::json::{}: first arg must be String, got {:?}",
+                fn_name, s_ty
+            )));
+        }
+        let s_val = self.unpack_view_if_needed(s_val, &s_ty)?;
+        let (from_val, from_ty) = self.lower_expr(&args[1], scope)?;
+        let (len_val, len_ty) = self.lower_expr(&args[2], scope)?;
+        if !matches!(from_ty, CodegenTy::Int) || !matches!(len_ty, CodegenTy::Int) {
+            return Err(CodegenError::Unsupported(format!(
+                "std::json::{}: from and len must be Int, got {:?}, {:?}",
+                fn_name, from_ty, len_ty
+            )));
+        }
+        let f = self
+            .module
+            .get_function(fn_name)
+            .unwrap_or_else(|| panic!("{} declared", fn_name));
+        let v = self
+            .builder
+            .build_call(f, &[s_val.into(), from_val.into(), len_val.into()], "json.scan.ret")
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
             .try_as_basic_value()
             .left()

--- a/crates/hale-codegen/tests/json_from_json.rs
+++ b/crates/hale-codegen/tests/json_from_json.rs
@@ -122,3 +122,27 @@ fn to_json_emits_valid_json_and_round_trips() {
     // round-trip preserves nested + escaped values
     assert!(out.contains(r#"rt=7 London buy"x"#), "round-trip wrong:\n{}", out);
 }
+
+#[test]
+fn simd_cursor_handles_escapes_nesting_and_chunk_boundaries() {
+    // Stresses the SIMD scan path: escaped quotes/backslashes inside
+    // strings (the quote-or-backslash scan), padding that pushes keys
+    // across 16-byte chunk boundaries, deep nesting on an unmatched key
+    // (depth scan), and heavy whitespace.
+    let src = r#"
+        type T {
+            tag: String  `json:"tag"`;
+            n: Int       `json:"n"`;
+        }
+        fn main() {
+            let body = "{  \"skip\" : { \"a\": [1,2,{\"deep\": \"x\"}], \"b\": 9 } ,
+                          \"tag\":  \"a\\\"b\\\\c\"  ,  \"n\" : -1234567890 }";
+            let t = T::from_json(body) or raise;
+            println("tag=", t.tag, " n=", to_string(t.n));
+        }
+    "#;
+    let (out, status) = build_and_run("stress", src);
+    assert!(status.success(), "run failed: {}", out);
+    // tag is the 3-escape string a"b\c ; n is the long negative int
+    assert!(out.contains(r#"tag=a"b\c n=-1234567890"#), "stress parse wrong:\n{}", out);
+}

--- a/notes/json-simd-tier3.md
+++ b/notes/json-simd-tier3.md
@@ -1,10 +1,18 @@
 # JSON Tier 3 — SIMD-accelerated parsing
 
-Status: **scope / proposal.** Nothing built. Written 2026-06-09 after JSON
-Tier 2 (`from_json` / `to_json`, scalar, schema-specialized) landed
-(#84–#88). This scopes the SIMD substrate the cursor was designed as a
-seam for — and, importantly, argues it's two separable levels, the first
-much cheaper than "implement simdjson."
+Status: **Level A in progress.** Object cursor on SSE2 landed 2026-06-09
+(workload: high-volume market-data JSON ingest). Remaining: the array
+cursor on the same primitives, then AVX2/NEON, then (if profiling
+demands) Level B. Written after JSON Tier 2 (`from_json` / `to_json`,
+scalar, schema-specialized) landed (#84–#88).
+
+**Landed (Level A, object cursor):** `lotus_json_next_struct_or_quote` /
+`next_quote_or_bs` / `next_non_ws` — SSE2 16-byte scans with a scalar
+tail + scalar fallback (`(char* s, from, len)`; the cursor passes the
+precomputed length so there's no per-step strlen). `__json_obj_step_span`
+rewired to jump structural-to-structural instead of byte-at-a-time. The
+generated `from_json` is unchanged (the seam held); existing json suites
++ a SIMD stress test pass, ASan/UBSan-clean. Known follow-ons below.
 
 ## Where we are
 


### PR DESCRIPTION
First slice of JSON Tier 3, for the high-volume market-data ingest path you named. Replaces the object cursor's byte-at-a-time inner loops with SSE2 scan primitives that jump structural-to-structural.

## New runtime primitives (`lotus_arena.c`) — `(char* s, from, len) -> i64`
- `lotus_json_next_struct_or_quote` — next `{ } [ ] , "`
- `lotus_json_next_quote_or_bs` — next `" \` (string scan)
- `lotus_json_next_non_ws` — next non-whitespace

SSE2 (baseline on x86-64) scans 16-byte chunks via `pcmpeqb` + `movemask`; a scalar tail handles the final < 16 bytes so the vector load is always in-bounds (`from + 16 <= len`) — **ASan/UBSan-clean**. Non-SSE2 targets use the scalar loop. The caller passes the precomputed length (Hale `String` is a NUL-terminated `char*`), so the walk never `strlen`s per step.

## The seam held
`__json_obj_step_span` rewired to jump via the primitives; **the generated `from_json` is unchanged** — Tier 3 is a scan swap *under* the cursor, exactly as the seam was designed. No surface change.

## Scope
Object cursor only. The array cursor (`__json_array_step_span` — the other half for array-of-records market data), AVX2/NEON, and the full structural index (Level B) are follow-ons, tracked in `notes/json-simd-tier3.md`.

## Tests
All json suites + corpus pass through the SIMD cursor. A stress test exercises escaped quotes/backslashes, deep nesting on a skipped key, chunk-boundary keys, and whitespace. ASan + UBSan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)