### PR TITLE
codegen: don't mangle locus method names (pond P1)

### DIFF
--- a/crates/hale-codegen/src/mangle.rs
+++ b/crates/hale-codegen/src/mangle.rs
@@ -555,7 +555,7 @@ impl<'a> Mangler<'a> {
                     }
                 }
             }
-            LocusMember::Fn(f) => self.walk_fn_decl(f),
+            LocusMember::Fn(f) => self.walk_method_decl(f),
             LocusMember::Const(c) => {
                 self.walk_type_expr(&mut c.ty);
                 self.walk_expr(&mut c.value);
@@ -666,8 +666,25 @@ impl<'a> Mangler<'a> {
         }
     }
 
+    /// Top-level free fn: its name is a seed top-level decl, so rewrite it
+    /// through the rename map, then walk the signature + body.
     fn walk_fn_decl(&mut self, f: &mut FnDecl) {
         self.rewrite_ident(&mut f.name.name);
+        self.walk_fn_signature_and_body(f);
+    }
+
+    /// Locus method: its name lives in *member* position — looked up on the
+    /// locus by its original name (the locus name carries the seed
+    /// prefix), never through the seed top-level rename map. Rewriting it
+    /// when a top-level fn happens to share the name renamed the decl away
+    /// from its (correctly-unrewritten) call sites → "locus … has no
+    /// method `name`" (pond P1, FRICTION method-name-shadowed-by-fn). So
+    /// walk the signature + body but leave the name alone.
+    fn walk_method_decl(&mut self, f: &mut FnDecl) {
+        self.walk_fn_signature_and_body(f);
+    }
+
+    fn walk_fn_signature_and_body(&mut self, f: &mut FnDecl) {
         self.push_scope();
         for g in &f.generics {
             self.bind(&g.name.name);

--- a/crates/hale-codegen/tests/cross_seed_imports.rs
+++ b/crates/hale-codegen/tests/cross_seed_imports.rs
@@ -385,3 +385,60 @@ fn consumer_uses_greeter_and_formatted_from_lib_toy() {
         stdout
     );
 }
+
+#[test]
+fn method_name_shadowed_by_top_level_fn_resolves() {
+    // pond P1 (FRICTION method-name-shadowed-by-fn): a cross-seed method
+    // call where the imported seed also has a top-level fn of the same
+    // name. The method decl lives in member position and must keep its
+    // name; before the fix the mangler renamed the *decl* to the fn's
+    // mangled name (because both shared `title`), while the call site
+    // correctly didn't — so codegen reported "locus … has no method
+    // `title`".
+    let lib_src = r#"
+        fn title(s: String) -> String { return s; }
+        locus Console {
+            params { }
+            fn title(s: String) { println(s); }
+        }
+    "#;
+    let consumer_src = r#"
+        fn main() {
+            let c = lib::Console { };
+            c.title("collision-ok");
+        }
+    "#;
+    let alias = "lib";
+    let mut lib_prog = parse_source(lib_src).expect("parse lib");
+    // Build the rename map (immutable borrow), then mangle the seed.
+    let seed_renames = {
+        let stem_refs: Vec<(String, &Program)> = vec![("thing".to_string(), &lib_prog)];
+        mangle::build_seed_renames(&stem_refs, alias)
+    };
+    let renames: Vec<(Vec<String>, String)> = seed_renames
+        .iter()
+        .map(|(name, mangled)| (vec![alias.to_string(), name.clone()], mangled.clone()))
+        .collect();
+    mangle::mangle_with_renames(&mut lib_prog, &seed_renames);
+
+    let mut consumer = parse_source(consumer_src).expect("parse consumer");
+    consumer.imports.clear();
+    consumer.items.extend(lib_prog.items);
+
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale_p1_method_shadow_{}", std::process::id()));
+    build_executable_with_imports(&consumer, &bin, &renames).expect("build consumer + lib");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(
+        out.status.success(),
+        "non-zero exit: {:?} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("collision-ok"),
+        "got: {:?}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}


### PR DESCRIPTION
Fixes the one true bug in the pond terminal-stack handoff (P1, FRICTION method-name-shadowed-by-fn).

A cross-seed method call failed at codegen when the imported seed had a top-level fn sharing the method's name:
```
// lib: top-level `fn title` AND a Console method `fn title`
c.title("hi");   // -> codegen error: locus __lib_..._Console has no method `title`
```

**Root cause — the opposite of the note's guess.** The call site was already fine (`Expr::Field`/`Path2` names are skipped in `walk_expr`). The bug is on the **declaration** side: the mangler walks locus methods through `walk_fn_decl`, which rewrites the fn's *name* via the seed rename map. Since `title` was in the map (from the top-level fn), the method *decl* got renamed to the fn's mangled name while the call kept `title` — decl/use mismatch.

**Fix:** a method name lives in member position — looked up on the locus by its original name (the locus name carries the seed prefix), never through the top-level rename map. Split `walk_fn_decl` into name-rewrite + signature/body, and route `LocusMember::Fn` through `walk_method_decl` (walks the body, leaves the name). Free fns unchanged; lifecycle/mode/failure methods already skipped the name.

**Test:** `method_name_shadowed_by_top_level_fn_resolves` — a colliding fn/method pair across seeds builds + runs. cross-seed (7), mangle, closed-world, corpus suites green; pond `term`/`tui`/`logfmt` seeds + the `report` example build with this.

Per the handoff, pond's workaround renames (`window_title`, `write_raw`) can keep their names — no revert needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)