### PR TITLE
perf(arena): pool the subregion struct — zero-alloc locus method calls

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -363,6 +363,19 @@ static __thread lotus_arena_chunk_t *
     g_chunk_pool[LOTUS_CHUNK_POOL_CAP];
 static __thread int g_chunk_pool_count = 0;
 
+/* 2026-06-15: per-thread free-list of arena STRUCTS, mirroring the chunk
+ * pool above. lotus_arena_create_subregion mallocs a fresh lotus_arena_t
+ * per call; the data chunk was already pooled, but the struct was the
+ * remaining allocation on the hot path — every locus method call opens +
+ * closes a scratch subregion, so that's one malloc + free per method call
+ * (measured: 1 alloc/call). Pooling the struct removes it. The
+ * subregion_lock mutex is created once (on the malloc path) and kept valid
+ * across reuse; every other field is reset on take (lotus_arena_alloc_struct).
+ * Freed on thread exit by the pool dtor. */
+#define LOTUS_STRUCT_POOL_CAP 256
+static __thread lotus_arena_t *g_struct_pool[LOTUS_STRUCT_POOL_CAP];
+static __thread int g_struct_pool_count = 0;
+
 /* LOTUS_CHUNK_POOL_STATS — when set, every chunk
  * acquire / release tallies into per-thread counters that
  * dump to stderr at process exit. Useful for diagnosing
@@ -459,6 +472,12 @@ static void lotus_chunk_pool_free_thread_dtor(void *unused) {
      * so __thread g_chunk_pool refers to that thread's own pool. */
     while (g_chunk_pool_count > 0) {
         free(g_chunk_pool[--g_chunk_pool_count]);
+    }
+    /* Same for the pooled arena structs (their subregion_lock is a
+     * static-init mutex, never pthread_mutex_init'd — free is the correct
+     * reclaim, no destroy needed). Runs on the exiting thread. */
+    while (g_struct_pool_count > 0) {
+        free(g_struct_pool[--g_struct_pool_count]);
     }
 }
 
@@ -1347,8 +1366,24 @@ static const pthread_mutex_t LOTUS_SUBREGION_MUTEX_INIT =
     PTHREAD_MUTEX_INITIALIZER;
 
 static lotus_arena_t *lotus_arena_alloc_struct(void) {
-    lotus_arena_t *a = (lotus_arena_t *)malloc(sizeof(lotus_arena_t));
-    if (!a) return NULL;
+    lotus_arena_t *a;
+    if (g_struct_pool_count > 0) {
+        /* Reuse a pooled struct — its subregion_lock is already a valid,
+         * unlocked mutex (kept across pooling), so skip re-init. */
+        a = g_struct_pool[--g_struct_pool_count];
+    } else {
+        a = (lotus_arena_t *)malloc(sizeof(lotus_arena_t));
+        if (!a) return NULL;
+        /* 2026-05-26 substrate-race fix: subregion freelist mutex.
+         * Used by create_subregion / destroy via the PARENT arena's
+         * pointer; arenas with no children never acquire the lock.
+         * Init via a const PTHREAD_MUTEX_INITIALIZER copy rather than
+         * pthread_mutex_init() — a plain store of a constant, no libc
+         * call — since arena create is a hot-path op. Initialized once
+         * here on the malloc path and kept valid across struct-pool
+         * reuse (perf opt, 2026-05-29; pooled 2026-06-15). */
+        a->subregion_lock = LOTUS_SUBREGION_MUTEX_INIT;
+    }
     a->default_chunk_size = lotus_arena_default_chunk_bytes();
     /* 2026-05-21: defer the initial chunk to the first
      * `lotus_arena_alloc` call. Per-method scratch reclaim
@@ -1373,16 +1408,8 @@ static lotus_arena_t *lotus_arena_alloc_struct(void) {
     a->chunk_byte_total = 0;
     a->chunk_byte_cap   = 0;
     a->cap_diag_name    = NULL;
-    /* 2026-05-26 substrate-race fix: subregion freelist mutex.
-     * Used by create_subregion / destroy via the PARENT arena's
-     * pointer; arenas with no children never acquire the lock.
-     * Init via a const PTHREAD_MUTEX_INITIALIZER copy rather than
-     * pthread_mutex_init() — a plain store of a constant, no libc
-     * call — since arena create is a hot-path op (every method
-     * scratch + every locus). The result is a usable default
-     * mutex, lockable later if the program goes multithreaded.
-     * (perf opt, 2026-05-29.) */
-    a->subregion_lock = LOTUS_SUBREGION_MUTEX_INIT;
+    /* subregion_lock is NOT reset here — it's initialized once on the
+     * malloc path above and kept valid across struct-pool reuse. */
     return a;
 }
 
