### PR TITLE
fix(wasm): heap-allocate the @export-locus singleton (was a dangling stack alloca)

### DIFF
--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -502,6 +502,7 @@ pub fn build_executable_with_options(
         target_data,
         is_wasm,
         wasm_exports: Vec::new(),
+        instantiating_persistent_singleton: false,
         program: &merged,
         current_fn: None,
         current_user_fn_ret: None,
@@ -1532,6 +1533,11 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// arena-less wrappers were emitted; passed to `wasm-ld
     /// --export=`. Empty on native builds.
     pub(crate) wasm_exports: Vec<String>,
+    /// WASM entry-inversion: set while `_hale_start` instantiates the
+    /// `@export locus` singleton, so `lower_locus_instantiation`
+    /// allocates its struct in the persistent program arena (not a
+    /// stack alloca — the singleton outlives `_hale_start`).
+    pub(crate) instantiating_persistent_singleton: bool,
     pub(crate) program: &'p Program,
     /// Set while lowering a function's body so that `if` / `while`
     /// can `append_basic_block` onto it.
@@ -8835,8 +8841,12 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             self.current_fn = Some(start_fn);
             self.deferred_dissolves.push(Vec::new());
             self.defer_next_locus_dissolve = true;
+            // Allocate the singleton in the persistent global arena, not
+            // a stack alloca — it must outlive _hale_start.
+            self.instantiating_persistent_singleton = true;
             let scope = Scope::default();
             let self_ptr = self.lower_locus_instantiation(lname, &[], &scope)?;
+            self.instantiating_persistent_singleton = false;
             self.defer_next_locus_dissolve = false;
             // Drop the frame WITHOUT flushing → no dissolve IR emitted.
             let _ = self.deferred_dissolves.pop();

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -329,6 +329,51 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                 .left()
                 .expect("lotus_arena_alloc returns ptr")
                 .into_pointer_value()
+        } else if self.instantiating_persistent_singleton {
+            // WASM entry-inversion: the `@export locus` singleton is
+            // instantiated in `_hale_start` but OUTLIVES it — the host
+            // calls its methods long after _hale_start returns. A stack
+            // alloca would be a dangle (and O2's DSE drops the now-"dead"
+            // field stores, so reads see garbage / aliased arrays — the
+            // multi-array-field bug). Allocate it in the program-global
+            // arena, which `_hale_start` creates and never destroys.
+            let ptr_t = self.context.ptr_type(AddressSpace::default());
+            let arena_global = self
+                .module
+                .get_global("lotus.arena.global")
+                .expect("arena global declared");
+            let global_arena = self
+                .builder
+                .build_load(
+                    ptr_t,
+                    arena_global.as_pointer_value(),
+                    &format!("{}.singleton.arena", locus_name),
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let alloc_fn = self
+                .module
+                .get_function("lotus_arena_alloc")
+                .expect("lotus_arena_alloc declared");
+            let i64_t = self.context.i64_type();
+            let size = info
+                .struct_ty
+                .size_of()
+                .expect("locus struct ty has known size");
+            self.builder
+                .build_call(
+                    alloc_fn,
+                    &[
+                        global_arena.into(),
+                        size.into(),
+                        i64_t.const_int(16, false).into(),
+                    ],
+                    &format!("{}.self.singleton", locus_name),
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                .try_as_basic_value()
+                .left()
+                .expect("lotus_arena_alloc returns ptr")
+                .into_pointer_value()
         } else if self.current_fn.is_some() {
             // Always hoist the locus-struct alloca to the fn's entry
             // block when we have one. A `build_alloca` placed at the

--- a/crates/hale-codegen/tests/wasm_target.rs
+++ b/crates/hale-codegen/tests/wasm_target.rs
@@ -189,6 +189,87 @@ console.log(v === 3n ? "LOCUS_STATE_OK" : ("LOCUS_STATE_FAIL:" + v));
     );
 }
 
+/// Regression: an `@export locus` with MULTIPLE mixed-type fixed-array
+/// fields must not alias under wasm. The singleton is instantiated in
+/// `_hale_start` but outlives it, so its struct must be heap-allocated
+/// in the persistent program arena — a stack alloca dangled, and O2's
+/// dead-store elimination then dropped the array-pointer field stores,
+/// making the Float arrays read the Int array's bits. Here `fill()`
+/// writes distinct values to three Float arrays + one Int array in a
+/// loop; reading them back across a separate call must return exactly
+/// what was written.
+#[test]
+fn wasm_export_locus_multiple_array_fields_no_alias() {
+    let (Some(_clang), Some(_wasm_ld), Some(node)) =
+        (tool("clang"), tool("wasm-ld"), tool("node"))
+    else {
+        eprintln!("SKIP wasm_export_locus_multiple_array_fields_no_alias: toolchain missing");
+        return;
+    };
+    let src = r#"
+        target wasm { }
+        @export locus T {
+            params {
+                ax:[Float;8]=[0.0;8]; ay:[Float;8]=[0.0;8];
+                az:[Float;8]=[0.0;8]; owner:[Int;8]=[0;8];
+            }
+            birth() { }
+            fn fill() {
+                let mut i = 0;
+                while i < 3 {
+                    self.ax[i] = 100.0 + std::math::int_to_float(i);
+                    self.ay[i] = 200.0 + std::math::int_to_float(i);
+                    self.az[i] = 300.0 + std::math::int_to_float(i);
+                    self.owner[i] = i * 10;
+                    i = i + 1;
+                }
+            }
+            fn rx(k:Int)->Float{return self.ax[k];}
+            fn ry(k:Int)->Float{return self.ay[k];}
+            fn rz(k:Int)->Float{return self.az[k];}
+            fn ro(k:Int)->Int{return self.owner[k];}
+        }
+    "#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let wasm = tmp("export_locus_arrays.wasm");
+    build_executable_with_options(&program, &wasm, &[], &wasm_opts())
+        .expect("wasm codegen + link");
+    let loader = wasm.with_extension("mjs");
+    let harness = wasm.with_extension("harness.mjs");
+    let loader_name = loader.file_name().unwrap().to_str().unwrap();
+    std::fs::write(
+        &harness,
+        format!(
+            r#"import {{ run }} from "./{loader_name}";
+const inst = await run(() => ({{}}));
+inst.exports.fill();
+let ok = true;
+for (let k = 0; k < 3; k++) {{
+  const x = inst.exports.rx(BigInt(k)), y = inst.exports.ry(BigInt(k));
+  const z = inst.exports.rz(BigInt(k)), o = inst.exports.ro(BigInt(k));
+  if (x !== 100+k || y !== 200+k || z !== 300+k || o !== BigInt(k*10)) {{
+    ok = false; console.log(`MISMATCH k=${{k}}: x=${{x}} y=${{y}} z=${{z}} o=${{o}}`);
+  }}
+}}
+console.log(ok ? "ARRAYS_OK" : "ARRAYS_FAIL");
+"#
+        ),
+    )
+    .expect("write harness");
+    let run = Command::new(&node).arg(&harness).output().expect("run node harness");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    let _ = std::fs::remove_file(&wasm);
+    let _ = std::fs::remove_file(&loader);
+    let _ = std::fs::remove_file(&harness);
+    assert!(
+        run.status.success() && stdout.contains("ARRAYS_OK"),
+        "multiple mixed-type array fields on an @export locus must not alias \
+         under wasm:\nstdout: {}\nstderr: {}",
+        stdout,
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
 fn tool(name: &str) -> Option<String> {
     for cand in [name, &format!("{}-18", name)] {
         if Command::new(cand).arg("--version").output().is_ok() {


### PR DESCRIPTION
## The bug

A wasm `@export locus` (the persistent singleton) read garbage from its fields when it had several fixed-array fields — the `Float` arrays returned the `Int` array's bits, looking like field aliasing. Only under `--target wasm32` + `-O2`; native and `-O0` were fine.

## Root cause

The singleton is instantiated in the synthesized `_hale_start`, but `lower_locus_instantiation` fell through to a **stack alloca** (`%self = alloca %locus.T`). The singleton **outlives `_hale_start`** — the JS host calls its methods later via the `@lotus.app.self` global. After `_hale_start` returned that stack was dead; `-O2`'s dead-store elimination then dropped the now-"dead" field stores, and the reused wasm stack made the fields read garbage. (Native survived by luck; `-O0` had no DSE.)

## Fix

A `Cx.instantiating_persistent_singleton` flag, set around the singleton's `lower_locus_instantiation` call, adds a branch in `instantiation.rs` (before the `current_fn` stack-alloca path) that allocates the struct in the **persistent program arena** — `lotus_arena_alloc(@lotus.arena.global, size, 16)` — instead of a stack alloca. The singleton is never dissolved and the global arena is never torn down, so it lives for the module's lifetime.

## Test

`wasm_target.rs::wasm_export_locus_multiple_array_fields_no_alias` — three `Float` arrays + one `Int` array on an `@export locus`, filled in a loop, read back across a separate host call; asserts exact values. Native builds unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)