### PR TITLE
feat(perspective): bus subscriptions swap on reperspective (perspectives 2c runtime)

### DIFF
--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -24040,6 +24040,80 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         self.builder
             .build_store(vt_gep, vtable.as_pointer_value())
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+
+        // Phase 2c-runtime: re-point the perspective's BUS
+        // subscriptions to the new impl's handlers. The old impl
+        // registered them under `slot.data` (its self ptr); Phase 3
+        // keeps that same `data`, so we tombstone every subscription
+        // on it (`quarantine_self`) and re-register each of the new
+        // impl's subscriptions on the SAME `data`. Published messages
+        // now land on the new impl's handler, operating on the shared
+        // preserved state — the async counterpart of the sync vtable
+        // flip. (A bounded per-swap cost: tombstoned entries are
+        // skipped, not compacted.)
+        let impl_info = self.user_loci.get(impl_name).cloned();
+        if let Some(impl_info) = impl_info {
+            if !impl_info.subscriptions.is_empty() {
+                let ptr_t = self.context.ptr_type(AddressSpace::default());
+                let data_gep = self
+                    .builder
+                    .build_struct_gep(fat_struct_ty, slot_ptr, 0, "reperspective.data.gep")
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                let data = self
+                    .builder
+                    .build_load(ptr_t, data_gep, "reperspective.data")
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                    .into_pointer_value();
+                let quar = self
+                    .module
+                    .get_function("lotus_bus_quarantine_self")
+                    .expect("lotus_bus_quarantine_self declared");
+                self.builder
+                    .build_call(quar, &[data.into()], "reperspective.bus.deregister")
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                // Register the new impl's handlers. Set `current_self`
+                // to the new impl over the shared `data` so a subscribe
+                // key-filter's `self.X` resolves against it.
+                let prev_self = self.current_self.clone();
+                self.current_self = Some(SelfCx {
+                    locus_name: impl_name.to_string(),
+                    struct_ty: impl_info.struct_ty,
+                    self_ptr: data,
+                    fields: impl_info.fields.clone(),
+                });
+                for (subject, handler_name, payload_type, key_filter) in
+                    &impl_info.subscriptions
+                {
+                    let handler_fn =
+                        impl_info.user_methods.get(handler_name).copied().ok_or_else(
+                            || {
+                                CodegenError::Unsupported(format!(
+                                    "reperspective: impl `{}` subscribes `{}` \
+                                     with handler `{}` but no such method",
+                                    impl_name, subject, handler_name
+                                ))
+                            },
+                        )?;
+                    // Match the instantiation path: prefer the
+                    // handler-reclaim wrapper when one was synthesized.
+                    let reg_handler = self
+                        .handler_reclaim_wrappers
+                        .get(&(impl_name.to_string(), handler_name.clone()))
+                        .copied()
+                        .unwrap_or(handler_fn);
+                    self.emit_bus_register(
+                        subject,
+                        data,
+                        reg_handler,
+                        None,
+                        payload_type,
+                        key_filter.as_ref(),
+                        true,
+                    )?;
+                }
+                self.current_self = prev_self;
+            }
+        }
         Ok(())
     }
 