@@ -1777,14 +1804,19 @@ void lotus_arena_destroy(lotus_arena_t *a) {
     a->free_list = NULL;
     if (mt_barrier) pthread_mutex_unlock(&a->subregion_lock);
     if (fl) free(fl);
-    /* Tear down the per-arena subregion lock. By the time we
-     * reach here the parent's lock (if any) has already been
-     * released and no future caller can reach this arena's
-     * lock — the destroying thread is exclusive on its own
-     * arena struct. Skip when single-threaded: the mutex was
-     * statically initialized and never locked, so a default
-     * mutex holds no resources to release (perf opt, 2026-05-29;
-     * reuses mt_barrier read above). */
+    /* Pool the struct for reuse (mirrors the chunk pool) instead of
+     * freeing it — removes the malloc/free per scratch open/close, the
+     * remaining per-method-call allocation. subregion_lock is unlocked
+     * here (the barrier above released it) and kept valid for the next
+     * lotus_arena_alloc_struct; it is NOT destroyed on the pool path.
+     * Freed at thread exit by the pool dtor. */
+    if (g_struct_pool_count < LOTUS_STRUCT_POOL_CAP) {
+        lotus_mark_thread_for_pool_dtor();
+        g_struct_pool[g_struct_pool_count++] = a;
+        return;
+    }
+    /* Pool full — tear down the lock (mt only; a static-init mutex never
+     * locked holds no resources) and free. */
     if (mt_barrier) pthread_mutex_destroy(&a->subregion_lock);
     free(a);
 }

--- a/crates/hale-codegen/tests/method_call_zero_alloc.rs
+++ b/crates/hale-codegen/tests/method_call_zero_alloc.rs
@@ -1,0 +1,57 @@
+//! A locus method call must do zero heap allocations in steady state
+//! (2026-06-15). Each call opens + closes a per-method scratch subregion;
+//! the data chunk was already pooled, but the subregion `lotus_arena_t`
+//! struct was malloc'd + freed per call (measured: 1 alloc/call). A
+//! per-thread struct pool (mirroring the chunk pool) removes it — important
+//! because the whole fast-protocol-I/O premise is zero-alloc hot loops, and
+//! a parser/handler that calls `self.method(...)` per tick would otherwise
+//! allocate on every call. Measured with the `std::diag` gate counter.
+
+use hale_codegen::build_executable;
+use std::process::Command;
+
+fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale_mcz_{}", name));
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (String::from_utf8_lossy(&out.stdout).to_string(), out.status)
+}
+
+#[test]
+fn locus_method_calls_are_zero_alloc() {
+    // Warm up once (first call mallocs the struct + chunk), then 1000 calls
+    // of both a no-arg and an arg-taking method: the struct comes from the
+    // per-thread pool and the chunk from the chunk pool, so the heap counter
+    // must not move.
+    let src = r#"
+        locus Counter {
+            params { n: Int = 1; }
+            fn tick() -> Int { return self.n + 1; }
+            fn tick2(x: Int) -> Int { return self.n + x; }
+        }
+        fn main() {
+            let c = Counter { };
+            let _ = c.tick();
+            let mut s = 0;
+            let a0 = std::diag::heap_alloc_count();
+            let mut i = 0;
+            while i < 1000 { s = s + c.tick(); i = i + 1; }
+            let noarg = std::diag::heap_alloc_count() - a0;
+            let b0 = std::diag::heap_alloc_count();
+            let mut j = 0;
+            while j < 1000 { s = s + c.tick2(j); j = j + 1; }
+            let arg = std::diag::heap_alloc_count() - b0;
+            println("noarg=", noarg, " arg=", arg, " s_ok=", s > 0);
+        }
+    "#;
+    let (out, status) = build_and_run("counter", src);
+    assert!(status.success(), "exit {:?}\n{}", status, out);
+    assert!(
+        out.contains("noarg=0 arg=0"),
+        "locus method calls must be zero-alloc in steady state; got: {:?}",
+        out
+    );
+}


### PR DESCRIPTION
## What

Every locus method call opens + closes a per-method scratch subregion. The data *chunk* was already amortized by the per-thread chunk pool, but `lotus_arena_create_subregion` still **malloc'd a fresh `lotus_arena_t` struct per call** (freed on close) — so each method call did one malloc + one free, even a trivial body. Measured via `std::diag`: exactly **1 alloc/call**.

That quietly undercuts the zero-alloc hot loops the fast-protocol-I/O work targets — a parser/handler calling `self.method(...)` per tick allocated on every call.

## Fix

A per-thread free-list of arena structs, mirroring the chunk pool: `lotus_arena_destroy` pushes the struct instead of freeing; `lotus_arena_alloc_struct` pops instead of mallocing. The `subregion_lock` mutex is initialized once on the malloc path and **kept valid (unlocked) across reuse** (not destroyed on the pool path); every other field is reset on take. Pool capped at 256, freed on thread exit by the existing pool dtor, pool-full falls back to free.

## Validation

- **1000-call method loop: 1000 → 0 heap allocs** ( pins it; no-arg + arg methods).
- **Corpus oracle clean — normal AND under ASan/LSan** (no leak, no use-after-free from the reuse).
- **Concurrency suites pass** (/) — the pool is per-thread and a struct is fully dead at destroy, so cross-thread reuse is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)