### PR TITLE
feat(alloc): D2 flag growing @form(vec|hashmap) inserts (GH #18 item 1, Phase D)

### DIFF
--- a/crates/hale-codegen/tests/alloc_model_rss.rs
+++ b/crates/hale-codegen/tests/alloc_model_rss.rs
@@ -235,3 +235,78 @@ fn store_latest_field_replace_grows_inplace_stays_flat() {
         inplace_rss
     );
 }
+
+// === Phase D / D2 (2026-06-25): a growing @form(vec) insert accumulates ===
+//
+// D2 flags `v.push(x)` where `v`'s declared type is a growing `@form(vec |
+// hashmap)` locus, in an unbounded context. `lotus_vec_push` grows a
+// geometric doubling buffer (cap*2) with the element memcpy'd in, so the
+// vec genuinely accumulates with the push count. This ties that verdict to
+// measured RSS so a future change that wrongly treats a vec insert as
+// bounded gets a red test. (Element is a 32-byte struct for a clean signal
+// above the test build's ~50 MB baseline; the loop bound `self.n` is
+// runtime, so loop-ranking can't prove it bounded.)
+
+const VEC_PUSH_GROWS: &str = r#"
+    type Cell { a: Int; b: Int; c: Int; d: Int; }
+    @form(vec) locus CellVec { capacity { heap items of Cell; } }
+    locus W {
+        params { buf: CellVec = CellVec { }; n: Int = 3000000; }
+        run() {
+            let mut i = 0;
+            while i < self.n {
+                self.buf.push(Cell { a: i, b: i, c: i, d: i });
+                i = i + 1;
+            }
+            print("len="); println(self.buf.len());
+            print("final_rss_mb="); println(std::process::rss_bytes() / 1048576);
+        }
+    }
+    fn main() { W { }; }
+"#;
+
+/// The control: the identical loop and vec, but no push — RSS stays at the
+/// runtime floor and the model finds no collection-insert site.
+const VEC_PUSH_CONTROL: &str = r#"
+    type Cell { a: Int; b: Int; c: Int; d: Int; }
+    @form(vec) locus CellVec { capacity { heap items of Cell; } }
+    locus W {
+        params { buf: CellVec = CellVec { }; n: Int = 3000000; sink: Int = 0; }
+        run() {
+            let mut i = 0;
+            while i < self.n { self.sink = self.sink + i; i = i + 1; }
+            print("sum="); println(self.sink);
+            print("final_rss_mb="); println(std::process::rss_bytes() / 1048576);
+        }
+    }
+    fn main() { W { }; }
+"#;
+
+#[test]
+fn collection_insert_growth_matches_rss() {
+    // Model side: the vec push is an unbounded collection-insert site; the
+    // control (no push) has none.
+    assert!(
+        model_has_unbounded_site(VEC_PUSH_GROWS),
+        "a vec push in an unbounded loop should be flagged unbounded"
+    );
+    assert!(
+        !model_has_unbounded_site(VEC_PUSH_CONTROL),
+        "the no-push control must not be flagged"
+    );
+
+    // Runtime side: the vec accumulates ~150 MB over 3M pushes of a 32-byte
+    // cell; the control sits at the floor. Assert relative to the control.
+    let grow_rss = build_and_rss("vec_push_grows", VEC_PUSH_GROWS);
+    let ctrl_rss = build_and_rss("vec_push_control", VEC_PUSH_CONTROL);
+
+    assert!(
+        grow_rss >= ctrl_rss + 80,
+        "a growing @form(vec) insert should add >80MB over the no-push \
+         control: grow={}MB, ctrl={}MB. If the gap collapsed, vec pushes no \
+         longer accumulate where the model says they do — the D2 \
+         collection-insert verdict must be revisited.",
+        grow_rss,
+        ctrl_rss
+    );
+}

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -69,6 +69,12 @@ pub enum AllocKind {
     ArrayLit,
     ArrayRepeat,
     BytesLit,
+    /// Phase D / D2: an insert into a growing `@form(vec | hashmap)` slot
+    /// (`v.push(x)` / `m.set(x)`). Detected when the receiver's *declared*
+    /// type resolves to such a form locus. The collection's backing buffer
+    /// grows with population and frees only at dissolve — so an insert in
+    /// an unbounded context accumulates. The string is the form name.
+    CollectionInsert(String),
 }
 
 impl AllocKind {
@@ -78,7 +84,31 @@ impl AllocKind {
             AllocKind::ArrayLit => "array-literal".to_string(),
             AllocKind::ArrayRepeat => "array-repeat".to_string(),
             AllocKind::BytesLit => "bytes-literal".to_string(),
+            AllocKind::CollectionInsert(form) => format!("{}-insert", form),
         }
+    }
+}
+
+/// Phase D / D2: the `@form(...)` names whose inserts grow without bound
+/// (backing buffer grows with population, frees only at dissolve). A
+/// `ring_buffer` / `lru_cache` is cap-bounded and excluded.
+fn form_grows(form_name: &str) -> bool {
+    matches!(form_name, "vec" | "hashmap")
+}
+
+/// Phase D / D2: the method names that *insert* into a collection (vs read
+/// it). Gated by `form_grows` on the receiver's form, so a `get`/`len`/`pop`
+/// never counts.
+fn is_insert_method(method: &str) -> bool {
+    matches!(method, "push" | "set" | "insert" | "add")
+}
+
+/// The unqualified name of a `Named` type expression (`SegVec` from
+/// `path::to::SegVec`), or `None` for primitives / arrays / etc.
+fn type_expr_name(te: &TypeExpr) -> Option<String> {
+    match te {
+        TypeExpr::Named { path, .. } => path.segments.last().map(|s| s.name.clone()),
+        _ => None,
     }
 }
 
