### PR TITLE
types: resource-budget count slice (GH #18 item 5)

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -858,6 +858,12 @@ fn run_check(target: &Path) -> ExitCode {
         print!("{}", hale_types::dump_alloc_summary(&bundle));
         return ExitCode::SUCCESS;
     }
+    // GH #18 item 5: dump the per-program resource budget (pinned threads,
+    // cooperative pools, bus subjects) and exit.
+    if std::env::args().any(|a| a == "--dump-resource-budget") {
+        print!("{}", hale_types::dump_resource_budget(&bundle));
+        return ExitCode::SUCCESS;
+    }
     let allow_unowned =
         std::env::args().any(|a| a == "--allow-unowned-subscriber");
     let mut diags = hale_types::check_bundle_opts(&bundle, allow_unowned);

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -25,6 +25,7 @@ pub mod alloc_summary;
 pub mod check;
 pub mod purity;
 pub mod resolve;
+pub mod resource_budget;
 pub mod symbol;
 pub mod sync_inference;
 pub mod ty;
@@ -90,6 +91,14 @@ pub fn check_bundle(bundle: &Bundle<'_>) -> Vec<Diag> {
 pub fn dump_alloc_summary(bundle: &Bundle<'_>) -> String {
     let progs: Vec<&hale_syntax::ast::Program> = bundle.programs.values().copied().collect();
     alloc_summary::summarize_programs(&progs).render()
+}
+
+/// Render the per-program resource budget — pinned threads, cooperative
+/// pools, bus subjects (GH #18 item 5, count slice). Drives
+/// `--dump-resource-budget`.
+pub fn dump_resource_budget(bundle: &Bundle<'_>) -> String {
+    let progs: Vec<&hale_syntax::ast::Program> = bundle.programs.values().copied().collect();
+    resource_budget::budget_for_programs(&progs).render()
 }
 
 /// Bound-solver warnings: one per unbounded-accumulation allocation site

--- a/crates/hale-types/src/resource_budget.rs
+++ b/crates/hale-types/src/resource_budget.rs
@@ -1,0 +1,174 @@
+//! GH #18 item 5 — resource-budget tracking, the count slice.
+//!
+//! A static tally of the language-visible resources a program acquires —
+//! a "linter" signal + the basis for a CI ceiling gate ("this PR raised
+//! the fd/thread/subject count — intentional?"). This slice covers the
+//! cheap, structural, top-level-walk resources with **zero false
+//! positives** (it's a count):
+//!
+//! - **OS threads** = pinned loci (`PlacementSpec::Pinned` placement
+//!   entries — one `pthread` each).
+//! - **Cooperative pools** = distinct `cooperative(pool = X)` names (one
+//!   shared OS thread each; `None` → the program's `main` thread).
+//! - **Bus subjects** = distinct registered subject strings
+//!   (subscribe/publish `canonical()` + `topic` decls — router entries).
+//!
+//! Held-fd counts + leak detection (which reuses `alloc_summary`'s
+//! unbounded-context dataflow) are the next stages — see
+//! `notes/resource-budgets.md`.
+
+use std::collections::BTreeSet;
+
+use hale_syntax::ast::*;
+
+/// Per-program resource tally.
+#[derive(Debug, Clone, Default)]
+pub struct ResourceBudget {
+    /// Pinned placement entries — one OS thread (`pthread`) each.
+    pub pinned_threads: usize,
+    /// Distinct cooperative pool names (one shared OS thread each).
+    /// `main` is the program's own thread (a `cooperative` with no pool).
+    pub cooperative_pools: BTreeSet<String>,
+    /// Distinct bus subject strings (router table entries).
+    pub bus_subjects: BTreeSet<String>,
+}
+
+/// Walk the bundle and tally the structural resources.
+pub fn budget_for_programs(programs: &[&Program]) -> ResourceBudget {
+    let mut b = ResourceBudget::default();
+    for program in programs {
+        for item in &program.items {
+            match item {
+                TopDecl::Topic(t) => {
+                    // A topic decl is a router registration; its subject
+                    // defaults to the topic name (a subscribe/publish that
+                    // references it dedupes via the same canonical string).
+                    b.bus_subjects.insert(t.name.name.clone());
+                }
+                TopDecl::Locus(l) => collect_locus(l, &mut b),
+                TopDecl::Module(m) => {
+                    for it in &m.items {
+                        if let TopDecl::Locus(l) = it {
+                            collect_locus(l, &mut b);
+                        } else if let TopDecl::Topic(t) = it {
+                            b.bus_subjects.insert(t.name.name.clone());
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    b
+}
+
+fn collect_locus(l: &LocusDecl, b: &mut ResourceBudget) {
+    for member in &l.members {
+        match member {
+            LocusMember::Placement(pb) => {
+                for entry in &pb.entries {
+                    match &entry.spec {
+                        PlacementSpec::Pinned { .. } => b.pinned_threads += 1,
+                        PlacementSpec::Cooperative { pool } => {
+                            let name = pool
+                                .as_ref()
+                                .map(|p| p.name.clone())
+                                .unwrap_or_else(|| "main".to_string());
+                            b.cooperative_pools.insert(name);
+                        }
+                    }
+                }
+            }
+            LocusMember::Bus(bus) => {
+                for bm in &bus.members {
+                    let subject = match bm {
+                        BusMember::Subscribe { subject, .. } => subject,
+                        BusMember::Publish { subject, .. } => subject,
+                    };
+                    b.bus_subjects.insert(subject.canonical().to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl ResourceBudget {
+    /// Human-readable dump for `--dump-resource-budget`.
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        out.push_str("# resource budget (GH #18 item 5, count slice)\n\n");
+        out.push_str(&format!("OS threads (pinned loci):  {}\n", self.pinned_threads));
+        out.push_str(&format!(
+            "cooperative pools:         {}{}\n",
+            self.cooperative_pools.len(),
+            if self.cooperative_pools.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "  [{}]",
+                    self.cooperative_pools.iter().cloned().collect::<Vec<_>>().join(", ")
+                )
+            }
+        ));
+        out.push_str(&format!("bus subjects:              {}\n", self.bus_subjects.len()));
+        for s in &self.bus_subjects {
+            out.push_str(&format!("    - {}\n", s));
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hale_syntax::parse_source;
+
+    fn budget(src: &str) -> ResourceBudget {
+        let program = parse_source(src).expect("parse");
+        budget_for_programs(&[&program])
+    }
+
+    #[test]
+    fn counts_bus_subjects_distinctly() {
+        // topic + a subscribe + a publish on two distinct subjects → 2.
+        let src = r#"
+            type T { n: Int; }
+            locus C {
+                bus {
+                    subscribe "in" as on_in of type T;
+                    publish "out" of type T;
+                }
+                fn on_in(m: T) { let _ = m.n; }
+            }
+            fn main() { }
+        "#;
+        let b = budget(src);
+        assert_eq!(b.bus_subjects.len(), 2, "subjects: {:?}", b.bus_subjects);
+        assert!(b.bus_subjects.contains("in"));
+        assert!(b.bus_subjects.contains("out"));
+    }
+
+    #[test]
+    fn dedupes_subject_across_subscribe_and_publish() {
+        let src = r#"
+            type T { n: Int; }
+            locus A { bus { publish "ev" of type T; } }
+            locus B {
+                bus { subscribe "ev" as on_ev of type T; }
+                fn on_ev(m: T) { let _ = m.n; }
+            }
+            fn main() { }
+        "#;
+        let b = budget(src);
+        assert_eq!(b.bus_subjects.len(), 1, "same subject should dedupe: {:?}", b.bus_subjects);
+    }
+
+    #[test]
+    fn no_resources_in_a_plain_program() {
+        let b = budget("fn main() { println(\"hi\"); }");
+        assert_eq!(b.pinned_threads, 0);
+        assert!(b.cooperative_pools.is_empty());
+        assert!(b.bus_subjects.is_empty());
+    }
+}

--- a/notes/resource-budgets.md
+++ b/notes/resource-budgets.md
@@ -1,0 +1,90 @@
+# Resource-budget tracking (GH #18 item 5)
+
+Status: **scope + count slice landed.** Written 2026-06-10. The verification
+candidate that "complements #1" and reuses the shared dataflow infra built
+for memory-bound proofs (#100/#101/#103). The issue frames it as a *linter*
+— a useful "is this in range" signal + a CI gate ("this PR raised the fd
+ceiling — intentional?"), not a proof.
+
+## The resources (language-visible)
+
+- **OS threads** = **pinned loci** (`PlacementSpec::Pinned` placement
+  entries on the main locus). The issue calls this "essentially free" — the
+  compiler already knows the count. One pinned placement = one
+  `pthread`.
+- **Cooperative pools** = distinct `cooperative(pool = X)` names — each is
+  one shared OS thread.
+- **Bus subjects** = distinct registered subject strings
+  (subscribe/publish `subject.canonical()` + `topic` decls). Each is a
+  router table entry.
+- **File descriptors** = held-fd loci (`std::io::tcp::Stream`/`Listener`,
+  `std::io::file::File`) + fd-opening calls.
+- **Arena chunks** — out of scope (an allocator-internal count, better
+  served by item #1's memory bounds).
+
+## Two flavors
+
+1. **Static counts (ceilings / CI gate).** A per-program tally of each
+   resource. Zero false positives — it's a count. A budget file (like the
+   `bench` baselines) gates regressions: a PR that takes pinned threads
+   3 → 8, or bus subjects 12 → 40, trips "intentional?". **This is the
+   slice that landed** (threads + pools + subjects — the cheap, structural,
+   top-level-walk resources).
+2. **Leak detection (reuses #1's dataflow).** A resource *acquired* in an
+   unbounded loop / unboundedly-invoked fn that isn't released per
+   iteration = an unbounded resource leak — the exact shape of #1's
+   allocation leak, but for fds/threads. `alloc_summary`'s
+   `unbounded_invoked` + `in_unbounded_loop` carry over directly.
+
+## The gap for leak detection (why it's the next stage, not this one)
+
+Hale fds are held by loci (`Stream`/`File`) that auto-close on dissolve.
+So an fd "leak" isn't an open without a close — it's an fd-opening call
+whose **result escapes** (stored to `self`, returned, pushed) so the
+holding locus stays resident, *in an unbounded context*. That's the same
+escape-into-unbounded-context obligation as #1 — but `alloc_summary`
+currently tags escape only on **direct allocation sites**, not on **call
+results** (an fd-open is a `Call`, recorded as a `CallEdge` without a
+result-escape tag). Closing that gap — result-escape tagging on resource-
+acquiring calls — is the leak-detection stage's real work, and it upgrades
+#1 too (a factory call whose result escapes in a loop). Deferred, scoped
+here.
+
+## Open question (from the issue), resolved
+
+> *Is there a generic "tracked resource" mechanism user code could extend,
+> or does the language ship a fixed set?*
+
+**Fixed set for v1.** The four language-visible resources above are
+substrate concepts (threads, pools, subjects, fds) the compiler already
+models; a user-extensible "tracked resource" framework is a speculative
+generalization with no concrete consumer yet. Ship the fixed set; revisit
+if a real use case (e.g. a user-defined pool of GPU contexts) appears.
+
+## Landed: the count slice
+
+`crates/hale-types/src/resource_budget.rs` — `budget_for_programs(&[&Program])`
+tallies pinned threads, cooperative pools, and bus subjects by a top-level
+walk (loci → `Placement` entries; bus members + `topic` decls →
+`subject.canonical()`). Surfaced via `hale check --dump-resource-budget`.
+No false positives (it's a count). Validated by unit tests.
+
+## Staging
+
+1. **Static counts** (threads + pools + subjects) — **landed**.
+2. **fd / held-fd-locus counts** — add an expr-walk tally of fd-opening
+   stdlib calls + held-fd locus instantiations. Still a count (zero-FP).
+3. **Budget gate** — a `resource-budgets.json`-style ceiling file + a
+   `--check-resource-budget` mode that fails when a count exceeds its
+   declared ceiling. The CI-gate payoff.
+4. **Leak detection** — result-escape tagging on resource-acquiring calls
+   (the gap above), then reuse `leak_sites` to flag an fd/thread acquired
+   in an unbounded context whose holder escapes. Warning-first, like #1.
+
+## Risks
+
+- **Counts drift without a gate.** A bare `--dump` is informational; the
+  value is the gate (stage 3). Until then it's a manual check.
+- **Leak detection's escape analysis** must avoid false positives on the
+  common bounded case (open + dissolve per iteration) — same discipline as
+  #1 (warning-first, zero-FP on the corpus before error).

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -79,12 +79,24 @@ diagnostic. See `spec/semantics.md § Locus method dispatch`.
 
 ## Not yet offered
 
-The remaining GitHub issue #18 candidates are **not** implemented and
-must not be assumed: memory-bound proofs (item 1), closure-assertion
-lifting (item 3), and resource-budget tracking (item 5). Item 4
-(bus-graph property checks) is fully landed. Closures still verify
-their invariants at *runtime*; nothing here proves allocation, fd, or
-thread bounds statically.
+Item 4 (bus-graph property checks) is fully landed. The remaining GitHub
+issue #18 candidates are partial or unstarted, and none is a default gate
+— don't assume them in a build:
+
+- **Memory-bound proofs (item 1)** — the analysis exists (per-method
+  allocation summary + call-graph escape/loop dataflow) and emits
+  unbounded-accumulation warnings, but **opt-in** via `hale check
+  --warn-unbounded-alloc`; not on by default. Type-aware String-concat
+  sites + loop-ranking are unfinished. See `notes/memory-bound-proofs.md`.
+- **Resource-budget tracking (item 5)** — a static **count** of pinned
+  threads / cooperative pools / bus subjects via `hale check
+  --dump-resource-budget`; informational only, no ceiling gate or fd-leak
+  detection yet. See `notes/resource-budgets.md`.
+- **Closure-assertion lifting (item 3)** — unstarted. Closures still
+  verify their invariants at *runtime*.
+
+Nothing here yet *proves* allocation, fd, or thread bounds as a
+build-failing gate; the item-1 warnings are advisory.
 
 Item 2 (race-completeness for substrate primitives) is a *substrate*
 quality bar, not a user-facing check: it model-checks the runtime's own


### PR DESCRIPTION
GH #18 **item 5 — resource-budget tracking**, the count slice. The verification candidate that "complements #1" and reuses the dataflow infra from #100/#101/#103. The issue frames it as a *linter* — a useful "is this in range" signal + the basis for a CI ceiling gate ("this PR raised the fd/thread/subject count — intentional?").

## What landed — the static count (zero false positives)
`resource_budget.rs::budget_for_programs` tallies the cheap, structural resources by a top-level walk:
- **OS threads** = pinned loci (`PlacementSpec::Pinned` placement entries)
- **cooperative pools** = distinct `cooperative(pool = X)` names
- **bus subjects** = distinct subscribe/publish `canonical()` + `topic` decls

Surfaced via `hale check --dump-resource-budget`:
```
OS threads (pinned loci):  1
cooperative pools:         1  [io]
bus subjects:              2
    - done
    - tick
```

## Scope doc resolves the design (`notes/resource-budgets.md`)
- **Count vs leak split.** Counts (this) are zero-FP. Leak detection reuses #1's `unbounded_invoked`/`in_unbounded_loop`.
- **Open question resolved:** fixed resource set for v1, not a user-extensible "tracked resource" framework (no concrete consumer yet).
- **The gap the leak stage must close:** `alloc_summary` tags escape on direct allocation *sites* but not on call *results* — and an fd "leak" is a resource-acquiring *call* whose result escapes in an unbounded context. Closing that reuses #1's dataflow **and upgrades #1 too** (a factory call whose result escapes in a loop). Staged: counts → fd counts → ceiling gate → leak detection.

`spec/verification.md` updated so item 5 (count) + item 1 (opt-in `--warn-unbounded-alloc`) are accurately described — neither is a default build gate.

## Tests
3 unit tests (distinct subjects, dedupe across subscribe/publish, empty program); 97/97 corpus fixtures dump cleanly; hale-types green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
