### PR TITLE
docs: fix ~21 dead spec links, lead with substrate positioning, denoise versions

### DIFF
--- a/docs/src/everyday/locus-gently.md
+++ b/docs/src/everyday/locus-gently.md
@@ -105,7 +105,7 @@ the app's top-level state and entry point now have a home. (At
 the services level, `run()` becomes a special *lifecycle* method
 the runtime drives — but as an ordinary method it already works.)
 
-**The namespace lotus** — a home for a coherent vocabulary of
+**The namespace locus** — a home for a coherent vocabulary of
 helpers, with little or no state. Hale's stand-in for a "module
 of functions" or a static class:
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,5 +1,9 @@
 # Introduction
 
+**A concurrent systems language with a model-checked, GC-free
+runtime — typed message-bus concurrency, data-race-free by
+design.**
+
 *One language. Four altitudes.*
 
 Most languages pick a level and live there. Python and

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -10,25 +10,25 @@ diagnostic's meaning, go there.
 
 | You want | Read |
 |---|---|
-| The formal grammar | [`spec/grammar.ebnf`](../../spec/grammar.ebnf) |
-| Lexical structure, literals, operators | [`spec/tokens.md`](../../spec/tokens.md) |
-| Operator precedence & associativity | [`spec/precedence.md`](../../spec/precedence.md) |
-| Operational semantics (lifecycle, bus, recovery, fallible) | [`spec/semantics.md`](../../spec/semantics.md) |
-| The type system | [`spec/types.md`](../../spec/types.md) |
-| Memory: regions, capacity slots, projection classes | [`spec/memory.md`](../../spec/memory.md) |
-| The form library (`vec` / `hashmap` / `ring_buffer`) | [`spec/forms.md`](../../spec/forms.md) |
-| The always-loaded runtime | [`spec/runtime.md`](../../spec/runtime.md) |
-| The standard library surface | [`spec/stdlib.md`](../../spec/stdlib.md) |
-| Idiomatic patterns & the six shapes | [`spec/styleguide.md`](../../spec/styleguide.md) |
-| The FFI contract — C (`@ffi("c")`) and the WASM host interface (`@ffi("js")` / `@export`) | [`spec/ffi.md`](../../spec/ffi.md) |
-| Dependencies & vendoring | [`spec/packages.md`](../../spec/packages.md) |
-| Project layout & imports | [`spec/projects.md`](../../spec/projects.md) |
-| How tests are written and run | [`spec/testing.md`](../../spec/testing.md) |
-| Why every design choice was made | [`spec/design-rationale.md`](../../spec/design-rationale.md) |
+| The formal grammar | [`spec/grammar.ebnf`](https://github.com/hale-lang/hale/blob/main/spec/grammar.ebnf) |
+| Lexical structure, literals, operators | [`spec/tokens.md`](https://github.com/hale-lang/hale/blob/main/spec/tokens.md) |
+| Operator precedence & associativity | [`spec/precedence.md`](https://github.com/hale-lang/hale/blob/main/spec/precedence.md) |
+| Operational semantics (lifecycle, bus, recovery, fallible) | [`spec/semantics.md`](https://github.com/hale-lang/hale/blob/main/spec/semantics.md) |
+| The type system | [`spec/types.md`](https://github.com/hale-lang/hale/blob/main/spec/types.md) |
+| Memory: regions, capacity slots, projection classes | [`spec/memory.md`](https://github.com/hale-lang/hale/blob/main/spec/memory.md) |
+| The form library (`vec` / `hashmap` / `ring_buffer`) | [`spec/forms.md`](https://github.com/hale-lang/hale/blob/main/spec/forms.md) |
+| The always-loaded runtime | [`spec/runtime.md`](https://github.com/hale-lang/hale/blob/main/spec/runtime.md) |
+| The standard library surface | [`spec/stdlib.md`](https://github.com/hale-lang/hale/blob/main/spec/stdlib.md) |
+| Idiomatic patterns & the six shapes | [`spec/styleguide.md`](https://github.com/hale-lang/hale/blob/main/spec/styleguide.md) |
+| The FFI contract — C (`@ffi("c")`) and the WASM host interface (`@ffi("js")` / `@export`) | [`spec/ffi.md`](https://github.com/hale-lang/hale/blob/main/spec/ffi.md) |
+| Dependencies & vendoring | [`spec/packages.md`](https://github.com/hale-lang/hale/blob/main/spec/packages.md) |
+| Project layout & imports | [`spec/projects.md`](https://github.com/hale-lang/hale/blob/main/spec/projects.md) |
+| How tests are written and run | [`spec/testing.md`](https://github.com/hale-lang/hale/blob/main/spec/testing.md) |
+| Why every design choice was made | [`spec/design-rationale.md`](https://github.com/hale-lang/hale/blob/main/spec/design-rationale.md) |
 
 ## Two more anchors
 
-- **[`AGENTS.md`](../../AGENTS.md)** — the load-bearing prompt for
+- **[`AGENTS.md`](https://github.com/hale-lang/hale/blob/main/AGENTS.md)** — the load-bearing prompt for
   agents writing `.hl`. It condenses the six idiomatic patterns,
   the "what's not in the language" reflexes, and the formal
   design model into one file. Excellent for a human, too.

--- a/docs/src/services/patterns.md
+++ b/docs/src/services/patterns.md
@@ -1,7 +1,7 @@
 # Composition patterns
 
-The [shape catalog](../../AGENTS.md) names the six building blocks —
-app locus, namespace lotus, service locus, spawned child, shape
+The [shape catalog](https://github.com/hale-lang/hale/blob/main/AGENTS.md) names the six building blocks —
+app locus, namespace locus, service locus, spawned child, shape
 type, free fn. This chapter is the next layer up: five *compositions*
 of those blocks that recur in real Hale services, distilled from
 production use. Reach for one of these when a problem feels like it

--- a/docs/src/systems/forms.md
+++ b/docs/src/systems/forms.md
@@ -44,8 +44,8 @@ evicts the least-recently-**used** entry over `cap` (a `get`
 counts as a use and saves an entry from eviction; `contains` does
 not). Its `get` is `fallible(KeyError)` on a miss.
 
-Both a `vec` and a `hashmap` also expose **batched iteration**
-(shipped 2026-07-02) — `for x in v.items { … }` walks the vec, and
+Both a `vec` and a `hashmap` also expose **batched iteration** —
+`for x in v.items { … }` walks the vec, and
 `for e in m.entries { … }` walks the map. The loop is an inline
 buffer/slot walk, not per-element method calls. (Don't mutate the
 form inside the body — a grow would rehash under the cursor.)

--- a/docs/src/systems/operations.md
+++ b/docs/src/systems/operations.md
@@ -162,7 +162,7 @@ fork failure raises rather than returning a bogus output.
 For a long-running child you drive incrementally, the lower-level
 `spawn` / `wait` / `kill` / `write_stdin` / `read_stdout` /
 `read_stderr` surface over a `Child` handle is in
-[`spec/stdlib.md`](../../../spec/stdlib.md).
+[`spec/stdlib.md`](https://github.com/hale-lang/hale/blob/main/spec/stdlib.md).
 
 Other process self-introspection: `std::process::pid()`,
 `std::process::exit(code)`, and `std::process::rss_bytes()` (peak

--- a/docs/src/systems/webassembly.md
+++ b/docs/src/systems/webassembly.md
@@ -211,5 +211,5 @@ parked in the runtime **state cell**, packed into `Bytes`:
 The `@export locus` model is preferred for anything with state; the
 state cell exists for the free-fn path and for hand-rolled layouts.
 
-See [`spec/ffi.md` § WASM host interface](../../../spec/ffi.md) for the
+See [`spec/ffi.md` § WASM host interface](https://github.com/hale-lang/hale/blob/main/spec/ffi.md) for the
 exact marshalling and diagnostic rules.

--- a/docs/src/the-design.md
+++ b/docs/src/the-design.md
@@ -79,11 +79,11 @@ variance doesn't reach into the shape.
 
 ## Going deeper
 
-- **[`AGENTS.md`](../../AGENTS.md)** — the formal model in one
+- **[`AGENTS.md`](https://github.com/hale-lang/hale/blob/main/AGENTS.md)** — the formal model in one
   page: nodes, hyperedges, and invariants, with the `locus ↔ Σ`
   mapping. Written for agents authoring `.hl`, but it's the
   tightest statement of the design for a human too.
-- **[`spec/design-rationale.md`](../../spec/design-rationale.md)**
+- **[`spec/design-rationale.md`](https://github.com/hale-lang/hale/blob/main/spec/design-rationale.md)**
   — every numbered design decision (`F.1` … `F.36`), the
   alternatives considered, and why each commitment is shaped the
   way it is.


### PR DESCRIPTION
Audit item #5.

- **Dead-link sweep.** 21 relative `../spec/…` / `../AGENTS.md` links (reference.md ×16, the-design.md ×2, operations.md, webassembly.md, patterns.md) escaped the mdBook site root and 404'd — the "canonical contract unreachable from the site" finding. Rewritten to the `github.com/hale-lang/hale/blob/main/…` form `verification.md` already uses. 0 residual.
- **Landing page positioning.** `introduction.md` now opens with the substrate line (model-checked, GC-free, data-race-free) before the four-altitudes framing.
- **Version denoise.** Fix the "namespace lotus" → "namespace locus" typo (a locus *kind*, not the runtime `lotus`); drop a raw date from forms.md.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)