@@ -642,13 +672,18 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
     // Phase 1 — collect every body with its key + entry classification.
     // For loci we first gather the set of bus-handler method names so a
     // method referenced by `subscribe ... -> handler` is tagged BusHandler.
-    let mut bodies: Vec<(FnKey, Block, Option<EntryKind>, Option<String>)> = Vec::new();
+    // The trailing `Vec<(String, String)>` seeds each body's var→type map
+    // from its params (D2).
+    type BodyEntry = (FnKey, Block, Option<EntryKind>, Option<String>, Vec<(String, String)>);
+    let mut bodies: Vec<BodyEntry> = Vec::new();
     let mut known: BTreeSet<FnKey> = BTreeSet::new();
     // GH #18 item 1 — the `@bounded` / `@unbounded` opt-in/carve-out sets.
     let mut bounded_loci: BTreeSet<String> = BTreeSet::new();
     let mut unbounded_fns: BTreeSet<FnKey> = BTreeSet::new();
     // Phase D / D1 — the per-locus storage shape.
     let mut locus_shapes: BTreeMap<String, LocusShape> = BTreeMap::new();
+    // Phase D / D2 — per-locus param field → declared type name.
+    let mut locus_field_types: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
 
     for program in programs {
         for item in &program.items {
@@ -660,7 +695,7 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
                         unbounded_fns.insert(key.clone());
                     }
                     known.insert(key.clone());
-                    bodies.push((key, decl.body.clone(), entry, None));
+                    bodies.push((key, decl.body.clone(), entry, None, param_var_types(&decl.params)));
                 }
                 TopDecl::Locus(l) => {
                     let locus = l.name.name.clone();
@@ -668,6 +703,7 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
                         bounded_loci.insert(locus.clone());
                     }
                     locus_shapes.insert(locus.clone(), locus_shape_of(l));
