### PR TITLE
types: result-escape tagging on call edges + fd-leak detection (GH #18 #1/#5)

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -871,6 +871,10 @@ fn run_check(target: &Path) -> ExitCode {
     if std::env::args().any(|a| a == "--warn-unbounded-alloc") {
         diags.extend(hale_types::unbounded_alloc_warnings(&bundle));
     }
+    // GH #18 item 5: opt-in fd-resource-leak warnings.
+    if std::env::args().any(|a| a == "--warn-resource-leak") {
+        diags.extend(hale_types::resource_leak_warnings(&bundle));
+    }
     if !diags.is_empty() {
         for d in &diags {
             eprintln!("{}", render_located(d, &file_bases, &sources));

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -51,7 +51,7 @@ impl FnKey {
     pub fn method(locus: impl Into<String>, name: impl Into<String>) -> Self {
         Self { locus: Some(locus.into()), fn_name: name.into() }
     }
-    fn display(&self) -> String {
+    pub fn display(&self) -> String {
         match &self.locus {
             Some(l) => format!("{}::{}", l, self.fn_name),
             None => self.fn_name.clone(),
@@ -224,6 +224,14 @@ pub struct CallEdge {
     /// True if the call is inside an unbounded loop — then the callee is
     /// invoked unboundedly many times regardless of its own multiplicity.
     pub in_unbounded_loop: bool,
+    /// Where the call's *result* flows — the call-result analog of an
+    /// allocation site's escape. A resource-acquiring call (an fd opener)
+    /// whose result escapes in an unbounded context holds the resource
+    /// resident → a leak; a `Local` result is bound-and-dissolved per
+    /// iteration → bounded. (Closes the gap noted in
+    /// notes/resource-budgets.md; also lets #1 see a factory call whose
+    /// result escapes when the callee body is external/unresolved.)
+    pub escape: Escape,
     pub span: Span,
 }
 
@@ -463,7 +471,12 @@ impl AllocSummary {
                     Callee::Resolved(k) => k.display(),
                     Callee::Unresolved(n) => format!("<unresolved: {}>", n),
                 };
-                out.push_str(&format!("    call  {} loop_depth={}\n", tgt, c.loop_depth));
+                out.push_str(&format!(
+                    "    call  {} loop_depth={} result={}\n",
+                    tgt,
+                    c.loop_depth,
+                    c.escape.label()
+                ));
             }
         }
         out
@@ -764,7 +777,7 @@ impl<'a> Walker<'a> {
             }
             Expr::Unary { operand, .. } => self.walk_expr(operand, depth, Escape::Local),
             Expr::Call { callee, args, span } => {
-                self.record_call(callee, *span, depth);
+                self.record_call(callee, *span, depth, escape);
                 // The callee receiver may itself allocate; its result
                 // doesn't escape via this site.
                 match callee.as_ref() {
@@ -810,7 +823,7 @@ impl<'a> Walker<'a> {
         }
     }
 
-    fn record_call(&mut self, callee: &Expr, span: Span, depth: u32) {
+    fn record_call(&mut self, callee: &Expr, span: Span, depth: u32, escape: Escape) {
         let resolved = match callee {
             Expr::Ident(id) => {
                 let key = FnKey::free_fn(id.name.clone());
@@ -842,6 +855,7 @@ impl<'a> Walker<'a> {
             callee: resolved,
             loop_depth: depth,
             in_unbounded_loop: self.loop_stack.iter().any(|bounded| !bounded),
+            escape,
             span,
         });
     }

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -108,6 +108,14 @@ pub fn unbounded_alloc_warnings(bundle: &Bundle<'_>) -> Vec<Diag> {
     alloc_summary::unbounded_alloc_diags(&progs)
 }
 
+/// Resource-leak warnings: an fd-acquiring call whose result is stored
+/// resident in an unbounded context (GH #18 item 5, leak stage). Opt-in
+/// via `--warn-resource-leak`.
+pub fn resource_leak_warnings(bundle: &Bundle<'_>) -> Vec<Diag> {
+    let progs: Vec<&hale_syntax::ast::Program> = bundle.programs.values().copied().collect();
+    resource_budget::resource_leak_diags(&progs)
+}
+
 pub fn check_bundle_opts(
     bundle: &Bundle<'_>,
     allow_unowned_subscriber: bool,

--- a/crates/hale-types/src/resource_budget.rs
+++ b/crates/hale-types/src/resource_budget.rs
@@ -20,6 +20,71 @@
 use std::collections::BTreeSet;
 
 use hale_syntax::ast::*;
+use hale_syntax::Diag;
+
+use crate::alloc_summary::{self, Callee, Escape};
+
+/// Stdlib path-calls that acquire a held OS resource (a file descriptor)
+/// — the result is a locus (`File` / `Stream` / `Listener`) that closes
+/// the fd on dissolve. If such a call's result is stored resident
+/// (`self`-store) and the call runs in an unbounded context, the fd
+/// accumulates. Unmangled paths (this analysis runs pre-rename).
+const FD_ACQUIRING_PATHS: &[&str] = &[
+    "std::io::file::open",
+    "std::io::tcp::connect",
+    "std::io::tcp::listen_socket",
+    "std::io::tcp::__listen_socket",
+    "std::io::tcp::accept_one",
+    "std::io::tcp::__accept_one",
+];
+
+/// GH #18 item 5, leak-detection stage: warn on an fd-acquiring call whose
+/// result is stored resident (`self`) in an unboundedly-invoked fn or an
+/// unbounded loop — the fd accumulates. Reuses `alloc_summary`'s
+/// call-result escape tagging + unbounded-context dataflow (the gap that
+/// item 1's site-only escape tagging left open). Opt-in via
+/// `hale check --warn-resource-leak`.
+pub fn resource_leak_diags(programs: &[&Program]) -> Vec<Diag> {
+    let summary = alloc_summary::summarize_programs(programs);
+    let unbounded = summary.unbounded_invoked();
+    let mut out = Vec::new();
+    for f in summary.fns.values() {
+        for c in &f.calls {
+            let path = match &c.callee {
+                Callee::Unresolved(p) => p,
+                Callee::Resolved(_) => continue,
+            };
+            if !FD_ACQUIRING_PATHS.contains(&path.as_str()) {
+                continue;
+            }
+            // The fd holder must escape its scope (stored resident) — a
+            // `Local` holder is bound + dissolved per iteration (the fd
+            // closes), so it's bounded.
+            if !matches!(c.escape, Escape::StoredToSelf) {
+                continue;
+            }
+            // ... in an unbounded context (a per-message handler, or a
+            // call inside an unbounded loop). A one-shot self-store (e.g.
+            // a server's single listener in birth) is fine.
+            if !(c.in_unbounded_loop || unbounded.contains(&f.key)) {
+                continue;
+            }
+            out.push(Diag::warn(
+                c.span,
+                format!(
+                    "unbounded fd acquisition: `{}` opens a held resource stored to \
+                     `self` in `{}`, which runs unboundedly (a per-message handler or a \
+                     call inside an unbounded loop) — the file descriptor accumulates \
+                     resident. Dissolve the holder per iteration (a scoped `let`), or \
+                     keep a single long-lived holder instead of re-opening.",
+                    path,
+                    f.key.display()
+                ),
+            ));
+        }
+    }
+    out
+}
 
 /// Per-program resource tally.
 #[derive(Debug, Clone, Default)]
@@ -170,5 +235,66 @@ mod tests {
         assert_eq!(b.pinned_threads, 0);
         assert!(b.cooperative_pools.is_empty());
         assert!(b.bus_subjects.is_empty());
+    }
+
+    // ---- leak detection (result-escape tagging) ----
+
+    fn leaks(src: &str) -> Vec<String> {
+        let program = parse_source(src).expect("parse");
+        resource_leak_diags(&[&program]).iter().map(|d| d.message.clone()).collect()
+    }
+
+    #[test]
+    fn fd_stored_to_self_in_handler_is_flagged() {
+        // A per-message handler that opens an fd and stores it resident →
+        // the fd accumulates per message. The result-escape tag (the call's
+        // result flows to self) + the unbounded handler context catch it.
+        let src = r#"
+            type Msg { path: String; }
+            locus Opener {
+                params { f: Int = 0; }
+                bus { subscribe "open" as on_open of type Msg; }
+                fn on_open(m: Msg) {
+                    self.f = std::io::file::open(m.path, "r") or raise;
+                }
+            }
+            fn main() { }
+        "#;
+        let ls = leaks(src);
+        assert_eq!(ls.len(), 1, "expected 1 fd-leak; got {:?}", ls);
+        assert!(ls[0].contains("unbounded fd acquisition"), "got: {:?}", ls);
+    }
+
+    #[test]
+    fn local_fd_in_handler_is_not_flagged() {
+        // The fd is bound to a `let` (not stored), so it dissolves at scope
+        // exit — bounded, not a leak.
+        let src = r#"
+            type Msg { path: String; }
+            locus Opener {
+                bus { subscribe "open" as on_open of type Msg; }
+                fn on_open(m: Msg) {
+                    let f = std::io::file::open(m.path, "r") or raise;
+                }
+            }
+            fn main() { }
+        "#;
+        assert!(leaks(src).is_empty(), "a let-scoped fd must not be flagged: {:?}", leaks(src));
+    }
+
+    #[test]
+    fn fd_stored_in_birth_is_not_flagged() {
+        // One-shot self-store (birth) — a single long-lived holder, not a
+        // per-iteration accumulation.
+        let src = r#"
+            locus Server {
+                params { sock: Int = 0; }
+                birth() {
+                    self.sock = std::io::tcp::listen_socket(8080) or raise;
+                }
+            }
+            fn main() { }
+        "#;
+        assert!(leaks(src).is_empty(), "a one-shot birth open is not a leak: {:?}", leaks(src));
     }
 }

--- a/notes/resource-budgets.md
+++ b/notes/resource-budgets.md
@@ -1,10 +1,21 @@
 # Resource-budget tracking (GH #18 item 5)
 
-Status: **scope + count slice landed.** Written 2026-06-10. The verification
-candidate that "complements #1" and reuses the shared dataflow infra built
-for memory-bound proofs (#100/#101/#103). The issue frames it as a *linter*
-— a useful "is this in range" signal + a CI gate ("this PR raised the fd
-ceiling — intentional?"), not a proof.
+Status: **count slice + fd-leak detection landed.** Written 2026-06-10. The
+verification candidate that "complements #1" and reuses the shared dataflow
+infra built for memory-bound proofs (#100/#101/#103). The issue frames it as
+a *linter* — a useful "is this in range" signal + a CI gate ("this PR raised
+the fd ceiling — intentional?"), not a proof.
+
+> **Leak detection landed (the gap below is closed).** `alloc_summary`'s
+> `CallEdge` now carries the **escape of the call's result** (the call-
+> result analog of an allocation site's escape), so an fd-acquiring call
+> (`std::io::file::open` / `tcp::connect`/`listen`/`accept`) whose result is
+> stored resident (`self`) in an unbounded context (a per-message handler /
+> a call in an unbounded loop) is flagged — the fd accumulates. Opt-in via
+> `hale check --warn-resource-leak`; `resource_budget::resource_leak_diags`.
+> Zero false positives on the corpus. This result-escape tagging also
+> upgrades **item #1** (a factory call whose result escapes in a loop is now
+> visible in the dump as `result=escaping=…`).
 
 ## The resources (language-visible)
 
@@ -36,19 +47,20 @@ ceiling — intentional?"), not a proof.
    allocation leak, but for fds/threads. `alloc_summary`'s
    `unbounded_invoked` + `in_unbounded_loop` carry over directly.
 
-## The gap for leak detection (why it's the next stage, not this one)
+## The gap for leak detection (now closed)
 
 Hale fds are held by loci (`Stream`/`File`) that auto-close on dissolve.
 So an fd "leak" isn't an open without a close — it's an fd-opening call
-whose **result escapes** (stored to `self`, returned, pushed) so the
-holding locus stays resident, *in an unbounded context*. That's the same
-escape-into-unbounded-context obligation as #1 — but `alloc_summary`
-currently tags escape only on **direct allocation sites**, not on **call
-results** (an fd-open is a `Call`, recorded as a `CallEdge` without a
-result-escape tag). Closing that gap — result-escape tagging on resource-
-acquiring calls — is the leak-detection stage's real work, and it upgrades
-#1 too (a factory call whose result escapes in a loop). Deferred, scoped
-here.
+whose **result escapes** (stored to `self`) so the holding locus stays
+resident, *in an unbounded context*. That's the same escape-into-unbounded-
+context obligation as #1 — but `alloc_summary` originally tagged escape only
+on **direct allocation sites**, not on **call results** (an fd-open is a
+`Call`, recorded as a `CallEdge`). **`CallEdge` now carries a result escape**
+(threaded from the same `escape` context that tags alloc sites, including
+the `let x = open(); … self.f = x;` indirection via the name pre-pass), so
+the leak check filters resource-acquiring calls with a `self`-store result
+in an unbounded context. A `Local` (let-scoped, dissolved per iteration)
+holder is bounded and not flagged.
 
 ## Open question (from the issue), resolved
 
@@ -72,14 +84,13 @@ No false positives (it's a count). Validated by unit tests.
 ## Staging
 
 1. **Static counts** (threads + pools + subjects) — **landed**.
-2. **fd / held-fd-locus counts** — add an expr-walk tally of fd-opening
-   stdlib calls + held-fd locus instantiations. Still a count (zero-FP).
-3. **Budget gate** — a `resource-budgets.json`-style ceiling file + a
+2. **Leak detection** — result-escape tagging on resource-acquiring calls
+   + the unbounded-context filter — **landed** (`--warn-resource-leak`).
+3. **fd / held-fd-locus counts** — add an expr-walk tally of fd-opening
+   calls + held-fd locus instantiations to the count dump. Still zero-FP.
+4. **Budget gate** — a `resource-budgets.json`-style ceiling file + a
    `--check-resource-budget` mode that fails when a count exceeds its
    declared ceiling. The CI-gate payoff.
-4. **Leak detection** — result-escape tagging on resource-acquiring calls
-   (the gap above), then reuse `leak_sites` to flag an fd/thread acquired
-   in an unbounded context whose holder escapes. Warning-first, like #1.
 
 ## Risks
 


### PR DESCRIPTION
Closes the gap that items **#1 and #5 converged on**: `alloc_summary` tagged escape on direct allocation *sites* but not on call *results*. `CallEdge` now carries the **escape of the call's result** — threaded from the same escape context that tags alloc sites (direct `self`-store/`return`/`send` positions, plus the `let x = call(); … self.f = x;` indirection via the name pre-pass). The dump surfaces it:
```
call  make loop_depth=1 result=escaping=self-store
```

## Use — GH #18 item 5 fd-leak detection
An fd-acquiring stdlib call (`std::io::file::open`, `tcp::connect`/`listen`/`accept`) whose result is **stored resident (`self`) in an unbounded context** (a per-message handler, or a call in an unbounded loop) accumulates the fd → flagged. `--warn-resource-leak`:
```
on_open: warning: unbounded fd acquisition: `std::io::file::open` opens a held
resource stored to `self` in `Opener::on_open`, which runs unboundedly … the
file descriptor accumulates resident. Dissolve the holder per iteration …
```
A `Local` (let-scoped, dissolved per iteration) holder is bounded → **not** flagged; a one-shot `birth` self-store is fine. **Zero false positives on the corpus.**

## Also upgrades #1
A factory call whose result escapes in a loop is now visible (`result=escaping=…`) where before only the callee's own alloc sites were caught (via `unbounded_invoked`) — the difference matters when the callee body is external/unresolved (cross-seed).

## Tests
3 resource-leak unit tests (self-store-in-handler flagged; let-scoped not flagged; birth one-shot not flagged); `alloc_summary` (16) + the alloc RSS test + full hale-types green; corpus zero-FP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
