### PR TITLE
fix(wasm): Decimal i128 builtins + @ffi("js") Int↔number marshaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,36 @@ behavior.
   (`p += snprintf(...)`). Test:
   `tests/wasm_target.rs::wasm_string_int_concat_formats`.
 
-  **Known separate limitation (NOT this fix):** `to_string(Decimal)` is still
-  wrong under wasm32 — the i128 decimal *value* is corrupted before it reaches
-  the formatter (same `(hi, lo)` pair miscompiles for both `to_string` and
-  `std::decimal::to_float`; the codegen i128→(hi,lo) split is correct, so the
-  fault is in i128 storage/representation on the wasm32 target, the i128-
-  alignment class noted in `spec/memory.md`). It was hidden by the empty stub
-  before; this fix surfaces it as garbage. Decimal→string on wasm needs its
-  own fix; Int/Float are correct.
+  (A follow-up — see the next entry — fixed `Decimal` on wasm too, which
+  this fix had surfaced as garbage.)
+
+- **Fixed `Decimal` under `--target wasm32` (i128 builtins).** clang lowers
+  `__int128` multiply / divide / →double to compiler-rt libcalls
+  (`__multi3` / `__udivti3` / `__umodti3` / `__divti3` / `__modti3` /
+  `__floatuntidf`), and Ubuntu's clang ships no `libclang_rt.builtins-wasm32.a`,
+  so `wasm-ld --allow-undefined` turned them into imports the JS loader stubbed
+  to 0 — every `Decimal` (the i128 mantissa at scale 9: arithmetic *and*
+  `to_string` *and* `std::decimal::to_float`) came out garbage. The bundled
+  wasm libc (`runtime/wasm/lotus_wasm_libc.c`) now **defines** those builtins,
+  with bodies that use only 64-bit ops (32-bit partial-product multiply,
+  shift-subtract divmod, `f64.convert_i64_u`-based i128→double) so they never
+  recurse into the very builtins they provide. Decimal on wasm now matches
+  native byte-for-byte (`5.0d`→`5`, `19.99d * 3.0d`→`59.97`, `10.0d / 4.0d`→
+  `2.5`, `to_float(19.99d)`→`19.99`). Test:
+  `tests/wasm_target.rs::wasm_decimal_i128_builtins`.
+
+- **`@ffi("js")` marshals `Int` / `Duration` as a JS `number` (f64), not a
+  `BigInt` (i64).** A Hale `Int` passed to a host import used to arrive in JS
+  as a `BigInt`, forcing every handler to `Number(x)` before using it (and a
+  host import returning `Int` had to hand back a `BigInt`). Now i64-class
+  scalars cross the `@ffi("js")` boundary as f64: the runtime `sitofp`s args
+  before the call and `fptosi`s the return, the import's wasm signature uses
+  f64, and the JS handler sees a plain `number`. Trade-off: f64's 53-bit
+  integer range — an `Int` beyond 2^53 loses precision across the boundary
+  (pass it as a `String`/`Bytes` payload instead). Scoped to `@ffi("js")`;
+  `@ffi("c")` keeps i64 (those resolve to linked C symbols expecting i64).
+  Test: `tests/wasm_target.rs::wasm_ffi_js_int_marshals_as_number`. See
+  `spec/ffi.md` § WASM host interface.
 
 - **`std::math::round` / `std::math::trunc` — Float→Int with a chosen
   rounding mode.** Both return an `Int` directly: `round(f)` is round-half-

--- a/crates/hale-codegen/runtime/wasm/lotus_wasm_libc.c
+++ b/crates/hale-codegen/runtime/wasm/lotus_wasm_libc.c
@@ -169,3 +169,106 @@ char *strdup(const char *s) {
  * shutdown replaces this in a later phase). */
 __attribute__((noreturn)) void exit(int code) { (void)code; __builtin_trap(); }
 __attribute__((noreturn)) void _exit(int code) { (void)code; __builtin_trap(); }
