### PR TITLE
feat(check): memory-bound proof warnings are opt-in (GH #18 item 1)

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -918,11 +918,15 @@ fn run_check(target: &Path) -> ExitCode {
     let allow_unowned =
         std::env::args().any(|a| a == "--allow-unowned-subscriber");
     let mut diags = hale_types::check_bundle_opts(&bundle, allow_unowned);
-    // GH #18 item 1: unbounded-allocation warnings, ON BY DEFAULT.
-    // `--no-warn-unbounded-alloc` opts out; `--warn-unbounded-alloc` is
-    // still accepted (now a no-op) for back-compat. The warnings are
-    // advisory — they print but don't fail the build (only errors do).
-    if !std::env::args().any(|a| a == "--no-warn-unbounded-alloc") {
+    // GH #18 item 1: unbounded-allocation warnings — OPT-IN, like the
+    // `--warn-resource-leak` / `@locality` budget surfaces. A memory-bound
+    // proof only means something for long-lived processes (daemons, bus
+    // handlers, persistent loci); a script that allocates and exits owes it
+    // nothing, so it pays nothing by default. `--warn-unbounded-alloc`
+    // requests the whole-program advisory survey; the warnings print but
+    // never fail the build (only errors do). `--no-warn-unbounded-alloc` is
+    // accepted-and-ignored for back-compat with the former default-on flag.
+    if std::env::args().any(|a| a == "--warn-unbounded-alloc") {
         diags.extend(hale_types::unbounded_alloc_warnings(&bundle));
     }
     // GH #18 item 5: opt-in fd-resource-leak warnings.

--- a/crates/hale-cli/tests/fixtures/unbounded-alloc-opt-in/app.hl
+++ b/crates/hale-cli/tests/fixtures/unbounded-alloc-opt-in/app.hl
@@ -1,0 +1,29 @@
+// A per-message handler that does a whole-value replace into `self`
+// each message — the canonical unbounded-accumulation shape the
+// memory-bound proof (GH #18 item 1) flags. Used to pin that the
+// warning is OPT-IN: silent by default, emitted under
+// `--warn-unbounded-alloc`, never a build failure either way.
+type Sample { value: Int; }
+type Holder { items: [Int; 4]; }
+
+locus Acc {
+    params {
+        latest: Holder = Holder { items: [0, 0, 0, 0] };
+    }
+    bus {
+        subscribe "sample" as on_sample of type Sample;
+    }
+    fn on_sample(s: Sample) {
+        self.latest = Holder { items: [s.value, s.value, s.value, s.value] };
+    }
+}
+
+locus Src {
+    bus { publish "sample" of type Sample; }
+    birth() { "sample" <- Sample { value: 1 }; }
+}
+
+fn main() {
+    Acc { };
+    Src { };
+}

--- a/crates/hale-cli/tests/unbounded_alloc_opt_in.rs
+++ b/crates/hale-cli/tests/unbounded_alloc_opt_in.rs
@@ -1,0 +1,80 @@
+//! GH #18 item 1 — the memory-bound-proof warning is OPT-IN.
+//!
+//! "Bounded per epoch" only means something for a long-lived process
+//! (a daemon, a bus handler, a persistent locus). A script that
+//! allocates and exits owes the proof nothing, so it pays nothing by
+//! default — the same descent-curve stance as the `@locality`
+//! cache-tier budgets (annotation/flag-gated, never automatic). This
+//! pins that contract so a future refactor can't silently re-enable
+//! the former default-on behavior:
+//!
+//!   - default: silent (no warning), build succeeds
+//!   - `--warn-unbounded-alloc`: emits the advisory warning, build
+//!     still succeeds (a warning, not an error)
+//!   - `--no-warn-unbounded-alloc`: accepted-and-ignored for
+//!     back-compat with the former default-on flag
+//!
+//! The fixture (`fixtures/unbounded-alloc-opt-in/app.hl`) is the
+//! canonical unbounded-accumulation shape: a per-message handler that
+//! whole-value-replaces a struct into `self` each message.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn hale_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_hale"))
+}
+
+fn app() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("unbounded-alloc-opt-in");
+    p.push("app.hl");
+    p
+}
+
+fn check(extra: &[&str]) -> (bool, String) {
+    let out = Command::new(hale_bin())
+        .arg("check")
+        .arg(app())
+        .args(extra)
+        .output()
+        .expect("invoke hale check");
+    (out.status.success(), String::from_utf8_lossy(&out.stderr).into_owned())
+}
+
+const WARN_NEEDLE: &str = "unbounded allocation";
+
+#[test]
+fn default_is_silent() {
+    let (ok, stderr) = check(&[]);
+    assert!(ok, "default check should succeed: {stderr}");
+    assert!(
+        !stderr.contains(WARN_NEEDLE),
+        "memory-bound warning must be OPT-IN — default run leaked it:\n{stderr}"
+    );
+}
+
+#[test]
+fn warn_flag_emits_advisory_but_succeeds() {
+    let (ok, stderr) = check(&["--warn-unbounded-alloc"]);
+    assert!(
+        stderr.contains(WARN_NEEDLE),
+        "--warn-unbounded-alloc should emit the advisory warning:\n{stderr}"
+    );
+    assert!(
+        ok,
+        "the warning is advisory — it must not fail the build:\n{stderr}"
+    );
+}
+
+#[test]
+fn no_warn_flag_is_accepted_noop() {
+    let (ok, stderr) = check(&["--no-warn-unbounded-alloc"]);
+    assert!(ok, "--no-warn-unbounded-alloc should be accepted: {stderr}");
+    assert!(
+        !stderr.contains(WARN_NEEDLE),
+        "back-compat opt-out must stay silent:\n{stderr}"
+    );
+}

--- a/docs/src/systems/operations.md
+++ b/docs/src/systems/operations.md
@@ -83,15 +83,19 @@ flags report on allocation shape:
 
 | Flag | Reports |
 |---|---|
+| `--warn-unbounded-alloc` | flag an allocation that escapes into an unbounded context and accumulates until its locus dissolves (advisory warnings) |
 | `--dump-alloc-summary` | every allocation site, escape-tagged (local / returned / stored-to-self / sent), with the bounded-vs-unbounded verdict |
 | `--dump-resource-budget` | per-locus resource counts (allocations, held fds) against declared ceilings |
 | `--locality-report` | per-locus working-set size against cache-tier budgets |
 
-The memory-bound warnings these surface are **on by default** in
-`hale check` (advisory — they print but don't fail the build);
-`--no-warn-unbounded-alloc` opts out. A warning here is the
-compile-time complement to the residency dump: it tells you *which
-site* can grow before you've watched it grow.
+The memory-bound warnings are **opt-in** — you switch them on with
+`--warn-unbounded-alloc` (advisory; they print but don't fail the
+build). The proof is opt-in by design: a bound *per epoch* only means
+something for a long-lived process, so a script that allocates and
+exits pays nothing by default — the same stance as the `@locality`
+cache-tier budgets. A warning here is the compile-time complement to
+the residency dump: it tells you *which site* can grow before you've
+watched it grow.
 
 ## Bus backpressure: bounding a flood
 

--- a/docs/src/systems/performance.md
+++ b/docs/src/systems/performance.md
@@ -92,7 +92,7 @@ into `self`, a connection child left resident — have a static
 shape, and `hale check` flags them before you ever measure RSS.
 These are advisory warnings, not build failures:
 
-- **On by default**, `hale check` flags an allocation that
+- `hale check app.hl --warn-unbounded-alloc` flags an allocation that
   accumulates without bound: a struct / array / bytes value created
   in a per-message bus handler (or a runtime-bounded loop) that
   escapes into `self`, where it lives until the locus dissolves —
@@ -102,8 +102,9 @@ These are advisory warnings, not build failures:
   instead of replacing the whole value, or the moves from this
   chapter — a capacity-bounded `@form`, route it over the bus, or a
   per-iteration child. A `while i < N { … }` counter with a constant
-  bound is *proven* bounded and left alone. `--no-warn-unbounded-alloc`
-  opts out.
+  bound is *proven* bounded and left alone. It's opt-in because a bound
+  *per epoch* only matters for a long-lived process — a script that
+  allocates and exits owes it nothing.
 - `hale check app.hl --warn-resource-leak` is the same idea for file
   descriptors: an `open` / `connect` / `accept` whose result is
   stored resident in an unbounded context, so fds pile up.

--- a/notes/memory-bound-proofs.md
+++ b/notes/memory-bound-proofs.md
@@ -41,8 +41,21 @@ reuse.
 > per-handler flags). *Still deferred:* the `@unbounded` escape valve and
 > type-aware String-concat sites.
 >
-> **Default-on deliberately held (2026-06-10).** Considered promoting
-> `--warn-unbounded-alloc` to fire by default; kept opt-in. The 4 flags are
+> **Reverted to opt-in (2026-06-25).** The warning was promoted to
+> default-on (#122) but later reversed: per Hale's descent-curve stance,
+> a bound *per epoch* only means something for a long-lived process, so a
+> script that allocates and exits owes the proof nothing and pays nothing
+> by default. The warning is now opt-in via `--warn-unbounded-alloc`
+> (advisory; never fails the build), mirroring how `@locality` cache-tier
+> budgets are flag/annotation-gated. `--no-warn-unbounded-alloc` is an
+> accepted no-op for back-compat. Next: a `@bounded` locus/module
+> annotation opts a scope into the proof as a hard *error* contract, with
+> `@unbounded` as the in-scope carve-out. The opt-in semantics are pinned
+> by `hale-cli` `unbounded_alloc_opt_in.rs`.
+>
+> **Default-on deliberately held, then shipped, then reverted.** The
+> 2026-06-10 reasoning below is retained for context; the conclusion
+> (kept opt-in) is once again the shipped behavior. The 4 flags are
 > *true* positives but include legitimately bounded-by-design patterns —
 > `22-moving-average`'s `Window::on_sample` keeps a fixed 4-elem window;
 > per the reclamation model the *replaced* arrays aren't freed until

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -79,15 +79,23 @@ diagnostic. See `spec/semantics.md § Locus method dispatch`.
 
 ## Default-on & opt-in analyses
 
-Two GitHub issue #18 analyses run **by default**: item 4 (bus-graph property
-checks — *errors*, fail the build) and item 1 (memory-bound — *advisory
-warnings*, print but don't fail). The rest are **opt-in** (behind a flag) or
-deferred. Only item 4 is a build gate; don't assume the others in a build:
+One GitHub issue #18 analysis runs **by default**: item 4 (bus-graph property
+checks — *errors*, fail the build). The rest, including item 1 (memory-bound),
+are **opt-in** (behind a flag) or deferred. Only item 4 is a build gate; don't
+assume the others in a build:
 
-- **Memory-bound proofs (item 1)** — **on by default** in `hale check`
-  (advisory warnings; they print but don't fail the build).
-  `--no-warn-unbounded-alloc` opts out; `--dump-alloc-summary` prints the
-  raw per-fn summary. A per-method allocation summary + call-graph
+- **Memory-bound proofs (item 1)** — **opt-in** in `hale check` via
+  `--warn-unbounded-alloc` (advisory warnings; they print but don't fail the
+  build). The proof is opt-in by design: "bounded per epoch" only means
+  something for a long-lived process (a daemon, a bus handler, a persistent
+  locus), so a script that allocates and exits owes it nothing and pays
+  nothing by default — the same descent-curve stance as the `@locality`
+  cache-tier budgets (annotation/flag-gated, never automatic). A future
+  `@bounded` locus/module annotation will opt a scope into the proof as a
+  hard *error* contract, with `@unbounded` as the in-scope carve-out.
+  `--dump-alloc-summary` prints the raw per-fn summary.
+  `--no-warn-unbounded-alloc` is accepted-and-ignored for back-compat with
+  the former default-on flag. A per-method allocation summary + call-graph
   escape/loop dataflow — with **escape-awareness** (a non-escaping local in
   a per-message handler is reclaimed at the per-delivery method-scratch
   destroy, so it isn't flagged), call-result escape tagging, and


### PR DESCRIPTION
## Summary

The unbounded-allocation warning (memory-bound proofs, GH #18 item 1) shipped **default-on** in #122. This reverts it to **opt-in**, behind `--warn-unbounded-alloc` — mirroring how `--warn-resource-leak` and the `@locality` cache-tier budgets are already flag/annotation-gated.

### Why

A bound *per epoch* only means something for a long-lived process — a daemon, a bus handler, a persistent locus. A script that allocates and exits owes the proof nothing, so by default it pays nothing: no warning, and no opt-out to remember. This is Hale's **descent-curve** stance — the proof obligation appears when you reach for the machinery that can violate it, not before. It also realigns item 1 with its siblings: `@locality` budgets and `--warn-resource-leak` were already opt-in, leaving the memory-bound warning the odd one out.

A future `@bounded` locus/module annotation will opt a scope into the proof as a hard **error** contract, with `@unbounded` as the in-scope carve-out (Phase B).

## Behavior

| Invocation | Result |
|---|---|
| `hale check app.hl` | silent (scripts pay nothing) |
| `hale check app.hl --warn-unbounded-alloc` | emits advisory warnings; build still succeeds |
| `hale check app.hl --no-warn-unbounded-alloc` | accepted-and-ignored (back-compat with the former default-on flag) |

## Changes

- `crates/hale-cli/src/main.rs` — flip emission to opt-in.
- `crates/hale-cli/tests/unbounded_alloc_opt_in.rs` (+ fixture) — pins all three behaviors so default-on can't silently return.
- `spec/verification.md` — item 1 is now opt-in; descent-curve rationale + forward pointer to `@bounded`/`@unbounded`.
- `docs/src/systems/operations.md`, `docs/src/systems/performance.md` — flag table + prose; the latter also resolves a contradiction with its own "none of these run by default" footer.
- `notes/memory-bound-proofs.md` — records the revert.

## Test

`cargo test --release -p hale-cli --test unbounded_alloc_opt_in -- --test-threads=1` → 3 passed. `hale-types` + `hale-cli` suites green (the only failure is a pre-existing `rustdoc`-can't-load-`libLLVM` env issue, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)