### PR TITLE
fix(runtime): serialize the shared bus-payload arena's bump

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -308,6 +308,18 @@ typedef struct lotus_arena {
      * one anyway for the case they themselves become a parent
      * via a nested sub-region. */
     pthread_mutex_t      subregion_lock;
+    /* 2026-06-13: set to 1 only on the shared g_bus_payload_arena. That
+     * arena is reachable lock-free via lotus_caller_arena_or_global() (the
+     * fallback when the per-thread caller_arena TLS is unset) — e.g. a
+     * per-byte std::bytes::from_int in a hot send path on two pinned
+     * threads. lotus_arena_alloc's bump (c->used) is otherwise unlocked, so
+     * concurrent allocs into this one shared arena would race and corrupt
+     * each other's allocations (garbled WS frame bytes — the fathom
+     * two-TLS-reader subscribe-corruption). When set, lotus_arena_alloc
+     * serializes its body on subregion_lock (otherwise idle on this flat
+     * arena). Per-instance arenas leave this 0 and keep the single-thread
+     * lock-free fast path. */
+    int                  shared_concurrent;
 } lotus_arena_t;
 
 /* Per-thread freelist of default-sized chunks (2026-05-21
@@ -1267,6 +1279,7 @@ static lotus_arena_t *lotus_arena_alloc_struct(void) {
     a->free_cap   = 0;
     a->next_slot  = 0;
     a->fixed_size = 0;
+    a->shared_concurrent = 0;
     a->chunk_byte_total = 0;
     a->chunk_byte_cap   = 0;
     a->cap_diag_name    = NULL;
@@ -1501,7 +1514,7 @@ static inline size_t lotus_arena_off_for(
     return (size_t)(aligned - base);
 }
 
-void *lotus_arena_alloc(lotus_arena_t *a, size_t size, size_t align) {
+static void *lotus_arena_alloc_nolock(lotus_arena_t *a, size_t size, size_t align) {
     if (!a) return NULL;
     if (size == 0) size = 1;        /* every alloc gets a unique addr */
     if (align == 0) align = 8;      /* default 8-byte alignment */
