### PR TITLE
feat(alloc): memory-bound proofs — opt-in gating + capacity-aware bounding (GH #18 item 1)

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -918,13 +918,22 @@ fn run_check(target: &Path) -> ExitCode {
     let allow_unowned =
         std::env::args().any(|a| a == "--allow-unowned-subscriber");
     let mut diags = hale_types::check_bundle_opts(&bundle, allow_unowned);
-    // GH #18 item 1: unbounded-allocation warnings, ON BY DEFAULT.
-    // `--no-warn-unbounded-alloc` opts out; `--warn-unbounded-alloc` is
-    // still accepted (now a no-op) for back-compat. The warnings are
-    // advisory — they print but don't fail the build (only errors do).
-    if !std::env::args().any(|a| a == "--no-warn-unbounded-alloc") {
-        diags.extend(hale_types::unbounded_alloc_warnings(&bundle));
-    }
+    // GH #18 item 1: unbounded-allocation warnings — OPT-IN, like the
+    // `--warn-resource-leak` / `@locality` budget surfaces. A memory-bound
+    // proof only means something for long-lived processes (daemons, bus
+    // handlers, persistent loci); a script that allocates and exits owes it
+    // nothing, so it pays nothing by default.
+    //
+    // Two opt-in surfaces (Phase B):
+    //  - `@bounded locus { … }` — the in-source opt-in. Its sites are
+    //    reported on every `hale check`, no flag needed.
+    //  - `--warn-unbounded-alloc` — the whole-program advisory survey
+    //    (every site, regardless of `@bounded`).
+    // `@unbounded fn` carves a fn out of both. The warnings print but never
+    // fail the build (only errors do). `--no-warn-unbounded-alloc` is
+    // accepted-and-ignored for back-compat with the former default-on flag.
+    let survey_all = std::env::args().any(|a| a == "--warn-unbounded-alloc");
+    diags.extend(hale_types::unbounded_alloc_warnings(&bundle, survey_all));
     // GH #18 item 5: opt-in fd-resource-leak warnings.
     if std::env::args().any(|a| a == "--warn-resource-leak") {
         diags.extend(hale_types::resource_leak_warnings(&bundle));

--- a/crates/hale-cli/tests/bounded_annotation.rs
+++ b/crates/hale-cli/tests/bounded_annotation.rs
@@ -1,0 +1,90 @@
+//! GH #18 item 1, Phase B — `@bounded` opts a locus into the
+//! memory-bound proof in-source; `@unbounded` carves a fn/hook out.
+//!
+//! Phase A made the proof opt-in (silent unless `--warn-unbounded-alloc`).
+//! Phase B adds the annotation surface so a long-lived locus can request
+//! the proof for itself — the descent-curve dual of the whole-program
+//! flag — without making scripts pay. This pins the end-to-end contract:
+//!
+//!   - a `@bounded` locus emits its leak warnings on a plain `hale check`,
+//!     no flag needed
+//!   - `@unbounded` on a method (or lifecycle hook) suppresses that body's
+//!     sites, with or without the survey flag
+//!   - a program with no `@bounded` locus stays silent by default
+//!     (Phase A behavior preserved)
+//!   - warnings remain advisory — they never fail the build
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn hale_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_hale"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("bounded-annotation");
+    p.push(name);
+    p
+}
+
+fn check(file: &str, extra: &[&str]) -> (bool, String) {
+    let out = Command::new(hale_bin())
+        .arg("check")
+        .arg(fixture(file))
+        .args(extra)
+        .output()
+        .expect("invoke hale check");
+    (out.status.success(), String::from_utf8_lossy(&out.stderr).into_owned())
+}
+
+const NEEDLE: &str = "unbounded allocation";
+
+#[test]
+fn bounded_locus_warns_by_default_carved_method_silent() {
+    // `app.hl`: a `@bounded` locus with two handlers — `on_sample`
+    // (flagged) and `@unbounded on_other` (carved out).
+    let (ok, stderr) = check("app.hl", &[]);
+    assert!(ok, "warnings are advisory, build must succeed:\n{stderr}");
+    assert!(
+        stderr.contains(NEEDLE),
+        "@bounded locus should warn on a plain check:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("on_sample"),
+        "the flagged handler should be named:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("on_other"),
+        "@unbounded handler must be carved out:\n{stderr}"
+    );
+}
+
+#[test]
+fn carve_out_holds_under_survey_flag() {
+    let (_ok, stderr) = check("app.hl", &["--warn-unbounded-alloc"]);
+    assert!(
+        !stderr.contains("on_other"),
+        "@unbounded suppresses even under the survey flag:\n{stderr}"
+    );
+}
+
+#[test]
+fn no_bounded_locus_is_silent_by_default() {
+    // `plain.hl`: the same leak shape with NO `@bounded` — Phase A says
+    // a script pays nothing by default.
+    let (ok, stderr) = check("plain.hl", &[]);
+    assert!(ok, "{stderr}");
+    assert!(
+        !stderr.contains(NEEDLE),
+        "no @bounded locus → silent without the flag:\n{stderr}"
+    );
+    // ...but the survey flag still finds it.
+    let (_ok, stderr) = check("plain.hl", &["--warn-unbounded-alloc"]);
+    assert!(
+        stderr.contains(NEEDLE),
+        "the survey flag reports it regardless of @bounded:\n{stderr}"
+    );
+}

--- a/crates/hale-cli/tests/fixtures/bounded-annotation/app.hl
+++ b/crates/hale-cli/tests/fixtures/bounded-annotation/app.hl
@@ -1,0 +1,33 @@
+// GH #18 item 1 Phase B — a @bounded locus opts into the memory-bound
+// proof; @unbounded carves one handler out.
+type Sample { value: Int; }
+type Holder { items: [Int; 4]; }
+
+@bounded locus Acc {
+    params {
+        latest: Holder = Holder { items: [0, 0, 0, 0] };
+        cache:  Holder = Holder { items: [0, 0, 0, 0] };
+    }
+    bus {
+        subscribe "sample"  as on_sample of type Sample;
+        subscribe "sample2" as on_other  of type Sample;
+    }
+    // flagged: whole-value replace each message accumulates in `self`.
+    fn on_sample(s: Sample) {
+        self.latest = Holder { items: [s.value, s.value, s.value, s.value] };
+    }
+    // carved out: an acknowledged intentional accumulation.
+    @unbounded fn on_other(s: Sample) {
+        self.cache = Holder { items: [s.value, s.value, s.value, s.value] };
+    }
+}
+
+locus Src {
+    bus { publish "sample" of type Sample; }
+    birth() { "sample" <- Sample { value: 1 }; }
+}
+
+fn main() {
+    Acc { };
+    Src { };
+}

--- a/crates/hale-cli/tests/fixtures/bounded-annotation/plain.hl
+++ b/crates/hale-cli/tests/fixtures/bounded-annotation/plain.hl
@@ -1,0 +1,26 @@
+// The same accumulation shape with NO @bounded opt-in — silent by
+// default (Phase A), reported only under --warn-unbounded-alloc.
+type Sample { value: Int; }
+type Holder { items: [Int; 4]; }
+
+locus Acc {
+    params {
+        latest: Holder = Holder { items: [0, 0, 0, 0] };
+    }
+    bus {
+        subscribe "sample" as on_sample of type Sample;
+    }
+    fn on_sample(s: Sample) {
+        self.latest = Holder { items: [s.value, s.value, s.value, s.value] };
+    }
+}
+
+locus Src {
+    bus { publish "sample" of type Sample; }
+    birth() { "sample" <- Sample { value: 1 }; }
+}
+
+fn main() {
+    Acc { };
+    Src { };
+}

--- a/crates/hale-cli/tests/fixtures/unbounded-alloc-opt-in/app.hl
+++ b/crates/hale-cli/tests/fixtures/unbounded-alloc-opt-in/app.hl
@@ -1,0 +1,29 @@
+// A per-message handler that does a whole-value replace into `self`
+// each message — the canonical unbounded-accumulation shape the
+// memory-bound proof (GH #18 item 1) flags. Used to pin that the
+// warning is OPT-IN: silent by default, emitted under
+// `--warn-unbounded-alloc`, never a build failure either way.
+type Sample { value: Int; }
+type Holder { items: [Int; 4]; }
+
+locus Acc {
+    params {
+        latest: Holder = Holder { items: [0, 0, 0, 0] };
+    }
+    bus {
+        subscribe "sample" as on_sample of type Sample;
+    }
+    fn on_sample(s: Sample) {
+        self.latest = Holder { items: [s.value, s.value, s.value, s.value] };
+    }
+}
+
+locus Src {
+    bus { publish "sample" of type Sample; }
+    birth() { "sample" <- Sample { value: 1 }; }
+}
+
+fn main() {
+    Acc { };
+    Src { };
+}

--- a/crates/hale-cli/tests/unbounded_alloc_opt_in.rs
+++ b/crates/hale-cli/tests/unbounded_alloc_opt_in.rs
@@ -1,0 +1,80 @@
+//! GH #18 item 1 — the memory-bound-proof warning is OPT-IN.
+//!
+//! "Bounded per epoch" only means something for a long-lived process
+//! (a daemon, a bus handler, a persistent locus). A script that
+//! allocates and exits owes the proof nothing, so it pays nothing by
+//! default — the same descent-curve stance as the `@locality`
+//! cache-tier budgets (annotation/flag-gated, never automatic). This
+//! pins that contract so a future refactor can't silently re-enable
+//! the former default-on behavior:
+//!
+//!   - default: silent (no warning), build succeeds
+//!   - `--warn-unbounded-alloc`: emits the advisory warning, build
+//!     still succeeds (a warning, not an error)
+//!   - `--no-warn-unbounded-alloc`: accepted-and-ignored for
+//!     back-compat with the former default-on flag
+//!
+//! The fixture (`fixtures/unbounded-alloc-opt-in/app.hl`) is the
+//! canonical unbounded-accumulation shape: a per-message handler that
+//! whole-value-replaces a struct into `self` each message.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn hale_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_hale"))
+}
+
+fn app() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("unbounded-alloc-opt-in");
+    p.push("app.hl");
+    p
+}
+
+fn check(extra: &[&str]) -> (bool, String) {
+    let out = Command::new(hale_bin())
+        .arg("check")
+        .arg(app())
+        .args(extra)
+        .output()
+        .expect("invoke hale check");
+    (out.status.success(), String::from_utf8_lossy(&out.stderr).into_owned())
+}
+
+const WARN_NEEDLE: &str = "unbounded allocation";
+
+#[test]
+fn default_is_silent() {
+    let (ok, stderr) = check(&[]);
+    assert!(ok, "default check should succeed: {stderr}");
+    assert!(
+        !stderr.contains(WARN_NEEDLE),
+        "memory-bound warning must be OPT-IN — default run leaked it:\n{stderr}"
+    );
+}
+
+#[test]
+fn warn_flag_emits_advisory_but_succeeds() {
+    let (ok, stderr) = check(&["--warn-unbounded-alloc"]);
+    assert!(
+        stderr.contains(WARN_NEEDLE),
+        "--warn-unbounded-alloc should emit the advisory warning:\n{stderr}"
+    );
+    assert!(
+        ok,
+        "the warning is advisory — it must not fail the build:\n{stderr}"
+    );
+}
+
+#[test]
+fn no_warn_flag_is_accepted_noop() {
+    let (ok, stderr) = check(&["--no-warn-unbounded-alloc"]);
+    assert!(ok, "--no-warn-unbounded-alloc should be accepted: {stderr}");
+    assert!(
+        !stderr.contains(WARN_NEEDLE),
+        "back-compat opt-out must stay silent:\n{stderr}"
+    );
+}

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -4840,6 +4840,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     fallible: None,
                     ffi: None,
                     export: false,
+                    unbounded: false,
                     body: Block {
                         stmts: Vec::new(),
                         tail: None,
@@ -7645,6 +7646,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             annotations: template.annotations.clone(),
             form: template.form.clone(),
             locality: template.locality.clone(),
+            bounded: template.bounded,
             members: new_members,
             span: template.span.clone(),
         })
