### PR TITLE
docs(readme): wholesale rewrite for public launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
 # Hale
 
-**A concurrent systems language with a model-checked, GC-free runtime** — typed message-bus concurrency, data-race-free by design.
+**You describe a system — the services, the messages between them,
+who owns what — and that description *is* the program.**
+
+One primitive, the **locus**, scales from a single function to a
+whole distributed system. There's no translation layer between the
+sentence you'd say out loud and the code you write.
 
 [![Tests](https://github.com/hale-lang/hale/actions/workflows/tests.yml/badge.svg)](https://github.com/hale-lang/hale/actions/workflows/tests.yml)
 [![Docs](https://github.com/hale-lang/hale/actions/workflows/docs.yml/badge.svg)](https://hale-lang.github.io/hale/)
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](./LICENSE)
 [![LLVM](https://img.shields.io/badge/LLVM-18-red.svg)](https://llvm.org/)
-[![Status](https://img.shields.io/badge/status-stabilizing-blue.svg)](#status)
-[![GC](https://img.shields.io/badge/GC-0-brightgreen.svg)](#what-hale-leaves-out)
-[![async/await](https://img.shields.io/badge/async%2Fawait-0-brightgreen.svg)](#what-hale-leaves-out)
+[![GC](https://img.shields.io/badge/GC-0-brightgreen.svg)](#what-you-dont-write)
+[![async/await](https://img.shields.io/badge/async%2Fawait-0-brightgreen.svg)](#what-you-dont-write)
 [![native](https://img.shields.io/badge/native-human_%2B_agent-8957e5.svg)](./AGENTS.md)
 
-**A language whose shape matches the shape of your thinking.**
-
-You know that feeling when you describe a system out loud —
+You know the feeling: you describe a system out loud —
 *"a matchmaker holds a queue of waiting players, spawns a match when
-enough are queued, then goes back to waiting"* — and then the code
-you actually write bears no resemblance to those words? Mutexes
-appear. Async machinery. Lifecycle wiring. Five files. By the time
-it works, the sentence you started with is buried.
+enough are queued, then goes back to waiting"* — and the code you
+actually write bears no resemblance to the sentence. Mutexes appear.
+Async machinery. Lifecycle wiring. Five files. By the time it works,
+the idea you started with is buried.
 
 Hale is a bet that the gap doesn't have to be there.
 
@@ -66,49 +68,49 @@ you thought them:
 - *"announces matches"* → `publish MatchReady`
 - *"when enough are queued"* → the `if`
 
-That's the whole service. No mutex to choose, no channel types, no
-`async`/`await`, no lifecycle wiring, no error handling at every
-boundary. You wrote down the idea; the idea is the program.
+No mutex to choose, no channel types, no `async`/`await`, no
+lifecycle wiring, no error handling at every boundary. You wrote down
+the idea; the idea is the program.
 
-## Write it at any altitude
+## One primitive, at any altitude
 
 Most languages pick a level and stay there — Python and JavaScript
 high, Go in the middle, Rust and C++ low. Hale is one language you
-write at any of those levels, moving between them without changing
-tools. There's a single primitive — the **locus** — and the only
-thing that changes as you go down is how much of it you choose to
-see.
+write at any of them, moving between levels without changing tools.
+There's a single building block — the **locus** — and the only thing
+that changes as you go down is how much of it you choose to see.
 
 | Altitude | You write… | Feels like… |
 |---|---|---|
 | **The basics** | variables, math, functions, control flow | a clean scripting language |
 | **Everyday programs** | files, JSON, HTTP, loci as objects | Python / Node |
-| **Concurrent services** | a typed bus, lifecycle, supervision | Go |
+| **Concurrent services** | a typed bus, lifecycle, supervision | Go / Erlang |
 | **Systems control** | memory layout, lifetime, zero-copy I/O, C bindings | Rust / C++ |
 
-Each level is self-contained. You can stop after the second one and
-write real applications; a function you wrote at the top still works
-at the bottom — you've just learned to see more of what was always
-there. The [docs](https://hale-lang.github.io/hale/) are organized
-as exactly this descent, so you go only as deep as you need.
+A function you wrote at the top still works at the bottom — you've
+just learned to see more of what was always there. The
+[docs](https://hale-lang.github.io/hale/) are organized as exactly
+this descent, so you go only as deep as you need.
 
-## What Hale leaves out
+## What you don't write
 
-A lot of the appeal is what *isn't* there to trip over:
+A lot of the appeal is what *isn't* there to trip over — or to make
+a coding model hallucinate:
 
-- **No `class`, `module`, `package`** — the **locus** is all of
-  them. Apps, services, caches, handlers, libraries: all loci.
+- **No `class`, `module`, `package`** — the **locus** is all of them.
+  Apps, services, caches, handlers, libraries: all loci.
 - **No `Vec<T>` / `Map<K,V>` ceremony** — declare a collection with
-  `@form` on a locus and get `push` / `get` / `len` synthesized.
-- **No `async` / `await`** — concurrency lives on a typed message
-  bus and the locus lifecycle. There's no function-coloring problem
-  because there are no async functions to color.
-- **No GC, and no borrow checker** — the locus hierarchy is
-  explicit, so cleanup is deterministic when a locus dissolves. You
-  never write `free`, and you never fight a lifetime annotation.
-- **No exceptions, no `panic` / `assert`** — a call that can fail
-  says so in its type, and you address it right at the call site.
-  Nothing propagates invisibly.
+  `@form` on a locus and get `push` / `get` / `len` synthesized,
+  type-specialized to your element.
+- **No `async` / `await`** — concurrency lives on a typed message bus
+  and the locus lifecycle. No function-coloring problem, because
+  there are no async functions to color.
+- **No GC, and no borrow checker** — the locus hierarchy is explicit,
+  so cleanup is deterministic when a locus dissolves. You never write
+  `free`, and you never fight a lifetime annotation.
+- **No exceptions, no `panic` / `assert`** — a call that can fail says
+  so in its type, and you address it right at the call site. Nothing
+  propagates invisibly.
 
 ## You declare intent; the compiler picks the mechanism
 
@@ -116,41 +118,27 @@ Each block on a locus states *what you mean* on an axis where other
 languages make you hand-pick a mechanism:
 
 - **`topic` + `bus { subscribe/publish }`** — what crosses between
-  loci. The compiler/binary picks the transport (in-process queue,
-  socket, broker) without changing your code.
-- **`placement { }`** — where loci run (a shared cooperative pool or
-  a dedicated thread), decided at deployment, not baked into the
-  logic.
-- **`@form(vec / hashmap / ring_buffer)`** — a collection's access
-  discipline; you get a tight, type-specialized implementation.
+  loci. The binary picks the transport (in-process queue, socket,
+  shared-memory ring, broker) without touching your logic.
+- **`placement { }`** — where loci run: a shared cooperative pool, a
+  dedicated thread, a pinned core, a NUMA node. Decided at deployment.
+- **`@form(vec / hashmap / ring_buffer / lru_cache)`** — a
+  collection's access discipline; you get a tight, specialized
+  implementation.
 - **`mode bulk / harmonic / resolution`** — an execution regime; the
   compiler emits vectorized, cache-tiled, or scalar code to match.
 
-The choices that are easy to get wrong — which lock, which
-container, which transport — stop being choices you make at the call
-site. That's also why the language is unusually pleasant to write
-*with* an LLM: the things models hallucinate on aren't in the code.
+The choices easy to get wrong — which lock, which container, which
+transport — stop being choices you make at the call site. It's also
+why Hale is unusually pleasant to write *with* a coding model: the
+things models hallucinate on aren't in the code.
 
-## Verified by construction
+## Deploy by editing `main`
 
-The substrate you stand on is checked, not hoped. Every concurrent
-primitive in the runtime — the lock-free map, the mailbox, the bus
-queue, the arena — is **model-checked under every interleaving**
-([GenMC](https://github.com/MPI-SWS/genmc)) on each CI run. Above it,
-the bus topology is a typed graph the compiler walks at build time:
-orphaned topics, re-entrant cycles, unbounded backpressure, and
-payload type-mismatches are caught before the program runs. You don't
-get a "verified" sticker on your whole program — you get a foundation
-whose coordination can't silently race. See
-[Verification](https://hale-lang.github.io/hale/verification.html).
-
-## Wire the whole system in `main`
-
-Two of those axes — *where loci run* and *how their messages travel*
-— come together in the `main` locus, in a `placement { }` block and
-a `bindings { }` block. This is the control panel for the entire
-program. The loci themselves don't mention threads or transports;
-`main` does, in one place:
+Where each locus runs and how its messages travel come together in
+the `main` locus — the control panel for the whole program. The loci
+themselves never mention threads or transports; `main` does, in one
+place:
 
 <!-- Rendered SVG; source assets/readme/placement.hl, regenerate with
      `python3 tools/hale_svg.py assets/readme/placement.hl assets/readme/placement.svg`.
@@ -167,22 +155,19 @@ main locus App {
         region_eu: GameRegion     = GameRegion { name: "eu-west" };
         sessions:  SessionWorkers = SessionWorkers { };
         metrics:   MetricsServer  = MetricsServer { port: 9100 };
-        admin:     AdminConsole   = AdminConsole { };
     }
 
     placement {
-        region_us: pinned(core = 1);                       // its own core
-        region_eu: pinned(core = 2);                       // a sibling, on another
-        sessions:  cooperative(pool = ws) where async_io;  // 1 thread, 1000s of players
+        region_us: pinned(node = 0);                       // thread + memory on NUMA node 0
+        region_eu: pinned(node = 1);                       // a sibling, on the other node
+        sessions:  cooperative(pool = ws) where async_io;  // 1 thread, thousands of players
         metrics:   cooperative(pool = io);                 // shares the io pool
-        // admin is unlisted -> cooperative(pool = main)
     }
 
     bindings {
-        // PlayerInput: not listed -> delivered by an in-process queue
         MatchReady:    unix("/run/match.sock");                       // AF_UNIX, role inferred
         WorldSnapshot: shm_ring("/world", slot_count: 1024, on_overflow: drop)
-                      where intra_machine, zero_copy;                 // shared-memory, no copy
+                      where intra_machine, zero_copy;                 // shared memory, no copy
         ChatRelay:     NatsAdapter { url: "nats://chat:4222" };       // a locus you wrote
         Replay:        unix("/run/replay.sock") codec(JsonCodec { }); // JSON on the wire
     }
@@ -191,179 +176,148 @@ main locus App {
 
 </details>
 
-**`placement { }` — where each locus runs.** Same-type siblings can
-sit on different cores; it keys on the field name, not the type.
-
-- `cooperative(pool = X)` — share pool `X`'s OS thread (the default
-  pool is `main`).
-- `pinned` / `pinned(core = N)` — a dedicated OS thread, optionally
-  pinned to a CPU core.
-- `where async_io` — turn a cooperative pool into an event loop, so
-  a blocking `recv` *parks* instead of stalling the thread. One
-  thread serves thousands of connections.
-
-**`bindings { }` — how each topic is delivered.** The publisher's
-`Topic <- value;` and the subscriber's `subscribe Topic` are
-identical no matter which line below you pick.
-
-- *(absent)* — an in-process cooperative queue. The default; no
-  entry needed.
-- `unix("/path")` — AF_UNIX framed bytes; listen/connect role
-  inferred from who publishes vs subscribes.
-- `udp://host:port` — datagrams, including IPv4 multicast.
-- `NatsAdapter { ... }` — any locus you write with a single `send`
-  method: NATS, MQTT, a custom broker.
-- `codec(JsonCodec { })` — JSON, protobuf, or a custom wire format
-  per binding, so a Python or Go peer can read it. Different
-  bindings on the same topic can carry different codecs.
-- `shm_ring(...) where zero_copy` — a shared-memory ring with no
-  copy at the locus boundary, for the hottest same-host routes.
-
-Here's the part that matters: **not one line of `GameRegion`,
-`SessionWorkers`, or `MetricsServer` changes** whether `MatchReady`
-is an in-process queue or a Unix socket, whether `region_us` is
-pinned to a core or cooperative on the main thread. You design the
-system once, and redeploy it — test, single binary, multi-binary,
+Not one line of `GameRegion`, `SessionWorkers`, or `MetricsServer`
+changes whether `MatchReady` is an in-process queue or a Unix socket,
+or whether `region_us` owns a NUMA node or shares the main thread. You
+design the system once and redeploy it — test, single binary,
 multi-host — by editing `main`.
+
+And you can redeploy it **while it runs.** A `perspective` is a live,
+swappable handle to a contract; `reperspective` re-points it at a new
+implementation with a single atomic store — hot code-swap at
+pointer-flip cost, no restart:
+
+```hale
+reperspective self.router as RouterV2;   // every caller sees V2 on the next call
+```
+
+`topology { }` to describe the machine, `placement { }` to map
+components onto its cores and memory, `reperspective` to redeploy them
+live. Kubernetes-shaped, in a single address space, at nanosecond
+cost.
+
+## Verified by construction
+
+The substrate you stand on is checked, not hoped. Every concurrent
+primitive in the runtime — the lock-free map, the mailbox, the bus
+queue, the arena — is **model-checked under every interleaving**
+([GenMC](https://github.com/MPI-SWS/genmc)) on each CI run. Above it,
+the compiler walks the bus topology as a typed graph at build time:
+orphaned topics, re-entrant cycles, unbounded backpressure, and
+payload type-mismatches are caught before the program runs. You don't
+get a "verified" sticker on your whole program — you get a foundation
+whose coordination can't silently race.
+[Verification →](https://hale-lang.github.io/hale/verification.html)
 
 ## See it on your own code
 
-Before you install anything: in
-[Claude Code](https://claude.ai/code), Cursor, or whatever LLM tool
-you use, drop this project's [`AGENTS.md`](./AGENTS.md) into the
-agent's context and ask it to re-read a module from your existing
-codebase **as loci, contracts, and bus topics**. What usually comes
-back is a decomposition that matches your mental model — because
-the agent is reasoning in the same vocabulary you already use about
-your code. If it looks right, you've felt the fit without writing a
-line of Hale.
+Before you install anything: in your coding assistant of choice, drop
+this project's [`AGENTS.md`](./AGENTS.md) into context and ask it to
+re-read a module from your existing codebase **as loci, contracts, and
+bus topics**. What usually comes back is a decomposition that matches
+your mental model — because the model is reasoning in the same
+vocabulary you already use about your system. If it looks right,
+you've felt the fit without writing a line of Hale.
 
 ## Try it
 
-**No install — [run Hale in your browser](https://hale-lang.github.io/hale/play/).** The
-playground runs real Hale compiled to WebAssembly, right on the page (the UI itself is a
-Hale `@export locus`).
+**No install — [run Hale in your browser](https://hale-lang.github.io/hale/play/).**
+The playground is real Hale, compiled to WebAssembly, running on the
+page (the UI itself is a Hale `@export locus` — the same `.hl` source
+runs native or in the browser).
 
-**Prebuilt binaries** for Linux are on the
-[releases page](https://github.com/hale-lang/hale/releases) — download, extract, and put
-`hale` on your `PATH`; no toolchain required. Or build from source:
+**Prebuilt Linux binaries** are on the
+[releases page](https://github.com/hale-lang/hale/releases) — download,
+extract, put `hale` on your `PATH`. Or build from source:
 
 ```sh
 git clone https://github.com/hale-lang/hale
 cd hale
-cargo build --release
+cargo build --release   # needs Rust 1.95+, LLVM 18, clang, git
 ```
 
-Requires Rust 1.95+, LLVM 18, `clang`, and `git`. Platform-specific
-install commands are in
-[`docs/src/getting-started/install.md`](./docs/src/getting-started/install.md).
-
-Write `hello.hl`:
+Then:
 
 ```hale
-fn main() {
-    println("Hello from Hale.");
-}
+// hello.hl
+fn main() { println("Hello from Hale."); }
 ```
-
-Run it, or compile a standalone native binary:
 
 ```sh
-cargo run -p hale-cli --bin hale -- run   hello.hl
-cargo run -p hale-cli --bin hale -- build hello.hl && ./hello
+hale run   hello.hl          # compile + run
+hale build hello.hl && ./hello
 ```
 
-Depending on Hale libraries? Declare them in `hale.toml`, then
-`hale fetch` vendors and pins them:
+Platform-specific setup (Linux, macOS/Apple Silicon) is in
+[the install guide](./docs/src/getting-started/install.md).
 
-```toml
-[deps]
-pond = { git = "https://github.com/hale-lang/pond", tag = "v0.8.0" }
-```
+## Hale commits, and tells you about it
+
+Opinionated by design — there's no permissive escape hatch, and
+that's the feature:
+
+- **One form per locus.** A locus is one container; you compose at the
+  locus level, not inside it.
+- **Three modes** — `bulk`, `harmonic`, `resolution`. No fourth; they
+  map to real hardware execution regimes.
+- **Vertical-only failure.** A parent decides recovery for its
+  children; failures never travel sideways.
+- **Closure assertions are language constructs.** You declare an
+  invariant; the runtime audits it. That's the point.
+
+If your problem decomposes cleanly into loci + bus + closures, you
+move fast. If it doesn't, the language tells you so.
+
+## Status
+
+Hale is **young** — the first public commits are weeks old, and it
+moves fast. It is not a toy: it's developed alongside a real
+production system, and the language surface is **stable** — most work
+between here and v1 is bugs, performance, and polish, not new syntax.
+Pin to a commit if you build on it.
+
+The native compiler self-hosts the topic system, structural
+interfaces, `@form(...)` collections, the `fallible(T)` error model,
+cooperative + pinned + topology-aware schedulers, live `reperspective`
+redeploy, and cross-process bus transports.
+
+**Performance** is a lead, not a cost: after the lock-free bus and
+static-dispatch devirtualization, message dispatch runs ahead of Go,
+collections lead too, and native codegen brings tight loops to parity
+with `clang -O3`. Methodology and current numbers live in
+[hale-lang/bench](https://github.com/hale-lang/bench).
+
+## The ecosystem
+
+The names mean things, and they fit together:
+
+- **hale** — the language. From the Old English *hāl*: "whole, sound,
+  uninjured." Same root as *whole*, *heal*, *health*.
+- **lotus** — the runtime substrate. C-runtime symbols are `lotus_*`.
+- **pond** — the contributed library catalog (web, databases,
+  observability, AI clients). *Many lotus grow in a pond.*
+- **heron** — the tree-sitter grammar; editors and the future LSP
+  drink from it.
 
 ## Where to go next
 
 - **[Docs site](https://hale-lang.github.io/hale/)** — the
   level-by-level tour. Start here.
 - **[`spec/`](./spec/)** — the canonical reference; the compiler
-  enforces exactly what it describes. Begin with
-  [`spec/styleguide.md`](./spec/styleguide.md).
-- **[`AGENTS.md`](./AGENTS.md)** — the load-bearing prompt for
-  agents writing `.hl` (and a tight read for humans).
-- **[`crates/hale-codegen/tests/fixtures/examples/`](./crates/hale-codegen/tests/fixtures/examples/)**
-  — ~70 working `.hl` programs.
-- **[hale-lang/pond](https://github.com/hale-lang/pond)** —
-  contributed libraries: web, databases, observability, AI clients.
-- **[`CONTRIBUTING.md`](./CONTRIBUTING.md)** — how the repo is built
-  and how to send a change.
-- **[Issues](https://github.com/hale-lang/hale/issues)** — bugs,
-  questions, and ideas; the place to start a conversation.
+  enforces what it describes.
+- **[`AGENTS.md`](./AGENTS.md)** — the load-bearing prompt for coding
+  models writing `.hl` (and a tight read for humans).
+- **[Examples](./crates/hale-codegen/tests/fixtures/examples/)** —
+  ~70 working `.hl` programs.
+- **[pond](https://github.com/hale-lang/pond)** · contributed
+  libraries. **[CONTRIBUTING](./CONTRIBUTING.md)** · how to build +
+  send a change. **[Issues](https://github.com/hale-lang/hale/issues)**
+  · questions, ideas, bugs.
 
-## The ecosystem
-
-The names mean things, and they fit together:
-
-- **hale** — the language. From the Old English *hāl*, "whole,
-  sound, uninjured." Same root as *whole*, *heal*, *health*.
-- **lotus** — the runtime substrate. C-runtime symbols are prefixed
-  `lotus_*`.
-- **pond** — the contributed library catalog. *Many lotus grow in a
-  pond.*
-- **heron** — the tree-sitter grammar; editors and the future LSP
-  drink from it.
-
-## State of the culture
-
-Hale commits hard and tells you about it:
-
-- **One form per locus.** Compose at the locus level.
-- **Three modes** (`bulk`, `harmonic`, `resolution`). No fourth —
-  they map to real hardware execution regimes.
-- **Vertical-only failure flow.** A parent decides recovery for its
-  children; failures never travel sideways.
-- **Region-based memory, deterministic dissolve.** No GC, no
-  reference counting.
-- **Closure assertions as language constructs.** The runtime audits
-  the invariants you declare. That's the point.
-
-If your problem decomposes cleanly into loci + bus + closures,
-you'll move fast. If it doesn't, the language tells you so — there's
-no permissive escape hatch, and that's the feature.
-
-## Status
-
-The language surface is **stable**. Most work between now and v1 is
-bugs, stability, and performance — not new syntax. Pin to a commit
-if you build on it. The native compiler self-hosts the topic system,
-structural interfaces, the `@form(...)` collections, the
-`fallible(T)` error model, cooperative + pinned schedulers, and
-cross-process bus transports.
-
-**Performance** (v0.9.2, AMD Ryzen 7 9800X3D): coordination is
-now a lead, not a cost. After v0.9.0's lock-free bus and
-static-dispatch devirtualization, `bus_dispatch` went from ~4×
-behind Go to **2.4× ahead** (1.79 ms → 196 µs) and
-`bus_dispatch_cross_pool` to **1.26× ahead**. Collections lead
-too (vec 3–4×, json_parse 2.3× vs Go), and native codegen brought
-tight-loop `fn_call` to **parity with clang -O3 C**. Headline
-shape: lock-free bus, static-dispatch devirtualization, native
-codegen, and interest-based ownership (accept bubbling).
-Methodology and current numbers:
-[hale-lang/bench](https://github.com/hale-lang/bench).
-
-## Beyond the native runtime
-
-Hale isn't tied to one runtime. The same `.hl` source also runs in
-the browser on [hale-js](https://github.com/hale-lang/hale-js) — the
-same `locus`, `bus`, and lifecycle against a browser capability
-profile — and the locus + bus shape is a deliberate fit for other
-substrates over time. The structural reason one shape carries across
-runtimes (and across how humans, LLMs, and machines each represent
-it) is written up in
-[hale-lang/papers](https://github.com/hale-lang/papers).
+Why one shape carries across native, browser, human, and model is
+written up in [hale-lang/papers](https://github.com/hale-lang/papers).
 
 ## License
 
-Licensed under the [Apache License, Version 2.0](./LICENSE).
-Attribution and third-party notices are tracked in
+[Apache License 2.0](./LICENSE). Third-party notices in
 [`NOTICE`](./NOTICE).


### PR DESCRIPTION
Stage 1 of the launch-prep pass. New identity line, folds in the v0.10 topology/perspectives deployment story (was absent), own-the-youth + soft prod framing, kills the dead hale-js link, compresses ~369→~325 lines. Matchmaker + deploy-in-main demos and the culture section retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)