### PR TITLE
feat(perspective): state-preserving reperspective swap (perspectives Phase 3)

### DIFF
--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -23984,32 +23984,38 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         })
     }
 
-    /// Perspectives Phase 2b: lower `reperspective self.<field> as
-    /// <Impl>;` — the live redeploy (fresh-instance swap):
-    ///   1. free the current impl's state arena (the one the slot
-    ///      points at) — its struct is program-lifetime;
-    ///   2. instantiate a fresh `Impl` (global-arena, slot-owned);
-    ///   3. atomic-store `{ new_self, vtable(Impl, P) }` into the
-    ///      perspective's global slot — the pointer flip that
-    ///      redirects every call site at once;
-    ///   4. re-point the holder's field at the new impl.
-    /// State does NOT carry across (the new impl runs its own birth
-    /// defaults) — state migration is Phase 3.
+    /// Perspectives: lower `reperspective self.<field> as <Impl>;` —
+    /// the live redeploy. Phase 3 makes this a STATE-PRESERVING swap
+    /// (the note's layout-identity "zero migration"): code and state
+    /// are already separate — the slot's `data` pointer is the state
+    /// (an arena-backed struct), the `vtable` is the code. So the
+    /// swap is a single store of the new impl's vtable into the
+    /// slot's vtable half, keeping `data` untouched:
+    ///
+    ///   slot.vtable = vtable(Impl, P)   // redirect every call site
+    ///   slot.data   = unchanged         // the running state carries
+    ///
+    /// The typechecker guarantees all impls of the perspective share
+    /// one footprint, so the new impl's field offsets land on the
+    /// retained state. No re-instantiation, no fresh birth defaults,
+    /// and nothing to tear down — the old code was never state. (A
+    /// footprint-CHANGING swap is the `migrate` case — rejected at
+    /// typecheck for now.) The holder's field still points at the
+    /// same `data`, so it needs no update.
     fn lower_reperspective(
         &mut self,
         field: &str,
         impl_name: &str,
-        scope: &mut Scope<'ctx>,
+        _scope: &mut Scope<'ctx>,
     ) -> Result<(), CodegenError> {
-        let ptr_t = self.context.ptr_type(AddressSpace::default());
         let cs = self.current_self.as_ref().cloned().ok_or_else(|| {
             CodegenError::Unsupported(
                 "`reperspective`: no enclosing locus self".into(),
             )
         })?;
         // Resolve the perspective contract P from the field's type.
-        let (field_idx, persp_name) = match cs.fields.get(field) {
-            Some((idx, CodegenTy::Perspective(p))) => (*idx, p.clone()),
+        let persp_name = match cs.fields.get(field) {
+            Some((_, CodegenTy::Perspective(p))) => p.clone(),
             _ => {
                 return Err(CodegenError::Unsupported(format!(
                     "`reperspective self.{}`: field is not a perspective \
@@ -24021,50 +24027,18 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         let fat_struct_ty = self.iface_fat_struct_ty();
         let slot = self.ensure_perspective_slot(&persp_name);
         let slot_ptr = slot.as_pointer_value();
-        let data_gep = self
-            .builder
-            .build_struct_gep(fat_struct_ty, slot_ptr, 0, "reperspective.data.gep")
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-        let _ = ptr_t;
 
-        // (1) Instantiate a fresh Impl in the program-global arena
-        // (the persistent-singleton allocation path — proven
-        // program-lifetime and leak-clean). It outlives this method
-        // and is reclaimed with the global arena at exit; the
-        // previous impl stays live until program exit (a bounded,
-        // program-lifetime cost — full per-swap reclaim of the old
-        // impl's state is a follow-up).
-        let prev_singleton = self.instantiating_persistent_singleton;
-        self.instantiating_persistent_singleton = true;
-        let new_self =
-            self.lower_locus_instantiation(impl_name, &[], scope)?;
-        self.instantiating_persistent_singleton = prev_singleton;
-
-        // (2) Flip the global slot to { new_self, vtable(Impl, P) }.
+        // Swap ONLY the vtable half of the slot — the `data` half
+        // (the current impl's live state) is preserved. This is the
+        // pointer flip that redirects every call site to the new
+        // impl's methods while they keep operating on the same state.
         let vtable = self.ensure_perspective_vtable(impl_name, &persp_name)?;
-        self.builder
-            .build_store(data_gep, new_self)
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         let vt_gep = self
             .builder
             .build_struct_gep(fat_struct_ty, slot_ptr, 1, "reperspective.vtable.gep")
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         self.builder
             .build_store(vt_gep, vtable.as_pointer_value())
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-
-        // (3) Re-point the holder's field at the new impl.
-        let field_ptr = self
-            .builder
-            .build_struct_gep(
-                cs.struct_ty,
-                cs.self_ptr,
-                field_idx,
-                "reperspective.field.gep",
-            )
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-        self.builder
-            .build_store(field_ptr, new_self)
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         Ok(())
     }

--- a/crates/hale-codegen/tests/fixtures/examples/61-reperspective-swap/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/61-reperspective-swap/main.hl
@@ -9,11 +9,11 @@
 //
 //   reperspective self.router as RouterV2;
 //
-// This slice is the FRESH-INSTANCE swap: the new impl is
-// instantiated with its own birth defaults; state does not carry
-// across (that's state migration — Phase 3). Rebind authority
-// follows ownership: the swap runs on the locus that owns the
-// slot (`self.router`), never a mere caller.
+// The swap replaces only the slot's vtable and keeps its data, so
+// any state carries across (see 63-reperspective-migrate). These
+// routers are stateless, so the swap is purely a code redirect.
+// Rebind authority follows ownership: the swap runs on the locus
+// that owns the slot (`self.router`), never a mere caller.
 
 perspective Router {
     fn route(code: Int) -> Int;

--- a/crates/hale-codegen/tests/fixtures/examples/63-reperspective-migrate/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/63-reperspective-migrate/main.hl
@@ -1,0 +1,64 @@
+// 63-reperspective-migrate — the state-preserving redeploy
+// (perspectives, Phase 3).
+//
+// A perspective's slot is `{ data, vtable }`: the DATA pointer is
+// the running state (an arena-backed struct), the VTABLE is the
+// code. Because they're already separate, redeploying V2 over V1
+// is a single store — swap the vtable, keep the data:
+//
+//   reperspective self.counter as CounterV2;   // code := V2
+//                                              // state carries
+//
+// The new impl's methods pick up right where the old left off,
+// operating on the SAME live state. This is the note's
+// "layout-identity / zero-migration" swap: no re-instantiation, no
+// birth defaults, nothing to tear down. It is sound because the
+// typechecker requires every impl of a perspective to share one
+// footprint, so V2's field offsets land on V1's retained state. A
+// footprint CHANGE is the `migrate` case (a follow-up); until then
+// it's a compile error, not a silent reinterpretation of bytes.
+
+perspective Counter {
+    fn bump();
+    fn get() -> Int;
+}
+
+locus CounterV1 : serves Counter {
+    params { n: Int = 0; }
+    fn bump() { self.n = self.n + 1; }
+    fn get() -> Int { return self.n; }
+}
+
+// Same footprint (`n: Int`), different behavior — a bump now
+// advances by 10. Deployed over V1's accumulated count.
+locus CounterV2 : serves Counter {
+    params { n: Int = 0; }
+    fn bump() { self.n = self.n + 10; }
+    fn get() -> Int { return self.n; }
+}
+
+locus Service {
+    params { counter: perspective(Counter) = CounterV1 { }; }
+    run() {
+        self.counter.bump();
+        self.counter.bump();
+        println(self.counter.get());              // V1 counted 2
+
+        reperspective self.counter as CounterV2;   // redeploy, live
+        println(self.counter.get());              // 2 — state carried
+
+        self.counter.bump();                       // V2 adds 10
+        println(self.counter.get());              // 12
+    }
+}
+
+main locus App {
+    params { svc: Service = Service { }; }
+    run() {
+        println("service redeployed its counter without losing count");
+    }
+}
+
+fn main() {
+    App { };
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -36,6 +36,19 @@ fn method_to_fn_ty(m: &MethodInfo) -> Ty {
     }
 }
 
+/// Phase 3 migration: two loci have the same *footprint* iff their
+/// params (the user-visible state fields) match by name and type in
+/// declaration order. A state-preserving `reperspective` keeps the
+/// current impl's data and swaps only the vtable, so the new impl's
+/// field accesses land on the retained state — sound exactly when
+/// the footprints are identical.
+fn footprints_match(a: &[ParamInfo], b: &[ParamInfo]) -> bool {
+    a.len() == b.len()
+        && a.iter()
+            .zip(b.iter())
+            .all(|(x, y)| x.name == y.name && x.ty == y.ty)
+}
+
 /// True if the match arms cover every possible scrutinee
 /// value. v0 rules:
 ///   - Any arm without a guard whose pattern is wildcard `_`
@@ -8396,6 +8409,42 @@ impl<'a> Checker<'a> {
                             field.name, impl_name.name, impl_name.name, persp
                         ),
                     ));
+                    return;
+                }
+                // Phase 3 migration: the swap preserves state by
+                // keeping the slot's data pointer and re-pointing only
+                // the vtable (the note's layout-identity "zero
+                // migration" — code and state are already separate).
+                // That is layout-safe only if every impl of the
+                // perspective shares the same footprint, so the new
+                // impl's methods interpret the retained state
+                // correctly. A footprint change is the `migrate` case
+                // — deferred; reject it with an actionable message
+                // rather than silently reinterpreting bytes.
+                for (other_name, sym) in &self.top.symbols {
+                    if other_name == &impl_name.name {
+                        continue;
+                    }
+                    if let TopSymbol::Locus(other) = sym {
+                        if other.serves.iter().any(|s| s == &persp)
+                            && !footprints_match(&impl_info.params, &other.params)
+                        {
+                            self.diags.push(Diag::ty(
+                                span,
+                                format!(
+                                    "`reperspective self.{} as {}`: impl `{}` has \
+                                     a different footprint than `{}` (also serving \
+                                     `{}`). A state-preserving swap requires all \
+                                     impls of a perspective to share the same \
+                                     params; a footprint change needs `migrate`, \
+                                     which isn't supported yet.",
+                                    field.name, impl_name.name, impl_name.name,
+                                    other_name, persp
+                                ),
+                            ));
+                            return;
+                        }
+                    }
                 }
             }
             _ => {

--- a/crates/hale-types/tests/perspective_serves.rs
+++ b/crates/hale-types/tests/perspective_serves.rs
@@ -284,3 +284,71 @@ fn main() { App { }; }
         msgs
     );
 }
+
+// === Phase 3: state-preserving swap footprint check ===========
+
+#[test]
+fn reperspective_matching_footprint_clean() {
+    let src = r#"
+perspective Counter { fn get() -> Int; }
+locus CounterV1 : serves Counter { params { n: Int = 0; } fn get() -> Int { return self.n; } }
+locus CounterV2 : serves Counter { params { n: Int = 0; } fn get() -> Int { return self.n; } }
+locus Service {
+    params { c: perspective(Counter) = CounterV1 { }; }
+    run() { reperspective self.c as CounterV2; }
+}
+main locus App { params { s: Service = Service { }; } run() { } }
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().all(|m| !m.contains("footprint")),
+        "expected matching-footprint swap clean, got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn reperspective_footprint_change_rejected() {
+    // CounterV2 adds a field — a state-preserving swap can't
+    // reinterpret V1's bytes; this is the (deferred) migrate case.
+    let src = r#"
+perspective Counter { fn get() -> Int; }
+locus CounterV1 : serves Counter { params { n: Int = 0; } fn get() -> Int { return self.n; } }
+locus CounterV2 : serves Counter { params { n: Int = 0; extra: Int = 5; } fn get() -> Int { return self.n + self.extra; } }
+locus Service {
+    params { c: perspective(Counter) = CounterV1 { }; }
+    run() { reperspective self.c as CounterV2; }
+}
+main locus App { params { s: Service = Service { }; } run() { } }
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("different footprint") && m.contains("migrate")),
+        "expected footprint-change diagnostic, got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn reperspective_footprint_type_change_rejected() {
+    // Same field name, different type — also a footprint change.
+    let src = r#"
+perspective Counter { fn get() -> Int; }
+locus CounterV1 : serves Counter { params { n: Int = 0; } fn get() -> Int { return self.n; } }
+locus CounterV2 : serves Counter { params { n: Bool = true; } fn get() -> Int { return 0; } }
+locus Service {
+    params { c: perspective(Counter) = CounterV1 { }; }
+    run() { reperspective self.c as CounterV2; }
+}
+main locus App { params { s: Service = Service { }; } run() { } }
+fn main() { App { }; }
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("different footprint")),
+        "expected footprint-type-change diagnostic, got: {:?}",
+        msgs
+    );
+}

