### PR TITLE
feat(ring_layout): in-band record-header field delivery (std::shm::last_record_*)

### DIFF
--- a/crates/hale-codegen/runtime/lotus_shm_ring.c
+++ b/crates/hale-codegen/runtime/lotus_shm_ring.c
@@ -309,7 +309,29 @@ typedef struct {
      * fence taken, and the cursor re-read; if the producer lapped the
      * record during the copy it is discarded rather than dispatched. */
     int      post_copy_recheck;
+    /* 2026-06-13 (#5 field-delivery follow-on): per-record header field
+     * offsets/widths. When width != 0, the byte_records reader decodes
+     * the field from each record's header (at off, `width` bytes LE,
+     * zero-extended) into a thread-local just before dispatch; the
+     * handler reads it via std::shm::last_record_{seq,kernel_ns,
+     * user_ns}() — the errno-style idiom of recv_stamped's
+     * last_recv_*_ns. The payload itself is still delivered as the
+     * BytesView / typed value; these surface the in-band header. */
+    uint64_t seq_off;        uint64_t seq_width;
+    uint64_t kernel_ns_off;  uint64_t kernel_ns_width;
+    uint64_t user_ns_off;    uint64_t user_ns_width;
 } lotus_shm_layout_t;
+
+/* Decoded header fields of the most recent record dispatched on this
+ * (reader) thread — read immediately in the handler via the
+ * std::shm::last_record_* getters. */
+static __thread int64_t g_last_record_seq       = 0;
+static __thread int64_t g_last_record_kernel_ns = 0;
+static __thread int64_t g_last_record_user_ns   = 0;
+
+int64_t lotus_shm_last_record_seq(void)       { return g_last_record_seq; }
+int64_t lotus_shm_last_record_kernel_ns(void) { return g_last_record_kernel_ns; }
+int64_t lotus_shm_last_record_user_ns(void)   { return g_last_record_user_ns; }
 
 #define LOTUS_RING_FRAMING_BYTE_RECORDS 0
 #define LOTUS_RING_FRAMING_SLOTS        1
@@ -349,7 +371,7 @@ static void shm_layout_write_uint(void *p, uint64_t width, uint64_t val) {
     memcpy(p, &val, (size_t)width);
 }
 