@@ -7717,6 +7719,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         .ret
                         .as_ref()
                         .map(|t| Self::substitute_type_expr(t, subst)),
+                    unbounded: lc.unbounded,
                     body: Self::substitute_block_type_ascriptions(
                         &lc.body, subst,
                     ),
@@ -7749,6 +7752,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 // field through for shape uniformity.
                 ffi: fd.ffi.clone(),
                 export: fd.export,
+                unbounded: fd.unbounded,
                 body: Self::substitute_block_type_ascriptions(
                     &fd.body, subst,
                 ),
@@ -7993,6 +7997,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             // time so in practice this is always None here.
             ffi: template.ffi.clone(),
             export: template.export,
+            unbounded: template.unbounded,
             body: new_body,
             span: template.span.clone(),
         })

--- a/crates/hale-codegen/tests/alloc_model_rss.rs
+++ b/crates/hale-codegen/tests/alloc_model_rss.rs
@@ -145,3 +145,168 @@ fn model_unbounded_verdict_matches_growing_rss() {
         flat_rss
     );
 }
+
+// === Phase C (2026-06-25): store-latest into a locus field is UNBOUNDED ===
+//
+// The note had hypothesized a "replace-vs-append refinement" treating a
+// whole-value field store (`self.f = X{}`) as *bounded*. RSS falsified it:
+// in Hale's bump arena a replaced value is not reclaimed until dissolve, so
+// a per-iteration whole-value replace accumulates — even for a fixed-size
+// `[Int; 4]`. These tests LOCK that finding so a future "optimization" that
+// wrongly suppresses store-latest gets a red test (and so the model's
+// flagging of it stays tied to measured RSS). See
+// `notes/memory-bound-proofs.md` §"Phase C finding".
+//
+// All three loops share the runtime bound `self.n` (not a const literal),
+// so loop-ranking can't prove them bounded — the genuine unbounded case.
+
+/// In-place indexed write into a fixed array field. No allocation: the slot
+/// is overwritten in existing inline storage. The model must NOT flag it,
+/// and RSS stays at the runtime floor. This is the *fix* the diagnostic
+/// steers toward.
+const INPLACE_FIELD_WRITE: &str = r#"
+    locus Acc {
+        params { recent: [Int; 4] = [0,0,0,0]; n: Int = 3000000; sink: Int = 0; }
+        run() {
+            let mut i = 0;
+            while i < self.n {
+                self.recent[i % 4] = i;
+                self.sink = self.sink + self.recent[0];
+                i = i + 1;
+            }
+            print("sum="); println(self.sink);
+            print("final_rss_mb="); println(std::process::rss_bytes() / 1048576);
+        }
+    }
+    fn main() { Acc { }; }
+"#;
+
+/// Whole-value replace of a fixed-size `[Int; 4]` field each iteration. The
+/// array literal bump-allocates a fresh 4-int array into the locus arena
+/// every trip; the prior one is not reclaimed until dissolve. The model
+/// flags it, and RSS climbs steeply with the trip count.
+const ARRAY_FIELD_REPLACE: &str = r#"
+    locus Acc {
+        params { recent: [Int; 4] = [0,0,0,0]; n: Int = 3000000; sink: Int = 0; }
+        run() {
+            let mut i = 0;
+            while i < self.n {
+                self.recent = [i, i, i, i];
+                self.sink = self.sink + self.recent[0];
+                i = i + 1;
+            }
+            print("sum="); println(self.sink);
+            print("final_rss_mb="); println(std::process::rss_bytes() / 1048576);
+        }
+    }
+    fn main() { Acc { }; }
+"#;
+
+#[test]
+fn store_latest_field_replace_grows_inplace_stays_flat() {
+    // Model side: the whole-value replace is an unbounded site; the
+    // in-place indexed write has no allocation site at all.
+    assert!(
+        model_has_unbounded_site(ARRAY_FIELD_REPLACE),
+        "whole-value `self.recent = [..]` replace must be flagged unbounded"
+    );
+    assert!(
+        !model_has_unbounded_site(INPLACE_FIELD_WRITE),
+        "in-place `self.recent[i] = v` writes allocate nothing — no false \
+         unbounded"
+    );
+
+    // Runtime side: RSS confirms the verdicts. The replace accumulates ~130
+    // MB over 3M trips; the in-place write sits at the runtime floor. Assert
+    // relative to the in-place baseline — the absolute floor varies with
+    // build config (see the model-vs-RSS test above).
+    let inplace_rss = build_and_rss("inplace_field_write", INPLACE_FIELD_WRITE);
+    let replace_rss = build_and_rss("array_field_replace", ARRAY_FIELD_REPLACE);
+
+    assert!(
+        replace_rss >= inplace_rss + 60,
+        "store-latest field replace should add >60MB over the in-place \
+         baseline: replace={}MB, inplace={}MB. If the gap collapsed, \
+         whole-value field assignment now reclaims per iteration — the \
+         'store-latest is unbounded' verdict (and the model that flags it) \
+         must be revisited before trusting any store-latest-is-bounded \
+         refinement.",
+        replace_rss,
+        inplace_rss
+    );
+}
+
+// === Phase D / D2 (2026-06-25): a growing @form(vec) insert accumulates ===
+//
+// D2 flags `v.push(x)` where `v`'s declared type is a growing `@form(vec |
+// hashmap)` locus, in an unbounded context. `lotus_vec_push` grows a
+// geometric doubling buffer (cap*2) with the element memcpy'd in, so the
+// vec genuinely accumulates with the push count. This ties that verdict to
+// measured RSS so a future change that wrongly treats a vec insert as
+// bounded gets a red test. (Element is a 32-byte struct for a clean signal
+// above the test build's ~50 MB baseline; the loop bound `self.n` is
+// runtime, so loop-ranking can't prove it bounded.)
+
+const VEC_PUSH_GROWS: &str = r#"
+    type Cell { a: Int; b: Int; c: Int; d: Int; }
+    @form(vec) locus CellVec { capacity { heap items of Cell; } }
+    locus W {
+        params { buf: CellVec = CellVec { }; n: Int = 3000000; }
+        run() {
+            let mut i = 0;
+            while i < self.n {
+                self.buf.push(Cell { a: i, b: i, c: i, d: i });
+                i = i + 1;
+            }
+            print("len="); println(self.buf.len());
+            print("final_rss_mb="); println(std::process::rss_bytes() / 1048576);
+        }
+    }
+    fn main() { W { }; }
+"#;
+
+/// The control: the identical loop and vec, but no push — RSS stays at the
+/// runtime floor and the model finds no collection-insert site.
+const VEC_PUSH_CONTROL: &str = r#"
+    type Cell { a: Int; b: Int; c: Int; d: Int; }
+    @form(vec) locus CellVec { capacity { heap items of Cell; } }
+    locus W {
+        params { buf: CellVec = CellVec { }; n: Int = 3000000; sink: Int = 0; }
+        run() {
+            let mut i = 0;
+            while i < self.n { self.sink = self.sink + i; i = i + 1; }
+            print("sum="); println(self.sink);
+            print("final_rss_mb="); println(std::process::rss_bytes() / 1048576);
+        }
+    }
+    fn main() { W { }; }
+"#;
+
+#[test]
+fn collection_insert_growth_matches_rss() {
+    // Model side: the vec push is an unbounded collection-insert site; the
+    // control (no push) has none.
+    assert!(
+        model_has_unbounded_site(VEC_PUSH_GROWS),
+        "a vec push in an unbounded loop should be flagged unbounded"
+    );
+    assert!(
+        !model_has_unbounded_site(VEC_PUSH_CONTROL),
+        "the no-push control must not be flagged"
+    );
+
+    // Runtime side: the vec accumulates ~150 MB over 3M pushes of a 32-byte
+    // cell; the control sits at the floor. Assert relative to the control.
+    let grow_rss = build_and_rss("vec_push_grows", VEC_PUSH_GROWS);
+    let ctrl_rss = build_and_rss("vec_push_control", VEC_PUSH_CONTROL);
+
+    assert!(
+        grow_rss >= ctrl_rss + 80,
+        "a growing @form(vec) insert should add >80MB over the no-push \
+         control: grow={}MB, ctrl={}MB. If the gap collapsed, vec pushes no \
+         longer accumulate where the model says they do — the D2 \
+         collection-insert verdict must be revisited.",
+        grow_rss,
+        ctrl_rss
+    );
+}

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -285,6 +285,15 @@ pub struct LocusDecl {
     /// tier's budget (or, for `any`, explicitly opts out of the
     /// global `--target-cache` gate).
     pub locality: Option<LocalityAnnotation>,
+    /// GH #18 item 1 (memory-bound proofs): `@bounded locus L { ... }`
+    /// opts this locus into the memory-bound proof. Its bodies are
+    /// checked for unbounded allocations regardless of the
+    /// `--warn-unbounded-alloc` flag — the in-source opt-in, the
+    /// descent-curve dual of the whole-program survey flag. A method
+    /// inside a `@bounded` locus may carry `@unbounded` to acknowledge
+    /// an intentional accumulation and silence its site. A no-op on
+    /// loci that allocate nothing unboundedly.
+    pub bounded: bool,
     pub members: Vec<LocusMember>,
     pub span: Span,
 }
@@ -1051,6 +1060,11 @@ pub struct LifecycleDecl {
     pub kind: LifecycleKind,
     pub params: Vec<Param>,
     pub ret: Option<TypeExpr>,
+    /// GH #18 item 1: `@unbounded run { ... }` (or any lifecycle hook)
+    /// acknowledges an intentionally-unbounded allocation in the hook
+    /// body — the carve-out for a `run`-loop accumulation inside a
+    /// `@bounded` locus, paralleling `@unbounded fn`.
+    pub unbounded: bool,
     pub body: Block,
     pub span: Span,
 }
