### PR TITLE
spec: correct free-fn value-allocation reclaim to match shipped behavior

### DIFF
--- a/notes/memory-bound-proofs.md
+++ b/notes/memory-bound-proofs.md
@@ -44,10 +44,11 @@ the model attributes a value allocation's reclaim to its enclosing
 false "bounded"). Only bus sends get a per-iteration boundary
 (`reclaim@bus-dispatch`).
 
-> **Open question for the user / spec:** is the spec aspirational (correct
-> it to "value allocations live until the enclosing locus dissolves") or is
-> free-fn region teardown an unimplemented reclaim (a runtime fix)? Left
-> untouched pending that call; the model encodes the *shipped* behavior.
+> **Resolved (2026-06-09):** the spec was corrected to match shipped
+> behavior — `spec/memory.md` §"Value allocations vs. the free-fn implicit
+> locus" now states that value allocations bump into the enclosing locus's
+> region and reclaim only at its dissolve, not at fn return. The model
+> encodes that.
 
 ## Goal
 

--- a/spec/memory.md
+++ b/spec/memory.md
@@ -219,6 +219,32 @@ returns when:
 - Body's last statement completes, AND
 - All children of the implicit locus have dissolved.
 
+### Value allocations vs. the free-fn implicit locus
+
+The free-fn implicit locus governs the lifetime of **child loci
+and bound handles** instantiated in the body — those dissolve at
+the function's return. It does **not** give the function a
+value-allocation arena of its own.
+
+Ordinary **value allocations** (struct / record literals,
+`String` concatenation, array and `Bytes` literals) made in a
+free `fn` body bump into the nearest enclosing **locus's** region
+and are reclaimed only when that locus dissolves — **not** when
+the function returns. A value allocated inside a helper `fn`
+called from a hot loop therefore accumulates in the caller's
+region exactly as if it had been written inline; the function
+boundary is not a reclamation boundary for values.
+
+The practical consequence: a value allocation inside an
+unbounded loop (a `run()` / bus-handler loop, a `while true`)
+grows the locus region without bound for the locus's lifetime —
+the recurring leak class behind several past OOMs. To bound it,
+either bound the loop, route the value over the bus (the payload
+arena reclaims per dispatch), or move the allocating work into a
+child locus that dissolves per iteration. The compile-time
+analysis that surfaces this is GitHub issue #18 item 1
+(memory-bound proofs); see `spec/verification.md`.
+
 ## Bookkeeping reclamation (per-arena defrag)
 
 Per F.3: within a parent's arena, dissolved-coordinatee


### PR DESCRIPTION
`spec/memory.md` §"Free fn functions" implied a free fn's implicit-locus region frees at return. Measurement (GH #18 item 1, step 2 — #101) shows otherwise: **value allocations in a free fn body are not reclaimed at return** — they bump into the nearest enclosing locus's region and persist until that locus dissolves. A struct allocated inside a non-inlinable per-iteration helper accumulates to ~99MB exactly as if inlined.

Adds §"Value allocations vs. the free-fn implicit locus": the implicit locus governs **child-locus + bound-handle** lifetime (those do dissolve at return), but ordinary **value** allocations reclaim at the enclosing **locus** dissolve, not the fn boundary. Documents the consequence (unbounded-loop accumulation = the recurring leak class) and the remedies (bound the loop, route over the bus, per-iteration child locus).

Per repo convention the spec describes **shipped** behavior, not aspiration. Resolves the open question flagged in `notes/memory-bound-proofs.md`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)