-/* Populate a descriptor from the flat 27-word array codegen emits.
+/* Populate a descriptor from the flat 33-word array codegen emits.
  * The slot contract is documented on
  * `lotus_bus_register_subscriber_shm_ring_layout`. */
 static void shm_layout_from_words(const uint64_t *w, lotus_shm_layout_t *d) {
@@ -381,6 +403,12 @@ static void shm_layout_from_words(const uint64_t *w, lotus_shm_layout_t *d) {
     d->pad_field_value   = w[24];
     d->has_pad_field     = (int)w[25];
     d->post_copy_recheck = (int)w[26];
+    d->seq_off           = w[27];
+    d->seq_width         = w[28];
+    d->kernel_ns_off     = w[29];
+    d->kernel_ns_width   = w[30];
+    d->user_ns_off       = w[31];
+    d->user_ns_width     = w[32];
 }
 
 /* Attach (read-only) to a foreign ring described by `desc`.
@@ -1377,6 +1405,23 @@ static void *shm_ring_layout_reader_thread(void *arg) {
                 break;
             }
             char *payload = base + phys + hdr;
+            /* Surface the in-band header fields (#5 follow-on): decode the
+             * declared scalars from this record's header into thread-locals
+             * the handler reads via std::shm::last_record_*. Cheap when
+             * unused (widths are 0). Read before any post_copy copy so they
+             * reflect this record. */
+            if (d->seq_width) {
+                g_last_record_seq = (int64_t)shm_layout_read_uint(
+                    base + phys + d->seq_off, d->seq_width);
+            }
+            if (d->kernel_ns_width) {
+                g_last_record_kernel_ns = (int64_t)shm_layout_read_uint(
+                    base + phys + d->kernel_ns_off, d->kernel_ns_width);
+            }
+            if (d->user_ns_width) {
+                g_last_record_user_ns = (int64_t)shm_layout_read_uint(
+                    base + phys + d->user_ns_off, d->user_ns_width);
+            }
             if (d->post_copy_recheck) {
                 /* Copy the record out, take an acquire fence, then re-read
                  * the cursor. A record starting at monotonic `local` is

--- a/crates/hale-codegen/src/bus/runtime.rs
+++ b/crates/hale-codegen/src/bus/runtime.rs
@@ -381,9 +381,9 @@ fn ring_repr_width(repr: &str) -> u64 {
 fn ring_layout_descriptor_words(
     decl: &hale_syntax::ast::RingLayoutDecl,
     value_size: u64,
-) -> [u64; 27] {
+) -> [u64; 33] {
     use hale_syntax::ast::RingAttrValue;
-    let mut w = [0u64; 27];
+    let mut w = [0u64; 33];
 
     // [0..2] magic
     if let Some(m) = decl.magic {
@@ -466,6 +466,15 @@ fn ring_layout_descriptor_words(
                 ("recheck", RingAttrValue::Ident(id)) if id.name == "post_copy" => {
                     w[26] = 1;
                 }
+                // #5 follow-on: in-band header field offsets/widths,
+                // decoded per record into thread-locals read by
+                // std::shm::last_record_{seq,kernel_ns,user_ns}.
+                ("seq_offset", RingAttrValue::Int(n)) => w[27] = *n as u64,
+                ("seq_width", RingAttrValue::Int(n)) => w[28] = *n as u64,
+                ("kernel_ns_offset", RingAttrValue::Int(n)) => w[29] = *n as u64,
+                ("kernel_ns_width", RingAttrValue::Int(n)) => w[30] = *n as u64,
+                ("user_ns_offset", RingAttrValue::Int(n)) => w[31] = *n as u64,
+                ("user_ns_width", RingAttrValue::Int(n)) => w[32] = *n as u64,
                 _ => {}
             }
         }

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -17066,6 +17066,32 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ["std", "io", "mirror", op] => {
                 self.lower_std_io_mirror(op, args, scope)
             }
+            // #5 follow-on: in-band record-header field getters — the
+            // decoded seq / kernel timestamp of the most recent
+            // foreign-ring record dispatched on this thread (errno-style,
+            // read immediately in the subscribe handler).
+            ["std", "shm", "last_record_seq"]
+            | ["std", "shm", "last_record_kernel_ns"]
+            | ["std", "shm", "last_record_user_ns"] => {
+                if !args.is_empty() {
+                    return Err(CodegenError::Unsupported(format!(
+                        "{}: takes 0 args, got {}", segs.join("::"), args.len()
+                    )));
+                }
+                let c_fn = format!("lotus_shm_{}", segs[2]);
+                let f = self
+                    .module
+                    .get_function(&c_fn)
+                    .expect("lotus_shm_last_record_* declared");
+                let v = self
+                    .builder
+                    .build_call(f, &[], "shm.last_record.ret")
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                    .try_as_basic_value()
+                    .left()
+                    .expect("returns i64");
+                Ok((v, CodegenTy::Int))
+            }
             // 2026-05-26 — UDP P4: getters for the source IP +
             // port of the last `recv_with_source` on this thread.
             ["std", "io", "udp", "last_source_host"] => {

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1650,6 +1650,16 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             i64_t.fn_type(&[ptr_t.into()], false),
             None,
         );
+        // #5 follow-on: std::shm::last_record_* getters — the decoded
+        // in-band header fields of the most recent foreign-ring record
+        // dispatched on this thread (0 if the field isn't declared).
+        for g in ["seq", "kernel_ns", "user_ns"] {
+            self.module.add_function(
+                &format!("lotus_shm_last_record_{}", g),
+                i64_t.fn_type(&[], false),
+                None,
+            );
+        }
 
         // std::io::sockopt::* named-constant getters. Each is a
         // zero-arg int-returning fn that returns the platform's

--- a/crates/hale-codegen/tests/shm_ring_layout_driver.c
+++ b/crates/hale-codegen/tests/shm_ring_layout_driver.c
@@ -146,8 +146,8 @@ static void on_raw(void *self, RawView v) {
     }
 }
 
-static void build_desc(uint64_t desc[27]) {
-    memset(desc, 0, 27 * sizeof(uint64_t));  /* [16..20]=0 → byte_records */
+static void build_desc(uint64_t desc[33]) {
+    memset(desc, 0, 33 * sizeof(uint64_t));  /* [16..20]=0 → byte_records */
     desc[0]  = MAGIC;        desc[1]  = 1;            /* magic, has_magic */
     desc[2]  = VERSION_OFF;  desc[3]  = VERSION_WIDTH;
     desc[4]  = VERSION_VAL;  desc[5]  = 1;            /* version_expect, has_version */
@@ -190,7 +190,7 @@ static int run(const char *name, uint64_t capacity, int n, int pace_us) {
 
     /* Consumer attaches after the header is valid; it starts reading
      * from the current cursor (0), so it sees every record below. */
-    uint64_t desc[27] = {0};
+    uint64_t desc[33] = {0};
     build_desc(desc);
     lotus_bus_register_subscriber_shm_ring_layout(
         "foreign.ticks", name, desc, NULL, on_record);
@@ -269,7 +269,7 @@ static int run(const char *name, uint64_t capacity, int n, int pace_us) {
  * framing symmetry end to end. `pace_us > 0` (with a small capacity)
  * forces the pad-at-wrap path on the producer side too. */
 static int run_producer(const char *name, uint64_t capacity, int n, int pace_us) {
-    uint64_t desc[27] = {0};
+    uint64_t desc[33] = {0};
     build_desc(desc);
 
     /* Producer creates + owns the ring. */
@@ -341,7 +341,7 @@ static int run_bad_bufsize(const char *name) {
     *(uint32_t *)(base + BUFSZ_OFF) = (uint32_t)capacity;
     atomic_store_explicit((_Atomic uint64_t *)(base + CURSOR_OFF), 0,
                           memory_order_release);
-    uint64_t desc[27] = {0};
+    uint64_t desc[33] = {0};
     build_desc(desc);
     /* Expected: open_layout rejects (cap % align != 0) → _exit(1). */
     lotus_bus_register_subscriber_shm_ring_layout(
@@ -372,7 +372,7 @@ static int run_short_record(const char *name) {
     _Atomic uint64_t *cursor = (_Atomic uint64_t *)(base + CURSOR_OFF);
     atomic_store_explicit(cursor, 0, memory_order_release);
 
-    uint64_t desc[27] = {0};
+    uint64_t desc[33] = {0};
     build_desc(desc);
     lotus_bus_register_subscriber_shm_ring_layout(
         "foreign.ticks", name, desc, NULL, on_record);
@@ -435,7 +435,7 @@ static int run_u64_lenprefix(const char *name) {
     _Atomic uint64_t *cursor = (_Atomic uint64_t *)(base + CURSOR_OFF);
     atomic_store_explicit(cursor, 0, memory_order_release);
 
-    uint64_t desc[27] = {0};
+    uint64_t desc[33] = {0};
     build_desc(desc);
     desc[11] = LW8;   /* len_prefix_width = 8 (u64) */
     lotus_bus_register_subscriber_shm_ring_layout(
@@ -493,7 +493,7 @@ static int run_heterogeneous(const char *name) {
     _Atomic uint64_t *cursor = (_Atomic uint64_t *)(base + CURSOR_OFF);
     atomic_store_explicit(cursor, 0, memory_order_release);
 
-    uint64_t desc[27] = {0};
+    uint64_t desc[33] = {0};
     build_desc(desc);
     desc[15] = 0;  /* value_size = 0 → raw BytesView path */
     lotus_bus_register_subscriber_shm_ring_layout(
@@ -645,6 +645,11 @@ static int run_produce_record_header(const char *name) {
         uint64_t off = DATA_AT + (local % capacity);
         *(uint32_t *)(base + off + RH_LEN_OFF) = (uint32_t)plen;
         *(uint8_t *)(base + off + RH_KIND_OFF) = 0;       /* Data */
+        /* In-band header fields (ws-fast shape): seq@8, kernel_ns@16,
+         * user_ns@24 — surfaced to the consumer via std::shm::last_record_*. */
+        *(uint64_t *)(base + off + 8)  = (uint64_t)(i + 1);
+        *(uint64_t *)(base + off + 16) = (uint64_t)((i + 1) * 1000);
+        *(uint64_t *)(base + off + 24) = (uint64_t)((i + 1) * 1000 + 7);
         int64_t val = (int64_t)(i + 1) * 7;
         memcpy(base + off + RH_BYTES, &val, sizeof(val));  /* payload @ 32 */
         local += step;
@@ -675,7 +680,7 @@ static int run_lotus_dogfood(const char *name) {
     /* A `ring_layout LotusRing` descriptor for the native LRSRNG1 header:
      * magic@0, slot_size@8, slot_count@16, seqno@24, slots@128. framing =
      * slots; geometry read from the header; cursor = the published seqno. */
-    uint64_t desc[27] = {0};
+    uint64_t desc[33] = {0};
     desc[0] = LOTUS_RING_MAGIC;
     desc[1] = 1;                  /* has_magic */
     desc[9] = 128;                /* data_at (header is two cache lines) */
@@ -755,7 +760,7 @@ static int run_produce_native_external(const char *name) {
  * the actual length. A raw (value_size == 0) consumer reads them back —
  * proving reserve/commit frames variable-length records correctly. */
 static int run_reserve_commit(const char *name) {
-    uint64_t desc[27] = {0};
+    uint64_t desc[33] = {0};
     build_desc(desc);
     desc[15] = 0;  /* value_size = 0 → raw consumer (variable records) */
     lotus_bus_register_shm_ring_layout("foreign.ticks", name, desc, 4096);

--- a/crates/hale-codegen/tests/shm_ring_record_header_fields.rs
+++ b/crates/hale-codegen/tests/shm_ring_record_header_fields.rs
@@ -1,0 +1,148 @@
+//! In-band record-header field delivery (#5 follow-on, fast-protocol-I/O).
+//!
+//! The `record_header` framing can declare where the per-record header
+//! scalars live (`seq_offset/width`, `kernel_ns_offset/width`,
+//! `user_ns_offset/width`); the byte_records reader decodes them per record
+//! into thread-locals the subscribe handler reads via
+//! `std::shm::last_record_{seq, kernel_ns, user_ns}()` — the errno-style
+//! idiom of `recv_stamped`'s `last_recv_*_ns`. The payload is still the
+//! BytesView; this surfaces the in-band sequence number + kernel/user
+//! timestamps a market-data consumer wants.
+//!
+//! End-to-end: the C producer (`produce_record_header`) writes ws-fast-shaped
+//! records with seq@8 / kernel_ns@16 / user_ns@24, and a Hale BytesView
+//! subscriber reads both the payload and the three header fields per record.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::build_executable;
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn unique_tag(label: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("rhf-{}-{}-{}", label, std::process::id(), nanos)
+}
+
+fn build_producer() -> PathBuf {
+    let mut driver_c = manifest_dir();
+    driver_c.push("tests");
+    driver_c.push("shm_ring_layout_driver.c");
+    let mut ring_c = manifest_dir();
+    ring_c.push("runtime");
+    ring_c.push("lotus_shm_ring.c");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("lotus_{}", unique_tag("producer")));
+    let status = Command::new("clang")
+        .arg(&driver_c)
+        .arg(&ring_c)
+        .arg("-O2")
+        .arg("-lrt")
+        .arg("-lpthread")
+        .arg("-o")
+        .arg(&bin)
+        .status()
+        .expect("clang");
+    assert!(status.success(), "clang failed building producer driver");
+    bin
+}
+
+#[test]
+fn hale_subscriber_reads_in_band_header_fields() {
+    let shm_name = format!("/hale-{}", unique_tag("e2e"));
+
+    let src = format!(
+        r#"
+        ring_layout WsFastish {{
+            magic 0x52494E47464D5431;
+            version 1 at 8 : u32;
+            buffer_size at 12 : u32;
+            data_at 128;
+            cursor published {{ at 64; repr atomic_u64; load acquire; unit bytes; }}
+            framing byte_records {{
+                len_prefix u32;
+                align 8;
+                record_header_bytes 32;
+                pad_field_offset 4; pad_field_width 1; pad_field_value 1;
+                seq_offset 8; seq_width 8;
+                kernel_ns_offset 16; kernel_ns_width 8;
+                user_ns_offset 24; user_ns_width 8;
+            }}
+            overflow lap_detect;
+        }}
+
+        topic Recs {{ payload: BytesView; }}
+
+        locus Sub {{
+            bus {{ subscribe Recs as on_rec; }}
+            fn on_rec(v: BytesView) {{
+                let val = std::bytes::read_i64_le(v, 0) or -1;
+                let seq = std::shm::last_record_seq();
+                let kns = std::shm::last_record_kernel_ns();
+                let uns = std::shm::last_record_user_ns();
+                println("rec val=", to_string(val), " seq=", to_string(seq),
+                        " kns=", to_string(kns), " uns=", to_string(uns));
+            }}
+        }}
+
+        main locus App {{
+            bindings {{
+                Recs: shm_ring("{shm_name}", on_overflow: drop, layout: WsFastish);
+            }}
+        }}
+
+        fn main() {{
+            App {{ }};
+            Sub {{ }};
+            time::sleep(1500ms);
+        }}
+    "#,
+        shm_name = shm_name,
+    );
+
+    let program = hale_syntax::parse_source(&src).expect("parse");
+    let mut consumer_bin = std::env::temp_dir();
+    consumer_bin.push(format!("lotus_{}.bin", unique_tag("consumer")));
+    build_executable(&program, &consumer_bin).expect("build consumer");
+
+    let producer_bin = build_producer();
+    let mut producer = Command::new(&producer_bin)
+        .arg("produce_record_header")
+        .arg(&shm_name)
+        .spawn()
+        .expect("spawn producer");
+    std::thread::sleep(std::time::Duration::from_millis(80));
+    let consumer_out = Command::new(&consumer_bin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run consumer");
+    let producer_status = producer.wait().expect("wait producer");
+    let _ = std::fs::remove_file(&producer_bin);
+    let _ = std::fs::remove_file(&consumer_bin);
+
+    assert!(producer_status.success(), "producer failed: {:?}", producer_status);
+    assert!(
+        consumer_out.status.success(),
+        "consumer failed: status={:?}\nstderr: {}",
+        consumer_out.status,
+        String::from_utf8_lossy(&consumer_out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&consumer_out.stdout);
+
+    // Record i (1-based): val=(i)*7, seq=i, kns=i*1000, uns=i*1000+7.
+    for i in 1..=40i64 {
+        let want = format!(
+            "rec val={} seq={} kns={} uns={}",
+            i * 7, i, i * 1000, i * 1000 + 7
+        );
+        assert!(stdout.contains(&want), "missing `{}`. stdout:\n{}", want, stdout);
+    }
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -4737,7 +4737,10 @@ impl<'a> Checker<'a> {
                 if !matches!(a.key.name.as_str(),
                     "len_prefix" | "align" | "pad_sentinel" | "slot_size"
                     | "record_header_bytes" | "pad_field_offset"
-                    | "pad_field_width" | "pad_field_value" | "recheck") {
+                    | "pad_field_width" | "pad_field_value" | "recheck"
+                    | "seq_offset" | "seq_width"
+                    | "kernel_ns_offset" | "kernel_ns_width"
+                    | "user_ns_offset" | "user_ns_width") {
                     self.diags.push(Diag::warn(
                         a.span,
                         format!(
@@ -4846,6 +4849,45 @@ impl<'a> Checker<'a> {
                             "ring_layout `{}`: unknown recheck mode (only `post_copy`)",
                             r.name.name)));
                     }
+                }
+            }
+            // #5 follow-on: in-band header field offsets/widths
+            // (seq/kernel_ns/user_ns) must fit inside the record header.
+            for (off_key, w_key) in [
+                ("seq_offset", "seq_width"),
+                ("kernel_ns_offset", "kernel_ns_width"),
+                ("user_ns_offset", "user_ns_width"),
+            ] {
+                let off = attr_int(off_key);
+                let w = attr_int(w_key);
+                if off.is_none() && w.is_none() {
+                    continue;
+                }
+                let span = fr.span;
+                match (off, w) {
+                    (Some(o), Some(width)) => {
+                        if !matches!(width, 1 | 2 | 4 | 8) {
+                            self.diags.push(Diag::ty(span, format!(
+                                "ring_layout `{}`: {} must be 1/2/4/8, got {}",
+                                r.name.name, w_key, width)));
+                        }
+                        if o < 0 {
+                            self.diags.push(Diag::ty(span, format!(
+                                "ring_layout `{}`: {} must be non-negative",
+                                r.name.name, off_key)));
+                        } else if let Some(rhv) = rh {
+                            if rhv > 0 && (o + width) as i64 > rhv {
+                                self.diags.push(Diag::ty(span, format!(
+                                    "ring_layout `{}`: header field [{}, {}) falls \
+                                     outside the {}-byte record header",
+                                    r.name.name, o, o + width, rhv)));
+                            }
+                        }
+                    }
+                    _ => self.diags.push(Diag::ty(span, format!(
+                        "ring_layout `{}`: header field `{}` needs both {} and {}",
+                        r.name.name, off_key.trim_end_matches("_offset"),
+                        off_key, w_key))),
                 }
             }
         }

--- a/crates/hale-types/tests/ring_layout.rs
+++ b/crates/hale-types/tests/ring_layout.rs
@@ -51,12 +51,21 @@ ring_layout WsFast {
         len_prefix u32; align 8;
         record_header_bytes 32;
         pad_field_offset 4; pad_field_width 1; pad_field_value 1;
+        seq_offset 8; seq_width 8;
+        kernel_ns_offset 16; kernel_ns_width 8;
         recheck post_copy;
     }
     overflow lap_detect;
 }
 "#;
     assert!(check(valid).is_empty(), "valid record_header should be clean; got: {:?}", check(valid));
+
+    // A declared header field beyond the record header → error.
+    let bad_field = valid.replace("seq_offset 8;", "seq_offset 40;");
+    assert!(
+        check(&bad_field).iter().any(|m| m.contains("outside the")),
+        "got: {:?}", check(&bad_field)
+    );
 
     // record_header_bytes not a multiple of align → error (the stride
     // formula header + align(len) would not hold).

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -970,9 +970,14 @@ the payload then starts `N` bytes into the record and the stride is
 a tail pad with a header *field* rather than a `len` sentinel (e.g. a
 `kind` byte where `1` means padding) declares
 `pad_field_offset` / `pad_field_width` / `pad_field_value`; a record
-whose field equals that value is skipped to the wrap. (Surfacing the
-named header fields to the handler is a follow-on; v1 delivers the
-payload as a `BytesView` with the header consumed by the framer.)
+whose field equals that value is skipped to the wrap. The in-band
+header scalars are surfaced to the handler by declaring their offsets
+(`seq_offset` / `seq_width`, `kernel_ns_offset` / `kernel_ns_width`,
+`user_ns_offset` / `user_ns_width`): the reader decodes them per record
+into thread-locals the subscribe handler reads via
+`std::shm::last_record_{seq, kernel_ns, user_ns}()` — the errno-style
+idiom of `recv_stamped`'s `last_recv_*_ns`. The payload itself is still
+delivered as the `BytesView` / typed value.
 `recheck post_copy` adds a torn-read guard: each record is copied out,
 an acquire fence taken, and the cursor re-read; if a free-running
 producer lapped the record during the copy it is discarded rather than


### PR DESCRIPTION
## What

The #5 follow-on — surface a foreign ring's per-record header scalars (sequence number, kernel/user RX timestamps) to the subscribe handler. This completes the ws-fast consumption story: a Hale market-data consumer reads the ring's records **zero-copy with the in-band wire timestamps**, no syscall.

## Mechanism (thread-local getters)

Per the decision: **thread-local getters**, not the payload-struct prefix — because ws-fast's payloads are *variable*-length, the getter idiom serves them cleanly (the payload stays a `BytesView`) with no struct-with-view construction. Same errno-style shape as `recv_stamped`'s `last_recv_*_ns`.

A `byte_records` framing declares where the header scalars live via flat attrs (zero grammar change, exactly like `pad_field`):

```
seq_offset 8;  seq_width 8;
kernel_ns_offset 16;  kernel_ns_width 8;
user_ns_offset 24;  user_ns_width 8;
```

The reader decodes each present field (LE, zero-extended) from each record's header into a thread-local just before dispatch; the handler reads them via `std::shm::last_record_{seq, kernel_ns, user_ns}() -> Int` immediately (same reader thread).

## How

- **runtime** (`lotus_shm_ring.c`): 6 descriptor fields + 3 `__thread` slots + `lotus_shm_last_record_*` getters; the byte_records loop decodes the declared fields before dispatch.
- **codegen**: descriptor 27 → 33 words; `std::shm::last_record_*` getter dispatch.
- **typecheck**: each declared field must fit inside `record_header_bytes`.

## Testing

`shm_ring_record_header_fields.rs`: the `produce_record_header` driver now writes `seq@8` / `kernel_ns@16` / `user_ns@24`; a Hale `BytesView` subscriber reads the payload **and** all three header fields per record across the wrapping ring. Plus a `ring_layout.rs` typecheck case (field beyond the header → error).

The C driver's hand-built descriptor arrays bumped 27 → 33 (the runtime now reads those words); the existing `shm_ring_layout` suite (10) + corpus oracle stay green.

## Plan status

The fast-protocol-I/O substrate plan and its one follow-on are now **fully complete**: ✅ #1 recv_stamped · ✅ #2 TCP_NODELAY · ✅ #3 MirrorRing · ✅ #4 byte primitives · ✅ #5 ring_layout record_header **+ field delivery (this)** · ✅ #6 recv-alloc audit · ✅ #7 gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
