### PR TITLE
feat(ring_layout): record_header framing + post_copy recheck

### DIFF
--- a/crates/hale-codegen/runtime/lotus_shm_ring.c
+++ b/crates/hale-codegen/runtime/lotus_shm_ring.c
@@ -288,6 +288,27 @@ typedef struct {
     uint64_t slot_size_width;
     uint64_t slot_count_off;
     uint64_t slot_count_width;
+    /* 2026-06-13 (#5, fast-protocol-I/O): record_header support for
+     * byte_records. `record_header_bytes` is the fixed per-record
+     * header size before the payload (0 = the len_prefix-only model,
+     * where the prefix IS the whole header). ws-fast's record is a
+     * 32-byte header (len@0:u32, kind, opcode, seq, kernel_ns, user_ns)
+     * then payload, so the payload starts at record_header_bytes and the
+     * stride is align_up(record_header_bytes + len, align) — equal to
+     * record_header_bytes + align(len) because record_header_bytes is
+     * required to be a multiple of align. `len` is still read at record
+     * offset 0 with len_prefix_width. A producer that marks a tail pad
+     * with a header *field* (ws-fast: kind==1) rather than a len
+     * sentinel sets has_pad_field + pad_field_{off,width,value}. */
+    uint64_t record_header_bytes;
+    uint64_t pad_field_off;
+    uint64_t pad_field_width;
+    uint64_t pad_field_value;
+    int      has_pad_field;
+    /* Torn-read guard: when set, a record is copied out, an acquire
+     * fence taken, and the cursor re-read; if the producer lapped the
+     * record during the copy it is discarded rather than dispatched. */
+    int      post_copy_recheck;
 } lotus_shm_layout_t;
 
 #define LOTUS_RING_FRAMING_BYTE_RECORDS 0
@@ -328,7 +349,7 @@ static void shm_layout_write_uint(void *p, uint64_t width, uint64_t val) {
     memcpy(p, &val, (size_t)width);
 }
 
