### PR TITLE
stdlib: BytesBuilder.append_str + StringView @ffi clarification (pond P3)

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -13028,6 +13028,26 @@ int64_t lotus_bytes_builder_append_scalar(void *handle, int64_t value,
     return 1;
 }
 
+/* std::bytes::BytesBuilder.append_str — append a Hale String's bytes
+ * (a NUL-terminated char*) in one strlen + one memcpy, instead of
+ * byte-walking through append_u8 (pond/tui's frame renderer did
+ * ~10k C calls per full-frame redraw). Returns 1 ok / 0 alloc-fail. */
+int64_t lotus_bytes_builder_append_str(void *handle, const char *str) {
+    if (!handle) return 0;
+    if (!str) return 1;
+    lotus_bytes_builder_t *b = (lotus_bytes_builder_t *)handle;
+    size_t add = strlen(str);
+    if (add == 0) return 1;
+    int64_t cur_len = lotus_bb_len(b);
+    size_t need = (size_t)cur_len + add;
+    if (!bb_ensure_cap(b, need)) return 0;
+    memcpy(b->buf + cur_len, str, add);
+    lotus_bb_set_len(b, (int64_t)need);
+    b->buf[need] = '\0';
+    b->mutation_epoch += 1;
+    return 1;
+}
+
 /* Zero-fill to the next `to_align` boundary (no-op if already
  * aligned or to_align <= 1). Returns 1 ok / 0 alloc-fail. */
 int64_t lotus_bytes_builder_append_pad(void *handle, int64_t to_align) {

--- a/crates/hale-codegen/runtime/stdlib/bytes_builder.hl
+++ b/crates/hale-codegen/runtime/stdlib/bytes_builder.hl
@@ -142,6 +142,17 @@ locus __StdBytesBytesBuilder {
             violate alloc_failed;
         }
     }
+    // pond P3: append a String's bytes (NUL-terminated) directly —
+    // one strlen + memcpy in the runtime, vs byte-walking through
+    // append_u8 (pond/tui's frame renderer did ~10k C calls per full
+    // redraw). The String is appended verbatim (no NUL, no length
+    // prefix); use snapshot()/finish() to materialize.
+    fn append_str(s: String) {
+        let ok = std::bytes::builder::__append_str(self.handle, s);
+        if ok == 0 {
+            violate alloc_failed;
+        }
+    }
     // Phase-3 Site 1 (2026-05-19): copy src[lo..hi) directly into
     // the builder's tail. Eliminates the
     // `slice(src, lo, hi) + append(chunk)` pair's intermediate

--- a/crates/hale-codegen/src/channels/mod.rs
+++ b/crates/hale-codegen/src/channels/mod.rs
@@ -1130,6 +1130,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             | ["std", "str", "builder_finish"]
             | ["std", "bytes", "builder", "__new"]
             | ["std", "bytes", "builder", "__append"]
+            | ["std", "bytes", "builder", "__append_str"]
             | ["std", "bytes", "builder", "__len"]
             | ["std", "bytes", "builder", "__finish"]
             | ["std", "bytes", "builder", "__shift_front"]

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -16280,6 +16280,10 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 let _ = self.lower_std_bytes_builder_append(args, scope)?;
                 Ok(())
             }
+            ["std", "bytes", "builder", "__append_str"] => {
+                let _ = self.lower_std_bytes_builder_append_str(args, scope)?;
+                Ok(())
+            }
             ["std", "bytes", "builder", "__len"] => {
                 let _ = self.lower_std_bytes_builder_len(args, scope)?;
                 Ok(())
@@ -16958,6 +16962,9 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             }
             ["std", "bytes", "builder", "__append"] => {
                 self.lower_std_bytes_builder_append(args, scope)
+            }
+            ["std", "bytes", "builder", "__append_str"] => {
+                self.lower_std_bytes_builder_append_str(args, scope)
             }
             ["std", "bytes", "builder", "__len"] => {
                 self.lower_std_bytes_builder_len(args, scope)

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -2334,6 +2334,14 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             bb_append_ty,
             None,
         );
