### PR TITLE
test: harden the UDP + cross-pool-bubble flakes under nextest concurrency

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -28,5 +28,13 @@ slow-timeout = { period = "60s", terminate-after = 8 }
 filter = 'binary(three_hop_import)'
 test-group = 'shared-fixture-dir'
 
+[[profile.default.overrides]]
+# UDP tests hardcode multicast groups (239.255.x) + ports; two running
+# concurrently cross-talk / collide on the group:port pair (the #178
+# loopback flake class). Serialize them against each other.
+filter = 'binary(bus_udp_transport) | binary(udp_multicast) | binary(udp_p4_source_and_timeout) | binary(udp_primitives)'
+test-group = 'serial-udp'
+
 [test-groups]
 shared-fixture-dir = { max-threads = 1 }
+serial-udp = { max-threads = 1 }

--- a/crates/hale-codegen/tests/ownership_bubble.rs
+++ b/crates/hale-codegen/tests/ownership_bubble.rs
@@ -61,7 +61,7 @@ fn run(bin: &std::path::PathBuf) -> String {
 /// them at 0, so they never need this.)
 fn run_expecting(bin: &std::path::PathBuf, needles: &[&str]) -> String {
     let mut last = String::new();
-    for attempt in 0..4 {
+    for attempt in 0..6 {
         let out = Command::new(bin).output().expect("run hale");
         assert!(
             out.status.success(),
@@ -116,7 +116,7 @@ const BUBBLE_SRC: &str = r#"
             // parallel-suite load (same de-flake as the crosspool
             // suite). Each sleep slice drains the pool queue.
             let mut waited: Int = 0;
-            while self.harmonic() < 2 && waited < 60 {
+            while self.harmonic() < 2 && waited < 120 {
                 std::time::sleep(100ms);
                 waited = waited + 1;
             }
@@ -301,7 +301,7 @@ fn non_singleton_ancestor_now_bubbles_via_threading() {
                 // parallel-suite load (same de-flake as the crosspool
                 // suite). Each sleep slice drains the pool queue.
                 let mut waited: Int = 0;
-                while self.harmonic() < 2 && waited < 60 {
+                while self.harmonic() < 2 && waited < 120 {
                     std::time::sleep(100ms);
                     waited = waited + 1;
                 }

--- a/crates/hale-codegen/tests/ownership_bubble_crosspool.rs
+++ b/crates/hale-codegen/tests/ownership_bubble_crosspool.rs
@@ -92,9 +92,11 @@ const XPOOL_SRC: &str = r#"
             // bubbles race pinned-thread startup, and a 300ms
             // window flaked on loaded CI runners (each sleep slice
             // drains the pool's queue, so delivery progresses
-            // through this loop). Bounded at ~6s.
+            // through this loop). Bounded at ~12s — generous so a
+            // starved delivery thread on a saturated CI runner still
+            // completes within one run (delivery needs <1s of real CPU).
             let mut waited: Int = 0;
-            while self.harmonic() < 3 && waited < 60 {
+            while self.harmonic() < 3 && waited < 120 {
                 std::time::sleep(100ms);
                 waited = waited + 1;
             }
@@ -167,7 +169,7 @@ fn world_collects_crosspool_bubbled_ships() {
     // is the same starvation the bubble_lock + 6s poll already chase, one
     // level more robust for the concurrent-CI case.
     let mut last = String::new();
-    for attempt in 0..4 {
+    for attempt in 0..6 {
         let out = Command::new(&bin).output().expect("run hale");
         assert!(
             out.status.success(),

--- a/crates/hale-codegen/tests/ownership_bubble_multi.rs
+++ b/crates/hale-codegen/tests/ownership_bubble_multi.rs
@@ -56,7 +56,7 @@ fn run(bin: &std::path::PathBuf) -> String {
 /// `run` (starvation keeps them at 0).
 fn run_expecting(bin: &std::path::PathBuf, needles: &[&str]) -> String {
     let mut last = String::new();
-    for attempt in 0..4 {
+    for attempt in 0..6 {
         let out = Command::new(bin).output().expect("run hale");
         assert!(
             out.status.success(),


### PR DESCRIPTION
The durable fix for the recurring CI `test N/4` flakes — two distinct root causes, each fixed at the source:

**UDP (resource collision).** `bus_udp_transport` / `udp_multicast` / `udp_primitives` / `udp_p4_source_and_timeout` hardcode multicast groups (`239.255.x`) + ports; two concurrent runs cross-talk on the group:port pair (the #178 class). Added a nextest `serial-udp` test-group (`max-threads = 1`) — no two ever run at once. Deterministic.

**Cross-pool bubble (CPU starvation).** The 3 `ownership_bubble*` tests already file-lock against each other, so the flake is starvation of the delivery thread by *other* heavy tests (corpus_oracle etc.) — a nextest group can't fix that. Delivery needs <1s of real CPU but was bounded to a 6s poll × 4 re-runs; under saturation all attempts could starve. Widened to **12s poll × 6 re-runs** (~72s of chances). Only spent under contention.

**Validated:** all 23 UDP+bubble tests green under nextest; the bubble suite passes **11/11 with the CPU fully saturated** (16 `yes` hogs) — the exact scenario that flaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)