### PR TITLE
types: held-fd counts in the resource budget (GH #18 item 5)

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -879,6 +879,7 @@ fn run_check(target: &Path) -> ExitCode {
                 pinned_threads: Option<usize>,
                 cooperative_pools: Option<usize>,
                 bus_subjects: Option<usize>,
+                fd_open_sites: Option<usize>,
             }
             let text = match std::fs::read_to_string(path) {
                 Ok(t) => t,
@@ -898,6 +899,7 @@ fn run_check(target: &Path) -> ExitCode {
                 pinned_threads: ct.pinned_threads,
                 cooperative_pools: ct.cooperative_pools,
                 bus_subjects: ct.bus_subjects,
+                fd_open_sites: ct.fd_open_sites,
             };
             let violations = hale_types::check_resource_ceiling(&bundle, &ceiling);
             if violations.is_empty() {

--- a/crates/hale-types/src/resource_budget.rs
+++ b/crates/hale-types/src/resource_budget.rs
@@ -96,6 +96,12 @@ pub struct ResourceBudget {
     pub cooperative_pools: BTreeSet<String>,
     /// Distinct bus subject strings (router table entries).
     pub bus_subjects: BTreeSet<String>,
+    /// fd-opening call sites (`std::io::file::open` / `tcp::connect` /
+    /// `listen` / `accept`) — the file-descriptor acquisition surface. A
+    /// static site count, not a runtime fd count. (Direct held-fd locus
+    /// instantiations — `tcp::Listener { }` — aren't counted yet; they'd
+    /// need path-qualified struct matching, see notes/resource-budgets.md.)
+    pub fd_open_sites: usize,
 }
 
 /// Declared per-resource ceilings (from a project's resource-budget file).
@@ -107,6 +113,7 @@ pub struct ResourceCeiling {
     pub pinned_threads: Option<usize>,
     pub cooperative_pools: Option<usize>,
     pub bus_subjects: Option<usize>,
+    pub fd_open_sites: Option<usize>,
 }
 
 /// Compare a tallied budget against declared ceilings. Returns one
@@ -127,6 +134,7 @@ pub fn check_ceiling(b: &ResourceBudget, c: &ResourceCeiling) -> Vec<String> {
     chk("pinned_threads (OS threads)", b.pinned_threads, c.pinned_threads);
     chk("cooperative_pools", b.cooperative_pools.len(), c.cooperative_pools);
     chk("bus_subjects", b.bus_subjects.len(), c.bus_subjects);
+    chk("fd_open_sites", b.fd_open_sites, c.fd_open_sites);
     v
 }
 
@@ -156,6 +164,15 @@ pub fn budget_for_programs(programs: &[&Program]) -> ResourceBudget {
             }
         }
     }
+    // fd-opening call sites — reuse alloc_summary's call edges (the FD
+    // paths are unambiguous qualified stdlib calls → zero FP).
+    let summary = alloc_summary::summarize_programs(programs);
+    b.fd_open_sites = summary
+        .fns
+        .values()
+        .flat_map(|f| f.calls.iter())
+        .filter(|c| matches!(&c.callee, Callee::Unresolved(p) if FD_ACQUIRING_PATHS.contains(&p.as_str())))
+        .count();
     b
 }
 
@@ -212,6 +229,7 @@ impl ResourceBudget {
         for s in &self.bus_subjects {
             out.push_str(&format!("    - {}\n", s));
         }
+        out.push_str(&format!("fd-opening call sites:     {}\n", self.fd_open_sites));
         out
     }
 }
@@ -259,6 +277,25 @@ mod tests {
         "#;
         let b = budget(src);
         assert_eq!(b.bus_subjects.len(), 1, "same subject should dedupe: {:?}", b.bus_subjects);
+    }
+
+    #[test]
+    fn counts_fd_open_call_sites() {
+        let src = r#"
+            type Msg { path: String; }
+            locus Opener {
+                bus { subscribe "open" as on_open of type Msg; }
+                fn on_open(m: Msg) {
+                    let a = std::io::file::open(m.path, "r") or raise;
+                    let c = std::io::tcp::connect("127.0.0.1", 80) or raise;
+                    let n = m.path;
+                }
+            }
+            fn main() { }
+        "#;
+        let program = parse_source(src).expect("parse");
+        let b = budget_for_programs(&[&program]);
+        assert_eq!(b.fd_open_sites, 2, "expected 2 fd-open sites (open + connect)");
     }
 
     #[test]

--- a/notes/resource-budgets.md
+++ b/notes/resource-budgets.md
@@ -97,9 +97,15 @@ No false positives (it's a count). Validated by unit tests.
    cooperative_pools = 2
    bus_subjects      = 16
    ```
-4. **fd / held-fd-locus counts** (remaining) — add an expr-walk tally of
-   fd-opening calls + held-fd locus instantiations to the count dump +
-   ceiling. Still zero-FP. The only unshipped stage.
+4. **fd counts** — **landed.** `fd_open_sites` tallies fd-opening call
+   sites (`std::io::file::open` / `tcp::connect`/`listen`/`accept`) by
+   reusing `alloc_summary`'s call edges (unambiguous qualified paths →
+   zero FP); shows in the dump + gated by the ceiling. *Remaining:* direct
+   held-fd locus instantiations (`tcp::Listener { }`) aren't counted — the
+   alloc summary keeps only a struct's last path segment, so matching by
+   name alone would risk colliding with a user type named `Listener` /
+   `Stream` / `File`; counting those needs path-qualified struct matching.
+   A minor tail; the call-site surface is the bulk of fd acquisition.
 
 ## Risks
 


### PR DESCRIPTION
Rounds out GH #18 **item 5**'s resource set with the file-descriptor surface — the last sliver.

`ResourceBudget` gains **`fd_open_sites`**: a tally of fd-opening call sites (`std::io::file::open`, `tcp::connect`/`listen`/`accept`), computed by **reusing `alloc_summary`'s call edges** (the FD paths are unambiguous qualified stdlib calls → zero FP). It shows in `--dump-resource-budget`:
```
fd-opening call sites:     2
```
and is gated by `--check-resource-budget` (both `ResourceCeiling` and the CLI `CeilingToml` gain `fd_open_sites`).

A static **site** count (the fd acquisition surface), not a runtime fd count.

## Remaining tail (noted)
Direct held-fd *locus instantiations* (`tcp::Listener { }`) aren't counted — `alloc_summary` keeps only a struct's last path segment, so matching `Listener`/`Stream`/`File` by name alone would risk colliding with a user type. Path-qualified struct matching is the minor follow-on; the call-site surface is the bulk of fd acquisition.

## Tests
`counts_fd_open_call_sites` (2 sites: open + connect); the ceiling on `fd_open_sites` gates over/within (exit 1 / 0); 97/97 corpus fixtures dump cleanly. hale-types green.

Item 5 now ships counts (threads / pools / subjects / fds), fd-leak detection (`--warn-resource-leak`), and the CI ceiling gate (`--check-resource-budget`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
