### PR TITLE
feat(check): @bounded / @unbounded annotations for memory-bound proofs (GH #18 item 1, Phase B)

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -922,13 +922,18 @@ fn run_check(target: &Path) -> ExitCode {
     // `--warn-resource-leak` / `@locality` budget surfaces. A memory-bound
     // proof only means something for long-lived processes (daemons, bus
     // handlers, persistent loci); a script that allocates and exits owes it
-    // nothing, so it pays nothing by default. `--warn-unbounded-alloc`
-    // requests the whole-program advisory survey; the warnings print but
-    // never fail the build (only errors do). `--no-warn-unbounded-alloc` is
+    // nothing, so it pays nothing by default.
+    //
+    // Two opt-in surfaces (Phase B):
+    //  - `@bounded locus { … }` — the in-source opt-in. Its sites are
+    //    reported on every `hale check`, no flag needed.
+    //  - `--warn-unbounded-alloc` — the whole-program advisory survey
+    //    (every site, regardless of `@bounded`).
+    // `@unbounded fn` carves a fn out of both. The warnings print but never
+    // fail the build (only errors do). `--no-warn-unbounded-alloc` is
     // accepted-and-ignored for back-compat with the former default-on flag.
-    if std::env::args().any(|a| a == "--warn-unbounded-alloc") {
-        diags.extend(hale_types::unbounded_alloc_warnings(&bundle));
-    }
+    let survey_all = std::env::args().any(|a| a == "--warn-unbounded-alloc");
+    diags.extend(hale_types::unbounded_alloc_warnings(&bundle, survey_all));
     // GH #18 item 5: opt-in fd-resource-leak warnings.
     if std::env::args().any(|a| a == "--warn-resource-leak") {
         diags.extend(hale_types::resource_leak_warnings(&bundle));

--- a/crates/hale-cli/tests/bounded_annotation.rs
+++ b/crates/hale-cli/tests/bounded_annotation.rs
@@ -1,0 +1,90 @@
+//! GH #18 item 1, Phase B — `@bounded` opts a locus into the
+//! memory-bound proof in-source; `@unbounded` carves a fn/hook out.
+//!
+//! Phase A made the proof opt-in (silent unless `--warn-unbounded-alloc`).
+//! Phase B adds the annotation surface so a long-lived locus can request
+//! the proof for itself — the descent-curve dual of the whole-program
+//! flag — without making scripts pay. This pins the end-to-end contract:
+//!
+//!   - a `@bounded` locus emits its leak warnings on a plain `hale check`,
+//!     no flag needed
+//!   - `@unbounded` on a method (or lifecycle hook) suppresses that body's
+//!     sites, with or without the survey flag
+//!   - a program with no `@bounded` locus stays silent by default
+//!     (Phase A behavior preserved)
+//!   - warnings remain advisory — they never fail the build
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn hale_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_hale"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("bounded-annotation");
+    p.push(name);
+    p
+}
+
+fn check(file: &str, extra: &[&str]) -> (bool, String) {
+    let out = Command::new(hale_bin())
+        .arg("check")
+        .arg(fixture(file))
+        .args(extra)
+        .output()
+        .expect("invoke hale check");
+    (out.status.success(), String::from_utf8_lossy(&out.stderr).into_owned())
+}
+
+const NEEDLE: &str = "unbounded allocation";
+
+#[test]
+fn bounded_locus_warns_by_default_carved_method_silent() {
+    // `app.hl`: a `@bounded` locus with two handlers — `on_sample`
+    // (flagged) and `@unbounded on_other` (carved out).
+    let (ok, stderr) = check("app.hl", &[]);
+    assert!(ok, "warnings are advisory, build must succeed:\n{stderr}");
+    assert!(
+        stderr.contains(NEEDLE),
+        "@bounded locus should warn on a plain check:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("on_sample"),
+        "the flagged handler should be named:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("on_other"),
+        "@unbounded handler must be carved out:\n{stderr}"
+    );
+}
+
+#[test]
+fn carve_out_holds_under_survey_flag() {
+    let (_ok, stderr) = check("app.hl", &["--warn-unbounded-alloc"]);
+    assert!(
+        !stderr.contains("on_other"),
+        "@unbounded suppresses even under the survey flag:\n{stderr}"
+    );
+}
+
+#[test]
+fn no_bounded_locus_is_silent_by_default() {
+    // `plain.hl`: the same leak shape with NO `@bounded` — Phase A says
+    // a script pays nothing by default.
+    let (ok, stderr) = check("plain.hl", &[]);
+    assert!(ok, "{stderr}");
+    assert!(
+        !stderr.contains(NEEDLE),
+        "no @bounded locus → silent without the flag:\n{stderr}"
+    );
+    // ...but the survey flag still finds it.
+    let (_ok, stderr) = check("plain.hl", &["--warn-unbounded-alloc"]);
+    assert!(
+        stderr.contains(NEEDLE),
+        "the survey flag reports it regardless of @bounded:\n{stderr}"
+    );
+}

--- a/crates/hale-cli/tests/fixtures/bounded-annotation/app.hl
+++ b/crates/hale-cli/tests/fixtures/bounded-annotation/app.hl
@@ -1,0 +1,33 @@
+// GH #18 item 1 Phase B — a @bounded locus opts into the memory-bound
+// proof; @unbounded carves one handler out.
+type Sample { value: Int; }
+type Holder { items: [Int; 4]; }
+
+@bounded locus Acc {
+    params {
+        latest: Holder = Holder { items: [0, 0, 0, 0] };
+        cache:  Holder = Holder { items: [0, 0, 0, 0] };
+    }
+    bus {
+        subscribe "sample"  as on_sample of type Sample;
+        subscribe "sample2" as on_other  of type Sample;
+    }
+    // flagged: whole-value replace each message accumulates in `self`.
+    fn on_sample(s: Sample) {
+        self.latest = Holder { items: [s.value, s.value, s.value, s.value] };
+    }
+    // carved out: an acknowledged intentional accumulation.
+    @unbounded fn on_other(s: Sample) {
+        self.cache = Holder { items: [s.value, s.value, s.value, s.value] };
+    }
+}
+
+locus Src {
+    bus { publish "sample" of type Sample; }
+    birth() { "sample" <- Sample { value: 1 }; }
+}
+
+fn main() {
+    Acc { };
+    Src { };
+}

--- a/crates/hale-cli/tests/fixtures/bounded-annotation/plain.hl
+++ b/crates/hale-cli/tests/fixtures/bounded-annotation/plain.hl
@@ -1,0 +1,26 @@
+// The same accumulation shape with NO @bounded opt-in — silent by
+// default (Phase A), reported only under --warn-unbounded-alloc.
+type Sample { value: Int; }
+type Holder { items: [Int; 4]; }
+
+locus Acc {
+    params {
+        latest: Holder = Holder { items: [0, 0, 0, 0] };
+    }
+    bus {
+        subscribe "sample" as on_sample of type Sample;
+    }
+    fn on_sample(s: Sample) {
+        self.latest = Holder { items: [s.value, s.value, s.value, s.value] };
+    }
+}
+
+locus Src {
+    bus { publish "sample" of type Sample; }
+    birth() { "sample" <- Sample { value: 1 }; }
+}
+
+fn main() {
+    Acc { };
+    Src { };
+}

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -4840,6 +4840,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     fallible: None,
                     ffi: None,
                     export: false,
+                    unbounded: false,
                     body: Block {
                         stmts: Vec::new(),
                         tail: None,
@@ -7645,6 +7646,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             annotations: template.annotations.clone(),
             form: template.form.clone(),
             locality: template.locality.clone(),
+            bounded: template.bounded,
             members: new_members,
             span: template.span.clone(),
         })
@@ -7717,6 +7719,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         .ret
                         .as_ref()
                         .map(|t| Self::substitute_type_expr(t, subst)),
+                    unbounded: lc.unbounded,
                     body: Self::substitute_block_type_ascriptions(
                         &lc.body, subst,
                     ),
@@ -7749,6 +7752,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 // field through for shape uniformity.
                 ffi: fd.ffi.clone(),
                 export: fd.export,
+                unbounded: fd.unbounded,
                 body: Self::substitute_block_type_ascriptions(
                     &fd.body, subst,
                 ),
@@ -7993,6 +7997,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             // time so in practice this is always None here.
             ffi: template.ffi.clone(),
             export: template.export,
+            unbounded: template.unbounded,
             body: new_body,
             span: template.span.clone(),
         })

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -285,6 +285,15 @@ pub struct LocusDecl {
     /// tier's budget (or, for `any`, explicitly opts out of the
     /// global `--target-cache` gate).
     pub locality: Option<LocalityAnnotation>,
+    /// GH #18 item 1 (memory-bound proofs): `@bounded locus L { ... }`
+    /// opts this locus into the memory-bound proof. Its bodies are
+    /// checked for unbounded allocations regardless of the
+    /// `--warn-unbounded-alloc` flag — the in-source opt-in, the
+    /// descent-curve dual of the whole-program survey flag. A method
+    /// inside a `@bounded` locus may carry `@unbounded` to acknowledge
+    /// an intentional accumulation and silence its site. A no-op on
+    /// loci that allocate nothing unboundedly.
+    pub bounded: bool,
     pub members: Vec<LocusMember>,
     pub span: Span,
 }