+
+/* ---- 128-bit integer builtins (compiler-rt) ----------------------
+ * clang lowers __int128 multiply / divide / int->double to these
+ * libcalls, and Ubuntu's clang ships no wasm32 builtins archive — so the
+ * runtime's Decimal path (i128 mantissa at scale 9: arithmetic +
+ * to_string + to_float) linked __multi3 / __udivti3 / __umodti3 /
+ * __floatuntidf as undefined imports that the JS loader stubbed to 0,
+ * making every Decimal on wasm garbage. Provide real implementations.
+ *
+ * The bodies use ONLY 64-bit operations (plus *constant* 128-bit
+ * shift/or to split & join the halves, which LLVM inlines to register
+ * moves) — never a 128-bit multiply, divide, or variable shift — so they
+ * cannot recurse into the very builtins they define. -fno-builtin (this
+ * TU) also keeps the loops from being re-recognized into libcalls. */
+typedef unsigned long long lotus_u64;
+#define LOTUS_LO64(x) ((lotus_u64)(x))
+#define LOTUS_HI64(x) ((lotus_u64)((unsigned __int128)(x) >> 64))
+#define LOTUS_MK128(hi, lo) \
+    (((unsigned __int128)(lotus_u64)(hi) << 64) | (unsigned __int128)(lotus_u64)(lo))
+
+unsigned __int128 __multi3(unsigned __int128 a, unsigned __int128 b) {
+    lotus_u64 alo = LOTUS_LO64(a), ahi = LOTUS_HI64(a);
+    lotus_u64 blo = LOTUS_LO64(b), bhi = LOTUS_HI64(b);
+    /* 64x64 -> 128 for alo*blo via 32-bit partial products. */
+    lotus_u64 a0 = (unsigned)alo, a1 = alo >> 32;
+    lotus_u64 b0 = (unsigned)blo, b1 = blo >> 32;
+    lotus_u64 t = a0 * b0;
+    lotus_u64 w0 = (unsigned)t;
+    lotus_u64 t1 = a1 * b0 + (t >> 32);
+    lotus_u64 w1 = (unsigned)t1;
+    lotus_u64 w2 = t1 >> 32;
+    lotus_u64 t2 = a0 * b1 + w1;
+    w1 = (unsigned)t2;
+    lotus_u64 lo_ll = (w1 << 32) | w0;
+    lotus_u64 hi_ll = a1 * b1 + w2 + (t2 >> 32);
+    /* + cross terms (only their low 64 bits land in the result's hi). */
+    lotus_u64 res_hi = hi_ll + alo * bhi + ahi * blo;
+    return LOTUS_MK128(res_hi, lo_ll);
+}
+
+/* Unsigned 128/128 divmod, shift-subtract over 64-bit halves. */
+static unsigned __int128 lotus_udivmod128(unsigned __int128 n,
+                                          unsigned __int128 d,
+                                          unsigned __int128 *rem) {
+    lotus_u64 n_hi = LOTUS_HI64(n), n_lo = LOTUS_LO64(n);
+    lotus_u64 d_hi = LOTUS_HI64(d), d_lo = LOTUS_LO64(d);
+    if ((d_hi | d_lo) == 0) __builtin_trap();   /* divide by zero */
+    lotus_u64 q_hi = 0, q_lo = 0;
+    lotus_u64 r_hi = 0, r_lo = 0;
+    for (int i = 127; i >= 0; i--) {
+        r_hi = (r_hi << 1) | (r_lo >> 63);      /* r <<= 1 */
+        r_lo = r_lo << 1;
+        lotus_u64 bit = (i < 64) ? ((n_lo >> i) & 1u)
+                                 : ((n_hi >> (i - 64)) & 1u);
+        r_lo |= bit;
+        if (r_hi > d_hi || (r_hi == d_hi && r_lo >= d_lo)) {  /* r >= d */
+            lotus_u64 borrow = (r_lo < d_lo) ? 1u : 0u;
+            r_lo = r_lo - d_lo;
+            r_hi = r_hi - d_hi - borrow;
+            if (i < 64) q_lo |= ((lotus_u64)1 << i);
+            else        q_hi |= ((lotus_u64)1 << (i - 64));
+        }
+    }
+    if (rem) *rem = LOTUS_MK128(r_hi, r_lo);
+    return LOTUS_MK128(q_hi, q_lo);
+}
+
+unsigned __int128 __udivti3(unsigned __int128 a, unsigned __int128 b) {
+    return lotus_udivmod128(a, b, 0);
+}
+unsigned __int128 __umodti3(unsigned __int128 a, unsigned __int128 b) {
+    unsigned __int128 r;
+    lotus_udivmod128(a, b, &r);
+    return r;
+}
+__int128 __divti3(__int128 a, __int128 b) {
+    int neg = 0;
+    unsigned __int128 ua = (a < 0) ? (neg ^= 1, (unsigned __int128)(-a))
+                                   : (unsigned __int128)a;
+    unsigned __int128 ub = (b < 0) ? (neg ^= 1, (unsigned __int128)(-b))
+                                   : (unsigned __int128)b;
+    unsigned __int128 q = lotus_udivmod128(ua, ub, 0);
+    return neg ? -(__int128)q : (__int128)q;
+}
+__int128 __modti3(__int128 a, __int128 b) {
+    int neg = (a < 0);
+    unsigned __int128 ua = (a < 0) ? (unsigned __int128)(-a) : (unsigned __int128)a;
+    unsigned __int128 ub = (b < 0) ? (unsigned __int128)(-b) : (unsigned __int128)b;
+    unsigned __int128 r;
+    lotus_udivmod128(ua, ub, &r);
+    return neg ? -(__int128)r : (__int128)r;
+}
+
+/* i128 -> double. u64 -> double is native wasm (f64.convert_i64_u). */
+double __floatuntidf(unsigned __int128 a) {
+    double hi = (double)LOTUS_HI64(a);
+    double lo = (double)LOTUS_LO64(a);
+    return hi * 18446744073709551616.0 + lo;   /* hi * 2^64 + lo */
+}
+double __floattidf(__int128 a) {
+    if (a < 0) return -__floatuntidf((unsigned __int128)(-a));
+    return __floatuntidf((unsigned __int128)a);
+}

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -2217,6 +2217,15 @@ pub(crate) struct FnSig<'ctx> {
     /// `lower_user_fn_call` — direct call with the user-visible
     /// args only.
     pub(crate) is_ffi: bool,
