### PR TITLE
feat(runtime): arena-on-node NUMA memory co-location for pinned(node/l3)

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -222,6 +222,19 @@ const char *__tsan_default_suppressions(void) {
 #ifndef MAP_HUGETLB
 #  define MAP_HUGETLB 0x40000   /* Linux-specific; fallback for builds where it's missing */
 #endif
+/* Topology arena-on-node (2026-07-05): NUMA memory binding via the
+ * raw `mbind` syscall. We go through syscall() rather than link
+ * libnuma so a node-pinned arena costs no new dynamic dependency —
+ * the whole feature stays zero-cost for programs that don't opt in.
+ * `__NR_mbind` comes from <sys/syscall.h>; MPOL_BIND (2) is the
+ * numaif ABI value, defined locally to avoid a libnuma-dev header
+ * dependency. Linux-only; everything below is #ifdef __linux__. */
+#if defined(__linux__)
+#include <sys/syscall.h>
+#ifndef MPOL_BIND
+#  define MPOL_BIND 2
+#endif
+#endif
 
 /* Default chunk size: 64KB. Big enough that most loci fit in
  * one chunk, small enough that a leaf locus that allocates a
@@ -406,6 +419,15 @@ typedef struct lotus_arena {
      * arena). Per-instance arenas leave this 0 and keep the single-thread
      * lock-free fast path. */
     int                  shared_concurrent;
+    /* Topology arena-on-node (2026-07-05). When >= 0, this arena's
+     * chunks are mmap'd (page-aligned) and `mbind`-bound to this
+     * NUMA node, so a node-pinned locus's working memory is
+     * co-located with the node its thread runs on. -1 (the default)
+     * takes the ordinary malloc / chunk-pool path — every non-node
+     * arena is byte-identical to before. Linux-only; on other hosts
+     * the bind is a no-op and the arena allocates normally. Set at
+     * create time via `lotus_arena_create_labeled_on_node`. */
+    int                  numa_node;
 } lotus_arena_t;
 
 /* Per-thread freelist of default-sized chunks (2026-05-21
@@ -1294,10 +1316,71 @@ static int lotus_hugepages_enabled(void) {
     return g_hugepages_enabled_cached;
 }
 
+/* Topology arena-on-node (2026-07-05): allocate one chunk whose
+ * pages are bound to NUMA node `node`. The chunk is mmap'd (so it's
+ * page-aligned — a prerequisite for mbind) and the region is
+ * `mbind`'d MPOL_BIND before it's first touched, so every page
+ * faults in on `node` regardless of which thread touches it first
+ * (the locus struct is instantiated on `main` but runs on its own
+ * pinned thread). The chunk carries via_mmap=1, so the release path
+ * munmaps it and it never enters the node-agnostic chunk pool.
+ *
+ * Best-effort, matching the affinity contract: if mmap fails, or
+ * mbind fails (node absent on this box, or the process lacks the
+ * capability), we return what we can — an unbound-but-usable chunk
+ * on mmap success, or NULL to let the caller fall back to malloc.
+ * Non-Linux: no mbind, just an mmap'd chunk (still correct, just
+ * not node-bound). */
+static lotus_arena_chunk_t *lotus_arena_new_chunk_on_node(
+    int node, size_t cap)
+{
+    long page = sysconf(_SC_PAGESIZE);
+    if (page <= 0) page = 4096;
+    size_t total = sizeof(lotus_arena_chunk_t) + cap;
+    size_t mmap_size =
+        (total + (size_t)page - 1) & ~((size_t)page - 1);
+    void *p = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (p == MAP_FAILED) return NULL;
+#if defined(__linux__)
+    /* Bind the region to `node` before first touch. Single-word
+     * nodemask covers nodes 0..63 — well past any real machine;
+     * skip binding (leave first-touch policy) for node >= 64. */
+    if (node >= 0 && node < (int)(8 * sizeof(unsigned long))) {
+        unsigned long nodemask = 1UL << node;
+        (void)syscall(__NR_mbind, p, (unsigned long)mmap_size,
+                      MPOL_BIND, &nodemask,
+                      (unsigned long)(8 * sizeof(unsigned long)),
+                      0u);
+        /* Return value ignored on purpose: an mbind failure leaves
+         * the region under the default (first-touch) policy, which
+         * is still correct memory — just not node-pinned. */
+    }
+#else
+    (void)node;
+#endif
+    lotus_arena_chunk_t *c = (lotus_arena_chunk_t *)p;
+    c->next = NULL;
+    c->used = 0;
+    c->cap  = cap;
+    c->via_mmap = 1;
+    c->mmap_size = mmap_size;
+    return c;
+}
+
 static lotus_arena_chunk_t *lotus_arena_new_chunk_for(
     struct lotus_arena *target, size_t cap)
 {
     lotus_mark_thread_for_pool_dtor();
+    /* Topology arena-on-node: a NUMA-bound arena gets each chunk
+     * mmap'd + mbind'd to its node, bypassing the node-agnostic
+     * chunk pool (whose recycled chunks carry no node binding).
+     * Falls through to the ordinary path if the mmap fails. */
+    if (target && target->numa_node >= 0) {
+        lotus_arena_chunk_t *c =
+            lotus_arena_new_chunk_on_node(target->numa_node, cap);
+        if (c) return c;
+    }
     lotus_chunk_pool_prefill_if_needed();
     /* Pool only the common-case default chunk size. Mixing
      * sizes in one freelist would force a scan per pop. */
@@ -1463,6 +1546,7 @@ static lotus_arena_t *lotus_arena_alloc_struct(void) {
     a->retire_pending = NULL;
     a->retire_shells = NULL;
     a->retire_free = NULL;
+    a->numa_node = -1;  /* topology arena-on-node: unbound by default */
     /* 2026-05-26 substrate-race fix: subregion freelist mutex.
      * Used by create_subregion / destroy via the PARENT arena's
      * pointer; arenas with no children never acquire the lock.
@@ -1498,6 +1582,25 @@ lotus_arena_t *lotus_arena_create(void) {
  * literal so this is automatic. */
 lotus_arena_t *lotus_arena_create_labeled(const char *label) {
     lotus_arena_t *a = lotus_arena_alloc_struct();
+    lotus_arena_residency_register(a, label);
+    return a;
+}
+
+/* Topology arena-on-node (2026-07-05). Same as
+ * lotus_arena_create_labeled but flags the arena for NUMA-node
+ * memory co-location: every chunk it grows is mmap'd + `mbind`'d
+ * to `node` (see lotus_arena_new_chunk_on_node), so a node-pinned
+ * locus's working set lands on the same node its thread runs on.
+ * Codegen emits this variant for a `pinned(node = N)` /
+ * `pinned(l3 = name)` placement (the node resolved from the
+ * `topology { }` block). `node < 0` degrades to the ordinary
+ * unbound arena. Linux-only; a no-op bind elsewhere. */
+lotus_arena_t *lotus_arena_create_labeled_on_node(
+    const char *label, int node)
+{
+    lotus_arena_t *a = lotus_arena_alloc_struct();
+    if (!a) return NULL;
+    if (node >= 0) a->numa_node = node;
     lotus_arena_residency_register(a, label);
     return a;
 }
@@ -1721,6 +1824,13 @@ lotus_arena_t *lotus_arena_create_subregion(lotus_arena_t *parent) {
     lotus_arena_t *a = lotus_arena_alloc_struct();
     if (!a) return NULL;
     a->parent = parent;
+    /* Topology arena-on-node (2026-07-05): a sub-region holds its
+     * own chunks, so it must inherit the parent's NUMA binding for
+     * co-location to reach the hot path — method scratch (the
+     * dominant per-invocation allocation) is a sub-region of the
+     * locus arena. A node-pinned locus's transient scratch lands
+     * on its node too; unbound parents (-1) leave children unbound. */
+    a->numa_node = parent->numa_node;
     /* 2026-05-26 substrate-race fix: lock the parent's
      * subregion tracker. Without this, two threads
      * concurrently creating sub-regions of the same parent

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1166,7 +1166,9 @@ pub fn build_executable_with_options(
         instantiating_for_parent_field: false,
         instantiating_into_payload_arena: false,
         placement_for_next_locus_instantiation: None,
+        numa_node_for_next_locus_instantiation: None,
         main_placement_map: BTreeMap::new(),
+        main_placement_node: BTreeMap::new(),
         main_locus_name: None,
         pinned_locus_types: BTreeSet::new(),
         params_init_self: None,
@@ -2981,6 +2983,15 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// the first nested locus instantiation absorbs the override
     /// and inner ones see None.
     pub(crate) placement_for_next_locus_instantiation: Option<ScheduleClass>,
+    /// Topology arena-on-node (2026-07-05): parallel to
+    /// `placement_for_next_locus_instantiation` — the resolved
+    /// NUMA node for the field being instantiated, when its
+    /// placement is `pinned(node = N)` / `pinned(l3 = name)`.
+    /// `Some(node)` routes the Fresh-strategy arena create through
+    /// `lotus_arena_create_labeled_on_node` so the locus's arena
+    /// co-locates with its thread's node. Consumed via `mem::take`
+    /// like its sibling.
+    pub(crate) numa_node_for_next_locus_instantiation: Option<i64>,
     /// F.31: per-main-locus map of `params` field name →
     /// effective placement. Built once at codegen startup from
     /// `main locus`'s `placement { }` block. Used by the
@@ -2989,6 +3000,12 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// absent field defaults to `Cooperative` (placement
     /// pool routing comes in Phase 4).
     pub(crate) main_placement_map: BTreeMap<String, ScheduleClass>,
+    /// Topology arena-on-node: per-main-locus map of `params`
+    /// field name → resolved NUMA node, for the `pinned(node/l3)`
+    /// entries whose arena binds to a node. Built alongside
+    /// `main_placement_map` in `collect_main_placement`; absent
+    /// fields (no node placement) simply don't appear.
+    pub(crate) main_placement_node: BTreeMap<String, i64>,
     /// F.31: name of the main locus (if any) for the bundle.
     /// Cached at startup so the params-init loop can detect
     /// "we're instantiating main" without re-walking the
@@ -7814,6 +7831,29 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         }
     }
 
+    /// Topology arena-on-node: the NUMA node an affinity binds its
+    /// *memory* to (as opposed to which cores its thread runs on).
+    /// `node = N` binds to `N` directly; `l3 = name` binds to the
+    /// node containing that cache domain. `cores` / bare `pinned`
+    /// have no node — their arenas stay unbound (ordinary malloc).
+    fn resolve_pin_node(
+        affinity: &PinAffinity,
+        topology: Option<&TopologyBlock>,
+    ) -> Option<i64> {
+        match affinity {
+            PinAffinity::Node(n) => {
+                // Only bind if the node is actually declared (so a
+                // typecheck-rejected reference doesn't leak to a
+                // bogus node id at codegen).
+                topology.and_then(|t| t.node_cores(*n)).map(|_| *n)
+            }
+            PinAffinity::L3(name) => {
+                topology.and_then(|t| t.node_of_l3(&name.name))
+            }
+            PinAffinity::Any | PinAffinity::Cores(_) => None,
+        }
+    }
+
     /// F.31 (2026-05-23): pre-pass over `main locus`'s
     /// `placement { }` block. Caches `main_locus_name` and
     /// populates `main_placement_map` keyed by field name with
@@ -7908,6 +7948,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                             let cores = Self::resolve_pin_affinity(
                                 affinity, topology,
                             );
+                            // Topology arena-on-node: record the
+                            // resolved node so the field's arena
+                            // create binds its memory to that node.
+                            if let Some(node) =
+                                Self::resolve_pin_node(affinity, topology)
+                            {
+                                self.main_placement_node.insert(
+                                    entry.field.name.clone(),
+                                    node,
+                                );
+                            }
                             ScheduleClass::Pinned(cores)
                         }
                         PlacementSpec::Cooperative { pool } => {

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -84,6 +84,14 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
         // arena_destroy via the existing is_pinned_entry path.
         let placement_override =
             std::mem::take(&mut self.placement_for_next_locus_instantiation);
+        // Topology arena-on-node: consume the parallel NUMA-node
+        // override (set for `pinned(node/l3)` fields) so the Fresh
+        // arena create below binds this locus's arena to its node.
+        // Taken here for the same reason as the placement override —
+        // a nested instantiation would otherwise clobber it.
+        let numa_node_override = std::mem::take(
+            &mut self.numa_node_for_next_locus_instantiation,
+        );
         // F.31 Phase 4: consume the parallel pool-name override
         // before any recursion happens (a nested instantiation
         // in this locus's params-init loop would otherwise
@@ -769,6 +777,30 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                             .build_call(
                                 sized_fn,
                                 &[label_ptr.into(), hint_val.into()],
+                                &format!("{}.arena", locus_name),
+                            )
+                            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                    } else if let Some(node) = numa_node_override {
+                        // Topology arena-on-node: a `pinned(node/l3)`
+                        // locus binds its arena's memory to the node
+                        // its thread runs on. (Node-pinned loci are
+                        // pinned, never on a cooperative pool, so
+                        // this is exclusive with the sized-hint path
+                        // above.)
+                        let on_node_fn = self
+                            .module
+                            .get_function(
+                                "lotus_arena_create_labeled_on_node",
+                            )
+                            .expect(
+                                "lotus_arena_create_labeled_on_node declared",
+                            );
+                        let node_val =
+                            self.context.i32_type().const_int(node as u64, true);
+                        self.builder
+                            .build_call(
+                                on_node_fn,
+                                &[label_ptr.into(), node_val.into()],
                                 &format!("{}.arena", locus_name),
                             )
                             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
@@ -1728,6 +1760,13 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                     .main_cooperative_pools
                     .get(fname.as_str())
                     .cloned();
+                // Topology arena-on-node: parallel NUMA-node set for
+                // `pinned(node/l3)` fields; None for every other
+                // placement (arena stays unbound).
+                self.numa_node_for_next_locus_instantiation = self
+                    .main_placement_node
+                    .get(fname.as_str())
+                    .copied();
             }
             // Phase-2 (2): set the parent-field flag so a locus
             // literal evaluated for this field doesn't run its

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -113,6 +113,20 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             arena_create_labeled_ty,
             None,
         );
+        // Topology arena-on-node (2026-07-05): NUMA-bound variant.
+        // Emitted at the Fresh-strategy locus instantiation when the
+        // locus is placed `pinned(node = N)` / `pinned(l3 = name)`;
+        // the node (resolved from the `topology { }` block) is passed
+        // as the second arg, and the arena mmap+mbinds its chunks to
+        // that node so the locus's memory co-locates with its thread.
+        // declare ptr @lotus_arena_create_labeled_on_node(ptr label, i32 node)
+        let arena_create_on_node_ty =
+            ptr_t.fn_type(&[ptr_t.into(), i32_t.into()], false);
+        self.module.add_function(
+            "lotus_arena_create_labeled_on_node",
+            arena_create_on_node_ty,
+            None,
+        );
         // F.32-3 (2026-05-25): sized variant. Emitted at the
         // Fresh-strategy locus instantiation when the locus is
         // placed on a non-`main` cooperative pool — codegen

--- a/crates/hale-codegen/tests/fixtures/examples/20c-topology-numa/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/20c-topology-numa/main.hl
@@ -22,15 +22,19 @@
 //   picky:  pinned(l3 = fast);  // thread affinity = the `fast`
 //                               //   domain's cores
 //
-// This slice binds the *thread* to the domain's core set — it
-// reuses the Phase 1a cpuset affinity path (the OS schedules the
-// thread freely within the set). Arena-on-node *memory*
-// co-location (the "thread + memory" payoff) is the follow-up
-// slice.
+// A node/l3-pinned locus gets BOTH halves of co-location:
+//   - thread affinity: the thread's cpuset mask is the domain's
+//     cores (reusing the Phase 1a affinity path);
+//   - memory: the locus's arena (and its method scratch) is
+//     mmap'd and `mbind`-bound to the node, so its working set
+//     lives on the same NUMA node its thread runs on.
 //
 // Best-effort + Linux-only, exactly like `pinned(cores = ...)`:
-// cores absent on the deploy box are skipped, and on non-Linux
-// hosts the affinity call is a no-op (the loci still run).
+// cores absent on the deploy box are skipped, memory binding
+// falls back to first-touch if `mbind` can't honor the node, and
+// on non-Linux hosts both are no-ops (the loci still run). An
+// `l3`-pinned locus binds its arena to the node that contains
+// that cache domain.
 
 locus NodeWorker {
     run() {

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -593,6 +593,19 @@ impl TopologyBlock {
         None
     }
 
+    /// The NUMA node id that contains L3 domain `name` — used to
+    /// co-locate an `l3`-pinned locus's arena with the node its
+    /// cache domain lives on (topology arena-on-node). `None` if
+    /// no domain with that name is declared.
+    pub fn node_of_l3(&self, name: &str) -> Option<i64> {
+        for node in &self.nodes {
+            if node.domains.iter().any(|d| d.name.name == name) {
+                return Some(node.id);
+            }
+        }
+        None
+    }
+
     /// All reserved cores, expanded/sorted/deduped.
     pub fn reserved_cores(&self) -> Vec<i64> {
         let mut v: Vec<i64> =

--- a/docs/src/services/concurrency.md
+++ b/docs/src/services/concurrency.md
@@ -140,12 +140,18 @@ and every `pinned(node/l3)` must name a domain you declared.
 L3-domain names are ordinary identifiers, so a reserved word
 (like `bulk`) can't be a domain name — pick a plain name.
 
-> **This slice is thread affinity only.** `node = N` currently
-> pins the *thread* to the node's cores. Binding the locus's
-> *arena* to that node's memory — the thread + memory
-> co-location that makes NUMA targeting pay off — is the next
-> slice. Until then, `node =` and `l3 =` are a named, validated
-> way to spell a cpuset.
+**Thread *and* memory co-location.** `pinned(node = N)` binds
+more than the thread: the locus's arena — and its per-call
+method scratch — is allocated on that NUMA node's memory (via
+`mbind`), so its working set lives next to the thread that uses
+it. That's the point of NUMA targeting: cross-node memory access
+is what kills big-box performance, and a node-pinned locus
+avoids it on both axes. `pinned(l3 = fast)` binds the arena to
+the node containing that cache domain. Like affinity, memory
+binding is a Linux optimization and best-effort — it falls back
+to normal allocation where the node can't be honored, and it
+costs nothing (no extra dependency, the ordinary allocation
+path) for loci that don't ask for a node.
 
 Placement keys on the *field name*, not the locus type, so two
 instances of the same locus type can live on different threads —

--- a/spec/design-rationale.md
+++ b/spec/design-rationale.md
@@ -3038,10 +3038,13 @@ purpose compiled language.
   (2026-07-05) adds the `topology { }` block (declare the host's
   nodes / L3 domains / reserved cores) and `pinned(node = N)` /
   `pinned(l3 = name)` — target a domain by name and the mask
-  becomes its cores. This slice is thread affinity only; binding
-  a node-pinned locus's *arena* to that node's memory (the
-  thread + memory co-location that motivates NUMA targeting) is
-  the follow-up slice.
+  becomes its cores. A node/l3-pinned locus gets the full
+  **thread + memory co-location** that motivates NUMA targeting:
+  its arena (and method scratch) is `mbind`-bound to the node, so
+  its working set lives on the node its thread runs on — cross-
+  node access, the thing that kills big-box perf, is avoided on
+  both axes. Raw `mbind` syscall, so no libnuma dependency;
+  best-effort and zero-cost off the opt-in path.
 - Per-method scratch (Phase 4, 2026-05-21) → tight
   allocate-touch-free loop on every method invocation →
   naturally L1-hot for the duration of one handler.

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -340,19 +340,37 @@ topology {
 A `placement { }` entry then targets a domain: `pinned(node =
 0)` sets the thread's affinity mask to node 0's core set (the
 union of its L3 domains — here `{4..12}`), and `pinned(l3 =
-fast)` sets it to the named domain's cores (`{4..8}`). This is
-the same cpuset affinity mechanism as `pinned(cores = ...)`;
-the compiler resolves the domain to a concrete core set at
-compile time (closed-world: node ids and domain cores are
-literals). Resolution is **thread affinity only** in this
-slice — binding a node-pinned locus's *arena* to that node's
-memory (the thread + memory co-location payoff) is a follow-up.
-Validation (unique node ids, globally-unique L3 names,
+fast)` sets it to the named domain's cores (`{4..8}`). The
+compiler resolves the domain to a concrete core set at compile
+time (closed-world: node ids and domain cores are literals),
+reusing the same cpuset affinity mechanism as `pinned(cores =
+...)`. Validation (unique node ids, globally-unique L3 names,
 non-overlapping domains, no domain/reserved overlap, and every
-`pinned(node/l3)` referencing a declared domain) is static; the
-runtime honoring stays best-effort and Linux-only, exactly like
-`pinned(core = N)`. L3-domain names go through the identifier
-rule, so a hard keyword (e.g. `bulk`) can't name a domain.
+`pinned(node/l3)` referencing a declared domain) is static. L3
+domain names go through the identifier rule, so a hard keyword
+(e.g. `bulk`) can't name a domain.
+
+**Thread + memory co-location.** A `pinned(node = N)` /
+`pinned(l3 = name)` locus binds not just its thread but its
+*memory*: its arena is created via
+`lotus_arena_create_labeled_on_node`, which flags the arena's
+NUMA node, and every chunk that arena grows is `mmap`'d
+(page-aligned) and bound to the node with the `mbind` syscall
+(`MPOL_BIND`) before first touch — so pages fault in on the
+node regardless of which thread touches them first (the locus
+struct is instantiated on `main` but runs on its own pinned
+thread). Sub-regions inherit the node, so a node-pinned locus's
+**method scratch** — the dominant per-invocation allocation —
+lands on its node too. `mbind` is invoked as a raw syscall, so
+this adds **no libnuma dependency**; the whole feature is
+zero-cost for programs that don't opt in (an unbound arena, the
+default, takes the ordinary malloc / chunk-pool path
+byte-for-byte). Best-effort and Linux-only, exactly like
+`pinned(core = N)`: an `mbind` the box can't honor (node absent,
+capability denied) falls back to first-touch, and on non-Linux
+hosts the arena allocates normally. (Huge-page-backed chunks
+and node binding don't currently combine — a node-bound arena
+uses regular pages; a follow-up.)
 
 **Single-threaded-method invariant.** A locus's methods may
 be invoked only on the OS thread that owns its placement's

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1881,9 +1881,15 @@ main locus App {
     closed-world (ids and domain cores are literals), so the
     selected core set is known at compile time. Whether those
     cores exist on the deploy box stays best-effort at runtime.
-    This slice resolves `node`/`l3` to *thread* affinity (reusing
-    the Phase 1a cpuset path); arena-on-node memory co-location is
-    a follow-up. (Topology Phase 1b, 2026-07-05.)
+    A `pinned(node/l3)` locus gets **thread + memory
+    co-location**: its thread is affinity-masked to the domain's
+    cores (Phase 1a cpuset path) *and* its arena — including
+    method-scratch sub-regions — is `mbind`-bound to the node, so
+    its working set lives on the node its thread runs on.
+    Node binding is a raw `mbind` syscall (no libnuma dependency),
+    Linux-only and best-effort (falls back to first-touch when
+    the node can't be honored); non-node arenas are unchanged.
+    (Topology Phase 1b, 2026-07-05.)
 
 ### Single-threaded-method invariant
 


### PR DESCRIPTION
Arena-on-node NUMA memory co-location (`mbind` the arena to the node its thread runs on). Re-created against main after the stack rebase; supersedes #170. Rebased, single-commit diff. Locally gated: 277 test binaries + ASan corpus green, mbind verified via strace.