@@ -1051,6 +1060,11 @@ pub struct LifecycleDecl {
     pub kind: LifecycleKind,
     pub params: Vec<Param>,
     pub ret: Option<TypeExpr>,
+    /// GH #18 item 1: `@unbounded run { ... }` (or any lifecycle hook)
+    /// acknowledges an intentionally-unbounded allocation in the hook
+    /// body — the carve-out for a `run`-loop accumulation inside a
+    /// `@bounded` locus, paralleling `@unbounded fn`.
+    pub unbounded: bool,
     pub body: Block,
     pub span: Span,
 }
@@ -1235,6 +1249,14 @@ pub struct FnDecl {
     /// `_hale_start` sets up) and passes the name to `wasm-ld
     /// --export=`. A no-op on native builds.
     pub export: bool,
+    /// GH #18 item 1 (memory-bound proofs): `@unbounded fn` acknowledges
+    /// that this fn intentionally allocates without a static bound (a
+    /// cache, an operator-sized accumulator). It suppresses the
+    /// memory-bound warning for every allocation site this fn owns — the
+    /// greppable carve-out inside a `@bounded` locus, and an explicit
+    /// silence under `--warn-unbounded-alloc`. Applies to free fns and
+    /// locus methods alike.
+    pub unbounded: bool,
     pub body: Block,
     pub span: Span,
 }

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -333,6 +333,7 @@ impl Parser {
         let mut form: Option<FormAnnotation> = None;
         let mut locality: Option<LocalityAnnotation> = None;
         let mut export_locus = false;
+        let mut bounded_locus = false;
         let mut leading_span: Option<Span> = None;
         loop {
             if !matches!(self.peek(), TokenKind::At) {
@@ -344,6 +345,13 @@ impl Parser {
             let is_locality =
                 matches!(&kind_tok, TokenKind::Ident(s) if s == "locality");
             let is_export = matches!(&kind_tok, TokenKind::Export);
+            // GH #18 item 1: `@bounded locus …` opts a locus into the
+            // memory-bound proof; `@unbounded fn …` carves a free fn
+            // out of it. Both are bare `@`-flags (no arglist).
+            let is_bounded =
+                matches!(&kind_tok, TokenKind::Ident(s) if s == "bounded");
+            let is_unbounded =
+                matches!(&kind_tok, TokenKind::Ident(s) if s == "unbounded");
             if is_export {
                 // WASM entry-inversion. `@export fn …` is a free-fn
                 // module export; `@export locus …` is the persistent
@@ -406,6 +414,52 @@ impl Parser {
                 fn_decl.span = ffi.span.merge(fn_decl.span);
                 return Ok(TopDecl::Fn(fn_decl));
             }
+            if is_bounded {
+                if bounded_locus {
+                    return Err(Diag::parse(
+                        self.peek_token().span,
+                        "duplicate `@bounded` annotation",
+                    ));
+                }
+                let at = self.expect(TokenKind::At, "@")?;
+                self.bump(); // consume `bounded`
+                bounded_locus = true;
+                leading_span = Some(match leading_span {
+                    Some(s) => s.merge(at.span),
+                    None => at.span,
+                });
+                continue;
+            }
+            if is_unbounded {
+                // fn-only carve-out. Mirrors `@ffi` / `@export fn`: consume
+                // the marker, parse the fn, tag it. It can't sit on a locus
+                // (a locus opts *in* with `@bounded`; `@unbounded` opts a
+                // single fn *out*).
+                if form.is_some() || locality.is_some() || export_locus
+                    || bounded_locus
+                {
+                    return Err(Diag::parse(
+                        self.peek_token().span,
+                        "`@unbounded` is fn-only; it can't stack with \
+                         `@form(...)` / `@locality(...)` / `@bounded` / \
+                         `@export locus` (those precede `locus`)",
+                    ));
+                }
+                let at = self.expect(TokenKind::At, "@")?;
+                self.bump(); // consume `unbounded`
+                if !matches!(self.peek(), TokenKind::Fn) {
+                    return Err(Diag::parse(
+                        self.peek_token().span,
+                        "expected `fn` after `@unbounded` — it acknowledges an \
+                         intentionally-unbounded fn, so a `locus` opts in with \
+                         `@bounded` instead",
+                    ));
+                }
+                let mut fn_decl = self.parse_fn_decl_with_ffi(None)?;
+                fn_decl.unbounded = true;
+                fn_decl.span = at.span.merge(fn_decl.span);
+                return Ok(TopDecl::Fn(fn_decl));
+            }
             if is_form {
                 if form.is_some() {
                     return Err(Diag::parse(
@@ -440,10 +494,11 @@ impl Parser {
             }
             return Err(Diag::parse(
                 self.peek_token().span,
-                "expected `form`, `locality`, or `ffi` after `@`",
+                "expected `form`, `locality`, `bounded`, `unbounded`, or \
+                 `ffi` after `@`",
             ));
         }
-        if form.is_some() || locality.is_some() || export_locus {
+        if form.is_some() || locality.is_some() || export_locus || bounded_locus {
             // Verify a `locus` (or contextual `main locus`)
             // follows.
             let next_is_locus = matches!(self.peek(), TokenKind::Locus);
@@ -455,7 +510,7 @@ impl Parser {
                 return Err(Diag::parse(
                     self.peek_token().span,
                     "expected `locus` (or `main locus`) after `@form(...)` \
-                     / `@locality(...)` / `@export` annotation",
+                     / `@locality(...)` / `@bounded` / `@export` annotation",
                 ));
             }
             let mut locus = self.parse_locus_decl()?;
@@ -465,6 +520,7 @@ impl Parser {
             locus.form = form;
             locus.locality = locality;
             locus.export = export_locus;
+            locus.bounded = bounded_locus;
             return Ok(TopDecl::Locus(locus));
         }
         match self.peek() {
@@ -1129,6 +1185,7 @@ impl Parser {
             annotations,
             form: None,
             locality: None,
+            bounded: false,
             members,
             span: kw.span.merge(close.span),
         })
@@ -1341,6 +1398,48 @@ impl Parser {
             TokenKind::OnFailure => self.parse_failure_decl().map(LocusMember::Failure),
             TokenKind::Closure => self.parse_closure_decl().map(LocusMember::Closure),
             TokenKind::Fn => self.parse_fn_decl().map(LocusMember::Fn),
+            // GH #18 item 1: `@unbounded` carve-out on a locus member —
+            // either a method (`@unbounded fn`, the common case: silence
+            // one handler) or a lifecycle hook (`@unbounded run { … }`, a
+            // `run`-loop accumulation). The only `@`-annotation valid on a
+            // member.
+            TokenKind::At => {
+                let kind_tok = self.peek_at(1);
+                if !matches!(&kind_tok, TokenKind::Ident(s) if s == "unbounded") {
+                    return Err(Diag::parse(
+                        self.peek_token().span,
+                        "the only `@` annotation valid on a locus member is \
+                         `@unbounded` (on a `fn` or a lifecycle hook — \
+                         acknowledge an intentionally-unbounded body)",
+                    ));
+                }
+                let at = self.expect(TokenKind::At, "@")?;
+                self.bump(); // consume `unbounded`
+                match self.peek() {
+                    TokenKind::Fn => {
+                        let mut fn_decl = self.parse_fn_decl()?;
+                        fn_decl.unbounded = true;
+                        fn_decl.span = at.span.merge(fn_decl.span);
+                        Ok(LocusMember::Fn(fn_decl))
+                    }
+                    TokenKind::Birth
+                    | TokenKind::Accept
+                    | TokenKind::Release
+                    | TokenKind::Run
+                    | TokenKind::Drain
+                    | TokenKind::Dissolve => {
+                        let mut lc = self.parse_lifecycle_decl()?;
+                        lc.unbounded = true;
+                        lc.span = at.span.merge(lc.span);
+                        Ok(LocusMember::Lifecycle(lc))
+                    }
+                    _ => Err(Diag::parse(
+                        self.peek_token().span,
+                        "expected `fn` or a lifecycle hook (`run`, `birth`, \
+                         …) after `@unbounded`",
+                    )),
+                }
+            }
             TokenKind::Const => self.parse_const_decl().map(LocusMember::Const),
             TokenKind::Type => self.parse_type_decl().map(LocusMember::Type),
             // Phase 2 contextual keyword — `bindings { ... }`.
@@ -2401,6 +2500,7 @@ impl Parser {
             kind,
             params,
             ret,
+            unbounded: false,
             span: kw_tok.span.merge(body.span),
             body,
         })
@@ -2974,6 +3074,7 @@ impl Parser {
                 fallible,
                 ffi,
                 export: false,
+                unbounded: false,
                 span: kw.span.merge(semi.span),
                 body,
             });
@@ -2993,6 +3094,7 @@ impl Parser {
             fallible,
             ffi,
             export: false,
+            unbounded: false,
             span: kw.span.merge(body.span),
             body,
         })
@@ -4808,6 +4910,111 @@ main locus App {
             }
             _ => panic!("expected locus"),
         }
+    }
+
+    // === GH #18 item 1: @bounded / @unbounded =============
+
+    #[test]
+    fn parse_bounded_locus() {
+        let src = "@bounded locus L { run() { } }";
+        let prog = parse_str(src).expect("parse failed");
+        match &prog.items[0] {
+            TopDecl::Locus(l) => assert!(l.bounded, "@bounded not recorded"),
+            _ => panic!("expected locus"),
+        }
+    }
+
+    #[test]
+    fn parse_bounded_stacks_with_form() {
+        // Order-independent stacking, like @locality + @form.
+        let src = "@form(vec) @bounded locus L { }";
+        let prog = parse_str(src).expect("parse failed");
+        match &prog.items[0] {
+            TopDecl::Locus(l) => {
+                assert!(l.bounded);
+                assert!(l.form.is_some());
+            }
+            _ => panic!("expected locus"),
+        }
+    }
+
+    #[test]
+    fn parse_bounded_rejects_duplicate() {
+        let err = parse_str("@bounded @bounded locus L { }")
+            .expect_err("expected parse error");
+        assert!(format!("{:?}", err).contains("duplicate `@bounded"));
+    }
+
+    #[test]
+    fn parse_unbounded_free_fn() {
+        let src = "@unbounded fn build() { }";
+        let prog = parse_str(src).expect("parse failed");
+        match &prog.items[0] {
+            TopDecl::Fn(f) => assert!(f.unbounded, "@unbounded not recorded"),
+            _ => panic!("expected fn"),
+        }
+    }
+
+    #[test]
+    fn parse_unbounded_method_and_lifecycle() {
+        let src = r#"
+@bounded locus L {
+    @unbounded fn handle() { }
+    @unbounded run() { }
+    fn plain() { }
+}
+"#;
+        let prog = parse_str(src).expect("parse failed");
+        let TopDecl::Locus(l) = &prog.items[0] else {
+            panic!("expected locus");
+        };
+        let mut saw_unbounded_fn = false;
+        let mut saw_unbounded_run = false;
+        let mut saw_plain_fn = false;
+        for m in &l.members {
+            match m {
+                LocusMember::Fn(f) if f.name.name == "handle" => {
+                    assert!(f.unbounded);
+                    saw_unbounded_fn = true;
+                }
+                LocusMember::Fn(f) if f.name.name == "plain" => {
+                    assert!(!f.unbounded);
+                    saw_plain_fn = true;
+                }
+                LocusMember::Lifecycle(lc)
+                    if matches!(lc.kind, LifecycleKind::Run) =>
+                {
+                    assert!(lc.unbounded);
+                    saw_unbounded_run = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_unbounded_fn && saw_unbounded_run && saw_plain_fn);
+    }
+
+    #[test]
+    fn parse_unbounded_rejects_non_fn_target() {
+        // `@unbounded` is fn/lifecycle-only — on a locus it's rejected and
+        // the diagnostic points at `@bounded` as the opt-in instead.
+        let err = parse_str("@unbounded locus L { }")
+            .expect_err("expected parse error");
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("opts in with `@bounded`"),
+            "wrong error: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_unbounded_rejects_stacking_with_form() {
+        // Stacked after another locus annotation, the fn-only guard fires.
+        let err = parse_str("@form(vec) @unbounded locus L { }")
+            .expect_err("expected parse error");
+        assert!(
+            format!("{:?}", err).contains("@unbounded` is fn-only"),
+            "wrong error"
+        );
     }
 
     #[test]

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -336,6 +336,25 @@ pub struct FnSummary {
 #[derive(Debug, Clone, Default)]
 pub struct AllocSummary {
     pub fns: BTreeMap<FnKey, FnSummary>,
+    /// GH #18 item 1: loci carrying `@bounded` — their leak sites are
+    /// reported even without the `--warn-unbounded-alloc` survey flag
+    /// (the in-source opt-in).
+    pub bounded_loci: BTreeSet<String>,
+    /// Fns carrying `@unbounded` — an acknowledged-intentional
+    /// accumulation. Their leak sites are dropped entirely (the
+    /// greppable carve-out), even under the survey flag.
+    pub unbounded_fns: BTreeSet<FnKey>,
+}
+
+impl AllocSummary {
+    /// Is this site's owning fn inside a `@bounded` locus? Drives
+    /// "report by default" without the survey flag.
+    pub fn owner_is_bounded_scope(&self, owner: &FnKey) -> bool {
+        owner
+            .locus
+            .as_ref()
+            .is_some_and(|l| self.bounded_loci.contains(l))
+    }
 }
 
 /// Why a site's final verdict is unbounded — the diagnostic anchor.
@@ -424,6 +443,12 @@ impl AllocSummary {
         let unbounded = self.unbounded_invoked();
         let mut out = Vec::new();
         for f in self.fns.values() {
+            // `@unbounded` is the acknowledged carve-out — its sites never
+            // surface, with or without the survey flag, in or out of a
+            // `@bounded` locus.
+            if self.unbounded_fns.contains(&f.key) {
+                continue;
+            }
             for s in &f.sites {
                 if self.final_verdict(&f.key, s, &unbounded) == SiteVerdict::AccumulatesUnbounded {
                     let reason = if matches!(s.verdict(), SiteVerdict::AccumulatesUnbounded) {
@@ -525,6 +550,9 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
     // method referenced by `subscribe ... -> handler` is tagged BusHandler.
     let mut bodies: Vec<(FnKey, Block, Option<EntryKind>, Option<String>)> = Vec::new();
     let mut known: BTreeSet<FnKey> = BTreeSet::new();
+    // GH #18 item 1 — the `@bounded` / `@unbounded` opt-in/carve-out sets.
+    let mut bounded_loci: BTreeSet<String> = BTreeSet::new();
+    let mut unbounded_fns: BTreeSet<FnKey> = BTreeSet::new();
 
     for program in programs {
         for item in &program.items {
@@ -532,11 +560,17 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
                 TopDecl::Fn(decl) => {
                     let key = FnKey::free_fn(decl.name.name.clone());
                     let entry = if decl.name.name == "main" { Some(EntryKind::Main) } else { None };
+                    if decl.unbounded {
+                        unbounded_fns.insert(key.clone());
+                    }
                     known.insert(key.clone());
                     bodies.push((key, decl.body.clone(), entry, None));
                 }
                 TopDecl::Locus(l) => {
                     let locus = l.name.name.clone();
+                    if l.bounded {
+                        bounded_loci.insert(locus.clone());
+                    }
                     let handlers = bus_handler_names(l);
                     for member in &l.members {
                         match member {
@@ -547,12 +581,18 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
                                 } else {
                                     None
                                 };
+                                if decl.unbounded {
+                                    unbounded_fns.insert(key.clone());
+                                }
                                 known.insert(key.clone());
                                 bodies.push((key, decl.body.clone(), entry, Some(locus.clone())));
                             }
                             LocusMember::Lifecycle(lc) => {
                                 let (name, entry) = lifecycle_key(lc.kind);
                                 let key = FnKey::method(locus.clone(), name);
+                                if lc.unbounded {
+                                    unbounded_fns.insert(key.clone());
+                                }
                                 known.insert(key.clone());
                                 bodies.push((key, lc.body.clone(), Some(entry), Some(locus.clone())));
                             }
@@ -591,17 +631,26 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
             },
         );
     }
+    summary.bounded_loci = bounded_loci;
+    summary.unbounded_fns = unbounded_fns;
     summary
 }
 
 /// Bound-solver diagnostics: a warning per unbounded-accumulation site.
-/// Opt-in (the corpus shows zero false positives, but allocation patterns
-/// are common enough that this is gated until validated for default-on).
-pub fn unbounded_alloc_diags(programs: &[&Program]) -> Vec<Diag> {
+///
+/// `include_all` selects the scope (GH #18 item 1, Phase B):
+/// - `false` (default `hale check`): only sites inside a `@bounded` locus —
+///   the in-source opt-in. A program with no `@bounded` locus is silent.
+/// - `true` (`--warn-unbounded-alloc`): every site, the whole-program
+///   survey.
+///
+/// Either way, `@unbounded`-fn sites are already dropped at `leak_sites()`.
+pub fn unbounded_alloc_diags(programs: &[&Program], include_all: bool) -> Vec<Diag> {
     let summary = summarize_programs(programs);
     summary
         .leak_sites()
         .iter()
+        .filter(|ls| include_all || summary.owner_is_bounded_scope(&ls.owner))
         .map(|ls| {
             let where_ = match ls.reason {
                 LeakReason::InUnboundedLoop => "inside an unbounded loop",
@@ -1487,8 +1536,47 @@ mod tests {
             fn main() { }
         "#;
         let program = hale_syntax::parse_source(src).expect("parse");
-        let diags = unbounded_alloc_diags(&[&program]);
+        // Survey mode (`--warn-unbounded-alloc`) reports the leak even
+        // though locus `C` carries no `@bounded` opt-in.
+        let diags = unbounded_alloc_diags(&[&program], true);
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("unbounded allocation"));
+    }
+
+    #[test]
+    fn bounded_locus_reports_without_the_survey_flag() {
+        // The same leak, but the locus opts in with `@bounded`. Now the
+        // default (non-survey) scope reports it.
+        let src = r#"
+            type Q { a: Int; }
+            @bounded locus C { run { while true { let q = Q { a: 1 }; } } }
+            fn main() { }
+        "#;
+        let program = hale_syntax::parse_source(src).expect("parse");
+        let scoped = unbounded_alloc_diags(&[&program], false);
+        assert_eq!(scoped.len(), 1, "@bounded locus reports by default");
+        assert!(scoped[0].message.contains("unbounded allocation"));
+    }
+
+    #[test]
+    fn unbounded_fn_carves_out_even_in_a_bounded_locus() {
+        // `@bounded` on the locus opts in; `@unbounded` on the method opts
+        // that one method back out — silent in survey mode AND scoped mode.
+        let src = r#"
+            type Q { a: Int; }
+            @bounded locus C {
+                @unbounded run { while true { let q = Q { a: 1 }; } }
+            }
+            fn main() { }
+        "#;
+        let program = hale_syntax::parse_source(src).expect("parse");
+        assert!(
+            unbounded_alloc_diags(&[&program], true).is_empty(),
+            "@unbounded suppresses the site under the survey flag"
+        );
+        assert!(
+            unbounded_alloc_diags(&[&program], false).is_empty(),
+            "@unbounded suppresses the site in @bounded scope too"
+        );
     }
 }

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -102,10 +102,13 @@ pub fn dump_resource_budget(bundle: &Bundle<'_>) -> String {
 }
 
 /// Bound-solver warnings: one per unbounded-accumulation allocation site
-/// (GH #18 item 1, step 3). Opt-in via `--warn-unbounded-alloc`.
-pub fn unbounded_alloc_warnings(bundle: &Bundle<'_>) -> Vec<Diag> {
+/// (GH #18 item 1). `include_all = false` reports only sites inside a
+/// `@bounded` locus (the always-on in-source opt-in); `true` is the
+/// whole-program survey behind `--warn-unbounded-alloc`. `@unbounded`-fn
+/// sites are suppressed in both modes.
+pub fn unbounded_alloc_warnings(bundle: &Bundle<'_>, include_all: bool) -> Vec<Diag> {
     let progs: Vec<&hale_syntax::ast::Program> = bundle.programs.values().copied().collect();
-    alloc_summary::unbounded_alloc_diags(&progs)
+    alloc_summary::unbounded_alloc_diags(&progs, include_all)
 }
 
 /// Resource-leak warnings: an fd-acquiring call whose result is stored

--- a/docs/src/systems/operations.md
+++ b/docs/src/systems/operations.md
@@ -88,14 +88,35 @@ flags report on allocation shape:
 | `--dump-resource-budget` | per-locus resource counts (allocations, held fds) against declared ceilings |
 | `--locality-report` | per-locus working-set size against cache-tier budgets |
 
-The memory-bound warnings are **opt-in** — you switch them on with
-`--warn-unbounded-alloc` (advisory; they print but don't fail the
-build). The proof is opt-in by design: a bound *per epoch* only means
-something for a long-lived process, so a script that allocates and
-exits pays nothing by default — the same stance as the `@locality`
-cache-tier budgets. A warning here is the compile-time complement to
-the residency dump: it tells you *which site* can grow before you've
-watched it grow.
+The memory-bound warnings are **opt-in** — a bound *per epoch* only
+means something for a long-lived process, so a script that allocates
+and exits pays nothing by default (the same stance as the `@locality`
+cache-tier budgets). There are two ways to opt in:
+
+- **Annotate the locus.** `@bounded locus L { … }` asks for the proof
+  on that locus specifically — its leak sites are reported on every
+  `hale check`, no flag. This is the in-source opt-in: the locus that
+  took on long-lived state requests the check on itself.
+
+  ```hale
+  @bounded locus Aggregator {
+      // ... handlers checked for unbounded accumulation ...
+
+      @unbounded fn on_snapshot(s: Snapshot) {
+          // acknowledged: this cache is operator-sized on purpose.
+          // @unbounded silences this body's sites — the greppable
+          // carve-out. Valid on a `fn` or a lifecycle hook (`@unbounded
+          // run { … }`).
+      }
+  }
+  ```
+
+- **Survey the whole program.** `--warn-unbounded-alloc` flags every
+  site regardless of `@bounded` (a `@unbounded` fn is still suppressed).
+
+Either way the warnings are advisory — they print but don't fail the
+build. A warning here is the compile-time complement to the residency
+dump: it tells you *which site* can grow before you've watched it grow.
 
 ## Bus backpressure: bounding a flood
 

--- a/docs/src/systems/performance.md
+++ b/docs/src/systems/performance.md
@@ -104,7 +104,10 @@ These are advisory warnings, not build failures:
   per-iteration child. A `while i < N { … }` counter with a constant
   bound is *proven* bounded and left alone. It's opt-in because a bound
   *per epoch* only matters for a long-lived process — a script that
-  allocates and exits owes it nothing.
+  allocates and exits owes it nothing. Annotate the long-lived locus
+  `@bounded` to get the check on every `hale check` without the flag,
+  and `@unbounded` (on a `fn` or a lifecycle hook) to acknowledge an
+  intentional accumulation and silence it.
 - `hale check app.hl --warn-resource-leak` is the same idea for file
   descriptors: an `open` / `connect` / `accept` whose result is
   stored resident in an unbounded context, so fds pile up.

--- a/notes/memory-bound-proofs.md
+++ b/notes/memory-bound-proofs.md
@@ -48,10 +48,24 @@ reuse.
 > by default. The warning is now opt-in via `--warn-unbounded-alloc`
 > (advisory; never fails the build), mirroring how `@locality` cache-tier
 > budgets are flag/annotation-gated. `--no-warn-unbounded-alloc` is an
-> accepted no-op for back-compat. Next: a `@bounded` locus/module
-> annotation opts a scope into the proof as a hard *error* contract, with
-> `@unbounded` as the in-scope carve-out. The opt-in semantics are pinned
-> by `hale-cli` `unbounded_alloc_opt_in.rs`.
+> accepted no-op for back-compat. The opt-in semantics are pinned by
+> `hale-cli` `unbounded_alloc_opt_in.rs`.
+>
+> **Phase B landed — `@bounded` / `@unbounded` (2026-06-25).** The
+> in-source opt-in: `@bounded locus L { … }` opts that locus into the
+> proof on every `hale check` (no flag); `@unbounded` on a `fn` or a
+> lifecycle hook (`@unbounded run { … }`) is the greppable carve-out that
+> silences one body's sites, in scoped mode AND under the survey flag.
+> `unbounded_alloc_diags(programs, include_all)` gates scope:
+> `include_all=false` reports only `@bounded`-locus sites (default check),
+> `true` is the whole-program survey (`--warn-unbounded-alloc`).
+> Implementation: `bounded: bool` on `LocusDecl`, `unbounded: bool` on
+> `FnDecl` + `LifecycleDecl`; `AllocSummary.{bounded_loci, unbounded_fns}`;
+> parser handles both as bare `@`-flags. **Severity is warning** — the
+> hard *error* contract for `@bounded` waits on the precision phases
+> (store-latest vs. append, `@form(cap)`) reaching zero in-scope FP.
+> Pinned by `hale-syntax` parser tests + `hale-cli` `bounded_annotation.rs`.
+> *Next: Phase C* — replace-vs-append refinement (RSS-validated).
 >
 > **Default-on deliberately held, then shipped, then reverted.** The
 > 2026-06-10 reasoning below is retained for context; the conclusion

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -181,7 +181,18 @@ locus_decl        = { locus_decorator } , [ "main" ] , "locus" , IDENTIFIER ,
 locus_decorator   = form_annotation
                   | locality_annotation
                   | export_annotation
+                  | bounded_annotation
                   ;
+
+(* GH #18 item 1 (memory-bound proofs): `@bounded` opts a locus into
+   the memory-bound proof — its bodies are checked for unbounded
+   allocations on every `hale check`, without the
+   `--warn-unbounded-alloc` survey flag. The in-source opt-in; the
+   `@unbounded` carve-out (see `fn_decorator` / `locus_member`)
+   silences a single fn or lifecycle hook inside it. `bounded` is a
+   contextual word recognized only after `@` in decorator position.
+   See `spec/verification.md`. *)
+bounded_annotation = "@" , "bounded" ;
 
 (* F.31 (2026-05-23): `schedule` removed from locus_annotation.
    Placement is a deployment seam; it lives in a `placement { }`
@@ -437,7 +448,10 @@ slot_kind         = "pool" | "heap" ;
    frees the locus. None are required; missing transitions use
    compiler-supplied defaults. *)
 
-lifecycle_decl    = lifecycle_keyword , [ "(" , [ param_list ] , ")" ] ,
+(* The optional `@unbounded` prefix (unbounded_annotation, § 13) is
+   the memory-bound-proof carve-out on a `run`-loop accumulation. *)
+lifecycle_decl    = [ unbounded_annotation ] ,
+                    lifecycle_keyword , [ "(" , [ param_list ] , ")" ] ,
                     [ "->" , type_expr ] , block ;
 lifecycle_keyword = "birth"
                   | "accept"
@@ -638,10 +652,20 @@ function_decl     = [ function_decorator ] ,
    name — a real-bodied top-level free fn, no-op on the native
    target. `export` is a reserved keyword; the two decorators are
    mutually exclusive (an import is not an export). See
-   `spec/ffi.md` § "WASM host interface". *)
-function_decorator = ffi_annotation | export_annotation ;
+   `spec/ffi.md` § "WASM host interface".
+
+   `@unbounded` (GH #18 item 1) acknowledges an intentionally-
+   unbounded fn, suppressing its memory-bound warnings (the
+   carve-out for a `@bounded` locus or the `--warn-unbounded-alloc`
+   survey). It also prefixes a locus member — a `function_decl` or a
+   `lifecycle_decl` (e.g. `@unbounded run { … }`) — inside a locus
+   body; `unbounded` is contextual, recognized only after `@`. See
+   `spec/verification.md`. *)
+function_decorator = ffi_annotation | export_annotation
+                   | unbounded_annotation ;
 ffi_annotation    = "@" , "ffi" , "(" , STRING_LIT , ")" ;
 export_annotation = "@" , "export" ;
+unbounded_annotation = "@" , "unbounded" ;
 
 (* v1.x-FORM-1: a fallible fn's return type is "value of T, or
    an error has occurred with payload P." Callers MUST address

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -84,15 +84,24 @@ checks — *errors*, fail the build). The rest, including item 1 (memory-bound),
 are **opt-in** (behind a flag) or deferred. Only item 4 is a build gate; don't
 assume the others in a build:
 
-- **Memory-bound proofs (item 1)** — **opt-in** in `hale check` via
-  `--warn-unbounded-alloc` (advisory warnings; they print but don't fail the
-  build). The proof is opt-in by design: "bounded per epoch" only means
-  something for a long-lived process (a daemon, a bus handler, a persistent
-  locus), so a script that allocates and exits owes it nothing and pays
-  nothing by default — the same descent-curve stance as the `@locality`
-  cache-tier budgets (annotation/flag-gated, never automatic). A future
-  `@bounded` locus/module annotation will opt a scope into the proof as a
-  hard *error* contract, with `@unbounded` as the in-scope carve-out.
+- **Memory-bound proofs (item 1)** — **opt-in**, two ways. The proof is
+  opt-in by design: "bounded per epoch" only means something for a
+  long-lived process (a daemon, a bus handler, a persistent locus), so a
+  script that allocates and exits owes it nothing and pays nothing by
+  default — the same descent-curve stance as the `@locality` cache-tier
+  budgets (annotation/flag-gated, never automatic). The two opt-in surfaces:
+  - **`@bounded locus L { … }`** — the in-source opt-in. A locus annotated
+    `@bounded` is checked on every `hale check` (no flag), and a
+    `@unbounded fn`/`@unbounded run { … }` inside it is the greppable
+    carve-out that silences one body's sites. This is the descent marker:
+    the locus that took on long-lived state asks for the proof on itself.
+    *(Currently advisory warnings; the intended end state is a hard
+    **error** contract once the precision refinements — store-latest vs.
+    append, `@form(cap)` composition — drive in-scope false positives to
+    zero.)*
+  - **`--warn-unbounded-alloc`** — the whole-program advisory survey. Flags
+    every site regardless of `@bounded` (a `@unbounded` fn is still
+    suppressed). Warnings print but never fail the build.
   `--dump-alloc-summary` prints the raw per-fn summary.
   `--no-warn-unbounded-alloc` is accepted-and-ignored for back-compat with
   the former default-on flag. A per-method allocation summary + call-graph


### PR DESCRIPTION
> **Stacked on #161** (Phase A — opt-in flag). Base is `feat/unbounded-alloc-opt-in` so this diff shows only Phase B; it'll retarget to `main` when #161 merges.

## Summary

Phase B of the memory-bound proof (GH #18 item 1). Phase A (#161) made the proof opt-in behind `--warn-unbounded-alloc` — scripts pay nothing by default. This adds the **in-source opt-in** so a long-lived locus can request the proof on itself: the descent-curve dual of the whole-program survey flag.

- **`@bounded locus L { … }`** — opts that locus into the proof on every `hale check`, no flag. The locus that took on long-lived state asks for the check on itself.
- **`@unbounded`** on a `fn` or a lifecycle hook (`@unbounded run { … }`) — the greppable carve-out. Silences that body's sites in `@bounded` scope **and** under the survey flag.
- A program with **no** `@bounded` locus stays silent by default (Phase A preserved); `--warn-unbounded-alloc` still surveys the whole program.

```hale
@bounded locus Aggregator {
    fn on_sample(s: Sample) {
        self.latest = Holder { … };   // ← flagged: accumulates in `self`
    }
    @unbounded fn on_snapshot(s: Snapshot) {
        self.cache = Holder { … };    // ← carved out: acknowledged on purpose
    }
}
```

Severity stays **warning** — the hard `@bounded`-as-*error* contract waits on the precision phases (store-latest vs. append, `@form(cap)` composition) reaching zero in-scope false positives (Phase E).

## Implementation

- **AST**: `bounded: bool` on `LocusDecl`; `unbounded: bool` on `FnDecl` + `LifecycleDecl`. Parser handles both as bare `@`-flags (contextual words after `@`). `@unbounded` is fn/lifecycle-only; a locus opts in with `@bounded` instead, and the rejection diagnostic points there.
- **Analysis** (`alloc_summary.rs`): `AllocSummary.{bounded_loci, unbounded_fns}`; `leak_sites()` drops `@unbounded`-owned sites; `unbounded_alloc_diags(progs, include_all)` gates scope (`false` = `@bounded`-only, `true` = survey).
- **CLI**: always emits `@bounded`-scope warnings; `--warn-unbounded-alloc` widens to all. Codegen treats both annotations as no-ops (propagated through monomorphization).

## Tests

- `hale-syntax` parser: parse `@bounded`/`@unbounded`, stacking with `@form`, duplicate + non-fn-target rejection, method + lifecycle.
- `hale-types` `alloc_summary`: `@bounded` reports without the flag; `@unbounded` carves out in scoped **and** survey mode.
- `hale-cli` `bounded_annotation.rs`: end-to-end — `@bounded` warns by default, carved method silent, no-`@bounded` silent-by-default, survey still finds it.
- Spot-checked codegen `generics` + `locus_let_lifecycle` (the monomorphization construction sites) — green. Full codegen sweep left to CI.

spec/verification.md, spec/grammar.ebnf, docs operations.md + performance.md, and notes/memory-bound-proofs.md updated in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)