### PR TITLE
types: R1 escape-awareness for --warn-unbounded-alloc + precision scope (GH #18 item 1)

### DIFF
--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -103,6 +103,25 @@ impl Escape {
             Escape::Sent => "escaping=bus-send",
         }
     }
+    /// Does this value survive its method's return — i.e. persist across
+    /// *invocations* of an unboundedly-invoked fn (a per-message handler)?
+    ///
+    /// A locus method / bus handler opens a **method-scratch subregion** at
+    /// entry and destroys it at exit (per delivery) — transients allocate
+    /// into the scratch and are freed per call, while escaping values are
+    /// copied out to `self` / the caller first (see
+    /// `open_method_scratch` / `emit_method_scratch_destroy` in codegen).
+    /// So a `Local` is reclaimed per invocation and does NOT accumulate
+    /// across deliveries; only `StoredToSelf` (persists in the locus) and
+    /// `Returned` (escapes to the caller) do. `Sent` is reclaimed per
+    /// dispatch (handled by its `AfterBusDispatch` reclaim scope).
+    ///
+    /// This is only about *cross-invocation* multiplicity. A `Local` in an
+    /// unbounded loop *within a single call* still accumulates until that
+    /// call returns — that case is caught by the in-loop verdict, not here.
+    fn persists_across_calls(&self) -> bool {
+        matches!(self, Escape::StoredToSelf | Escape::Returned)
+    }
 }
 
 /// When an allocation's memory is actually reclaimed — the *empirically
