### PR TITLE
notes: scope GH #18 item 3 (closure lifting) — easy case already handled

### DIFF
--- a/notes/closure-lifting.md
+++ b/notes/closure-lifting.md
@@ -1,0 +1,69 @@
+# Closure-assertion lifting (GH #18 item 3)
+
+Status: **scoped — and the tractable slice turned out to be already handled
+by an existing typecheck rule, so no code shipped.** Written 2026-06-10. The
+last unstarted GH #18 verification candidate. The issue: Hale closures are
+runtime invariant checks; many can be proven statically, so the runtime
+check is dead weight — lift the provable subset, leave the rest as runtime
+asserts. Opportunistic, gates nothing.
+
+## Reality check: Hale closures are `~~ within` band checks
+
+The issue's example — *"a closure like `count >= 0` over a never-decremented
+counter"* — is a **comparison** assertion. Hale doesn't have those. A Hale
+closure is:
+
+```hale
+closure within_band {
+    sum(self.delta) ~~ 0 within 100;   // |left - right| <= tolerance
+    epoch tick;
+}
+```
+
+an **approximate-equality band check** — `|left - right| <= tolerance` —
+evaluated per epoch over *runtime / accumulated* quantities (`sum(...)`
+accumulators, `self.field` reads).
+
+## Finding: the constant case is already forbidden
+
+The obvious tractable slice was "fold constant closure assertions: lift the
+always-true ones, error on the always-false ones." **It's redundant.**
+`check.rs` (the "closure" typecheck arm, ~line 6029) already rejects any
+closure whose assertion observes no runtime-varying value:
+
+> `closure 'X': both assertion sides are pure literals; a closure must
+> observe at least one runtime-varying value (e.g. self.x) to audit
+> anything`
+
+Verified this fires on both pure literals (`1.0 ~~ 2.0 within 0.1`) **and**
+const arithmetic (`2.0 - 1.0 ~~ 0.5 within 0.1`) — so a fully-constant
+closure (satisfiable or not) is already a compile error. There are no valid
+all-constant closures to lift, and the always-false bug-catch is subsumed:
+Hale rejects the *whole class* as pointless, not just the unsatisfiable
+members. A constant-fold "lifting" pass would be dead code that only fires
+alongside an existing type error. **Not shipped** (a prototype was written
+and backed out once this was confirmed).
+
+## What's actually left: case 3 (symbolic, deferred)
+
+Every closure that *survives* typecheck observes a runtime value, so the
+only liftable closures are ones provable from **how that runtime value is
+produced** — e.g. proving `sum(self.delta) ~~ 0 within 100` always holds
+from the producer arithmetic feeding `self.delta`. That's the issue's
+"symbolic execution of closure bodies": reason about the accumulator + the
+self-field writes that feed it. It would reuse the dataflow infra
+(`alloc_summary`'s self-field-write tracking + the closure accumulator
+model) and a check→codegen handoff to skip the runtime check for proven
+closures.
+
+## Honest recommendation: don't build case 3 (yet)
+
+This is the **lowest-leverage** #18 item, and the finding makes it lower
+still: the easy win is already done by an existing rule, and the remaining
+win is a substantial symbolic-execution effort whose payoff is removing a
+runtime check from a *niche* feature (closures) on the *provable* subset of
+an *already-runtime-only* set. The cost/benefit doesn't favor it now. Revisit
+only if (a) closures see materially heavier use, and (b) a profiled workload
+shows closure checks on a hot path. Until then, item #3 is **complete as
+far as it's worth taking** — the constant case is handled, the symbolic case
+is scoped and deliberately parked.

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -95,8 +95,14 @@ issue #18 candidates are partial or unstarted, and none is a default gate
   and **fd-leak detection** (`--warn-resource-leak` — an fd-acquiring call
   whose result is stored resident in an unbounded context, opt-in). Held-fd
   *counts* are the one unshipped piece. See `notes/resource-budgets.md`.
-- **Closure-assertion lifting (item 3)** — unstarted. Closures still
-  verify their invariants at *runtime*.
+- **Closure-assertion lifting (item 3)** — scoped, deliberately parked.
+  The tractable case (constant assertions) is already handled: typecheck
+  rejects any closure whose assertion observes no runtime-varying value
+  (pure literals *or* const arithmetic), so there are no constant closures
+  to lift. The only liftable closures are ones provable from producer
+  arithmetic (symbolic execution) — low-leverage for a niche feature, not
+  built. Closures still verify their (runtime-observing) invariants at
+  *runtime*. See `notes/closure-lifting.md`.
 
 Nothing here yet *proves* allocation, fd, or thread bounds as a
 build-failing gate; the item-1 warnings are advisory.


### PR DESCRIPTION
Investigated GH #18 **item 3 (closure-assertion lifting)** — the last unstarted verification candidate. The outcome is a finding + a scope, not a feature, and the reasoning is the deliverable.

## Two findings
1. **Hale closures don't match the issue's example.** The issue motivates with *"a closure like `count >= 0`"* — a comparison. Hale closures are `left ~~ right within tolerance` band checks (`|left - right| <= tolerance`) over **runtime/accumulated** quantities (`sum(self.delta) ~~ 0 within 100`).
2. **The tractable slice is already handled.** The obvious first step — constant-fold a closure assertion, lift always-true / error always-false — is **redundant**: the existing typecheck arm (`check.rs ~6029`) already rejects any closure whose assertion observes no runtime-varying value, and it catches **both pure literals and const arithmetic** (verified `2.0 - 1.0 ~~ 0.5` errors). So there are no valid constant closures to lift, and the bug-catch is subsumed (Hale rejects the whole class). A constant-fold pass would be dead code firing only alongside an existing type error.

**I prototyped the constant-fold pass, confirmed it was redundant against the existing rule, and backed it out** rather than ship dead code.

## What's left, and why it's parked
Every closure that survives typecheck observes a runtime value, so the only liftable ones are provable from **producer arithmetic** — symbolic execution over the accumulator + self-field writes (would reuse `alloc_summary`'s dataflow). That's the lowest-leverage #18 item: the easy win is already done, and the remaining win removes a runtime check from the provable subset of a niche feature. **Recommendation: parked** — revisit only if closures see heavier use *and* profiling shows them hot.

`spec/verification.md` + `notes/closure-lifting.md` record the finding. Docs only; the prototype code is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
