### PR TITLE
fix(runtime): dedup anchor-retirement retire so aliased key/value blob isn't double-freed

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -3291,12 +3291,52 @@ static void lotus_hashmap_grow(lotus_hashmap_t *m) {
 
 void lotus_arena_retire_str(void *arena_ptr, char *s);
 
+/* Does one of the OLD cell's String fields in [0, upto) retire the
+ * blob `p`? A field retires its old pointer iff it changed (overwrite
+ * path) or this is the remove path (new_v == NULL). Used to dedup the
+ * key clone and any repeated value-field pointers within a single
+ * retire_cell call: a blob that is reachable from more than one field
+ * — or from both the map key AND a value field (see the aliasing note
+ * in lotus_hashmap_retire_cell) — must be retired exactly ONCE.
+ * Retiring it twice pushes it onto retire_pending twice, which
+ * self-links the freelist node at flush (header.next = itself) and
+ * hands the same block to two owners → freelist corruption / SEGV.
+ * O(upto); upto is the value struct's String-field count (small) and
+ * this runs only on the cold retire path. */
+static int lotus_cell_field_retires_ptr(const lotus_hashmap_t *m,
+                                         const char *old_v,
+                                         const char *new_v,
+                                         const char *p, int32_t upto) {
+    for (int32_t ri = 0; ri < upto; ri++) {
+        int32_t off = m->retire_offsets[ri];
+        char *oldp;
+        memcpy(&oldp, old_v + off, sizeof(char *));
+        if (oldp != p) continue;
+        if (new_v) {
+            char *newp;
+            memcpy(&newp, new_v + off, sizeof(char *));
+            if (oldp == newp) continue; /* survives → not retired here */
+        }
+        return 1;
+    }
+    return 0;
+}
+
 /* Retire every string blob a dying/overwritten cell owns: the
  * descriptor's value fields plus (for string-keyed maps) the key
  * clone itself. `new_v`/`new_key` non-NULL = overwrite path, and
  * a pointer that survives into the new cell is NOT retired (the
  * RMW key-reuse idiom, the grow-rebuild re-insert). NULL = remove
- * path, everything retires. */
+ * path, everything retires.
+ *
+ * Aliasing (2026-07-06 fix): for a String-keyed map whose value
+ * struct carries the `indexed_by` field, codegen clones the key ONCE
+ * and stores the same pointer as both the map key (slot+1) and that
+ * value field. The value-field loop and the key-clone block would
+ * then each retire it — a double-push. So every retire is guarded
+ * against a prior retire of the same blob within this call: value
+ * fields dedup against earlier value fields, and the key clone dedups
+ * against all value fields. */
 __attribute__((noinline, cold))
 static void lotus_hashmap_retire_cell(lotus_hashmap_t *m, char *slot,
                                       const char *new_key,
@@ -3313,6 +3353,9 @@ static void lotus_hashmap_retire_cell(lotus_hashmap_t *m, char *slot,
             memcpy(&newp, new_v + off, sizeof(char *));
             if (oldp == newp) continue;
         }
+        /* dedup vs an earlier field aliasing the same blob */
+        if (lotus_cell_field_retires_ptr(m, old_v, new_v, oldp, ri))
+            continue;
         lotus_arena_retire_str(m->retire_arena, oldp);
     }
     if (m->key_type_tag == LOTUS_HASHMAP_KEY_STRING) {
@@ -3321,7 +3364,9 @@ static void lotus_hashmap_retire_cell(lotus_hashmap_t *m, char *slot,
         if (oldk) {
             char *newk = NULL;
             if (new_key) memcpy(&newk, new_key, sizeof(char *));
-            if (oldk != newk) {
+            if (oldk != newk &&
+                !lotus_cell_field_retires_ptr(m, old_v, new_v, oldk,
+                                              m->retire_n)) {
                 lotus_arena_retire_str(m->retire_arena, oldk);
             }
         }

--- a/crates/hale-codegen/tests/fixtures/examples/65-hashmap-anchor-churn/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/65-hashmap-anchor-churn/main.hl
@@ -1,0 +1,86 @@
+// 65-hashmap-anchor-churn — anchor-retirement freelist regression.
+//
+// Guards the P0 fixed 2026-07-06: a use-after-free in the retired-block
+// freelist (lotus_arena.c). A String-keyed @form(hashmap) whose value
+// struct carries the `indexed_by` field aliases ONE clone as both the
+// map key (slot+1) and that value field — codegen clones the key once
+// and stores the same pointer in both places. lotus_hashmap_retire_cell
+// retired it in the value-field loop AND again in the key-clone block,
+// pushing the same blob onto retire_pending twice. At flush the two
+// shells self-linked the freelist node (header.next = itself); the next
+// clone popped it while it stayed linked, wrote string bytes over the
+// {size,next} header, and a later pop dereferenced string content as a
+// next-pointer → SIGSEGV in lotus_retire_free_pop.
+//
+// The trigger needs a SECOND key of a DIFFERENT byte length entering the
+// map mid-churn (the pop's size band lets a shorter request claim a
+// longer block), so this churns two interleaved keys:
+//   "signals|KKN:S:btc-usd" (22B) : "beta|KKN:S:btc-usd" (19B) = 43 : 1.
+// Pre-fix this SEGVs within ~50k churns; post-fix it completes and the
+// per-key totals stay coherent (retire is deduped to once per blob).
+//
+// Keys are rebuilt each churn from slices + concat (a static-literal key
+// short-circuits str_clone and never exercises the retire/reuse path).
+
+type ChurnSlot { key: String = ""; qty: Int = 0; }
+
+@form(hashmap)
+locus ChurnMap {
+    capacity { pool rows of ChurnSlot indexed_by key; }
+}
+
+main locus HashmapAnchorChurn {
+    params {
+        basis: ChurnMap = ChurnMap { };
+        iters: Int = 120000;
+    }
+
+    // One churn: rebuild the key from a line, read-modify-write the slot
+    // under it. Building the key HERE (not in run) keeps this method's
+    // scratch arena resetting each call, so only the map's own arena —
+    // the anchor-retirement reuse path under test — persists.
+    fn step(src: String) {
+        let desk   = col(src, 1);
+        let symbol = col(src, 2);
+        let k = desk + "|" + symbol;
+        let cur = self.basis.get(k) or ChurnSlot { };
+        self.basis.set(ChurnSlot { key: k, qty: cur.qty + 1 });
+    }
+
+    run() {
+        let line  = "TQ3ZXO\tsignals\tKKN:S:btc-usd\tbuy";
+        let line2 = "TQ3ZXO\tbeta\tKKN:S:btc-usd\tbuy";
+        let mut i = 0;
+        while i < self.iters {
+            self.step(if i % 44 == 43 { line2 } else { line });
+            i = i + 1;
+        }
+        let sig = self.basis.get("signals" + "|" + "KKN:S:btc-usd") or ChurnSlot { };
+        let bet = self.basis.get("beta" + "|" + "KKN:S:btc-usd") or ChurnSlot { };
+        // sig + bet must equal iters (no lost updates); each key advanced
+        // once per churn it owned.
+        println("churn done: signals=", sig.qty, " beta=", bet.qty,
+                " total=", sig.qty + bet.qty);
+    }
+}
+
+fn main() {
+    HashmapAnchorChurn { };
+}
+
+// col — the idx-th tab-separated column of a line.
+fn col(line: String, idx: Int) -> String {
+    let total = len(line);
+    let mut pos = 0;
+    let mut cur = 0;
+    while pos <= total {
+        let rest = line[pos..total];
+        let tab = std::str::index_of(rest, "\t");
+        let chunk = if tab < 0 { rest } else { rest[0..tab] };
+        if cur == idx { return chunk; }
+        if tab < 0 { return ""; }
+        pos = pos + tab + 1;
+        cur = cur + 1;
+    }
+    return "";
+}

--- a/crates/hale-codegen/tests/form_hashmap_codegen.rs
+++ b/crates/hale-codegen/tests/form_hashmap_codegen.rs
@@ -453,3 +453,114 @@ fn hashmap_set_bigcell_with_array_field_does_not_leak() {
         stderr
     );
 }
+
+/// Anchor-retirement freelist corruption regression (P0, fixed
+/// 2026-07-06). A String-keyed map whose value struct carries the
+/// `indexed_by` field aliases ONE clone as both the map key and that
+/// value field (codegen clones the key once, stores the same pointer
+/// in both). `lotus_hashmap_retire_cell` retired it twice — once in
+/// the value-field loop, once in the key-clone block — double-pushing
+/// the blob onto retire_pending; at flush the two shells self-linked
+/// the freelist node (header.next = itself), so a later pop walked
+/// string bytes as a next-pointer → SIGSEGV in lotus_retire_free_pop.
+/// The corruption needs a SECOND key of a DIFFERENT byte length in the
+/// map (the pop's size band lets a shorter request claim a longer
+/// block), so this churns two interleaved keys of different lengths.
+///
+/// Two assertions in one: (1) it must not crash — pre-fix this SEGVs
+/// within tens of thousands of churns; (2) reuse must be PRESERVED —
+/// the map arena's chunk count stays flat, proving the retire/reuse
+/// path still recycles blocks (the fix only DEDUPS the double retire).
+#[test]
+fn hashmap_string_key_two_length_churn_no_freelist_corruption() {
+    // The map is a FIELD churned via the owning locus's method — the
+    // real pattern (a locus holding a @form map, its methods churning
+    // it). The retire/flush/reuse cycle fires at the owning method's
+    // activation boundary; a direct-local map in a free fn never
+    // flushes (and would leak regardless of this fix), so the structure
+    // matters for the reuse half of the assertion.
+    let src = r#"
+        type Slot { key: String = ""; qty: Int = 0; }
+        @form(hashmap)
+        locus SkChurn { capacity { pool rows of Slot indexed_by key; } }
+        main locus Holder {
+            params { basis: SkChurn = SkChurn { }; }
+            fn churn(k: String) {
+                let cur = self.basis.get(k) or Slot { };
+                self.basis.set(Slot { key: k, qty: cur.qty + 1 });
+            }
+            run() {
+                let base = "KKN:S:btc-usd";
+                // Warm both keys into the map, then dump residency.
+                self.churn("signals|" + base);
+                self.churn("beta|" + base);
+                std::process::dump_arena_residency();
+                let mut i = 0;
+                while i < 60000 {
+                    // "signals|" (22B) : "beta|" (19B) interleaved 43:1 —
+                    // concat forces a dynamic (non-.rodata) key each set,
+                    // so the clone/retire/reuse path is exercised.
+                    self.churn(if i % 44 == 43 { "beta|" + base } else { "signals|" + base });
+                    i = i + 1;
+                }
+                std::process::dump_arena_residency();
+                let sig = self.basis.get("signals|" + base) or Slot { };
+                let bet = self.basis.get("beta|" + base) or Slot { };
+                println("total=", sig.qty + bet.qty);
+            }
+        }
+        fn main() { Holder { }; }
+    "#;
+    let bin = build("sk_two_length_churn", src);
+    let out = Command::new(&bin)
+        .env("LOTUS_ARENA_RESIDENCY", "1")
+        .output()
+        .expect("run");
+    let _ = std::fs::remove_file(&bin);
+    // (1) no crash — pre-fix this exits via SIGSEGV.
+    assert!(
+        out.status.success(),
+        "non-zero exit (freelist corruption regressed?): {:?} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // 2 warm-up churns + 60000 loop churns = 60002 increments split
+    // across the two keys; the sum must equal the total churn count
+    // (no lost updates from the retire/reuse cycle).
+    assert!(
+        stdout.contains("total=60002"),
+        "expected coherent total=60002, got: {:?}",
+        stdout
+    );
+    // (2) reuse preserved — the map arena's chunk count stays flat
+    // (the clones live in SkChurn's own arena; retire/reuse recycles
+    // them so it never grows past its initial chunk).
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let chunks: Vec<usize> = stderr
+        .lines()
+        .filter(|ln| ln.contains("label=SkChurn ") || ln.contains("label=SkChurn]"))
+        .filter_map(|ln| {
+            ln.split("chunks=")
+                .nth(1)
+                .and_then(|s| s.split_whitespace().next())
+                .and_then(|s| s.parse::<usize>().ok())
+        })
+        .collect();
+    assert!(
+        chunks.len() >= 2,
+        "expected two SkChurn-arena residency rows, got {:?} (stderr={})",
+        chunks,
+        stderr
+    );
+    let first = chunks[0];
+    let last = *chunks.last().unwrap();
+    assert!(
+        last <= first + 1,
+        "SkChurn arena grew across 60k two-length churns: chunks {} → {} \
+         (retire/reuse regressed to unbounded growth). stderr={}",
+        first,
+        last,
+        stderr
+    );
+}


### PR DESCRIPTION
## P0: anchor-retirement freelist corruption → SEGV on multi-key `@form(hashmap)` churn

Fixes the use-after-free introduced by the anchor-retirement work (`2b350e8` / `0755d91` / `60c255d`, 2026-07-02). Every fathom binary rebuilt past `2b350e8` segfaulted on multi-key `@form(hashmap)` churn — the prod fleet was pinned to pre-`2b350e8` images.

### Root cause
A String-keyed `@form(hashmap)` whose value struct carries the `indexed_by` field aliases **one** clone as both the map key (`slot+1`) and that value field: codegen clones the key once and stores the same pointer in both places, and every `String` field (including the key field) is in `retire_offsets`. So `lotus_hashmap_retire_cell` retired that blob **twice** — once in the value-field loop, once in the key-clone block — pushing it onto `retire_pending` twice. At flush the two shells self-linked the freelist node (`header.next = itself`); the next clone popped it while still linked, the string write clobbered the `{size,next}` header, and a later pop dereferenced string bytes as a next-pointer → **SIGSEGV in `lotus_retire_free_pop`**.

The corruption needs a second key of a *different byte length* in the map (the pop size band lets a shorter request claim a longer block) — which is why the prod ledger boot backfill died at ~fill 44, the moment a second desk's key entered the cost-basis map.

### Fix
Retire each dead blob **at most once** per `retire_cell` call via an allocation-free O(n) dedup helper (`lotus_cell_field_retires_ptr`): value fields dedup vs earlier fields; the key clone dedups vs all value fields. `n` = the value struct's String-field count, on the already-cold `noinline` retire path. The reuse machinery is untouched — this only removes the double-retire, which also fixes the orphaned-block leak the double-push caused. Steady-state re-anchor churn still recycles blocks (map arena stays flat).

### Verification
- `smoke-arena-churn` 200k → exit 0, coherent totals (signals 195455 + beta 4545 = 200000, no lost updates)
- Block reuse preserved: isolated field+method churn holds the map arena at **1 chunk / 64 KB across 60k churns**
- New corpus fixture `65-hashmap-anchor-churn`: SEGV pre-fix (139) → clean post-fix, **ASan + LeakSanitizer clean**
- New `hashmap_string_key_two_length_churn_no_freelist_corruption` test (no crash + coherent total + reuse-flat via residency dump)
- Full hale workspace suite: **277 test binaries, 0 failures**
- fathom `ledger-query-check.sh` 9/9 · `realized-pnl-check.sh` all PASS · **`fathom_probe` real-data boot backfilled past fill 44 to steady state, no SEGV**

Closes the fathom `FRICTION.md` 2026-07-06 P0 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)