### PR TITLE
docs(spec): reconcile testing.md + fix package-manager and lockfree-hashmap contradictions

### DIFF
--- a/spec/styleguide.md
+++ b/spec/styleguide.md
@@ -577,9 +577,12 @@ underlying surface lands.
   (one directory), all `.hl` files share a top-level scope
   (F.19). Across seeds, vendor a library into your tree and
   write `import "lib/<name>" as <alias>;` at the top of the
-  importing file; references read as `<alias>::Name`. v1 has
-  no package manager, no fetch, no versioning — the source IS
-  the dependency. See `spec/projects.md` for project shapes,
+  importing file; references read as `<alias>::Name`. v1's
+  dependency step is minimal and git-based: `hale fetch` vendors
+  the deps declared in `hale.toml` into `vendor/` and pins their
+  commit SHAs in `hale.lock` (see `spec/packages.md`) — no central
+  registry and no semver resolution, so the pinned source IS the
+  dependency. See `spec/projects.md` for project shapes,
   resolution order, and the mangling scheme;
   `crates/hale-codegen/tests/fixtures/lib-toy/` is the
   worked-example fixture.

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -7,8 +7,12 @@ discipline (closure tests, k_max bounds, projection-class
 invariants, multi-perspective stability commit-rules) needs
 testing infrastructure to be enforced.
 
-This document specifies the *design* of the testing pipeline.
-Implementation follows once the compiler exists.
+`hale test` (Layer 1 + Layer 2 discovery and execution) ships
+today. The benchmark, formatter, and standalone-verify tooling
+described below (`hale bench` / `hale fmt` / `hale verify`) is
+specified here but **not yet implemented** — the shipping CLI is
+`lex` / `parse` / `check` / `run` / `build` / `test` / `fetch`.
+Those sections describe the intended design, not current behavior.
 
 ## Three layers of correctness
 
@@ -176,12 +180,13 @@ tests by suffix (`_test.hl`) regardless of location.
 | `hale check` | Static checks: parse, typecheck, framework discipline |
 | `hale test` | Run all `*_test.hl` files in the project |
 | `hale test -run pattern` | Run matching tests only |
-| `hale bench` | Run all `*_bench.hl` files |
-| `hale bench -compare` | Build and run external equivalents alongside |
-| `hale verify` | Layer-2 discipline checks specifically (no execution) |
-| `hale fmt` | Canonical formatter (Go-style: zero config) |
+| `hale bench` *(planned)* | Run all `*_bench.hl` files |
+| `hale bench -compare` *(planned)* | Build and run external equivalents alongside |
+| `hale verify` *(planned)* | Layer-2 discipline checks specifically (no execution) |
+| `hale fmt` *(planned)* | Canonical formatter (Go-style: zero config) |
 
-`hale test` runs Layer 1 + Layer 2. `hale bench` runs Layer 3.
+`hale test` runs Layer 1 + Layer 2 today; `hale bench` (planned)
+runs Layer 3.
 
 ## Test assertion library
 
@@ -253,7 +258,7 @@ Actions annotations, etc.) are downstream conversions.
 ## What writing this surfaces (for resolution)
 
 1. **`bench` annotation: keyword, attribute, or naming convention?**
-   Go uses `BenchmarkName`. Rust uses `#[bench]`. Lotus has
+   Go uses `BenchmarkName`. Rust uses `#[bench]`. Hale has
    neither attributes nor magic-name conventions yet. Decision
    pending; probably an attribute (`@bench fn ...`) added to
    the grammar in v0.2.

--- a/spec/types.md
+++ b/spec/types.md
@@ -667,7 +667,7 @@ the form annotation:
 | `@form(hashmap)` | single-pool only | densest layout, no sync overhead, cross-pool calls rejected |
 | `@form(hashmap, sync = serialized)` | per-map mutex (F.32-1α) | correct cross-pool; throughput bounded by lock contention |
 | `@form(hashmap, sync = striped)` | cell-level CAS + per-map rwlock for grow + cache-padded cells (F.32-1β2-v2) | parallel writers; grow path serializes; rwlock overhead can outweigh parallelism on cheap-payload workloads |
-| `@form(hashmap, sync = lockfree, cap = N)` | fixed-cap, cell-level CAS, no rwlock or mutex (F.32-1γ-v1) | highest measured throughput on the false-sharing bench; no grow, no remove in v1 |
+| `@form(hashmap, sync = lockfree)` (optional `cap = N` hint) | cell-level CAS, no rwlock or mutex on the steady-state path; `remove` via tombstones + lazy grow with a brief migration stall (F.32-1γ-v2) | highest measured throughput on the false-sharing bench |
 
 When a locus carries a recognized sync discipline, cross-
 pool method calls into it are accepted without diagnostic —


### PR DESCRIPTION
Part of audit item #6.

- **testing.md** — was a pre-compiler design doc. `hale test` ships today; `hale bench`/`hale fmt`/`hale verify` are now marked *(planned)*; "Lotus" → "Hale". (Removes the "documents commands that don't exist" counterexample to the README's "compiler enforces exactly what it describes".)
- **styleguide.md** ↔ **packages.md** — styleguide claimed "no package manager, no fetch, no versioning", but `hale fetch` ships (`hale.toml` → `vendor/`, SHA-pinned via `hale.lock`). Reworded to the shipped vendoring model.
- **types.md** ↔ **forms.md** — types.md said lockfree hashmap has "no grow, no remove in v1"; forms.md documents both shipped in F.32-1γ-v2. Aligned types.md.

Remaining spec contradictions from the audit (`or`/`discard` routing, import identity, and the terser ones) need impl-behavior confirmation to resolve safely — flagged, not guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)