### PR TITLE
unbounded-alloc: name bounded fixes in the warning + fix moving-average in place

### DIFF
--- a/crates/hale-codegen/tests/fixtures/examples/22-moving-average/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/22-moving-average/main.hl
@@ -3,7 +3,8 @@
 //
 // What this exercises end-to-end:
 //   - Fixed-cap array as locus state (`[Int; 4]`).
-//   - Mutation through self.X = ... (replace oldest slot).
+//   - In-place indexed slot write (`self.recent[head] = ...`),
+//     so the window never reallocates.
 //   - Subscribe + publish on the bus, with a typed payload.
 //   - For-over-array inside a handler body.
 //   - A modular index walking the circular buffer, written
@@ -50,22 +51,11 @@ locus Window {
     }
 
     fn on_sample(s: Sample) {
-        // Slot the new value at `head`. We can't write
-        // self.recent[head] = ... in v0 codegen (indexed
-        // self assignment is gated), so we rebuild the array
-        // by mapping over the old contents — replace one
-        // slot, copy the rest.
-        let mut next = [0, 0, 0, 0];
-        let mut i = 0;
-        while i < 4 {
-            if i == self.head {
-                next[i] = s.value;
-            } else {
-                next[i] = self.recent[i];
-            }
-            i = i + 1;
-        }
-        self.recent = next;
+        // Overwrite the oldest slot in place via indexed
+        // self-assignment. No per-message array allocation, so the
+        // window doesn't accumulate replaced arrays in the locus
+        // arena — the state is exactly the four live slots.
+        self.recent[self.head] = s.value;
         self.head = (self.head + 1) % 4;
 
         // Recompute the rolling sum + emit smoothed value.

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -615,8 +615,11 @@ pub fn unbounded_alloc_diags(programs: &[&Program]) -> Vec<Diag> {
                 format!(
                     "unbounded allocation: this {} {} accumulates in `{}`'s region \
                      until the locus dissolves — it is never reclaimed per iteration, \
-                     so it grows without bound. Bound the loop, route the value over the \
-                     bus (the payload arena reclaims per dispatch), or move the allocating \
+                     so it grows without bound. Bound the loop; store it in a \
+                     capacity-bounded form (`@form(ring_buffer)` / `@form(lru_cache)` / \
+                     a `capacity` slot) instead of a replaced field; mutate fixed state \
+                     in place rather than rebuilding it; route the value over the bus \
+                     (the payload arena reclaims per dispatch); or move the allocating \
                      work into a per-iteration child locus.",
                     ls.kind.label(),
                     where_,


### PR DESCRIPTION
Two precision-pass items toward default-on (GH #18 item 1).

**R2-lite — message.** The warning now names the idiomatic fixes: store it in a capacity-bounded form (`@form(ring_buffer)` / `@form(lru_cache)` / a `capacity` slot) instead of a replaced field, and mutate fixed state in place rather than rebuilding it.

**22-moving-average — fixed in place.** Rewrote the handler to `self.recent[self.head] = s.value` instead of rebuilding the array every message. The old code was a *documented workaround for gated indexed self-assignment* — but **that feature works now**, so the comment was stale and the array-rebuild was a real per-message leak. Output identical (25/75/150/250/350/450); no longer warns; simpler.

Corpus `--warn-unbounded-alloc`: **3 → 2**. The two survivors are the fitter's single-value `self.latest_kernel = Kernel{…}` store-latest — which forms *don't* cover (it's one value, not a collection). That's the sidecar's case, not a form/flatten case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)