### PR TITLE
feat(wasm): host interface — @export/entry-inversion + persistent locus

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -6714,6 +6714,69 @@ void *lotus_bytes_from_buf(lotus_arena_t *a, const void *src, int64_t len) {
     return blob;
 }
 
+/* ---- WASM host seam: an inbound-message inbox --------------------
+ * Lets the JS loader hand bytes (a WebSocket frame, a fetch body) into a
+ * wasm-compiled Hale program without a JS-side parser. The flow:
+ *   1. JS calls `lotus_wasm_alloc(n)` to get a pointer into wasm memory
+ *      and writes its n message bytes there (via `instance.exports.memory`).
+ *   2. JS calls `lotus_wasm_set_inbox(n)` to publish that as the current
+ *      message.
+ *   3. The Hale side reads it each frame via `lotus_wasm_inbox()`, which
+ *      returns a standard Bytes blob ([int64 len | data]); Hale parses it
+ *      with std::json. Re-reading is free (a static buffer, no alloc).
+ * The inbox is a single fixed-capacity slot (latest message wins) — a
+ * snapshot/command is tiny, and the client only needs the freshest state.
+ * `lotus_wasm_alloc`/`lotus_wasm_set_inbox` are exported by `link_wasm`;
+ * `lotus_wasm_inbox` is reached from Hale via `@ffi("c")`. All plain C
+ * with no POSIX deps — inert (and unreferenced -> gc'd) on native. */
+#define LOTUS_WASM_INBOX_CAP (64 * 1024)
+/* Bytes-blob layout in place: [int64 len][data...]; the int64[] element
+ * type forces the 8-byte alignment the length prefix needs. */
+static int64_t g_wasm_inbox_buf[(LOTUS_WASM_INBOX_CAP / 8) + 2];
+
+void *lotus_wasm_alloc(int32_t n) {
+    (void)n; /* fixed-cap slot; JS writes straight into the data region */
+    return (uint8_t *)g_wasm_inbox_buf + sizeof(int64_t);
+}
+
+void lotus_wasm_set_inbox(int32_t len) {
+    if (len < 0) len = 0;
+    if (len > LOTUS_WASM_INBOX_CAP) len = LOTUS_WASM_INBOX_CAP;
+    g_wasm_inbox_buf[0] = (int64_t)len;
+}
+
+void *lotus_wasm_inbox(void) {
+    return g_wasm_inbox_buf[0] > 0 ? (void *)g_wasm_inbox_buf : (void *)0;
+}
+
+/* ---- WASM persistent state cell ---------------------------------
+ * Entry-inversion needs Hale to hold state ACROSS exported calls, but
+ * an `@export` fn allocates in a per-call subregion that's freed on
+ * return — so a value built in `on_message` would dangle by the time
+ * `frame` runs. This cell owns its own arena and deep-copies whatever
+ * Bytes Hale hands it, so the stored value outlives the call. The app
+ * packs its state into a Bytes blob (std::bytes builders) and reads it
+ * back via the binary-pack readers. set() replaces (destroy+recreate
+ * the arena → bounded; latest state wins). A stopgap until a persistent
+ * stateful-locus model lands; reached from Hale via @ffi("c"). */
+static lotus_arena_t *g_wasm_state_arena = NULL;
+static void *g_wasm_state_blob = NULL;
+
+void lotus_wasm_state_set(void *bytes) {
+    if (g_wasm_state_arena) {
+        lotus_arena_destroy(g_wasm_state_arena);
+    }
+    g_wasm_state_arena = lotus_arena_create_labeled("lotus.wasm.state");
+    if (bytes) {
+        g_wasm_state_blob = lotus_bytes_from_buf(
+            g_wasm_state_arena, lotus_bytes_data(bytes), lotus_bytes_len(bytes));
+    } else {
+        g_wasm_state_blob = (void *)0;
+    }
+}
+
+void *lotus_wasm_state_get(void) { return g_wasm_state_blob; }
+
 /* F.30 (2026-05-20): deep-copy a Bytes blob (length-prefixed,
  * may contain embedded NULs) into `a`. The companion to
  * `lotus_str_clone` for the binary path; needed for
@@ -6941,6 +7004,32 @@ static int lotus__transport_set_addr(struct sockaddr_un *addr,
     return 0;
 }
 
+/* Mark a runtime-created fd close-on-exec. Without this, a fork+exec
+ * via std::process::spawn (e.g. a daemon spawning game-runner children)
+ * leaks every open listen/accept/connect socket into the child: the
+ * child inherits a copy, so a peer that waits for EOF (HTTP read-to-
+ * close, etc.) never sees the connection fully close even after the
+ * parent closes its own copy, and the child also pins the parent's
+ * listen ports alive past the parent's death. Sockets are never meant
+ * to survive an exec here (the child opens its own); stdin/out/err and
+ * the std::process stdout/stderr pipes are inherited via dup2, which
+ * clears CLOEXEC on the duped fd, so this doesn't disturb them. Applied
+ * at every socket()/accept() site below. F_SETFD is a cheap, race-free
+ * (post-creation, pre-publish) toggle; best-effort — a failure leaves
+ * the pre-existing inherit-on-exec behavior rather than failing the fd. */
+static void lotus_set_cloexec(int fd) {
+#ifndef __wasm__
+    if (fd < 0) return;
+    int fl = fcntl(fd, F_GETFD, 0);
+    if (fl < 0) return;
+    (void)fcntl(fd, F_SETFD, fl | FD_CLOEXEC);
+#else
+    /* No fork/exec under wasm — close-on-exec is meaningless, and the
+     * bundled wasm libc declares neither F_SETFD nor FD_CLOEXEC. */
+    (void)fd;
+#endif
+}
+
 lotus_transport_t *lotus_transport_create(const char *path, int role) {
     if (!path) {
         errno = EINVAL;
@@ -6957,6 +7046,7 @@ lotus_transport_t *lotus_transport_create(const char *path, int role) {
         perror("lotus_transport_create: socket");
         return NULL;
     }
+    lotus_set_cloexec(sock);
 
     if (role == LOTUS_TRANSPORT_LISTEN) {
         /* Best-effort: clear any stale socket file so bind succeeds
@@ -6980,6 +7070,7 @@ lotus_transport_t *lotus_transport_create(const char *path, int role) {
             unlink(path);
             return NULL;
         }
+        lotus_set_cloexec(conn);
         lotus_transport_t *t = (lotus_transport_t *)calloc(1, sizeof(*t));
         if (!t) {
             close(conn);
@@ -7228,6 +7319,7 @@ lotus_tcp_t *lotus_tcp_create(const char *host, uint16_t port, int role) {
         perror("lotus_tcp_create: socket");
         return NULL;
     }
+    lotus_set_cloexec(sock);
 
     if (role == LOTUS_TCP_LISTEN) {
         int one = 1;
@@ -7260,6 +7352,7 @@ lotus_tcp_t *lotus_tcp_create(const char *host, uint16_t port, int role) {
             close(sock);
             return NULL;
         }
+        lotus_set_cloexec(conn);
         int nodelay = 1;
         (void)setsockopt(conn, IPPROTO_TCP, TCP_NODELAY,
                          &nodelay, sizeof(nodelay));
@@ -7424,6 +7517,7 @@ int lotus_tcp_listen_socket(const char *host, uint16_t port) {
         perror("lotus_tcp_listen_socket: socket");
         return -1;
     }
+    lotus_set_cloexec(sock);
     int one = 1;
     if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) < 0) {
         perror("lotus_tcp_listen_socket: SO_REUSEADDR");
@@ -7536,6 +7630,7 @@ int lotus_tcp_accept_one(int listen_fd) {
         }
         int conn = accept(listen_fd, NULL, NULL);
         if (conn >= 0) {
+            lotus_set_cloexec(conn);
             int nodelay = 1;
             (void)setsockopt(conn, IPPROTO_TCP, TCP_NODELAY,
                              &nodelay, sizeof(nodelay));
@@ -7611,6 +7706,7 @@ int lotus_tcp_connect(const char *host, uint16_t port) {
         perror("lotus_tcp_connect: socket");
         return -1;
     }
+    lotus_set_cloexec(sock);
     struct timespec backoff = { 0, 5L * 1000L * 1000L };
     int attempts = 200;
     while (attempts-- > 0) {
@@ -7706,6 +7802,7 @@ int lotus_udp_bind(const char *host, uint16_t port) {
         perror("lotus_udp_bind: socket");
         return -1;
     }
+    lotus_set_cloexec(sock);
     int one = 1;
     if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) < 0) {
         perror("lotus_udp_bind: SO_REUSEADDR");
@@ -9810,6 +9907,7 @@ static void *lotus_bus_udp_reader_thread_main(void *arg) {
         free(args);
         return NULL;
     }
+    lotus_set_cloexec(fd);
     int one = 1;
     /* SO_REUSEADDR so multiple subscribers on the same multicast
      * group can bind the same port. Required for multicast;
@@ -10075,6 +10173,7 @@ void lotus_bus_register_remote(const char *subject,
                 perror("lotus_bus_register_remote: udp socket");
                 return;
             }
+            lotus_set_cloexec(fd);
             /* Bind to an ephemeral local port so the kernel picks
              * a source addr for our sendto's. INADDR_ANY lets the
              * kernel select the route-appropriate interface. */

--- a/crates/hale-codegen/runtime/wasm/lotus_wasm_shim.h
+++ b/crates/hale-codegen/runtime/wasm/lotus_wasm_shim.h
@@ -105,19 +105,75 @@ static inline int snprintf(char *buf, size_t n, const char *fmt, ...) {
     (void)fmt; if (buf && n) buf[0] = 0; return 0;
 }
 
-/* env parsing helpers (dead on wasm: getenv() returns NULL). */
-static inline unsigned long strtoul(const char *s, char **e, int base) {
-    (void)s; (void)base; if (e) *e = (char *)s; return 0;
+/* Numeric string parsing. Self-contained (no syscalls), so std::str::parse_int
+ * / parse_float work under wasm just as they do natively — the portable
+ * stdlib promise. Not bit-exact IEEE rounding for strtod, but correct for
+ * the decimal magnitudes app/protocol data uses. */
+static inline int lotus_wasm_isspace_(int c) {
+    return c == ' ' || (c >= '\t' && c <= '\r');
+}
+static inline long long strtoll(const char *s, char **e, int base) {
+    const char *p = s;
+    while (lotus_wasm_isspace_((unsigned char)*p)) p++;
+    int neg = 0;
+    if (*p == '+' || *p == '-') { neg = (*p == '-'); p++; }
+    if ((base == 0 || base == 16) && p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) {
+        p += 2; base = 16;
+    } else if (base == 0 && p[0] == '0') {
+        base = 8;
+    } else if (base == 0) {
+        base = 10;
+    }
+    long long acc = 0; int any = 0;
+    for (;;) {
+        int c = (unsigned char)*p, d;
+        if (c >= '0' && c <= '9') d = c - '0';
+        else if (c >= 'a' && c <= 'z') d = c - 'a' + 10;
+        else if (c >= 'A' && c <= 'Z') d = c - 'A' + 10;
+        else break;
+        if (d >= base) break;
+        acc = acc * base + d; any = 1; p++;
+    }
+    if (e) *e = (char *)(any ? p : s);
+    return neg ? -acc : acc;
+}
+static inline unsigned long long strtoull(const char *s, char **e, int b) {
+    return (unsigned long long)strtoll(s, e, b);
 }
 static inline long strtol(const char *s, char **e, int base) {
-    (void)s; (void)base; if (e) *e = (char *)s; return 0;
+    return (long)strtoll(s, e, base);
 }
-/* NB: numeric string parsing is stubbed for v1 — std::str::parse_* would
- * return 0 on wasm until real impls land. Inert for compute/bus programs;
- * a known limitation tracked for the runtime port. */
-static inline unsigned long long strtoull(const char *s, char **e, int b) { (void)b; if (e) *e = (char *)s; return 0; }
-static inline long long strtoll(const char *s, char **e, int b) { (void)b; if (e) *e = (char *)s; return 0; }
-static inline double strtod(const char *s, char **e) { if (e) *e = (char *)s; return 0.0; }
+static inline unsigned long strtoul(const char *s, char **e, int base) {
+    return (unsigned long)strtoull(s, e, base);
+}
+static inline double strtod(const char *s, char **e) {
+    const char *p = s;
+    while (lotus_wasm_isspace_((unsigned char)*p)) p++;
+    int neg = 0;
+    if (*p == '+' || *p == '-') { neg = (*p == '-'); p++; }
+    double v = 0.0; int any = 0;
+    while (*p >= '0' && *p <= '9') { v = v * 10.0 + (*p - '0'); p++; any = 1; }
+    if (*p == '.') {
+        p++;
+        double frac = 0.0, scale = 1.0;
+        while (*p >= '0' && *p <= '9') { frac = frac * 10.0 + (*p - '0'); scale *= 10.0; p++; any = 1; }
+        v += frac / scale;
+    }
+    if (any && (*p == 'e' || *p == 'E')) {
+        const char *ep = p + 1; int eneg = 0;
+        if (*ep == '+' || *ep == '-') { eneg = (*ep == '-'); ep++; }
+        if (*ep >= '0' && *ep <= '9') {
+            int exp = 0;
+            while (*ep >= '0' && *ep <= '9') { exp = exp * 10 + (*ep - '0'); ep++; }
+            double pw = 1.0;
+            for (int i = 0; i < exp; i++) pw *= 10.0;
+            if (eneg) v /= pw; else v *= pw;
+            p = ep;
+        }
+    }
+    if (e) *e = (char *)(any ? p : s);
+    return neg ? -v : v;
+}
 static inline char *strerror(int e) { (void)e; return (char *)""; }
 
 /* math + format constants (math.h / inttypes.h are gated out). */

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -501,6 +501,7 @@ pub fn build_executable_with_options(
         builder,
         target_data,
         is_wasm,
+        wasm_exports: Vec::new(),
         program: &merged,
         current_fn: None,
         current_user_fn_ret: None,
@@ -610,7 +611,7 @@ pub fn build_executable_with_options(
         // Compile the self-contained wasm runtime (arena core + bundled
         // libc) and link it into the user object with wasm-ld, producing
         // a runnable `.wasm`. No native libs / no clang link line.
-        link_wasm(&obj_path, output_path)?;
+        link_wasm(&obj_path, output_path, &cx.wasm_exports)?;
         let _ = std::fs::remove_file(&obj_path);
         return Ok(());
     }
@@ -863,7 +864,11 @@ fn resolve_tool(base: &str) -> String {
     base.to_string()
 }
 
-fn link_wasm(user_obj: &Path, output: &Path) -> Result<(), CodegenError> {
+fn link_wasm(
+    user_obj: &Path,
+    output: &Path,
+    extra_exports: &[String],
+) -> Result<(), CodegenError> {
     let mkerr = |m: String| CodegenError::Link(m);
     // Unique temp dir for the staged runtime sources.
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -917,14 +922,26 @@ fn link_wasm(user_obj: &Path, output: &Path) -> Result<(), CodegenError> {
     // (println -> printf/puts) as host imports the JS loader provides.
     // (A richer export policy — @export, plus the _hale_start/_hale_tick
     // entry inversion for run()-driven programs — is the next slice.)
-    let status = Command::new(&wasm_ld)
-        .arg(user_obj)
+    let mut cmd = Command::new(&wasm_ld);
+    cmd.arg(user_obj)
         .arg(&arena_o)
         .arg(&libc_o)
         .arg("--no-entry")
-        .arg("--export=main")
+        .arg("--export-if-defined=main")
         .arg("--export=__heap_base")
         .arg("--export-if-defined=memory")
+        // WASM host seam: the JS loader writes an inbound message into wasm
+        // memory via lotus_wasm_alloc, then publishes it with
+        // lotus_wasm_set_inbox; the Hale side reads it with lotus_wasm_inbox
+        // (reached via @ffi("c"), so kept without an explicit export).
+        .arg("--export=lotus_wasm_alloc")
+        .arg("--export=lotus_wasm_set_inbox");
+    // Entry-inversion: `@export` fn wrappers + `_hale_start` (collected
+    // by synthesize_wasm_export_wrappers).
+    for name in extra_exports {
+        cmd.arg(format!("--export={name}"));
+    }
+    let status = cmd
         .arg("--gc-sections")
         .arg("--allow-undefined")
         .arg("-o")
@@ -996,6 +1013,15 @@ export async function run(glue) {
     putchar: (c) => { emit(String.fromCharCode(c & 0xff)); return 0; },
     // Built-in @ffi("js") host import: console debug from Hale.
     console_log: (p) => { console.log(cstr(p)); return 0; },
+    // libm: std::math lowers sin/cos/tan/... to these libm symbols, which
+    // a self-contained wasm build has no library for. JS `Math` is the
+    // natural host provider in the browser/node, so std::math works under
+    // wasm with no app glue. (sqrt/fabs usually lower to native wasm
+    // instructions and won't appear as imports; harmless to provide.)
+    sin: Math.sin, cos: Math.cos, tan: Math.tan,
+    asin: Math.asin, acos: Math.acos, atan: Math.atan, atan2: Math.atan2,
+    sqrt: Math.sqrt, exp: Math.exp, log: Math.log, pow: Math.pow,
+    tanh: Math.tanh, floor: Math.floor, ceil: Math.ceil, fabs: Math.abs,
   };
   // User-supplied @ffi("js") host imports (canvas, input, ws, ...). The
   // factory receives helpers for reading wasm memory; its functions
@@ -1034,7 +1060,13 @@ export async function run(glue) {
   }
   const instance = await WebAssembly.instantiate(mod, { env });
   mem = instance.exports.memory;
-  if (instance.exports.main) instance.exports.main(0, 0);
+  // Entry-inversion: if the module exports `_hale_start`, it sets up a
+  // PERSISTENT program arena and the host then drives the `@export` fns
+  // (e.g. per requestAnimationFrame). `main` is NOT called in that mode
+  // — its create+destroy of the arena would clobber the persistent one.
+  // A classic program (no `_hale_start`) runs `main` once as before.
+  if (instance.exports._hale_start) instance.exports._hale_start();
+  else if (instance.exports.main) instance.exports.main(0, 0);
   flush();
   return instance;
 }
@@ -1496,6 +1528,10 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// WASM plan: true when compiling for wasm32. Gates the wasm-incompatible
     /// `main` startup (transport/pool/thread bring-up) for entry inversion.
     pub(crate) is_wasm: bool,
+    /// WASM entry-inversion: names of `@export` free fns whose
+    /// arena-less wrappers were emitted; passed to `wasm-ld
+    /// --export=`. Empty on native builds.
+    pub(crate) wasm_exports: Vec<String>,
     pub(crate) program: &'p Program,
     /// Set while lowering a function's body so that `if` / `while`
     /// can `append_basic_block` onto it.
@@ -4747,17 +4783,52 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
 
     fn lower_program(&mut self) -> Result<(), CodegenError> {
         // Locate fn main.
-        let main_decl = self
+        let main_found = self
             .program
             .items
             .iter()
             .find_map(|item| match item {
                 TopDecl::Fn(f) if f.name.name == "main" => Some(f.clone()),
                 _ => None,
-            })
-            .ok_or_else(|| {
-                CodegenError::Unsupported("program has no `fn main()`".to_string())
-            })?;
+            });
+        let main_decl = match main_found {
+            Some(m) => m,
+            None => {
+                // WASM entry-inversion: a program of only `@export` fns
+                // needs no `fn main` — the loader drives `_hale_start` +
+                // the exports. Synthesize an empty `main` to satisfy the
+                // rest of lowering; it's emitted but never called.
+                let has_exports = self.is_wasm
+                    && self.program.items.iter().any(|item| {
+                        matches!(item, TopDecl::Fn(f) if f.export)
+                            || matches!(item, TopDecl::Locus(l) if l.export)
+                    });
+                if !has_exports {
+                    return Err(CodegenError::Unsupported(
+                        "program has no `fn main()`".to_string(),
+                    ));
+                }
+                let sp = self.program.span.clone();
+                FnDecl {
+                    name: Ident {
+                        name: "main".to_string(),
+                        span: sp.clone(),
+                    },
+                    generics: Vec::new(),
+                    params: Vec::new(),
+                    ret: None,
+                    fallible: None,
+                    ffi: None,
+                    export: false,
+                    body: Block {
+                        stmts: Vec::new(),
+                        tail: None,
+                        span: sp.clone(),
+                    },
+                    span: sp,
+                }
+            }
+        };
 
         // Pre-pass: register the built-in `ClosureViolation` type.
         // The interpreter exposes this as a Value::Struct with
@@ -5260,6 +5331,12 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // Pass D: lower bodies of user-defined fns.
         for f in &user_fn_decls {
             self.lower_user_fn_body(f)?;
+        }
+
+        // WASM entry-inversion: emit the arena-less export wrappers for
+        // `@export` fns + the `_hale_start` setup entry. No-op on native.
+        if self.is_wasm {
+            self.synthesize_wasm_export_wrappers(&user_fn_decls)?;
         }
 
         // Pass 3: the C entry point — i32 @main(i32 argc, ptr argv).
@@ -7543,6 +7620,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 span: template.name.span.clone(),
             },
             is_main: template.is_main,
+            export: template.export,
             generics: Vec::new(),
             annotations: template.annotations.clone(),
             form: template.form.clone(),
@@ -7650,6 +7728,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 // Stage 1, never on locus members — but copy the
                 // field through for shape uniformity.
                 ffi: fd.ffi.clone(),
+                export: fd.export,
                 body: Self::substitute_block_type_ascriptions(
                     &fd.body, subst,
                 ),
@@ -7893,6 +7972,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             // annotation; @ffi + generics is rejected at parse
             // time so in practice this is always None here.
             ffi: template.ffi.clone(),
+            export: template.export,
             body: new_body,
             span: template.span.clone(),
         })
@@ -8605,7 +8685,19 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     .fn_type(&llvm_param_tys, false),
             }
         };
-        let func = self.module.add_function(&f.name.name, fn_ty, None);
+        // WASM entry-inversion: an `@export` fn's real (arena-ABI)
+        // implementation takes an internal symbol; the literal name is
+        // claimed by the arena-less export wrapper emitted later
+        // (synthesize_wasm_export_wrappers). Internal Hale callers
+        // resolve through `user_fns[name].func` (the SSA value), so the
+        // symbol rename is invisible to them. Native builds keep the
+        // literal name (no wrapper, `@export` is a no-op).
+        let impl_symbol = if self.is_wasm && f.export {
+            format!("__hale_impl_{}", f.name.name)
+        } else {
+            f.name.name.clone()
+        };
+        let func = self.module.add_function(&impl_symbol, fn_ty, None);
         // FORM-3: classify the body. Conservative — only catches
         // bodies that provably don't touch the arena allocator.
         // Fallible fns inherit `false` because the `fail E { ... }`
@@ -8627,6 +8719,299 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 is_ffi: false,
             },
         );