+                    locus_field_types.insert(locus.clone(), locus_param_field_types(l));
                     let handlers = bus_handler_names(l);
                     for member in &l.members {
                         match member {
@@ -682,7 +718,13 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
                                     unbounded_fns.insert(key.clone());
                                 }
                                 known.insert(key.clone());
-                                bodies.push((key, decl.body.clone(), entry, Some(locus.clone())));
+                                bodies.push((
+                                    key,
+                                    decl.body.clone(),
+                                    entry,
+                                    Some(locus.clone()),
+                                    param_var_types(&decl.params),
+                                ));
                             }
                             LocusMember::Lifecycle(lc) => {
                                 let (name, entry) = lifecycle_key(lc.kind);
@@ -691,7 +733,13 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
                                     unbounded_fns.insert(key.clone());
                                 }
                                 known.insert(key.clone());
-                                bodies.push((key, lc.body.clone(), Some(entry), Some(locus.clone())));
+                                bodies.push((
+                                    key,
+                                    lc.body.clone(),
+                                    Some(entry),
+                                    Some(locus.clone()),
+                                    param_var_types(&lc.params),
+                                ));
                             }
                             _ => {}
                         }
@@ -702,10 +750,21 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
         }
     }
 
+    // D2: type name → `@form(...)` name, for receiver-form lookup.
+    let form_of: BTreeMap<String, String> = locus_shapes
+        .iter()
+        .filter_map(|(name, shape)| shape.form.as_ref().map(|f| (name.clone(), f.name.clone())))
+        .collect();
+    let empty_fields: BTreeMap<String, String> = BTreeMap::new();
+
     // Phase 2 — walk each body.
     let mut summary = AllocSummary::default();
-    for (key, body, entry, enclosing_locus) in &bodies {
+    for (key, body, entry, enclosing_locus, param_types) in &bodies {
         let escaping = collect_escaping_names(body);
+        let field_types = enclosing_locus
+            .as_ref()
+            .and_then(|l| locus_field_types.get(l))
+            .unwrap_or(&empty_fields);
         let mut w = Walker {
             sites: Vec::new(),
             calls: Vec::new(),
@@ -716,6 +775,9 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
             loop_stack: Vec::new(),
             fn_body: body,
             store_target: None,
+            var_types: param_types.iter().cloned().collect(),
+            field_types,
+            form_of: &form_of,
         };
         w.walk_block(body, 0, Escape::Local);
         summary.fns.insert(
@@ -733,6 +795,31 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
     summary.unbounded_fns = unbounded_fns;
     summary.locus_shapes = locus_shapes;
     summary
+}
+
+/// D2: a fn's params as (name, declared-type-name) pairs — the seed for
+/// the var→type map (only `Named` types; primitives/arrays are skipped).
+fn param_var_types(params: &[Param]) -> Vec<(String, String)> {
+    params
+        .iter()
+        .filter_map(|p| type_expr_name(&p.ty).map(|t| (p.name.name.clone(), t)))
+        .collect()
+}
+
+/// D2: a locus's `params { … }` fields as field → declared-type-name, so a
+/// `self.<field>.push(x)` can resolve `<field>`'s form.
+fn locus_param_field_types(l: &LocusDecl) -> BTreeMap<String, String> {
+    let mut m = BTreeMap::new();
+    for member in &l.members {
+        if let LocusMember::Params(pb) = member {
+            for pd in &pb.params {
+                if let Some(tn) = pd.ty.as_ref().and_then(type_expr_name) {
+                    m.insert(pd.name.name.clone(), tn);
+                }
+            }
+        }
+    }
+    m
 }
 
 /// Phase D / D1: distill a `LocusDecl` into the storage shape the bound
@@ -860,6 +947,16 @@ struct Walker<'a> {
     /// the RHS walk of a `self.<field> = …` statement so an escaping
     /// allocation in that RHS records which field it lands in.
     store_target: Option<String>,
+    /// Phase D / D2 (lite): local var / param name → declared type *name*,
+    /// seeded from this fn's params and grown by typed `let`s. Lets a
+    /// `v.push(x)` resolve `v`'s type to ask whether it is a growing form.
+    var_types: BTreeMap<String, String>,
+    /// The enclosing locus's param fields → declared type name, so a
+    /// `self.<field>.push(x)` resolves `<field>`'s type the same way.
+    field_types: &'a BTreeMap<String, String>,
+    /// Every locus's `@form(...)` name, keyed by locus type name — the
+    /// lookup `var_types`/`field_types` feed into `form_grows`.
+    form_of: &'a BTreeMap<String, String>,
 }
 
 impl<'a> Walker<'a> {
@@ -881,6 +978,43 @@ impl<'a> Walker<'a> {
             span,
         });
     }
