### PR TITLE
test(udp): kill the loopback round-trip flake under nextest concurrency

### DIFF
--- a/crates/hale-codegen/tests/udp_primitives.rs
+++ b/crates/hale-codegen/tests/udp_primitives.rs
@@ -48,12 +48,23 @@ fn build_and_run(name: &str, source: &str) -> (String, String, std::process::Exi
 
 #[test]
 fn send_recv_round_trip_over_loopback() {
-    let port = pick_free_port();
-    // Receiver binds first, sender binds ephemeral port (port 0
-    // = OS-assigned), then sends. Receiver loops on recv,
-    // converts bytes back to a String for comparison.
-    let src = format!(
-        r#"
+    // `pick_free_port` has an unavoidable TOCTOU window: between
+    // dropping the probe and the compiled program's UDP bind, a
+    // concurrent test process (nextest runs test binaries in
+    // parallel) can claim the port, so the bind fails and the
+    // program exits nonzero. That's a pure port race, not a logic
+    // bug — retry with a FRESH port a few times. The round-trip is
+    // deterministic once the bind succeeds, so a real failure still
+    // surfaces (all attempts fail identically), while the race
+    // needs several consecutive collisions to leak through.
+    let mut last: Option<(String, String, std::process::ExitStatus)> = None;
+    for attempt in 0..5 {
+        let port = pick_free_port();
+        // Receiver binds first, sender binds ephemeral port (port 0
+        // = OS-assigned), then sends. Receiver loops on recv,
+        // converts bytes back to a String for comparison.
+        let src = format!(
+            r#"
         fn main() {{
             let recv_fd = std::io::udp::bind("127.0.0.1", {port}) or raise;
             let send_fd = std::io::udp::bind("", 0) or raise;
@@ -66,14 +77,23 @@ fn send_recv_round_trip_over_loopback() {
             std::io::udp::close(recv_fd);
         }}
     "#,
-        port = port,
-    );
-    let (stdout, stderr, status) = build_and_run("rt", &src);
-    assert!(status.success(), "exit: {:?}\nstderr: {}", status, stderr);
-    assert!(
-        stdout.contains("got=hello, hale udp"),
-        "missing payload; stdout: {:?}",
-        stdout,
+            port = port,
+        );
+        let (stdout, stderr, status) = build_and_run("rt", &src);
+        if status.success() && stdout.contains("got=hello, hale udp") {
+            return; // clean round-trip
+        }
+        eprintln!(
+            "udp round-trip attempt {} failed (likely port {} race), retrying",
+            attempt, port
+        );
+        last = Some((stdout, stderr, status));
+    }
+    let (stdout, stderr, status) = last.expect("at least one attempt");
+    panic!(
+        "udp round-trip failed after 5 attempts; \
+         exit: {:?}\nstderr: {}\nstdout: {:?}",
+        status, stderr, stdout
     );
 }
 


### PR DESCRIPTION
`hale-codegen::udp_primitives::send_recv_round_trip_over_loopback` intermittently reddened the `tests` job on `main` (failed the 2a and 2c merge runs, passed 2b — same code, pure timing).

## Root cause
`pick_free_port()` probes a free port with a `TcpListener`, drops it, then the compiled `.hl` program binds UDP on that port. Between the drop and the bind there's an unavoidable TOCTOU window — and nextest runs test binaries **in parallel**, so a concurrent test process can claim the port first. The bind fails, `or raise` exits nonzero, the test fails. Not a logic bug — a shared-resource race.

## Fix
Retry the round-trip up to 5 times, each with a **fresh** port; only fail if every attempt fails (nonzero exit *or* missing payload). Deterministic once the bind wins the port, so a genuine regression still fails all 5 identically, while the race now needs 5 consecutive collisions to leak — negligible. Compile is ~0.15s, so retries are cheap and only pay when the race fires.

## Verified
6 consecutive full-workspace `cargo nextest run --release --workspace` passes clean (1631/1631), vs a ~1-in-4 failure rate before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)