+        Ok(())
+    }
+
+    /// WASM entry-inversion (2026-06-16). Emit:
+    ///   * `_hale_start()` — a once-at-load setup entry that creates the
+    ///     PERSISTENT program arena + bus queue and stores them in the
+    ///     usual globals. Unlike `main`, nothing is torn down, so values
+    ///     an export allocates (or parks via the runtime state cell) live
+    ///     for the module's lifetime. The JS loader calls it before any
+    ///     export, and (in entry-inversion mode) does NOT call `main` —
+    ///     so `main`'s own create+destroy of the arena can't clobber it.
+    ///   * one arena-less wrapper per `@export fn`, under the literal fn
+    ///     name, that loads that persistent arena and tail-calls the real
+    ///     implementation (`__hale_impl_<name>`, arena-ABI). The JS host
+    ///     calls these with just the declared args.
+    /// Collected names are handed to `wasm-ld --export=`.
+    fn synthesize_wasm_export_wrappers(
+        &mut self,
+        user_fn_decls: &[FnDecl],
+    ) -> Result<(), CodegenError> {
+        let has_export_fn = user_fn_decls.iter().any(|f| f.export);
+        // The persistent singleton: `@export locus L { ... }` (at most one).
+        let export_locus_name: Option<String> = self
+            .program
+            .items
+            .iter()
+            .find_map(|it| match it {
+                TopDecl::Locus(l) if l.export => Some(l.name.name.clone()),
+                _ => None,
+            });
+        if !has_export_fn && export_locus_name.is_none() {
+            return Ok(());
+        }
+        let ptr_t = self.context.ptr_type(AddressSpace::default());
+        let void_t = self.context.void_type();
+        let emit = |s: &str| CodegenError::LlvmEmit(s.to_string());
+
+        // ---- _hale_start(): persistent arena + bus queue -------------
+        let start_fn =
+            self.module
+                .add_function("_hale_start", void_t.fn_type(&[], false), None);
+        let entry = self.context.append_basic_block(start_fn, "entry");
+        self.builder.position_at_end(entry);
+        let arena_create = self
+            .module
+            .get_function("lotus_arena_create_labeled")
+            .expect("lotus_arena_create_labeled declared");
+        let label = self
+            .builder
+            .build_global_string_ptr("lotus.arena.global", "hale_start.arena.label")
+            .map_err(|e| emit(&e.to_string()))?
+            .as_pointer_value();
+        let arena_ptr = self
+            .builder
+            .build_call(arena_create, &[label.into()], "hale_start.arena")
+            .map_err(|e| emit(&e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .expect("arena ptr");
+        let arena_global = self
+            .module
+            .get_global("lotus.arena.global")
+            .expect("arena global declared");
+        self.builder
+            .build_store(arena_global.as_pointer_value(), arena_ptr)
+            .map_err(|e| emit(&e.to_string()))?;
+        let q_create = self
+            .module
+            .get_function("lotus_bus_queue_create")
+            .expect("lotus_bus_queue_create declared");
+        let q_ptr = self
+            .builder
+            .build_call(q_create, &[], "hale_start.queue")
+            .map_err(|e| emit(&e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .expect("queue ptr");
+        let q_global = self
+            .module
+            .get_global("lotus.bus_queue.global")
+            .expect("bus queue global declared");
+        self.builder
+            .build_store(q_global.as_pointer_value(), q_ptr)
+            .map_err(|e| emit(&e.to_string()))?;
+        let set_q = self
+            .module
+            .get_function("lotus_bus_set_queue")
+            .expect("lotus_bus_set_queue declared");
+        self.builder
+            .build_call(set_q, &[q_ptr.into()], "")
+            .map_err(|e| emit(&e.to_string()))?;
+
+        // Persistent singleton: instantiate the `@export locus` here.
+        // birth() runs now; the dissolve is registered in a frame we
+        // then DISCARD (pop, never flush) so it never fires — the app
+        // lives for the module's lifetime. self-ptr → `@lotus.app.self`.
+        if let Some(ref lname) = export_locus_name {
+            if self
+                .user_loci
+                .get(lname)
+                .map_or(false, |i| i.methods.contains_key("run"))
+            {
+                return Err(CodegenError::Unsupported(format!(
+                    "@export locus `{}` must not define `run()` — a wasm \
+                     singleton is host-driven via its `@export` methods, not \
+                     a cooperative run loop",
+                    lname
+                )));
+            }
+            let app_self_global =
+                self.module.add_global(ptr_t, None, "lotus.app.self");
+            app_self_global.set_initializer(&ptr_t.const_null());
+            app_self_global.set_linkage(inkwell::module::Linkage::Internal);
+            self.current_fn = Some(start_fn);
+            self.deferred_dissolves.push(Vec::new());
+            self.defer_next_locus_dissolve = true;
+            let scope = Scope::default();
+            let self_ptr = self.lower_locus_instantiation(lname, &[], &scope)?;
+            self.defer_next_locus_dissolve = false;
+            // Drop the frame WITHOUT flushing → no dissolve IR emitted.
+            let _ = self.deferred_dissolves.pop();
+            self.builder
+                .build_store(app_self_global.as_pointer_value(), self_ptr)
+                .map_err(|e| emit(&e.to_string()))?;
+            self.current_fn = None;
+        }
+        self.builder
+            .build_return(None)
+            .map_err(|e| emit(&e.to_string()))?;
+        self.wasm_exports.push("_hale_start".to_string());
+
+        // ---- one wrapper per @export fn ------------------------------
+        for f in user_fn_decls {
+            if !f.export {
+                continue;
+            }
+            let name = &f.name.name;
+            let sig = self
+                .user_fns
+                .get(name)
+                .cloned()
+                .expect("@export fn declared in pass B");
+            if sig.fallible.is_some() {
+                return Err(CodegenError::Unsupported(format!(
+                    "@export fn `{}`: fallible exports are not supported \
+                     yet (wasm entry-inversion v1)",
+                    name
+                )));
+            }
+            let mut wparam_tys: Vec<inkwell::types::BasicMetadataTypeEnum> =
+                Vec::with_capacity(sig.params.len());
+            for p in &sig.params {
+                wparam_tys.push(self.llvm_basic_type(p).into());
+            }
+            let wrapper_ty = match &sig.ret {
+                Some(rt) => self.llvm_basic_type(rt).fn_type(&wparam_tys, false),
+                None => void_t.fn_type(&wparam_tys, false),
+            };
+            let wrapper = self.module.add_function(name, wrapper_ty, None);
+            let wentry = self.context.append_basic_block(wrapper, "entry");
+            self.builder.position_at_end(wentry);
+            let arena_ld = self
+                .builder
+                .build_load(ptr_t, arena_global.as_pointer_value(), "export.arena")
+                .map_err(|e| emit(&e.to_string()))?;
+            let mut call_args: Vec<inkwell::values::BasicMetadataValueEnum> =
+                Vec::with_capacity(sig.params.len() + 1);
+            call_args.push(arena_ld.into());
+            for i in 0..sig.params.len() {
+                call_args.push(
+                    wrapper
+                        .get_nth_param(i as u32)
+                        .expect("wrapper param")
+                        .into(),
+                );
+            }
+            let call = self
+                .builder
+                .build_call(sig.func, &call_args, "export.call")
+                .map_err(|e| emit(&e.to_string()))?;
+            match &sig.ret {
+                Some(_) => {
+                    let rv = call
+                        .try_as_basic_value()
+                        .left()
+                        .expect("non-void export returns a value");
+                    self.builder
+                        .build_return(Some(&rv))
+                        .map_err(|e| emit(&e.to_string()))?;
+                }
+                None => {
+                    self.builder
+                        .build_return(None)
+                        .map_err(|e| emit(&e.to_string()))?;
+                }
+            }
+            self.wasm_exports.push(name.clone());
+        }
+
+        // ---- export wrappers for the @export locus's methods ---------
+        // Each non-fallible `fn` method becomes a wasm export under its
+        // bare name: load the singleton self-ptr, call the method
+        // (`[self_ptr, host args...]`), return the result. State lives in
+        // the locus's fields, so it persists across these calls.
+        if let Some(lname) = export_locus_name {
+            let methods: Vec<(String, inkwell::values::FunctionValue<'ctx>)> = self
+                .user_loci
+                .get(&lname)
+                .map(|i| {
+                    i.user_methods.iter().map(|(k, v)| (k.clone(), *v)).collect()
+                })
+                .unwrap_or_default();
+            // Methods declared `fallible(E)` can't be exported (v1 — the
+            // host has no error channel); they stay internal.
+            let fallible_methods: std::collections::BTreeSet<String> = self
+                .program
+                .items
+                .iter()
+                .find_map(|it| match it {
+                    TopDecl::Locus(l) if l.name.name == lname => Some(
+                        l.members
+                            .iter()
+                            .filter_map(|m| match m {
+                                LocusMember::Fn(fd) if fd.fallible.is_some() => {
+                                    Some(fd.name.name.clone())
+                                }
+                                _ => None,
+                            })
+                            .collect(),
+                    ),
+                    _ => None,
+                })
+                .unwrap_or_default();
+            let app_self_global = self
+                .module
+                .get_global("lotus.app.self")
+                .expect("app self global declared in _hale_start");
+            for (mname, mfunc) in methods {
+                if fallible_methods.contains(&mname) {
+                    continue;
+                }
+                // Defensive: skip a bare-name collision with an existing
+                // symbol (method symbols are `Locus.method`, so the bare
+                // name is normally free).
+                if self.module.get_function(&mname).is_some() {
+                    continue;
+                }
+                let fnty = mfunc.get_type();
+                let ptys = fnty.get_param_types(); // [self_ptr, args...]
+                let wparams: Vec<inkwell::types::BasicMetadataTypeEnum> =
+                    ptys.iter().skip(1).map(|t| (*t).into()).collect();
+                let wrapper_ty = match fnty.get_return_type() {
+                    Some(rt) => rt.fn_type(&wparams, false),
+                    None => void_t.fn_type(&wparams, false),
+                };
+                let wrapper = self.module.add_function(&mname, wrapper_ty, None);
+                let wentry = self.context.append_basic_block(wrapper, "entry");
+                self.builder.position_at_end(wentry);
+                let self_ld = self
+                    .builder
+                    .build_load(ptr_t, app_self_global.as_pointer_value(), "app.self")
+                    .map_err(|e| emit(&e.to_string()))?;
+                let mut args: Vec<inkwell::values::BasicMetadataValueEnum> =
+                    Vec::with_capacity(wparams.len() + 1);
+                args.push(self_ld.into());
+                for i in 0..wparams.len() {
+                    args.push(
+                        wrapper.get_nth_param(i as u32).expect("wrapper param").into(),
+                    );
+                }
+                let call = self
+                    .builder
+                    .build_call(mfunc, &args, "method.export.call")
+                    .map_err(|e| emit(&e.to_string()))?;
+                match fnty.get_return_type() {
+                    Some(_) => {
+                        let rv = call
+                            .try_as_basic_value()
+                            .left()
+                            .expect("non-void method returns a value");
+                        self.builder
+                            .build_return(Some(&rv))
+                            .map_err(|e| emit(&e.to_string()))?;
+                    }
+                    None => {
+                        self.builder
+                            .build_return(None)
+                            .map_err(|e| emit(&e.to_string()))?;
+                    }
+                }
+                self.wasm_exports.push(mname.clone());
+            }
+        }
         Ok(())
     }
 

--- a/crates/hale-codegen/tests/wasm_target.rs
+++ b/crates/hale-codegen/tests/wasm_target.rs
@@ -65,6 +65,130 @@ fn wasm_ffi_js_host_import() {
     );
 }
 
+/// WASM entry-inversion: `@export fn` + the synthesized `_hale_start` +
+/// the runtime state cell give a wasm module PERSISTENT state across
+/// separate host calls. A program with only `@export` fns (no `fn main`)
+/// builds; the loader auto-calls `_hale_start` (persistent arena) and the
+/// host then drives the exports. Here `bump()` increments a counter
+/// packed into a Bytes blob parked in the state cell, and `get()` reads
+/// it back — three separate `bump()` calls must accumulate to 3, proving
+/// the state survived across calls (not reset per call like `main`).
+#[test]
+fn wasm_export_entry_inversion_persists_state() {
+    let (Some(_clang), Some(_wasm_ld), Some(node)) =
+        (tool("clang"), tool("wasm-ld"), tool("node"))
+    else {
+        eprintln!("SKIP wasm_export_entry_inversion_persists_state: toolchain missing");
+        return;
+    };
+    let src = r#"
+        target wasm { }
+        @ffi("c") fn lotus_wasm_state_set(b: Bytes);
+        @ffi("c") fn lotus_wasm_state_get() -> Bytes;
+        fn current() -> Int {
+            let s = lotus_wasm_state_get();
+            if len(s) >= 4 { return std::bytes::read_u32_le(s, 0) or 0; }
+            return 0;
+        }
+        @export fn bump() {
+            let n = current() + 1;
+            let b = std::bytes::BytesBuilder { };
+            b.append_u32_le(n);
+            lotus_wasm_state_set(b.snapshot());
+        }
+        @export fn get() -> Int { return current(); }
+    "#;
+    let program = hale_syntax::parse_source(src).expect("parse @export program");
+    let wasm = tmp("export_ei.wasm");
+    build_executable_with_options(&program, &wasm, &[], &wasm_opts())
+        .expect("wasm codegen + link");
+    let loader = wasm.with_extension("mjs");
+    // Drive the exports from a harness: _hale_start runs at load, then
+    // three bumps, then read the accumulated counter.
+    let harness = wasm.with_extension("harness.mjs");
+    let loader_name = loader.file_name().unwrap().to_str().unwrap();
+    std::fs::write(
+        &harness,
+        format!(
+            r#"import {{ run }} from "./{loader_name}";
+const inst = await run(() => ({{}}));
+if (inst.exports.get() !== 0n) {{ console.log("BAD_INIT"); process.exit(1); }}
+inst.exports.bump(); inst.exports.bump(); inst.exports.bump();
+const v = inst.exports.get();
+console.log(v === 3n ? "EXPORT_STATE_OK" : ("EXPORT_STATE_FAIL:" + v));
+"#
+        ),
+    )
+    .expect("write harness");
+    let run = Command::new(&node).arg(&harness).output().expect("run node harness");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    let _ = std::fs::remove_file(&wasm);
+    let _ = std::fs::remove_file(&loader);
+    let _ = std::fs::remove_file(&harness);
+    assert!(
+        run.status.success() && stdout.contains("EXPORT_STATE_OK"),
+        "@export persistent state should accumulate to 3:\nstdout: {}\nstderr: {}",
+        stdout,
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
+/// WASM entry-inversion, persistent-locus model: `@export locus L`
+/// designates a singleton instantiated once by `_hale_start` and never
+/// dissolved; its `fn` methods become exports, and state lives in the
+/// locus's own fields (not packed Bytes). `bump()` increments a field,
+/// `get()` reads it — three `bump()` calls accumulate to 3, proving the
+/// singleton (and its `self.n`) persisted across host calls.
+#[test]
+fn wasm_export_locus_persists_field_state() {
+    let (Some(_clang), Some(_wasm_ld), Some(node)) =
+        (tool("clang"), tool("wasm-ld"), tool("node"))
+    else {
+        eprintln!("SKIP wasm_export_locus_persists_field_state: toolchain missing");
+        return;
+    };
+    let src = r#"
+        target wasm { }
+        @export locus Counter {
+            params { n: Int = 0; }
+            birth() { }
+            fn bump() { self.n = self.n + 1; }
+            fn get() -> Int { return self.n; }
+        }
+    "#;
+    let program = hale_syntax::parse_source(src).expect("parse @export locus");
+    let wasm = tmp("export_locus.wasm");
+    build_executable_with_options(&program, &wasm, &[], &wasm_opts())
+        .expect("wasm codegen + link");
+    let loader = wasm.with_extension("mjs");
+    let harness = wasm.with_extension("harness.mjs");
+    let loader_name = loader.file_name().unwrap().to_str().unwrap();
+    std::fs::write(
+        &harness,
+        format!(
+            r#"import {{ run }} from "./{loader_name}";
+const inst = await run(() => ({{}}));   // _hale_start instantiates Counter
+if (inst.exports.get() !== 0n) {{ console.log("BAD_INIT"); process.exit(1); }}
+inst.exports.bump(); inst.exports.bump(); inst.exports.bump();
+const v = inst.exports.get();
+console.log(v === 3n ? "LOCUS_STATE_OK" : ("LOCUS_STATE_FAIL:" + v));
+"#
+        ),
+    )
+    .expect("write harness");
+    let run = Command::new(&node).arg(&harness).output().expect("run node harness");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    let _ = std::fs::remove_file(&wasm);
+    let _ = std::fs::remove_file(&loader);
+    let _ = std::fs::remove_file(&harness);
+    assert!(
+        run.status.success() && stdout.contains("LOCUS_STATE_OK"),
+        "@export locus field state should accumulate to 3:\nstdout: {}\nstderr: {}",
+        stdout,
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
 fn tool(name: &str) -> Option<String> {
     for cand in [name, &format!("{}-18", name)] {
         if Command::new(cand).arg("--version").output().is_ok() {

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -259,6 +259,14 @@ pub struct LocusDecl {
     /// non-main locus carrying a `bindings { }` block is a
     /// parse error.
     pub is_main: bool,
+    /// WASM entry-inversion (2026-06-16): `@export locus L { ... }`
+    /// marks the persistent singleton "app" of a wasm program. It is
+    /// instantiated once by the synthesized `_hale_start` (birth only,
+    /// never dissolved), its self-pointer stashed in a global, and its
+    /// non-fallible `fn` methods emitted as wasm export wrappers so the
+    /// JS host can drive it. State lives in the locus's params and
+    /// survives across calls. A no-op on native builds.
+    pub export: bool,
     /// m63: optional generic param list on the locus
     /// declaration. `locus Cache<K, V> { ... }` parses to a
     /// non-empty Vec; non-generic loci leave this empty.
@@ -1220,6 +1228,13 @@ pub struct FnDecl {
     /// codegen) take the FFI-specific code paths. See
     /// `notes/ffi-design.md` and `spec/ffi.md`.
     pub ffi: Option<FfiAnnotation>,
+    /// WASM entry-inversion (2026-06-16): `@export fn` marks a free
+    /// function as a wasm module export, callable from the JS host.
+    /// On a wasm build codegen emits an arena-less wrapper under the
+    /// literal name (supplying the persistent program arena that
+    /// `_hale_start` sets up) and passes the name to `wasm-ld
+    /// --export=`. A no-op on native builds.
+    pub export: bool,
     pub body: Block,
     pub span: Span,
 }

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -332,6 +332,7 @@ impl Parser {
         // (for `main locus`) — locus path — or `Fn` (for `@ffi`).
         let mut form: Option<FormAnnotation> = None;
         let mut locality: Option<LocalityAnnotation> = None;
+        let mut export_locus = false;
         let mut leading_span: Option<Span> = None;
         loop {
             if !matches!(self.peek(), TokenKind::At) {
@@ -342,6 +343,49 @@ impl Parser {
             let is_form = matches!(&kind_tok, TokenKind::Ident(s) if s == "form");
             let is_locality =
                 matches!(&kind_tok, TokenKind::Ident(s) if s == "locality");
+            let is_export = matches!(&kind_tok, TokenKind::Export);
+            if is_export {
+                // WASM entry-inversion. `@export fn …` is a free-fn
+                // module export; `@export locus …` is the persistent
+                // singleton "app" whose methods are exported. Peek past
+                // `@export` to decide which.
+                let at = self.expect(TokenKind::At, "@")?;
+                self.bump(); // consume `export`
+                if matches!(self.peek(), TokenKind::Fn) {
+                    if form.is_some() || locality.is_some() || export_locus {
+                        return Err(Diag::parse(
+                            at.span,
+                            "`@export fn` can't stack with `@form(...)` / \
+                             `@locality(...)` / `@export locus`",
+                        ));
+                    }
+                    let mut fn_decl = self.parse_fn_decl_with_ffi(None)?;
+                    if fn_decl.ffi.is_some() {
+                        return Err(Diag::parse(
+                            at.span,
+                            "`@export` and `@ffi` are mutually exclusive — an \
+                             FFI import is not a module export",
+                        ));
+                    }
+                    fn_decl.export = true;
+                    fn_decl.span = at.span.merge(fn_decl.span);
+                    return Ok(TopDecl::Fn(fn_decl));
+                }
+                // `@export locus …` — mark and fall through to the
+                // locus parse at the end of the annotation loop.
+                if export_locus {
+                    return Err(Diag::parse(
+                        at.span,
+                        "duplicate `@export` annotation",
+                    ));
+                }
+                export_locus = true;
+                leading_span = Some(match leading_span {
+                    Some(s) => s.merge(at.span),
+                    None => at.span,
+                });
+                continue;
+            }
             if is_ffi {
                 if form.is_some() || locality.is_some() {
                     return Err(Diag::parse(
@@ -399,7 +443,7 @@ impl Parser {
                 "expected `form`, `locality`, or `ffi` after `@`",
             ));
         }
-        if form.is_some() || locality.is_some() {
+        if form.is_some() || locality.is_some() || export_locus {
             // Verify a `locus` (or contextual `main locus`)
             // follows.
             let next_is_locus = matches!(self.peek(), TokenKind::Locus);
@@ -411,7 +455,7 @@ impl Parser {
                 return Err(Diag::parse(
                     self.peek_token().span,
                     "expected `locus` (or `main locus`) after `@form(...)` \
-                     / `@locality(...)` annotation",
+                     / `@locality(...)` / `@export` annotation",
                 ));
             }
             let mut locus = self.parse_locus_decl()?;
@@ -420,6 +464,7 @@ impl Parser {
             }
             locus.form = form;
             locus.locality = locality;
+            locus.export = export_locus;
             return Ok(TopDecl::Locus(locus));
         }
         match self.peek() {
@@ -1079,6 +1124,7 @@ impl Parser {
         Ok(LocusDecl {
             name,
             is_main,
+            export: false,
             generics,
             annotations,
             form: None,
@@ -2927,6 +2973,7 @@ impl Parser {
                 ret,
                 fallible,
                 ffi,
+                export: false,
                 span: kw.span.merge(semi.span),
                 body,
             });
@@ -2945,6 +2992,7 @@ impl Parser {
             ret,
             fallible,
             ffi,
+            export: false,
             span: kw.span.merge(body.span),
             body,
         })

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -45,6 +45,7 @@
 - [Forms under the hood](./systems/forms.md)
 - [Zero-copy & the high-frequency bus](./systems/zero-copy-bus.md)
 - [Binding C](./systems/binding-c.md)
+- [WebAssembly & the browser](./systems/webassembly.md)
 - [Cross-process & hot-load](./systems/cross-process.md)
 - [Operations & debugging](./systems/operations.md)
 - [Modes](./systems/modes.md)

--- a/docs/src/systems/webassembly.md
+++ b/docs/src/systems/webassembly.md
@@ -1,0 +1,157 @@
+# WebAssembly & the browser
+
+> **Coming from the web stack?** Hale compiles to a self-contained
+> `.wasm` plus a small `.mjs` loader — no Emscripten, no bundler.
+> The same locus/bus/`std::*` program you run natively can run in
+> the browser; you choose the target at build time. The browser
+> APIs you can't reimplement (fetch, WebSocket, WebGL, the DOM)
+> come in as thin host functions, and Hale functions you want the
+> page to call go out as exports.
+
+## Building for wasm
+
+```sh
+hale build --target wasm32 client/main.hl
+```
+
+This emits `client/main.wasm` (self-contained — a tiny bundled
+libc, no external runtime) and `client/main.mjs` (a loader that
+instantiates the module and wires the host functions). The program
+declares the target so the typechecker can gate the parts of the
+standard library that need syscalls:
+
+```hale
+target wasm { }
+```
+
+Under `target wasm`, the portable stdlib works as usual
+(`std::str`, `std::bytes`, `std::json`, `std::math`, …), but the
+POSIX-backed namespaces (`std::io::tcp`, `std::process`,
+`std::http`, …) are rejected at typecheck — the browser sandbox has
+no syscalls. Reach the outside world through host functions instead.
+
+## Calling the host: `@ffi("js")`
+
+`@ffi("js")` is the wasm sibling of [`@ffi("c")`](./binding-c.md):
+it declares a function the JavaScript loader provides.
+
+```hale
+target wasm { }
+@ffi("js") fn console_log(msg: String);
+@ffi("js") fn draw_line(x1: Float, y1: Float, z1: Float,
+                        x2: Float, y2: Float, z2: Float);
+```
+
+Marshalling matches the C boundary: `Float` is a JS number (the
+easy case), `Int` is an i64 → a JS `BigInt` (prefer `Float` for
+host-facing numbers), and `String`/`Bytes` arrive as a pointer the
+loader reads out of wasm memory. The loader ships a built-in
+`console_log` and the libm set (so `std::math` just works); your
+page supplies the rest through `run(glue)`:
+
+```js
+import { run } from "./main.mjs";
+const inst = await run((h) => ({
+  draw_line: (x1,y1,z1,x2,y2,z2) => { /* push to a WebGL buffer */ },
+}));
+```
+
+## Letting the host call you: `@export` + the app locus
+
+To run a game loop or react to network messages, the *host* needs
+to call *into* Hale. The browser-client shape is an **`@export
+locus`** — the persistent "app" of your program:
+
+```hale
+@export locus Client {
+    params { sx: Float = 0.0; sy: Float = 0.0; ready: Bool = false; }
+    birth() { }
+    fn on_message() { /* parse an inbound frame, update fields */ }
+    fn frame()      { /* render from the fields */ }
+}
+```
+
+Each `fn` method becomes a wasm export the page calls by name
+(`inst.exports.frame()`). State lives in the locus's fields and
+**persists across calls** — `on_message()` writes `self.sx`,
+`frame()` reads it, just like a native locus. On the native target
+`@export` is a no-op. (There is also a lower-level `@export fn` for
+free functions — same export, but stateless; see below.) Methods
+may not be `fallible` (the host has no error channel), and the locus
+must not define `run()` — the host drives it.
+
+## The run-model: entry inversion
+
+A native program blocks in `main`. A browser program can't — it
+must return to the event loop so the page stays responsive. So a
+program built with `@export` runs **inverted**: there is no `main`,
+and the host drives the exports (typically `frame()` once per
+`requestAnimationFrame`).
+
+The compiler synthesizes an exported **`_hale_start()`** that sets
+up a *persistent* program arena and **instantiates your `@export
+locus`** (running `birth`). The loader calls it once at startup;
+after that the page drives the methods:
+
+```js
+const inst = await run(glue);     // _hale_start ran here (Client is alive)
+function tick() {
+  inst.exports.frame();
+  requestAnimationFrame(tick);
+}
+requestAnimationFrame(tick);
+```
+
+A program made of `@export` declarations needs no `fn main` at all.
+
+## Inbound messages
+
+The page hands network bytes to Hale through the **inbox**: write
+them into wasm memory, publish the length, then call a method.
+
+```js
+// JS: hand a WebSocket frame to Hale, then notify it
+const bytes = new TextEncoder().encode(ev.data);
+const ptr = inst.exports.lotus_wasm_alloc(bytes.length);
+new Uint8Array(inst.exports.memory.buffer).set(bytes, ptr);
+inst.exports.lotus_wasm_set_inbox(bytes.length);
+inst.exports.on_message();
+```
+
+```hale
+@ffi("c") fn lotus_wasm_inbox() -> Bytes;   // the bytes JS wrote
+
+// inside the Client locus:
+fn on_message() {
+    let msg = lotus_wasm_inbox();
+    if len(msg) > 0 {
+        let s = std::str::from_bytes(msg);
+        // ... std::json parse, then store into self.* ...
+        self.ready = true;
+    }
+}
+```
+
+This is the full pattern for a browser client: the page owns the
+transport (fetch / WebSocket) and the GL context; the `@export
+locus` parses the protocol with `std::json`, holds the game state
+in its fields, runs the camera, and emits geometry — the same code
+shape it would have natively.
+
+## Lower-level: `@export fn` + the state cell
+
+If you don't want a locus, you can export free functions
+(`@export fn frame()`). These are stateless — each call's
+allocations are released on return — so cross-call state must be
+parked in the runtime **state cell**, packed into `Bytes`:
+
+```hale
+@ffi("c") fn lotus_wasm_state_set(b: Bytes);
+@ffi("c") fn lotus_wasm_state_get() -> Bytes;
+```
+
+The `@export locus` model is preferred for anything with state; the
+state cell exists for the free-fn path and for hand-rolled layouts.
+
+See [`spec/ffi.md` § WASM host interface](../reference.md) for the
+exact marshalling and diagnostic rules.

--- a/spec/ffi.md
+++ b/spec/ffi.md
@@ -26,8 +26,9 @@ absent — the declaration terminates with `;`. The compiler
 synthesizes an empty body internally so downstream passes keep
 the same `FnDecl` shape; user code MAY NOT write a `{...}` block.
 
-The ABI string is the literal `"c"`. Other ABI strings are
-reserved for future extensions and are rejected at parse time.
+The ABI string is the literal `"c"` (native C-ABI binding) or
+`"js"` (a WASM host import — see [§ WASM host interface](#wasm-host-interface)).
+Any other ABI string is rejected at parse time.
 
 ## Position
 
@@ -313,6 +314,9 @@ Parser errors:
   return an error sentinel, the Hale wrapper above translates
   to \`fallible(E)\` if needed`
 - `expected \`fn\` after \`@ffi(...)\` annotation`
+- `expected \`fn\` after \`@export\` annotation`
+- `\`@export\` and \`@ffi\` are mutually exclusive — an FFI import
+  is not a module export`
 
 Typecheck errors:
 
@@ -329,6 +333,88 @@ Codegen errors:
   etc. fall here.
 - `@ffi fn \`<name>\`: parameter defaults are not supported
   across the C-ABI boundary`
+- `@export fn \`<name>\`: fallible exports are not supported yet
+  (wasm entry-inversion v1)`
+
+## WASM host interface
+
+On the `wasm32` target (`hale build --target wasm32`; the program
+declares `target wasm { }`) the foreign boundary is the JavaScript
+host rather than a C library. The same `@ffi` machinery serves the
+inbound direction, and a dual annotation `@export` serves the
+outbound direction.
+
+### `@ffi("js")` — host imports (host → into Hale's callees)
+
+`@ffi("js") fn name(...);` declares a function the **JS loader**
+provides at instantiation (a wasm `env` import), e.g.:
+
+```
+target wasm { }
+@ffi("js") fn console_log(msg: String);
+@ffi("js") fn draw_line(x1: Float, y1: Float, z1: Float,
+                        x2: Float, y2: Float, z2: Float);
+```
+
+Marshalling mirrors `@ffi("c")`: scalars pass directly (`Int` is an
+i64 → a JS `BigInt` at the boundary; `Float` is an f64 → a plain JS
+number, so `Float` is the friction-free numeric type for host
+imports), and `String`/`Bytes` pass as a pointer into wasm linear
+memory (the loader reads them with a `TextDecoder` over the module's
+`memory`). The generated `.mjs` loader supplies a built-in
+`console_log` plus the libm set (`sin`/`cos`/`tan`/`sqrt`/… mapped to
+JS `Math.*`, so `std::math` works under wasm with no app glue); an
+app wires its own imports through `run(glue)`. Position and the
+generic / defaulted restrictions are the same as `@ffi("c")`.
+
+### `@export` — exports (Hale → callable by the host)
+
+Two forms; both are wasm-only (a **no-op on the native target**) and
+both produce a wasm module export the host calls by its literal name.
+
+**`@export fn name(...) { ... }`** — a top-level free fn. Unlike
+`@ffi` it has a real Hale body. It is valid only on top-level free fns
+(same position rule as `@ffi`), is **not** `@ffi` (mutually exclusive
+— an import is not an export), and is **not** `fallible(E)` (v1 — the
+host has no error channel).
+
+**`@export locus L { ... }`** — the persistent singleton "app." At
+most one per program. It is instantiated **once** (birth runs; it is
+never dissolved), and each of its non-fallible `fn` methods becomes a
+wasm export the host calls (`inst.exports.<method>()`). State lives in
+the locus's params — ordinary Hale fields that survive across calls
+because the singleton persists. The locus **must not define `run()`**
+(it is host-driven via its methods, not a cooperative run loop);
+`fallible` methods stay internal (not exported).
+
+### Entry-inversion run-model
+
+A program built with `@export` runs **inverted**: instead of a
+blocking `main`, the host drives the exports. The compiler synthesizes
+and exports **`_hale_start()`**, which creates a **persistent** program
+arena (and bus queue) that is *not* torn down — and, for an `@export
+locus`, instantiates the singleton there and stashes its pointer. The
+generated loader calls `_hale_start` once at instantiation and then the
+host calls the exports (e.g. one per `requestAnimationFrame`). A
+program with no `fn main` is valid when it has any `@export`; if
+`_hale_start` is present the loader does **not** call `main` (its
+create-then-destroy of the arena would clobber the persistent one).
+
+Holding state across calls:
+
+- **`@export locus` (preferred):** state is the locus's fields,
+  mutated in one method and read in another — plain Hale, no
+  marshalling. This is the natural shape for a browser client.
+- **`@export fn` (lower-level):** each call's allocations are released
+  on return, so cross-call state goes through the runtime **host seam**
+  — `@ffi("c") fn lotus_wasm_state_set(b: Bytes);` /
+  `lotus_wasm_state_get() -> Bytes;` deep-copies a packed `Bytes` blob
+  into its own arena so it survives.
+
+Inbound messages use the seam in either model:
+`lotus_wasm_alloc(n)` / `lotus_wasm_set_inbox(len)` (wasm exports the
+host calls to write bytes in) + `@ffi("c") fn lotus_wasm_inbox() ->
+Bytes;` (Hale reads them and parses with `std::json` / `std::bytes`).
 
 ## Cross-references
 

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -174,8 +174,13 @@ locality_tier     = "L1" | "L2" | "L3" | "any" ;
 locus_decl        = { locus_decorator } , [ "main" ] , "locus" , IDENTIFIER ,
                     [ locus_annotations ] ,
                     "{" , { locus_member } , "}" ;
+(* `@export locus` (export_annotation, defined in § 13) marks the
+   persistent singleton "app" of a wasm program — instantiated once,
+   never dissolved, its `fn` methods exported. See `spec/ffi.md`
+   § "WASM host interface". *)
 locus_decorator   = form_annotation
                   | locality_annotation
+                  | export_annotation
                   ;
 
 (* F.31 (2026-05-23): `schedule` removed from locus_annotation.
@@ -617,9 +622,23 @@ function_type     = "fn" , "(" , [ type_expr , { "," , type_expr } ] , ")" ,
 const_decl        = "const" , IDENTIFIER , ":" , type_expr , "=" ,
                     expression , ";" ;
 
-function_decl     = "fn" , IDENTIFIER , [ generic_params ] ,
+function_decl     = [ function_decorator ] ,
+                    "fn" , IDENTIFIER , [ generic_params ] ,
                     "(" , [ param_list ] , ")" ,
-                    [ "->" , type_expr ] , [ fallible_marker ] , block ;
+                    [ "->" , type_expr ] , [ fallible_marker ] ,
+                    ( block | ";" ) ;
+
+(* A free fn may carry one fn-level decorator. `@ffi("c"|"js")`
+   marks an external binding — a native C-ABI symbol ("c") or a
+   WASM host import ("js"); the body is absent (terminates with
+   `;`). `@export` marks a wasm module export the JS host calls by
+   name — a real-bodied top-level free fn, no-op on the native
+   target. `export` is a reserved keyword; the two decorators are
+   mutually exclusive (an import is not an export). See
+   `spec/ffi.md` § "WASM host interface". *)
+function_decorator = ffi_annotation | export_annotation ;
+ffi_annotation    = "@" , "ffi" , "(" , STRING_LIT , ")" ;
+export_annotation = "@" , "export" ;
 
 (* v1.x-FORM-1: a fallible fn's return type is "value of T, or
    an error has occurred with payload P." Callers MUST address


### PR DESCRIPTION
## What

Adds the **WASM host interface** so a Hale program can be driven by a JavaScript host — the enabler for full-stack browser apps (the Lightcone client lives in a separate repo and is the motivating use case).

## Language surface

- **`@export fn`** — export a free fn to the wasm host; codegen emits an arena-less wrapper over the persistent program arena.
- **`@export locus`** — the persistent singleton "app": instantiated once by the synthesized `_hale_start` (birth runs, never dissolved), each non-fallible `fn` method exported. **State lives in the locus's fields** and persists across host calls.
- **Entry inversion** — `_hale_start` sets up a persistent arena (and instantiates the `@export locus`); the loader calls it once, then the host drives the exports (e.g. one per `requestAnimationFrame`). No `fn main` required.

Documented in `spec/ffi.md` (new "WASM host interface" section), `spec/grammar.ebnf` (new `function_decorator` / `locus_decorator` cases), and a new `docs/src/systems/webassembly.md` chapter.

## Runtime / host seam (`runtime/lotus_arena.c`)

- **Inbox** (`lotus_wasm_alloc` / `lotus_wasm_set_inbox` / `lotus_wasm_inbox`) — hand host bytes (a WebSocket frame) into Hale as `Bytes`.
- **State cell** (`lotus_wasm_state_set` / `_get`) — persistent state for the `@export fn` path.
- **Sockets are now close-on-exec.** A `fork`+`exec` (`std::process::spawn`) no longer leaks the parent's accepted/listen/udp sockets into the child — this had hung read-to-EOF HTTP clients talking through a forking daemon. Gated out under `__wasm__` (no fork there).

## Portable stdlib under wasm

- Real `strtod` / `strtoll` / `strtol` / `strtoul` in the wasm libc shim (were stubs returning `0`, so `parse_int`/`parse_float` silently returned `0`).
- The generated JS loader provides libm via JS `Math.*`, so `std::math` works under wasm with no app glue.

## Tests

`crates/hale-codegen/tests/wasm_target.rs` gains `@export`-fn and `@export`-locus persistence tests (state survives across separate host calls). Native builds are unaffected (`@export` is a no-op on native; CLOEXEC is gated out under `__wasm__`); existing wasm/gating/syntax suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
