### PR TITLE
fix(runtime): close use-after-free race in the TLS handle table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ behavior.
 
 ## Unreleased
 
+- **Fixed a use-after-free race in the TLS handle table.** `lotus_tls_connect`
+  `realloc`s (and thus *moves*) the global handle table when it grows on
+  connect, while `recv_into`/`recv_bytes`/`send_bytes` read
+  `g_tls_entries[handle]` lock-free. A connect on one connection that crossed
+  a growth boundary while a *sibling* connection was mid-recv/send indexed a
+  freed base → a wrong/garbage SSL object on the other connection (presents as
+  "a busy connection silently kills a quiet sibling after enough
+  reconnect churn"). The handle→SSL/fd resolution now happens under the table
+  lock — held only for the table read, never across the blocking
+  `SSL_read`/`SSL_write`, so concurrent connections still proceed in parallel.
+  Same class as the udp remote-table relocation race fixed in #19.
+
 - **TLS recv/send timeouts + a distinguishable recv-timeout sentinel.** Added
   `std::io::tls::set_recv_timeout(handle, d)` / `set_send_timeout` — the
   handle-aware siblings of the `std::io::tcp` timeout setters (TLS connections

--- a/crates/hale-codegen/runtime/lotus_tls.c
+++ b/crates/hale-codegen/runtime/lotus_tls.c
@@ -125,6 +125,38 @@ static SSL_CTX *lotus_tls__ctx_get(void) {
     return ctx;
 }
 
+/* Resolve a handle to its SSL object / raw fd UNDER the table lock.
+ *
+ * `g_tls_entries` is realloc'd (and thus *moved*) when the handle table
+ * grows on connect; every connect/reconnect adds a never-reclaimed slot, so
+ * a long-lived program crosses the 8 → 16 → 32 … growth boundaries. A
+ * lock-free `g_tls_entries[handle]` read in recv/send racing a sibling's
+ * connect-time realloc would index a freed base — a use-after-free that
+ * surfaces as a wrong/garbage SSL object on the *other* connection (the
+ * "busy sibling silently kills the quiet connection after reconnect churn"
+ * shape). Same class as the udp remote-table relocation race fixed in #19.
+ *
+ * The lock is held only for the table read (a couple of loads) — NOT across
+ * the blocking SSL_read/SSL_write below; holding it there would serialize
+ * concurrent connections and reintroduce starvation. The SSL object / fd
+ * themselves are stable once registered (until close), so using them
+ * lock-free after the resolution is safe. */
+static SSL *lotus_tls__handle_ssl(int handle) {
+    if (handle < 0) return NULL;
+    pthread_mutex_lock(&g_tls_mutex);
+    SSL *ssl = ((size_t)handle < g_tls_count) ? g_tls_entries[handle].ssl : NULL;
+    pthread_mutex_unlock(&g_tls_mutex);
+    return ssl;
+}
+
+static int lotus_tls__handle_fd(int handle) {
+    if (handle < 0) return -1;
+    pthread_mutex_lock(&g_tls_mutex);
+    int fd = ((size_t)handle < g_tls_count) ? g_tls_entries[handle].raw_fd : -1;
+    pthread_mutex_unlock(&g_tls_mutex);
+    return fd;
+}
+
 int lotus_tls_connect(const char *host, uint16_t port) {
     if (!host) {
         errno = EINVAL;
@@ -204,15 +236,11 @@ int lotus_tls_connect(const char *host, uint16_t port) {
 }
 
 int lotus_tls_send_bytes(int handle, const void *bytes_ptr) {
-    if (handle < 0 || (size_t)handle >= g_tls_count) {
-        errno = EBADF;
-        return -1;
-    }
     if (!bytes_ptr) {
         errno = EINVAL;
         return -1;
     }
-    SSL *ssl = g_tls_entries[handle].ssl;
+    SSL *ssl = lotus_tls__handle_ssl(handle);
     if (!ssl) {
         errno = EBADF;
         return -1;
@@ -244,10 +272,10 @@ int lotus_tls_send_bytes(int handle, const void *bytes_ptr) {
 }
 
 void *lotus_tls_recv_bytes(int handle, int max_bytes) {
-    if (handle < 0 || (size_t)handle >= g_tls_count || max_bytes <= 0) {
+    if (max_bytes <= 0) {
         return lotus_tls__bytes_empty();
     }
-    SSL *ssl = g_tls_entries[handle].ssl;
+    SSL *ssl = lotus_tls__handle_ssl(handle);
     if (!ssl) return lotus_tls__bytes_empty();
 
     lotus_arena_t *parena = lotus_bus_payload_arena_get();
@@ -284,10 +312,8 @@ void *lotus_tls_recv_bytes(int handle, int max_bytes) {
  * g_bus_payload_arena. Return semantics: > 0 bytes read, 0 peer
  * closed cleanly, < 0 fatal error. */
 int64_t lotus_tls_recv_into(int handle, void *builder, int64_t max_bytes) {
-    if (handle < 0 || (size_t)handle >= g_tls_count || max_bytes <= 0) {
-        return -1;
-    }
-    SSL *ssl = g_tls_entries[handle].ssl;
+    if (max_bytes <= 0) return -1;
+    SSL *ssl = lotus_tls__handle_ssl(handle);
     if (!ssl) return -1;
     char *tail = (char *)lotus_bytes_builder_reserve(builder, max_bytes);
     if (!tail) return -1;
@@ -356,15 +382,13 @@ extern int lotus_tcp_set_recv_timeout_ns(int fd, int64_t ns);
 extern int lotus_tcp_set_send_timeout_ns(int fd, int64_t ns);
 
 int lotus_tls_set_recv_timeout_ns(int handle, int64_t ns) {
-    if (handle < 0 || (size_t)handle >= g_tls_count) return -1;
-    int fd = g_tls_entries[handle].raw_fd;
+    int fd = lotus_tls__handle_fd(handle);
     if (fd < 0) return -1;
     return lotus_tcp_set_recv_timeout_ns(fd, ns);
 }
 
 int lotus_tls_set_send_timeout_ns(int handle, int64_t ns) {
-    if (handle < 0 || (size_t)handle >= g_tls_count) return -1;
-    int fd = g_tls_entries[handle].raw_fd;
+    int fd = lotus_tls__handle_fd(handle);
     if (fd < 0) return -1;
     return lotus_tcp_set_send_timeout_ns(fd, ns);
 }


### PR DESCRIPTION
Fixes a use-after-free data race in the TLS handle table, surfaced while building the two-concurrent-TLS-connection repro for the fathom starvation report (notes/tls-concurrent-recv-starvation.md).

## The bug

`lotus_tls_connect` `realloc`s the global `g_tls_entries` handle table when it grows — and every connect/reconnect adds a **never-reclaimed** slot, so a long-lived program crosses the 8 → 16 → 32 … growth boundaries. Meanwhile `recv_into` / `recv_bytes` / `send_bytes` read `g_tls_entries[handle]` **lock-free**. A connect on one connection that moves the table while a **sibling** connection is mid-recv/send indexes a freed base → a wrong/garbage `SSL` object on the *other* connection.

Presents as **"a busy connection silently kills a quiet sibling after enough reconnect churn"** — a candidate mechanism for the fathom two-TLS-reader starvation once the readers have reconnected past the first growth boundary. Same class as the udp remote-table relocation race fixed in #19.

## The fix

Resolve `handle → SSL*/fd` through `lotus_tls__handle_ssl` / `lotus_tls__handle_fd`, which take `g_tls_mutex` for the **table read only** — **not** across the blocking `SSL_read`/`SSL_write` (holding it there would serialize concurrent connections and reintroduce starvation). The `SSL` object / fd are stable once registered, so they're used lock-free after resolution. Applied to `recv_into`, `recv_bytes`, `send_bytes`, and the `set_recv`/`set_send_timeout` setters.

## Verification

- `io_tls` https GET still returns 200; `recv_timeout_sentinel` green; the two-connection HTTPS repro (busy 40 + quiet 20, with connection churn) stays clean.
- Full `hale-codegen` suite: **207 binaries, 0 failed.**
- Behavior unchanged for correct sequential use — this is a correctness-only fix.

The race is timing-dependent and best gated under TSAN with concurrent connect+recv; left as a follow-up since it doesn't reproduce deterministically in a short run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