--- a/crates/hale-codegen/tests/fixtures/examples/64-perspective-bus-swap/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/64-perspective-bus-swap/main.hl
@@ -1,0 +1,65 @@
+// 64-perspective-bus-swap — hot-swapping a BUS-backed perspective
+// (perspectives, Phase 2c async runtime).
+//
+// A perspective's contract can declare a bus surface, and a
+// `reperspective` re-points that too: the swap tombstones the
+// current impl's subscriptions on the shared slot state and
+// re-registers the new impl's handlers on the SAME state. So a
+// message published after the swap lands on the new handler,
+// while state accumulated by the old handler carries across —
+// the async counterpart of the sync vtable flip.
+//
+//   "orders" <- Order { id: 1 };            // V1.on_order
+//   reperspective self.router as OrderV2;
+//   "orders" <- Order { id: 2 };            // V2.on_order, same state
+//
+// Note on ordering: cooperative bus dispatch is DEFERRED — a
+// publish enqueues a cell capturing the handler registered at
+// that moment, and the handlers run when the queue drains (after
+// run() returns). So the prints below appear after run()'s own
+// output, and each message runs on whichever impl was current
+// when it was published: message 1 on V1, message 2 on V2.
+
+type Order { id: Int; }
+
+perspective OrderRouter {
+    fn total() -> Int;
+    bus { subscribe "orders" as on_order of type Order; }
+}
+
+locus OrderV1 : serves OrderRouter {
+    params { sum: Int = 0; }
+    fn total() -> Int { return self.sum; }
+    bus { subscribe "orders" as on_order of type Order; }
+    fn on_order(o: Order) {
+        self.sum = self.sum + o.id;
+        println("v1 booked order ", o.id, ", running sum=", self.sum);
+    }
+}
+
+// Same footprint (`sum: Int`); a new pricing rule (10x weight).
+// Deployed live over V1's accumulated sum.
+locus OrderV2 : serves OrderRouter {
+    params { sum: Int = 0; }
+    fn total() -> Int { return self.sum; }
+    bus { subscribe "orders" as on_order of type Order; }
+    fn on_order(o: Order) {
+        self.sum = self.sum + (o.id * 10);
+        println("v2 booked order ", o.id, ", running sum=", self.sum);
+    }
+}
+
+locus Service {
+    params { router: perspective(OrderRouter) = OrderV1 { }; }
+    bus { publish "orders" of type Order; }
+    run() {
+        "orders" <- Order { id: 1 };             // → V1: sum 0 -> 1
+        reperspective self.router as OrderV2;     // redeploy the router
+        "orders" <- Order { id: 3 };             // → V2: sum 1 -> 31
+        println("service running; orders drain to the live router");
+    }
+}
+
+fn main() {
+    Service { };
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -8381,21 +8381,14 @@ impl<'a> Checker<'a> {
         // impl's subscriptions), which is not built yet. Reject with a
         // clear message rather than silently leaving the old impl's
         // subscriptions live.
-        if let Some(TopSymbol::Perspective(pi)) = self.top.lookup(&persp) {
-            if !pi.bus_subscribes.is_empty() || !pi.bus_publishes.is_empty() {
-                self.diags.push(Diag::ty(
-                    span,
-                    format!(
-                        "`reperspective self.{}`: perspective `{}` declares a \
-                         bus surface; swapping a bus-backed perspective isn't \
-                         supported yet (the async mailbox re-point is a \
-                         follow-up). A sync-only perspective can be swapped.",
-                        field.name, persp
-                    ),
-                ));
-                return;
-            }
-        }
+        // Phase 2c-runtime: a bus-backed perspective now swaps its
+        // subscriptions too (the codegen tombstones the current
+        // impl's registrations on the shared slot data and
+        // re-registers the new impl's handlers). Perspective impls
+        // are designated via a field default, never a `placement`
+        // entry, so they are always cooperative — the re-registration
+        // routes through the global queue, no mailbox hand-off. No
+        // gate needed.
         // The new impl must be a locus that serves this perspective.
         match self.top.lookup(&impl_name.name) {
             Some(TopSymbol::Locus(impl_info)) => {

--- a/crates/hale-types/tests/perspective_serves.rs
+++ b/crates/hale-types/tests/perspective_serves.rs
@@ -253,7 +253,10 @@ fn main() { App { }; }
 }
 
 #[test]
-fn reperspective_bus_perspective_gated() {
+fn reperspective_bus_perspective_allowed() {
+    // Phase 2c-runtime: swapping a bus-backed perspective is now
+    // supported (the codegen re-points the subscriptions), so long
+    // as the impls share a footprint like any other swap.
     let src = r#"
 type Order { id: Int; }
 perspective OrderRouter {
@@ -279,8 +282,10 @@ fn main() { App { }; }
 "#;
     let msgs = check(src);
     assert!(
-        msgs.iter().any(|m| m.contains("bus surface") && m.contains("supported yet")),
-        "expected bus-perspective swap gate, got: {:?}",
+        msgs.iter().all(|m| !m.contains("supported yet")
+            && !m.contains("bus surface")
+            && !m.contains("footprint")),
+        "expected bus-perspective swap to be allowed, got: {:?}",
         msgs
     );
 }

--- a/docs/src/services/perspectives.md
+++ b/docs/src/services/perspectives.md
@@ -157,8 +157,20 @@ A `serves` impl must provide every declared edge — the methods
 it must provide the `fn`s. This keeps a perspective's full ABI in
 one place.
 
-Today this ships the contract surface and its conformance check.
-Live-swapping a *bus-backed* perspective — atomically re-pointing
-its subscriptions to a new impl — is a follow-up; until it lands,
-`reperspective` on a perspective that declares a bus surface is a
-compile error (a sync-only perspective swaps fine).
+And `reperspective` re-points the bus edges too. The swap
+tombstones the current impl's subscriptions on the shared slot
+state and re-registers the new impl's handlers on that same state,
+so a message published *after* the swap lands on the new handler
+while state the old handler accumulated carries across — the async
+counterpart of the sync vtable flip:
+
+```hale
+"orders" <- Order { id: 1 };            // → the old impl's handler
+reperspective self.router as OrderV2;   // redeploy, live
+"orders" <- Order { id: 2 };            // → the new impl's handler
+```
+
+Cooperative bus dispatch is deferred (a publish enqueues a cell
+capturing the handler current at that moment; handlers run when
+the queue drains), so each message runs on whichever impl was live
+when it was published — the swap boundary is respected.

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -2322,14 +2322,28 @@ swap redirects **every** call site at once: the same
   tree is the redeploy authority. The typechecker requires the field
   to be a `perspective(P)` param of the current locus and the new
   impl to `serve P`.
+- **Bus edges swap too (Phase 2c-runtime).** When the perspective
+  declares a bus surface, the swap also re-points its subscriptions:
+  it tombstones the current impl's registrations on the shared slot
+  `data` (`lotus_bus_quarantine_self`) and re-registers the new
+  impl's handlers on that same `data`. A message published after the
+  swap dispatches to the new handler, operating on the carried
+  state. Cooperative dispatch is deferred (a publish captures the
+  handler current at that moment; handlers run at drain), so the
+  swap boundary is respected per message. Perspective impls are
+  designated (never `placement`-pinned), so they are cooperative —
+  the re-registration routes through the global queue, no mailbox
+  hand-off. (Cost: tombstoned entries are skipped, not compacted — a
+  bounded per-swap cost.)
 
 ## Perspective hot-load
 
-> **Status:** Phase 2b + 3 ship the core `reperspective` swap
+> **Status:** Phase 2b + 3 + 2c ship the `reperspective` swap
 > (above): the atomic slot re-point, state-preserving across impls
-> of one footprint. A footprint-changing `migrate`, and the
-> bus-arrival / decode / `stable_when` / drain flow below (bus-driven
-> redeploy), remain the aspirational path (Phase 2c-runtime / later).
+> of one footprint, re-pointing sync dispatch AND bus subscriptions.
+> A footprint-changing `migrate`, and the bus-arrival / decode /
+> `stable_when` / drain flow below (transport-driven redeploy from
+> the wire), remain the aspirational path.
 
 For each `perspective P { ... }` instance currently active:
 


### PR DESCRIPTION
Completes the **async half** of the perspective hot-swap: `reperspective` now re-points a bus-backed perspective's subscriptions, not just its sync vtable. It reuses Phase 3's shared-state insight — the swap keeps the slot's `data`, and bus subscriptions are keyed by that same `self_ptr` — so it tombstones the current impl's registrations (`lotus_bus_quarantine_self(data)`) and re-registers the new impl's handlers on the **same** `data`.

```hale
"orders" <- Order { id: 1 };            // → V1.on_order (sum 0->1)
reperspective self.router as OrderV2;    // redeploy the router live
"orders" <- Order { id: 3 };            // → V2.on_order (sum 1->31, carried)
```

A message published after the swap dispatches to the new impl's handler, operating on the state the old handler accumulated. Verified end-to-end: `v1 books order 1 → sum 1`, `v2 books order 3 → sum 31`. Cooperative dispatch is deferred (a publish captures the handler current at that moment; handlers run at drain), so the swap boundary is respected per message.

## Changes
- **codegen** — `lower_reperspective`, after the vtable flip, loads `slot.data`, `quarantine_self`s it, then `emit_bus_register`s each of the new impl's `subscriptions` on that data (reclaim-wrapper preference matched to the instantiation path; `owned_beyond_scope=true`; cooperative `mailbox=None`).
- **typecheck** — the bus-perspective swap gate is removed. Perspective impls are designated (never `placement`-pinned) so they're always cooperative → global-queue routing, no mailbox hand-off, no gate needed. The Phase 3 footprint-identity rule still applies.
- **spec/docs** — semantics.md live-swap section (bus edges swap too); docs/src chapter; Status note now covers 2c.

## Testing
- `64-perspective-bus-swap` fixture (corpus + ASan + examples parse).
- Previously-gated typecheck test flipped to `..._allowed`.
- Full `cargo nextest run --release --workspace`: **1634 passed, 0 failed**; corpus 71 fixtures clean + ASan.

> Bounded cost: tombstoned bus entries are skipped at dispatch, not compacted — a per-swap cost, consistent with the rest of the swap machinery. Remaining aspirational piece: transport-driven redeploy from the wire (decode + `stable_when` + drain) and a footprint-changing `migrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)