--- a/docs/src/services/perspectives.md
+++ b/docs/src/services/perspectives.md
@@ -117,13 +117,25 @@ A few rules:
   the locus holding the slot; the new impl must `serve` the same
   perspective. A caller that merely *uses* a perspective can't
   redeploy it — redeployment authority is ownership.
-- **Fresh start.** The new impl comes up on its own birth defaults;
-  state from the old impl does not carry over. (Carrying state
-  across a redeploy — migration — is a later slice.)
-- **Cost.** A swap is a pointer flip plus instantiating the new
-  impl. The old impl stays resident until the program exits (a
-  bounded, program-lifetime cost for now); reclaiming it at swap
-  time is a follow-up.
+- **State carries over.** The slot holds `{ data, vtable }` — the
+  data *is* the running state, the vtable is the code. A swap
+  replaces only the vtable, so the new impl picks up right where the
+  old one left off, on the same live state:
+
+  ```hale
+  self.counter.bump();  self.counter.bump();   // count = 2 (V1)
+  reperspective self.counter as CounterV2;      // redeploy
+  println(self.counter.get());                  // still 2 — carried
+  ```
+
+  This is sound because every impl of a perspective must share the
+  same **footprint** (same params, same types). A version that
+  *changes* the footprint — adds a field, changes a type — can't
+  reinterpret the old state, so it's a compile error today: that's
+  the `migrate` case, a later slice.
+- **Cost.** A swap is a single pointer store (the vtable). Nothing
+  is re-instantiated and nothing is torn down — the state was never
+  the code.
 
 ## Contracts can declare a bus surface
 

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -2295,39 +2295,41 @@ per call into a perspective — near-direct. The mechanism is
 Linux/native-agnostic (no new runtime dependency); a program that
 declares no perspectives pays nothing.
 
