### PR TITLE
cli: --check-resource-budget ceiling gate (GH #18 item 5)

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -864,6 +864,55 @@ fn run_check(target: &Path) -> ExitCode {
         print!("{}", hale_types::dump_resource_budget(&bundle));
         return ExitCode::SUCCESS;
     }
+    // GH #18 item 5: the CI gate. `--check-resource-budget <path>` reads a
+    // TOML ceiling file and fails the build if any count exceeds it.
+    {
+        let cli_args: Vec<String> = std::env::args().collect();
+        let ceiling_path = cli_args
+            .iter()
+            .position(|a| a == "--check-resource-budget")
+            .and_then(|i| cli_args.get(i + 1));
+        if let Some(path) = ceiling_path {
+            #[derive(serde::Deserialize, Default)]
+            #[serde(deny_unknown_fields)]
+            struct CeilingToml {
+                pinned_threads: Option<usize>,
+                cooperative_pools: Option<usize>,
+                bus_subjects: Option<usize>,
+            }
+            let text = match std::fs::read_to_string(path) {
+                Ok(t) => t,
+                Err(e) => {
+                    eprintln!("--check-resource-budget: cannot read `{}`: {}", path, e);
+                    return ExitCode::from(1);
+                }
+            };
+            let ct: CeilingToml = match toml::from_str(&text) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("--check-resource-budget: invalid budget file `{}`: {}", path, e);
+                    return ExitCode::from(1);
+                }
+            };
+            let ceiling = hale_types::resource_budget::ResourceCeiling {
+                pinned_threads: ct.pinned_threads,
+                cooperative_pools: ct.cooperative_pools,
+                bus_subjects: ct.bus_subjects,
+            };
+            let violations = hale_types::check_resource_ceiling(&bundle, &ceiling);
+            if violations.is_empty() {
+                println!("resource budget OK (within `{}`)", path);
+                return ExitCode::SUCCESS;
+            }
+            for v in &violations {
+                eprintln!(
+                    "resource budget exceeded: {} — raise the ceiling in `{}` if intentional",
+                    v, path
+                );
+            }
+            return ExitCode::from(1);
+        }
+    }
     let allow_unowned =
         std::env::args().any(|a| a == "--allow-unowned-subscriber");
     let mut diags = hale_types::check_bundle_opts(&bundle, allow_unowned);

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -116,6 +116,18 @@ pub fn resource_leak_warnings(bundle: &Bundle<'_>) -> Vec<Diag> {
     resource_budget::resource_leak_diags(&progs)
 }
 
