### PR TITLE
examples: fitter updates the kernel in place (clears the last unbounded-alloc warnings)

### DIFF
--- a/crates/hale-codegen/tests/fixtures/examples/fitter-applier-demo/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/fitter-applier-demo/main.hl
@@ -103,14 +103,12 @@ locus FitterL {
     }
 
     fn on_observation(obs: Observation) {
-        // Refit the kernel from the new observation. v0 stub:
-        // bump perspective_id each time, leave the scale at
-        // 1.0d.
-        self.latest_kernel = Kernel {
-            scale: self.latest_kernel.scale,
-            valid_after: obs.timestamp,
-            perspective_id: self.latest_kernel.perspective_id + 1,
-        };
+        // Refit the kernel from the new observation in place — bump
+        // perspective_id, leave the scale at 1.0d. Mutating the fields
+        // avoids re-allocating the whole struct every message, so the
+        // kernel state doesn't accumulate in the locus arena.
+        self.latest_kernel.valid_after = obs.timestamp;
+        self.latest_kernel.perspective_id = self.latest_kernel.perspective_id + 1;
         self.validation_count = self.validation_count + 1;
 
         // Multi-perspective stability commit-rule: ship only

--- a/crates/hale-codegen/tests/fixtures/examples/fitter-applier-pair/fitter.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/fitter-applier-pair/fitter.hl
@@ -38,14 +38,14 @@ locus FitterL {
     }
 
     fn on_observation(obs: Observation) {
-        // Update fitted kernel from the new observation.
-        // In production this is real curve fitting; here a
-        // stub that increments perspective_id each time.
-        self.latest_kernel = Kernel {
-            scale: self.latest_kernel.scale,
-            valid_after: obs.timestamp,
-            perspective_id: self.latest_kernel.perspective_id + 1,
-        };
+        // Update the fitted kernel in place from the new observation
+        // (scale is carried unchanged). Mutating the fields avoids
+        // re-allocating the whole struct every message, so the kernel
+        // state doesn't accumulate in the locus arena. In production
+        // this is real curve fitting; here a stub that bumps
+        // perspective_id each time.
+        self.latest_kernel.valid_after = obs.timestamp;
+        self.latest_kernel.perspective_id = self.latest_kernel.perspective_id + 1;
         self.validation_count = self.validation_count + 1;
 
         // Wrap as a perspective, ship if stable.


### PR DESCRIPTION
Both fitter examples did `self.latest_kernel = Kernel { ... }` every observation — a **whole-struct replace**. Measured (RSS A/B), that genuinely leaks: Hale bump-allocates a fresh struct each message and the old lingers in the locus arena (~512 B/msg for a 512-byte struct). It is **not** an in-place overwrite.

The fix: mutate the fields in place (`self.latest_kernel.field = v`) — which Hale already supports and which is the free copy/assign (RSS A/B: **zero** delta vs the no-store control). Same shape as the 22-moving-average in-place fix.

**Corpus `--warn-unbounded-alloc`: 2 → 0.** Both warnings were true positives; **no sidecar / no flatten** needed — in-place mutation is the answer, and the warning correctly pointed at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)