-/* Populate a descriptor from the flat 16-word array codegen emits.
+/* Populate a descriptor from the flat 27-word array codegen emits.
  * The slot contract is documented on
  * `lotus_bus_register_subscriber_shm_ring_layout`. */
 static void shm_layout_from_words(const uint64_t *w, lotus_shm_layout_t *d) {
@@ -354,6 +375,12 @@ static void shm_layout_from_words(const uint64_t *w, lotus_shm_layout_t *d) {
     d->slot_size_width   = w[18];
     d->slot_count_off    = w[19];
     d->slot_count_width  = w[20];
+    d->record_header_bytes = w[21];
+    d->pad_field_off     = w[22];
+    d->pad_field_width   = w[23];
+    d->pad_field_value   = w[24];
+    d->has_pad_field     = (int)w[25];
+    d->post_copy_recheck = (int)w[26];
 }
 
 /* Attach (read-only) to a foreign ring described by `desc`.
@@ -1250,6 +1277,17 @@ static void *shm_ring_layout_reader_thread(void *arg) {
      * experiments/foreign-ring-throughput. */
     uint64_t pos = 0;
     int initialized = 0;
+    /* Per-record header size before the payload. 0 (the len-prefix-only
+     * model) → the prefix IS the header. record_header_bytes is a
+     * multiple of align (validated at typecheck), so the existing
+     * align_up(hdr + len, align) stride equals hdr + align(len). */
+    uint64_t hdr = d->record_header_bytes ? d->record_header_bytes
+                                          : d->len_prefix_width;
+    /* Scratch for the post_copy torn-read guard: a record is memcpy'd
+     * here, then the cursor is re-read; if it was lapped during the copy
+     * the record is discarded. Grown on demand, freed at thread exit. */
+    char  *scratch = NULL;
+    size_t scratch_cap = 0;
     while (!atomic_load_explicit(&sub->should_stop,
                                   memory_order_acquire)) {
         uint64_t committed = atomic_load_explicit(
@@ -1273,17 +1311,41 @@ static void *shm_ring_layout_reader_thread(void *arg) {
             continue;
         }
         while (local < committed) {
-            /* The len-prefix read itself must stay within the data
-             * region. With a conforming ring (cap % align == 0,
-             * len_prefix_width <= align, pos always align-aligned) this
-             * always holds; the guard defends against a hostile cursor.
-             * pos < cap and len_prefix_width <= 8, so no overflow. */
-            if (pos + d->len_prefix_width > cap) {
+            /* The whole record header must stay within the data region
+             * before the physical wrap. With a conforming ring (cap %
+             * align == 0, hdr <= align or a multiple of it, pos always
+             * align-aligned) this always holds; the guard defends against
+             * a hostile cursor. pos < cap and hdr <= 8 (len-prefix) or a
+             * small fixed header, so no overflow. */
+            if (pos + hdr > cap) {
+                if (d->record_header_bytes) {
+                    /* record_header mode: records never straddle the wrap,
+                     * so "no room for a header at the tail" means the
+                     * producer left a gap — pad to the boundary. */
+                    local += cap - pos;
+                    pos = 0;
+                    continue;
+                }
+                /* len-prefix mode: a conforming ring keeps the prefix
+                 * inside the region; this is a hostile cursor — resync. */
                 local = committed;
                 pos = committed % cap;
                 break;
             }
             uint64_t phys = d->data_at + pos;
+            /* Header-field pad marker (e.g. ws-fast kind==1): the
+             * producer wrote a tail pad to avoid straddling the wrap.
+             * Jump to the next boundary. Checked before len so a pad
+             * record's len field is never interpreted as a real length. */
+            if (d->has_pad_field) {
+                uint64_t kv = shm_layout_read_uint(
+                    base + phys + d->pad_field_off, d->pad_field_width);
+                if (kv == d->pad_field_value) {
+                    local += cap - pos;
+                    pos = 0;
+                    continue;
+                }
+            }
             uint64_t len = shm_layout_read_uint(base + phys,
                                                 d->len_prefix_width);
             if (d->has_pad_sentinel && len == d->pad_sentinel) {
@@ -1305,17 +1367,54 @@ static void *shm_ring_layout_reader_thread(void *arg) {
                 break;
             }
             /* The record's payload must fit before the wrap. Overflow-
-             * safe: pos + len_prefix_width <= cap (checked above), so the
-             * room is `cap - pos - len_prefix_width`; compare `len`
-             * against it without adding the (attacker-controlled) len. */
-            uint64_t room = cap - pos - d->len_prefix_width;
+             * safe: pos + hdr <= cap (checked above), so the room is
+             * `cap - pos - hdr`; compare `len` against it without adding
+             * the (attacker-controlled) len. */
+            uint64_t room = cap - pos - hdr;
             if (len == 0 || len > room) {
                 local = committed;
                 pos = committed % cap;
                 break;
             }
-            char *payload = base + phys + d->len_prefix_width;
-            if (d->value_size == 0) {
+            char *payload = base + phys + hdr;
+            if (d->post_copy_recheck) {
+                /* Copy the record out, take an acquire fence, then re-read
+                 * the cursor. A record starting at monotonic `local` is
+                 * intact only while the producer hasn't yet written
+                 * `local + cap` (which would overwrite its first physical
+                 * byte). If the re-read shows it lapped during our copy,
+                 * the copied bytes may be torn — discard and resync rather
+                 * than hand a frankenrecord to the handler. */
+                if (scratch_cap < (size_t)len) {
+                    char *ns = (char *)realloc(scratch, (size_t)len);
+                    if (ns) { scratch = ns; scratch_cap = (size_t)len; }
+                }
+                if (scratch_cap >= (size_t)len) {
+                    memcpy(scratch, payload, (size_t)len);
+                    atomic_thread_fence(memory_order_acquire);
+                    uint64_t recommitted = atomic_load_explicit(
+                        (const _Atomic uint64_t *)(base + d->cursor_off),
+                        memory_order_acquire);
+                    if (recommitted - local > cap) {
+                        local = recommitted;
+                        pos = recommitted % cap;
+                        break;
+                    }
+                    if (d->value_size == 0) {
+                        shm_layout_dispatch_view(sub, scratch, len);
+                    } else {
+                        sub->handler_fn(sub->self_ptr, scratch);
+                    }
+                } else {
+                    /* realloc failed — fall back to a zero-copy dispatch
+                     * (no torn-read guard this once) rather than drop. */
+                    if (d->value_size == 0) {
+                        shm_layout_dispatch_view(sub, payload, len);
+                    } else {
+                        sub->handler_fn(sub->self_ptr, payload);
+                    }
+                }
+            } else if (d->value_size == 0) {
                 /* Raw-frame mode: the bound payload is a BytesView, so
                  * the consumer can't assume a fixed record size. Hand
                  * the handler a bounded BytesView over the record payload;
@@ -1327,7 +1426,7 @@ static void *shm_ring_layout_reader_thread(void *arg) {
                  * (len == value_size, checked above); hand its pointer. */
                 sub->handler_fn(sub->self_ptr, payload);
             }
-            uint64_t step = d->len_prefix_width + len;
+            uint64_t step = hdr + len;
             if (d->align > 1) {
                 step = (step + d->align - 1) & ~(d->align - 1);
             }
@@ -1336,6 +1435,7 @@ static void *shm_ring_layout_reader_thread(void *arg) {
             if (pos >= cap) pos -= cap;   /* step <= cap, no straddle */
         }
     }
+    free(scratch);
     return NULL;
 }
 

--- a/crates/hale-codegen/src/bus/runtime.rs
+++ b/crates/hale-codegen/src/bus/runtime.rs
@@ -381,9 +381,9 @@ fn ring_repr_width(repr: &str) -> u64 {
 fn ring_layout_descriptor_words(
     decl: &hale_syntax::ast::RingLayoutDecl,
     value_size: u64,
-) -> [u64; 21] {
+) -> [u64; 27] {
     use hale_syntax::ast::RingAttrValue;
-    let mut w = [0u64; 21];
+    let mut w = [0u64; 27];
 
     // [0..2] magic
     if let Some(m) = decl.magic {
@@ -425,7 +425,15 @@ fn ring_layout_descriptor_words(
     }
 
     // [11..15] framing: len_prefix width, align, pad_sentinel.
+    // [21..27] (#5, fast-protocol-I/O): record_header_bytes (fixed
+    // per-record header before the payload — ws-fast's 32-byte
+    // len/kind/opcode/seq/kernel_ns/user_ns), a header-field padding
+    // discriminant (pad_field_offset/width/value — ws-fast marks a
+    // tail pad with kind==1, not a len sentinel), and the post_copy
+    // lap re-check flag.
     w[12] = 1; // align default (no sub-record padding)
+    let (mut pad_off, mut pad_width, mut pad_val, mut has_pad_field) =
+        (0u64, 0u64, 0u64, 0u64);
     if let Some(f) = &decl.framing {
         for a in &f.attrs {
             match (a.key.name.as_str(), &a.value) {
@@ -442,10 +450,30 @@ fn ring_layout_descriptor_words(
                     w[13] = *n as u64;
                     w[14] = 1;
                 }
+                ("record_header_bytes", RingAttrValue::Int(n)) => {
+                    w[21] = *n as u64;
+                }
+                ("pad_field_offset", RingAttrValue::Int(n)) => {
+                    pad_off = *n as u64;
+                    has_pad_field = 1;
+                }
+                ("pad_field_width", RingAttrValue::Int(n)) => {
+                    pad_width = *n as u64;
+                }
+                ("pad_field_value", RingAttrValue::Int(n)) => {
+                    pad_val = *n as u64;
+                }
+                ("recheck", RingAttrValue::Ident(id)) if id.name == "post_copy" => {
+                    w[26] = 1;
+                }
                 _ => {}
             }
         }
     }
+    w[22] = pad_off;
+    w[23] = pad_width;
+    w[24] = pad_val;
+    w[25] = has_pad_field;
 
     // [15] value_size: the bound payload's fixed byte size. The consumer
     // requires each record's framed `len` to equal this before handing

--- a/crates/hale-codegen/tests/shm_ring_layout_driver.c
+++ b/crates/hale-codegen/tests/shm_ring_layout_driver.c
@@ -146,8 +146,8 @@ static void on_raw(void *self, RawView v) {
     }
 }
 
-static void build_desc(uint64_t desc[21]) {
-    memset(desc, 0, 21 * sizeof(uint64_t));  /* [16..20]=0 → byte_records */
+static void build_desc(uint64_t desc[27]) {
+    memset(desc, 0, 27 * sizeof(uint64_t));  /* [16..20]=0 → byte_records */
     desc[0]  = MAGIC;        desc[1]  = 1;            /* magic, has_magic */
     desc[2]  = VERSION_OFF;  desc[3]  = VERSION_WIDTH;
     desc[4]  = VERSION_VAL;  desc[5]  = 1;            /* version_expect, has_version */
@@ -190,7 +190,7 @@ static int run(const char *name, uint64_t capacity, int n, int pace_us) {
 
     /* Consumer attaches after the header is valid; it starts reading
      * from the current cursor (0), so it sees every record below. */
-    uint64_t desc[21] = {0};
+    uint64_t desc[27] = {0};
     build_desc(desc);
     lotus_bus_register_subscriber_shm_ring_layout(
         "foreign.ticks", name, desc, NULL, on_record);
@@ -269,7 +269,7 @@ static int run(const char *name, uint64_t capacity, int n, int pace_us) {
  * framing symmetry end to end. `pace_us > 0` (with a small capacity)
  * forces the pad-at-wrap path on the producer side too. */
 static int run_producer(const char *name, uint64_t capacity, int n, int pace_us) {
-    uint64_t desc[21] = {0};
+    uint64_t desc[27] = {0};
     build_desc(desc);
 
     /* Producer creates + owns the ring. */
@@ -341,7 +341,7 @@ static int run_bad_bufsize(const char *name) {
     *(uint32_t *)(base + BUFSZ_OFF) = (uint32_t)capacity;
     atomic_store_explicit((_Atomic uint64_t *)(base + CURSOR_OFF), 0,
                           memory_order_release);
-    uint64_t desc[21] = {0};
+    uint64_t desc[27] = {0};
     build_desc(desc);
     /* Expected: open_layout rejects (cap % align != 0) → _exit(1). */
     lotus_bus_register_subscriber_shm_ring_layout(
@@ -372,7 +372,7 @@ static int run_short_record(const char *name) {
     _Atomic uint64_t *cursor = (_Atomic uint64_t *)(base + CURSOR_OFF);
     atomic_store_explicit(cursor, 0, memory_order_release);
 
-    uint64_t desc[21] = {0};
+    uint64_t desc[27] = {0};
     build_desc(desc);
     lotus_bus_register_subscriber_shm_ring_layout(
         "foreign.ticks", name, desc, NULL, on_record);
@@ -435,7 +435,7 @@ static int run_u64_lenprefix(const char *name) {
     _Atomic uint64_t *cursor = (_Atomic uint64_t *)(base + CURSOR_OFF);
     atomic_store_explicit(cursor, 0, memory_order_release);
 
-    uint64_t desc[21] = {0};
+    uint64_t desc[27] = {0};
     build_desc(desc);
     desc[11] = LW8;   /* len_prefix_width = 8 (u64) */
     lotus_bus_register_subscriber_shm_ring_layout(
@@ -493,7 +493,7 @@ static int run_heterogeneous(const char *name) {
     _Atomic uint64_t *cursor = (_Atomic uint64_t *)(base + CURSOR_OFF);
     atomic_store_explicit(cursor, 0, memory_order_release);
 
-    uint64_t desc[21] = {0};
+    uint64_t desc[27] = {0};
     build_desc(desc);
     desc[15] = 0;  /* value_size = 0 → raw BytesView path */
     lotus_bus_register_subscriber_shm_ring_layout(
@@ -594,6 +594,70 @@ static int run_produce_external(const char *name) {
     return 0;
 }
 
+/* record_header external producer (#5, fast-protocol-I/O). Writes
+ * ws-fast-shaped records: a fixed 32-byte header (len@0:u32, kind@4:u8
+ * — 0 Data, 1 Padding) then the payload, stride = 32 + align8(len).
+ * Records never straddle the wrap: when one won't fit before the
+ * boundary, a kind==1 pad record fills the remainder. No in-process
+ * consumer — a separate Hale process binds `layout:` with
+ * record_header_bytes/pad_field/recheck and reads the i64 payload.
+ * capacity 272 = 6*40 + 32: six 40-byte records then an exactly-32-byte
+ * pad header at the tail, so the kind==1 pad path is exercised every
+ * wrap. Paced 2ms/record (20x the reader's 100us poll) so it never
+ * laps. */
+#define RH_BYTES 32
+#define RH_LEN_OFF 0
+#define RH_KIND_OFF 4
+static int run_produce_record_header(const char *name) {
+    uint64_t capacity = 272;  /* multiple of ALIGN(8); 6*40 + 32 pad */
+    size_t total = DATA_AT + (size_t)capacity;
+    int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
+    if (fd < 0) { fprintf(stderr, "shm_open: %s\n", strerror(errno)); return 2; }
+    if (ftruncate(fd, (off_t)total) != 0) { shm_unlink(name); return 2; }
+    void *map = mmap(NULL, total, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (map == MAP_FAILED) { shm_unlink(name); return 2; }
+    char *base = (char *)map;
+    *(uint64_t *)(base + 0) = MAGIC;
+    *(uint32_t *)(base + VERSION_OFF) = (uint32_t)VERSION_VAL;
+    *(uint32_t *)(base + BUFSZ_OFF) = (uint32_t)capacity;
+    _Atomic uint64_t *cursor = (_Atomic uint64_t *)(base + CURSOR_OFF);
+    atomic_store_explicit(cursor, 0, memory_order_release);
+
+    struct timespec attach_wait = {0, 250 * 1000 * 1000};  /* 250ms */
+    nanosleep(&attach_wait, NULL);
+
+    int n = 40;
+    uint64_t plen = 8;  /* one i64 payload */
+    uint64_t step = RH_BYTES + align_up(plen, ALIGN);  /* 40 */
+    uint64_t local = 0;
+    for (int i = 0; i < n; i++) {
+        if ((local % capacity) + step > capacity) {
+            /* Tail pad: a kind==1 header fills the remainder to the wrap. */
+            uint64_t off = DATA_AT + (local % capacity);
+            *(uint32_t *)(base + off + RH_LEN_OFF) = 0;
+            *(uint8_t *)(base + off + RH_KIND_OFF) = 1;  /* Padding */
+            uint64_t rem = capacity - (local % capacity);
+            local += rem;
+            atomic_store_explicit(cursor, local, memory_order_release);
+            struct timespec p = {0, 2 * 1000 * 1000};
+            nanosleep(&p, NULL);
+        }
+        uint64_t off = DATA_AT + (local % capacity);
+        *(uint32_t *)(base + off + RH_LEN_OFF) = (uint32_t)plen;
+        *(uint8_t *)(base + off + RH_KIND_OFF) = 0;       /* Data */
+        int64_t val = (int64_t)(i + 1) * 7;
+        memcpy(base + off + RH_BYTES, &val, sizeof(val));  /* payload @ 32 */
+        local += step;
+        atomic_store_explicit(cursor, local, memory_order_release);
+        struct timespec p = {0, 2 * 1000 * 1000};
+        nanosleep(&p, NULL);
+    }
+    struct timespec drain = {0, 400 * 1000 * 1000};
+    nanosleep(&drain, NULL);
+    munmap(map, total); close(fd); shm_unlink(name);
+    return 0;
+}
+
 /* Dogfood: the native LotusRing (LRSRNG1) slot ring, read through the
  * `ring_layout` abstraction. The NATIVE producer (lotus_shm_ring_open +
  * claim/commit) writes the ring; a layout-`slots` consumer attaches with
@@ -611,7 +675,7 @@ static int run_lotus_dogfood(const char *name) {
     /* A `ring_layout LotusRing` descriptor for the native LRSRNG1 header:
      * magic@0, slot_size@8, slot_count@16, seqno@24, slots@128. framing =
      * slots; geometry read from the header; cursor = the published seqno. */
-    uint64_t desc[21] = {0};
+    uint64_t desc[27] = {0};
     desc[0] = LOTUS_RING_MAGIC;
     desc[1] = 1;                  /* has_magic */
     desc[9] = 128;                /* data_at (header is two cache lines) */
@@ -691,7 +755,7 @@ static int run_produce_native_external(const char *name) {
  * the actual length. A raw (value_size == 0) consumer reads them back —
  * proving reserve/commit frames variable-length records correctly. */
 static int run_reserve_commit(const char *name) {
-    uint64_t desc[21] = {0};
+    uint64_t desc[27] = {0};
     build_desc(desc);
     desc[15] = 0;  /* value_size = 0 → raw consumer (variable records) */
     lotus_bus_register_shm_ring_layout("foreign.ticks", name, desc, 4096);
@@ -765,6 +829,9 @@ int main(int argc, char **argv) {
     }
     if (strcmp(argv[1], "produce_external") == 0) {
         return run_produce_external(argv[2]);
+    }
+    if (strcmp(argv[1], "produce_record_header") == 0) {
+        return run_produce_record_header(argv[2]);
     }
     if (strcmp(argv[1], "heterogeneous") == 0) {
         return run_heterogeneous(argv[2]);

--- a/crates/hale-codegen/tests/shm_ring_layout_record_header.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_record_header.rs
@@ -1,0 +1,147 @@
+//! `record_header` framing + `post_copy` recheck (#5 of the
+//! fast-protocol-I/O substrate plan).
+//!
+//! A foreign ring whose records have a fixed 32-byte header
+//! (len@0:u32, kind@4:u8 — ws-fast's shape) before the payload: stride is
+//! `record_header_bytes + align(len)`, the payload starts past the header,
+//! and a `kind == 1` header field marks a tail pad (not a len sentinel).
+//! Without `record_header_bytes` the reader would desync after one record.
+//!
+//! End-to-end: the C producer (`shm_ring_layout_driver.c
+//! produce_record_header`) writes 40 ws-fast-shaped records through a small
+//! ring (forcing repeated kind==1 tail pads at the wrap); a Hale BytesView
+//! subscriber bound with `record_header_bytes`/`pad_field`/`recheck
+//! post_copy` reads each i64 payload in order.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::build_executable;
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn unique_tag(label: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("rh-{}-{}-{}", label, std::process::id(), nanos)
+}
+
+fn build_producer() -> PathBuf {
+    let mut driver_c = manifest_dir();
+    driver_c.push("tests");
+    driver_c.push("shm_ring_layout_driver.c");
+    let mut ring_c = manifest_dir();
+    ring_c.push("runtime");
+    ring_c.push("lotus_shm_ring.c");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("lotus_{}", unique_tag("producer")));
+    let status = Command::new("clang")
+        .arg(&driver_c)
+        .arg(&ring_c)
+        .arg("-O2")
+        .arg("-lrt")
+        .arg("-lpthread")
+        .arg("-o")
+        .arg(&bin)
+        .status()
+        .expect("clang");
+    assert!(status.success(), "clang failed building producer driver");
+    bin
+}
+
+#[test]
+fn hale_subscriber_reads_record_header_ring_with_post_copy() {
+    let shm_name = format!("/hale-{}", unique_tag("e2e"));
+
+    let src = format!(
+        r#"
+        ring_layout WsFastish {{
+            magic 0x52494E47464D5431;
+            version 1 at 8 : u32;
+            buffer_size at 12 : u32;
+            data_at 128;
+            cursor published {{ at 64; repr atomic_u64; load acquire; unit bytes; }}
+            framing byte_records {{
+                len_prefix u32;
+                align 8;
+                record_header_bytes 32;
+                pad_field_offset 4;
+                pad_field_width 1;
+                pad_field_value 1;
+                recheck post_copy;
+            }}
+            overflow lap_detect;
+        }}
+
+        topic Recs {{ payload: BytesView; }}
+
+        locus Sub {{
+            bus {{ subscribe Recs as on_rec; }}
+            fn on_rec(v: BytesView) {{
+                let val = std::bytes::read_i64_le(v, 0) or -1;
+                println("rec val=", to_string(val));
+            }}
+        }}
+
+        main locus App {{
+            bindings {{
+                Recs: shm_ring("{shm_name}", on_overflow: drop, layout: WsFastish);
+            }}
+        }}
+
+        fn main() {{
+            App {{ }};
+            Sub {{ }};
+            time::sleep(1500ms);
+        }}
+    "#,
+        shm_name = shm_name,
+    );
+
+    let program = hale_syntax::parse_source(&src).expect("parse");
+    let mut consumer_bin = std::env::temp_dir();
+    consumer_bin.push(format!("lotus_{}.bin", unique_tag("consumer")));
+    build_executable(&program, &consumer_bin).expect("build consumer");
+
+    let producer_bin = build_producer();
+
+    let mut producer = Command::new(&producer_bin)
+        .arg("produce_record_header")
+        .arg(&shm_name)
+        .spawn()
+        .expect("spawn producer");
+
+    std::thread::sleep(std::time::Duration::from_millis(80));
+
+    let consumer_out = Command::new(&consumer_bin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run consumer");
+
+    let producer_status = producer.wait().expect("wait producer");
+    let _ = std::fs::remove_file(&producer_bin);
+    let _ = std::fs::remove_file(&consumer_bin);
+
+    assert!(producer_status.success(), "producer failed: {:?}", producer_status);
+    assert!(
+        consumer_out.status.success(),
+        "consumer failed: status={:?}\nstderr: {}",
+        consumer_out.status,
+        String::from_utf8_lossy(&consumer_out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&consumer_out.stdout);
+
+    // val = (i+1)*7 for i in 0..40 → 7, 14, ..., 280. If the stride or
+    // payload offset were wrong the reader would desync after the first
+    // record; if pad-skip were wrong it would stall at the first wrap.
+    for i in 0..40 {
+        let want = format!("rec val={}", (i + 1) * 7);
+        assert!(stdout.contains(&want), "missing `{}`. stdout:\n{}", want, stdout);
+    }
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -4734,15 +4734,117 @@ impl<'a> Checker<'a> {
         if let Some(fr) = &r.framing {
             for a in &fr.attrs {
                 if !matches!(a.key.name.as_str(),
-                    "len_prefix" | "align" | "pad_sentinel" | "slot_size") {
+                    "len_prefix" | "align" | "pad_sentinel" | "slot_size"
+                    | "record_header_bytes" | "pad_field_offset"
+                    | "pad_field_width" | "pad_field_value" | "recheck") {
                     self.diags.push(Diag::warn(
                         a.span,
                         format!(
                             "ring_layout `{}`: unknown framing attribute `{}` \
-                             (recognized: len_prefix, align, pad_sentinel, slot_size)",
+                             (recognized: len_prefix, align, pad_sentinel, \
+                             slot_size, record_header_bytes, pad_field_offset, \
+                             pad_field_width, pad_field_value, recheck)",
                             r.name.name, a.key.name
                         ),
                     ));
+                }
+            }
+        }
+
+        // #5 (fast-protocol-I/O): validate the record_header / pad_field /
+        // recheck attrs (byte_records). record_header_bytes is the fixed
+        // per-record header before the payload; it must be a multiple of
+        // `align` (so the reader's align_up(hdr + len, align) stride equals
+        // header + align(len)) and at least len_prefix wide (the len field
+        // lives at record offset 0). A pad_field (a header discriminant
+        // marking a tail pad, e.g. ws-fast kind==1) must fit inside the
+        // header. `recheck` only knows `post_copy`.
+        if let Some(fr) = &r.framing {
+            let attr_int = |key: &str| -> Option<i64> {
+                fr.attrs.iter().find_map(|a| match (&a.key.name[..], &a.value) {
+                    (k, RingAttrValue::Int(n)) if k == key => Some(*n),
+                    _ => None,
+                })
+            };
+            let align = attr_int("align").unwrap_or(1).max(1) as u64;
+            let len_prefix_w = fr
+                .attrs
+                .iter()
+                .find(|a| a.key.name == "len_prefix")
+                .and_then(|a| match &a.value {
+                    RingAttrValue::Ident(id) => Some(match id.name.as_str() {
+                        "u8" | "i8" => 1u64,
+                        "u16" | "i16" => 2,
+                        "u32" | "i32" | "f32" => 4,
+                        "u64" | "i64" | "f64" => 8,
+                        _ => 0,
+                    }),
+                    RingAttrValue::Int(n) => Some(*n as u64),
+                })
+                .unwrap_or(0);
+            let rh = attr_int("record_header_bytes");
+            if let Some(rhv) = rh {
+                let span = fr.span;
+                if rhv <= 0 {
+                    self.diags.push(Diag::ty(span, format!(
+                        "ring_layout `{}`: record_header_bytes must be positive",
+                        r.name.name)));
+                } else {
+                    let rhu = rhv as u64;
+                    if align > 1 && rhu % align != 0 {
+                        self.diags.push(Diag::ty(span, format!(
+                            "ring_layout `{}`: record_header_bytes ({}) must be a \
+                             multiple of align ({}) — the record stride is \
+                             header + align(len)", r.name.name, rhu, align)));
+                    }
+                    if len_prefix_w != 0 && rhu < len_prefix_w {
+                        self.diags.push(Diag::ty(span, format!(
+                            "ring_layout `{}`: record_header_bytes ({}) is smaller \
+                             than len_prefix ({}) — the length field at record \
+                             offset 0 would not fit", r.name.name, rhu, len_prefix_w)));
+                    }
+                }
+            }
+            // pad_field: offset/width/value must be coherent and fit the header.
+            let pad_off = attr_int("pad_field_offset");
+            let pad_w = attr_int("pad_field_width");
+            let pad_v = attr_int("pad_field_value");
+            if pad_off.is_some() || pad_w.is_some() || pad_v.is_some() {
+                let span = fr.span;
+                match (pad_off, pad_w, pad_v) {
+                    (Some(off), Some(w), Some(_)) => {
+                        if !matches!(w, 1 | 2 | 4 | 8) {
+                            self.diags.push(Diag::ty(span, format!(
+                                "ring_layout `{}`: pad_field_width must be 1/2/4/8, got {}",
+                                r.name.name, w)));
+                        }
+                        if off < 0 {
+                            self.diags.push(Diag::ty(span, format!(
+                                "ring_layout `{}`: pad_field_offset must be non-negative",
+                                r.name.name)));
+                        } else if let Some(rhv) = rh {
+                            if rhv > 0 && (off + w) as i64 > rhv {
+                                self.diags.push(Diag::ty(span, format!(
+                                    "ring_layout `{}`: pad_field [{}, {}) falls outside \
+                                     the {}-byte record header",
+                                    r.name.name, off, off + w, rhv)));
+                            }
+                        }
+                    }
+                    _ => self.diags.push(Diag::ty(span, format!(
+                        "ring_layout `{}`: a pad_field needs all of pad_field_offset, \
+                         pad_field_width, pad_field_value", r.name.name))),
+                }
+            }
+            // recheck: only post_copy is known.
+            for a in &fr.attrs {
+                if a.key.name == "recheck" {
+                    let ok = matches!(&a.value, RingAttrValue::Ident(id) if id.name == "post_copy");
+                    if !ok {
+                        self.diags.push(Diag::ty(a.span, format!(
+                            "ring_layout `{}`: unknown recheck mode (only `post_copy`)",
+                            r.name.name)));
+                    }
                 }
             }
         }

--- a/crates/hale-types/tests/ring_layout.rs
+++ b/crates/hale-types/tests/ring_layout.rs
@@ -37,6 +37,51 @@ fn valid_layout_is_clean() {
 }
 
 #[test]
+fn record_header_clean_and_validated() {
+    // A valid record_header layout (ws-fast-ish: 32-byte header, kind-pad,
+    // post_copy recheck) typechecks clean.
+    let valid = r#"
+ring_layout WsFast {
+    magic 0x52494E47464D5431;
+    version 1 at 8 : u32;
+    buffer_size at 12 : u32;
+    data_at 128;
+    cursor published { at 64; repr atomic_u64; load acquire; unit bytes; }
+    framing byte_records {
+        len_prefix u32; align 8;
+        record_header_bytes 32;
+        pad_field_offset 4; pad_field_width 1; pad_field_value 1;
+        recheck post_copy;
+    }
+    overflow lap_detect;
+}
+"#;
+    assert!(check(valid).is_empty(), "valid record_header should be clean; got: {:?}", check(valid));
+
+    // record_header_bytes not a multiple of align → error (the stride
+    // formula header + align(len) would not hold).
+    let bad_align = valid.replace("record_header_bytes 32;", "record_header_bytes 30;");
+    assert!(
+        check(&bad_align).iter().any(|m| m.contains("must be a multiple of align")),
+        "got: {:?}", check(&bad_align)
+    );
+
+    // pad_field beyond the header → error.
+    let bad_pad = valid.replace("pad_field_offset 4;", "pad_field_offset 40;");
+    assert!(
+        check(&bad_pad).iter().any(|m| m.contains("outside the")),
+        "got: {:?}", check(&bad_pad)
+    );
+
+    // unknown recheck mode → error.
+    let bad_recheck = valid.replace("recheck post_copy;", "recheck seqlock;");
+    assert!(
+        check(&bad_recheck).iter().any(|m| m.contains("unknown recheck mode")),
+        "got: {:?}", check(&bad_recheck)
+    );
+}
+
+#[test]
 fn unknown_scalar_repr_errors() {
     let src = r#"
 ring_layout R {

--- a/notes/binary-shm-ring-interop.md
+++ b/notes/binary-shm-ring-interop.md
@@ -260,6 +260,29 @@ runtime already does for `LRSRNG1`; this just parameterizes it.
 > Still out of scope: the producer path for foreign layouts (M3),
 > `slots` framing, historical replay, multi-cursor back-pressure.
 
+> **#5 (LANDED, 2026-06-13): record headers + post-copy recheck**
+> (fast-protocol-I/O substrate plan). Extends `byte_records` so a
+> producer with a fixed per-record header before the payload (ws-fast's
+> 32-byte `len/kind/opcode/seq/kernel_ns/user_ns`) can be consumed
+> correctly — without it the reader desyncs after one record. New
+> `byte_records` framing attributes (all `ring_attr`, no grammar
+> change): `record_header_bytes N` (payload starts at `N`, stride
+> `N + align(len)`, `N % align == 0`), `pad_field_offset/width/value`
+> (a header-field padding marker — ws-fast's `kind == 1` — instead of a
+> `len` sentinel), and `recheck post_copy` (copy → acquire fence →
+> reload cursor → discard-if-lapped torn-read guard). Descriptor grows
+> 21 → 27 words; the consumer loop substitutes `header_bytes` for
+> `len_prefix_width` in the payload offset / room / stride and adds the
+> pad-field + post-copy branches. Validated end-to-end by a C
+> producer writing ws-fast-shaped records through a small wrapping ring
+> (`shm_ring_layout_driver.c produce_record_header`) ↔ a Hale
+> `BytesView` subscriber (`shm_ring_layout_record_header.rs`), plus
+> typecheck tests. **Correctness slice only:** the payload is delivered
+> as a `BytesView`; surfacing the named header fields (`seq`,
+> `kernel_ns`) to the handler is the follow-on, decided to use the
+> **payload-struct-prefix** mechanism (the bound struct's leading
+> fields map to the header, reusing typed dispatch).
+
 The external stack's ring becomes a declaration:
 
 ```hale

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -959,6 +959,25 @@ The `layout:` reference must resolve to a declared `ring_layout`
 (else a typecheck diagnostic). A binding with no `layout:` is the
 native ring, unchanged.
 
+*Record headers (`record_header_bytes`).* The default `byte_records`
+shape is `[len_prefix][payload]` — the prefix is the whole per-record
+overhead. A real foreign producer often prepends a fixed header
+(sequence number, kernel timestamps, opcode) before the payload. Set
+`record_header_bytes N` on the `byte_records` framing to describe it:
+the payload then starts `N` bytes into the record and the stride is
+`N + align(len)` (the `len` field is still read at record offset 0 with
+`len_prefix`). `N` must be a multiple of `align`. A producer that marks
+a tail pad with a header *field* rather than a `len` sentinel (e.g. a
+`kind` byte where `1` means padding) declares
+`pad_field_offset` / `pad_field_width` / `pad_field_value`; a record
+whose field equals that value is skipped to the wrap. (Surfacing the
+named header fields to the handler is a follow-on; v1 delivers the
+payload as a `BytesView` with the header consumed by the framer.)
+`recheck post_copy` adds a torn-read guard: each record is copied out,
+an acquire fence taken, and the cursor re-read; if a free-running
+producer lapped the record during the copy it is discarded rather than
+handed to the handler.
+
 *Slot rings (`framing slots`).* The example above is a variable-length
 `byte_records` ring. A `slots` framing describes a fixed-stride slot
 ring instead — the shape of the native Lotus ring itself. The geometry


### PR DESCRIPTION
## What

#5 of the fast-protocol-I/O substrate plan — and the continuation of shm-ring-interop **Proposal B**. Lets a Hale subscriber consume a foreign `byte_records` ring whose records carry a **fixed per-record header** before the payload (ws-fast's 32-byte `len/kind/opcode/seq/kernel_ns/user_ns`). Without it the reader computes the wrong stride (`align_up(len_prefix + len)` vs. `header + align(len)`) and **desyncs after one record**.

This is the **correctness slice** (per the scoping decision): the payload is delivered as a `BytesView` with the header consumed by the framer. Surfacing the named header fields (`seq`, `kernel_ns`, …) to the handler is the follow-on — decided to use the **payload-struct-prefix** mechanism.

## New `byte_records` framing attributes

All are plain `ring_attr` (`key value;`) — **zero grammar / AST / parser change**:

- **`record_header_bytes N`** — payload starts `N` bytes into the record; stride is `align_up(N + len, align)` which equals `N + align(len)` because `N` is required to be a multiple of `align`. `len` is still read at record offset 0 with `len_prefix`.
- **`pad_field_offset/width/value`** — a header-*field* padding marker (ws-fast's `kind == 1`) instead of a `len` sentinel; a record whose field equals the value is skipped to the wrap.
- **`recheck post_copy`** — torn-read guard: copy the record out, acquire fence, reload the cursor, and **discard rather than dispatch** if a free-running producer lapped it during the copy.

## How

- **runtime** (`lotus_shm_ring.c`): descriptor `lotus_shm_layout_t` gains `record_header_bytes`, `pad_field_*`, `post_copy_recheck`; the `byte_records` loop substitutes `header_bytes` for `len_prefix_width` in the payload offset / room / stride and adds the pad-field + post-copy branches. The len_prefix-only path is **byte-for-byte unchanged** (`record_header_bytes 0` → `header_bytes = len_prefix_width`).
- **codegen** (`bus/runtime.rs`): descriptor word array `21 → 27`, built from the new framing attrs.
- **typecheck** (`check.rs`): validates `N % align == 0`, `N >= len_prefix`, pad_field within the header, `recheck ∈ {post_copy}`.

## Testing

- **End-to-end**: a C producer writing ws-fast-shaped records through a small wrapping ring (`shm_ring_layout_driver.c produce_record_header` — `cap 272 = 6×40 + 32`, exercising the `kind==1` tail pad **every wrap**) ↔ a Hale `BytesView` subscriber (`shm_ring_layout_record_header.rs`) that reads all 40 i64 payloads in order. Wrong stride/offset → desync after record 1; wrong pad-skip → stall at the first wrap.
- **Typecheck**: `ring_layout.rs` cases — bad align multiple, pad outside header, unknown recheck.
- **Regression**: the descriptor-width bump is mirrored in the C driver (`desc[21] → desc[27]`); the existing `shm_ring_layout` suite (10), `lotus_dogfood`, and the **corpus oracle** all pass.

## Spec / plan

`semantics.md` § "Foreign rings" documents `record_header_bytes` / `pad_field` / `recheck post_copy`; milestone recorded in `notes/binary-shm-ring-interop.md`.

Plan status: ✅ #2 TCP_NODELAY · ✅ #7 gates · ✅ #1 recv_stamped · ✅ #4 byte primitives · ✅ #5 (this). Remaining: **#3 MirrorRing**, the field-delivery follow-on, and **#6 TLS plaintext-alloc audit**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