+    /// True when this is an `@ffi("js")` host import (wasm). The JS
+    /// boundary speaks f64 (JS `number`), not i64 (which marshals as
+    /// a `BigInt` and forces callers to `Number(x)`), so Int /
+    /// Duration params + return are marshaled as f64 at the boundary
+    /// (`sitofp` before the call, `fptosi` after). Distinct from
+    /// `@ffi("c")`, which keeps i64 even on wasm (those resolve to
+    /// linked C symbols that genuinely expect i64). 2^53 precision
+    /// caveat — see `spec/ffi.md` § WASM host interface.
+    pub(crate) ffi_js: bool,
 }
 
 /// FORM-3 (2026-05-13): syntactic classifier for fn bodies that
@@ -8728,6 +8737,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 fallible: fallible_payload_ty,
                 non_allocating,
                 is_ffi: false,
+                ffi_js: false,
             },
         );
         Ok(())
@@ -9042,6 +9052,15 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// Result: LLVM emits `declare <ret> @<name>(<args>)` and the
     /// final link line picks up the implementation.
     fn declare_ffi_fn(&mut self, f: &FnDecl) -> Result<(), CodegenError> {
+        // `@ffi("js")` host imports marshal i64-class scalars as f64
+        // (JS `number`) instead of i64 (JS `BigInt`). `@ffi("c")`
+        // keeps i64 — on wasm those resolve to linked runtime C
+        // symbols that expect i64, not the JS boundary.
+        let ffi_js = f
+            .ffi
+            .as_ref()
+            .map(|a| a.abi == "js")
+            .unwrap_or(false);
         let mut param_tys = Vec::with_capacity(f.params.len());
         let mut llvm_param_tys: Vec<inkwell::types::BasicMetadataTypeEnum> =
             Vec::with_capacity(f.params.len());
@@ -9055,7 +9074,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 )));
             }
             let lt = self.type_expr_to_codegen_ty(&p.ty)?;
