### PR TITLE
docs(spec): resolve 4 more cross-file contradictions (impl-verified)

### DIFF
--- a/spec/forms.md
+++ b/spec/forms.md
@@ -134,7 +134,10 @@ commitment — it changes the pool's layout and access path.
 
 A locus without `@form(...)` gets the **literal F.22 default
 lowering**: pool slots become `lotus_pool_t*` chunked free-list;
-heap slots become `lotus_heap_t*` doubling buffer. The user's
+heap slots become a `lotus_heap_t*` doubly-linked live list
+(individual O(1) alloc/free, wholesale-freed at dissolve — the
+contiguous doubling buffer is the `@form(vec)` specialization,
+not the default). The user's
 own methods run as written; no synthesis, no shape verification
 beyond the normal capacity-slot machinery.
 

--- a/spec/precedence.md
+++ b/spec/precedence.md
@@ -83,8 +83,10 @@ a() or b() or raise
 ```
 
 The RHS of `or` is one of:
-- the contextual keyword `raise` (diverges via closure
-  violation routing), or
+- the contextual keyword `raise` (diverges by re-entering the
+  enclosing `fallible(E)` fn's error-return path — the value-error
+  channel, orthogonal to closure tests; past every fallible frame
+  it root-panics via `lotus_root_panic`), or
 - `discard` (swallow the error, substitute Unit; rejected at
   typecheck when the success type is non-Unit), or
 - `fail <expr>` (diverge like `raise`, but with a fresh payload

--- a/spec/projects.md
+++ b/spec/projects.md
@@ -399,12 +399,14 @@ Explicit non-features of the v1 project / import system. A
 future milestone may relax some of them when concrete friction
 demonstrates the need.
 
-- **No transitive deduplication.** A library reached through two
-  different import paths ships as two compiled copies — per-
-  importer mangling, no shared identity. The recursive resolution
-  added in A4 (2026-05-17) follows each library's own imports
-  scoped to that library, but does not unify references across
-  importers.
+- **Deduplication is by canonical path, not content.** A library
+  reached through two different importers gets ONE shared identity
+  — its `<lib_id>` is derived from its canonical path and
+  deduplicated in the resolver's visited set (the 2026-05-22
+  change; see § "No re-exports" above), so the same source yields
+  the same symbols across consumers. What's *not* done is
+  content-level unification: two libraries vendored at different
+  paths are distinct symbols even if byte-identical.
 - **No registry / version ranges / semver.** Dependency pins
   are exact git refs. See `spec/packages.md` § "What's NOT in
   v1" for the full list of package-management non-features.

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -887,8 +887,11 @@ Transport surface:
   timeouts, point-to-point role for p2p shapes). The grammar
   distinguishes substrate vs adapter by the head's case
   (lowercase keyword `unix` vs capitalized locus name).
-  Inbound dispatch from an adapter into the local handler set
-  awaits the `__bus_local_dispatch` opening (deferred).
+  Inbound dispatch from an adapter into the local handler set is
+  handled by `std::bus::__local_dispatch(subject, bytes)` (m105):
+  it reconstructs the payload against the subject's registered
+  deserialize fn and fans into local subscribers via
+  `lotus_bus_dispatch_wire`.
 
 - `shm_ring("/name", slot_count: N, on_overflow: <policy>)` —
   POSIX SHM ring substrate backing the zero-copy route. Name


### PR DESCRIPTION
Continues audit item #6c. Each fix verified against the shipping code:

- **precedence.md** — `or raise` is the value-error channel (fallible-return + root-panic), not "closure violation routing".
- **projects.md** — lib identity is canonical-path deduplicated (shared symbols); corrected the stale "per-importer mangling / two copies" claim in the NOT-shipped list.
- **semantics.md** — adapter inbound dispatch ships (`__local_dispatch` → `lotus_bus_dispatch_wire`, m105), was marked "deferred".
- **forms.md** — the default heap slot is a `lotus_heap_t*` doubly-linked list; the "doubling buffer" is the `@form(vec)` specialization.

With C2/C4 (#189) that's 6 of 8. The remaining two (bus-queue boundedness, reserved-vs-shipped reorg) had no locatable stale statement — left flagged rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)