### PR TITLE
docs: reconcile perspectives with the shipped v0.10 model

### DIFF
--- a/docs/src/services/perspectives.md
+++ b/docs/src/services/perspectives.md
@@ -8,9 +8,9 @@ swap a component's implementation without the code that calls it
 changing.
 
 > This chapter covers what ships today: declaring a contract, an
-> implementation that `serves` it, and calling through the slot.
-> The live swap (re-pointing the slot at a new implementation
-> while the program runs) is the next slice.
+> implementation that `serves` it, calling through the slot, and
+> the live swap — re-pointing the slot at a new implementation
+> while the program runs, via `reperspective` (last section).
 
 ## The contract
 
@@ -72,8 +72,8 @@ Every holder of `perspective(Router)` funnels through it. That's a
 deliberate design choice: because there's a single indirection and
 the compiler sees every call site, re-pointing that one slot will
 redirect the entire program at once — a single pointer flip, no
-matter how many holders. (That live re-point is the next slice;
-today the slot is set once, at designation.)
+matter how many holders. That live re-point is the `reperspective`
+statement — see [Live redeploy](#live-redeploy-reperspective) below.
 
 The cost is one load plus one predicted indirect call per call into
 a perspective — near-direct. A program that declares no

--- a/docs/src/systems/cross-process.md
+++ b/docs/src/systems/cross-process.md
@@ -1,5 +1,17 @@
 # Cross-process & hot-load
 
+> **Status + terminology.** This chapter describes the
+> *transport-driven* perspective — a serializable state bundle
+> shipped between processes and hot-loaded from the wire. That path
+> is **design/aspirational**: it is specified but not yet shipped.
+> It reuses the `perspective` keyword but is distinct from the
+> shipped, in-process perspective — a live-swappable *contract* + a
+> program-global slot re-pointed with `reperspective` — covered in
+> [Perspectives](../services/perspectives.md) (and normatively in
+> `spec/semantics.md`). Both are the same idea (a stable, versioned
+> boundary you can re-point at pointer-flip cost); today only the
+> in-process contract/slot path runs.
+
 > **Coming from Rust / C++?** This is typed, versioned state
 > shipped between processes — but without a separate `.proto` and
 > a codegen step. A `perspective` is a serializable parameter

--- a/spec/design-rationale.md
+++ b/spec/design-rationale.md
@@ -492,10 +492,13 @@ perspective Kernel<T> {
 }
 ```
 
-**Commits to.** A perspective is a serializable parameter bundle
-within a shared compiled-in schema. Both producer (fitter) and
-consumer (applier) compile from the same Hale source, so the
-type *is* the contract; the bus carries only parameter values.
+**Commits to.** In the transport-driven hot-load model (the
+aspirational path — see `semantics.md` § "Perspective hot-load"; the
+*shipped* perspective is the in-process contract + slot), a
+perspective is a serializable parameter bundle within a shared
+compiled-in schema. Both producer (fitter) and consumer (applier)
+compile from the same Hale source, so the type *is* the contract;
+the bus carries only parameter values.
 
 **Why.** This is the fitter/applier split: one process fits
 parameters from observations; another applies them at high

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -606,10 +606,13 @@ epoch_spec        = "tick"
 
 (* === 10. Perspective declaration ============================== *)
 
-(* A perspective is a serializable parameter bundle within a
-   compiled-in shared schema. Both analyst and executor binaries
-   compile from the same lotus source, so the perspective type
-   is the contract. The bus carries only parameter values. *)
+(* Shipped (Phase 2): a perspective is a CONTRACT — bodyless `fn`
+   signatures (and optionally a bus surface) forming a stable ABI,
+   reached through a live-swappable program-global slot (see the
+   Phase 2a/2c comments below and spec/semantics.md). The
+   params_block / stable_when / serialize_as members below are the
+   serializable-parameter-bundle form used by the aspirational
+   transport-driven hot-load path. *)
 
 perspective_decl  = "perspective" , IDENTIFIER , [ generic_params ] ,
                     "{" , { perspective_member } , "}" ;

--- a/spec/memory.md
+++ b/spec/memory.md
@@ -1320,12 +1320,16 @@ right release function reachable at child dissolve.
 
 ## Future work
 
-- **Hot-load preservation across perspective updates.** When a
-  perspective is hot-loaded, the receiving locus's arena state
-  is preserved across the swap; the new perspective's translation
-  functions replace the old. v0 specifies the perspective hot-
-  load mechanism (runtime.md); the memory-level interaction is
-  TBD.
+- **Hot-load preservation across perspective updates.** The
+  in-process live swap (`reperspective`, Phase 3) preserves the
+  receiving locus's arena state across the swap: the perspective
+  slot is `{ data, vtable }`, so re-pointing at a new impl of the
+  same footprint stores only the new vtable — `data` (the
+  arena-backed state) is untouched and the new impl's methods
+  continue on it. The remaining future piece is the same
+  preservation for a *transport-driven* wire redeploy whose new
+  impl changes the footprint (the `migrate` case). See
+  `spec/semantics.md` § "The live swap".
 - **Region size hints.** Initial chunk sizes per locus are
   taken from declared params. Per The Design's locus-as-region
   invariant, the load-bearing property is *lifetime* (wholesale

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1089,15 +1089,24 @@ zero_copy binding produces.
 
 ### Perspective infrastructure
 
-- **Stable-perspective tracking.** For each `perspective T`,
-  the runtime tracks how many independent perspectives have
-  validated; `stable_when` is invoked to determine commit
-  status.
-- **Hot-load.** The runtime accepts a serialized
-  `T`-perspective from a transport, verifies the type
-  signature against the locally-compiled `T`, and atomically
-  installs it. Old perspective is preserved until the new one
-  is committed (no torn read).
+- **The global slot.** Each `perspective P` has one program-global
+  `{ data, vtable }` slot (`__persp.<P>`). Every holder of
+  `perspective(P)` dispatches through it — a load plus a predicted
+  indirect call, near-direct cost. A program that declares no
+  perspectives pays nothing.
+- **Live swap (`reperspective`).** Re-points the slot at a new
+  `serves P` impl with a single atomic store, redirecting every
+  call site at once. State-preserving across impls of one footprint:
+  the `{ data, vtable }` split means `data` — the live, arena-backed
+  state — is untouched and only the vtable changes. When the
+  perspective declares a bus surface, the swap also re-points its
+  subscriptions on that same `data`. (See `spec/semantics.md`
+  § Perspectives.)
+- **Wire hot-load (aspirational).** Transport-driven redeploy —
+  decode a serialized perspective against the compiled-in schema,
+  gate on `stable_when`, atomically install with no torn read — is
+  specified but not yet shipped. See `spec/semantics.md`
+  § "Perspective hot-load".
 
 ### Failure handling
 

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -2231,8 +2231,8 @@ A `perspective P { ... }` is a **contract** — a set of bodyless
 `fn` signatures that form a stable ABI boundary — plus a
 program-global, live-rebindable **slot** that holders dispatch
 through. Phase 2a (2026-07-06) ships the contract, conformance,
-the slot type, and dispatch; the live swap (`reperspective`) is
-the next slice.
+the slot type, and dispatch; the live swap (`reperspective`)
+followed in Phase 2b + 3 (see "The live swap" below).
 
 ```hale
 perspective Router {

--- a/spec/types.md
+++ b/spec/types.md
@@ -116,14 +116,18 @@ typecheck and codegen.
 
 ## Perspective types
 
-A `perspective P { ... }` declaration introduces a *perspective
-type* P — a serializable parameter bundle within a shared
-compiled-in schema. Used for fitter↔applier communication
-(among other things). Has:
-
-- Params (the parameter bundle)
-- A `stable_when { ... }` block (commit predicate)
-- Optional `serialize_as TypeV1` annotation
+A `perspective P { ... }` declaration introduces a *contract
+type* P — a set of bodyless `fn` signatures (optionally a
+`bus { subscribe/publish ... }` surface) that form a stable ABI
+boundary. Holders program against the **slot type**
+`perspective(P)` — never a concrete impl — and dispatch through a
+single program-global, live-rebindable slot. A locus
+`L : serves P` provides the contract and can be swapped in behind
+the slot at pointer-flip cost via `reperspective`. An optional
+`stable_when { ... }` predicate feeds the (aspirational)
+transport-driven hot-load path. See
+[`semantics.md` § Perspectives](./semantics.md) for the full model
+(contract / `serves` / slot / live swap).
 
 ## Interface types (F.20)
 


### PR DESCRIPTION
The v0.10 flagship (`perspective` = a live-swappable contract + slot + `reperspective`) was specced correctly in `spec/semantics.md`, but several places still described the **old**, pre-v0.10 meaning (a serializable parameter bundle with `stable_when` / `serialize_as` / wire hot-load) as current — the "flagship feature described wrongly where a reviewer looks" finding.

Reconciled:
- **`semantics.md`** — the intro called the live swap "the next slice" though the same section documents it shipped.
- **`types.md`** — the "perspective type = serializable bundle" stub → the contract/slot model.
- **`runtime.md`** — "Perspective infrastructure" (stable-tracking + hot-load) → the global slot + `reperspective`; wire hot-load now labeled aspirational.
- **`memory.md`** — state-preserving swap moved out of "Future work / TBD" (it shipped in Phase 3).
- **`docs/services/perspectives.md`** — two "next slice" claims → the shipped `reperspective` (the page already documents it working).
- **`docs/systems/cross-process.md`** — added a status+terminology callout distinguishing the aspirational transport-shipped perspective from the shipped in-process one.
- **`grammar.ebnf` + `design-rationale.md`** — scoped the old "serializable bundle" definition as the aspirational hot-load path.

Docs/spec only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)