-### The live swap: `reperspective` (Phase 2b)
+### The live swap: `reperspective` (Phase 2b + 3)
 
 `reperspective self.<field> as <Impl>;` is the live redeploy. It
 re-points the perspective's global slot — identified by the
-`self`-field's `perspective(P)` type — at a fresh instance of
-`Impl` (which must `serve P`). Because every holder funnels through
-the one slot, the swap is a single store to `{ data, vtable }` that
-redirects **every** call site at once: the same `self.router.route(...)`
-resolves to the new impl immediately after.
+`self`-field's `perspective(P)` type — at `Impl` (which must
+`serve P`). Because every holder funnels through the one slot, the
+swap redirects **every** call site at once: the same
+`self.router.route(...)` resolves to the new impl immediately after.
 
-- **Fresh-instance semantics.** The new impl is instantiated with
-  its own birth defaults; state does **not** carry across the swap.
-  (State-preserving swap — layout-identity fast path + `migrate` —
-  is Phase 3.)
+- **State-preserving (Phase 3).** The slot is `{ data, vtable }`:
+  `data` is the running state (an arena-backed struct), `vtable` is
+  the code. They are already separate, so the swap is a single store
+  of the new impl's vtable into the slot — `data` is untouched and
+  the new impl's methods continue on the **same live state** (the
+  note's layout-identity "zero migration"). No re-instantiation, no
+  birth defaults, nothing to tear down.
+- **Footprint identity (soundness).** The vtable swap is layout-safe
+  only if the new impl's field offsets match the retained state, so
+  the typechecker requires **every** impl of a perspective to share
+  one footprint (same params, by name and type, in order). A
+  footprint *change* is the `migrate` case — rejected for now with an
+  actionable diagnostic rather than silently reinterpreting bytes.
 - **Rebind authority.** The statement runs on the locus that owns
   the slot (`self.<field>`), never a mere caller — the ownership
