### PR TITLE
json: SIMD-accelerate the array cursor (Tier 3 Level A, part 2)

### DIFF
--- a/crates/hale-codegen/runtime/stdlib/json.hl
+++ b/crates/hale-codegen/runtime/stdlib/json.hl
@@ -660,13 +660,7 @@ type __JsonArrayIterSpan {
 
 fn __json_array_first_span(json: String) -> std::json::ArrayIterSpan {
     let total = len(json);
-    // Skip leading whitespace.
-    let mut p = 0;
-    while p < total {
-        let c = std::str::byte_at_unchecked(json, p);
-        if c == 32 || c == 9 || c == 10 || c == 13 { p = p + 1; }
-        else { break; }
-    }
+    let p = std::json::next_non_ws(json, 0, total);
     if p >= total {
         return std::json::ArrayIterSpan {
             pos: total, cur_start: -1, cur_end: 0, done: true
@@ -697,11 +691,10 @@ fn __json_array_step_span(json: String, start: Int)
     -> std::json::ArrayIterSpan
 {
     let total = len(json);
-    let mut p = start;
-    while p < total {
-        let c = std::str::byte_at_unchecked(json, p);
-        if c == 32 || c == 9 || c == 10 || c == 13 || c == 44 { p = p + 1; }
-        else { break; }
+    // Skip whitespace, then any leading comma (+ trailing whitespace).
+    let mut p = std::json::next_non_ws(json, start, total);
+    while p < total && std::str::byte_at_unchecked(json, p) == 44 {
+        p = std::json::next_non_ws(json, p + 1, total);
     }
     if p >= total {
         return std::json::ArrayIterSpan {
@@ -715,27 +708,34 @@ fn __json_array_step_span(json: String, start: Int)
             pos: p + 1, cur_start: -1, cur_end: 0, done: true
         };
     }
+    // Element value: jump structural-to-structural, tracking nesting and
+    // skipping string contents wholesale (cur_end lands on the delimiter,
+    // matching the scalar iterator — element spans are not ws-trimmed).
     let elem_start = p;
     let mut depth = 0;
-    let mut in_str = false;
-    while p < total {
-        let ch = std::str::byte_at_unchecked(json, p);
-        if in_str {
-            if ch == 92 { p = p + 2; continue; }
-            if ch == 34 { in_str = false; }
-            p = p + 1;
-            continue;
+    let mut scanning = true;
+    while scanning {
+        p = std::json::next_struct_or_quote(json, p, total);
+        if p >= total {
+            p = total;
+            scanning = false;
+        } else {
+            let ch = std::str::byte_at_unchecked(json, p);
+            if ch == 34 {  // string — skip to its closing quote
+                let mut sp = std::json::next_quote_or_bs(json, p + 1, total);
+                while sp < total && std::str::byte_at_unchecked(json, sp) == 92 {
+                    sp = std::json::next_quote_or_bs(json, sp + 2, total);
+                }
+                if sp >= total { p = total; scanning = false; } else { p = sp + 1; }
+            } else if ch == 123 || ch == 91 {  // { [
+                depth = depth + 1;
+                p = p + 1;
+            } else if ch == 125 || ch == 93 {  // } ]
+                if depth == 0 { scanning = false; } else { depth = depth - 1; p = p + 1; }
+            } else {  // comma
+                if depth == 0 { scanning = false; } else { p = p + 1; }
+            }
         }
-        if ch == 34 { in_str = true; p = p + 1; continue; }
-        if ch == 123 || ch == 91 { depth = depth + 1; p = p + 1; continue; }
-        if ch == 125 || ch == 93 {
-            if depth == 0 { break; }
-            depth = depth - 1;
-            p = p + 1;
-            continue;
-        }
-        if ch == 44 && depth == 0 { break; }
-        p = p + 1;
     }
     return std::json::ArrayIterSpan {
         pos: p, cur_start: elem_start, cur_end: p, done: false
@@ -810,11 +810,7 @@ type __JsonObjectIterSpan {
 
 fn __json_obj_first_span(json: String) -> std::json::ObjectIterSpan {
     let total = len(json);
-    let mut p = 0;
-    while p < total {
-        let c = std::str::byte_at_unchecked(json, p);
-        if c == 32 || c == 9 || c == 10 || c == 13 { p = p + 1; } else { break; }
-    }
+    let p = std::json::next_non_ws(json, 0, total);
     if p >= total || std::str::byte_at_unchecked(json, p) != 123 {
         // Not an object (`{`).
         return std::json::ObjectIterSpan {

--- a/crates/hale-codegen/tests/json_span_iter.rs
+++ b/crates/hale-codegen/tests/json_span_iter.rs
@@ -163,3 +163,27 @@ fn find_field_raw_in_with_explicit_bounds() {
     let c_line = stdout.lines().find(|l| l.starts_with("c=")).unwrap();
     assert_eq!(c_line, "c=", "expected c=<empty>, got: {:?}", c_line);
 }
+
+#[test]
+fn array_of_records_walk_through_simd_cursor() {
+    // Market-data shape: an array of objects. Walk the array (array
+    // cursor) and parse each element (object cursor) — both SIMD now.
+    let src = r#"
+        type Level { px: Float `json:"px"`; sz: Int `json:"sz"`; }
+        fn main() {
+            let book = "[ {\"px\": 1.5, \"sz\": 10}, {\"px\": 2.25, \"sz\": 20},
+                          {\"px\": 3.0, \"sz\": 30, \"note\": \"x\\\"y\"} ]";
+            let mut it = std::json::array_first_span(book);
+            let mut total = 0;
+            while !it.done {
+                let lvl = Level::from_json(std::json::iter_substring(it, book)) or raise;
+                total = total + lvl.sz;
+                it = std::json::array_next_span(it, book);
+            }
+            println("total=", to_string(total));
+        }
+    "#;
+    let (out, status) = build_and_run("arr_rec", src);
+    assert!(status.success(), "run failed: {}", out);
+    assert!(out.contains("total=60"), "array-of-records walk wrong:\n{}", out);
+}

--- a/notes/json-simd-tier3.md
+++ b/notes/json-simd-tier3.md
@@ -1,10 +1,11 @@
 # JSON Tier 3 — SIMD-accelerated parsing
 
-Status: **Level A in progress.** Object cursor on SSE2 landed 2026-06-09
-(workload: high-volume market-data JSON ingest). Remaining: the array
-cursor on the same primitives, then AVX2/NEON, then (if profiling
-demands) Level B. Written after JSON Tier 2 (`from_json` / `to_json`,
-scalar, schema-specialized) landed (#84–#88).
+Status: **Level A (SSE2) landed for both cursors, 2026-06-09** (workload:
+high-volume market-data JSON ingest). Object + array cursors both jump
+structural-to-structural via the SIMD primitives. Remaining: AVX2/NEON
+(wider chunks + ARM, behind runtime dispatch), then (if profiling demands)
+Level B. Written after JSON Tier 2 (`from_json` / `to_json`, scalar,
+schema-specialized) landed (#84–#88).
 
 **Landed (Level A, object cursor):** `lotus_json_next_struct_or_quote` /
 `next_quote_or_bs` / `next_non_ws` — SSE2 16-byte scans with a scalar


### PR DESCRIPTION
Completes the SIMD scan layer. `__json_array_step_span` now jumps structural-to-structural via the same primitives the object cursor uses (#90), instead of byte-at-a-time.

This is the **other half of the market-data path**: array-of-records (order books, trade batches) walks the array cursor to iterate, then the object cursor to parse each element — both SIMD now.

- Element span still lands on the delimiter (not ws-trimmed), **byte-identical to the scalar iterator** — `next_struct_or_quote` stops on the same byte the old loop did.
- Also rewired the leading-whitespace skip in both `*_first_span` entry points to `next_non_ws`.

## Tests
`json_span_iter` + `json_range_helpers` + the full json suite pass through the SIMD array cursor; a new array-of-records test walks an array of objects (incl. an escaped quote) and parses each. **ASan + UBSan clean.**

Note: the pre-existing `high_volume_walk_bounded_rss` ASan failure is unrelated — it fails identically on main (ASan's memory overhead exceeds the test's RSS bound); green in normal CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)