### PR TITLE
ci: stop tests-workflow disk exhaustion (wider purge via shared action)

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,26 @@
+name: Free disk space
+description: >
+  Reclaim the ~40GB of preinstalled toolchains ubuntu-latest ships but
+  this workspace never uses, so the LLVM-linked release/sanitizer build
+  (dozens of statically-linked test binaries) doesn't exhaust the runner
+  disk with "No space left on device".
+
+# This job only needs Rust — installed by rust-toolchain into ~/.rustup,
+# NOT the hosted-tool cache — plus apt-installed LLVM. Everything removed
+# below is unused by the build. An earlier, smaller purge
+# (dotnet/ghc/android/CodeQL only) still tipped over on unlucky runners,
+# hence the wider set + the before/after `df` so a recurrence is legible
+# in the log. Shared by every heavy job in tests.yml so the set is
+# maintained in one place (it used to be copy-pasted and drifted).
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        echo "disk before:"; df -h / | tail -1
+        sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+                    /usr/local/lib/android /opt/hostedtoolcache \
+                    /usr/share/swift /usr/local/share/boost \
+                    /usr/local/share/powershell /usr/lib/jvm
+        sudo docker image prune -af 2>/dev/null || true
+        echo "disk after:";  df -h / | tail -1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,23 +57,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # ubuntu-latest ships ~25-30GB of preinstalled toolchains this
-      # build never uses (dotnet, Android SDK, GHC, CodeQL). Reclaim
-      # them up front — the release build + nextest archive of an
-      # LLVM-linked workspace had been intermittently exhausting the
-      # runner disk ("No space left on device" in build+archive).
-      # ubuntu-latest ships ~25-30GB of preinstalled toolchains this
-      # build never uses (dotnet, Android SDK, GHC, CodeQL). Reclaim
-      # them up front — the release build of an LLVM-linked workspace
-      # had been intermittently exhausting the runner disk. Fixtures
-      # resolve via CARGO_MANIFEST_DIR against this checkout, so the
-      # build + run happen in-place with no path remap.
+      # Fixtures resolve via CARGO_MANIFEST_DIR against this checkout,
+      # so build + run happen in-place with no path remap.
       - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
-                      /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
-          sudo docker image prune -af 2>/dev/null || true
-          df -h /
+        uses: ./.github/actions/free-disk-space
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -151,17 +138,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # ubuntu-latest ships ~25-30GB of preinstalled toolchains this
-      # build never uses (dotnet, Android SDK, GHC, CodeQL). Reclaim
-      # them up front — the release build + nextest archive of an
-      # LLVM-linked workspace had been intermittently exhausting the
-      # runner disk ("No space left on device" in build+archive).
       - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
-                      /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
-          sudo docker image prune -af 2>/dev/null || true
-          df -h /
+        uses: ./.github/actions/free-disk-space
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -233,17 +211,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # ubuntu-latest ships ~25-30GB of preinstalled toolchains this
-      # build never uses (dotnet, Android SDK, GHC, CodeQL). Reclaim
-      # them up front — the release build + nextest archive of an
-      # LLVM-linked workspace had been intermittently exhausting the
-      # runner disk ("No space left on device" in build+archive).
       - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
-                      /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
-          sudo docker image prune -af 2>/dev/null || true
-          df -h /
+        uses: ./.github/actions/free-disk-space
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -325,10 +294,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
-                      /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
-          df -h /
+        uses: ./.github/actions/free-disk-space
 
       - name: Install LLVM 18 + clang + cmake
         run: |


### PR DESCRIPTION
A `tests` run went red on **`No space left on device`** — not a test failure (the shards that had disk passed 412/412 and 417/417), but the runner filling up. The four heavy jobs (`test` / `tsan` / `asan` / `genmc`) each build the LLVM-linked workspace; the sanitizer builds are larger still.

Each job *already* had a "Free disk space" step, but the purge was **copy-pasted four times and had drifted** — two carried a duplicated comment block, `genmc` omitted the docker prune, and all freed too little (dotnet/ghc/android/CodeQL only, ~20 GB), so unlucky runners still tipped over.

- New composite action **`.github/actions/free-disk-space`** — one maintained purge covering the full unused set (adds Swift, the whole hosted-tool cache, boost, PowerShell, bundled JVMs → **~40 GB**), with a before/after `df` so any recurrence is legible.
- All four jobs now `uses: ./.github/actions/free-disk-space` instead of their own drifted copy.

Build/test invocation is unchanged — this only reclaims space before it runs. The green run of this PR is itself the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)