+
+    /// D2: if `recv` is a value whose *declared* type is a growing
+    /// `@form(vec | hashmap)` locus, the form name. Resolves a bare var via
+    /// `var_types` and a `self.<field>` via `field_types`.
+    fn growing_form_of_receiver(&self, recv: &Expr) -> Option<String> {
+        let ty_name = match recv {
+            Expr::Ident(v) => self.var_types.get(&v.name)?,
+            Expr::Field { receiver, name, .. } | Expr::Path2 { receiver, name, .. }
+                if matches!(receiver.as_ref(), Expr::KwSelf(_)) =>
+            {
+                self.field_types.get(&name.name)?
+            }
+            _ => return None,
+        };
+        let form = self.form_of.get(ty_name)?;
+        if form_grows(form) {
+            Some(form.clone())
+        } else {
+            None
+        }
+    }
+
+    /// D2: record a growing-collection insert as an accumulating site. It
+    /// persists into the collection (reclaim at the owner's dissolve), so
+    /// in an unbounded context it accumulates — same verdict path as a
+    /// `StoredToSelf` value alloc.
+    fn push_collection_insert(&mut self, form: String, depth: u32, span: Span) {
+        self.sites.push(AllocSite {
+            kind: AllocKind::CollectionInsert(form),
+            escape: Escape::StoredToSelf,
+            loop_depth: depth,
+            in_unbounded_loop: self.loop_stack.iter().any(|bounded| !bounded),
+            reclaim: ReclaimScope::EnclosingLocus,
+            target_field: None,
+            span,
+        });
+    }
 }
 
 impl<'a> Walker<'a> {
@@ -895,7 +1029,12 @@ impl<'a> Walker<'a> {
 
     fn walk_stmt(&mut self, stmt: &Stmt, depth: u32) {
         match stmt {
-            Stmt::Let { name, value, .. } => {
+            Stmt::Let { name, ty, value, .. } => {
+                // D2: a typed `let v: T = …` extends the var→type map so a
+                // later `v.push(x)` can resolve `v`'s form.
+                if let Some(tn) = ty.as_ref().and_then(type_expr_name) {
+                    self.var_types.insert(name.name.clone(), tn);
+                }
                 let esc = self.escaping.get(&name.name).copied().unwrap_or(Escape::Local);
                 self.walk_expr(value, depth, esc);
             }
@@ -1035,6 +1174,17 @@ impl<'a> Walker<'a> {
             Expr::Unary { operand, .. } => self.walk_expr(operand, depth, Escape::Local),
             Expr::Call { callee, args, span } => {
                 self.record_call(callee, *span, depth, escape);
+                // D2: a `recv.<insert>(x)` where `recv`'s declared type is a
+                // growing form is itself an accumulating allocation.
+                if let Expr::Field { receiver, name, .. }
+                | Expr::Path2 { receiver, name, .. } = callee.as_ref()
+                {
+                    if is_insert_method(&name.name) {
+                        if let Some(form) = self.growing_form_of_receiver(receiver) {
+                            self.push_collection_insert(form, depth, *span);
+                        }
+                    }
+                }
                 // The callee receiver may itself allocate; its result
                 // doesn't escape via this site.
                 match callee.as_ref() {
@@ -1871,5 +2021,128 @@ mod tests {
         let f = fns(&s, &FnKey::method("C", "run"));
         let call = f.calls.iter().find(|c| c.receiver_slot.is_some()).expect("slot call");
         assert_eq!(call.receiver_slot.as_deref(), Some("log"));
+    }
+
+    // === Phase D / D2: growing-collection (@form vec/hashmap) inserts =====
+
+    fn insert_site(f: &FnSummary) -> Option<&AllocSite> {
+        f.sites.iter().find(|s| matches!(s.kind, AllocKind::CollectionInsert(_)))
+    }
+
+    #[test]
+    fn d2_vec_field_push_in_handler_is_unbounded() {
+        let src = r#"
+            @form(vec) locus IntVec { capacity { heap items of Int; } }
+            locus W {
+                params { buf: IntVec = IntVec { }; }
+                bus { subscribe "ev" as on_ev of type Int; }
+                fn on_ev(x: Int) { self.buf.push(x); }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("W", "on_ev"));
+        let site = insert_site(&f).expect("vec-insert site");
+        assert_eq!(site.kind, AllocKind::CollectionInsert("vec".into()));
+        // A per-message handler is an unbounded-invocation context.
+        let leaks = s.leak_sites();
+        assert!(
+            leaks.iter().any(|l| matches!(l.kind, AllocKind::CollectionInsert(_))),
+            "vec push in a per-message handler should be flagged"
+        );
+    }
+
+    #[test]
+    fn d2_vec_param_push_called_once_is_not_flagged() {
+        let src = r#"
+            @form(vec) locus IntVec { capacity { heap items of Int; } }
+            fn double_push(v: IntVec, n: Int) { v.push(n); v.push(n); }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::free_fn("double_push"));
+        // The insert is recorded (typed param resolved)…
+        assert!(insert_site(&f).is_some(), "param-typed vec push is detected");
+        // …but called once, not in a loop → not a leak.
+        assert_eq!(insert_site(&f).unwrap().verdict(), SiteVerdict::OncePerInvocation);
+        assert!(s.leak_sites().is_empty(), "a call-once push is bounded");
+    }
+
+    #[test]
+    fn d2_ring_buffer_push_is_not_flagged() {
+        // ring_buffer is cap-bounded — its push is not a growing insert.
+        let src = r#"
+            @form(ring_buffer, cap = 16) locus Ring { capacity { pool slots of Int; } }
+            locus W {
+                params { r: Ring = Ring { }; }
+                bus { subscribe "ev" as on_ev of type Int; }
+                fn on_ev(x: Int) { self.r.push(x); }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("W", "on_ev"));
+        assert!(insert_site(&f).is_none(), "ring_buffer push must not flag");
+        assert!(s.leak_sites().is_empty());
+    }
+
+    #[test]
+    fn d2_bounded_loop_push_is_not_a_leak() {
+        let src = r#"
+            @form(vec) locus IntVec { capacity { heap items of Int; } }
+            locus W {
+                params { buf: IntVec = IntVec { }; }
+                run { let mut i = 0; while i < 4 { self.buf.push(i); i = i + 1; } }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("W", "run"));
+        let site = insert_site(&f).expect("insert detected");
+        assert_eq!(
+            site.verdict(),
+            SiteVerdict::AccumulatesBoundedLoop,
+            "a const-bounded loop bounds the inserts"
+        );
+        assert!(s.leak_sites().is_empty());
+    }
+
+    #[test]
+    fn d2_user_method_named_push_on_non_form_locus_is_not_flagged() {
+        // `Segment` is a plain locus with a user `push` method — not a form.
+        // (The `54-geom-leading-edge` corpus shape.) Must not flag.
+        let src = r#"
+            locus Segment {
+                fn push(t: Int) { }
+            }
+            locus W {
+                params { seg: Segment = Segment { }; }
+                run { while true { self.seg.push(1); } }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("W", "run"));
+        assert!(insert_site(&f).is_none(), "user push on a non-form locus is not an insert");
+        assert!(s.leak_sites().is_empty());
+    }
+
+    #[test]
+    fn d2_typed_let_receiver_resolves() {
+        let src = r#"
+            @form(hashmap) locus Map { capacity { pool entries of Int; } }
+            locus W {
+                run {
+                    let m: Map = Map { };
+                    while true { m.set(1); }
+                }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("W", "run"));
+        let site = insert_site(&f).expect("typed-let hashmap insert detected");
+        assert_eq!(site.kind, AllocKind::CollectionInsert("hashmap".into()));
+        assert_eq!(site.verdict(), SiteVerdict::AccumulatesUnbounded);
     }
 }

--- a/docs/src/systems/performance.md
+++ b/docs/src/systems/performance.md
@@ -108,6 +108,15 @@ These are advisory warnings, not build failures:
   `@bounded` to get the check on every `hale check` without the flag,
   and `@unbounded` (on a `fn` or a lifecycle hook) to acknowledge an
   intentional accumulation and silence it.
+- The same check flags an **insert into a growing collection** —
+  `v.push(x)` / `m.set(x)` where `v` / `m` is a `@form(vec)` or
+  `@form(hashmap)` — when it runs in an unbounded context. The backing
+  buffer grows with population and frees only at dissolve, so a push
+  per message accumulates. A `@form(ring_buffer)` / `@form(lru_cache)`
+  is cap-bounded and never flagged; switching to one (or bounding the
+  loop) is the fix. (Detection reads the receiver's *declared* type, so
+  it sees `fn f(v: IntVec)` and `self.buf: IntVec` but not an untyped
+  `let`.)
 - `hale check app.hl --warn-resource-leak` is the same idea for file
   descriptors: an `open` / `connect` / `accept` whose result is
   stored resident in an unbounded context, so fds pile up.

--- a/notes/memory-bound-proofs.md
+++ b/notes/memory-bound-proofs.md
@@ -324,13 +324,28 @@ store-latest assertion.
      The reusable infra for D2. Discovery finding: the walker previously
      tagged slot-insert *arguments* `Local`, so collection growth
      (`self.items.push(X{})`) is currently **undetected** — D2's job.
-   - **D2 — model the slot-insert allocation channel + bound it.** Treat
-     `acquire`/`alloc`/`push`/`set` into a capacity data slot as an
-     allocation tagged with that slot's discipline; flag unbounded
-     (`heap`/`vec`/`hashmap`) inserts in unbounded contexts; leave
-     `ring_buffer` (cap) and balanced `pool` alone. Warning, opt-in-gated,
-     RSS-validated. (Recognition `cap=N` bounds *entity* count, fed by
-     `accept` — a separate analysis the value-alloc walker doesn't track.)
+   - **D2 (LANDED 2026-06-25) — growing-collection inserts.** A discovery
+     pass found the corpus inserts via `v.push(x)` on a *typed* receiver
+     (`v: IntVec`, `self.buf: IntVec`), not direct `self.<slot>.alloc()` —
+     so detection is **type-aware**, the same class as the deferred
+     String-concat. Chosen approach: **D2-lite** — a lightweight var→
+     *declared*-type map (fn params, typed `let`s, locus param fields)
+     matched against `locus_shapes[T].form`. A `push`/`set`/`insert`/`add`
+     whose receiver type is a `@form(vec | hashmap)` becomes a
+     `CollectionInsert` site (escape=self-store, reclaim@dissolve), so it
+     flows through the existing verdict path: flagged in an unbounded
+     context, bounded by a const loop, suppressed by `@unbounded`. A
+     `@form(ring_buffer | lru_cache)` is cap-bounded → not flagged; a user
+     `push` method on a *non-form* locus → not flagged (the
+     `54-geom-leading-edge` `Segment` shape, confirmed). **Zero corpus
+     false positives** (68 fixtures). RSS-validated: a 3M `@form(vec)`
+     push-of-32B-struct hits 210 MB vs a 55 MB no-push control (`lotus_vec_
+     push` grows a geometric `cap*2` buffer; `rss_bytes()` is peak/maxrss).
+     *Misses (deferred to a type-aware stage):* untyped `let`, reassignment,
+     return-of-form, and the clear/reset balance case (a vec cleared each
+     iteration is bounded-by-peak — opt-in gating + `@unbounded` absorb it).
+     (Recognition `cap=N` bounds *entity* count, fed by `accept` — a
+     separate analysis the value-alloc walker doesn't track.)
    - **D3 — per-cell field bounds** (a bounded cell with a growing `String`
      field). Optional; can defer.
 

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -115,8 +115,15 @@ assume the others in a build:
   value each time); the fix is **in-place mutation** (`self.f.x = v` /
   `self.a[i] = v`), a capacity-bounded `@form` (`ring_buffer` / `lru_cache`
   / a `capacity` slot), the bus (reclaims per dispatch), or a per-iteration
-  child locus. Zero corpus false positives. Type-aware String-concat sites
-  remain deferred. See `notes/memory-bound-proofs.md`.
+  child locus. It also flags an **insert into a growing collection** —
+  `v.push(x)` / `m.set(x)` where the receiver's declared type is a
+  `@form(vec)` / `@form(hashmap)` locus — in an unbounded context; the
+  backing buffer grows with population and frees only at dissolve. A
+  `@form(ring_buffer)` / `@form(lru_cache)` is cap-bounded and excluded.
+  (Detection reads *declared* receiver types — params, typed `let`s, locus
+  param fields — not inferred ones.) Zero corpus false positives. Type-aware
+  String-concat sites and untyped-receiver collection inserts remain
+  deferred. See `notes/memory-bound-proofs.md`.
 - **Resource-budget tracking (item 5)** — fully shipped, opt-in. A static
   **count** of pinned threads / cooperative pools / bus subjects /
   fd-acquisition sites (fd-opening calls *and* held-fd `Listener` /


### PR DESCRIPTION
> **Stacked on #164** (D1). Base is `feat/alloc-slot-shape`; retargets up the stack as it merges.

## Summary

**D2 of Phase D** — detect unbounded growth into collection slots, the leak class the type-free walker missed (it tagged insert *args* `Local`). A discovery pass found the corpus inserts via `v.push(x)` on a **typed** receiver (`v: IntVec`, `self.buf: IntVec`), not direct `self.<slot>.alloc()` — so detection is inherently type-aware, the same class as the deferred String-concat. Chosen approach: **D2-lite** — a lightweight *declared*-type map, no resolver coupling.

## How it works

- A var→declared-type map seeded from fn params + typed `let`s, plus a locus param-field→type map, matched against D1's `locus_shapes[T].form`.
- A `push`/`set`/`insert`/`add` whose receiver type is a `@form(vec | hashmap)` locus becomes an `AllocKind::CollectionInsert` site (escape = self-store, reclaim @ dissolve), so it flows through the **existing** verdict path:
  - flagged in an unbounded context (per-message handler / runtime loop)
  - bounded by a const loop (`accumulates×const`)
  - suppressed by `@unbounded`, gated by `@bounded`/survey
- `@form(ring_buffer | lru_cache)` is cap-bounded → **not** flagged. A user-defined `push` method on a non-form locus → **not** flagged (the `54-geom-leading-edge` `Segment` shape).

## Validation

- **Zero corpus false positives** — surveyed all 68 example fixtures.
- **RSS-validated** (`alloc_model_rss`): a 3M `@form(vec)` push of a 32-byte struct hits **~210 MB** vs a **~55 MB** no-push control. Confirmed `lotus_vec_push` grows a geometric `cap*2` buffer with the element memcpy'd in — the vec genuinely accumulates.
- **6 D2 unit tests**: vec field push in a handler flagged; param push called once bounded; ring_buffer not flagged; bounded loop bounded; user `push` on a non-form locus not flagged; typed-`let` receiver resolves. `hale-types` lib: 210 passed.

## Deferred (to a type-aware stage, with String-concat)

Untyped `let`, reassignment, return-of-form receivers, and the clear/reset balance case (a vec cleared each iteration is bounded-by-peak). The opt-in gating + `@unbounded` carve-out absorb the false-positive edge until then.

## Next

**D3** (per-cell field bounds — a bounded cell with a growing `String` field) — optional; or fold the remaining type-aware detections (untyped receivers + String-concat) into one type-aware stage. **Phase E** promotes `@bounded` to a hard error once in-scope FPs hold at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)