+/// Check a bundle's resource counts against declared ceilings (GH #18 item
+/// 5, the CI gate). Returns one violation message per over-budget resource
+/// (empty = within budget). Drives `--check-resource-budget`.
+pub fn check_resource_ceiling(
+    bundle: &Bundle<'_>,
+    ceiling: &resource_budget::ResourceCeiling,
+) -> Vec<String> {
+    let progs: Vec<&hale_syntax::ast::Program> = bundle.programs.values().copied().collect();
+    let budget = resource_budget::budget_for_programs(&progs);
+    resource_budget::check_ceiling(&budget, ceiling)
+}
+
 pub fn check_bundle_opts(
     bundle: &Bundle<'_>,
     allow_unowned_subscriber: bool,

--- a/crates/hale-types/src/resource_budget.rs
+++ b/crates/hale-types/src/resource_budget.rs
@@ -98,6 +98,38 @@ pub struct ResourceBudget {
     pub bus_subjects: BTreeSet<String>,
 }
 
+/// Declared per-resource ceilings (from a project's resource-budget file).
+/// `None` = no ceiling for that resource. A count exceeding its ceiling
+/// fails `--check-resource-budget` — the CI gate ("this PR raised the
+/// thread/subject count — intentional? bump the ceiling").
+#[derive(Debug, Clone, Default)]
+pub struct ResourceCeiling {
+    pub pinned_threads: Option<usize>,
+    pub cooperative_pools: Option<usize>,
+    pub bus_subjects: Option<usize>,
+}
+
+/// Compare a tallied budget against declared ceilings. Returns one
+/// violation message per resource over its ceiling (empty = within
+/// budget). Resources without a declared ceiling are unconstrained.
+pub fn check_ceiling(b: &ResourceBudget, c: &ResourceCeiling) -> Vec<String> {
+    let mut v = Vec::new();
+    let mut chk = |name: &str, actual: usize, ceil: Option<usize>| {
+        if let Some(max) = ceil {
+            if actual > max {
+                v.push(format!(
+                    "{}: {} exceeds the declared ceiling of {}",
+                    name, actual, max
+                ));
+            }
+        }
+    };
+    chk("pinned_threads (OS threads)", b.pinned_threads, c.pinned_threads);
+    chk("cooperative_pools", b.cooperative_pools.len(), c.cooperative_pools);
+    chk("bus_subjects", b.bus_subjects.len(), c.bus_subjects);
+    v
+}
+
 /// Walk the bundle and tally the structural resources.
 pub fn budget_for_programs(programs: &[&Program]) -> ResourceBudget {
     let mut b = ResourceBudget::default();
@@ -227,6 +259,39 @@ mod tests {
         "#;
         let b = budget(src);
         assert_eq!(b.bus_subjects.len(), 1, "same subject should dedupe: {:?}", b.bus_subjects);
+    }
+
+    #[test]
+    fn ceiling_check_flags_over_budget_and_passes_within() {
+        let src = r#"
+            type T { n: Int; }
+            locus C {
+                bus {
+                    subscribe "a" as oa of type T;
+                    publish "b" of type T;
+                    subscribe "c" as oc of type T;
+                }
+                fn oa(m: T) { let _ = m.n; }
+                fn oc(m: T) { let _ = m.n; }
+            }
+            fn main() { }
+        "#;
+        let program = parse_source(src).expect("parse");
+        let b = budget_for_programs(&[&program]);
+        assert_eq!(b.bus_subjects.len(), 3);
+        // Ceiling 2 → over budget.
+        let over = check_ceiling(
+            &b,
+            &ResourceCeiling { bus_subjects: Some(2), ..Default::default() },
+        );
+        assert_eq!(over.len(), 1, "{:?}", over);
+        assert!(over[0].contains("bus_subjects: 3 exceeds"), "{:?}", over);
+        // Ceiling 3 → within budget; no ceiling on the others → unconstrained.
+        let within = check_ceiling(
+            &b,
+            &ResourceCeiling { bus_subjects: Some(3), ..Default::default() },
+        );
+        assert!(within.is_empty(), "should be within budget: {:?}", within);
     }
 
     #[test]

--- a/notes/resource-budgets.md
+++ b/notes/resource-budgets.md
@@ -86,11 +86,20 @@ No false positives (it's a count). Validated by unit tests.
 1. **Static counts** (threads + pools + subjects) — **landed**.
 2. **Leak detection** — result-escape tagging on resource-acquiring calls
    + the unbounded-context filter — **landed** (`--warn-resource-leak`).
-3. **fd / held-fd-locus counts** — add an expr-walk tally of fd-opening
-   calls + held-fd locus instantiations to the count dump. Still zero-FP.
-4. **Budget gate** — a `resource-budgets.json`-style ceiling file + a
-   `--check-resource-budget` mode that fails when a count exceeds its
-   declared ceiling. The CI-gate payoff.
+3. **Budget gate** — **landed.** `hale check <prog> --check-resource-budget
+   <file.toml>` reads a TOML ceiling file and exits non-zero if any count
+   exceeds its declared ceiling (the CI payoff: "this PR raised the
+   thread/subject count — bump the ceiling if intentional"). Unknown keys
+   error (typo protection); a resource with no declared ceiling is
+   unconstrained. Format:
+   ```toml
+   pinned_threads    = 4
+   cooperative_pools = 2
+   bus_subjects      = 16
+   ```
+4. **fd / held-fd-locus counts** (remaining) — add an expr-walk tally of
+   fd-opening calls + held-fd locus instantiations to the count dump +
+   ceiling. Still zero-FP. The only unshipped stage.
 
 ## Risks
 

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -89,9 +89,12 @@ issue #18 candidates are partial or unstarted, and none is a default gate
   --warn-unbounded-alloc`; not on by default. Type-aware String-concat
   sites + loop-ranking are unfinished. See `notes/memory-bound-proofs.md`.
 - **Resource-budget tracking (item 5)** — a static **count** of pinned
-  threads / cooperative pools / bus subjects via `hale check
-  --dump-resource-budget`; informational only, no ceiling gate or fd-leak
-  detection yet. See `notes/resource-budgets.md`.
+  threads / cooperative pools / bus subjects (`hale check
+  --dump-resource-budget`); a **CI ceiling gate** (`--check-resource-budget
+  <file.toml>` — fails the build when a count exceeds a declared ceiling);
+  and **fd-leak detection** (`--warn-resource-leak` — an fd-acquiring call
+  whose result is stored resident in an unbounded context, opt-in). Held-fd
+  *counts* are the one unshipped piece. See `notes/resource-budgets.md`.
 - **Closure-assertion lifting (item 3)** — unstarted. Closures still
   verify their invariants at *runtime*.
 


### PR DESCRIPTION
The **CI-gate payoff** for resource budgets (GH #18 item 5). `hale check <prog> --check-resource-budget <file.toml>` reads a TOML ceiling file and exits non-zero if any resource count exceeds its declared ceiling — so a PR that raises the pinned-thread / cooperative-pool / bus-subject count trips the gate ("bump the ceiling if intentional").

```toml
# budget.toml
pinned_threads    = 4
cooperative_pools = 2
bus_subjects      = 16
```

- `resource_budget::{ResourceCeiling, check_ceiling}` (hale-types, no new dep — just the struct + comparison) returns one violation per over-budget resource.
- The CLI parses the TOML (`serde`, `deny_unknown_fields` → typo'd keys error) into the ceiling + calls `check_resource_ceiling`. A resource with **no declared ceiling is unconstrained**.

## Exit codes (all verified)
| case | exit |
|---|---|
| within budget | 0 (`resource budget OK`) |
| over budget | 1 (`bus_subjects: 3 exceeds the declared ceiling of 2`) |
| typo'd key | 1 (TOML parse error) |
| unreadable / missing file | 1 |

## Tests
`ceiling_check_flags_over_budget_and_passes_within` (hale-types); CLI exercised across over/within/typo/missing-file. hale-types green. `spec/verification.md` updated.

Item 5 now ships counts (`--dump-resource-budget`), this CI gate, and fd-leak detection (`--warn-resource-leak`, #112) — held-fd *counts* are the one unshipped piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
