### PR TITLE
feat(stdlib): expose std::io::tcp::__set_recv_timeout_ns (bounded accept)

### DIFF
--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -16764,6 +16764,10 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 let _ = self.lower_std_io_tcp_shutdown_listen_socket(args, scope)?;
                 Ok(())
             }
+            ["std", "io", "tcp", "__set_recv_timeout_ns"] => {
+                let _ = self.lower_std_io_tcp_set_recv_timeout(args, scope)?;
+                Ok(())
+            }
             ["std", "io", "udp", "__close"]
             | ["std", "io", "udp", "close"] => {
                 let _ = self.lower_std_io_udp_close(args, scope)?;
@@ -17571,6 +17575,9 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             }
             ["std", "io", "tcp", "__shutdown_listen_socket"] => {
                 self.lower_std_io_tcp_shutdown_listen_socket(args, scope)
+            }
+            ["std", "io", "tcp", "__set_recv_timeout_ns"] => {
+                self.lower_std_io_tcp_set_recv_timeout(args, scope)
             }
             ["std", "io", "udp", "__close"]
             | ["std", "io", "udp", "close"] => {

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1507,6 +1507,18 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             tcp_shutdown_listen_ty,
             None,
         );
+        // declare i32 @lotus_tcp_set_recv_timeout_ns(i32 fd, i64 ns)
+        // SO_RCVTIMEO on the socket. On a main-thread blocking
+        // accept() this bounds the wait (accept returns -1 after
+        // `ns`), letting a server give up an idle listen instead of
+        // blocking forever. ns <= 0 clears the timeout.
+        let tcp_set_timeout_ty =
+            i32_t.fn_type(&[i32_t.into(), i64_t.into()], false);
+        self.module.add_function(
+            "lotus_tcp_set_recv_timeout_ns",
+            tcp_set_timeout_ty,
+            None,
+        );
 
         // TLS substrate (std::io::tls::*). Client-only at v1:
         // a handshaked connection identified by an opaque int

--- a/crates/hale-codegen/src/stdlib/io_tcp.rs
+++ b/crates/hale-codegen/src/stdlib/io_tcp.rs
@@ -84,6 +84,11 @@ pub(crate) trait IoTcpStdlib<'ctx> {
         args: &[Expr],
         scope: &Scope<'ctx>,
     ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
+    fn lower_std_io_tcp_set_recv_timeout(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
 }
 
 impl<'ctx, 'p> IoTcpStdlib<'ctx> for Cx<'ctx, 'p> {
@@ -815,6 +820,68 @@ impl<'ctx, 'p> IoTcpStdlib<'ctx> for Cx<'ctx, 'p> {
         let ret_i64 = self
             .builder
             .build_int_s_extend(ret_i32, i64_t, "close.i64")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        Ok((ret_i64.into(), CodegenTy::Int))
+    }
+
+    /// `std::io::tcp::__set_recv_timeout_ns(fd: Int, ns: Int) -> Int`.
+    /// SO_RCVTIMEO on the socket; on a main-thread blocking accept()
+    /// this bounds the idle wait (accept returns -1 after `ns`).
+    /// Returns the setsockopt result (0 / -1).
+    fn lower_std_io_tcp_set_recv_timeout(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        if args.len() != 2 {
+            return Err(CodegenError::Unsupported(format!(
+                "std::io::tcp::__set_recv_timeout_ns takes 2 args \
+                 (fd, ns), got {}",
+                args.len()
+            )));
+        }
+        let (fd_val, fd_ty) = self.lower_expr(&args[0], scope)?;
+        if fd_ty != CodegenTy::Int {
+            return Err(CodegenError::Unsupported(format!(
+                "std::io::tcp::__set_recv_timeout_ns: fd must be Int, \
+                 got {:?}",
+                fd_ty
+            )));
+        }
+        let (ns_val, ns_ty) = self.lower_expr(&args[1], scope)?;
+        if ns_ty != CodegenTy::Int {
+            return Err(CodegenError::Unsupported(format!(
+                "std::io::tcp::__set_recv_timeout_ns: ns must be Int, \
+                 got {:?}",
+                ns_ty
+            )));
+        }
+        let i32_t = self.context.i32_type();
+        let i64_t = self.context.i64_type();
+        let fd_i32 = self
+            .builder
+            .build_int_truncate(fd_val.into_int_value(), i32_t, "to.fd.i32")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let f = self
+            .module
+            .get_function("lotus_tcp_set_recv_timeout_ns")
+            .expect("lotus_tcp_set_recv_timeout_ns declared");
+        let call = self
+            .builder
+            .build_call(
+                f,
+                &[fd_i32.into(), ns_val.into_int_value().into()],
+                "to.ret",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let ret_i32 = call
+            .try_as_basic_value()
+            .left()
+            .expect("returns i32")
+            .into_int_value();
+        let ret_i64 = self
+            .builder
+            .build_int_s_extend(ret_i32, i64_t, "to.i64")
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         Ok((ret_i64.into(), CodegenTy::Int))
     }

--- a/crates/hale-types/src/purity.rs
+++ b/crates/hale-types/src/purity.rs
@@ -118,6 +118,7 @@ const IMPURE_STDLIB_PATHS: &[&[&str]] = &[
     &["std", "io", "tcp", "__accept_one"],
     &["std", "io", "tcp", "__connect"],
     &["std", "io", "tcp", "__close_fd"],
+    &["std", "io", "tcp", "__set_recv_timeout_ns"],
     &["std", "io", "tcp", "set_recv_timeout"],
     &["std", "io", "tcp", "set_send_timeout"],
     &["std", "io", "tcp", "set_nodelay"],


### PR DESCRIPTION
The runtime already had `lotus_tcp_set_recv_timeout_ns` (SO_RCVTIMEO) but it wasn't reachable from Hale. Expose it as the internal primitive:

```
std::io::tcp::__set_recv_timeout_ns(fd: Int, ns: Int) -> Int
```

mirroring `__close_fd`: extern decl (`shared/builtins.rs`), path-call lowering (`stdlib/io_tcp.rs`), the two codegen match arms, and an impure-I/O entry (`hale-types/purity.rs`).

On a main-thread blocking `accept()`, `SO_RCVTIMEO` makes `accept()` return `-1` after the timeout, so a server can bound an idle listen instead of blocking forever. Causality's game runner uses it to give up an orphaned slot and free its port. No spec change — `__`-internal primitive like `__accept_one` / `__close_fd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)