+        // declare i64 @lotus_bytes_builder_append_str(ptr handle, ptr str)
+        // — append a Hale String's bytes (NUL-terminated) in one
+        // strlen + memcpy. Same (ptr, ptr) shape as __append.
+        self.module.add_function(
+            "lotus_bytes_builder_append_str",
+            bb_append_ty,
+            None,
+        );
         // declare i64 @lotus_bytes_builder_append_scalar(ptr handle,
         //   i64 value, i32 width, i32 big_endian) — binary-pack writer.
         let i32_bbas = self.context.i32_type();

--- a/crates/hale-codegen/src/stdlib/bytes.rs
+++ b/crates/hale-codegen/src/stdlib/bytes.rs
@@ -46,6 +46,11 @@ pub(crate) trait BytesStdlib<'ctx> {
         args: &[Expr],
         scope: &Scope<'ctx>,
     ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
+    fn lower_std_bytes_builder_append_str(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
     fn lower_std_bytes_builder_len(
         &mut self,
         args: &[Expr],
@@ -927,6 +932,53 @@ impl<'ctx, 'p> BytesStdlib<'ctx> for Cx<'ctx, 'p> {
         // Returns i64 status: 1=ok, 0=fail (realloc NULL or null
         // handle). The BytesBuilder locus's `append` method checks
         // this and routes to `violate alloc_failed` on 0 per F.27.
+        let status = call
+            .try_as_basic_value()
+            .left()
+            .expect("returns i64 status");
+        Ok((status, CodegenTy::Int))
+    }
+
+    /// pond P3: `std::bytes::builder::__append_str(handle, s: String)`.
+    /// Append a Hale String's bytes in one C call (strlen + memcpy in the
+    /// runtime), instead of byte-walking through append_u8. Returns i64
+    /// status (1=ok / 0=alloc-fail) like `__append`.
+    fn lower_std_bytes_builder_append_str(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        if args.len() != 2 {
+            return Err(CodegenError::Unsupported(format!(
+                "std::bytes::builder::__append_str takes 2 args (handle, s), got {}",
+                args.len()
+            )));
+        }
+        let (_h_int, handle_ptr) = self.lower_bytes_builder_handle_arg(
+            &args[0],
+            scope,
+            "std::bytes::builder::__append_str",
+        )?;
+        let (s_val, s_ty) = self.lower_expr(&args[1], scope)?;
+        // String only — NOT StringView. A String is a NUL-terminated
+        // char* the runtime can strlen; a StringView is (ptr, len) into a
+        // larger buffer with no NUL at its end, so strlen would overrun it.
+        // A view must be materialized (std::str::clone / a slice) first.
+        if !matches!(s_ty, CodegenTy::String) {
+            return Err(CodegenError::Unsupported(format!(
+                "std::bytes::builder::__append_str: s must be String (not \
+                 StringView — it isn't NUL-terminated; materialize it first), got {:?}",
+                s_ty
+            )));
+        }
+        let f = self
+            .module
+            .get_function("lotus_bytes_builder_append_str")
+            .expect("lotus_bytes_builder_append_str declared");
+        let call = self
+            .builder
+            .build_call(f, &[handle_ptr.into(), s_val.into()], "bb.append_str.ret")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         let status = call
             .try_as_basic_value()
             .left()

--- a/crates/hale-codegen/tests/bytes_builder_inplace.rs
+++ b/crates/hale-codegen/tests/bytes_builder_inplace.rs
@@ -268,3 +268,26 @@ fn recv_loop_simulation_recycles_capacity() {
     assert!(stdout.contains("final_len=0"), "got: {:?}", stdout);
     assert!(stdout.contains("body=done"), "got: {:?}", stdout);
 }
+
+#[test]
+fn builder_append_str_appends_string_bytes() {
+    // pond P3: append a String's bytes in one C call instead of
+    // byte-walking through append_u8.
+    let src = r#"
+        fn main() {
+            let b = std::bytes::BytesBuilder { initial_cap: 4 };
+            b.append_str("hello, ");
+            b.append_str("");
+            b.append_str("world");
+            b.append_u8(33);
+            print("s=");
+            println(std::str::from_bytes(b.snapshot()));
+            print("len=");
+            println(b.len());
+        }
+    "#;
+    let (stdout, status) = build_and_run("append_str", src);
+    assert!(status.success(), "exit: {:?}", status);
+    assert!(stdout.contains("s=hello, world!"), "got: {:?}", stdout);
+    assert!(stdout.contains("len=13"), "got: {:?}", stdout);
+}

--- a/spec/ffi.md
+++ b/spec/ffi.md
@@ -75,7 +75,7 @@ matching C-ABI representation at the call boundary:
 | `Int` | `i64` | `int64_t` | 64-bit signed throughout. |
 | `Float` | `double` | `double` | 64-bit IEEE 754. |
 | `Bool` | `i32` | `int32_t` | Hale's i1 zero-extends to i32 at the call, truncates back at the return. Avoids C `_Bool` cross-platform ambiguity. |
-| `String` | `ptr` | `const char *` | NUL-terminated. Caller owns; callee MUST NOT retain past the call. |
+| `String` | `ptr` | `const char *` | NUL-terminated. Caller owns; callee MUST NOT retain past the call. A `StringView` does **not** implicitly coerce to a `String` parameter — it isn't NUL-terminated, so a `char*`-expecting callee would `strlen` past its end. Pass a view as a `StringView` parameter (→ `lotus_view_t`, length-carrying) or materialize it first via `std::str::clone`. |
 | `Bytes` | `ptr` | `void *` (header) | Points at Hale's `[int64 len][payload]` header — callee uses `lotus_bytes_len(p)` / `lotus_bytes_data(p)` (declared in `lotus_arena.h`) to inspect. Caller owns. |
 | `BytesView` / `StringView` | `{ ptr, i64 }` (struct by value) | `lotus_view_t` | 16-byte F.30b view layout. C glue MAY use `lotus_view_data` to recover the payload pointer + length. |
 | `Duration` / `Time` | `i64` | `int64_t` | Both are 64-bit nanosecond counts under the hood. |

--- a/spec/stdlib.md
+++ b/spec/stdlib.md
@@ -114,7 +114,10 @@ The discipline that follows:
 
 1. **Pick one role per binding.** A binding is either a
    `BytesBuilder` (long-lived growable buffer with methods
-   `append` / `len` / `shift_front` / `clear` / `snapshot` /
+   `append` (chunk: Bytes) / `append_str` (s: String — append the
+   string's bytes verbatim in one strlen + memcpy; `String` only,
+   a non-NUL-terminated `StringView` must be materialized first) /
+   `len` / `shift_front` / `clear` / `snapshot` /
    `finish` / `view` / `text_view`, plus the binary-pack writers
    below) or a `Bytes` (immutable length-prefixed blob with
    functions `at` / `slice` / `len` / `concat`). The typechecker


### PR DESCRIPTION
`std::bytes::BytesBuilder` had `append(Bytes)` + `append_u8` but no String append, so pond/tui's frame renderer byte-walked Strings through `append_u8` — **~10k C calls per full-frame redraw**. (spec/design-rationale §F.36's codec example already calls `b.append_str(...)` — the spec assumed it exists.)

**Adds `append_str(s: String)`:** one C primitive (`lotus_bytes_builder_append_str` — strlen + memcpy via `bb_ensure_cap`), wired through the path-call dispatch (stmt + expr positions + the channels classifier), and the locus method (violates `alloc_failed` on realloc-NULL like `append`).

**`String` only, not `StringView`:** a String is a NUL-terminated `char*` the runtime can `strlen`; a StringView is `(ptr, len)` with no NUL at its end, so `strlen` would overrun it. (Slices like `s[lo..hi]` are owned Strings, so they work.)

## Answers P3's secondary question
**StringView does NOT coerce to a `String` @ffi parameter** — `lower_ffi_fn_call` does an exact type check, and *correctly* so (the view isn't NUL-terminated, so a `char*` callee would strlen past its end). So pond/tui's per-frame `std::str::clone` is **correct, not a workaround**; the zero-copy alternative is to declare the @ffi param as `StringView` (→ `lotus_view_t`, length-carrying). Documented in `spec/ffi.md`, and `append_str` added to the builder surface in `spec/stdlib.md`.

## Tests
`builder_append_str_appends_string_bytes` (empty-string + multi-append + a u8); bytes builder/violate/pack suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)