### PR TITLE
json_gen: skip unescape copy for escape-free string fields

### DIFF
--- a/crates/hale-syntax/src/json_gen.rs
+++ b/crates/hale-syntax/src/json_gen.rs
@@ -251,6 +251,10 @@ fn generate_parser_src(t: &JsonType) -> String {
     b.push_str("            } else {\n");
     b.push_str("                __q = std::json::next_non_ws(__s, __q + 1, __total);\n");
     b.push_str("                let __vs = __q;\n");
+    // Track whether a string value contained a backslash escape — lets a
+    // String field skip the unescape copy entirely in the common
+    // escape-free case (it falls out of the value scan for free).
+    b.push_str("                let mut __esc = false;\n");
     // Value end: jump structural-to-structural, skipping strings + nesting.
     b.push_str("                let mut __depth = 0;\n");
     b.push_str("                let mut __vscan = true;\n");
@@ -262,6 +266,7 @@ fn generate_parser_src(t: &JsonType) -> String {
     b.push_str("                        if __c == 34 {\n");
     b.push_str("                            let mut __sp = std::json::next_quote_or_bs(__s, __q + 1, __total);\n");
     b.push_str("                            while __sp < __total && std::str::byte_at_unchecked(__s, __sp) == 92 {\n");
+    b.push_str("                                __esc = true;\n");
     b.push_str("                                __sp = std::json::next_quote_or_bs(__s, __sp + 2, __total);\n");
     b.push_str("                            }\n");
     b.push_str("                            if __sp >= __total { __q = __total; __vscan = false; } else { __q = __sp + 1; }\n");
@@ -290,6 +295,13 @@ fn generate_parser_src(t: &JsonType) -> String {
             f.key
         ));
         match &f.kind {
+            // String: slice directly when escape-free (the common case),
+            // only unescape-copy when the scan saw a backslash.
+            FieldKind::Scalar(ScalarTy::Str) => b.push_str(&format!(
+                "                    if __esc {{ __f_{} = std::json::unescape_string(__s[(__vs + 1)..(__ve - 1)]); }} \
+                 else {{ __f_{} = __s[(__vs + 1)..(__ve - 1)]; }}\n",
+                f.name, f.name
+            )),
             FieldKind::Scalar(s) => b.push_str(&format!(
                 "                    __f_{} = {};\n",
                 f.name,


### PR DESCRIPTION
Follow-up perf on the inlined parser (#93). The benchmark showed the one String field cost ~23ms of 98ms — it always did slice + unescape (two allocs + a copy), even though almost all JSON strings have no escapes.

The value scan already enters its backslash-skip loop only when a string value has an escape, so I set an `__esc` flag there (free — no extra call). A String field then **slices the source directly when escape-free**, and only unescape-copies when `__esc`.

| | before | after |
|---|--------|-------|
| time (200k × 7-field) | 98 ms | **75 ms** |
| memory | 43 MB | **30 MB** |

The String field is now ~free for escape-free strings (we're at the all-int floor). **Now beats Go ~2× and Python ~2.9×, ~1.47× behind V8** (was 1.9×). Escaped strings still unescape correctly (stress test passes); full json suite + ASan green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)