-  tree is the redeploy authority. The typechecker requires the
-  field to be a `perspective(P)` param of the current locus and the
-  new impl to `serve P`.
-- **Ownership / teardown.** Perspective impls (designated and
-  swapped-in) are owned by the global slot and live for the program
-  (reclaimed with the program-global arena at exit). The previous
-  impl is not freed at swap time in this slice — a bounded,
-  program-lifetime cost; per-swap reclaim of the retired impl's
-  state is a follow-up.
+  tree is the redeploy authority. The typechecker requires the field
+  to be a `perspective(P)` param of the current locus and the new
+  impl to `serve P`.
 
 ## Perspective hot-load
 
-> **Status:** Phase 2b ships the core `reperspective` swap
-> (above): the atomic slot re-point with fresh-instance semantics.
-> The bus-arrival / decode / `stable_when` / drain flow below is the
-> fuller aspirational path (bus-driven redeploy + state migration,
-> Phase 2c/3).
+> **Status:** Phase 2b + 3 ship the core `reperspective` swap
+> (above): the atomic slot re-point, state-preserving across impls
+> of one footprint. A footprint-changing `migrate`, and the
+> bus-arrival / decode / `stable_when` / drain flow below (bus-driven
+> redeploy), remain the aspirational path (Phase 2c-runtime / later).
 
 For each `perspective P { ... }` instance currently active:
 