-            let llvm_ty = self.llvm_ffi_param_type(&lt, &f.name.name, &p.name.name)?;
+            let llvm_ty = self.llvm_ffi_param_type(&lt, ffi_js, &f.name.name, &p.name.name)?;
             llvm_param_tys.push(llvm_ty);
             param_tys.push(lt);
             defaults.push(None);
@@ -9092,7 +9111,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             match &ret_ty {
                 Some(rt) => {
                     let llvm_ret =
-                        self.llvm_ffi_return_type(rt, &f.name.name)?;
+                        self.llvm_ffi_return_type(rt, ffi_js, &f.name.name)?;
                     llvm_ret.fn_type(&llvm_param_tys, false)
                 }
                 None => self
@@ -9112,6 +9131,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 fallible: None,
                 non_allocating: true,
                 is_ffi: true,
+                ffi_js,
             },
         );
         Ok(())
@@ -9126,11 +9146,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     fn llvm_ffi_param_type(
         &self,
         ty: &CodegenTy,
+        is_js: bool,
         fn_name: &str,
         param_name: &str,
     ) -> Result<inkwell::types::BasicMetadataTypeEnum<'ctx>, CodegenError> {
         let ptr_t = self.context.ptr_type(AddressSpace::default());
         match ty {
+            // `@ffi("js")`: i64-class scalars cross as f64 (JS number),
+            // not i64 (BigInt). The call site sitofp's before the call.
+            CodegenTy::Int | CodegenTy::Duration if is_js => {
+                Ok(self.context.f64_type().into())
+            }
             CodegenTy::Int
             | CodegenTy::Duration
             | CodegenTy::Time => Ok(self.context.i64_type().into()),
@@ -9194,10 +9220,16 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     fn llvm_ffi_return_type(
         &self,
         ty: &CodegenTy,
+        is_js: bool,
         fn_name: &str,
     ) -> Result<inkwell::types::BasicTypeEnum<'ctx>, CodegenError> {
         let ptr_t = self.context.ptr_type(AddressSpace::default());
         match ty {
+            // `@ffi("js")`: i64-class scalars return as f64 (JS number);
+            // the call site fptosi's the result back to i64.
+            CodegenTy::Int | CodegenTy::Duration if is_js => {
+                Ok(self.context.f64_type().into())
+            }
             CodegenTy::Int
             | CodegenTy::Duration
             | CodegenTy::Time => Ok(self.context.i64_type().into()),
@@ -10123,6 +10155,21 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             }
             let coerced: inkwell::values::BasicValueEnum<'ctx> =
                 match expected {
+                    CodegenTy::Int | CodegenTy::Duration if sig.ffi_js => {
+                        // `@ffi("js")`: marshal the i64 as f64 (JS
+                        // number) so the host handler doesn't receive
+                        // a BigInt. Exact for |n| < 2^53.
+                        let f64_t = self.context.f64_type();
+                        let f = self
+                            .builder
+                            .build_signed_int_to_float(
+                                val.into_int_value(),
+                                f64_t,
+                                "ffi.js.int.to_f64",
+                            )
+                            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                        f.into()
+                    }
                     CodegenTy::Bool => {
                         // Hale Bool lowers to LLVM i1; the C ABI
                         // table uses i32. Zero-extend at the call.
@@ -10174,6 +10221,20 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         ))
                     })?;
                 let coerced = match &ret_ty {
+                    CodegenTy::Int | CodegenTy::Duration if sig.ffi_js => {
+                        // `@ffi("js")` returned an f64 (JS number);
+                        // narrow back to i64 (round toward zero).
+                        let i64_t = self.context.i64_type();
+                        let n = self
+                            .builder
+                            .build_float_to_signed_int(
+                                raw.into_float_value(),
+                                i64_t,
+                                "ffi.js.f64.to_int",
+                            )
+                            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                        n.into()
+                    }
                     CodegenTy::Bool => {
                         // C-side returned i32; truncate back to i1
                         // for Hale's Bool ABI internally.

--- a/crates/hale-codegen/tests/wasm_target.rs
+++ b/crates/hale-codegen/tests/wasm_target.rs
@@ -118,6 +118,121 @@ fn wasm_string_int_concat_formats() {
     }
 }
 
+/// `@ffi("js")` marshals Hale `Int` as a JS `number` (f64), not a
+/// `BigInt` (i64). Before, a host handler `(n) => ...` received a
+/// BigInt and had to `Number(n)` everywhere — a recurring sharp edge.
+/// Now `typeof n === "number"` on the way out, and an `Int`-returning
+/// host import accepts a plain JS number on the way back (f64→i64).
+/// `@ffi("c")` keeps i64 (those are linked C symbols). 2^53 caveat.
+#[test]
+fn wasm_ffi_js_int_marshals_as_number() {
+    let (Some(_clang), Some(_wasm_ld), Some(node)) =
+        (tool("clang"), tool("wasm-ld"), tool("node"))
+    else {
+        eprintln!("SKIP wasm_ffi_js_int_marshals_as_number: toolchain missing");
+        return;
+    };
+    let src = r#"
+        target wasm { }
+        @ffi("js") fn want_number(n: Int);
+        @ffi("js") fn next_id() -> Int;
+        @export locus M {
+            params { _x: Int = 0; }
+            birth() { }
+            fn go() {
+                want_number(42);
+                want_number(0 - 7);
+                let id = next_id();
+                want_number(id + 1);
+            }
+        }
+    "#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let wasm = tmp("ffijs_int.wasm");
+    build_executable_with_options(&program, &wasm, &[], &wasm_opts())
+        .expect("wasm codegen + link");
+    let loader = wasm.with_extension("mjs");
+    let harness = wasm.with_extension("harness.mjs");
+    let loader_name = loader.file_name().unwrap().to_str().unwrap();
+    std::fs::write(
+        &harness,
+        format!(
+            r#"import {{ run }} from "./{loader_name}";
+const seen = [];
+const inst = await run(() => ({{
+  want_number: (n) => seen.push([typeof n, Number(n)]),
+  next_id: () => 1000,
+}}));
+inst.exports.go();
+const ok = seen.length === 3 && seen.every(([t]) => t === "number")
+  && seen[0][1] === 42 && seen[1][1] === -7 && seen[2][1] === 1001;
+console.log(ok ? "FFIJS_NUMBER_OK" : ("FFIJS_NUMBER_FAIL:" + JSON.stringify(seen)));
+"#
+        ),
+    )
+    .expect("write harness");
+    let run = Command::new(&node).arg(&harness).output().expect("run node harness");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    let _ = std::fs::remove_file(&wasm);
+    let _ = std::fs::remove_file(&loader);
+    let _ = std::fs::remove_file(&harness);
+    assert!(
+        run.status.success() && stdout.contains("FFIJS_NUMBER_OK"),
+        "@ffi(\"js\") Int should cross as a JS number both ways:\n\
+         stdout: {}\nstderr: {}",
+        stdout,
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
+/// Decimal (i128 mantissa, scale 9) must format and compute correctly
+/// under wasm32. Regression: clang lowers i128 multiply/divide/→double
+/// to compiler-rt libcalls (`__multi3` / `__udivti3` / `__umodti3` /
+/// `__floatuntidf`), Ubuntu's clang ships no wasm32 builtins archive, so
+/// `--allow-undefined` turned them into imports the loader stubbed to 0 —
+/// every Decimal came out garbage. The bundled wasm libc now defines
+/// those builtins (64-bit-only bodies). Checks formatting, negatives,
+/// `*`, `/`, `+`, and `std::decimal::to_float`.
+#[test]
+fn wasm_decimal_i128_builtins() {
+    let (Some(_clang), Some(_wasm_ld), Some(node)) =
+        (tool("clang"), tool("wasm-ld"), tool("node"))
+    else {
+        eprintln!("SKIP wasm_decimal_i128_builtins: toolchain missing");
+        return;
+    };
+    let src = r#"
+        target wasm { }
+        @ffi("js") fn console_log(msg: String);
+        fn main() {
+            console_log("a=" + 5.0d);
+            console_log("b=" + 19.99d);
+            console_log("neg=" + (0.0d - 2.5d));
+            console_log("mul=" + (19.99d * 3.0d));
+            console_log("div=" + (10.0d / 4.0d));
+            console_log("tf=" + std::decimal::to_float(19.99d));
+        }
+    "#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let wasm = tmp("decimal.wasm");
+    build_executable_with_options(&program, &wasm, &[], &wasm_opts())
+        .expect("wasm codegen + link");
+    let loader = wasm.with_extension("mjs");
+    let run = Command::new(&node).arg(&loader).output().expect("run node loader");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    let _ = std::fs::remove_file(&wasm);
+    let _ = std::fs::remove_file(&loader);
+    for expect in ["a=5", "b=19.99", "neg=-2.5", "mul=59.97", "div=2.5", "tf=19.99"] {
+        assert!(
+            stdout.contains(expect),
+            "wasm Decimal wrong (expected line {:?}):\nstdout: {}\nstderr: {}",
+            expect,
+            stdout,
+            String::from_utf8_lossy(&run.stderr)
+        );
+    }
+}
+
 /// WASM entry-inversion: `@export fn` + the synthesized `_hale_start` +
 /// the runtime state cell give a wasm module PERSISTENT state across
 /// separate host calls. A program with only `@export` fns (no `fn main`)

--- a/docs/src/systems/webassembly.md
+++ b/docs/src/systems/webassembly.md
@@ -42,12 +42,16 @@ target wasm { }
                         x2: Float, y2: Float, z2: Float);
 ```
 
-Marshalling matches the C boundary: `Float` is a JS number (the
-easy case), `Int` is an i64 → a JS `BigInt` (prefer `Float` for
-host-facing numbers), and `String`/`Bytes` arrive as a pointer the
-loader reads out of wasm memory. The loader ships a built-in
-`console_log` and the libm set (so `std::math` just works); your
-page supplies the rest through `run(glue)`:
+Marshalling: `Float` and `Int` both arrive as a plain JS `number` —
+an `@ffi("js")` `Int` crosses as f64, *not* a `BigInt`, so your host
+handler gets a number with no `Number(x)` step, and an `Int`-returning
+import takes a plain number back. (The one caveat is f64's range:
+`Int`s beyond 2^53 lose precision across this boundary — send those as
+a `String`/`Bytes` payload. And this applies to `@ffi("js")` only;
+`@ffi("c")` keeps i64.) `String`/`Bytes` arrive as a pointer the loader
+reads out of wasm memory. The loader ships a built-in `console_log` and
+the libm set (so `std::math` just works); your page supplies the rest
+through `run(glue)`:
 
 ```js
 import { run } from "./main.mjs";

--- a/spec/ffi.md
+++ b/spec/ffi.md
@@ -356,16 +356,24 @@ target wasm { }
                         x2: Float, y2: Float, z2: Float);
 ```
 
-Marshalling mirrors `@ffi("c")`: scalars pass directly (`Int` is an
-i64 → a JS `BigInt` at the boundary; `Float` is an f64 → a plain JS
-number, so `Float` is the friction-free numeric type for host
-imports), and `String`/`Bytes` pass as a pointer into wasm linear
-memory (the loader reads them with a `TextDecoder` over the module's
-`memory`). The generated `.mjs` loader supplies a built-in
-`console_log` plus the libm set (`sin`/`cos`/`tan`/`sqrt`/… mapped to
-JS `Math.*`, so `std::math` works under wasm with no app glue); an
-app wires its own imports through `run(glue)`. Position and the
-generic / defaulted restrictions are the same as `@ffi("c")`.
+Marshalling: `Float` passes directly as a JS `number` (f64). `Int`
+and `Duration` are i64 internally, but at the **`@ffi("js")`** boundary
+they marshal as **f64 (JS `number`), not i64 (which crosses as a JS
+`BigInt`)** — the host handler receives a plain number, with no
+`Number(x)` dance, and an `Int`-returning host import accepts a plain
+JS number back (the runtime `sitofp`s before the call and `fptosi`s the
+return). The trade-off is f64's 53-bit integer range: an `Int` whose
+magnitude exceeds 2^53 loses precision across this boundary — pass such
+values as a `String`/`Bytes` payload instead. (This is **only**
+`@ffi("js")`. `@ffi("c")` keeps i64 — on wasm those resolve to linked
+runtime C symbols that genuinely expect i64.) `String`/`Bytes` pass as
+a pointer into wasm linear memory (the loader reads them with a
+`TextDecoder` over the module's `memory`). The generated `.mjs` loader
+supplies a built-in `console_log` plus the libm set
+(`sin`/`cos`/`tan`/`sqrt`/… mapped to JS `Math.*`, so `std::math` works
+under wasm with no app glue); an app wires its own imports through
+`run(glue)`. Position and the generic / defaulted restrictions are the
+same as `@ffi("c")`.
 
 ### `@export` — exports (Hale → callable by the host)
 


### PR DESCRIPTION
Closes the two wasm32 remainders flagged after the String+Int fix (#158).

## 1. Decimal was garbage under `--target wasm32`

clang lowers `__int128` multiply / divide / →double to compiler-rt libcalls (`__multi3`, `__udivti3`, `__umodti3`, `__divti3`, `__modti3`, `__floatuntidf`). Ubuntu's clang ships no `libclang_rt.builtins-wasm32.a`, so `wasm-ld --allow-undefined` turned them into imports the JS loader stubbed to `0` — every `Decimal` (i128 mantissa, scale 9) came out garbage: arithmetic *and* `to_string` *and* `std::decimal::to_float`. (The #158 snprintf fix had surfaced this — it was empty before, garbage after.)

**Fix:** the bundled wasm libc (`runtime/wasm/lotus_wasm_libc.c`) now *defines* those builtins, with bodies that use **only 64-bit operations** (32-bit partial-product multiply, shift-subtract 128÷128 divmod, `f64.convert_i64_u`-based i128→double) so they never recurse into the very builtins they provide. `-fno-builtin` (already on that TU) keeps the loops from being re-recognized into libcalls.

Verified **byte-identical to native**: `5.0d`→`5`, `19.99d`→`19.99`, `0.0d - 2.5d`→`-2.5`, `19.99d * 3.0d`→`59.97`, `10.0d / 4.0d`→`2.5`, `to_float(19.99d)`→`19.99`. The `__*ti3` / `__float*` imports are gone from the module.

## 2. `@ffi("js")` Int crossed as a JS `BigInt`

A Hale `Int` passed to a host import arrived in JS as a `BigInt` (i64), forcing every handler to `Number(x)`; an `Int`-returning import had to hand back a `BigInt`. The recurring sharp edge from the original handoff.

**Fix:** at the `@ffi("js")` boundary, `Int` / `Duration` marshal as **f64 (JS `number`)** — the import's wasm signature uses f64, the runtime `sitofp`s args before the call and `fptosi`s the return. Now `typeof n === "number"` in handlers, both directions. Gated on `abi == "js"` (new `FnSig.ffi_js` flag); **`@ffi("c")` keeps i64** — on wasm those resolve to linked runtime C symbols that genuinely expect i64 (e.g. `lotus_wasm_*`). Trade-off: f64's 53-bit integer range — an `Int` beyond 2^53 loses precision across the boundary (pass it as `String`/`Bytes`).

## Tests / docs

- `tests/wasm_target.rs::wasm_decimal_i128_builtins`
- `tests/wasm_target.rs::wasm_ffi_js_int_marshals_as_number`
- Full `wasm_target` suite green (10/10, incl. the existing `@ffi("c")` entry-inversion tests — C path intact); native `ffi_basic` / `ffi_string_return` green.
- `spec/ffi.md` § WASM host interface + `docs/src/systems/webassembly.md` updated; the #158 "Decimal still wrong on wasm" note retracted in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)