### PR TITLE
test(alloc): lock store-latest-is-unbounded with RSS; reframe Phase D to the capacity axis (GH #18 item 1)

### DIFF
--- a/crates/hale-codegen/tests/alloc_model_rss.rs
+++ b/crates/hale-codegen/tests/alloc_model_rss.rs
@@ -145,3 +145,93 @@ fn model_unbounded_verdict_matches_growing_rss() {
         flat_rss
     );
 }
+
+// === Phase C (2026-06-25): store-latest into a locus field is UNBOUNDED ===
+//
+// The note had hypothesized a "replace-vs-append refinement" treating a
+// whole-value field store (`self.f = X{}`) as *bounded*. RSS falsified it:
+// in Hale's bump arena a replaced value is not reclaimed until dissolve, so
+// a per-iteration whole-value replace accumulates — even for a fixed-size
+// `[Int; 4]`. These tests LOCK that finding so a future "optimization" that
+// wrongly suppresses store-latest gets a red test (and so the model's
+// flagging of it stays tied to measured RSS). See
+// `notes/memory-bound-proofs.md` §"Phase C finding".
+//
+// All three loops share the runtime bound `self.n` (not a const literal),
+// so loop-ranking can't prove them bounded — the genuine unbounded case.
+
+/// In-place indexed write into a fixed array field. No allocation: the slot
+/// is overwritten in existing inline storage. The model must NOT flag it,
+/// and RSS stays at the runtime floor. This is the *fix* the diagnostic
+/// steers toward.
+const INPLACE_FIELD_WRITE: &str = r#"
+    locus Acc {
+        params { recent: [Int; 4] = [0,0,0,0]; n: Int = 3000000; sink: Int = 0; }
+        run() {
+            let mut i = 0;
+            while i < self.n {
+                self.recent[i % 4] = i;
+                self.sink = self.sink + self.recent[0];
+                i = i + 1;
+            }
+            print("sum="); println(self.sink);
+            print("final_rss_mb="); println(std::process::rss_bytes() / 1048576);
+        }
+    }
+    fn main() { Acc { }; }
+"#;
+
+/// Whole-value replace of a fixed-size `[Int; 4]` field each iteration. The
+/// array literal bump-allocates a fresh 4-int array into the locus arena
+/// every trip; the prior one is not reclaimed until dissolve. The model
+/// flags it, and RSS climbs steeply with the trip count.
+const ARRAY_FIELD_REPLACE: &str = r#"
+    locus Acc {
+        params { recent: [Int; 4] = [0,0,0,0]; n: Int = 3000000; sink: Int = 0; }
+        run() {
+            let mut i = 0;
+            while i < self.n {
+                self.recent = [i, i, i, i];
+                self.sink = self.sink + self.recent[0];
+                i = i + 1;
+            }
+            print("sum="); println(self.sink);
+            print("final_rss_mb="); println(std::process::rss_bytes() / 1048576);
+        }
+    }
+    fn main() { Acc { }; }
+"#;
+
+#[test]
+fn store_latest_field_replace_grows_inplace_stays_flat() {
+    // Model side: the whole-value replace is an unbounded site; the
+    // in-place indexed write has no allocation site at all.
+    assert!(
+        model_has_unbounded_site(ARRAY_FIELD_REPLACE),
+        "whole-value `self.recent = [..]` replace must be flagged unbounded"
+    );
+    assert!(
+        !model_has_unbounded_site(INPLACE_FIELD_WRITE),
+        "in-place `self.recent[i] = v` writes allocate nothing — no false \
+         unbounded"
+    );
+
+    // Runtime side: RSS confirms the verdicts. The replace accumulates ~130
+    // MB over 3M trips; the in-place write sits at the runtime floor. Assert
+    // relative to the in-place baseline — the absolute floor varies with
+    // build config (see the model-vs-RSS test above).
+    let inplace_rss = build_and_rss("inplace_field_write", INPLACE_FIELD_WRITE);
+    let replace_rss = build_and_rss("array_field_replace", ARRAY_FIELD_REPLACE);
+
+    assert!(
+        replace_rss >= inplace_rss + 60,
+        "store-latest field replace should add >60MB over the in-place \
+         baseline: replace={}MB, inplace={}MB. If the gap collapsed, \
+         whole-value field assignment now reclaims per iteration — the \
+         'store-latest is unbounded' verdict (and the model that flags it) \
+         must be revisited before trusting any store-latest-is-bounded \
+         refinement.",
+        replace_rss,
+        inplace_rss
+    );
+}

