### PR TITLE
fix(wasm): silence -Wbuiltin-requires-header on the freestanding shim

### DIFF
--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -898,7 +898,12 @@ fn link_wasm(
     let wasm_ld = resolve_tool("wasm-ld");
     let cc = |src: &Path, out: &Path, extra: &[&str]| -> Result<(), CodegenError> {
         let status = Command::new(&clang)
-            .args(["--target=wasm32", "-mbulk-memory", "-O2", "-c"])
+            // -Wno-builtin-requires-header: the freestanding wasm shim
+            // intentionally forward-declares libc (fopen/etc.) instead of
+            // pulling in headers; clang's builtin-header note is a false
+            // positive here.
+            .args(["--target=wasm32", "-mbulk-memory", "-O2", "-c",
+                   "-Wno-builtin-requires-header"])
             .args(extra)
             .arg(src)
             .arg("-o")


### PR DESCRIPTION
The wasm runtime shim forward-declares libc (`fopen`/etc.) for a freestanding build; clang's `-Wbuiltin-requires-header` on the `fopen` decl is a false positive that printed on every wasm compile. Pass `-Wno-builtin-requires-header` to the wasm clang invocation. No behavior change; wasm builds are now warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)