### PR TITLE
cli: turn --warn-unbounded-alloc on by default (GH #18 item 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ behavior.
 
 ---
 
+## Unreleased
+
+- **Memory-bound warnings on by default (GitHub #18 item 1).**
+  `hale check` now emits unbounded-allocation warnings without a flag.
+  They're **advisory** — they print but don't fail the build (only errors
+  do); `--no-warn-unbounded-alloc` opts out. The analysis reached zero
+  corpus false positives first: escape-awareness (a non-escaping local in a
+  per-message handler is reclaimed at the per-delivery method-scratch
+  destroy, so it isn't flagged) and loop-ranking (a `while v < N` const
+  counter is proven bounded). The warning flags a value that's allocated in
+  a per-message handler / unbounded loop, escapes, and accumulates until
+  the locus dissolves — e.g. a whole-value field replace
+  `self.f = Struct{…}`, which bump-allocates a fresh value each time. The
+  fix it points at is **in-place mutation** (`self.f.x = v` /
+  `self.a[i] = v`), a capacity-bounded `@form`, the bus, or a per-iteration
+  child locus. The `22-moving-average` and fitter examples were updated to
+  mutate in place.
+
+---
+
 ## v0.8.3 — verification track, SHM-ring interop, fast JSON
 
 The largest release since v0.8.0 (cumulative since v0.8.2). Four

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -918,8 +918,11 @@ fn run_check(target: &Path) -> ExitCode {
     let allow_unowned =
         std::env::args().any(|a| a == "--allow-unowned-subscriber");
     let mut diags = hale_types::check_bundle_opts(&bundle, allow_unowned);
-    // GH #18 item 1 step 3: opt-in unbounded-allocation warnings.
-    if std::env::args().any(|a| a == "--warn-unbounded-alloc") {
+    // GH #18 item 1: unbounded-allocation warnings, ON BY DEFAULT.
+    // `--no-warn-unbounded-alloc` opts out; `--warn-unbounded-alloc` is
+    // still accepted (now a no-op) for back-compat. The warnings are
+    // advisory — they print but don't fail the build (only errors do).
+    if !std::env::args().any(|a| a == "--no-warn-unbounded-alloc") {
         diags.extend(hale_types::unbounded_alloc_warnings(&bundle));
     }
     // GH #18 item 5: opt-in fd-resource-leak warnings.

--- a/docs/src/systems/performance.md
+++ b/docs/src/systems/performance.md
@@ -89,17 +89,21 @@ ends. If RSS tracks connection count, this is almost always why.
 
 The growth patterns above — a per-message handler that allocates
 into `self`, a connection child left resident — have a static
-shape, and `hale check` can flag them before you ever measure RSS.
-These are **opt-in** advisory warnings, not build failures:
+shape, and `hale check` flags them before you ever measure RSS.
+These are advisory warnings, not build failures:
 
-- `hale check app.hl --warn-unbounded-alloc` flags an allocation
-  that accumulates without bound: a struct / array / bytes value
-  created in a per-message bus handler (or a runtime-bounded loop)
-  and stored into `self`, where it lives until the locus dissolves.
-  The fix is the one from this chapter — route it over the bus,
-  bound the loop, or move it into a per-iteration child. A
-  `while i < N { … }` counter with a constant bound is *proven*
-  bounded and left alone.
+- **On by default**, `hale check` flags an allocation that
+  accumulates without bound: a struct / array / bytes value created
+  in a per-message bus handler (or a runtime-bounded loop) that
+  escapes into `self`, where it lives until the locus dissolves —
+  e.g. a whole-value replace `self.latest = Thing{…}`, which
+  bump-allocates a fresh value each message. The fix is usually
+  **in-place mutation** (`self.latest.field = v`, `self.arr[i] = v`)
+  instead of replacing the whole value, or the moves from this
+  chapter — a capacity-bounded `@form`, route it over the bus, or a
+  per-iteration child. A `while i < N { … }` counter with a constant
+  bound is *proven* bounded and left alone. `--no-warn-unbounded-alloc`
+  opts out.
 - `hale check app.hl --warn-resource-leak` is the same idea for file
   descriptors: an `open` / `connect` / `accept` whose result is
   stored resident in an unbounded context, so fds pile up.

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -77,23 +77,29 @@ CQRS is GitHub issue #18 item 6; its three sanctioned remedies
 (parent-child + contract, bus mediator, delegation) are named in the
 diagnostic. See `spec/semantics.md § Locus method dispatch`.
 
-## Opt-in & deferred analyses
+## Default-on & opt-in analyses
 
-Item 4 (bus-graph property checks) is fully landed and runs by default.
-The other GitHub issue #18 candidates are **opt-in** (behind a flag) or
-deferred — none is a default gate, so don't assume them in a build:
+Two GitHub issue #18 analyses run **by default**: item 4 (bus-graph property
+checks — *errors*, fail the build) and item 1 (memory-bound — *advisory
+warnings*, print but don't fail). The rest are **opt-in** (behind a flag) or
+deferred. Only item 4 is a build gate; don't assume the others in a build:
 
-- **Memory-bound proofs (item 1)** — the analysis exists (per-method
-  allocation summary + call-graph escape/loop dataflow, including
-  call-result escape tagging and **loop-ranking** that proves a
-  `while v < N` const counter bounded) and emits unbounded-accumulation
-  warnings, **opt-in** via `hale check --warn-unbounded-alloc`
-  (`--dump-alloc-summary` prints the raw per-fn allocation summary). Not on
-  by default — *deliberately held* pending an `@unbounded` escape valve +
-  a replace-vs-append refinement, because the warnings include
-  legitimately bounded-by-design patterns (a fixed-window store-latest) the
-  author would accept. Type-aware String-concat sites remain deferred. See
-  `notes/memory-bound-proofs.md`.
+- **Memory-bound proofs (item 1)** — **on by default** in `hale check`
+  (advisory warnings; they print but don't fail the build).
+  `--no-warn-unbounded-alloc` opts out; `--dump-alloc-summary` prints the
+  raw per-fn summary. A per-method allocation summary + call-graph
+  escape/loop dataflow — with **escape-awareness** (a non-escaping local in
+  a per-message handler is reclaimed at the per-delivery method-scratch
+  destroy, so it isn't flagged), call-result escape tagging, and
+  **loop-ranking** (a `while v < N` const counter is proven bounded) — flags
+  a value allocated in a per-message handler / unbounded loop that escapes
+  and **accumulates until the locus dissolves**. A whole-value replace
+  (`self.f = Struct{…}`) genuinely leaks (the arena bump-allocates a fresh
+  value each time); the fix is **in-place mutation** (`self.f.x = v` /
+  `self.a[i] = v`), a capacity-bounded `@form` (`ring_buffer` / `lru_cache`
+  / a `capacity` slot), the bus (reclaims per dispatch), or a per-iteration
+  child locus. Zero corpus false positives. Type-aware String-concat sites
+  remain deferred. See `notes/memory-bound-proofs.md`.
 - **Resource-budget tracking (item 5)** — fully shipped, opt-in. A static
   **count** of pinned threads / cooperative pools / bus subjects /
   fd-acquisition sites (fd-opening calls *and* held-fd `Listener` /


### PR DESCRIPTION
The memory-bound warning now runs in `hale check` without a flag. **Advisory** — prints but doesn't fail the build (only errors do); `--no-warn-unbounded-alloc` opts out, `--warn-unbounded-alloc` still accepted as a no-op.

Default-on is justified now that the analysis is at **zero corpus false positives**: escape-awareness (R1) and loop-ranking removed the FP classes, and the three former corpus warnings were all true positives fixed by **in-place mutation**. The deliberated `@unbounded` escape hatch and the runtime sidecar both turned out unnecessary — the warning is correct and its fix (`self.f.x = v` instead of `self.f = Struct{…}`) is idiomatic and already supported.

Verified: a leaky whole-value-replace handler warns by default; corpus is 0 by default; `--no-warn` suppresses; build exits 0 (advisory). spec/verification.md + docs + CHANGELOG (Unreleased) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)