--- a/notes/memory-bound-proofs.md
+++ b/notes/memory-bound-proofs.md
@@ -212,14 +212,71 @@ and validated against the corpus (the inverse check: every program the
 pass says is bounded should show flat RSS under the
 `high_volume_walk_bounded_rss`-style harness).
 
-## `@form(hashmap)` interaction (the issue's open question)
+## Bounded sinks live on the capacity/projection axis, NOT `@form` (2026-06-25)
 
-A `@form(hashmap, cap = N)` is a *bounded* sink for the cells themselves
-(fixed cap), but a cell with a `String`/array field is unbounded if that
-field grows per update (leak class 2). So the pass composes: the cell
-count is bounded by `cap`; the per-cell field allocations must themselves
-be bounded (a fixed-width scalar field is; an appended-to `String` field
-is not). The `@form` cap is an input to the solver, not a free pass.
+An earlier draft framed this as "`@form(hashmap, cap = N)` composition" —
+the `@form` cap as a bound the solver reads. **That is wrong**, and the
+spec says so plainly: `@form` is an *access discipline* (vec / hashmap /
+ring_buffer — picks a lowering + synthesizes methods), and
+`spec/forms.md` is explicit that *"discipline goes on the capacity slot,
+not in the annotation."* The `cap = N` that appears on
+`@form(hashmap, …, cap = N)` is *"an optional initial-size hint"*
+(forms.md), **not a bound** — the map still lazily grows. So `@form`
+bounds nothing; reading it for a bound is a category error.
+
+The bound lives on the **capacity/projection axis**, in three tiers:
+
+| Construct | Bound character |
+|---|---|
+| `: projection recognition(cap = N, fixed_cell)` | **Hard static cap.** N cells; overflow is a *runtime error*. `spec/memory.md` calls it "the one real cap." The clean bounded sink. |
+| `capacity { pool X of T; }` | Recyclable cells (chunked free-list, geometric growth capped at 4096/chunk). Bounded **iff** acquire/release is balanced — high-water tracks peak population, not a static N. |
+| `capacity { heap Y of T; }` / `@form(vec)` / `@form(hashmap)` | Individually freed at dissolve; grows with total population. Unbounded unless population is bounded. |
+
+### The organizing insight: bound model is per storage slot
+
+A locus's storage is an N-tuple of slots (`spec/memory.md` §"capacity
+slots"). The proof must route each *escaping* allocation to the slot it
+lands in and apply that slot's bound model:
+
+- **Slot 0 — the locus's own bump Arena.** Where `self.field = X{}`
+  value allocations land. Bump-allocated, reclaimed only at dissolve, so
+  a per-iteration store-latest **accumulates** — measured, see the Phase
+  C finding below. This slot is the `@bounded`/`@unbounded` story and the
+  store-latest (A/B) fork. No capacity construct governs it.
+- **Slots 1..N — capacity pool/heap + projection.** Where collections /
+  accepted-child entities live. Bound = the table above: `recognition`
+  cap is a hard static bound; `pool` is bounded-by-balanced-release;
+  `heap`/`vec`/`hashmap` grow with population.
+
+This also lines up with the entity-vs-data taxonomy: `recognition`
+(accept'd entities, hard `fixed_cell` cap) vs `@form`/`capacity` (data).
+
+### Phase C finding — store-latest is unbounded (measured 2026-06-25)
+
+The note had hypothesized a "replace-vs-append refinement" treating a
+store-latest (`self.x = …`) as *bounded*. **RSS measurement falsified
+it.** A `run()` loop doing a whole-value field replace each iteration
+(3M trips, runtime bound) over a baseline of ~55 MB:
+
+| variant | RSS | grows? |
+|---|---|---|
+| `self.recent[i] = v` (in-place indexed) | 55 MB | no — baseline |
+| `self.recent = [i,i,i,i]` (fixed `[Int;4]` replace) | 188 MB | **+133 MB** |
+| `self.h = Holder{…}` (flat all-scalar struct replace) | 96 MB | **+41 MB** |
+
+Whole-value field replacement bump-allocates a fresh value each iteration
+into slot 0; the replaced value is **not** reclaimed until dissolve —
+even for a fixed-size `[Int;4]`. The current model already flags exactly
+the growing cases and leaves in-place writes alone, so **the model is
+sound and there is no false positive to fix.** The "store-latest is
+bounded" refinement is **dropped as unsound.** Two follow-on directions
+remain open (the slot-0 fork): **(A)** lock the soundness with RSS
+regression tests + redirect precision effort to the capacity/projection
+axis; or **(B)** a *codegen* change making fixed-size value-type field
+assignment an in-place memcpy (no bump-alloc) so store-latest becomes
+genuinely bounded, then teach the model. A is analysis-faithful and
+cheap; B is a larger codegen-correctness effort that supersedes A's
+store-latest assertion.
 
 ## Scope boundaries
 
@@ -245,8 +302,20 @@ is not). The `@form` cap is an input to the solver, not a free pass.
 3. **Bound solver + `@unbounded`** — the escape-into-unbounded-context
    obligation, bounded loops/sinks, the diagnostic. Warning first (like
    the bus-graph checks shipped), error once the false-positive rate on
