### PR TITLE
chore: neutralize external/internal proper-noun references in foreign-ring work

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -14089,7 +14089,7 @@ int64_t lotus_tcp_recv_stamped(int fd, void *builder, int64_t max_bytes) {
     /* Defensive cmsg read: inspect ONLY the first control message and
      * validate its length before touching the payload. We never walk
      * with CMSG_NXTHDR — some libcs loop forever on a zero-length cmsg
-     * (ws-fast's socket.rs learned this the hard way) — and we only ever
+     * (the reference crate's socket.rs learned this the hard way) — and we only ever
      * enable the single SCM_TIMESTAMPNS option, so the first cmsg is all
      * there is to read. MSG_CTRUNC means the control data was truncated;
      * skip rather than read a partial timespec. */

--- a/crates/hale-codegen/runtime/lotus_shm_ring.c
+++ b/crates/hale-codegen/runtime/lotus_shm_ring.c
@@ -291,14 +291,14 @@ typedef struct {
     /* 2026-06-13 (#5, fast-protocol-I/O): record_header support for
      * byte_records. `record_header_bytes` is the fixed per-record
      * header size before the payload (0 = the len_prefix-only model,
-     * where the prefix IS the whole header). ws-fast's record is a
+     * where the prefix IS the whole header). the reference crate's record is a
      * 32-byte header (len@0:u32, kind, opcode, seq, kernel_ns, user_ns)
      * then payload, so the payload starts at record_header_bytes and the
      * stride is align_up(record_header_bytes + len, align) — equal to
      * record_header_bytes + align(len) because record_header_bytes is
      * required to be a multiple of align. `len` is still read at record
      * offset 0 with len_prefix_width. A producer that marks a tail pad
-     * with a header *field* (ws-fast: kind==1) rather than a len
+     * with a header *field* (the reference crate: kind==1) rather than a len
      * sentinel sets has_pad_field + pad_field_{off,width,value}. */
     uint64_t record_header_bytes;
     uint64_t pad_field_off;
@@ -1361,7 +1361,7 @@ static void *shm_ring_layout_reader_thread(void *arg) {
                 break;
             }
             uint64_t phys = d->data_at + pos;
-            /* Header-field pad marker (e.g. ws-fast kind==1): the
+            /* Header-field pad marker (e.g. the reference crate kind==1): the
              * producer wrote a tail pad to avoid straddling the wrap.
              * Jump to the next boundary. Checked before len so a pad
              * record's len field is never interpreted as a real length. */

--- a/crates/hale-codegen/src/bus/runtime.rs
+++ b/crates/hale-codegen/src/bus/runtime.rs
@@ -426,9 +426,9 @@ fn ring_layout_descriptor_words(
 
     // [11..15] framing: len_prefix width, align, pad_sentinel.
     // [21..27] (#5, fast-protocol-I/O): record_header_bytes (fixed
-    // per-record header before the payload — ws-fast's 32-byte
+    // per-record header before the payload — the reference crate's 32-byte
     // len/kind/opcode/seq/kernel_ns/user_ns), a header-field padding
-    // discriminant (pad_field_offset/width/value — ws-fast marks a
+    // discriminant (pad_field_offset/width/value — the reference crate marks a
     // tail pad with kind==1, not a len sentinel), and the post_copy
     // lap re-check flag.
     w[12] = 1; // align default (no sub-record padding)

--- a/crates/hale-codegen/tests/shm_ring_layout_driver.c
+++ b/crates/hale-codegen/tests/shm_ring_layout_driver.c
@@ -595,7 +595,7 @@ static int run_produce_external(const char *name) {
 }
 
 /* record_header external producer (#5, fast-protocol-I/O). Writes
- * ws-fast-shaped records: a fixed 32-byte header (len@0:u32, kind@4:u8
+ * fixed-header records: a fixed 32-byte header (len@0:u32, kind@4:u8
  * — 0 Data, 1 Padding) then the payload, stride = 32 + align8(len).
  * Records never straddle the wrap: when one won't fit before the
  * boundary, a kind==1 pad record fills the remainder. No in-process
@@ -645,7 +645,7 @@ static int run_produce_record_header(const char *name) {
         uint64_t off = DATA_AT + (local % capacity);
         *(uint32_t *)(base + off + RH_LEN_OFF) = (uint32_t)plen;
         *(uint8_t *)(base + off + RH_KIND_OFF) = 0;       /* Data */
-        /* In-band header fields (ws-fast shape): seq@8, kernel_ns@16,
+        /* In-band header fields (the reference crate shape): seq@8, kernel_ns@16,
          * user_ns@24 — surfaced to the consumer via std::shm::last_record_*. */
         *(uint64_t *)(base + off + 8)  = (uint64_t)(i + 1);
         *(uint64_t *)(base + off + 16) = (uint64_t)((i + 1) * 1000);

--- a/crates/hale-codegen/tests/shm_ring_layout_record_header.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_record_header.rs
@@ -2,13 +2,13 @@
 //! fast-protocol-I/O substrate plan).
 //!
 //! A foreign ring whose records have a fixed 32-byte header
-//! (len@0:u32, kind@4:u8 — ws-fast's shape) before the payload: stride is
+//! (len@0:u32, kind@4:u8 — the reference crate's shape) before the payload: stride is
 //! `record_header_bytes + align(len)`, the payload starts past the header,
 //! and a `kind == 1` header field marks a tail pad (not a len sentinel).
 //! Without `record_header_bytes` the reader would desync after one record.
 //!
 //! End-to-end: the C producer (`shm_ring_layout_driver.c
-//! produce_record_header`) writes 40 ws-fast-shaped records through a small
+//! produce_record_header`) writes 40 fixed-header records through a small
 //! ring (forcing repeated kind==1 tail pads at the wrap); a Hale BytesView
 //! subscriber bound with `record_header_bytes`/`pad_field`/`recheck
 //! post_copy` reads each i64 payload in order.
@@ -60,7 +60,7 @@ fn hale_subscriber_reads_record_header_ring_with_post_copy() {
 
     let src = format!(
         r#"
-        ring_layout WsFastish {{
+        ring_layout FixedHdrRing {{
             magic 0x52494E47464D5431;
             version 1 at 8 : u32;
             buffer_size at 12 : u32;
@@ -90,7 +90,7 @@ fn hale_subscriber_reads_record_header_ring_with_post_copy() {
 
         main locus App {{
             bindings {{
-                Recs: shm_ring("{shm_name}", on_overflow: drop, layout: WsFastish);
+                Recs: shm_ring("{shm_name}", on_overflow: drop, layout: FixedHdrRing);
             }}
         }}
 

--- a/crates/hale-codegen/tests/shm_ring_record_header_fields.rs
+++ b/crates/hale-codegen/tests/shm_ring_record_header_fields.rs
@@ -9,7 +9,7 @@
 //! BytesView; this surfaces the in-band sequence number + kernel/user
 //! timestamps a market-data consumer wants.
 //!
-//! End-to-end: the C producer (`produce_record_header`) writes ws-fast-shaped
+//! End-to-end: the C producer (`produce_record_header`) writes fixed-header
 //! records with seq@8 / kernel_ns@16 / user_ns@24, and a Hale BytesView
 //! subscriber reads both the payload and the three header fields per record.
 
@@ -60,7 +60,7 @@ fn hale_subscriber_reads_in_band_header_fields() {
 
     let src = format!(
         r#"
-        ring_layout WsFastish {{
+        ring_layout FixedHdrRing {{
             magic 0x52494E47464D5431;
             version 1 at 8 : u32;
             buffer_size at 12 : u32;
@@ -94,7 +94,7 @@ fn hale_subscriber_reads_in_band_header_fields() {
 
         main locus App {{
             bindings {{
-                Recs: shm_ring("{shm_name}", on_overflow: drop, layout: WsFastish);
+                Recs: shm_ring("{shm_name}", on_overflow: drop, layout: FixedHdrRing);
             }}
         }}
 

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -4761,7 +4761,7 @@ impl<'a> Checker<'a> {
         // `align` (so the reader's align_up(hdr + len, align) stride equals
         // header + align(len)) and at least len_prefix wide (the len field
         // lives at record offset 0). A pad_field (a header discriminant
-        // marking a tail pad, e.g. ws-fast kind==1) must fit inside the
+        // marking a tail pad, e.g. the reference crate kind==1) must fit inside the
         // header. `recheck` only knows `post_copy`.
         if let Some(fr) = &r.framing {
             let attr_int = |key: &str| -> Option<i64> {

--- a/crates/hale-types/tests/ring_layout.rs
+++ b/crates/hale-types/tests/ring_layout.rs
@@ -38,10 +38,10 @@ fn valid_layout_is_clean() {
 
 #[test]
 fn record_header_clean_and_validated() {
-    // A valid record_header layout (ws-fast-ish: 32-byte header, kind-pad,
+    // A valid record_header layout (fixed-header: 32-byte header, kind-pad,
     // post_copy recheck) typechecks clean.
     let valid = r#"
-ring_layout WsFast {
+ring_layout FixedHdrRing {
     magic 0x52494E47464D5431;
     version 1 at 8 : u32;
     buffer_size at 12 : u32;

--- a/crates/hale-types/tests/ring_layout_binding.rs
+++ b/crates/hale-types/tests/ring_layout_binding.rs
@@ -166,7 +166,7 @@ locus Sub {{
 }}
 main locus App {{
     bindings {{
-        Recs: shm_ring("/foreign.ticks", on_overflow: drop, layout: MagusRing);
+        Recs: shm_ring("/foreign.ticks", on_overflow: drop, layout: ForeignRing);
     }}
 }}
 fn main() {{ App {{ }}; Sub {{ }}; }}

--- a/notes/binary-shm-ring-interop.md
+++ b/notes/binary-shm-ring-interop.md
@@ -262,19 +262,19 @@ runtime already does for `LRSRNG1`; this just parameterizes it.
 
 > **#5 (LANDED, 2026-06-13): record headers + post-copy recheck**
 > (fast-protocol-I/O substrate plan). Extends `byte_records` so a
-> producer with a fixed per-record header before the payload (ws-fast's
+> producer with a fixed per-record header before the payload (the reference crate's
 > 32-byte `len/kind/opcode/seq/kernel_ns/user_ns`) can be consumed
 > correctly — without it the reader desyncs after one record. New
 > `byte_records` framing attributes (all `ring_attr`, no grammar
 > change): `record_header_bytes N` (payload starts at `N`, stride
 > `N + align(len)`, `N % align == 0`), `pad_field_offset/width/value`
-> (a header-field padding marker — ws-fast's `kind == 1` — instead of a
+> (a header-field padding marker — the reference crate's `kind == 1` — instead of a
 > `len` sentinel), and `recheck post_copy` (copy → acquire fence →
 > reload cursor → discard-if-lapped torn-read guard). Descriptor grows
 > 21 → 27 words; the consumer loop substitutes `header_bytes` for
 > `len_prefix_width` in the payload offset / room / stride and adds the
 > pad-field + post-copy branches. Validated end-to-end by a C
-> producer writing ws-fast-shaped records through a small wrapping ring
+> producer writing fixed-header records through a small wrapping ring
 > (`shm_ring_layout_driver.c produce_record_header`) ↔ a Hale
 > `BytesView` subscriber (`shm_ring_layout_record_header.rs`), plus
 > typecheck tests. **Correctness slice only:** the payload is delivered

--- a/notes/fast-protocol-io-substrate-2026-06-13.md
+++ b/notes/fast-protocol-io-substrate-2026-06-13.md
@@ -20,11 +20,11 @@ the design rationale; the syntax that shipped differs in spots — e.g. the
 header fields are surfaced via thread-local getters rather than a
 payload-struct prefix; see `spec/` for the shipped surface).
 
-**Provenance.** Prompted by a teardown of `sorcery-labs/ws-fast` (MIT, Rust,
+**Provenance.** Prompted by a teardown of a reference low-latency WebSocket ingress crate (MIT, Rust,
 ~6.9k LOC) — a sync, caller-driven WebSocket *ingress* crate for HFT
 market-data. We compared it against `pond/websocket` to ask "can we beat it?"
 The useful answer turned out to be a substrate question, not a library one,
-and it generalizes well past WebSocket. Credit to ws-fast for the design; the
+and it generalizes well past WebSocket. Credit to the reference crate for the design; the
 techniques below are largely theirs, recast as Hale substrate work.
 
 ---
@@ -40,7 +40,7 @@ should own. If they live in `std::*` + codegen + runtime, then `pond/http`,
 `pond/pq`, `pond/websocket`, and every future protocol get them for free, and
 the libraries stay thin — which is the whole Hale bet.
 
-A speed story that lives in a library (the ws-fast model) is the anti-Hale
+A speed story that lives in a library (the reference-crate model) is the anti-Hale
 outcome. The Hale outcome is a fast substrate that makes the library trivial.
 
 This note enumerates the gaps, sketches the stdlib shape and the codegen/
@@ -50,7 +50,7 @@ two specific places.
 
 ---
 
-## Where ws-fast's speed actually comes from
+## Where the reference crate's speed actually comes from
 
 Categorized as **(A)** substrate gap absent from Hale today, **(B)** a
 codegen/runtime property Hale's model targets but must be shown to achieve, or
@@ -101,7 +101,7 @@ std::io::tcp::last_recv_user_ns()   -> Int;   // clock_gettime(CLOCK_REALTIME) a
 Runtime: a `lotus_tcp_recv_stamped` that builds the `msghdr`/cmsg buffer, does
 one `recvmsg`, and walks control messages **defensively** (refuse zero-length
 or short cmsg headers; do not use `CMSG_NXTHDR` macros — some libcs infinite-
-loop on a zero-length cmsg; ws-fast's `socket.rs` learned this). One setsockopt
+loop on a zero-length cmsg; the reference crate's `socket.rs` learned this). One setsockopt
 (`SO_TIMESTAMPNS`) at socket setup. Benefits: every protocol gets wire-arrival
 time with no extra syscall. This is the first thing to ship.
 
@@ -148,18 +148,18 @@ every length/delimiter-framed parser (HTTP header CRLF, etc.).
 
 ### 5. `ring_layout`: a per-record header + post-copy lap re-check  ·  MEDIUM leverage, MEDIUM cost
 
-`ring_layout` (Proposal B) already consumes foreign SPMC rings — and ws-fast's
-bus (`ws_fast_bus.h`) is exactly such a ring with a published C ABI. But it
+`ring_layout` (Proposal B) already consumes foreign SPMC rings — and the reference crate's
+bus (`the foreign bus ABI header`) is exactly such a ring with a published C ABI. But it
 **cannot be consumed today**, for two precise reasons (byte-level detail in the
 appendix):
 
 - `byte_records` assumes the only per-record overhead is the length prefix:
-  stride = `align_up(len_prefix + len, align)`. ws-fast's record header is
+  stride = `align_up(len_prefix + len, align)`. The reference crate's record header is
   **32 bytes** (`len, kind, opcode, seq, kernel_ns, user_ns`), so its stride is
   `32 + align8(len)`. A Hale reader computes the wrong stride and desyncs after
   one record, and has no way to read `seq`/timestamps.
 - Hale's `lap_detect` (per `spec/semantics.md` ~L1140) is a **pre-read** resync.
-  ws-fast's correctness rests on a **post-copy** re-check (copy → acquire fence
+  the reference crate's correctness rests on a **post-copy** re-check (copy → acquire fence
   → reload cursor → re-verify the window still exceeds the stride) that proves
   the copied bytes were not clobbered *during* the copy by the free-running
   writer. Without it, a fast foreign producer can hand a torn record to the
@@ -169,13 +169,13 @@ Proposed: a `record_header N { name at off : repr; ... }` block inside
 `framing byte_records` (reusing the segment-header scalar mechanism), so stride
 = `record_header_bytes + align(len)` and the named fields are delivered
 alongside the payload view; plus an `overflow lap_detect { recheck post_copy; }`
-knob. This single change is where "consume ws-fast" and "fix the substrate"
+knob. This single change is where "consume the reference crate" and "fix the substrate"
 become the *same* work — and it also enriches Hale's own producer side.
 
 ### 6. Audit + bound `std::io::tls` plaintext allocation  ·  MEDIUM leverage, MEDIUM–HIGH cost
 
 Every TLS protocol pays whatever `std::io::tls`'s OpenSSL binding allocates per
-record. ws-fast measured rustls at exactly one alloc + one copy per app-data
+record. The reference crate measured rustls at exactly one alloc + one copy per app-data
 record and *pinned it with a test*. We should measure `lotus_tls.c`'s behavior,
 drive `recv_into` toward bounded/zero per-record allocation, and gate it (§7).
 `SSL_MODE_RELEASE_BUFFERS` is already set (good); the open question is the
@@ -183,16 +183,16 @@ per-record plaintext copy.
 
 ### 7. Test-time guarantees: the rigor that *keeps* the wins  ·  MEDIUM leverage, MEDIUM cost
 
-The wins above regress silently without gates. ws-fast's real moat is its test
+The wins above regress silently without gates. The reference crate's real moat is its test
 harness, and the disciplines port even if the code doesn't:
 
 - **Allocation gate** — a global-allocator shim that counts alloc/dealloc, with
   a `window { ... }` helper asserting *zero* (or an exact pinned count) inside
   a steady-state region. Hale has `--warn-unbounded-alloc` at compile time;
   this is the runtime/test-time complement ("this loop did zero allocs").
-- **Syscall gate** — assert "exactly one `recvmsg` per poll" (ws-fast re-execs
+- **Syscall gate** — assert "exactly one `recvmsg` per poll" (the reference crate re-execs
   under `strace -c -e trace=recvmsg`; an interposed counter works too).
-- **Conformance-as-pinned-regression** — adopt ws-fast's autobahn rule: pin the
+- **Conformance-as-pinned-regression** — adopt the reference crate's autobahn rule: pin the
   per-case verdict, and treat a *new pass* as a regression-until-justified, not
   just a new failure. It caught two real bugs for them.
 
@@ -208,7 +208,7 @@ harness, and the disciplines port even if the code doesn't:
 
 2. **We are not chasing hand-tuned-Rust ns-per-syscall on a single socket.**
    Every Hale syscall crosses the managed FFI boundary with arena-snapshot
-   semantics; ws-fast's `recvmsg` is a direct libc call. Substrate work shrinks
+   semantics; the reference crate's `recvmsg` is a direct libc call. Substrate work shrinks
    the per-call overhead but does not erase it. And kernel timestamps measure
    wire arrival — if a cooperative pool then schedules the handler behind other
    work, end-to-end latency includes jitter the stamp can't see. The target is
@@ -220,11 +220,11 @@ harness, and the disciplines port even if the code doesn't:
    `recvmsg`-for-WebSocket. The parse hot loop stays in the library and is
    written to the grain — and a *general* parser (fragmentation, HTTP/2,
    compression negotiation) inherently pays more branches than a deliberately
-   narrow one like ws-fast's. The I/O floor generalizes cleanly; the parse loop
+   narrow one like the reference crate's. The I/O floor generalizes cleanly; the parse loop
    generalizes only as *primitives*.
 
 4. **No hidden async runtime, no compression in the hot path** — these are
-   ws-fast's non-goals too, and for the same reason (zero-copy + predictability).
+   the reference crate's non-goals too, and for the same reason (zero-copy + predictability).
 
 ---
 
@@ -235,7 +235,7 @@ harness, and the disciplines port even if the code doesn't:
    `pond/websocket`. Land first.
 2. **#4 (byte primitives)** — cheap, isolated.
 3. **#3 (MirrorRing) and #5 (ring_layout record header)** — the two structural
-   items; #5 unblocks foreign-ring interop (incl. consuming ws-fast).
+   items; #5 unblocks foreign-ring interop (incl. consuming the reference crate).
 4. **#6 (TLS audit) and #7 (gates)** — ongoing; #7 should land alongside #1 so
    the first wins are pinned from day one.
 
@@ -249,20 +249,20 @@ harness, and the disciplines port even if the code doesn't:
   same pass (reuse a cork buffer instead of a fresh `BytesBuilder` per frame;
   pre-buffer `getrandom` entropy instead of one syscall per frame; block-XOR
   masking via #4 instead of byte-by-byte `from_int`).
-- A `ring_layout WsFastBus` (appendix) consuming a live ws-fast segment
+- A `ring_layout RefBus` (appendix) consuming a live reference-crate segment
   zero-copy with in-band kernel timestamps — the concrete interop proof.
 
 ---
 
-## Appendix — the exact `ring_layout` gap vs `ws_fast_bus.h`
+## Appendix — the exact `ring_layout` gap vs `the foreign bus ABI header`
 
-**ws-fast segment** (little-endian, 64-bit): `magic@0` (`"WSFBUS01"` =
+**the reference crate segment** (little-endian, 64-bit): `magic@0` (`"WSFBUS01"` =
 `0x5753464255533031`, written last at init), `version@8:u32`, `capacity@16:u64`
 (power of two), `generation@24:u64`, `write_cursor@128` (atomic u64, *alone on
 its cache line* — the 128-byte isolation matters on both 64 B x86 and 128 B
 Apple lines), `data@256`.
 
-**ws-fast record** (8-byte aligned, never wraps; stride = `32 + ((len+7)&~7)`):
+**the reference crate record** (8-byte aligned, never wraps; stride = `32 + ((len+7)&~7)`):
 
 | off | field | repr | note |
 |---|---|---|---|
@@ -285,7 +285,7 @@ offers no way to surface `seq`/`kernel_ns`/`user_ns`.
 settle):
 
 ```hale
-ring_layout WsFastBus {
+ring_layout RefBus {
     magic 0x5753464255533031;
     version    1  at 8  : u32;
     buffer_size   at 16 : u64;            // capacity
@@ -311,10 +311,10 @@ ring_layout WsFastBus {
 
 Delivered-record access: the handler receives the payload `BytesView` plus
 generated accessors for the named header fields (`rec.seq()`, `rec.kernel_ns()`,
-`rec.opcode()`), so a Hale market-data consumer reads ws-fast's output
+`rec.opcode()`), so a Hale market-data consumer reads the reference crate's output
 zero-copy *with* wire-arrival timestamps and never makes a syscall to get them.
 
-References: `ws_fast_bus.h` (the ABI + the literate reader proof),
+References: `the foreign bus ABI header` (the ABI + the literate reader proof),
 `src/bus.rs` (Rust side + layout test against the header), `src/ring.rs`
 (MirrorRing), `src/socket.rs` (recvmsg + cmsg walk), `tests/{no_alloc,
 syscall_gate,bus_layout}.rs` (the rigor bar).


### PR DESCRIPTION
Replaces a named external reference crate and an internal-system-derived fixture name with neutral terms across the ring_layout / record-header comments, tests, and design notes (`ForeignRing` / `FixedHdrRing` fixtures; "the reference crate" / "a reference low-latency WebSocket ingress crate" for the external design). Comments, fixture names, and notes only — no behavior change. Established domain framing already pervasive in the repo is left as-is; scoped to the named proper nouns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)