### PR TITLE
feat(perspective): bus surface in the contract + conformance (perspectives 2c)

### DIFF
--- a/crates/hale-codegen/src/mangle.rs
+++ b/crates/hale-codegen/src/mangle.rs
@@ -301,6 +301,20 @@ impl<'a> QualifiedRenameApplier<'a> {
                             }
                         }
                         PerspectiveMember::StableWhen(_) => {}
+                        // Phase 2c: contract bus surface — rewrite
+                        // subject payload types like a locus bus block.
+                        PerspectiveMember::Bus(bb) => {
+                            for bm in &mut bb.members {
+                                match bm {
+                                    BusMember::Subscribe { ty, .. }
+                                    | BusMember::Publish { ty, .. } => {
+                                        if let Some(t) = ty {
+                                            self.rewrite_type_expr(t);
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -636,6 +650,30 @@ impl<'a> Mangler<'a> {
                 PerspectiveMember::StableWhen(b) => self.walk_block(b),
                 PerspectiveMember::SerializeAs(t) => self.walk_type_expr(t),
                 PerspectiveMember::Fn(f) => self.walk_fn_decl(f),
+                // Phase 2c: contract bus surface.
+                PerspectiveMember::Bus(bb) => {
+                    for bm in &mut bb.members {
+                        match bm {
+                            BusMember::Subscribe { subject, handler, ty, .. } => {
+                                if let BusSubject::Topic(id) = subject {
+                                    self.rewrite_ident(&mut id.name);
+                                }
+                                self.rewrite_ident(&mut handler.name);
+                                if let Some(t) = ty {
+                                    self.walk_type_expr(t);
+                                }
+                            }
+                            BusMember::Publish { subject, ty, .. } => {
+                                if let BusSubject::Topic(id) = subject {
+                                    self.rewrite_ident(&mut id.name);
+                                }
+                                if let Some(t) = ty {
+                                    self.walk_type_expr(t);
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/hale-codegen/tests/fixtures/examples/62-perspective-bus-contract/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/62-perspective-bus-contract/main.hl
@@ -1,0 +1,52 @@
+// 62-perspective-bus-contract — a perspective contract that
+// declares its BUS surface, not just its sync methods
+// (perspectives, Phase 2c).
+//
+// The async slot: a perspective reached over the bus dispatches
+// to "the current impl's mailbox." So the CONTRACT — the stable
+// ABI a swap is checked against — must be able to name the bus
+// edges too, exactly as it names the sync `fn`s:
+//
+//   perspective OrderRouter {
+//       fn health() -> Int;                          // sync ABI
+//       bus { subscribe "orders" as on_order of type Order; }
+//   }
+//
+// A `serves` impl must provide every declared edge — the sync
+// methods AND the bus subscriptions — checked structurally.
+//
+// This slice ships the contract surface + conformance. The live
+// mailbox re-point on `reperspective` (re-pointing a bus-backed
+// perspective's subscriptions atomically) is the follow-up; until
+// it lands, swapping a bus-backed perspective is a compile error.
+
+type Order { id: Int; }
+
+perspective OrderRouter {
+    fn health() -> Int;
+    bus { subscribe "orders" as on_order of type Order; }
+}
+
+locus RouterV1 : serves OrderRouter {
+    fn health() -> Int { return 1; }
+    bus { subscribe "orders" as on_order of type Order; }
+    fn on_order(o: Order) {
+        println("routed an order");
+    }
+}
+
+main locus App {
+    params {
+        router: perspective(OrderRouter) = RouterV1 { };
+    }
+    run() {
+        // Sync dispatch through the perspective slot still works;
+        // the impl's bus subscription is live via the normal bus.
+        println(self.router.health());
+        println("order router up (contract declares its bus surface)");
+    }
+}
+
+fn main() {
+    App { };
+}

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -1368,6 +1368,13 @@ pub enum PerspectiveMember {
     StableWhen(Block),
     SerializeAs(TypeExpr),
     Fn(FnDecl),
+    /// Phase 2c (2026-07-06): the perspective contract's BUS surface
+    /// — `bus { subscribe "..." ...; publish "..." ...; }`. These
+    /// edges are part of the swappable ABI (a perspective reached
+    /// over the bus dispatches to "the current impl's mailbox"), so
+    /// a `serves` impl must provide them, exactly as it must provide
+    /// the contract `fn`s. Reuses the locus `bus { }` block shape.
+    Bus(BusBlock),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -3185,6 +3185,8 @@ impl Parser {
                 Ok(PerspectiveMember::SerializeAs(ty))
             }
             TokenKind::Fn => self.parse_contract_fn().map(PerspectiveMember::Fn),
+            // Phase 2c: the perspective contract's bus surface.
+            TokenKind::Bus => self.parse_bus_block().map(PerspectiveMember::Bus),
             other => Err(Diag::parse(
                 self.peek_token().span,
                 format!("expected perspective member, got {:?}", other),
@@ -7528,6 +7530,25 @@ fn main() { }
         assert_eq!(l.serves.len(), 1);
         assert_eq!(l.serves[0].name, "Router");
         assert_eq!(l.annotations.len(), 1);
+    }
+
+    #[test]
+    fn parse_perspective_bus_surface() {
+        let src = r#"
+type Order { id: Int; }
+perspective OrderRouter {
+    fn health() -> Int;
+    bus { subscribe "orders" as on_order of type Order; }
+}
+fn main() { }
+"#;
+        let prog = parse_str(src).expect("parse");
+        let p = prog.items.iter().find_map(|d| match d {
+            TopDecl::Perspective(p) => Some(p),
+            _ => None,
+        }).expect("perspective");
+        let has_bus = p.members.iter().any(|m| matches!(m, PerspectiveMember::Bus(_)));
+        assert!(has_bus, "expected a Bus member in the perspective contract");
     }
 
     #[test]

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -8279,6 +8279,32 @@ impl<'a> Checker<'a> {
                     ));
                 }
             }
+            // Phase 2c: bus-surface conformance — the impl must
+            // subscribe / publish every subject the contract declares.
+            for want in &persp.bus_subscribes {
+                if !locus.bus_subscribes.iter().any(|s| &s.subject == want) {
+                    self.diags.push(Diag::ty(
+                        persp_name.span,
+                        format!(
+                            "locus `{}` serves `{}` but does not subscribe \
+                             the contract subject `{}`",
+                            decl.name.name, persp_name.name, want
+                        ),
+                    ));
+                }
+            }
+            for want in &persp.bus_publishes {
+                if !locus.bus_publishes.iter().any(|s| &s.subject == want) {
+                    self.diags.push(Diag::ty(
+                        persp_name.span,
+                        format!(
+                            "locus `{}` serves `{}` but does not publish \
+                             the contract subject `{}`",
+                            decl.name.name, persp_name.name, want
+                        ),
+                    ));
+                }
+            }
         }
     }
 
@@ -8337,6 +8363,26 @@ impl<'a> Checker<'a> {
                 return;
             }
         };
+        // Phase 2c gate: swapping a perspective that has a BUS surface
+        // needs the async mailbox-swap runtime (re-point the current
+        // impl's subscriptions), which is not built yet. Reject with a
+        // clear message rather than silently leaving the old impl's
+        // subscriptions live.
+        if let Some(TopSymbol::Perspective(pi)) = self.top.lookup(&persp) {
+            if !pi.bus_subscribes.is_empty() || !pi.bus_publishes.is_empty() {
+                self.diags.push(Diag::ty(
+                    span,
+                    format!(
+                        "`reperspective self.{}`: perspective `{}` declares a \
+                         bus surface; swapping a bus-backed perspective isn't \
+                         supported yet (the async mailbox re-point is a \
+                         follow-up). A sync-only perspective can be swapped.",
+                        field.name, persp
+                    ),
+                ));
+                return;
+            }
+        }
         // The new impl must be a locus that serves this perspective.
         match self.top.lookup(&impl_name.name) {
             Some(TopSymbol::Locus(impl_info)) => {

--- a/crates/hale-types/src/resolve.rs
+++ b/crates/hale-types/src/resolve.rs
@@ -983,6 +983,23 @@ fn register_type(
     register_symbol(scope, &decl.name.name, TopSymbol::Type(info), decl.span, diags);
 }
 
+/// Phase 2c: a canonical string key for a bus subject, used to
+/// compare a perspective contract's bus edges against a serving
+/// locus's. Literal subjects use their text; topic refs use the
+/// topic name; qualified refs join the segments.
+fn bus_subject_key(subject: &BusSubject) -> String {
+    match subject {
+        BusSubject::Literal { subject, .. } => subject.clone(),
+        BusSubject::Topic(id) => id.name.clone(),
+        BusSubject::QualifiedTopic(path) => path
+            .segments
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect::<Vec<_>>()
+            .join("::"),
+    }
+}
+
 fn register_perspective(
     decl: &PerspectiveDecl,
     known: &BTreeMap<String, Span>,
@@ -992,8 +1009,23 @@ fn register_perspective(
     let mut params = Vec::new();
     let mut serialize_as = None;
     let mut methods: Vec<MethodInfo> = Vec::new();
+    let mut bus_subscribes: Vec<String> = Vec::new();
+    let mut bus_publishes: Vec<String> = Vec::new();
     for member in &decl.members {
         match member {
+            // Phase 2c: contract bus surface — collect subject keys.
+            PerspectiveMember::Bus(bb) => {
+                for bm in &bb.members {
+                    match bm {
+                        BusMember::Subscribe { subject, .. } => {
+                            bus_subscribes.push(bus_subject_key(subject));
+                        }
+                        BusMember::Publish { subject, .. } => {
+                            bus_publishes.push(bus_subject_key(subject));
+                        }
+                    }
+                }
+            }
             PerspectiveMember::Params(pb) => {
                 for p in &pb.params {
                     let ty = match &p.ty {
@@ -1051,6 +1083,8 @@ fn register_perspective(
         params,
         serialize_as,
         methods,
+        bus_subscribes,
+        bus_publishes,
         span: decl.span,
     };
     register_symbol(

--- a/crates/hale-types/src/symbol.rs
+++ b/crates/hale-types/src/symbol.rs
@@ -252,6 +252,12 @@ pub struct PerspectiveInfo {
     pub params: Vec<ParamInfo>,
     pub serialize_as: Option<Ty>,
     pub methods: Vec<MethodInfo>,
+    /// Phase 2c: the contract's bus surface — the subjects the
+    /// perspective subscribes / publishes (as canonical subject
+    /// keys). A `serves` impl must subscribe / publish each of
+    /// these. Empty for a sync-only perspective.
+    pub bus_subscribes: Vec<String>,
+    pub bus_publishes: Vec<String>,
     pub span: Span,
 }
 

--- a/crates/hale-types/tests/perspective_serves.rs
+++ b/crates/hale-types/tests/perspective_serves.rs
@@ -199,3 +199,88 @@ fn main() { App { }; }
         msgs
     );
 }
+
+// === Phase 2c: bus surface in the contract ====================
+
+#[test]
+fn bus_perspective_conforming_clean() {
+    let src = r#"
+type Order { id: Int; }
+perspective OrderRouter {
+    fn health() -> Int;
+    bus { subscribe "orders" as on_order of type Order; }
+}
+locus RouterV1 : serves OrderRouter {
+    fn health() -> Int { return 1; }
+    bus { subscribe "orders" as on_order of type Order; }
+    fn on_order(o: Order) { }
+}
+main locus App { params { r: perspective(OrderRouter) = RouterV1 { }; } run() { } }
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    // The only diagnostic is the orphan-topic warning (the demo has
+    // no publisher for "orders"); no conformance error should fire.
+    assert!(
+        msgs.iter().all(|m| !m.contains("does not subscribe")
+            && !m.contains("does not publish")
+            && !m.contains("missing contract method")),
+        "expected no conformance error on a conforming bus-perspective, got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn bus_perspective_missing_subscription_rejected() {
+    let src = r#"
+type Order { id: Int; }
+perspective OrderRouter {
+    fn health() -> Int;
+    bus { subscribe "orders" as on_order of type Order; }
+}
+locus RouterV1 : serves OrderRouter {
+    fn health() -> Int { return 1; }
+}
+main locus App { params { r: RouterV1 = RouterV1 { }; } run() { } }
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("does not subscribe") && m.contains("orders")),
+        "expected missing-subscription diagnostic, got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn reperspective_bus_perspective_gated() {
+    let src = r#"
+type Order { id: Int; }
+perspective OrderRouter {
+    fn health() -> Int;
+    bus { subscribe "orders" as on_order of type Order; }
+}
+locus RouterV1 : serves OrderRouter {
+    fn health() -> Int { return 1; }
+    bus { subscribe "orders" as on_order of type Order; }
+    fn on_order(o: Order) { }
+}
+locus RouterV2 : serves OrderRouter {
+    fn health() -> Int { return 2; }
+    bus { subscribe "orders" as on_order of type Order; }
+    fn on_order(o: Order) { }
+}
+locus Gateway {
+    params { r: perspective(OrderRouter) = RouterV1 { }; }
+    run() { reperspective self.r as RouterV2; }
+}
+main locus App { params { gw: Gateway = Gateway { }; } run() { } }
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("bus surface") && m.contains("supported yet")),
+        "expected bus-perspective swap gate, got: {:?}",
+        msgs
+    );
+}

--- a/docs/src/services/perspectives.md
+++ b/docs/src/services/perspectives.md
@@ -124,3 +124,29 @@ A few rules:
   impl. The old impl stays resident until the program exits (a
   bounded, program-lifetime cost for now); reclaiming it at swap
   time is a follow-up.
+
+## Contracts can declare a bus surface
+
+A perspective reached over the bus dispatches to *the current
+impl's mailbox* — so the contract, the thing a swap is checked
+against, can name its bus edges too, not just its sync methods:
+
+```hale
+type Order { id: Int; }
+
+perspective OrderRouter {
+    fn health() -> Int;                            // sync ABI
+    bus { subscribe "orders" as on_order of type Order; }
+}
+```
+
+A `serves` impl must provide every declared edge — the methods
+*and* the bus subscriptions — checked structurally, the same way
+it must provide the `fn`s. This keeps a perspective's full ABI in
+one place.
+
+Today this ships the contract surface and its conformance check.
+Live-swapping a *bus-backed* perspective — atomically re-pointing
+its subscriptions to a new impl — is a follow-up; until it lands,
+`reperspective` on a perspective that declares a bus surface is a
+compile error (a sync-only perspective swaps fine).

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -618,7 +618,14 @@ perspective_member= params_block
                   | "stable_when" , block
                   | "serialize_as" , type_expr , ";"
                   | contract_fn
+                  | bus_block
                   ;
+(* Phase 2c (2026-07-06): a perspective contract may declare its BUS
+   surface (`bus { subscribe/publish ... }`, the locus bus-block
+   shape). These edges are part of the swappable ABI; a `serves`
+   impl must provide each declared subject. Swapping a bus-backed
+   perspective needs the async mailbox re-point (a follow-up); until
+   then `reperspective` on such a perspective is rejected. *)
 (* Phase 2a: a perspective's `fn` members are CONTRACT signatures
    — a bodyless `fn route(r: Req) -> Resp;` declares the ABI a
    `serves`-ing locus must provide. A bodied `fn { ... }` is still

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -2253,9 +2253,14 @@ locus Gateway {
 
 **`serves` conformance (error).** A `locus L : serves P` must
 provide every contract method P declares — matching arity, param
-types, and return type. A missing or mismatched method, or
-`serves` naming an unknown / non-perspective symbol, is a
-typecheck error. This is the perspective analog of interface
+types, and return type — **and** (Phase 2c) every bus edge P's
+contract declares: a `bus { subscribe/publish ... }` block in the
+perspective is part of the ABI, so a serving impl must subscribe /
+publish each named subject. A missing or mismatched method, a
+missing bus edge, or `serves` naming an unknown / non-perspective
+symbol, is a typecheck error. Live-swapping a bus-backed
+perspective (re-pointing its subscriptions) is a follow-up; until
+then `reperspective` on such a perspective is rejected. This is the perspective analog of interface
 structural satisfaction (and reuses its shape). The synthesized
 `is_stable` (from `stable_when`) is not a contract method the impl
 must provide.


### PR DESCRIPTION
The async half of a perspective's ABI (contract surface). A perspective reached over the bus dispatches to *the current impl's mailbox*, so the **contract** can declare its bus edges too — not just its sync `fn`s. This slice ships the contract surface + conformance; the runtime async routing (publish→perspective→current mailbox, and `reperspective` re-pointing subscriptions) is a follow-up.

```hale
perspective OrderRouter {
    fn health() -> Int;                            // sync ABI
    bus { subscribe "orders" as on_order of type Order; }
}
locus RouterV1 : serves OrderRouter {              // must provide BOTH
    fn health() -> Int { return 1; }
    bus { subscribe "orders" as on_order of type Order; }
    fn on_order(o: Order) { ... }
}
```

## Changes
- **ast/parser** — `PerspectiveMember::Bus(BusBlock)` (reuses the locus bus-block shape).
- **typecheck** — `PerspectiveInfo` gains bus_subscribes/bus_publishes; `check_serves_conformance` verifies the impl provides each contract bus edge alongside the methods.
- **gate** — `reperspective` on a bus-backed perspective is rejected (the async mailbox re-point is a follow-up); sync-only perspectives still swap.
- **spec/docs** — grammar.ebnf, semantics.md, docs/src perspectives chapter.

## Testing
- `62-perspective-bus-contract` fixture (corpus + ASan + examples parse).
- Parser + typecheck tests (conforming clean; missing subscription rejected; bus-perspective swap gated).
- Full `cargo test --release --workspace -- --test-threads=1`: **277 binaries, 0 failures**; corpus 69 fixtures clean + ASan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)