-   the corpus is zero.
-4. **`@form` composition** — the cap-as-input + per-cell-field bounds.
+   the corpus is zero. *(Shipped. Phase A made it opt-in via
+   `--warn-unbounded-alloc`; Phase B added the `@bounded` locus opt-in +
+   `@unbounded` carve-out — see the status block at the top.)*
+4. **Capacity/projection-aware slot bounding** *(was mislabeled "`@form`
+   composition")* — route each escaping allocation to the storage slot it
+   lands in and apply that slot's bound model: `recognition(cap = N)` is a
+   hard static bound; a `pool` slot is bounded-by-balanced-release; a
+   `heap` slot / `vec` / `hashmap` grows with population; slot 0 (the bump
+   Arena) accumulates a store-latest. Then compose per-cell field bounds
+   (a fixed-scalar cell field is bounded; an appended-to `String` field is
+   not). The bound is read from the **capacity block + projection class**,
+   never from `@form` (an access discipline that bounds nothing). See
+   "Bounded sinks live on the capacity/projection axis" above.
+   *Pre-req decision: the slot-0 store-latest (A/B) fork.*
 
 ## Risks
 


### PR DESCRIPTION
> **Stacked on #162** (Phase B). Base is `feat/bounded-annotation`; retargets to `main` as the stack merges.

## Summary

Phase C of the memory-bound proof — **rescoped by measurement**. The design note had hypothesized a "replace-vs-append refinement" treating a whole-value field store (`self.f = X{}`) as *bounded*. RSS **falsified** it: in Hale's bump arena a replaced value isn't reclaimed until dissolve, so a per-iteration whole-value replace accumulates — even for a fixed-size `[Int; 4]`.

| variant (3M-trip `run` loop) | RSS | grows? |
|---|---|---|
| `self.recent[i] = v` (in-place indexed) | 55 MB | no — baseline |
| `self.recent = [i,i,i,i]` (`[Int;4]` replace) | 188 MB | **+133 MB** |
| `self.h = Holder{…}` (flat struct replace) | 96 MB | **+41 MB** |

The model already flags exactly the growing cases and leaves in-place writes alone — so **it's sound and there's no false positive to fix.** The refinement is dropped as unsound.

## Changes

- **`alloc_model_rss.rs`** — new `store_latest_field_replace_grows_inplace_stays_flat`: asserts the whole-value replace is model-flagged **and** adds >60 MB over the in-place baseline, while the in-place write allocates nothing and isn't flagged. A future "optimization" that wrongly suppresses store-latest now gets a red test.
- **`notes/memory-bound-proofs.md`** — records the measurement and **reframes the roadmap**:
  - Bounds live on the **capacity/projection axis**, NOT `@form`. `@form` is an access discipline (`spec/forms.md`: *"discipline goes on the capacity slot, not in the annotation"*); the `cap=N` form-arg is a size *hint*, not a bound.
  - The proof is **per storage slot**: slot 0 (the locus bump Arena) is the store-latest story; slots 1..N (capacity `pool`/`heap` + the `recognition(cap=N, fixed_cell)` projection's hard cap) are the reframed **Phase D — capacity/projection-aware slot bounding** (was mislabeled "@form(cap) composition").

`spec/verification.md` already states the whole-value replace leaks (Phase A), so no spec change — the measurement confirms it.

## Test

`cargo test --release -p hale-codegen --test alloc_model_rss -- --test-threads=1` → 2 passed.

## Next

**Phase D** — capacity/projection-aware slot bounding: route each escaping allocation to the storage slot it lands in and apply that slot's bound model (`recognition` cap = hard bound; `pool` = bounded-by-balanced-release; `heap`/`vec`/`hashmap` = grows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)