### PR TITLE
fix(codegen): locus-field reassignment is a lifecycle transition (WS1#4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ behavior.
 
 ## Unreleased
 
+- **Whole-value reassignment of a locus-typed field is now a lifecycle
+  transition (post-audit WS1#4 — soundness fix).** `self.conn = WsClient
+  { … }` from a member fn previously lowered the RHS locus literal as a
+  scope-bound temporary: birth ran, the pointer was stored, then the
+  temporary was dissolved at the method's exit — leaving the field pointing
+  at a torn-down locus (closed `@ffi` handles / freed arena → use-after-free
+  on next use; the fathom refgw-evm reconnect crash), while the old value
+  leaked. It now reclaims the old instance (its `drain`/`dissolve` run) and
+  constructs the new one into the owning locus's arena, owned by the field
+  and not scope-dissolved. Clean-compile→segfault closed; regression-gated by
+  `ws1_ffi_handle_reassign`. In-place mutation (`self.conn.url = …`) remains
+  the cheaper path for "same instance, reconfigure." See `spec/types.md`.
+
 - **Docs-truth pass (post-audit WS5).** New book chapters: *Operations &
   debugging* (the bus-drop / arena-residency / backpressure diagnostics with
   two worked triage walkthroughs) and *Composition patterns* (the three-locus

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -10451,6 +10451,45 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 Ok(BlockEnd::Open)
             }
             Stmt::Assign { target, op, value, .. } => {
+                // WS1#4: `self.<locusfield> = <LocusLiteral>` is a
+                // lifecycle transition (dissolve the old instance,
+                // construct a new one owned by the field), NOT a
+                // value store. Lowered normally the RHS locus literal
+                // is a scope-bound temporary dissolved at this
+                // method's exit, leaving the field pointing at a
+                // torn-down locus (closed @ffi handles / freed arena
+                // → use-after-free; fathom refgw-evm reconnect). Route
+                // it through the lifecycle-aware path instead.
+                if matches!(op, AssignOp::Eq)
+                    && target.head.name == "self"
+                    && target.tail.len() == 1
+                {
+                    if let LValueSeg::Field(fname) = &target.tail[0] {
+                        let field = self
+                            .current_self
+                            .as_ref()
+                            .and_then(|cs| cs.fields.get(&fname.name).cloned());
+                        if let (
+                            Some((field_idx, CodegenTy::LocusRef(field_locus))),
+                            Expr::Struct { path, inits, .. },
+                        ) = (field, value)
+                        {
+                            if path.segments.len() == 1
+                                && self
+                                    .user_loci
+                                    .contains_key(&path.segments[0].name)
+                            {
+                                return self.lower_locus_field_reassign(
+                                    field_idx,
+                                    &field_locus,
+                                    &path.segments[0].name,
+                                    inits,
+                                    scope,
+                                );
+                            }
+                        }
+                    }
+                }
                 // Resolve the target into a (slot_ptr, slot_ty)
                 // pair. Bare locals come from the scope; `self.X`
                 // GEPs into the current method's self-struct.
@@ -21229,6 +21268,109 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// there's no long-lived `self.__arena` to anchor into), so
     /// using it uniformly is always at least as correct as a bare
     /// store.
+    /// WS1#4 — lower `self.<field> = <LocusLiteral>` as a lifecycle
+    /// transition rather than a value store. The default lowering
+    /// treats the RHS locus literal as a scope-bound temporary
+    /// (dissolved at this method's exit), so the field ends up
+    /// pointing at a torn-down locus — closed `@ffi` handles, freed
+    /// arena, use-after-free on next use (the fathom refgw-evm
+    /// `self.conn = ws::WsClient { … }` reconnect crash). Instead:
+    ///   (1) reclaim the OLD instance (`__reclaim_<L>` runs its
+    ///       drain / dissolve so its resources are released);
+    ///   (2) construct the NEW instance into self's own arena, owned
+    ///       by the field and NOT scope-dissolved — the same
+    ///       `instantiating_for_parent_field` + arena-override path a
+    ///       field-default child takes in params-init, so the
+    ///       parent's dissolve cascade reclaims it through the field;
+    ///   (3) repoint the field at the live new instance.
+    /// In-place mutation (`self.conn.url = …`) stays the cheap path
+    /// for "same instance, reconfigure". (v1: the new instance
+    /// inherits the parent's pool; reassigning a *pinned*-placed
+    /// field doesn't re-apply the pinned placement — out of scope.)
+    fn lower_locus_field_reassign(
+        &mut self,
+        field_idx: u32,
+        field_locus: &str,
+        new_locus: &str,
+        inits: &[StructInit],
+        scope: &Scope<'ctx>,
+    ) -> Result<BlockEnd, CodegenError> {
+        let cs = self.current_self.as_ref().cloned().ok_or_else(|| {
+            CodegenError::Unsupported(
+                "locus-field reassignment outside a locus method".to_string(),
+            )
+        })?;
+        let ptr_t = self.context.ptr_type(AddressSpace::default());
+        let field_slot = self
+            .builder
+            .build_struct_gep(
+                cs.struct_ty,
+                cs.self_ptr,
+                field_idx,
+                &format!("self.{}.reassign.slot", field_locus),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+
+        // (1) Reclaim the OLD value. `__reclaim_<L>` runs the full
+        // teardown spine (drain / release / dissolve + arena
+        // destroy) and is idempotent via its `__arena`-null latch.
+        let old_ptr = self
+            .builder
+            .build_load(
+                ptr_t,
+                field_slot,
+                &format!("self.{}.reassign.old", field_locus),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .into_pointer_value();
+        if let Some(reclaim) = self.reclaim_fns.get(field_locus).copied() {
+            self.builder
+                .build_call(
+                    reclaim,
+                    &[old_ptr.into()],
+                    &format!("{}.reassign.reclaim_old", field_locus),
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        }
+
+        // (2) Construct the NEW value into self's arena, owned by the
+        // field. Load self.__arena; set the same overrides a
+        // field-default child gets in params-init.
+        let parent_info =
+            self.user_loci.get(&cs.locus_name).cloned().ok_or_else(|| {
+                CodegenError::Unsupported(format!(
+                    "no locus `{}` for field reassignment",
+                    cs.locus_name
+                ))
+            })?;
+        let arena_slot = self
+            .builder
+            .build_struct_gep(
+                parent_info.struct_ty,
+                cs.self_ptr,
+                parent_info.arena_field_idx,
+                "self.reassign.__arena.slot",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let self_arena = self
+            .builder
+            .build_load(ptr_t, arena_slot, "self.reassign.__arena")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .into_pointer_value();
+
+        let prev_arena = self.current_arena_override;
+        self.current_arena_override = Some(self_arena);
+        self.instantiating_for_parent_field = true;
+        let new_ptr = self.lower_locus_instantiation(new_locus, inits, scope)?;
+        self.current_arena_override = prev_arena;
+
+        // (3) Repoint the field at the live new instance.
+        self.builder
+            .build_store(field_slot, new_ptr)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        Ok(BlockEnd::Open)
+    }
+
     fn finish_lvalue_assign(
         &mut self,
         slot_ptr: PointerValue<'ctx>,

--- a/crates/hale-codegen/tests/ws1_ffi_handle_reassign.rs
+++ b/crates/hale-codegen/tests/ws1_ffi_handle_reassign.rs
@@ -1,0 +1,161 @@
+//! WS1#4 — whole-value reassignment of a nested locus param that
+//! holds an `@ffi`-acquired resource handle.
+//!
+//! fathom (refgw-evm `set_rpc_ws`) reported that `self.conn =
+//! ws::WsClient { url: …, … }` to swap an endpoint left the new
+//! client half-initialized — `conn.url` logged `(null)` and the
+//! first `read_msg()` cored — while in-place mutation
+//! (`self.conn.url = …`) worked. My earlier synthetic probes
+//! (`ws1_cross_seed_locus_reassign`) used a plain `Int` "handle"
+//! set in `birth()` and passed, so the residual is specific to a
+//! locus that holds a *real FFI resource* and whose `birth()`
+//! acquires it. This models that faithfully:
+//!
+//!   - `Conn.birth()` acquires an `@ffi` handle (a fake fd from a C
+//!     side-table that tracks live handles).
+//!   - `Conn.drain()` releases it.
+//!   - `Gw` holds `conn: Conn` as a nested param and reassigns the
+//!     WHOLE locus in `reconnect()`.
+//!
+//! The correct semantics (what reassignment SHOULD do) is a
+//! lifecycle transition: dissolve the old (→ release its handle)
+//! and fully instantiate the new (params + birth → acquire a new
+//! handle). The test observes both:
+//!   - new instance fully initialized? (url = "second", fd live)
+//!   - old instance released?           (live-handle count back to 1)
+//! A half-init (empty url / dead fd) or a leak (count climbs) or a
+//! crash all fail it.
+
+use std::process::Command;
+
+use hale_codegen::{build_executable_with_options, BuildOptions};
+
+fn build_with_csrc(name: &str, hale_src: &str, csrc_body: &str) -> std::path::PathBuf {
+    let program = hale_syntax::parse_source(hale_src).expect("parse");
+    let mut tmpdir = std::env::temp_dir();
+    tmpdir.push(format!("hale_test_ws1_ffi_reassign_{}", name));
+    let _ = std::fs::create_dir_all(&tmpdir);
+    let csrc_path = tmpdir.join("glue.c");
+    std::fs::write(&csrc_path, csrc_body).expect("write csrc");
+    let bin = tmpdir.join("main");
+    let options = BuildOptions {
+        link_libs: Vec::new(),
+        csrc_files: vec![csrc_path.clone()],
+    };
+    build_executable_with_options(&program, &bin, &[], &options).expect("build");
+    let _ = std::fs::remove_file(&csrc_path);
+    bin
+}
+
+const GLUE: &str = r#"
+    #include <stdint.h>
+    static int g_open[4096];
+    static int64_t g_next = 1;
+    static int64_t g_live = 0;
+    int64_t ffi_conn_open(const char *url) {
+        (void)url;
+        int64_t h = g_next++;
+        if (h >= 0 && h < 4096) g_open[h] = 1;
+        g_live++;
+        return h;
+    }
+    void ffi_conn_close(int64_t h) {
+        if (h > 0 && h < 4096 && g_open[h]) { g_open[h] = 0; g_live--; }
+    }
+    int64_t ffi_open_count(void) { return g_live; }
+    int64_t ffi_handle_alive(int64_t h) {
+        return (h > 0 && h < 4096 && g_open[h]) ? 1 : 0;
+    }
+"#;
+
+const SRC: &str = r#"
+    @ffi("c") fn ffi_conn_open(url: String) -> Int;
+    @ffi("c") fn ffi_conn_close(h: Int) -> ();
+    @ffi("c") fn ffi_open_count() -> Int;
+    @ffi("c") fn ffi_handle_alive(h: Int) -> Int;
+
+    locus Conn {
+        params { url: String = ""; fd: Int = 0; }
+        birth() { self.fd = ffi_conn_open(self.url); }
+        drain() { ffi_conn_close(self.fd); }
+        fn url_of() -> String { return self.url; }
+        fn fd_of() -> Int { return self.fd; }
+        fn alive() -> Int { return ffi_handle_alive(self.fd); }
+    }
+
+    locus Gw {
+        params { conn: Conn = Conn { url: "wss://first" }; }
+        fn reconnect() { self.conn = Conn { url: "wss://second" }; }
+        run() {
+            println("init   url=", self.conn.url_of(),
+                    " fd=", self.conn.fd_of(),
+                    " alive=", self.conn.alive(),
+                    " live=", ffi_open_count());
+            self.reconnect();
+            println("reconn url=", self.conn.url_of(),
+                    " fd=", self.conn.fd_of(),
+                    " alive=", self.conn.alive(),
+                    " live=", ffi_open_count());
+        }
+    }
+
+    fn main() { Gw { }; }
+"#;
+
+// WS1#4 regression gate. `self.conn = Conn {…}` is lowered as a
+// lifecycle transition (`lower_locus_field_reassign`): the old
+// instance is reclaimed (its `@ffi` handle released) and the new
+// one is constructed into self's arena, owned by the field and not
+// scope-dissolved — so the field points at a LIVE instance. Was a
+// use-after-free + leak before the fix (the RHS was a scope-bound
+// temporary dissolved at method exit; the old value leaked).
+#[test]
+fn ffi_handle_locus_whole_reassign() {
+    let bin = build_with_csrc("reassign", SRC, GLUE);
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    // Diagnostic first — print what actually happened regardless of
+    // pass/fail, so a reproduction is legible in CI logs.
+    eprintln!("--- stdout ---\n{}\n--- status: {:?} ---\n{}", stdout, out.status, stderr);
+
+    assert!(
+        out.status.success(),
+        "binary crashed on reassignment (WS1#4 — segfault): {:?}\nstdout:\n{}\nstderr:\n{}",
+        out.status,
+        stdout,
+        stderr
+    );
+    let reconn = stdout
+        .lines()
+        .find(|l| l.starts_with("reconn "))
+        .unwrap_or("")
+        .to_string();
+    // The reassigned-in instance must be LIVE when read after the
+    // reassignment: its url set, AND its `@ffi` handle still open.
+    assert!(
+        reconn.contains("url=wss://second"),
+        "new instance's url not set by reassignment. reconn line: {:?}",
+        reconn
+    );
+    assert!(
+        reconn.contains("alive=1"),
+        "WS1#4 REPRODUCES: after `self.conn = Conn {{…}}` the new \
+         instance's handle is already dead — the RHS locus literal was \
+         dissolved as a scope-bound temporary, so `self.conn` points at \
+         a torn-down locus (in fathom: closed socket → read_msg cores). \
+         reconn line: {:?}",
+        reconn
+    );
+    // Exactly one handle open after reconnect AND it's the live new
+    // one (asserted above) ⇒ the old was released. A leak shows as
+    // the new being dead (alive=0) while live stays 1 = the OLD.
+    assert!(
+        reconn.contains("live=1"),
+        "WS1#4: handle accounting wrong after reassignment (old leaked \
+         and/or new not opened). reconn line: {:?}",
+        reconn
+    );
+}

--- a/spec/types.md
+++ b/spec/types.md
@@ -365,6 +365,25 @@ For `params` / locus state, the implicit rule is that fields
 are mutable through `self.x = ...` (per F.3). The locus's
 state is the locus's mutable bundle.
 
+**Reassigning a locus-typed field is a lifecycle transition.**
+A field that holds a child locus (`params { conn: WsClient =
+WsClient { … }; }`) can be whole-value reassigned from a member
+fn (`self.conn = WsClient { … }`). Because a locus is not a plain
+value — it owns a region and possibly `@ffi`-acquired resources —
+this is lowered as **dissolve-the-old + construct-the-new**, not a
+pointer store: the previous instance is reclaimed (its `drain` /
+`dissolve` run, releasing its resources) and the new instance is
+constructed into the owning locus's arena, owned by the field (so
+the parent's dissolve cascade reclaims it). The field always
+points at a fully-live instance. (Before this rule the new
+instance was a scope-bound temporary dissolved at the method's
+exit — a use-after-free; see WS1#4.) For "same instance,
+reconfigure," prefer **in-place mutation** (`self.conn.url = …`),
+which keeps the locus's identity and resources and is cheaper.
+v1 limitation: the reassigned instance inherits the owner's pool;
+reassigning a field with an explicit non-default `placement` does
+not re-apply that placement.
+
 ## k_max as a typing rule
 
 Per F.1 / F.3: the compiler computes


### PR DESCRIPTION
Closes the last genuinely-open item from the post-audit hardening review (WS1#4) — and it was a live soundness bug, not stale.

## The bug

`self.conn = ws::WsClient { … }` from a member fn (fathom refgw-evm's `set_rpc_ws` reconnect) lowered the RHS locus literal as a **scope-bound temporary**: birth ran, the pointer was stored into the field, then the temporary was dissolved at the method's scope exit — closing its `@ffi` socket fd and freeing its arena. The field was left pointing at a **torn-down locus** → `conn.url` reads `(null)`, first `read_msg()` cores. Separately, the **old** field value was overwritten without being dissolved → its resources leaked.

A faithful synthetic repro (`@ffi`-acquired handle in `birth()`, released in `drain()`, tracked C-side) confirmed both modes at HEAD:

```
init   url=wss://first  fd=1 alive=1 live=1
reconn url=wss://second fd=2 alive=0 live=1   ← new handle DEAD, old leaked
```

## The fix

A locus is not a plain value — it owns a region and possibly `@ffi`-acquired resources — so whole-value reassignment of a locus-typed field must be a **lifecycle transition**, not a pointer store. New `lower_locus_field_reassign` (driven from the `Stmt::Assign` `self.<field>` path):

1. **reclaim the old** instance via `__reclaim_<L>` (its `drain`/`dissolve` run; idempotent via the `__arena`-null latch);
2. **construct the new** instance into self's own arena, owned by the field and **not** scope-dissolved — the same `instantiating_for_parent_field` + arena-override path params-init already uses for a field-default child, so the parent's dissolve cascade reclaims it through the field;
3. **repoint** the field at the live new instance.

No new lifecycle machinery — just wiring the existing field-ownership + `__reclaim` pieces to the reassignment site. Detection is narrow: plain `=`, target `self.<field>` where the field is a `LocusRef`, RHS a single-segment locus literal. Everything else falls through unchanged.

After the fix: `reconn … fd=2 alive=1 live=1` — new instance live, old released.

In-place mutation (`self.conn.url = …`) stays the cheap path for "same instance, reconfigure." v1 caveat (noted in code + spec): the reassigned instance inherits the owner's pool; reassigning an explicitly-placed (e.g. pinned) field doesn't re-apply that placement.

## Verification

- New gate `ws1_ffi_handle_reassign` (the repro) — was use-after-free + leak, now green.
- Plain cross-seed reassignment + all lifecycle/reclaim tests still pass.
- **Full `hale-codegen` suite: 206 binaries, 0 failed; corpus oracle green** — no regressions in the `Stmt::Assign` blast radius.
- `spec/types.md` + `CHANGELOG.md` updated in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
