### PR TITLE
fix(shm): post_copy torn-read guard resyncs at cap-S, not a full lap

### DIFF
--- a/crates/hale-codegen/runtime/lotus_shm_ring.c
+++ b/crates/hale-codegen/runtime/lotus_shm_ring.c
@@ -979,6 +979,12 @@ int lotus_bus_publish_shm_ring_layout(const char *subject,
                     (unsigned long long)cap);
             _exit(1);
         }
+        /* Release fence before this record's body stores, ordering the
+         * PREVIOUS record's cursor publish ahead of them (proof part (a),
+         * the foreign bus ABI header). Without it, on a weakly-ordered CPU (ARM) a
+         * reader could observe a body clobber before the cursor advance
+         * that proves it, and accept a torn record. A no-op on x86-TSO. */
+        atomic_thread_fence(memory_order_release);
         /* Tail-pad if the record would straddle the wrap. `p->pos`
          * tracks `p->local % cap` incrementally — no per-record modulo. */
         uint64_t pos = p->pos;
@@ -1055,6 +1061,11 @@ void *lotus_bus_reserve_shm_ring_layout(const char *subject, uint64_t max) {
         }
         p->reserved_max = max;
         p->has_reservation = 1;
+        /* Release fence before the caller's body stores into the reserved
+         * slot, ordering the previous publish ahead of them (proof part
+         * (a), the foreign bus ABI header). The matching publish is the release store
+         * in lotus_bus_commit_shm_ring_layout. */
+        atomic_thread_fence(memory_order_release);
         return base + d->data_at + pos + d->len_prefix_width;
     }
     fprintf(stderr,
@@ -1311,9 +1322,22 @@ static void *shm_ring_layout_reader_thread(void *arg) {
      * align_up(hdr + len, align) stride equals hdr + align(len). */
     uint64_t hdr = d->record_header_bytes ? d->record_header_bytes
                                           : d->len_prefix_width;
-    /* Scratch for the post_copy torn-read guard: a record is memcpy'd
-     * here, then the cursor is re-read; if it was lapped during the copy
-     * the record is discarded. Grown on demand, freed at thread exit. */
+    /* Torn-read slack S and the safe window — matches the reference crate's
+     * bus proof (the foreign bus ABI header). A reader's copy of the record at logical
+     * `local` is provably untorn only while the producer has not advanced
+     * to within S bytes of lapping it, i.e. while `cursor - local <=
+     * cap - S`. S also bounds the largest record the reader will accept.
+     * S = min(cap/4, 1 MiB), the same expression the producer uses. */
+    uint64_t S = cap / 4;
+    if (S > (1ull << 20)) S = 1ull << 20;
+    if (S == 0) S = cap;                       /* degenerate tiny ring */
+    uint64_t window = (S < cap) ? cap - S : 0;
+    /* Scratch for the post_copy torn-read guard: the whole record (header
+     * + payload, <= S bytes) is memcpy'd here, then the cursor is re-read
+     * behind an acquire fence; the record is discarded if the producer
+     * lapped into it during the copy. Sized once to S — no per-record
+     * realloc, and never an unguarded fallback dispatch. Allocated lazily
+     * below, only when the layout asks for the recheck. */
     char  *scratch = NULL;
     size_t scratch_cap = 0;
     while (!atomic_load_explicit(&sub->should_stop,
@@ -1331,9 +1355,12 @@ static void *shm_ring_layout_reader_thread(void *arg) {
             nanosleep(&ts, NULL);
             continue;
         }
-        /* Lapped: missed bytes are gone — resync to a commit
-         * boundary and drop the gap. */
-        if (committed - local > cap) {
+        /* Lapped: missed bytes are gone — resync to a commit boundary and
+         * drop the gap. With the recheck on, resync at the safe window
+         * (cap - S) rather than a full cap, so we never even begin copying
+         * a record the producer has already reached. */
+        uint64_t lap_threshold = d->post_copy_recheck ? window : cap;
+        if (committed - local > lap_threshold) {
             local = committed;
             pos = committed % cap;
             continue;
@@ -1361,55 +1388,134 @@ static void *shm_ring_layout_reader_thread(void *arg) {
                 break;
             }
             uint64_t phys = d->data_at + pos;
-            /* Header-field pad marker (e.g. the reference crate kind==1): the
-             * producer wrote a tail pad to avoid straddling the wrap.
-             * Jump to the next boundary. Checked before len so a pad
-             * record's len field is never interpreted as a real length. */
+
+            if (d->post_copy_recheck) {
+                /* ---- Two-stage torn-read proof (the foreign bus ABI header) ----
+                 * A free-running producer can overwrite this record while
+                 * we read it. So: copy the HEADER, acquire-fence, re-read
+                 * the cursor — if the producer advanced past the safe
+                 * window (cap - S) during the copy, the header may be torn
+                 * and MUST NOT be parsed. Then parse `len` from the COPY,
+                 * bound it, copy the PAYLOAD, fence, and re-read again.
+                 * Only a record that survives both window checks is
+                 * authentic; its header fields AND payload are then read
+                 * from the stable copy, never from live (racing) memory. */
+                if (!scratch) {
+                    /* Size scratch once to S (the max record). On OOM, never
+                     * dispatch unguarded — back off and re-snapshot. */
+                    scratch = (char *)malloc((size_t)S);
+                    scratch_cap = scratch ? (size_t)S : 0;
+                    if (!scratch) {
+                        struct timespec ts = {0, 100 * 1000};  /* 100us */
+                        nanosleep(&ts, NULL);
+                        break;
+                    }
+                }
+                /* A conforming layout has hdr <= the smallest record <= S;
+                 * a hostile hdr that won't fit scratch can't be guarded. */
+                if ((uint64_t)hdr > (uint64_t)scratch_cap) {
+                    local = committed; pos = committed % cap; break;
+                }
+                memcpy(scratch, base + phys, (size_t)hdr);
+                atomic_thread_fence(memory_order_acquire);
+                uint64_t w1 = atomic_load_explicit(
+                    (const _Atomic uint64_t *)(base + d->cursor_off),
+                    memory_order_acquire);
+                if (w1 - local > window) {     /* header copy torn / lapped */
+                    local = w1; pos = w1 % cap; break;
+                }
+                /* All header decisions are made from the COPY (never live):
+                 * pad marker first, so a pad record's len field is never
+                 * read as a real length. */
+                if (d->has_pad_field) {
+                    uint64_t kv = shm_layout_read_uint(
+                        scratch + d->pad_field_off, d->pad_field_width);
+                    if (kv == d->pad_field_value) {
+                        local += cap - pos; pos = 0; continue;
+                    }
+                }
+                uint64_t len = shm_layout_read_uint(scratch,
+                                                    d->len_prefix_width);
+                if (d->has_pad_sentinel && len == d->pad_sentinel) {
+                    local += cap - pos; pos = 0; continue;
+                }
+                if (d->value_size != 0 && len != d->value_size) {
+                    local = committed; pos = committed % cap; break;
+                }
+                uint64_t room = cap - pos - hdr;
+                if (len == 0 || len > room) {
+                    local = committed; pos = committed % cap; break;
+                }
+                uint64_t step = hdr + len;
+                if (d->align > 1) {
+                    step = (step + d->align - 1) & ~(d->align - 1);
+                }
+                /* A record larger than the slack can never be proven
+                 * untorn (cap - S would be unsatisfiable) — treat an
+                 * over-large frame as corruption and resync. The second
+                 * clause guards the scratch payload write. */
+                if (step > S || (size_t)len > scratch_cap - (size_t)hdr) {
+                    local = committed; pos = committed % cap; break;
+                }
+                memcpy(scratch + hdr, base + phys + hdr, (size_t)len);
+                atomic_thread_fence(memory_order_acquire);
+                uint64_t w2 = atomic_load_explicit(
+                    (const _Atomic uint64_t *)(base + d->cursor_off),
+                    memory_order_acquire);
+                if (w2 - local > window) {     /* payload copy torn / lapped */
+                    local = w2; pos = w2 % cap; break;
+                }
+                /* Authentic. Surface the in-band header fields from the
+                 * STABLE COPY (so a torn/discarded record never leaks
+                 * stale seq/timestamps), then dispatch from the copy. */
+                if (d->seq_width) {
+                    g_last_record_seq = (int64_t)shm_layout_read_uint(
+                        scratch + d->seq_off, d->seq_width);
+                }
+                if (d->kernel_ns_width) {
+                    g_last_record_kernel_ns = (int64_t)shm_layout_read_uint(
+                        scratch + d->kernel_ns_off, d->kernel_ns_width);
+                }
+                if (d->user_ns_width) {
+                    g_last_record_user_ns = (int64_t)shm_layout_read_uint(
+                        scratch + d->user_ns_off, d->user_ns_width);
+                }
+                if (d->value_size == 0) {
+                    shm_layout_dispatch_view(sub, scratch + hdr, len);
+                } else {
+                    sub->handler_fn(sub->self_ptr, scratch + hdr);
+                }
+                local += step;
+                pos += step;
+                if (pos >= cap) pos -= cap;
+                continue;
+            }
+
+            /* ---- Non-recheck path: zero-copy live dispatch. Lossy + safe
+             * for an attach-after, non-free-running in-process producer
+             * (the consumer resyncs on a full-cap lap). Unchanged behavior;
+             * a free-running foreign producer should set `recheck
+             * post_copy` to get the torn-read proof above. ---- */
             if (d->has_pad_field) {
                 uint64_t kv = shm_layout_read_uint(
                     base + phys + d->pad_field_off, d->pad_field_width);
                 if (kv == d->pad_field_value) {
-                    local += cap - pos;
-                    pos = 0;
-                    continue;
+                    local += cap - pos; pos = 0; continue;
                 }
             }
             uint64_t len = shm_layout_read_uint(base + phys,
                                                 d->len_prefix_width);
             if (d->has_pad_sentinel && len == d->pad_sentinel) {
-                /* Tail pad — jump to the next wrap boundary. */
-                local += cap - pos;
-                pos = 0;
-                continue;
+                local += cap - pos; pos = 0; continue;
             }
-            /* The handler reads exactly `value_size` bytes; a conforming
-             * producer frames `len == value_size`. A non-conforming /
-             * hostile producer with a short (or long) record would let
-             * the handler read past the framed bytes — treat any
-             * mismatch as corruption and resync rather than dispatch.
-             * (Checking this first also pins `len` to a known-small
-             * value before the arithmetic below.) */
             if (d->value_size != 0 && len != d->value_size) {
-                local = committed;
-                pos = committed % cap;
-                break;
+                local = committed; pos = committed % cap; break;
             }
-            /* The record's payload must fit before the wrap. Overflow-
-             * safe: pos + hdr <= cap (checked above), so the room is
-             * `cap - pos - hdr`; compare `len` against it without adding
-             * the (attacker-controlled) len. */
             uint64_t room = cap - pos - hdr;
             if (len == 0 || len > room) {
-                local = committed;
-                pos = committed % cap;
-                break;
+                local = committed; pos = committed % cap; break;
             }
             char *payload = base + phys + hdr;
-            /* Surface the in-band header fields (#5 follow-on): decode the
-             * declared scalars from this record's header into thread-locals
-             * the handler reads via std::shm::last_record_*. Cheap when
-             * unused (widths are 0). Read before any post_copy copy so they
-             * reflect this record. */
             if (d->seq_width) {
                 g_last_record_seq = (int64_t)shm_layout_read_uint(
                     base + phys + d->seq_off, d->seq_width);
@@ -1422,53 +1528,9 @@ static void *shm_ring_layout_reader_thread(void *arg) {
                 g_last_record_user_ns = (int64_t)shm_layout_read_uint(
                     base + phys + d->user_ns_off, d->user_ns_width);
             }
-            if (d->post_copy_recheck) {
-                /* Copy the record out, take an acquire fence, then re-read
-                 * the cursor. A record starting at monotonic `local` is
-                 * intact only while the producer hasn't yet written
-                 * `local + cap` (which would overwrite its first physical
-                 * byte). If the re-read shows it lapped during our copy,
-                 * the copied bytes may be torn — discard and resync rather
-                 * than hand a frankenrecord to the handler. */
-                if (scratch_cap < (size_t)len) {
-                    char *ns = (char *)realloc(scratch, (size_t)len);
-                    if (ns) { scratch = ns; scratch_cap = (size_t)len; }
-                }
-                if (scratch_cap >= (size_t)len) {
-                    memcpy(scratch, payload, (size_t)len);
-                    atomic_thread_fence(memory_order_acquire);
-                    uint64_t recommitted = atomic_load_explicit(
-                        (const _Atomic uint64_t *)(base + d->cursor_off),
-                        memory_order_acquire);
-                    if (recommitted - local > cap) {
-                        local = recommitted;
-                        pos = recommitted % cap;
-                        break;
-                    }
-                    if (d->value_size == 0) {
-                        shm_layout_dispatch_view(sub, scratch, len);
-                    } else {
-                        sub->handler_fn(sub->self_ptr, scratch);
-                    }
-                } else {
-                    /* realloc failed — fall back to a zero-copy dispatch
-                     * (no torn-read guard this once) rather than drop. */
-                    if (d->value_size == 0) {
-                        shm_layout_dispatch_view(sub, payload, len);
-                    } else {
-                        sub->handler_fn(sub->self_ptr, payload);
-                    }
-                }
-            } else if (d->value_size == 0) {
-                /* Raw-frame mode: the bound payload is a BytesView, so
-                 * the consumer can't assume a fixed record size. Hand
-                 * the handler a bounded BytesView over the record payload;
-                 * it decodes (discriminator + std::bytes::read_*) itself.
-                 * The framed `len` is already validated to fit above. */
+            if (d->value_size == 0) {
                 shm_layout_dispatch_view(sub, payload, len);
             } else {
-                /* Typed-flat mode: the record IS the payload struct
-                 * (len == value_size, checked above); hand its pointer. */
                 sub->handler_fn(sub->self_ptr, payload);
             }
             uint64_t step = hdr + len;

--- a/crates/hale-codegen/tests/shm_ring_layout_driver.c
+++ b/crates/hale-codegen/tests/shm_ring_layout_driver.c
@@ -813,15 +813,156 @@ static int run_reserve_commit(const char *name) {
     return 0;
 }
 
+/* ---- torn-read regression: deterministic danger-band delivery ----
+ *
+ * The pre-fix post_copy guard resynced only after the producer had lapped by
+ * a full `cap` (`recommitted - local > cap`); the proof (the foreign bus ABI header)
+ * requires resyncing at the safe window `cap - S` (S = min(cap/4, 1 MiB)),
+ * because a producer within S of lapping can already be overwriting the
+ * record the reader is copying. So the bug is precisely: the reader delivers
+ * a record whose lag behind the cursor lies in the danger band (cap-S, cap),
+ * where a correct reader must resync instead.
+ *
+ * Rather than race two free-running threads (flaky — and the throttling
+ * needed to keep the reader off the live edge deadlocks the *fixed* reader,
+ * which resyncs past the backlog), this drives the window decision DIRECTLY
+ * and deterministically: plant one record at a lag in the danger band whose
+ * header seq disagrees with its payload (the shape a real mid-copy tear
+ * produces) and observe whether the reader delivers it.
+ *
+ *   correct reader (window = cap - S): resyncs past it → never delivered.
+ *   pre-fix reader (window = cap):     delivers it    → handler flags torn.
+ *
+ * A consistent control record at low lag is delivered first by BOTH readers,
+ * so a fixed reader's zero danger-band deliveries read as "correctly
+ * skipped", not "never ran". */
+#define CLOBBER_PLEN 60000   /* multiple of 16: word-wise scan + half split */
+#define CLOBBER_CAP  (1 << 20)
+static _Atomic long g_clobber_delivered = 0;
+static _Atomic long g_clobber_torn = 0;
+
+extern int64_t lotus_shm_last_record_seq(void);
+
+static void on_clobber(void *self, void *slot) {
+    (void)self;
+    /* A conforming record has every payload byte equal to (seq & 0xff), with
+     * seq taken from the same record's header — true only if the read was
+     * untorn. Word-wise compare (PLEN/8 u64s). */
+    const uint64_t *q = (const uint64_t *)slot;
+    int64_t seq = lotus_shm_last_record_seq();
+    uint64_t wantw = (uint64_t)(unsigned char)(seq & 0xff) * 0x0101010101010101ULL;
+    int torn = 0;
+    for (int i = 0; i < CLOBBER_PLEN / 8; i++) {
+        if (q[i] != wantw) { torn = 1; break; }
+    }
+    atomic_fetch_add_explicit(&g_clobber_delivered, 1, memory_order_relaxed);
+    if (torn) atomic_fetch_add_explicit(&g_clobber_torn, 1, memory_order_relaxed);
+}
+
+/* Plant one record at ring offset `pos`: header seq + a payload whose first
+ * half is byte `b0` and second half `b1`. b0 == b1 == seq&0xff is a
+ * conforming record; b1 != seq&0xff is a torn-looking one. */
+static void clobber_plant(char *base, uint64_t pos, uint64_t seq,
+                          unsigned char b0, unsigned char b1) {
+    uint64_t off = DATA_AT + pos;
+    *(uint32_t *)(base + off + RH_LEN_OFF) = (uint32_t)CLOBBER_PLEN;
+    *(uint8_t *)(base + off + RH_KIND_OFF) = 0;            /* Data */
+    *(uint64_t *)(base + off + 8) = seq;                   /* seq @ 8 */
+    memset(base + off + RH_BYTES, b0, CLOBBER_PLEN / 2);
+    memset(base + off + RH_BYTES + CLOBBER_PLEN / 2, b1, CLOBBER_PLEN / 2);
+}
+
+static int run_clobber(const char *name) {
+    uint64_t capacity = CLOBBER_CAP;
+    uint64_t S = capacity / 4;                                /* matches the reader */
+    uint64_t step = RH_BYTES + align_up(CLOBBER_PLEN, ALIGN); /* 32 + 60000 */
+    size_t total = DATA_AT + (size_t)capacity;
+    int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
+    if (fd < 0) { fprintf(stderr, "shm_open: %s\n", strerror(errno)); return 2; }
+    if (ftruncate(fd, (off_t)total) != 0) { shm_unlink(name); return 2; }
+    void *map = mmap(NULL, total, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (map == MAP_FAILED) { shm_unlink(name); return 2; }
+    char *base = (char *)map;
+    *(uint64_t *)(base + 0) = MAGIC;
+    *(uint32_t *)(base + VERSION_OFF) = (uint32_t)VERSION_VAL;
+    *(uint32_t *)(base + BUFSZ_OFF) = (uint32_t)capacity;
+    _Atomic uint64_t *cursor = (_Atomic uint64_t *)(base + CURSOR_OFF);
+    atomic_store_explicit(cursor, 0, memory_order_release);
+
+    /* record_header(32) + value_size(PLEN) + seq@8 + pad kind@4==1 +
+     * recheck post_copy. */
+    uint64_t desc[33] = {0};
+    desc[0]  = MAGIC;       desc[1]  = 1;
+    desc[2]  = VERSION_OFF; desc[3]  = VERSION_WIDTH; desc[4] = VERSION_VAL; desc[5] = 1;
+    desc[6]  = BUFSZ_OFF;   desc[7]  = BUFSZ_WIDTH;   desc[8] = 1;
+    desc[9]  = DATA_AT;     desc[10] = CURSOR_OFF;
+    desc[11] = LEN_WIDTH;   desc[12] = ALIGN;
+    desc[15] = CLOBBER_PLEN;                          /* value_size (typed) */
+    desc[21] = RH_BYTES;                              /* record_header_bytes */
+    desc[22] = RH_KIND_OFF; desc[23] = 1; desc[24] = 1; desc[25] = 1;  /* pad kind==1 */
+    desc[26] = 1;                                     /* post_copy_recheck */
+    desc[27] = 8;           desc[28] = 8;             /* seq @ 8, u64 */
+
+    lotus_bus_register_subscriber_shm_ring_layout(
+        "clobber.ticks", name, desc, NULL, on_clobber);
+    struct timespec warmup = {0, 5 * 1000 * 1000};  /* 5ms to attach + park at 0 */
+    nanosleep(&warmup, NULL);
+
+    /* Phase A — a CONSISTENT control record at low lag (1 record behind).
+     * Both readers deliver it; proves the reader thread is alive. */
+    clobber_plant(base, 0, /*seq*/ 1, /*b0*/ 1, /*b1*/ 1);
+    atomic_store_explicit(cursor, step, memory_order_release);
+    struct timespec settle = {0, 200 * 1000 * 1000};  /* 200ms */
+    nanosleep(&settle, NULL);
+
+    /* Phase B — a deliberately TORN record (header seq=2 but its second
+     * payload half is 99, not 2) planted at lag `danger` in the band
+     * (cap - S, cap). The reader, now parked at local=step, must decide:
+     * a correct window (cap - S) resyncs past it (never delivered); the
+     * pre-fix window (cap) delivers it and the handler flags the tear. */
+    clobber_plant(base, step, /*seq*/ 2, /*b0*/ 2, /*b1*/ 99);
+    uint64_t danger = capacity - S / 2;                /* in (cap - S, cap) */
+    atomic_store_explicit(cursor, step + danger, memory_order_release);
+    nanosleep(&settle, NULL);
+
+    long delivered = atomic_load_explicit(&g_clobber_delivered, memory_order_acquire);
+    long torn = atomic_load_explicit(&g_clobber_torn, memory_order_acquire);
+
+    /* The reader holds its own mapping; the atexit teardown stops + joins
+     * it. Drop the producer mapping + name. */
+    munmap(map, total); close(fd); shm_unlink(name);
+
+    fprintf(stderr, "clobber: delivered=%ld torn=%ld (lag=%llu band=(%llu,%llu))\n",
+            delivered, torn, (unsigned long long)danger,
+            (unsigned long long)(capacity - S), (unsigned long long)capacity);
+    if (delivered < 1) {
+        fprintf(stderr, "clobber: the reader never delivered the control "
+                "record — it is not reading; inconclusive\n");
+        return 4;
+    }
+    if (torn != 0) {
+        fprintf(stderr,
+                "clobber: a record at lag %llu in the danger band (cap-S, cap) "
+                "was delivered — the post_copy window is `cap`, not `cap-S`, so "
+                "the reader hands out records a free-running producer can be "
+                "overwriting mid-copy\n", (unsigned long long)danger);
+        return 3;
+    }
+    return 0;
+}
+
 int main(int argc, char **argv) {
     if (argc < 3) {
         fprintf(stderr,
                 "usage: %s <roundtrip|wrap|producer|producer_wrap|"
                 "bad_bufsize|short_record|u64_lenprefix|heterogeneous|"
                 "produce_external|lotus_dogfood|produce_native_external|"
-                "reserve_commit> <shm_name>\n",
+                "reserve_commit|clobber> <shm_name>\n",
                 argv[0]);
         return 1;
+    }
+    if (strcmp(argv[1], "clobber") == 0) {
+        return run_clobber(argv[2]);
     }
     if (strcmp(argv[1], "reserve_commit") == 0) {
         return run_reserve_commit(argv[2]);

--- a/crates/hale-codegen/tests/shm_ring_torn_read_stress.rs
+++ b/crates/hale-codegen/tests/shm_ring_torn_read_stress.rs
@@ -1,0 +1,84 @@
+//! Torn-read regression for the `post_copy` SPMC ring guard
+//! (fast-protocol-I/O #5, hardening 2026-06-13).
+//!
+//! The pre-fix guard resynced only after the producer had lapped by a full
+//! `cap`; the proof (the foreign bus ABI header) requires resyncing at the safe window
+//! `cap - S` (S = min(cap/4, 1 MiB)), because a producer within `S` of
+//! lapping can already be overwriting the record the reader is copying. So
+//! the bug is precisely that the reader delivers a record whose lag behind
+//! the cursor lies in the danger band (cap-S, cap).
+//!
+//! The C `clobber` driver drives that decision DETERMINISTICALLY (no thread
+//! race): it plants one record at a lag in the danger band whose header seq
+//! disagrees with its payload — the shape a real mid-copy tear produces —
+//! and checks whether the reader delivers it.
+//!
+//!   correct reader (window = cap - S): resyncs past it → never delivered.
+//!   pre-fix reader (window = cap):     delivers it    → driver returns rc 3.
+//!
+//! A consistent control record at low lag is delivered first by both readers,
+//! so a correct reader's zero danger-band deliveries read as "correctly
+//! skipped", not "never ran" (driver rc 4). Deterministic: fails on the bug,
+//! passes on the fix, every run.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn unique_tag() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("clobber-{}-{}", std::process::id(), nanos)
+}
+
+fn build_driver() -> PathBuf {
+    let mut driver_c = manifest_dir();
+    driver_c.push("tests");
+    driver_c.push("shm_ring_layout_driver.c");
+    let mut ring_c = manifest_dir();
+    ring_c.push("runtime");
+    ring_c.push("lotus_shm_ring.c");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("lotus_{}", unique_tag()));
+    let status = Command::new("clang")
+        .arg(&driver_c)
+        .arg(&ring_c)
+        .arg("-O2")
+        .arg("-lrt")
+        .arg("-lpthread")
+        .arg("-o")
+        .arg(&bin)
+        .status()
+        .expect("clang");
+    assert!(status.success(), "clang failed building the clobber driver");
+    bin
+}
+
+#[test]
+fn post_copy_guard_resyncs_past_danger_band_records() {
+    let bin = build_driver();
+    let shm_name = format!("/hale-{}", unique_tag());
+
+    let out = Command::new(&bin)
+        .arg("clobber")
+        .arg(&shm_name)
+        .output()
+        .expect("run clobber driver");
+
+    let _ = std::fs::remove_file(&bin);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    // Surface the `delivered=.. torn=..` line even on success (--nocapture).
+    eprint!("{stderr}");
+    assert!(
+        out.status.success(),
+        "torn-read regression failed: status={:?}\nstderr:\n{stderr}",
+        out.status,
+    );
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -4891,6 +4891,50 @@ impl<'a> Checker<'a> {
                         off_key, w_key))),
                 }
             }
+            // A declared in-band header field requires a record_header_bytes
+            // (otherwise the reader's header is only the length prefix and
+            // the field reads past the record — silent corruption), and no
+            // two header fields (or a field and the length prefix at offset
+            // 0) may overlap.
+            let mut intervals: Vec<(&str, i64, i64)> = Vec::new();
+            if len_prefix_w > 0 {
+                intervals.push(("len_prefix", 0, len_prefix_w as i64));
+            }
+            let mut any_header_field = false;
+            for (name, off_key, w_key) in [
+                ("pad_field", "pad_field_offset", "pad_field_width"),
+                ("seq", "seq_offset", "seq_width"),
+                ("kernel_ns", "kernel_ns_offset", "kernel_ns_width"),
+                ("user_ns", "user_ns_offset", "user_ns_width"),
+            ] {
+                if let (Some(o), Some(w)) = (attr_int(off_key), attr_int(w_key)) {
+                    any_header_field = true;
+                    if o >= 0 && matches!(w, 1 | 2 | 4 | 8) {
+                        intervals.push((name, o, o + w));
+                    }
+                }
+            }
+            if any_header_field && rh.map_or(true, |v| v <= 0) {
+                self.diags.push(Diag::ty(fr.span, format!(
+                    "ring_layout `{}`: record_header_bytes must be declared \
+                     (and positive) when in-band header fields (pad_field / \
+                     seq / kernel_ns / user_ns) are used — without it the \
+                     reader's header is only the length prefix and the field \
+                     would read past the record",
+                    r.name.name)));
+            }
+            for i in 0..intervals.len() {
+                for j in (i + 1)..intervals.len() {
+                    let (an, a0, a1) = intervals[i];
+                    let (bn, b0, b1) = intervals[j];
+                    if a0 < b1 && b0 < a1 {
+                        self.diags.push(Diag::ty(fr.span, format!(
+                            "ring_layout `{}`: header fields `{}` [{}, {}) and \
+                             `{}` [{}, {}) overlap",
+                            r.name.name, an, a0, a1, bn, b0, b1)));
+                    }
+                }
+            }
         }
     }
 

--- a/crates/hale-types/tests/ring_layout.rs
+++ b/crates/hale-types/tests/ring_layout.rs
@@ -91,6 +91,56 @@ ring_layout FixedHdrRing {
 }
 
 #[test]
+fn record_header_missing_size_and_overlap_error() {
+    // A header field declared WITHOUT record_header_bytes: the reader's
+    // header would be only the length prefix and the field would read past
+    // the record (silent corruption) — must be rejected.
+    let no_size = r#"
+ring_layout NoSize {
+    magic 0x52494E47464D5431;
+    version 1 at 8 : u32;
+    buffer_size at 12 : u32;
+    data_at 128;
+    cursor published { at 64; repr atomic_u64; load acquire; unit bytes; }
+    framing byte_records {
+        len_prefix u32; align 8;
+        seq_offset 8; seq_width 8;
+    }
+    overflow lap_detect;
+}
+"#;
+    assert!(
+        check(no_size).iter().any(|m| m.contains("record_header_bytes must be declared")),
+        "a header field without record_header_bytes must error; got: {:?}",
+        check(no_size)
+    );
+
+    // Two header fields whose byte ranges overlap (seq [8,16), kernel_ns
+    // [12,20)) — silently mis-reads one over the other — must be rejected.
+    let overlap = r#"
+ring_layout Overlap {
+    magic 0x52494E47464D5431;
+    version 1 at 8 : u32;
+    buffer_size at 12 : u32;
+    data_at 128;
+    cursor published { at 64; repr atomic_u64; load acquire; unit bytes; }
+    framing byte_records {
+        len_prefix u32; align 8;
+        record_header_bytes 32;
+        seq_offset 8; seq_width 8;
+        kernel_ns_offset 12; kernel_ns_width 8;
+    }
+    overflow lap_detect;
+}
+"#;
+    assert!(
+        check(overlap).iter().any(|m| m.contains("overlap")),
+        "overlapping header fields must error; got: {:?}",
+        check(overlap)
+    );
+}
+
+#[test]
 fn unknown_scalar_repr_errors() {
     let src = r#"
 ring_layout R {


### PR DESCRIPTION
Hardens the #5 `byte_records` `post_copy` recheck. The shipped guard resynced only after a full-`cap` lap, but a free-running producer within `S = min(cap/4, 1 MiB)` of lapping can already be overwriting the record the reader is mid-copy — so a record whose lag lands in the danger band `(cap-S, cap)` can be delivered torn. Fix narrows the safe window to `cap - S`.

Also adds header-field geometry validation at typecheck (a declared in-band field requires `record_header_bytes`; no two fields — or a field and the len prefix — may overlap).

**Test:** a deterministic C `clobber` driver plants one record in the danger band whose header seq disagrees with its payload (a mid-copy tear's shape) and checks delivery — correct reader resyncs past it, pre-fix reader delivers it (rc 3). Plus ring_layout.rs typecheck cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)