### PR TITLE
docs: v0.8.3 changelog + spec/docs sweep for the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,113 @@ behavior.
 
 ---
 
-## v0.8.3 — CQRS at the locus boundary + F.34 windowed closures
+## v0.8.3 — verification track, SHM-ring interop, fast JSON
 
-A small release focused on closing structural-design rules at
-typecheck. Three compile-time rejections previously only
-discoverable as silent runtime behavior become hard errors; one
-new closure-clause closes the rate-budget gap; one substrate
-diagnostic closes the silent-drop debug gap.
+The largest release since v0.8.0 (cumulative since v0.8.2). Four
+headline arcs, no source-level breaking changes:
+
+- the compile-time **verification track** (GitHub issue #18) — six
+  candidate analyses, four built, one a substrate gate, one parked;
+- **binary shared-memory-ring interop** — read/write foreign SHM
+  rings by declaring their layout, plus `std::bytes` packing;
+- a **JSON parse/emit performance pass** that lands near V8;
+- retirement of the tree-walking interpreter and a new `std::term`
+  primitive surface.
+
+### Compile-time verification (GitHub issue #18)
+
+The verification roadmap, addressed. The canonical catalog is the
+new `spec/verification.md` (#47).
+
+- **Bus-graph property checks (item 4)** — fully landed, runs by
+  default. Interprocedural blocking-call detection (warning, #44),
+  orphan-topic check (#45), bus-cycle warning + re-entrant
+  sync-deadlock error (#46), backpressure check (#48), and bus
+  subject type-mismatch (#49).
+- **Race-completeness for substrate primitives (item 2)** — a GenMC
+  model-checking gate (#50–53) over the lockfree hashmap, the
+  pinned-locus mailbox, and the cooperative-pool bus queue under all
+  C11 interleavings, wired into CI (#52). A substrate quality bar,
+  not a user-facing check.
+- **Memory-bound proofs (item 1)** — opt-in
+  (`hale check --warn-unbounded-alloc`, `--dump-alloc-summary`). A
+  per-method allocation summary + call-graph escape/loop dataflow
+  (#100), an empirically-validated reclamation model (#101) that
+  **corrected the spec** (#102 — value allocations live until the
+  enclosing locus dissolves; free-fn returns do *not* reclaim per
+  call), a bound solver with call-graph propagation (#103),
+  call-result escape tagging (#112), and **loop-ranking** that proves
+  a `while v < N` const counter bounded (#117). Kept off-default
+  deliberately (#118) pending an `@unbounded` escape valve, since the
+  warnings include legitimately bounded-by-design patterns.
+- **Resource-budget tracking (item 5)** — opt-in. Static counts of
+  pinned threads / cooperative pools / bus subjects / fd-acquisition
+  sites (`--dump-resource-budget`, #111/#115/#116), a CI ceiling gate
+  (`--check-resource-budget budget.toml`, #113), and fd-leak
+  detection (`--warn-resource-leak`, #112).
+- **Closure-assertion lifting (item 3)** — scoped and **deliberately
+  parked** (#114): the tractable constant case is already handled by
+  typecheck, and the remaining symbolic case is low-leverage for a
+  niche feature.
+
+### Binary shared-memory-ring interop
+
+Read and write *externally-defined* binary SHM broadcast rings by
+declaring their layout — no hand-written FFI.
+
+- **`std::bytes` binary packing** (#55, #56) — bounds-checked
+  little/big-endian readers (`read_u8` … `read_u64_{le,be}`, signed +
+  float variants) and `BytesBuilder` writers (`append_u16_le` …
+  `append_pad`).
+- **`ring_layout` declaration** (#57) — a top-level decl describing a
+  foreign ring's magic / version / cursor / framing / overflow; a
+  `shm_ring(..., layout: N)` binding kwarg (#58) binds a topic to it.
+  Read-only consumer (#59), producer (#61), and `ring_layout` ↔
+  payload conformance checks (#60), cataloged in `spec/verification.md`
+  (#66).
+- **Raw `BytesView` payload mode** (#72, #77) — a bounded view per
+  record for heterogeneous rings, with a symmetric producer path;
+  native-ring `slots` framing reachable through the same abstraction
+  (#75).
+- **Go-style struct field tags** (#80) + **repr-tagged field
+  accessors** (#81, #82) — direct typed field access over a raw frame
+  at compile-computed offsets.
+- **Zero-copy ring write surface** (#78, #79) — a reserve/commit split
+  for writing records in place. OOB-hole fixes at the foreign-producer
+  boundary (#67), under UBSan in CI (#68).
+
+### JSON performance
+
+A parse + emit pass bringing generated JSON codecs near V8.
+
+- **Tier 2 — generated codecs from `json:` tags** (#84–88): a
+  single-pass object-member cursor, `Type::from_json` (including
+  nested structs), and a symmetric `Type::to_json`.
+- **Tier 3 — SIMD** (#90–92): SIMD-accelerated object/array cursors
+  with an AVX2 path for the scan primitives.
+- **Inline leaf primitives** (#93–97): the generated parser inlined
+  (no per-field cursor structs), the unescape copy skipped for
+  escape-free strings, and `byte_at` / `range_eq` inlined to
+  gep+load / direct compares. A representative parse went ~291 ms →
+  ~58 ms — within range of V8.
+
+### Standard library & runtime
+
+- **`std::term` + raw byte I/O** (#108–110): `is_tty(fd) -> Bool`,
+  `size() -> TermSize`, the `RawMode` guard locus (atexit-backed
+  termios restore), `std::io::stdout::write_bytes`, and
+  `std::io::stdin::read_byte` — terminal hygiene with no vendored FFI
+  glue.
+- **Interpreter retired** (#41, #42): `hale run` now compiles + execs
+  via codegen; the tree-walking `hale-runtime` crate is deleted, so
+  there is no interpreter/codegen parity to maintain.
+- **Stale-view panic via `exit()`** (#106) so `atexit` cleanup (e.g.
+  the `RawMode` restore) runs on a panic path.
+- **`BytesBuilder.append_str`** (#105) + a clarified StringView
+  non-coercion rule at `@ffi` params.
+- **ECDSA P-256** gains a `fallible(CryptoError)` form (#43).
+- **Locus method names no longer mangled** (#104) — fixes inline /
+  `accept`'d loci referenced in method bodies.
 
 ### Language surface
 
@@ -100,6 +200,22 @@ diagnostic closes the silent-drop debug gap.
   index resolution pattern (the previous example used the
   now-rejected `reg.counter().inc()` shape).
 - **`spec/design-rationale.md`** — new F.34 entry.
+- **`spec/verification.md`** (new) — the canonical catalog of all
+  static checks: the default bus-graph rules, the `ring_layout`
+  conformance + geometry checks, and the opt-in memory/resource
+  analyses (with the `--check-resource-budget` TOML schema).
+- **`spec/memory.md`** — corrected to the shipped reclamation model
+  (value allocations live until the enclosing locus dissolves;
+  free-fn returns don't reclaim per call).
+- **`spec/stdlib.md`** — `std::term` + `std::io::{stdin,stdout}` raw
+  I/O rows; the `std::bytes` binary-pack reader/writer family;
+  `BytesBuilder.append_str`.
+- **`spec/ffi.md`** / **`spec/semantics.md`** / **`spec/grammar.ebnf`**
+  — StringView non-coercion at `@ffi` params; the `ring_layout`
+  declaration grammar + foreign-ring payload modes.
+- **mdBook** — `systems/performance.md` gains a "Catching it at
+  compile time" section (the analysis flags); `everyday/cli-config.md`
+  gains "Interactive terminal I/O" (`std::term` / raw byte I/O).
 
 ---
 

--- a/docs/src/everyday/cli-config.md
+++ b/docs/src/everyday/cli-config.md
@@ -47,6 +47,48 @@ The resolver checks the argument, then the prefixed environment
 variable (`MYAPP_PORT`), then the supplied default. Empty values
 fall through to the next layer rather than counting as "set."
 
+## Interactive terminal I/O
+
+For a tool that draws to the terminal or reads keystrokes, a few
+`std::` primitives cover the OS surface without an FFI dependency.
+
+`std::term::is_tty(fd)` answers *"is this a terminal?"* — the usual
+guard for whether to emit color:
+
+```hale
+let color = std::term::is_tty(2);   // fd 2 = stderr
+```
+
+`std::term::size()` returns a `TermSize { cols, rows }` record (and
+`{0, 0}` when stdout isn't a tty). `std::term::RawMode` is a guard
+locus that puts the terminal in raw mode for its lifetime — no line
+buffering, no echo — and restores it on scope exit, and on a panic
+or unhandled error too via an atexit backstop:
+
+```hale
+fn main() {
+    let raw = std::term::RawMode { };       // birth: enter raw mode
+    // ... read keys, draw frames ...
+}                                           // dissolve: restore the terminal
+```
+
+For the bytes themselves, `std::io::stdin::read_byte(timeout_ms)`
+polls one byte (`0..255`, `-1` on timeout, `-2` on EOF), and
+`std::io::stdout::write_bytes(s)` does a raw, unbuffered write — it
+`fflush`es first so it stays ordered with any `println` output:
+
+```hale
+loop {
+    let b = std::io::stdin::read_byte(100);   // 100ms poll
+    if b == -1 { continue; }                    // timeout: redraw, tick, …
+    if b == -2 { break; }                       // EOF
+    std::io::stdout::write_bytes("got a key\r\n");
+}
+```
+
+These are primitives, not a TUI — key decoding and styling live in
+a library on top of them.
+
 ## Where this fits
 
 This is the boundary between the outside world and your program.

--- a/docs/src/systems/performance.md
+++ b/docs/src/systems/performance.md
@@ -85,6 +85,54 @@ count. Make them **flows** — declare `release(c: Conn)` on the
 parent — so each child's region is reclaimed when its connection
 ends. If RSS tracks connection count, this is almost always why.
 
+## Catching it at compile time
+
+The growth patterns above — a per-message handler that allocates
+into `self`, a connection child left resident — have a static
+shape, and `hale check` can flag them before you ever measure RSS.
+These are **opt-in** advisory warnings, not build failures:
+
+- `hale check app.hl --warn-unbounded-alloc` flags an allocation
+  that accumulates without bound: a struct / array / bytes value
+  created in a per-message bus handler (or a runtime-bounded loop)
+  and stored into `self`, where it lives until the locus dissolves.
+  The fix is the one from this chapter — route it over the bus,
+  bound the loop, or move it into a per-iteration child. A
+  `while i < N { … }` counter with a constant bound is *proven*
+  bounded and left alone.
+- `hale check app.hl --warn-resource-leak` is the same idea for file
+  descriptors: an `open` / `connect` / `accept` whose result is
+  stored resident in an unbounded context, so fds pile up.
+
+For the resource *surface* — thread / pool / subject / fd counts,
+not a leak — there's a budget you can read or gate on:
+
+```sh
+hale check app.hl --dump-resource-budget
+# OS threads (pinned loci):  1
+# cooperative pools:         1  [io]
+# bus subjects:              4
+# fd acquisition sites:      2
+```
+
+Drop a ceiling file in CI and the build fails when a count climbs
+past it — *"this PR added a pinned thread; bump the ceiling if you
+meant to."* Every key is optional:
+
+```toml
+# budget.toml
+pinned_threads = 4
+bus_subjects   = 16
+```
+
+```sh
+hale check app.hl --check-resource-budget budget.toml
+```
+
+None of these run by default — they're tools you reach for when a
+program's memory or fd surface is something you want to hold the
+line on.
+
 ## Knobs for when it's not your code
 
 The substrate exposes diagnostics and glibc tuning via

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -77,24 +77,41 @@ CQRS is GitHub issue #18 item 6; its three sanctioned remedies
 (parent-child + contract, bus mediator, delegation) are named in the
 diagnostic. See `spec/semantics.md § Locus method dispatch`.
 
-## Not yet offered
+## Opt-in & deferred analyses
 
-Item 4 (bus-graph property checks) is fully landed. The remaining GitHub
-issue #18 candidates are partial or unstarted, and none is a default gate
-— don't assume them in a build:
+Item 4 (bus-graph property checks) is fully landed and runs by default.
+The other GitHub issue #18 candidates are **opt-in** (behind a flag) or
+deferred — none is a default gate, so don't assume them in a build:
 
 - **Memory-bound proofs (item 1)** — the analysis exists (per-method
-  allocation summary + call-graph escape/loop dataflow) and emits
-  unbounded-accumulation warnings, but **opt-in** via `hale check
-  --warn-unbounded-alloc`; not on by default. Type-aware String-concat
-  sites + loop-ranking are unfinished. See `notes/memory-bound-proofs.md`.
-- **Resource-budget tracking (item 5)** — a static **count** of pinned
-  threads / cooperative pools / bus subjects (`hale check
-  --dump-resource-budget`); a **CI ceiling gate** (`--check-resource-budget
-  <file.toml>` — fails the build when a count exceeds a declared ceiling);
-  and **fd-leak detection** (`--warn-resource-leak` — an fd-acquiring call
-  whose result is stored resident in an unbounded context, opt-in). Held-fd
-  *counts* are the one unshipped piece. See `notes/resource-budgets.md`.
+  allocation summary + call-graph escape/loop dataflow, including
+  call-result escape tagging and **loop-ranking** that proves a
+  `while v < N` const counter bounded) and emits unbounded-accumulation
+  warnings, **opt-in** via `hale check --warn-unbounded-alloc`
+  (`--dump-alloc-summary` prints the raw per-fn allocation summary). Not on
+  by default — *deliberately held* pending an `@unbounded` escape valve +
+  a replace-vs-append refinement, because the warnings include
+  legitimately bounded-by-design patterns (a fixed-window store-latest) the
+  author would accept. Type-aware String-concat sites remain deferred. See
+  `notes/memory-bound-proofs.md`.
+- **Resource-budget tracking (item 5)** — fully shipped, opt-in. A static
+  **count** of pinned threads / cooperative pools / bus subjects /
+  fd-acquisition sites (fd-opening calls *and* held-fd `Listener` /
+  `Stream` instantiations) via `hale check --dump-resource-budget`; a **CI
+  ceiling gate** `--check-resource-budget <file.toml>` (fails the build
+  when a count exceeds a declared ceiling); and **fd-leak detection**
+  `--warn-resource-leak` (an fd-acquiring call whose result is stored
+  resident in an unbounded context). See `notes/resource-budgets.md`.
+
+  The ceiling file is TOML; every key is optional (an absent key leaves
+  that resource unconstrained, an unknown key is an error):
+
+  ```toml
+  pinned_threads    = 4
+  cooperative_pools = 2
+  bus_subjects      = 16
+  fd_open_sites     = 8
+  ```
 - **Closure-assertion lifting (item 3)** — scoped, deliberately parked.
   The tractable case (constant assertions) is already handled: typecheck
   rejects any closure whose assertion observes no runtime-varying value


### PR DESCRIPTION
Release-prep documentation pass for **v0.8.3**.

- **CHANGELOG**: comprehensive v0.8.3 section across the full 159-commit span since v0.8.2 (verification track, SHM-ring interop, fast JSON, std::term, interpreter retirement). The prior section only covered the early CQRS/F.34 batch.
- **spec/verification.md**: fixed stale spots — loop-ranking landed (#117), held-fd counts shipped (#115/#116); added the `--check-resource-budget` TOML schema + `--dump-alloc-summary`; renamed the section since item 5 is fully shipped.
- **mdBook**: `systems/performance.md` compile-time analysis flags; `everyday/cli-config.md` interactive terminal I/O — both user-facing surface that shipped without docs.

mdBook builds clean. Docs/changelog only; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)