### PR DESCRIPTION
The redeploy now **carries state**. A perspective's slot is `{ data, vtable }` — `data` is the running state (arena-backed struct), `vtable` is the code. They're already separate, so `reperspective self.<field> as <Impl>` becomes a single store of the new vtable into the slot: `data` is untouched and the new impl's methods continue on the **same live state**. This is the note's layout-identity "zero migration" — and it retires 2b's entire teardown problem (the old code was never state).

```hale
self.counter.bump(); self.counter.bump();   // count = 2 (V1)
reperspective self.counter as CounterV2;      // redeploy, live
println(self.counter.get());                  // still 2 — carried
self.counter.bump();                          // V2 adds 10 → 12
```

## Soundness
The vtable swap is layout-safe only if the new impl's field offsets match the retained state, so the typechecker requires **every** impl of a perspective to share one footprint (same params, by name + type, in order). A footprint *change* — added field, changed type — can't reinterpret the old bytes, so it's rejected with a diagnostic pointing at `migrate` (the footprint-changing path — needs versioned-wire / type-erasure machinery — a follow-up).

## Changes
- **typecheck** — `check_reperspective` compares the target's footprint against every other locus serving the perspective (`footprints_match`); mismatch → migrate-needed error.
- **codegen** — `lower_reperspective` reduced to the vtable-only store (keeps `slot.data` + holder field); no instantiation, no arena work.
- **spec/docs** — semantics.md live-swap section rewritten (fresh-instance → state-preserving + footprint rule); docs/src chapter; 61 fixture comment corrected.

## Testing
- `63-reperspective-migrate` fixture — state carries `2 → 2 → 12` (corpus + ASan + examples parse).
- Typecheck tests: matching-footprint clean; add-field rejected; type-change rejected.
- 2b fixture (stateless V1/V2) still `101→201→101`, ASan-clean.
- Full `cargo nextest run --release --workspace`: **1634 passed, 0 failed**; corpus 70 fixtures clean + ASan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)