@@ -383,7 +402,16 @@ impl AllocSummary {
         let intra = site.verdict();
         match intra {
             SiteVerdict::AccumulatesUnbounded | SiteVerdict::PerIterationReclaim => intra,
-            _ if unbounded.contains(owner) && site.reclaim.accumulates_in_loop() => {
+            // Cross-invocation accumulation (a per-message handler / a fn
+            // reached from an unbounded loop): only ESCAPING values persist
+            // across invocations. A non-escaping `Local` is reclaimed at the
+            // per-call method-scratch destroy (R1 — escape-awareness), so it
+            // does not accumulate across deliveries. The in-loop case
+            // (intra == AccumulatesUnbounded) is handled above and untouched.
+            _ if unbounded.contains(owner)
+                && site.reclaim.accumulates_in_loop()
+                && site.escape.persists_across_calls() =>
+            {
                 SiteVerdict::AccumulatesUnbounded
             }
             _ => intra,
@@ -1191,6 +1219,62 @@ mod tests {
             ),
             SiteVerdict::AccumulatesUnbounded,
             "a runtime init must stay unbounded"
+        );
+    }
+
+    #[test]
+    fn r1_escape_awareness_on_the_cross_invocation_path() {
+        // (a) a per-message handler builds a transient it does NOT store →
+        // reclaimed at the per-delivery method-scratch destroy → not a leak.
+        let transient = r#"
+            type T { n: Int; }
+            type Tmp { a: Int; b: Int; }
+            locus L {
+                params { last: Int = 0; }
+                bus { subscribe "in" as on_in of type T; }
+                fn on_in(m: T) { let tmp = Tmp { a: m.n, b: m.n }; self.last = tmp.a; }
+            }
+            fn main() { }
+        "#;
+        assert!(
+            summarize(transient).leak_sites().is_empty(),
+            "a non-escaping handler local is reclaimed per delivery — must not flag"
+        );
+
+        // (b) the same handler storing the struct INTO self → escapes the
+        // scratch → accumulates across deliveries → flagged.
+        let stored = r#"
+            type T { n: Int; }
+            type Tmp { a: Int; b: Int; }
+            locus L {
+                params { last: Tmp; }
+                bus { subscribe "in" as on_in of type T; }
+                fn on_in(m: T) { self.last = Tmp { a: m.n, b: m.n }; }
+            }
+            fn main() { }
+        "#;
+        assert_eq!(
+            summarize(stored).leak_sites().len(),
+            1,
+            "a self-stored handler alloc persists across deliveries — must flag"
+        );
+
+        // (c) a non-escaping local in an UNBOUNDED LOOP inside the handler
+        // accumulates within the (never-returning) call → still flagged.
+        // R1 only changes the cross-invocation path, not the in-loop one.
+        let in_loop = r#"
+            type T { n: Int; }
+            type Tmp { a: Int; }
+            locus L {
+                bus { subscribe "in" as on_in of type T; }
+                fn on_in(m: T) { while true { let tmp = Tmp { a: m.n }; let _ = tmp.a; } }
+            }
+            fn main() { }
+        "#;
+        assert_eq!(
+            summarize(in_loop).leak_sites().len(),
+            1,
+            "a non-escaping local in an unbounded loop still accumulates within the call"
         );
     }
 

--- a/notes/unbounded-alloc-precision.md
+++ b/notes/unbounded-alloc-precision.md
@@ -1,0 +1,171 @@
+# Precision refinements for `--warn-unbounded-alloc` (GH #18 item 1)
+
+Status: **scoped** (2026-06-11). The path to making the memory-bound
+warning precise enough to eventually be **default-on** — replacing the
+rejected `@unbounded` escape-hatch idea (an escape hatch lets people opt
+out of the substrate discipline the check exists to enforce; the right
+move is to make the warning *right*, not silenceable). See the default-on
+decision in [[memory-bound-proofs]] and the escape-hatch discussion that
+killed `@unbounded`.
+
+## What the warning actually does today (grounded)
+
+`leak_sites` / `final_verdict` (`alloc_summary.rs`) flags a Struct / Array /
+`[v; N]` / Bytes literal when **either**:
+
+- it's inside an **unbounded loop** (`while true`, runtime `for`-iter, a
+  non-const-counter `while`), **or**
+- its owner fn is **unbounded-invoked** (a per-message bus handler, or
+  reached through a call in an unbounded loop) **and** its reclaim scope is
+  `EnclosingLocus`.
+
+`EnclosingLocus` is **everything except a bus `Sent`** — so `Local`,
+`Returned`, and `StoredToSelf` all qualify. There is **no escape filter and
+no lifetime filter.** That is the imprecision.
+
+## The framing correction (vs. my first sketch)
+
+"Replace-vs-append reduces false positives" is **wrong** as stated. In a
+bump arena a `self.f = new_value` *replace* also leaks resident memory —
+the old value's bytes are never reclaimed until the locus dissolves (bump
+pointers don't go backwards). So a replace in a *long-running* locus is a
+**true positive**, not noise. The real false-positive sources are
+different, and replace-vs-append earns its keep for *message precision* and
+*runtime-fix targeting*, not for silencing.
+
+## The actual false-positive sources
+
+1. **Transient local scratch in a handler.** `fn on_msg(m) { let t =
+   Struct{…}; use(t); }` — `t` never escapes. The method-scratch
+   sub-region is reclaimed at method return (the leak that *was* there was
+   fixed — see [[compiled-corpus-oracle-harness]]), so `t` does **not**
+   accumulate across messages. But `final_verdict` flags it anyway
+   (`EnclosingLocus`, owner unbounded-invoked). **This is the biggest false
+   positive class.**
+2. **Accumulation in a short-lived locus.** The same `self.x = alloc` is a
+   leak in a long-running service and *fine* in a per-connection
+   `accept`'d child that `release`s (its whole region is reclaimed when the
+   connection ends) or a one-shot batch `main` (reclaimed at exit). The
+   check is blind to the owner's lifetime.
+
+A long-running-locus *replace* (the moving-average `self.window = [...]`)
+is **not** in this list — it genuinely leaks resident memory and should
+stay flagged. The author's "it's a bounded 4-window" belief is wrong about
+the runtime; the fix is to route it over the bus, use a fixed slot, or the
+runtime sidecar below — not to suppress.
+
+## R1 premise — CONFIRMED (via codegen, definitively)
+
+**Does a non-escaping local literal in a per-message handler accumulate
+across messages? No.** Settled by reading the codegen rather than an RSS
+proxy: a locus method / bus handler **opens a method-scratch subregion at
+entry** (`open_method_scratch`, `method.rs:656`) and **destroys it at exit,
+per delivery** (`emit_method_scratch_destroy`, `method.rs:728` — the comment
+warns that skipping the destroy "leaks one subregion per delivery").
+Transients allocate into the scratch and are freed per call; escaping
+values are copied out to `self` / the caller first. So `Local` is reclaimed
+per invocation; the `alloc_summary` model's `Local → EnclosingLocus →
+accumulates` over-flags. **R1 is a soundness fix.** The in-loop case is
+unaffected (a local in a loop *within one call* accumulates until the call
+returns — RSS-validated — so R1 leaves the in-loop verdict path untouched).
+
+## The three refinements
+
+### R1 — escape-awareness on the cross-invocation path — **LANDED**
+
+In the **unbounded-invoked** path only, require the site to **escape its
+handler** (`StoredToSelf` / `Returned`, via `Escape::persists_across_calls`)
+before flagging; a non-escaping `Local` is reclaimed per invocation (method
+scratch). The **in-loop** path (`site.verdict() == AccumulatesUnbounded`) is
+untouched. A one-clause change in `final_verdict`.
+
+**Corpus impact: 4 → 3 warnings.** R1 removed a genuine false positive —
+`fitter.hl`'s `on_observation` builds `let p = KernelPerspective { … }`,
+calls `p.is_stable()`, and discards it (the publish sends
+`self.latest_kernel`, not `p`). `p` is a transient reclaimed per delivery;
+it was being wrongly flagged. The three survivors are all real
+`self.X = …` stores (true positives). So the earlier "4 genuine flags, zero
+FPs" claim was off by one — R1 found it.
+
+### R2 — replace-vs-append on the escaping case (message precision + runtime-fix targeting)
+
+Among `StoredToSelf` sites, split by a syntactic test on the assignment:
+`self.f = E` is **grow/append** iff `E` reads `self.f` (e.g.
+`self.buf = self.buf + chunk`, a push onto `self.f`); otherwise **replace**
+(`self.window = compute(m)`).
+
+- **Append** — incorporates all prior values → unbounded by construction.
+  Warn with high confidence; advice = "bound / cap / route."
+- **Replace** — one live value; resident-only leak (the arena keeps old
+  copies). Warn **only if the locus is long-running** (R3), with a
+  replace-specific message: *"one value is live, but the old one isn't
+  reclaimed until the locus dissolves — use a fixed `capacity` slot, route
+  over the bus, or shorten the locus lifetime."* Replace-of-a-fixed-size
+  field is the runtime-fix candidate (below).
+
+### R3 — lifetime-awareness (kills the short-lived-locus false positives)
+
+Classify the owner locus's lifetime from its lifecycle shape (compile-time
+known):
+
+- **Long-running / resident** — a top-level singleton, a locus with a
+  non-trivial `run()`, a bus subscriber with no `release` above it.
+  Accumulation = forever → **warn**.
+- **Short-lived / flow** — an `accept`'d child whose parent declares
+  `release` (region reclaimed per unit of work), a one-shot `main` in a
+  non-service program, a per-request flow. Accumulation bounded by the
+  (bounded) lifetime → **don't warn** (or downgrade to a note).
+
+Conservative default: unknown / can't classify → treat as long-running
+(warn). Never a false "bounded."
+
+## How they compose
+
+| site | owner lifetime | verdict after refinements |
+|---|---|---|
+| non-escaping `Local` in a handler | any | **silent** (R1 — reclaimed per call) |
+| `Local` in an unbounded loop | any | **warn** (unchanged — accumulates within the call) |
+| `StoredToSelf` *append* (`self.f = self.f + x`) | long-running | **warn** (unbounded by construction) |
+| `StoredToSelf` *append* | short-lived | silent / note (R3) |
+| `StoredToSelf` *replace* (`self.f = E`) | long-running | **warn**, replace-specific message (R2) |
+| `StoredToSelf` *replace* | short-lived | **silent** (R3) |
+
+The corpus's moving-average / fitter warnings are long-running `StoredToSelf`
+sites, so they **stay** (true positives) — with sharper messages. What goes
+away is transient handler scratch (R1) and any short-lived-locus
+accumulation (R3). That's the point: after the refinements the surviving
+warnings should all be true positives, which is the precondition for
+default-on.
+
+## Runtime sidecar (optional, makes replace genuinely bounded)
+
+A **free-on-overwrite / in-place slot reuse** for a *fixed-size* heap-typed
+`self` field: allocate the field's storage once, overwrite in place on
+reassignment. Turns long-running fixed-size replace (the moving-average
+window) from a resident leak into a true constant. Variable-size replace (a
+grown String) can't reuse a fixed slot and stays a real leak. With this,
+R2's replace case can drop to "bounded" for fixed-size fields. Out of scope
+for the analysis work; flagged here as the principled fix the replace
+diagnostic should point at.
+
+## Staging
+
+0. **Validate** the handler-scratch reclaim question — **DONE** (confirmed
+   via codegen; see above).
+1. **R1** — escape-awareness on the cross-invocation path — **LANDED**
+   (corpus 4 → 3, removed a transient-local FP).
+2. **R3** — lifetime classification. Removes short-lived-locus warnings.
+   *(next)*
+3. **R2** — replace-vs-append messaging + runtime-fix targeting.
+4. **Re-evaluate default-on** — only once the surviving corpus warnings are
+   all true positives. Then it's a warning that's *right*, needing no
+   escape hatch.
+
+## Risk
+
+- **R1's premise is empirical** — if handler scratch is *not* reclaimed
+  per-invocation, R1 is unsound and the model is right to flag locals;
+  hence the validation gate. Don't ship R1 on the assumption.
+- **Lifetime classification must stay conservative** — a misclassified
+  long-running locus as "short-lived" would hide a real leak. Unknown →
+  long-running.


### PR DESCRIPTION
Scopes the precision refinements that replace the rejected `@unbounded` escape hatch (`notes/unbounded-alloc-precision.md`) and lands the first one.

## The framing correction (in the scope)
"Replace-vs-append reduces false positives" is **wrong**: a `self.f = new` *replace* also leaks resident memory in a bump arena (old copies linger until dissolve), so it's a true positive in a long-running locus. The real false-positive sources are **transient handler scratch (R1)** and **short-lived loci (R3)**.

## R1 — escape-awareness (this PR)
The warning flagged **any** Struct/Array/Bytes literal in a per-message handler regardless of escape. But the codegen shows a locus method / bus handler **opens a method-scratch subregion at entry and destroys it per delivery** (`open_method_scratch` / `emit_method_scratch_destroy`) — transients are reclaimed per call; only escaping values are copied out first. So a non-escaping `Local` does **not** accumulate across deliveries.

`final_verdict`'s cross-invocation arm now requires `Escape::persists_across_calls()` (`StoredToSelf` / `Returned`). The in-loop path (a local in an unbounded loop *within one call*) is untouched.

## Corpus: 4 → 3 (R1 found a real FP)
`fitter.hl`'s `on_observation` builds `let p = KernelPerspective { … }`, calls `p.is_stable()`, and discards it (the publish sends `self.latest_kernel`, not `p`). `p` is reclaimed per delivery — it was being wrongly flagged. The 3 survivors are all real `self.X = …` stores. (So the earlier "4 genuine flags, zero FPs" claim was off by one.)

## Validation
R1's premise was confirmed by **codegen inspection** (the scratch is opened+destroyed per delivery), not an RSS proxy — stronger evidence. Tests: `r1_escape_awareness_on_the_cross_invocation_path` (transient not flagged / self-stored flagged / in-loop still flagged); hale-types **197** + alloc RSS green.

Next in the scope: **R3** (lifetime-awareness) removes short-lived-locus warnings; then **R2** (replace-vs-append messaging). Default-on is re-evaluated only once the survivors are all true positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