@@ -1583,6 +1596,26 @@ void *lotus_arena_alloc(lotus_arena_t *a, size_t size, size_t align) {
     void *p    = base + off;
     c->used    = off + size;
     return p;
+}
+
+/* Public entry point. For the single shared arena flagged
+ * `shared_concurrent` (g_bus_payload_arena), serialize the bump on the
+ * arena's own subregion_lock — it's reachable lock-free from two pinned
+ * threads via lotus_caller_arena_or_global() and the unlocked bump above
+ * would race (garbled allocations). The lock is held only for the bump, not
+ * across any blocking work; per-instance arenas (the overwhelming common
+ * case) skip it and keep the single-thread fast path. No recursion into
+ * lotus_arena_alloc happens under the lock (the fresh-chunk path mallocs /
+ * pulls from the per-thread chunk pool), so the non-recursive mutex is
+ * safe. */
+void *lotus_arena_alloc(lotus_arena_t *a, size_t size, size_t align) {
+    if (a && a->shared_concurrent) {
+        pthread_mutex_lock(&a->subregion_lock);
+        void *p = lotus_arena_alloc_nolock(a, size, align);
+        pthread_mutex_unlock(&a->subregion_lock);
+        return p;
+    }
+    return lotus_arena_alloc_nolock(a, size, align);
 }
 
 void lotus_arena_destroy(lotus_arena_t *a) {
@@ -10449,6 +10482,10 @@ static pthread_mutex_t  g_bus_payload_arena_mutex = PTHREAD_MUTEX_INITIALIZER;
 static lotus_arena_t *lotus_bus_payload_arena_create_capped(void) {
     lotus_arena_t *a = lotus_arena_create_labeled("g_bus_payload_arena");
     if (!a) return NULL;
+    /* Shared across pinned threads via the lock-free
+     * lotus_caller_arena_or_global() fallback — make lotus_arena_alloc
+     * serialize its bump on this arena. (2026-06-13) */
+    a->shared_concurrent = 1;
     size_t cap = LOTUS_BUS_PAYLOAD_ARENA_DEFAULT_CAP_BYTES;
     const char *env = getenv("LOTUS_BUS_PAYLOAD_ARENA_CAP");
     if (env && env[0]) {

--- a/notes/tls-concurrent-recv-starvation.md
+++ b/notes/tls-concurrent-recv-starvation.md
@@ -1,12 +1,84 @@
 # Handoff: two concurrent blocking TLS recvs — the second is starved
 
-**Status:** **REFRAMED 2026-06-12 (hale side).** The substrate is **not** the cause — see the Corrected Verdict below. The original fathom report (preserved in full beneath it) is the symptom record; its lead hypothesis (substrate scheduler / TLS-recv fairness) is **refuted**. The actual root cause is a missing connection-liveness check in pond's `WsClient.read_msg`, and the fix is pond-side with an already-shipped primitive.
+**Status:** **RE-AUDITED 2026-06-13 (hale side).** Two distinct symptoms have been reported under this title. (1) The *original* "blocks forever, zero notifications" is a half-open-connection hang in pond's `read_msg` — see the Corrected Verdict (2026-06-12) below; pond-side fix, primitive shipped. (2) fathom's *refined* repro (`apps/smoke-ws-concurrency`) shows a **different** symptom — the quiet connection gets a **valid** sub-ack but no pushes, payload-size-dependent — i.e. a *garbled subscribe frame*, not a hang. The substrate was re-audited for (2): a real latent shared-arena race was found and fixed (`lotus_tls_recv_bytes`), **but both of pond's actual WS paths were proven not to touch it**, so symptom (2) is still open and pond-side. See the 2026-06-13 section directly below.
 **Area (corrected):** `pond/websocket/client.hl` `read_msg` (half-open detection / recv timeout). **NOT** `std::io::tls` or the pinned-locus scheduler.
 **Severity:** real for any sparse/idle long-lived stream, but it's a connection-liveness bug, not a concurrency limit. Multi-connection ingest is *not* blocked by the substrate.
 
 ---
 
-## CORRECTED VERDICT (2026-06-12) — substrate exonerated; it's a half-open-connection hang in pond
+## UPDATE 2026-06-13 — garbled-subscribe-frame symptom: substrate re-audited, latent recv_bytes race fixed, pond WS paths exonerated
+
+fathom's `apps/smoke-ws-concurrency` repro is a **different** failure mode
+from the half-open hang: the quiet connection receives a **valid
+subscribe-ack** (so the socket is alive and bidirectional — not half-open),
+then gets **zero pushes** with **flat `bytes_received`**, and the failure is
+**payload-size-dependent** (small `newHeads` survives; the larger
+`eth_subscribe(logs, …)` filter fails; two `newHeads` both stream; a single
+log-sub alone works). That fingerprint is a **corrupted/garbled subscribe
+frame** — the envelope parses (valid ack) but the `params` filter is mangled,
+so it matches nothing and never pushes.
+
+### Hypothesis tested: per-byte `from_int` racing a shared arena
+
+pond's `emit_frame` masks the payload with one `std::bytes::from_int` per
+byte. `from_int` routes through `lotus_caller_arena_or_global()`. **If** the
+per-thread `caller_arena` TLS is unset, that falls back to the single global
+`g_bus_payload_arena`, and `from_int` then allocates via `lotus_arena_alloc`
+whose bump (`c->used`) is **unlocked**. Two pinned WsClients building frames
+concurrently into that one shared arena would race the bump → overlapping
+1-byte temporaries → wrong bytes appended → garbled frame, worse for larger
+payloads. Fits every symptom.
+
+### Result: hypothesis REFUTED for pond's paths (but a real adjacent race found)
+
+A direct repro (`/tmp/arena_race.hl`: two `pinned(core=6/7)` loci each
+building 48-byte patterns via per-byte `from_int`+`append` and checksumming,
+200k iters) reported **`corrupt=0` with *and* without the fix.** That means
+**`caller_arena` is per-thread during a pinned `run()`** — so `from_int`
+there allocates in the per-thread scratch, never the shared arena. The
+`emit_frame` hypothesis is **wrong**.
+
+Tracing the two pond WS paths to the metal confirms **neither touches the
+shared arena**:
+
+| pond WS path | runtime | shared arena? |
+|---|---|---|
+| recv — `recv_into` | `lotus_tls_recv_into` → `SSL_read(ssl, tail, n)` straight into the per-instance `rx_buf` | **no** — no arena alloc at all |
+| send — `emit_frame` per-byte `from_int` | `lotus_caller_arena_or_global()` → per-thread `caller_arena` in `run()` (validated `corrupt=0`) | **no** — per-thread scratch |
+
+So the substrate does **not** corrupt pond's frames. Symptom (2) originates
+in pond's own `.hl` logic or a concurrency interaction not yet reproduced.
+
+### The real race that *was* found and fixed (separate path, not pond's)
+
+`lotus_tls_recv_bytes` allocates its blob from `lotus_bus_payload_arena_get()`
+— the **shared global arena, always, ignoring `caller_arena`** — via a
+lock-free `lotus_arena_alloc`. So **two pinned loci calling
+`std::io::tls::recv_bytes` concurrently race the unlocked bump** and corrupt
+each other's received blobs. (`lotus_tcp_recv_bytes` uses
+`caller_arena_or_global`, so it's per-thread-safe when `caller_arena` is set,
+i.e. in `run()`/handlers.) Fix (lotus_arena.c): a per-arena
+`shared_concurrent` flag, set only on `g_bus_payload_arena`, makes
+`lotus_arena_alloc` serialize its bump on the arena's `subregion_lock`.
+Per-instance arenas keep the lock-free fast path (validated unchanged by the
+`corrupt=0` repro). This is genuine hardening — but pond's WsClient uses
+`recv_into`, **not** `recv_bytes`, so it does **not** explain fathom's bug.
+
+### Next step for symptom (2) — instrument the actual bytes (pond-side)
+
+Static analysis + the substrate audit have exonerated the runtime; the
+divergence is now best found by capturing it directly. In
+`apps/smoke-ws-concurrency`, hexdump the **exact bytes handed to `write_all`**
+for the quiet connection's subscribe frame, and compare against the bytes a
+**working single-connection** run writes for the same subscribe. Whatever
+differs (a mangled length, a wrong mask, a truncated payload, interleaved
+writes to the same fd) localizes it to the producing `.hl` code. Candidates
+to scrutinize in pond, in order: (a) any **shared mutable state** in the
+frame/subscribe builder reused across the two pinned clients (a module-level
+or accidentally-shared buffer/seed); (b) `write_all` partial-write handling
+under concurrent sends; (c) the `mask_seed` LCG if two clients can ever share
+one instance. The substrate guarantees per-instance locus fields are not
+shared — so the leak, if real, is a pond-level aliasing of a builder/seed.
 
 The substrate-scheduler / TLS-recv-fairness hypothesis was tested layer by
 layer with dependency-free repros (timed, not judged by cross-thread print

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -296,6 +296,17 @@ makes M:N safe — without it, multi-pool deployments would
 silently race on locus arenas (which are unsynchronized bump
 allocators).
 
+The single shared **bus payload arena** is the deliberate
+exception to "one owning thread per arena": it is reachable
+concurrently from any pool, because some stdlib primitives
+allocate their result there directly rather than into a
+per-locus arena (e.g. `std::io::tls::recv_bytes`, which always
+targets it regardless of the caller's per-thread scratch). That
+arena therefore carries an internal lock on its bump — two
+pinned loci calling such a primitive at once do not corrupt each
+other's allocations. Per-locus arenas keep the lock-free bump;
+only this one shared arena pays for the lock.
+
 #### Why no "greedy" class
 
 A natural temptation is to want a third option: "shares a


### PR DESCRIPTION
## What

`lotus_tls_recv_bytes` allocates its result blob from the single global `g_bus_payload_arena` (via `lotus_bus_payload_arena_get()`) — **always, ignoring the per-thread `caller_arena` scratch** — and `lotus_arena_alloc` bumps `c->used` without a lock. So two pinned loci calling `std::io::tls::recv_bytes` concurrently race the shared bump and corrupt each other's received blobs.

(`recv_bytes` on the tcp side uses `caller_arena_or_global`, so it's per-thread-safe when `caller_arena` is set — i.e. inside `run()`/handlers. The tls path is the unconditionally-shared one.)

## Fix

A per-arena `shared_concurrent` flag, set only on `g_bus_payload_arena`. When set, `lotus_arena_alloc` serializes its body on the arena's existing `subregion_lock` (otherwise idle on this flat arena). Every per-instance locus arena leaves the flag `0` and keeps the **lock-free single-thread fast path** — the lock cost lands only on the one arena that is genuinely shared across threads.

`spec/runtime.md` records the shared bus-payload arena as the deliberate exception to the one-owning-thread-per-arena invariant, now synchronized on its bump.

## Honest scope — this is hardening, not the fathom fix

This closes a **code-evident latent race**, but it is **not** the fix for the fathom concurrent-TLS WS "garbled subscribe frame" symptom. That investigation (`notes/tls-concurrent-recv-starvation.md`, 2026-06-13 section) proved pond's two WS paths never touch the shared arena:

| pond WS path | runtime | shared arena? |
|---|---|---|
| recv — `recv_into` | `SSL_read` into a per-instance buffer | no |
| send — `emit_frame` per-byte `from_int` | per-thread `caller_arena` in `run()` (validated `corrupt=0`) | no |

pond uses `recv_into`, not `recv_bytes`. The garbled-subscribe-frame symptom remains pond-side and open.

## Testing

- Trivial program build exercises the modified runtime (compiles + runs clean).
- `recv_timeout_sentinel` / `io_tls` codegen tests pass.
- A two-pinned-locus per-byte-`from_int` checksum repro (200k iters) reports `corrupt=0` both with and without the change — confirming the per-instance fast path is byte-for-byte unaffected.
- **Caveat:** no failing regression test — triggering the `tls::recv_bytes` race needs a concurrent-TLS-recv harness (TLS server) the fixture suite isn't set up for. The race is code-identified; the fix is validated to not regress the fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