@@ -1235,6 +1249,14 @@ pub struct FnDecl {
     /// `_hale_start` sets up) and passes the name to `wasm-ld
     /// --export=`. A no-op on native builds.
     pub export: bool,
+    /// GH #18 item 1 (memory-bound proofs): `@unbounded fn` acknowledges
+    /// that this fn intentionally allocates without a static bound (a
+    /// cache, an operator-sized accumulator). It suppresses the
+    /// memory-bound warning for every allocation site this fn owns — the
+    /// greppable carve-out inside a `@bounded` locus, and an explicit
+    /// silence under `--warn-unbounded-alloc`. Applies to free fns and
+    /// locus methods alike.
+    pub unbounded: bool,
     pub body: Block,
     pub span: Span,
 }

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -333,6 +333,7 @@ impl Parser {
         let mut form: Option<FormAnnotation> = None;
         let mut locality: Option<LocalityAnnotation> = None;
         let mut export_locus = false;
+        let mut bounded_locus = false;
         let mut leading_span: Option<Span> = None;
         loop {
             if !matches!(self.peek(), TokenKind::At) {
@@ -344,6 +345,13 @@ impl Parser {
             let is_locality =
                 matches!(&kind_tok, TokenKind::Ident(s) if s == "locality");
             let is_export = matches!(&kind_tok, TokenKind::Export);
+            // GH #18 item 1: `@bounded locus …` opts a locus into the
+            // memory-bound proof; `@unbounded fn …` carves a free fn
+            // out of it. Both are bare `@`-flags (no arglist).
+            let is_bounded =
+                matches!(&kind_tok, TokenKind::Ident(s) if s == "bounded");
+            let is_unbounded =
+                matches!(&kind_tok, TokenKind::Ident(s) if s == "unbounded");
             if is_export {
                 // WASM entry-inversion. `@export fn …` is a free-fn
                 // module export; `@export locus …` is the persistent
@@ -406,6 +414,52 @@ impl Parser {
                 fn_decl.span = ffi.span.merge(fn_decl.span);
                 return Ok(TopDecl::Fn(fn_decl));
             }
+            if is_bounded {
+                if bounded_locus {
+                    return Err(Diag::parse(
+                        self.peek_token().span,
+                        "duplicate `@bounded` annotation",
+                    ));
+                }
+                let at = self.expect(TokenKind::At, "@")?;
+                self.bump(); // consume `bounded`
+                bounded_locus = true;
+                leading_span = Some(match leading_span {
+                    Some(s) => s.merge(at.span),
+                    None => at.span,
+                });
+                continue;
+            }
+            if is_unbounded {
+                // fn-only carve-out. Mirrors `@ffi` / `@export fn`: consume
+                // the marker, parse the fn, tag it. It can't sit on a locus
+                // (a locus opts *in* with `@bounded`; `@unbounded` opts a
+                // single fn *out*).
+                if form.is_some() || locality.is_some() || export_locus
+                    || bounded_locus
+                {
+                    return Err(Diag::parse(
+                        self.peek_token().span,
+                        "`@unbounded` is fn-only; it can't stack with \
+                         `@form(...)` / `@locality(...)` / `@bounded` / \
+                         `@export locus` (those precede `locus`)",
+                    ));
+                }
+                let at = self.expect(TokenKind::At, "@")?;
+                self.bump(); // consume `unbounded`
+                if !matches!(self.peek(), TokenKind::Fn) {
+                    return Err(Diag::parse(
+                        self.peek_token().span,
+                        "expected `fn` after `@unbounded` — it acknowledges an \
+                         intentionally-unbounded fn, so a `locus` opts in with \
+                         `@bounded` instead",
+                    ));
+                }
+                let mut fn_decl = self.parse_fn_decl_with_ffi(None)?;
+                fn_decl.unbounded = true;
+                fn_decl.span = at.span.merge(fn_decl.span);
+                return Ok(TopDecl::Fn(fn_decl));
+            }
             if is_form {
                 if form.is_some() {
                     return Err(Diag::parse(
@@ -440,10 +494,11 @@ impl Parser {
             }
             return Err(Diag::parse(
                 self.peek_token().span,
-                "expected `form`, `locality`, or `ffi` after `@`",
+                "expected `form`, `locality`, `bounded`, `unbounded`, or \
+                 `ffi` after `@`",
             ));
         }
-        if form.is_some() || locality.is_some() || export_locus {
+        if form.is_some() || locality.is_some() || export_locus || bounded_locus {
             // Verify a `locus` (or contextual `main locus`)
             // follows.
             let next_is_locus = matches!(self.peek(), TokenKind::Locus);
@@ -455,7 +510,7 @@ impl Parser {
                 return Err(Diag::parse(
                     self.peek_token().span,
                     "expected `locus` (or `main locus`) after `@form(...)` \
-                     / `@locality(...)` / `@export` annotation",
+                     / `@locality(...)` / `@bounded` / `@export` annotation",
                 ));
             }
             let mut locus = self.parse_locus_decl()?;
@@ -465,6 +520,7 @@ impl Parser {
             locus.form = form;
             locus.locality = locality;
             locus.export = export_locus;
+            locus.bounded = bounded_locus;
             return Ok(TopDecl::Locus(locus));
         }
         match self.peek() {
@@ -1129,6 +1185,7 @@ impl Parser {
             annotations,
             form: None,
             locality: None,
+            bounded: false,
             members,
             span: kw.span.merge(close.span),
         })
@@ -1341,6 +1398,48 @@ impl Parser {
             TokenKind::OnFailure => self.parse_failure_decl().map(LocusMember::Failure),
             TokenKind::Closure => self.parse_closure_decl().map(LocusMember::Closure),
             TokenKind::Fn => self.parse_fn_decl().map(LocusMember::Fn),
+            // GH #18 item 1: `@unbounded` carve-out on a locus member —
+            // either a method (`@unbounded fn`, the common case: silence
+            // one handler) or a lifecycle hook (`@unbounded run { … }`, a
+            // `run`-loop accumulation). The only `@`-annotation valid on a
+            // member.
+            TokenKind::At => {
+                let kind_tok = self.peek_at(1);
+                if !matches!(&kind_tok, TokenKind::Ident(s) if s == "unbounded") {
+                    return Err(Diag::parse(
+                        self.peek_token().span,
+                        "the only `@` annotation valid on a locus member is \
+                         `@unbounded` (on a `fn` or a lifecycle hook — \
+                         acknowledge an intentionally-unbounded body)",
+                    ));
+                }
+                let at = self.expect(TokenKind::At, "@")?;
+                self.bump(); // consume `unbounded`
+                match self.peek() {
+                    TokenKind::Fn => {
+                        let mut fn_decl = self.parse_fn_decl()?;
+                        fn_decl.unbounded = true;
+                        fn_decl.span = at.span.merge(fn_decl.span);
+                        Ok(LocusMember::Fn(fn_decl))
+                    }
+                    TokenKind::Birth
+                    | TokenKind::Accept
+                    | TokenKind::Release
+                    | TokenKind::Run
+                    | TokenKind::Drain
+                    | TokenKind::Dissolve => {
+                        let mut lc = self.parse_lifecycle_decl()?;
+                        lc.unbounded = true;
+                        lc.span = at.span.merge(lc.span);
+                        Ok(LocusMember::Lifecycle(lc))
+                    }
+                    _ => Err(Diag::parse(
+                        self.peek_token().span,
+                        "expected `fn` or a lifecycle hook (`run`, `birth`, \
+                         …) after `@unbounded`",
+                    )),
+                }
+            }
             TokenKind::Const => self.parse_const_decl().map(LocusMember::Const),
             TokenKind::Type => self.parse_type_decl().map(LocusMember::Type),
             // Phase 2 contextual keyword — `bindings { ... }`.
@@ -2401,6 +2500,7 @@ impl Parser {
             kind,
             params,
             ret,
+            unbounded: false,
             span: kw_tok.span.merge(body.span),
             body,
         })
@@ -2974,6 +3074,7 @@ impl Parser {
                 fallible,
                 ffi,
                 export: false,
+                unbounded: false,
                 span: kw.span.merge(semi.span),
                 body,
             });
@@ -2993,6 +3094,7 @@ impl Parser {
             fallible,
             ffi,
             export: false,
+            unbounded: false,
             span: kw.span.merge(body.span),
             body,
         })
@@ -4808,6 +4910,111 @@ main locus App {
             }
             _ => panic!("expected locus"),
         }
+    }
+
+    // === GH #18 item 1: @bounded / @unbounded =============
+
+    #[test]
+    fn parse_bounded_locus() {
+        let src = "@bounded locus L { run() { } }";
+        let prog = parse_str(src).expect("parse failed");
+        match &prog.items[0] {
+            TopDecl::Locus(l) => assert!(l.bounded, "@bounded not recorded"),
+            _ => panic!("expected locus"),
+        }
+    }
+
+    #[test]
+    fn parse_bounded_stacks_with_form() {
+        // Order-independent stacking, like @locality + @form.
+        let src = "@form(vec) @bounded locus L { }";
+        let prog = parse_str(src).expect("parse failed");
+        match &prog.items[0] {
+            TopDecl::Locus(l) => {
+                assert!(l.bounded);
+                assert!(l.form.is_some());
+            }
+            _ => panic!("expected locus"),
+        }
+    }
+
+    #[test]
+    fn parse_bounded_rejects_duplicate() {
+        let err = parse_str("@bounded @bounded locus L { }")
+            .expect_err("expected parse error");
+        assert!(format!("{:?}", err).contains("duplicate `@bounded"));
+    }
+
+    #[test]
+    fn parse_unbounded_free_fn() {
+        let src = "@unbounded fn build() { }";
+        let prog = parse_str(src).expect("parse failed");
+        match &prog.items[0] {
+            TopDecl::Fn(f) => assert!(f.unbounded, "@unbounded not recorded"),
+            _ => panic!("expected fn"),
+        }
+    }
+
+    #[test]
+    fn parse_unbounded_method_and_lifecycle() {
+        let src = r#"
+@bounded locus L {
+    @unbounded fn handle() { }
+    @unbounded run() { }
+    fn plain() { }
+}
+"#;
+        let prog = parse_str(src).expect("parse failed");
+        let TopDecl::Locus(l) = &prog.items[0] else {
+            panic!("expected locus");
+        };
+        let mut saw_unbounded_fn = false;
+        let mut saw_unbounded_run = false;
+        let mut saw_plain_fn = false;
+        for m in &l.members {
+            match m {
+                LocusMember::Fn(f) if f.name.name == "handle" => {
+                    assert!(f.unbounded);
+                    saw_unbounded_fn = true;
+                }
+                LocusMember::Fn(f) if f.name.name == "plain" => {
+                    assert!(!f.unbounded);
+                    saw_plain_fn = true;
+                }
+                LocusMember::Lifecycle(lc)
+                    if matches!(lc.kind, LifecycleKind::Run) =>
+                {
+                    assert!(lc.unbounded);
+                    saw_unbounded_run = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_unbounded_fn && saw_unbounded_run && saw_plain_fn);
+    }
+
+    #[test]
+    fn parse_unbounded_rejects_non_fn_target() {
+        // `@unbounded` is fn/lifecycle-only — on a locus it's rejected and
+        // the diagnostic points at `@bounded` as the opt-in instead.
+        let err = parse_str("@unbounded locus L { }")
+            .expect_err("expected parse error");
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("opts in with `@bounded`"),
+            "wrong error: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_unbounded_rejects_stacking_with_form() {
+        // Stacked after another locus annotation, the fn-only guard fires.
+        let err = parse_str("@form(vec) @unbounded locus L { }")
+            .expect_err("expected parse error");
+        assert!(
+            format!("{:?}", err).contains("@unbounded` is fn-only"),
+            "wrong error"
+        );
     }
 
     #[test]

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -69,6 +69,12 @@ pub enum AllocKind {
     ArrayLit,
     ArrayRepeat,
     BytesLit,
+    /// Phase D / D2: an insert into a growing `@form(vec | hashmap)` slot
+    /// (`v.push(x)` / `m.set(x)`). Detected when the receiver's *declared*
+    /// type resolves to such a form locus. The collection's backing buffer
+    /// grows with population and frees only at dissolve — so an insert in
+    /// an unbounded context accumulates. The string is the form name.
+    CollectionInsert(String),
 }
 
 impl AllocKind {
@@ -78,7 +84,31 @@ impl AllocKind {
             AllocKind::ArrayLit => "array-literal".to_string(),
             AllocKind::ArrayRepeat => "array-repeat".to_string(),
             AllocKind::BytesLit => "bytes-literal".to_string(),
+            AllocKind::CollectionInsert(form) => format!("{}-insert", form),
         }
+    }
+}
+
+/// Phase D / D2: the `@form(...)` names whose inserts grow without bound
+/// (backing buffer grows with population, frees only at dissolve). A
+/// `ring_buffer` / `lru_cache` is cap-bounded and excluded.
+fn form_grows(form_name: &str) -> bool {
+    matches!(form_name, "vec" | "hashmap")
+}
+
+/// Phase D / D2: the method names that *insert* into a collection (vs read
+/// it). Gated by `form_grows` on the receiver's form, so a `get`/`len`/`pop`
+/// never counts.
+fn is_insert_method(method: &str) -> bool {
+    matches!(method, "push" | "set" | "insert" | "add")
+}
+
+/// The unqualified name of a `Named` type expression (`SegVec` from
+/// `path::to::SegVec`), or `None` for primitives / arrays / etc.
+fn type_expr_name(te: &TypeExpr) -> Option<String> {
+    match te {
+        TypeExpr::Named { path, .. } => path.segments.last().map(|s| s.name.clone()),
+        _ => None,
     }
 }
 
@@ -208,6 +238,11 @@ pub struct AllocSite {
     /// trip count.
     pub in_unbounded_loop: bool,
     pub reclaim: ReclaimScope,
+    /// Phase D / D1: when this allocation is stored straight into a
+    /// `self.<field>` (a whole-value replace, `StoredToSelf`), the field
+    /// name. `None` for non-self escapes and for indexed in-place writes.
+    /// The solver (D2) uses it to ask whether `<field>` is a capacity slot.
+    pub target_field: Option<String>,
     pub span: Span,
 }
 
@@ -251,6 +286,12 @@ pub struct CallEdge {
     /// notes/resource-budgets.md; also lets #1 see a factory call whose
     /// result escapes when the callee body is external/unresolved.)
     pub escape: Escape,
+    /// Phase D / D1: when the call is a method on a `self.<slot>` receiver
+    /// (`self.entries.acquire()`, `self.items.alloc()`), the slot name.
+    /// `None` for free fns, `self`-methods, and form methods (`self.push`,
+    /// where the slot is implicit from `@form`). The solver (D2) pairs this
+    /// with the method name + `LocusShape` to classify a slot insert.
+    pub receiver_slot: Option<String>,
     pub span: Span,
 }
 
@@ -332,10 +373,70 @@ pub struct FnSummary {
     pub loops: Vec<LoopInfo>,
 }
 
+/// A distilled view of a locus's storage shape (GH #18 item 1, Phase D —
+/// D1 infra). The bound solver reads this to decide which storage slot an
+/// escaping allocation lands in and how that slot bounds it:
+///
+/// - **slot 0** — the locus's own bump Arena (no entry here; the default).
+/// - **slots 1..N** — `capacity { pool/heap … }` slots, optionally fronted
+///   by a `@form`. `pool` recycles (bounded-by-balanced-release); `heap`
+///   grows; `@form(ring_buffer)` is cap-bounded; `@form(vec)` /
+///   `@form(hashmap)` grow.
+///
+/// D1 only *captures* this — no verdict reads it yet (that's D2).
+#[derive(Debug, Clone, Default)]
+pub struct LocusShape {
+    pub name: String,
+    pub capacity_slots: Vec<SlotShape>,
+    pub form: Option<FormShape>,
+    /// `: projection recognition(cap = N, …)` — a hard static cap on
+    /// *child-entity* count (fed by `accept`). Recorded for completeness;
+    /// the value-allocation proof reads the capacity-data slots, not this
+    /// (entity-count bounding is a separate analysis).
+    pub recognition_cap: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SlotShape {
+    pub name: String,
+    pub kind: CapacitySlotKind,
+}
+
+#[derive(Debug, Clone)]
+pub struct FormShape {
+    pub name: String,
+    /// A `cap = N` form-arg, if a literal int. NOTE: per `spec/forms.md`
+    /// this is an *initial-size hint* for vec/hashmap (not a bound); it is
+    /// a real cap for ring_buffer. The solver (D2) interprets it per form.
+    pub cap: Option<i64>,
+}
+
 /// The bundle-wide allocation summary + call graph.
 #[derive(Debug, Clone, Default)]
 pub struct AllocSummary {
     pub fns: BTreeMap<FnKey, FnSummary>,
+    /// GH #18 item 1: loci carrying `@bounded` — their leak sites are
+    /// reported even without the `--warn-unbounded-alloc` survey flag
+    /// (the in-source opt-in).
+    pub bounded_loci: BTreeSet<String>,
+    /// Fns carrying `@unbounded` — an acknowledged-intentional
+    /// accumulation. Their leak sites are dropped entirely (the
+    /// greppable carve-out), even under the survey flag.
+    pub unbounded_fns: BTreeSet<FnKey>,
+    /// Per-locus storage shape (Phase D / D1) — capacity slots, `@form`,
+    /// projection cap. Keyed by locus name.
+    pub locus_shapes: BTreeMap<String, LocusShape>,
+}
+
+impl AllocSummary {
+    /// Is this site's owning fn inside a `@bounded` locus? Drives
+    /// "report by default" without the survey flag.
+    pub fn owner_is_bounded_scope(&self, owner: &FnKey) -> bool {
+        owner
+            .locus
+            .as_ref()
+            .is_some_and(|l| self.bounded_loci.contains(l))
+    }
 }
 
 /// Why a site's final verdict is unbounded — the diagnostic anchor.
@@ -424,6 +525,12 @@ impl AllocSummary {
         let unbounded = self.unbounded_invoked();
         let mut out = Vec::new();
         for f in self.fns.values() {
+            // `@unbounded` is the acknowledged carve-out — its sites never
+            // surface, with or without the survey flag, in or out of a
+            // `@bounded` locus.
+            if self.unbounded_fns.contains(&f.key) {
+                continue;
+            }
             for s in &f.sites {
                 if self.final_verdict(&f.key, s, &unbounded) == SiteVerdict::AccumulatesUnbounded {
                     let reason = if matches!(s.verdict(), SiteVerdict::AccumulatesUnbounded) {
@@ -448,7 +555,7 @@ impl AllocSummary {
     pub fn render(&self) -> String {
         let unbounded = self.unbounded_invoked();
         let mut out = String::new();
-        out.push_str("# allocation summary (GH #18 item 1, steps 1-3)\n");
+        out.push_str("# allocation summary (GH #18 item 1, steps 1-3 + D1 slot shape)\n");
         let entries: Vec<&FnSummary> = self.fns.values().filter(|f| f.entry.is_some()).collect();
         out.push_str(&format!(
             "# {} fns, {} entry points, {} invoked-unboundedly\n\n",
@@ -456,6 +563,36 @@ impl AllocSummary {
             entries.len(),
             unbounded.len()
         ));
+        // D1: per-locus storage shape — the capacity slots, `@form`, and
+        // projection cap the bound solver (D2) will read.
+        for shape in self.locus_shapes.values() {
+            if shape.capacity_slots.is_empty()
+                && shape.form.is_none()
+                && shape.recognition_cap.is_none()
+            {
+                continue;
+            }
+            out.push_str(&format!("locus {} [shape]\n", shape.name));
+            for slot in &shape.capacity_slots {
+                let kind = match slot.kind {
+                    CapacitySlotKind::Pool => "pool",
+                    CapacitySlotKind::Heap => "heap",
+                };
+                out.push_str(&format!("    slot  {} ({})\n", slot.name, kind));
+            }
+            if let Some(form) = &shape.form {
+                let cap = form.cap.map(|c| format!(", cap={}", c)).unwrap_or_default();
+                out.push_str(&format!("    form  @form({}{})\n", form.name, cap));
+            }
+            if let Some(cap) = shape.recognition_cap {
+                out.push_str(&format!("    proj  recognition(cap={})\n", cap));
+            }
+        }
+        if !self.locus_shapes.values().all(|s| {
+            s.capacity_slots.is_empty() && s.form.is_none() && s.recognition_cap.is_none()
+        }) {
+            out.push('\n');
+        }
         for f in self.fns.values() {
             let mut tags = Vec::new();
             if let Some(e) = f.entry {
@@ -489,14 +626,20 @@ impl AllocSummary {
                 } else {
                     ""
                 };
+                let field = s
+                    .target_field
+                    .as_ref()
+                    .map(|f| format!(" ->self.{}", f))
+                    .unwrap_or_default();
                 out.push_str(&format!(
-                    "    alloc {:<16} {:<20} {:<22} {:<22} @{}..{}{}\n",
+                    "    alloc {:<16} {:<20} {:<22} {:<22} @{}..{}{}{}\n",
                     s.kind.label(),
                     s.escape.label(),
                     v.label(),
                     s.reclaim.label(),
                     s.span.start.0,
                     s.span.end.0,
+                    field,
                     flag
                 ));
             }
@@ -505,11 +648,17 @@ impl AllocSummary {
                     Callee::Resolved(k) => k.display(),
                     Callee::Unresolved(n) => format!("<unresolved: {}>", n),
                 };
+                let slot = c
+                    .receiver_slot
+                    .as_ref()
+                    .map(|s| format!(" recv=self.{}", s))
+                    .unwrap_or_default();
                 out.push_str(&format!(
-                    "    call  {} loop_depth={} result={}\n",
+                    "    call  {} loop_depth={} result={}{}\n",
                     tgt,
                     c.loop_depth,
-                    c.escape.label()
+                    c.escape.label(),
+                    slot
                 ));
             }
         }
@@ -523,8 +672,18 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
     // Phase 1 — collect every body with its key + entry classification.
     // For loci we first gather the set of bus-handler method names so a
     // method referenced by `subscribe ... -> handler` is tagged BusHandler.
-    let mut bodies: Vec<(FnKey, Block, Option<EntryKind>, Option<String>)> = Vec::new();
+    // The trailing `Vec<(String, String)>` seeds each body's var→type map
+    // from its params (D2).
+    type BodyEntry = (FnKey, Block, Option<EntryKind>, Option<String>, Vec<(String, String)>);
+    let mut bodies: Vec<BodyEntry> = Vec::new();
     let mut known: BTreeSet<FnKey> = BTreeSet::new();
+    // GH #18 item 1 — the `@bounded` / `@unbounded` opt-in/carve-out sets.
+    let mut bounded_loci: BTreeSet<String> = BTreeSet::new();
+    let mut unbounded_fns: BTreeSet<FnKey> = BTreeSet::new();
+    // Phase D / D1 — the per-locus storage shape.
+    let mut locus_shapes: BTreeMap<String, LocusShape> = BTreeMap::new();
+    // Phase D / D2 — per-locus param field → declared type name.
+    let mut locus_field_types: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
 
     for program in programs {
         for item in &program.items {
@@ -532,11 +691,19 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
                 TopDecl::Fn(decl) => {
                     let key = FnKey::free_fn(decl.name.name.clone());
                     let entry = if decl.name.name == "main" { Some(EntryKind::Main) } else { None };
+                    if decl.unbounded {
+                        unbounded_fns.insert(key.clone());
+                    }
                     known.insert(key.clone());
-                    bodies.push((key, decl.body.clone(), entry, None));
+                    bodies.push((key, decl.body.clone(), entry, None, param_var_types(&decl.params)));
                 }
                 TopDecl::Locus(l) => {
                     let locus = l.name.name.clone();
+                    if l.bounded {
+                        bounded_loci.insert(locus.clone());
+                    }
+                    locus_shapes.insert(locus.clone(), locus_shape_of(l));
+                    locus_field_types.insert(locus.clone(), locus_param_field_types(l));
                     let handlers = bus_handler_names(l);
                     for member in &l.members {
                         match member {
@@ -547,14 +714,32 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
                                 } else {
                                     None
                                 };
+                                if decl.unbounded {
+                                    unbounded_fns.insert(key.clone());
+                                }
                                 known.insert(key.clone());
-                                bodies.push((key, decl.body.clone(), entry, Some(locus.clone())));
+                                bodies.push((
+                                    key,
+                                    decl.body.clone(),
+                                    entry,
+                                    Some(locus.clone()),
+                                    param_var_types(&decl.params),
+                                ));
                             }
                             LocusMember::Lifecycle(lc) => {
                                 let (name, entry) = lifecycle_key(lc.kind);
                                 let key = FnKey::method(locus.clone(), name);
+                                if lc.unbounded {
+                                    unbounded_fns.insert(key.clone());
+                                }
                                 known.insert(key.clone());
-                                bodies.push((key, lc.body.clone(), Some(entry), Some(locus.clone())));
+                                bodies.push((
+                                    key,
+                                    lc.body.clone(),
+                                    Some(entry),
+                                    Some(locus.clone()),
+                                    param_var_types(&lc.params),
+                                ));
                             }
                             _ => {}
                         }
@@ -565,10 +750,21 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
         }
     }
 
+    // D2: type name → `@form(...)` name, for receiver-form lookup.
+    let form_of: BTreeMap<String, String> = locus_shapes
+        .iter()
+        .filter_map(|(name, shape)| shape.form.as_ref().map(|f| (name.clone(), f.name.clone())))
+        .collect();
+    let empty_fields: BTreeMap<String, String> = BTreeMap::new();
+
     // Phase 2 — walk each body.
     let mut summary = AllocSummary::default();
-    for (key, body, entry, enclosing_locus) in &bodies {
+    for (key, body, entry, enclosing_locus, param_types) in &bodies {
         let escaping = collect_escaping_names(body);
+        let field_types = enclosing_locus
+            .as_ref()
+            .and_then(|l| locus_field_types.get(l))
+            .unwrap_or(&empty_fields);
         let mut w = Walker {
             sites: Vec::new(),
             calls: Vec::new(),
@@ -578,6 +774,10 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
             known: &known,
             loop_stack: Vec::new(),
             fn_body: body,
+            store_target: None,
+            var_types: param_types.iter().cloned().collect(),
+            field_types,
+            form_of: &form_of,
         };
         w.walk_block(body, 0, Escape::Local);
         summary.fns.insert(
@@ -591,17 +791,90 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
             },
         );
     }
+    summary.bounded_loci = bounded_loci;
+    summary.unbounded_fns = unbounded_fns;
+    summary.locus_shapes = locus_shapes;
     summary
 }
 
+/// D2: a fn's params as (name, declared-type-name) pairs — the seed for
+/// the var→type map (only `Named` types; primitives/arrays are skipped).
+fn param_var_types(params: &[Param]) -> Vec<(String, String)> {
+    params
+        .iter()
+        .filter_map(|p| type_expr_name(&p.ty).map(|t| (p.name.name.clone(), t)))
+        .collect()
+}
+
+/// D2: a locus's `params { … }` fields as field → declared-type-name, so a
+/// `self.<field>.push(x)` can resolve `<field>`'s form.
+fn locus_param_field_types(l: &LocusDecl) -> BTreeMap<String, String> {
+    let mut m = BTreeMap::new();
+    for member in &l.members {
+        if let LocusMember::Params(pb) = member {
+            for pd in &pb.params {
+                if let Some(tn) = pd.ty.as_ref().and_then(type_expr_name) {
+                    m.insert(pd.name.name.clone(), tn);
+                }
+            }
+        }
+    }
+    m
+}
+
+/// Phase D / D1: distill a `LocusDecl` into the storage shape the bound
+/// solver reads — capacity slots, `@form`, and the recognition projection
+/// cap. Pure AST read; no type inference.
+fn locus_shape_of(l: &LocusDecl) -> LocusShape {
+    let mut capacity_slots = Vec::new();
+    for m in &l.members {
+        if let LocusMember::Capacity(cb) = m {
+            for slot in &cb.slots {
+                capacity_slots.push(SlotShape {
+                    name: slot.name.name.clone(),
+                    kind: slot.kind,
+                });
+            }
+        }
+    }
+    let form = l.form.as_ref().map(|f| FormShape {
+        name: f.name.name.clone(),
+        cap: f.args.iter().find_map(|a| {
+            if a.name.name == "cap" {
+                if let Expr::Literal(Literal::Int(n), _) = &a.value {
+                    return Some(*n);
+                }
+            }
+            None
+        }),
+    });
+    let recognition_cap = l.annotations.iter().find_map(|a| match a {
+        LocusAnnotation::Projection(ProjectionClass::Recognition(Some(p))) => Some(p.cap),
+        _ => None,
+    });
+    LocusShape {
+        name: l.name.name.clone(),
+        capacity_slots,
+        form,
+        recognition_cap,
+    }
+}
+
 /// Bound-solver diagnostics: a warning per unbounded-accumulation site.
-/// Opt-in (the corpus shows zero false positives, but allocation patterns
-/// are common enough that this is gated until validated for default-on).
-pub fn unbounded_alloc_diags(programs: &[&Program]) -> Vec<Diag> {
+///
+/// `include_all` selects the scope (GH #18 item 1, Phase B):
+/// - `false` (default `hale check`): only sites inside a `@bounded` locus —
+///   the in-source opt-in. A program with no `@bounded` locus is silent.
+/// - `true` (`--warn-unbounded-alloc`): every site, the whole-program
+///   survey.
+///
+/// Either way, `@unbounded`-fn sites are already dropped at `leak_sites()`.
+pub fn unbounded_alloc_diags(programs: &[&Program], include_all: bool) -> Vec<Diag> {
     let summary = summarize_programs(programs);
     summary
         .leak_sites()
         .iter()
+        .filter(|ls| include_all || summary.owner_is_bounded_scope(&ls.owner))
         .map(|ls| {
             let where_ = match ls.reason {
                 LeakReason::InUnboundedLoop => "inside an unbounded loop",
@@ -670,16 +943,75 @@ struct Walker<'a> {
     /// `while v < N` counter is const-bounded (const init + only positive
     /// const increments anywhere in the fn).
     fn_body: &'a Block,
+    /// Phase D / D1: the `self.<field>` currently being assigned, set around
+    /// the RHS walk of a `self.<field> = …` statement so an escaping
+    /// allocation in that RHS records which field it lands in.
+    store_target: Option<String>,
+    /// Phase D / D2 (lite): local var / param name → declared type *name*,
+    /// seeded from this fn's params and grown by typed `let`s. Lets a
+    /// `v.push(x)` resolve `v`'s type to ask whether it is a growing form.
+    var_types: BTreeMap<String, String>,
+    /// The enclosing locus's param fields → declared type name, so a
+    /// `self.<field>.push(x)` resolves `<field>`'s type the same way.
+    field_types: &'a BTreeMap<String, String>,
+    /// Every locus's `@form(...)` name, keyed by locus type name — the
+    /// lookup `var_types`/`field_types` feed into `form_grows`.
+    form_of: &'a BTreeMap<String, String>,
 }
 
 impl<'a> Walker<'a> {
     fn push_site(&mut self, kind: AllocKind, escape: Escape, depth: u32, span: Span) {
+        // Only a StoredToSelf escape carries a target field — that's the
+        // `self.<field> = <alloc>` whole-value replace the solver bounds.
+        let target_field = if escape == Escape::StoredToSelf {
+            self.store_target.clone()
+        } else {
+            None
+        };
         self.sites.push(AllocSite {
             kind,
             escape,
             loop_depth: depth,
             in_unbounded_loop: self.loop_stack.iter().any(|bounded| !bounded),
             reclaim: ReclaimScope::of(escape),
+            target_field,
+            span,
+        });
+    }
+
+    /// D2: if `recv` is a value whose *declared* type is a growing
+    /// `@form(vec | hashmap)` locus, the form name. Resolves a bare var via
+    /// `var_types` and a `self.<field>` via `field_types`.
+    fn growing_form_of_receiver(&self, recv: &Expr) -> Option<String> {
+        let ty_name = match recv {
+            Expr::Ident(v) => self.var_types.get(&v.name)?,
+            Expr::Field { receiver, name, .. } | Expr::Path2 { receiver, name, .. }
+                if matches!(receiver.as_ref(), Expr::KwSelf(_)) =>
+            {
+                self.field_types.get(&name.name)?
+            }
+            _ => return None,
+        };
+        let form = self.form_of.get(ty_name)?;
+        if form_grows(form) {
+            Some(form.clone())
+        } else {
+            None
+        }
+    }
+
+    /// D2: record a growing-collection insert as an accumulating site. It
+    /// persists into the collection (reclaim at the owner's dissolve), so
+    /// in an unbounded context it accumulates — same verdict path as a
+    /// `StoredToSelf` value alloc.
+    fn push_collection_insert(&mut self, form: String, depth: u32, span: Span) {
+        self.sites.push(AllocSite {
+            kind: AllocKind::CollectionInsert(form),
+            escape: Escape::StoredToSelf,
+            loop_depth: depth,
+            in_unbounded_loop: self.loop_stack.iter().any(|bounded| !bounded),
+            reclaim: ReclaimScope::EnclosingLocus,
+            target_field: None,
             span,
         });
     }
@@ -697,7 +1029,12 @@ impl<'a> Walker<'a> {
 
     fn walk_stmt(&mut self, stmt: &Stmt, depth: u32) {
         match stmt {
-            Stmt::Let { name, value, .. } => {
+            Stmt::Let { name, ty, value, .. } => {
+                // D2: a typed `let v: T = …` extends the var→type map so a
+                // later `v.push(x)` can resolve `v`'s form.
+                if let Some(tn) = ty.as_ref().and_then(type_expr_name) {
+                    self.var_types.insert(name.name.clone(), tn);
+                }
                 let esc = self.escaping.get(&name.name).copied().unwrap_or(Escape::Local);
                 self.walk_expr(value, depth, esc);
             }
@@ -708,7 +1045,16 @@ impl<'a> Walker<'a> {
                 } else {
                     self.escaping.get(&target.head.name).copied().unwrap_or(Escape::Local)
                 };
+                // D1: record the `self.<field>` being assigned for the RHS
+                // walk — but only for a whole-field replace (`self.f = …`),
+                // not an indexed in-place write (`self.f[i] = …`, which has
+                // a trailing `Index` segment and allocates nothing new).
+                let prev = self.store_target.take();
+                if esc == Escape::StoredToSelf {
+                    self.store_target = self_replace_field(target);
+                }
                 self.walk_expr(value, depth, esc);
+                self.store_target = prev;
             }
             Stmt::Return(Some(e), _) => self.walk_expr(e, depth, Escape::Returned),
             Stmt::Return(None, _) => {}
@@ -828,6 +1174,17 @@ impl<'a> Walker<'a> {
             Expr::Unary { operand, .. } => self.walk_expr(operand, depth, Escape::Local),
             Expr::Call { callee, args, span } => {
                 self.record_call(callee, *span, depth, escape);
+                // D2: a `recv.<insert>(x)` where `recv`'s declared type is a
+                // growing form is itself an accumulating allocation.
+                if let Expr::Field { receiver, name, .. }
+                | Expr::Path2 { receiver, name, .. } = callee.as_ref()
+                {
+                    if is_insert_method(&name.name) {
+                        if let Some(form) = self.growing_form_of_receiver(receiver) {
+                            self.push_collection_insert(form, depth, *span);
+                        }
+                    }
+                }
                 // The callee receiver may itself allocate; its result
                 // doesn't escape via this site.
                 match callee.as_ref() {
@@ -906,8 +1263,40 @@ impl<'a> Walker<'a> {
             loop_depth: depth,
             in_unbounded_loop: self.loop_stack.iter().any(|bounded| !bounded),
             escape,
+            receiver_slot: self_slot_receiver(callee),
             span,
         });
+    }
+}
+
+/// D1: the `self.<field>` field name of a whole-value replace
+/// (`self.f = …`), or `None` for an indexed in-place write (`self.f[i] = …`)
+/// or a nested store (`self.f.g = …`). A clean top-level whole-field
+/// replace is `tail == [Field(name)]`.
+fn self_replace_field(target: &LValue) -> Option<String> {
+    if target.head.name != "self" {
+        return None;
+    }
+    match target.tail.as_slice() {
+        [LValueSeg::Field(f)] => Some(f.name.clone()),
+        _ => None,
+    }
+}
+
+/// D1: for a call whose callee is `self.<slot>.<method>(…)`, the slot name.
+/// `None` for free fns, `self`-methods, and form methods (`self.push`).
+fn self_slot_receiver(callee: &Expr) -> Option<String> {
+    let (Expr::Field { receiver, .. } | Expr::Path2 { receiver, .. }) = callee else {
+        return None;
+    };
+    match receiver.as_ref() {
+        Expr::Field { receiver: inner, name, .. }
+        | Expr::Path2 { receiver: inner, name, .. }
+            if matches!(inner.as_ref(), Expr::KwSelf(_)) =>
+        {
+            Some(name.name.clone())
+        }
+        _ => None,
     }
 }
 
@@ -1487,8 +1876,273 @@ mod tests {
             fn main() { }
         "#;
         let program = hale_syntax::parse_source(src).expect("parse");
-        let diags = unbounded_alloc_diags(&[&program]);
+        // Survey mode (`--warn-unbounded-alloc`) reports the leak even
+        // though locus `C` carries no `@bounded` opt-in.
+        let diags = unbounded_alloc_diags(&[&program], true);
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("unbounded allocation"));
+    }
+
+    #[test]
+    fn bounded_locus_reports_without_the_survey_flag() {
+        // The same leak, but the locus opts in with `@bounded`. Now the
+        // default (non-survey) scope reports it.
+        let src = r#"
+            type Q { a: Int; }
+            @bounded locus C { run { while true { let q = Q { a: 1 }; } } }
+            fn main() { }
+        "#;
+        let program = hale_syntax::parse_source(src).expect("parse");
+        let scoped = unbounded_alloc_diags(&[&program], false);
+        assert_eq!(scoped.len(), 1, "@bounded locus reports by default");
+        assert!(scoped[0].message.contains("unbounded allocation"));
+    }
+
+    #[test]
+    fn unbounded_fn_carves_out_even_in_a_bounded_locus() {
+        // `@bounded` on the locus opts in; `@unbounded` on the method opts
+        // that one method back out — silent in survey mode AND scoped mode.
+        let src = r#"
+            type Q { a: Int; }
+            @bounded locus C {
+                @unbounded run { while true { let q = Q { a: 1 }; } }
+            }
+            fn main() { }
+        "#;
+        let program = hale_syntax::parse_source(src).expect("parse");
+        assert!(
+            unbounded_alloc_diags(&[&program], true).is_empty(),
+            "@unbounded suppresses the site under the survey flag"
+        );
+        assert!(
+            unbounded_alloc_diags(&[&program], false).is_empty(),
+            "@unbounded suppresses the site in @bounded scope too"
+        );
+    }
+
+    // === Phase D / D1: storage-shape + slot/field identity capture =====
+
+    #[test]
+    fn d1_captures_capacity_slots_and_form() {
+        let src = r#"
+            type Entry { k: Int; }
+            @form(hashmap, cap = 1024)
+            locus Reg { capacity { pool entries of Entry indexed_by k; } }
+            locus Plain { capacity { heap log of Entry; } }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let reg = s.locus_shapes.get("Reg").expect("Reg shape");
+        assert_eq!(reg.capacity_slots.len(), 1);
+        assert_eq!(reg.capacity_slots[0].name, "entries");
+        assert!(matches!(reg.capacity_slots[0].kind, CapacitySlotKind::Pool));
+        let form = reg.form.as_ref().expect("@form captured");
+        assert_eq!(form.name, "hashmap");
+        assert_eq!(form.cap, Some(1024), "cap form-arg captured as a literal");
+
+        let plain = s.locus_shapes.get("Plain").expect("Plain shape");
+        assert!(matches!(plain.capacity_slots[0].kind, CapacitySlotKind::Heap));
+        assert!(plain.form.is_none());
+    }
+
+    #[test]
+    fn d1_captures_recognition_cap() {
+        let src = r#"
+            type Leaf { v: Int; }
+            locus Coord : projection recognition(cap = 64, fixed_cell) {
+                contract { consume value: Int; }
+                accept(c: Leaf) { }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let coord = s.locus_shapes.get("Coord").expect("Coord shape");
+        assert_eq!(coord.recognition_cap, Some(64));
+    }
+
+    #[test]
+    fn d1_store_latest_records_target_field() {
+        let src = r#"
+            type Q { a: Int; }
+            locus C {
+                params { latest: Q = Q { a: 0 }; }
+                run { while true { self.latest = Q { a: 1 }; } }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("C", "run"));
+        let st = f.sites.iter().find(|s| matches!(s.kind, AllocKind::StructLit(_))).expect("struct");
+        assert_eq!(st.escape, Escape::StoredToSelf);
+        assert_eq!(
+            st.target_field.as_deref(),
+            Some("latest"),
+            "whole-value `self.latest = …` replace records the field"
+        );
+        // The verdict is unchanged by D1 — this is still a slot-0 leak.
+        assert_eq!(st.verdict(), SiteVerdict::AccumulatesUnbounded);
+    }
+
+    #[test]
+    fn d1_indexed_inplace_write_has_no_target_field() {
+        // An indexed in-place write allocates nothing; a *local* struct in
+        // the same body must not pick up a target field.
+        let src = r#"
+            type Q { a: Int; }
+            locus C {
+                params { recent: [Int; 4] = [0,0,0,0]; }
+                run {
+                    while true {
+                        self.recent[0] = 1;
+                        let q = Q { a: 2 };
+                    }
+                }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("C", "run"));
+        let st = f.sites.iter().find(|s| matches!(s.kind, AllocKind::StructLit(_))).expect("struct");
+        assert_eq!(st.escape, Escape::Local);
+        assert_eq!(st.target_field, None, "a local alloc has no self-field target");
+    }
+
+    #[test]
+    fn d1_slot_insert_records_receiver_slot() {
+        let src = r#"
+            type Q { a: Int; }
+            locus C {
+                capacity { heap log of Q; }
+                run { let c = self.log.alloc(); }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("C", "run"));
+        let call = f.calls.iter().find(|c| c.receiver_slot.is_some()).expect("slot call");
+        assert_eq!(call.receiver_slot.as_deref(), Some("log"));
+    }
+
+    // === Phase D / D2: growing-collection (@form vec/hashmap) inserts =====
+
+    fn insert_site(f: &FnSummary) -> Option<&AllocSite> {
+        f.sites.iter().find(|s| matches!(s.kind, AllocKind::CollectionInsert(_)))
+    }
+
+    #[test]
+    fn d2_vec_field_push_in_handler_is_unbounded() {
+        let src = r#"
+            @form(vec) locus IntVec { capacity { heap items of Int; } }
+            locus W {
+                params { buf: IntVec = IntVec { }; }
+                bus { subscribe "ev" as on_ev of type Int; }
+                fn on_ev(x: Int) { self.buf.push(x); }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("W", "on_ev"));
+        let site = insert_site(&f).expect("vec-insert site");
+        assert_eq!(site.kind, AllocKind::CollectionInsert("vec".into()));
+        // A per-message handler is an unbounded-invocation context.
+        let leaks = s.leak_sites();
+        assert!(
+            leaks.iter().any(|l| matches!(l.kind, AllocKind::CollectionInsert(_))),
+            "vec push in a per-message handler should be flagged"
+        );
+    }
+
+    #[test]
+    fn d2_vec_param_push_called_once_is_not_flagged() {
+        let src = r#"
+            @form(vec) locus IntVec { capacity { heap items of Int; } }
+            fn double_push(v: IntVec, n: Int) { v.push(n); v.push(n); }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::free_fn("double_push"));
+        // The insert is recorded (typed param resolved)…
+        assert!(insert_site(&f).is_some(), "param-typed vec push is detected");
+        // …but called once, not in a loop → not a leak.
+        assert_eq!(insert_site(&f).unwrap().verdict(), SiteVerdict::OncePerInvocation);
+        assert!(s.leak_sites().is_empty(), "a call-once push is bounded");
+    }
+
+    #[test]
+    fn d2_ring_buffer_push_is_not_flagged() {
+        // ring_buffer is cap-bounded — its push is not a growing insert.
+        let src = r#"
+            @form(ring_buffer, cap = 16) locus Ring { capacity { pool slots of Int; } }
+            locus W {
+                params { r: Ring = Ring { }; }
+                bus { subscribe "ev" as on_ev of type Int; }
+                fn on_ev(x: Int) { self.r.push(x); }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("W", "on_ev"));
+        assert!(insert_site(&f).is_none(), "ring_buffer push must not flag");
+        assert!(s.leak_sites().is_empty());
+    }
+
+    #[test]
+    fn d2_bounded_loop_push_is_not_a_leak() {
+        let src = r#"
+            @form(vec) locus IntVec { capacity { heap items of Int; } }
+            locus W {
+                params { buf: IntVec = IntVec { }; }
+                run { let mut i = 0; while i < 4 { self.buf.push(i); i = i + 1; } }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("W", "run"));
+        let site = insert_site(&f).expect("insert detected");
+        assert_eq!(
+            site.verdict(),
+            SiteVerdict::AccumulatesBoundedLoop,
+            "a const-bounded loop bounds the inserts"
+        );
+        assert!(s.leak_sites().is_empty());
+    }
+
+    #[test]
+    fn d2_user_method_named_push_on_non_form_locus_is_not_flagged() {
+        // `Segment` is a plain locus with a user `push` method — not a form.
+        // (The `54-geom-leading-edge` corpus shape.) Must not flag.
+        let src = r#"
+            locus Segment {
+                fn push(t: Int) { }
+            }
+            locus W {
+                params { seg: Segment = Segment { }; }
+                run { while true { self.seg.push(1); } }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("W", "run"));
+        assert!(insert_site(&f).is_none(), "user push on a non-form locus is not an insert");
+        assert!(s.leak_sites().is_empty());
+    }
+
+    #[test]
+    fn d2_typed_let_receiver_resolves() {
+        let src = r#"
+            @form(hashmap) locus Map { capacity { pool entries of Int; } }
+            locus W {
+                run {
+                    let m: Map = Map { };
+                    while true { m.set(1); }
+                }
+            }
+            fn main() { }
+        "#;
+        let s = summarize(src);
+        let f = fns(&s, &FnKey::method("W", "run"));
+        let site = insert_site(&f).expect("typed-let hashmap insert detected");
+        assert_eq!(site.kind, AllocKind::CollectionInsert("hashmap".into()));
+        assert_eq!(site.verdict(), SiteVerdict::AccumulatesUnbounded);
     }
 }

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -102,10 +102,13 @@ pub fn dump_resource_budget(bundle: &Bundle<'_>) -> String {
 }
 
 /// Bound-solver warnings: one per unbounded-accumulation allocation site
-/// (GH #18 item 1, step 3). Opt-in via `--warn-unbounded-alloc`.
-pub fn unbounded_alloc_warnings(bundle: &Bundle<'_>) -> Vec<Diag> {
+/// (GH #18 item 1). `include_all = false` reports only sites inside a
+/// `@bounded` locus (the always-on in-source opt-in); `true` is the
+/// whole-program survey behind `--warn-unbounded-alloc`. `@unbounded`-fn
+/// sites are suppressed in both modes.
+pub fn unbounded_alloc_warnings(bundle: &Bundle<'_>, include_all: bool) -> Vec<Diag> {
     let progs: Vec<&hale_syntax::ast::Program> = bundle.programs.values().copied().collect();
-    alloc_summary::unbounded_alloc_diags(&progs)
+    alloc_summary::unbounded_alloc_diags(&progs, include_all)
 }
 
 /// Resource-leak warnings: an fd-acquiring call whose result is stored

--- a/docs/src/systems/operations.md
+++ b/docs/src/systems/operations.md
@@ -83,15 +83,40 @@ flags report on allocation shape:
 
 | Flag | Reports |
 |---|---|
-| `--dump-alloc-summary` | every allocation site, escape-tagged (local / returned / stored-to-self / sent), with the bounded-vs-unbounded verdict |
+| `--warn-unbounded-alloc` | flag an allocation that escapes into an unbounded context and accumulates until its locus dissolves (advisory warnings) |
+| `--dump-alloc-summary` | every allocation site, escape-tagged (local / returned / stored-to-self / sent), with the bounded-vs-unbounded verdict; plus each locus's storage shape (capacity slots, `@form`, projection cap) and the `self.<field>` / `self.<slot>` an allocation targets |
 | `--dump-resource-budget` | per-locus resource counts (allocations, held fds) against declared ceilings |
 | `--locality-report` | per-locus working-set size against cache-tier budgets |
 
-The memory-bound warnings these surface are **on by default** in
-`hale check` (advisory — they print but don't fail the build);
-`--no-warn-unbounded-alloc` opts out. A warning here is the
-compile-time complement to the residency dump: it tells you *which
-site* can grow before you've watched it grow.
+The memory-bound warnings are **opt-in** — a bound *per epoch* only
+means something for a long-lived process, so a script that allocates
+and exits pays nothing by default (the same stance as the `@locality`
+cache-tier budgets). There are two ways to opt in:
+
+- **Annotate the locus.** `@bounded locus L { … }` asks for the proof
+  on that locus specifically — its leak sites are reported on every
+  `hale check`, no flag. This is the in-source opt-in: the locus that
+  took on long-lived state requests the check on itself.
+
+  ```hale
+  @bounded locus Aggregator {
+      // ... handlers checked for unbounded accumulation ...
+
+      @unbounded fn on_snapshot(s: Snapshot) {
+          // acknowledged: this cache is operator-sized on purpose.
+          // @unbounded silences this body's sites — the greppable
+          // carve-out. Valid on a `fn` or a lifecycle hook (`@unbounded
+          // run { … }`).
+      }
+  }
+  ```
+
+- **Survey the whole program.** `--warn-unbounded-alloc` flags every
+  site regardless of `@bounded` (a `@unbounded` fn is still suppressed).
+
+Either way the warnings are advisory — they print but don't fail the
+build. A warning here is the compile-time complement to the residency
+dump: it tells you *which site* can grow before you've watched it grow.
 
 ## Bus backpressure: bounding a flood
 

--- a/docs/src/systems/performance.md
+++ b/docs/src/systems/performance.md
@@ -92,7 +92,7 @@ into `self`, a connection child left resident — have a static
 shape, and `hale check` flags them before you ever measure RSS.
 These are advisory warnings, not build failures:
 
-- **On by default**, `hale check` flags an allocation that
+- `hale check app.hl --warn-unbounded-alloc` flags an allocation that
   accumulates without bound: a struct / array / bytes value created
   in a per-message bus handler (or a runtime-bounded loop) that
   escapes into `self`, where it lives until the locus dissolves —
@@ -102,8 +102,21 @@ These are advisory warnings, not build failures:
   instead of replacing the whole value, or the moves from this
   chapter — a capacity-bounded `@form`, route it over the bus, or a
   per-iteration child. A `while i < N { … }` counter with a constant
-  bound is *proven* bounded and left alone. `--no-warn-unbounded-alloc`
-  opts out.
+  bound is *proven* bounded and left alone. It's opt-in because a bound
+  *per epoch* only matters for a long-lived process — a script that
+  allocates and exits owes it nothing. Annotate the long-lived locus
+  `@bounded` to get the check on every `hale check` without the flag,
+  and `@unbounded` (on a `fn` or a lifecycle hook) to acknowledge an
+  intentional accumulation and silence it.
+- The same check flags an **insert into a growing collection** —
+  `v.push(x)` / `m.set(x)` where `v` / `m` is a `@form(vec)` or
+  `@form(hashmap)` — when it runs in an unbounded context. The backing
+  buffer grows with population and frees only at dissolve, so a push
+  per message accumulates. A `@form(ring_buffer)` / `@form(lru_cache)`
+  is cap-bounded and never flagged; switching to one (or bounding the
+  loop) is the fix. (Detection reads the receiver's *declared* type, so
+  it sees `fn f(v: IntVec)` and `self.buf: IntVec` but not an untyped
+  `let`.)
 - `hale check app.hl --warn-resource-leak` is the same idea for file
   descriptors: an `open` / `connect` / `accept` whose result is
   stored resident in an unbounded context, so fds pile up.

--- a/notes/memory-bound-proofs.md
+++ b/notes/memory-bound-proofs.md
@@ -41,8 +41,35 @@ reuse.
 > per-handler flags). *Still deferred:* the `@unbounded` escape valve and
 > type-aware String-concat sites.
 >
-> **Default-on deliberately held (2026-06-10).** Considered promoting
-> `--warn-unbounded-alloc` to fire by default; kept opt-in. The 4 flags are
+> **Reverted to opt-in (2026-06-25).** The warning was promoted to
+> default-on (#122) but later reversed: per Hale's descent-curve stance,
+> a bound *per epoch* only means something for a long-lived process, so a
+> script that allocates and exits owes the proof nothing and pays nothing
+> by default. The warning is now opt-in via `--warn-unbounded-alloc`
+> (advisory; never fails the build), mirroring how `@locality` cache-tier
+> budgets are flag/annotation-gated. `--no-warn-unbounded-alloc` is an
+> accepted no-op for back-compat. The opt-in semantics are pinned by
+> `hale-cli` `unbounded_alloc_opt_in.rs`.
+>
+> **Phase B landed — `@bounded` / `@unbounded` (2026-06-25).** The
+> in-source opt-in: `@bounded locus L { … }` opts that locus into the
+> proof on every `hale check` (no flag); `@unbounded` on a `fn` or a
+> lifecycle hook (`@unbounded run { … }`) is the greppable carve-out that
+> silences one body's sites, in scoped mode AND under the survey flag.
+> `unbounded_alloc_diags(programs, include_all)` gates scope:
+> `include_all=false` reports only `@bounded`-locus sites (default check),
+> `true` is the whole-program survey (`--warn-unbounded-alloc`).
+> Implementation: `bounded: bool` on `LocusDecl`, `unbounded: bool` on
+> `FnDecl` + `LifecycleDecl`; `AllocSummary.{bounded_loci, unbounded_fns}`;
+> parser handles both as bare `@`-flags. **Severity is warning** — the
+> hard *error* contract for `@bounded` waits on the precision phases
+> (store-latest vs. append, `@form(cap)`) reaching zero in-scope FP.
+> Pinned by `hale-syntax` parser tests + `hale-cli` `bounded_annotation.rs`.
+> *Next: Phase C* — replace-vs-append refinement (RSS-validated).
+>
+> **Default-on deliberately held, then shipped, then reverted.** The
+> 2026-06-10 reasoning below is retained for context; the conclusion
+> (kept opt-in) is once again the shipped behavior. The 4 flags are
 > *true* positives but include legitimately bounded-by-design patterns —
 > `22-moving-average`'s `Window::on_sample` keeps a fixed 4-elem window;
 > per the reclamation model the *replaced* arrays aren't freed until
@@ -185,14 +212,71 @@ and validated against the corpus (the inverse check: every program the
 pass says is bounded should show flat RSS under the
 `high_volume_walk_bounded_rss`-style harness).
 
-## `@form(hashmap)` interaction (the issue's open question)
+## Bounded sinks live on the capacity/projection axis, NOT `@form` (2026-06-25)
 
-A `@form(hashmap, cap = N)` is a *bounded* sink for the cells themselves
-(fixed cap), but a cell with a `String`/array field is unbounded if that
-field grows per update (leak class 2). So the pass composes: the cell
-count is bounded by `cap`; the per-cell field allocations must themselves
-be bounded (a fixed-width scalar field is; an appended-to `String` field
-is not). The `@form` cap is an input to the solver, not a free pass.
+An earlier draft framed this as "`@form(hashmap, cap = N)` composition" —
+the `@form` cap as a bound the solver reads. **That is wrong**, and the
+spec says so plainly: `@form` is an *access discipline* (vec / hashmap /
+ring_buffer — picks a lowering + synthesizes methods), and
+`spec/forms.md` is explicit that *"discipline goes on the capacity slot,
+not in the annotation."* The `cap = N` that appears on
+`@form(hashmap, …, cap = N)` is *"an optional initial-size hint"*
+(forms.md), **not a bound** — the map still lazily grows. So `@form`
+bounds nothing; reading it for a bound is a category error.
+
+The bound lives on the **capacity/projection axis**, in three tiers:
+
+| Construct | Bound character |
+|---|---|
+| `: projection recognition(cap = N, fixed_cell)` | **Hard static cap.** N cells; overflow is a *runtime error*. `spec/memory.md` calls it "the one real cap." The clean bounded sink. |
+| `capacity { pool X of T; }` | Recyclable cells (chunked free-list, geometric growth capped at 4096/chunk). Bounded **iff** acquire/release is balanced — high-water tracks peak population, not a static N. |
+| `capacity { heap Y of T; }` / `@form(vec)` / `@form(hashmap)` | Individually freed at dissolve; grows with total population. Unbounded unless population is bounded. |
+
+### The organizing insight: bound model is per storage slot
+
+A locus's storage is an N-tuple of slots (`spec/memory.md` §"capacity
+slots"). The proof must route each *escaping* allocation to the slot it
+lands in and apply that slot's bound model:
+
+- **Slot 0 — the locus's own bump Arena.** Where `self.field = X{}`
+  value allocations land. Bump-allocated, reclaimed only at dissolve, so
+  a per-iteration store-latest **accumulates** — measured, see the Phase
+  C finding below. This slot is the `@bounded`/`@unbounded` story and the
+  store-latest (A/B) fork. No capacity construct governs it.
+- **Slots 1..N — capacity pool/heap + projection.** Where collections /
+  accepted-child entities live. Bound = the table above: `recognition`
+  cap is a hard static bound; `pool` is bounded-by-balanced-release;
+  `heap`/`vec`/`hashmap` grow with population.
+
+This also lines up with the entity-vs-data taxonomy: `recognition`
+(accept'd entities, hard `fixed_cell` cap) vs `@form`/`capacity` (data).
+
+### Phase C finding — store-latest is unbounded (measured 2026-06-25)
+
+The note had hypothesized a "replace-vs-append refinement" treating a
+store-latest (`self.x = …`) as *bounded*. **RSS measurement falsified
+it.** A `run()` loop doing a whole-value field replace each iteration
+(3M trips, runtime bound) over a baseline of ~55 MB:
+
+| variant | RSS | grows? |
+|---|---|---|
+| `self.recent[i] = v` (in-place indexed) | 55 MB | no — baseline |
+| `self.recent = [i,i,i,i]` (fixed `[Int;4]` replace) | 188 MB | **+133 MB** |
+| `self.h = Holder{…}` (flat all-scalar struct replace) | 96 MB | **+41 MB** |
+
+Whole-value field replacement bump-allocates a fresh value each iteration
+into slot 0; the replaced value is **not** reclaimed until dissolve —
+even for a fixed-size `[Int;4]`. The current model already flags exactly
+the growing cases and leaves in-place writes alone, so **the model is
+sound and there is no false positive to fix.** The "store-latest is
+bounded" refinement is **dropped as unsound.** Two follow-on directions
+remain open (the slot-0 fork): **(A)** lock the soundness with RSS
+regression tests + redirect precision effort to the capacity/projection
+axis; or **(B)** a *codegen* change making fixed-size value-type field
+assignment an in-place memcpy (no bump-alloc) so store-latest becomes
+genuinely bounded, then teach the model. A is analysis-faithful and
+cheap; B is a larger codegen-correctness effort that supersedes A's
+store-latest assertion.
 
 ## Scope boundaries
 
@@ -218,8 +302,52 @@ is not). The `@form` cap is an input to the solver, not a free pass.
 3. **Bound solver + `@unbounded`** — the escape-into-unbounded-context
    obligation, bounded loops/sinks, the diagnostic. Warning first (like
    the bus-graph checks shipped), error once the false-positive rate on
-   the corpus is zero.
-4. **`@form` composition** — the cap-as-input + per-cell-field bounds.
+   the corpus is zero. *(Shipped. Phase A made it opt-in via
+   `--warn-unbounded-alloc`; Phase B added the `@bounded` locus opt-in +
+   `@unbounded` carve-out — see the status block at the top.)*
+4. **Capacity/projection-aware slot bounding** *(was mislabeled "`@form`
+   composition")* — route each escaping allocation to the storage slot it
+   lands in and apply that slot's bound model: `recognition(cap = N)` is a
+   hard static bound; a `pool` slot is bounded-by-balanced-release; a
+   `heap` slot / `vec` / `hashmap` grows with population; slot 0 (the bump
+   Arena) accumulates a store-latest. Then compose per-cell field bounds
+   (a fixed-scalar cell field is bounded; an appended-to `String` field is
+   not). The bound is read from the **capacity block + projection class**,
+   never from `@form` (an access discipline that bounds nothing). See
+   "Bounded sinks live on the capacity/projection axis" above. Staged:
+   - **D1 (LANDED 2026-06-25) — the slot-shape scaffold.** A `LocusShape`
+     (capacity slots `[(name, kind)]`, `@form` + cap-arg, recognition cap)
+     distilled from each `LocusDecl` onto `AllocSummary.locus_shapes`;
+     `AllocSite.target_field` records the `self.<field>` of a whole-value
+     replace; `CallEdge.receiver_slot` records the `self.<slot>` of a slot
+     method call. Surfaced in `--dump-alloc-summary`. **No verdict change.**
+     The reusable infra for D2. Discovery finding: the walker previously
+     tagged slot-insert *arguments* `Local`, so collection growth
+     (`self.items.push(X{})`) is currently **undetected** — D2's job.
+   - **D2 (LANDED 2026-06-25) — growing-collection inserts.** A discovery
+     pass found the corpus inserts via `v.push(x)` on a *typed* receiver
+     (`v: IntVec`, `self.buf: IntVec`), not direct `self.<slot>.alloc()` —
+     so detection is **type-aware**, the same class as the deferred
+     String-concat. Chosen approach: **D2-lite** — a lightweight var→
+     *declared*-type map (fn params, typed `let`s, locus param fields)
+     matched against `locus_shapes[T].form`. A `push`/`set`/`insert`/`add`
+     whose receiver type is a `@form(vec | hashmap)` becomes a
+     `CollectionInsert` site (escape=self-store, reclaim@dissolve), so it
+     flows through the existing verdict path: flagged in an unbounded
+     context, bounded by a const loop, suppressed by `@unbounded`. A
+     `@form(ring_buffer | lru_cache)` is cap-bounded → not flagged; a user
+     `push` method on a *non-form* locus → not flagged (the
+     `54-geom-leading-edge` `Segment` shape, confirmed). **Zero corpus
+     false positives** (68 fixtures). RSS-validated: a 3M `@form(vec)`
+     push-of-32B-struct hits 210 MB vs a 55 MB no-push control (`lotus_vec_
+     push` grows a geometric `cap*2` buffer; `rss_bytes()` is peak/maxrss).
+     *Misses (deferred to a type-aware stage):* untyped `let`, reassignment,
+     return-of-form, and the clear/reset balance case (a vec cleared each
+     iteration is bounded-by-peak — opt-in gating + `@unbounded` absorb it).
+     (Recognition `cap=N` bounds *entity* count, fed by `accept` — a
+     separate analysis the value-alloc walker doesn't track.)
+   - **D3 — per-cell field bounds** (a bounded cell with a growing `String`
+     field). Optional; can defer.
 
 ## Risks
 

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -181,7 +181,18 @@ locus_decl        = { locus_decorator } , [ "main" ] , "locus" , IDENTIFIER ,
 locus_decorator   = form_annotation
                   | locality_annotation
                   | export_annotation
+                  | bounded_annotation
                   ;
+
+(* GH #18 item 1 (memory-bound proofs): `@bounded` opts a locus into
+   the memory-bound proof — its bodies are checked for unbounded
+   allocations on every `hale check`, without the
+   `--warn-unbounded-alloc` survey flag. The in-source opt-in; the
+   `@unbounded` carve-out (see `fn_decorator` / `locus_member`)
+   silences a single fn or lifecycle hook inside it. `bounded` is a
+   contextual word recognized only after `@` in decorator position.
+   See `spec/verification.md`. *)
+bounded_annotation = "@" , "bounded" ;
 
 (* F.31 (2026-05-23): `schedule` removed from locus_annotation.
    Placement is a deployment seam; it lives in a `placement { }`
@@ -437,7 +448,10 @@ slot_kind         = "pool" | "heap" ;
    frees the locus. None are required; missing transitions use
    compiler-supplied defaults. *)
 
-lifecycle_decl    = lifecycle_keyword , [ "(" , [ param_list ] , ")" ] ,
+(* The optional `@unbounded` prefix (unbounded_annotation, § 13) is
+   the memory-bound-proof carve-out on a `run`-loop accumulation. *)
+lifecycle_decl    = [ unbounded_annotation ] ,
+                    lifecycle_keyword , [ "(" , [ param_list ] , ")" ] ,
                     [ "->" , type_expr ] , block ;
 lifecycle_keyword = "birth"
                   | "accept"
@@ -638,10 +652,20 @@ function_decl     = [ function_decorator ] ,
    name — a real-bodied top-level free fn, no-op on the native
    target. `export` is a reserved keyword; the two decorators are
    mutually exclusive (an import is not an export). See
-   `spec/ffi.md` § "WASM host interface". *)
-function_decorator = ffi_annotation | export_annotation ;
+   `spec/ffi.md` § "WASM host interface".
+
+   `@unbounded` (GH #18 item 1) acknowledges an intentionally-
+   unbounded fn, suppressing its memory-bound warnings (the
+   carve-out for a `@bounded` locus or the `--warn-unbounded-alloc`
+   survey). It also prefixes a locus member — a `function_decl` or a
+   `lifecycle_decl` (e.g. `@unbounded run { … }`) — inside a locus
+   body; `unbounded` is contextual, recognized only after `@`. See
+   `spec/verification.md`. *)
+function_decorator = ffi_annotation | export_annotation
+                   | unbounded_annotation ;
 ffi_annotation    = "@" , "ffi" , "(" , STRING_LIT , ")" ;
 export_annotation = "@" , "export" ;
+unbounded_annotation = "@" , "unbounded" ;
 
 (* v1.x-FORM-1: a fallible fn's return type is "value of T, or
    an error has occurred with payload P." Callers MUST address

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -79,15 +79,32 @@ diagnostic. See `spec/semantics.md § Locus method dispatch`.
 
 ## Default-on & opt-in analyses
 
-Two GitHub issue #18 analyses run **by default**: item 4 (bus-graph property
-checks — *errors*, fail the build) and item 1 (memory-bound — *advisory
-warnings*, print but don't fail). The rest are **opt-in** (behind a flag) or
-deferred. Only item 4 is a build gate; don't assume the others in a build:
+One GitHub issue #18 analysis runs **by default**: item 4 (bus-graph property
+checks — *errors*, fail the build). The rest, including item 1 (memory-bound),
+are **opt-in** (behind a flag) or deferred. Only item 4 is a build gate; don't
+assume the others in a build:
 
-- **Memory-bound proofs (item 1)** — **on by default** in `hale check`
-  (advisory warnings; they print but don't fail the build).
-  `--no-warn-unbounded-alloc` opts out; `--dump-alloc-summary` prints the
-  raw per-fn summary. A per-method allocation summary + call-graph
+- **Memory-bound proofs (item 1)** — **opt-in**, two ways. The proof is
+  opt-in by design: "bounded per epoch" only means something for a
+  long-lived process (a daemon, a bus handler, a persistent locus), so a
+  script that allocates and exits owes it nothing and pays nothing by
+  default — the same descent-curve stance as the `@locality` cache-tier
+  budgets (annotation/flag-gated, never automatic). The two opt-in surfaces:
+  - **`@bounded locus L { … }`** — the in-source opt-in. A locus annotated
+    `@bounded` is checked on every `hale check` (no flag), and a
+    `@unbounded fn`/`@unbounded run { … }` inside it is the greppable
+    carve-out that silences one body's sites. This is the descent marker:
+    the locus that took on long-lived state asks for the proof on itself.
+    *(Currently advisory warnings; the intended end state is a hard
+    **error** contract once the precision refinements — store-latest vs.
+    append, `@form(cap)` composition — drive in-scope false positives to
+    zero.)*
+  - **`--warn-unbounded-alloc`** — the whole-program advisory survey. Flags
+    every site regardless of `@bounded` (a `@unbounded` fn is still
+    suppressed). Warnings print but never fail the build.
+  `--dump-alloc-summary` prints the raw per-fn summary.
+  `--no-warn-unbounded-alloc` is accepted-and-ignored for back-compat with
+  the former default-on flag. A per-method allocation summary + call-graph
   escape/loop dataflow — with **escape-awareness** (a non-escaping local in
   a per-message handler is reclaimed at the per-delivery method-scratch
   destroy, so it isn't flagged), call-result escape tagging, and
@@ -98,8 +115,15 @@ deferred. Only item 4 is a build gate; don't assume the others in a build:
   value each time); the fix is **in-place mutation** (`self.f.x = v` /
   `self.a[i] = v`), a capacity-bounded `@form` (`ring_buffer` / `lru_cache`
   / a `capacity` slot), the bus (reclaims per dispatch), or a per-iteration
-  child locus. Zero corpus false positives. Type-aware String-concat sites
-  remain deferred. See `notes/memory-bound-proofs.md`.
+  child locus. It also flags an **insert into a growing collection** —
+  `v.push(x)` / `m.set(x)` where the receiver's declared type is a
+  `@form(vec)` / `@form(hashmap)` locus — in an unbounded context; the
+  backing buffer grows with population and frees only at dissolve. A
+  `@form(ring_buffer)` / `@form(lru_cache)` is cap-bounded and excluded.
+  (Detection reads *declared* receiver types — params, typed `let`s, locus
+  param fields — not inferred ones.) Zero corpus false positives. Type-aware
+  String-concat sites and untyped-receiver collection inserts remain
+  deferred. See `notes/memory-bound-proofs.md`.
 - **Resource-budget tracking (item 5)** — fully shipped, opt-in. A static
   **count** of pinned threads / cooperative pools / bus subjects /
   fd-acquisition sites (fd-opening calls *and* held-fd `Listener` /


### PR DESCRIPTION
Consolidates the 5-PR stack (#161–#165) into one squashed PR for a single manual merge. Tree is byte-identical to the green tip of that stack.

Carries GH #18 item 1 from a default-on warning to a descent-curve-aligned, capacity-aware analysis, in five phases:

### A — opt-in gating
The unbounded-allocation warning shipped **default-on**, which contradicts Hale's descent curve: a bound *per epoch* only means something for a long-lived process, so a script that allocates and exits owes the proof nothing. Reverted to **opt-in** behind `--warn-unbounded-alloc` (advisory; never fails the build), mirroring the `@locality` cache-tier budgets. `--no-warn-unbounded-alloc` kept as an accepted no-op.

### B — `@bounded` / `@unbounded`
The in-source opt-in: `@bounded locus L {}` checks that locus on every `hale check` (no flag); `@unbounded` on a `fn` or lifecycle hook is the greppable carve-out. `unbounded_alloc_diags(progs, include_all)` gates scope (false = `@bounded`-only, true = whole-program survey). Severity stays **warning** — the hard `@bounded`-as-error contract waits on sustained zero in-scope FPs.

### C — store-latest soundness lock + reframe
The note's "replace-vs-append refinement" hypothesis (store-latest is bounded) is **falsified by RSS**: in the bump arena a replaced value isn't reclaimed until dissolve, so whole-value `self.f = X{}` accumulates — even a fixed `[Int;4]` (+133 MB / 3M trips). The model already flags exactly the growing cases → sound, no false positive. Locked with an RSS regression test; refinement dropped. **Reframe:** bounds live on the **capacity/projection axis, not `@form`** (an access discipline); the proof is **per storage slot**.

### D1 — slot-shape scaffold (no verdict change)
A `LocusShape` (capacity slots, `@form` + cap-arg, recognition cap) distilled onto `AllocSummary.locus_shapes`; `AllocSite.target_field` and `CallEdge.receiver_slot` capture the `self.<field>` / `self.<slot>` an allocation targets. Surfaced in `--dump-alloc-summary`.

### D2 — growing-collection inserts
A `push`/`set`/`insert`/`add` whose receiver's **declared** type is a `@form(vec|hashmap)` locus becomes a `CollectionInsert` site flowing through the existing verdict path (flagged in an unbounded context, bounded by a const loop, `@unbounded`-suppressible). Lightweight declared-type tracking (params, typed `let`s, locus param fields) — **no resolver coupling**. `ring_buffer` / `lru_cache` (cap-bounded) and a user `push` on a non-form locus are not flagged.

## Validation
- **Zero corpus false positives** — 68 example fixtures surveyed.
- **RSS-validated** (`alloc_model_rss`): store-latest replace +133 MB; a 3M `@form(vec)` push of a 32-byte struct → ~210 MB vs ~55 MB no-push control.
- Pins: `hale-cli` `unbounded_alloc_opt_in` + `bounded_annotation`; `hale-syntax` parser tests; `hale-types` `alloc_summary` unit tests; `hale-codegen` `alloc_model_rss`. `hale-types` lib: 210 passing.

## Deferred / next
A future **type-aware stage** (untyped-receiver collection inserts + String-concat), **D3** (per-cell field bounds), and **Phase E** (promote `@bounded` to a hard *error* at sustained zero in-scope FPs). Design doc: `notes/memory-bound-proofs.md`. Per-phase progress: GH #18 comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)