### PR TITLE
fix(codegen): resolve self.<scalar> in param defaults lexically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ Eight substrate findings from a downstream service built on hale
   (including fields with no placement entry and the main locus's
   own `run()`) warn naming every offender — the second-born
   `run()` never starts, and the failure was silent.
+- **`self.<scalar>` in nested-literal param defaults works.**
+  `conn: Ws = Ws { conn_fd: self.fd }` now resolves `self`
+  lexically (the declaring locus) even when the instantiation
+  happens inside another locus's method body; call-site overrides
+  keep resolving to the caller (F.4). A default reading a
+  later-declared sibling is now a compile error instead of an
+  uninitialized read.
 - Filed as issues: migrating `Stream.send`/`recv` to
   `fallible(IoError)` (finding 5) and implicit error propagation
   on tail-position `return` (finding 8).

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1186,6 +1186,8 @@ pub fn build_executable_with_options(
         main_locus_name: None,
         pinned_locus_types: BTreeSet::new(),
         params_init_self: None,
+        in_params_default: false,
+        params_init_initialized: None,
         main_cooperative_pools: BTreeMap::new(),
         async_io_pools: BTreeSet::new(),
         cooperative_pool_for_next_locus_instantiation: None,
@@ -3051,6 +3053,28 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// `lower_locus_instantiation` calls preserve their own
     /// prior value via the save/restore in the loop's setup.
     pub(crate) params_init_self: Option<SelfCx<'ctx>>,
+    /// downstream handoff 2026-07-14 (finding 4): true while lowering a
+    /// params-DEFAULT expression (the text written inside the
+    /// instantiated locus's own `params { }` block), false for
+    /// call-site override expressions and method bodies. Decides
+    /// `self.X` precedence in the `Expr::Field`/KwSelf arm:
+    /// default text resolves against `params_init_self` (the
+    /// declaring locus) even when a method body's `current_self`
+    /// is live — a locus instantiated inside another locus's
+    /// handler must not have its defaults' `self.X` captured by
+    /// the enclosing method's locus. Override expressions restore
+    /// the flag saved at frame entry, mirroring the F.4
+    /// `prev_params_init_self` swap (an override inherits the
+    /// context of the code that wrote the literal).
+    pub(crate) in_params_default: bool,
+    /// Finding 4 companion: the params fields already stored by the
+    /// innermost params-init loop, so a default that reads a
+    /// LATER-declared sibling (`a: Int = self.b; b: Int = 1;`) is
+    /// rejected instead of GEP+loading an uninitialized slot.
+    /// Swapped alongside `params_init_self` (frame entry, override
+    /// lowering, frame exit). Typecheck currently skips default
+    /// exprs entirely (Milestone-2 cut), so codegen owns this rule.
+    pub(crate) params_init_initialized: Option<BTreeSet<String>>,
     /// F.31 Phase 3b: set of locus type names that are
     /// instantiated pinned-equivalent SOMEWHERE in the bundle.
     /// Populated from: (a) `placement { field: pinned[(core=N)]; }`
@@ -18015,17 +18039,61 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 // Sibling fields stored earlier in the params-
                 // init loop are readable; field-order discipline
                 // ensures the GEP+load sees an initialized slot.
-                let cs = self
-                    .current_self
-                    .as_ref()
-                    .cloned()
-                    .or_else(|| self.params_init_self.as_ref().cloned())
-                    .ok_or_else(|| {
-                        CodegenError::Unsupported(format!(
-                            "self.{} read outside a locus method",
-                            name.name
-                        ))
-                    })?;
+                //
+                // downstream handoff 2026-07-14 (finding 4): precedence
+                // is by LEXICAL context, not just liveness. While
+                // lowering a params-DEFAULT expression
+                // (`in_params_default`), `self.X` is text written
+                // inside the instantiated locus's own params
+                // block, so it resolves against `params_init_self`
+                // (the declaring locus) even when the
+                // instantiation happens inside another locus's
+                // method body and `current_self` is live —
+                // pre-fix, a `Ws { conn_fd: self.fd }` default
+                // lowered under a handler's `current_self` and
+                // died with "no field `fd` on locus self".
+                // Override / method-body expressions keep the
+                // original current_self-first order (F.4).
+                let cs = if self.in_params_default {
+                    if let Some(pis) = self.params_init_self.as_ref() {
+                        // Defaults run in declaration order; a read
+                        // of a later-declared sibling would GEP+load
+                        // an uninitialized slot — reject it.
+                        if pis.fields.contains_key(&name.name) {
+                            if let Some(init) =
+                                self.params_init_initialized.as_ref()
+                            {
+                                if !init.contains(&name.name) {
+                                    return Err(CodegenError::Unsupported(
+                                        format!(
+                                            "param default reads `self.{}` \
+                                             before it is initialized — \
+                                             defaults run in declaration \
+                                             order; declare `{}` earlier or \
+                                             pass the value at the creation \
+                                             site",
+                                            name.name, name.name
+                                        ),
+                                    ));
+                                }
+                            }
+                        }
+                        Some(pis.clone())
+                    } else {
+                        self.current_self.as_ref().cloned()
+                    }
+                } else {
+                    self.current_self
+                        .as_ref()
+                        .cloned()
+                        .or_else(|| self.params_init_self.as_ref().cloned())
+                }
+                .ok_or_else(|| {
+                    CodegenError::Unsupported(format!(
+                        "self.{} read outside a locus method",
+                        name.name
+                    ))
+                })?;
                 // F.16 / F.27 synthetic fields. B14 lifted the bodies
                 // into helpers so non-`self` locus receivers
                 // (`g.k_max`, `g.draining`) hit the same lowering.

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -5,7 +5,7 @@
 //! spawn, and the deferred-dissolve frame for long-lived loci.
 //! Round 4d of the codegen model-org refactor — the heavyweight.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use hale_syntax::ast::{
     BirthCheckDecl, CapacitySlotKind, Expr, Literal, LocusMember,
@@ -1736,6 +1736,14 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
         // resolve_failure_route consults as a fallback when
         // current_self is None.
         let prev_params_init_self = self.params_init_self.take();
+        // Finding 4 (downstream handoff 2026-07-14): remember whether the
+        // code that WROTE this instantiation was itself params-
+        // default text — override expressions inherit that context
+        // (they're written at the literal's site), while this
+        // locus's own default expressions set the flag true below.
+        let prev_in_params_default = self.in_params_default;
+        let prev_params_init_initialized = self.params_init_initialized.take();
+        self.params_init_initialized = Some(BTreeSet::new());
         self.params_init_self = Some(SelfCx {
             locus_name: locus_name.to_string(),
             struct_ty: info.struct_ty,
@@ -1811,7 +1819,11 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                         // The extra replica's self_ptr isn't stored in a
                         // field (replicas are non-addressable workers);
                         // it lives only in the deferred-dissolve frame.
+                        // Finding 4: replica exprs are default text.
+                        let saved_ipd = self.in_params_default;
+                        self.in_params_default = true;
                         let _ = self.lower_expr(&rep_expr, scope)?;
+                        self.in_params_default = saved_ipd;
                         self.instantiating_for_parent_field = prev_flag;
                     }
                     // Restore replica 0's overrides for the normal path
@@ -1889,6 +1901,11 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                         size,
                     )
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                // Zero-init counts as initialized for later
+                // siblings' default reads.
+                if let Some(init) = self.params_init_initialized.as_mut() {
+                    init.insert(fname.clone());
+                }
                 continue;
             }
             let prev_field_flag = self.instantiating_for_parent_field;
@@ -1914,7 +1931,20 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                     // put ours back.
                     let inner_pis = self.params_init_self.take();
                     self.params_init_self = prev_params_init_self.clone();
+                    // Finding 4: the override's `self.X` precedence
+                    // follows the context that wrote the literal
+                    // (default text of an outer locus → true; a
+                    // method body / fn main → false), mirroring the
+                    // params_init_self swap above. The initialized-
+                    // fields set travels with its SelfCx.
+                    let inner_ipd = self.in_params_default;
+                    self.in_params_default = prev_in_params_default;
+                    let inner_init = self.params_init_initialized.take();
+                    self.params_init_initialized =
+                        prev_params_init_initialized.clone();
                     let r = self.lower_expr(expr, scope)?;
+                    self.params_init_initialized = inner_init;
+                    self.in_params_default = inner_ipd;
                     self.params_init_self = inner_pis;
                     let owned = !self.instantiating_for_parent_field;
                     self.instantiating_for_parent_field = prev_field_flag;
@@ -1937,7 +1967,16 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                             (r.0, r.1, false, from_lit)
                         }
                         DefaultInit::Expr(e) => {
+                            // Finding 4: this is the declaring
+                            // locus's own default text — `self.X`
+                            // inside it (including nested-literal
+                            // field inits) resolves against
+                            // params_init_self even under a live
+                            // method-body current_self.
+                            let saved_ipd = self.in_params_default;
+                            self.in_params_default = true;
                             let r = self.lower_expr(e, scope)?;
+                            self.in_params_default = saved_ipd;
                             let owned = !self.instantiating_for_parent_field;
                             self.instantiating_for_parent_field =
                                 prev_field_flag;
@@ -2173,6 +2212,11 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                 }
             }
+            // Finding 4: this field's slot is now stored — later
+            // siblings' defaults may read it.
+            if let Some(init) = self.params_init_initialized.as_mut() {
+                init.insert(fname.clone());
+            }
         }
         self.current_arena_override = prev_arena_override;
         // F.31 Phase 3b: restore params-init-parent context.
@@ -2180,6 +2224,7 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
         // have already stored their __parent_self values via
         // resolve_failure_route's lookup of params_init_self.
         self.params_init_self = prev_params_init_self;
+        self.params_init_initialized = prev_params_init_initialized;
         // F.31 Phase 4: cooperative-pool restore is deferred to
         // function exit (after the run_bb code that consumes it
         // — see end of fn + the pinned-branch early-return).
@@ -2804,7 +2849,12 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
             // new locus so the key-filter EXPR's `self.X` reads
             // resolve correctly. Save / restore around the loop
             // (same pattern birth_check_decls uses below).
+            // Finding 4: the where-clause is member text of THIS
+            // locus, not params-default text of the outer one —
+            // clear in_params_default so current_self wins even
+            // when this instantiation sits inside an outer default.
             let prev_self = self.current_self.clone();
+            let prev_ipd_sub = std::mem::replace(&mut self.in_params_default, false);
             self.current_self = Some(SelfCx {
                 locus_name: locus_name.to_string(),
                 struct_ty: info.struct_ty,
@@ -2872,6 +2922,7 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                     )?;
                 }
             }
+            self.in_params_default = prev_ipd_sub;
             self.current_self = prev_self;
         }
 
@@ -2977,8 +3028,12 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                     // Phase 3 same setup as the cooperative path
                     // above — set current_self for the key-filter
-                    // EXPR's `self.X` reads.
+                    // EXPR's `self.X` reads (and clear
+                    // in_params_default: member text, not default
+                    // text — see finding 4).
                     let prev_self_pinned = self.current_self.clone();
+                    let prev_ipd_pinned =
+                        std::mem::replace(&mut self.in_params_default, false);
                     self.current_self = Some(SelfCx {
                         locus_name: locus_name.to_string(),
                         struct_ty: info.struct_ty,
@@ -3009,6 +3064,7 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                             owned_beyond_scope,
                         )?;
                     }
+                    self.in_params_default = prev_ipd_pinned;
                     self.current_self = prev_self_pinned;
                     Some(mb_ptr)
                 } else {
@@ -3401,8 +3457,10 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
         if !birth_check_decls.is_empty() {
             // We need current_self set for `self.X` reads in the
             // cond expressions to resolve against the newly-
-            // constructed locus.
+            // constructed locus. (in_params_default cleared:
+            // birth_check conds are member text — finding 4.)
             let prev_self = self.current_self.clone();
+            let prev_ipd_bc = std::mem::replace(&mut self.in_params_default, false);
             self.current_self = Some(SelfCx {
                 locus_name: locus_name.to_string(),
                 struct_ty: info.struct_ty,
@@ -3413,6 +3471,7 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
             for bc in &birth_check_decls {
                 self.emit_birth_check(&bc, self_ptr, &info, &locus_name, &mut scope)?;
             }
+            self.in_params_default = prev_ipd_bc;
             self.current_self = prev_self;
         }
         // m41: gate run() on __quarantined. If a parent's

--- a/crates/hale-codegen/tests/params_default_scalar_self_ref.rs
+++ b/crates/hale-codegen/tests/params_default_scalar_self_ref.rs
@@ -1,0 +1,227 @@
+//! downstream handoff 2026-07-14 finding 4: `self.<scalar>` inside a
+//! nested-locus-literal param default ("no field `fd` on locus
+//! self" at codegen; typecheck passed). Root cause: `current_self`
+//! took precedence over `params_init_self` in the `self.X` field
+//! read, so when the declaring locus was instantiated from inside
+//! another locus's method body, the override's `self.fd` resolved
+//! against the *enclosing method's* locus. The semantics pinned
+//! here: `self` in any expression resolves to the locus whose
+//! source text lexically contains it — params-default text
+//! (including nested-literal field inits written inside a default)
+//! resolves to the declaring locus; a locus-literal field init
+//! written in a method body resolves to that method's locus (F.4,
+//! see sibling_field_forward_ref.rs).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::build_executable;
+
+fn unique_path(tag: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "lt-pdssr-{}-{}-{}.bin",
+        tag,
+        std::process::id(),
+        nanos,
+    ));
+    p
+}
+
+fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = unique_path(name);
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (String::from_utf8_lossy(&out.stdout).to_string(), out.status)
+}
+
+// The reported shape, shared by the quadrant tests below.
+const CONN_DECLS: &str = r#"
+    locus Ws {
+        params { conn_fd: Int = 0; }
+    }
+    locus Conn {
+        params {
+            fd: Int = -1;
+            conn: Ws = Ws { conn_fd: self.fd };
+        }
+        birth() { println("conn_fd=", self.conn.conn_fd); }
+    }
+"#;
+
+#[test]
+fn quadrant_a_fn_main_context() {
+    // Instantiated from fn main(): current_self is None, so
+    // params_init_self already resolved correctly pre-fix.
+    let src = format!(
+        r#"{CONN_DECLS}
+        fn main() {{ Conn {{ }}; }}
+    "#
+    );
+    let (stdout, status) = build_and_run("fn_main", &src);
+    assert!(status.success(), "non-zero: {:?}\nstdout: {}", status, stdout);
+    assert!(stdout.contains("conn_fd=-1"), "got: {:?}", stdout);
+}
+
+#[test]
+fn quadrant_b_main_params_default() {
+    let src = format!(
+        r#"{CONN_DECLS}
+        main locus App {{
+            params {{ c: Conn = Conn {{ }}; }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#
+    );
+    let (stdout, status) = build_and_run("main_params", &src);
+    assert!(status.success(), "non-zero: {:?}\nstdout: {}", status, stdout);
+    assert!(stdout.contains("conn_fd=-1"), "got: {:?}", stdout);
+}
+
+#[test]
+fn quadrant_c_method_body_context() {
+    // The reported shape: the declaring locus is instantiated
+    // inside another locus's method body (a per-connection child
+    // born in an accept/dispatch handler). Pre-fix: "no field `fd`
+    // on locus self" because current_self (Gateway) shadowed
+    // params_init_self (Conn).
+    let src = format!(
+        r#"{CONN_DECLS}
+        locus Gateway {{
+            params {{ started: Int = 0; }}
+            run() {{
+                let c = Conn {{ }};
+            }}
+        }}
+        fn main() {{ Gateway {{ }}; }}
+    "#
+    );
+    let (stdout, status) = build_and_run("method_body", &src);
+    assert!(status.success(), "non-zero: {:?}\nstdout: {}", status, stdout);
+    assert!(stdout.contains("conn_fd=-1"), "got: {:?}", stdout);
+}
+
+#[test]
+fn quadrant_d_field_reassign_context() {
+    // `self.c = Conn { };` in a method — the field-reassign
+    // instantiation path, also a method-body context.
+    let src = format!(
+        r#"{CONN_DECLS}
+        locus Holder {{
+            params {{ c: Conn = Conn {{ }}; }}
+            fn swap() {{ self.c = Conn {{ }}; }}
+            run() {{ self.swap(); }}
+        }}
+        fn main() {{ Holder {{ }}; }}
+    "#
+    );
+    let (stdout, status) = build_and_run("reassign", &src);
+    assert!(status.success(), "non-zero: {:?}\nstdout: {}", status, stdout);
+    // Once at params-init, once at swap().
+    assert_eq!(
+        stdout.matches("conn_fd=-1").count(),
+        2,
+        "expected two births with the declared default; got: {:?}",
+        stdout
+    );
+}
+
+#[test]
+fn call_site_override_still_resolves_to_caller() {
+    // The F.4 rule this fix must NOT regress: an override written
+    // at a method-body call site resolves `self.X` against the
+    // CALLER (here M.endpoint), not the instantiated locus.
+    let src = r#"
+        locus Ws {
+            params { conn_fd: Int = 0; }
+        }
+        locus Conn {
+            params {
+                fd: Int = -1;
+                conn: Ws = Ws { conn_fd: self.fd };
+            }
+            birth() { println("fd=", self.fd, " conn_fd=", self.conn.conn_fd); }
+        }
+        locus M {
+            params { endpoint: Int = 42; }
+            run() {
+                let c = Conn { fd: self.endpoint };
+            }
+        }
+        fn main() { M { }; }
+    "#;
+    let (stdout, status) = build_and_run("call_site", src);
+    assert!(status.success(), "non-zero: {:?}\nstdout: {}", status, stdout);
+    assert!(
+        stdout.contains("fd=42 conn_fd=42"),
+        "the override must land the caller's endpoint in fd, and the \
+         nested default must read it; got: {:?}",
+        stdout
+    );
+}
+
+#[test]
+fn default_reading_later_sibling_is_rejected() {
+    // Defaults run in declaration order; pre-guard this GEP+loaded
+    // an uninitialized slot silently.
+    let src = r#"
+        locus L {
+            params {
+                a: Int = self.b;
+                b: Int = 1;
+            }
+        }
+        fn main() { L { }; }
+    "#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = unique_path("fwd_ref");
+    let err = build_executable(&program, &bin)
+        .expect_err("forward-ref default must be rejected");
+    let _ = std::fs::remove_file(&bin);
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("before it is initialized"),
+        "expected the declaration-order error; got: {msg}"
+    );
+}
+
+#[test]
+fn two_level_recursion_resolves_innermost() {
+    // A default whose literal's locus has its own self-reading
+    // default: each default resolves against its OWN declaring
+    // locus (innermost), while the outer literal's explicit init
+    // resolves against the outer locus.
+    let src = r#"
+        locus Inner {
+            params {
+                x: Int = 3;
+                y: Int = self.x + 1;
+            }
+        }
+        locus Outer {
+            params {
+                n: Int = 7;
+                inner: Inner = Inner { };
+                m: Int = self.n + 100;
+            }
+            birth() {
+                println("inner.y=", self.inner.y, " m=", self.m);
+            }
+        }
+        fn main() { Outer { }; }
+    "#;
+    let (stdout, status) = build_and_run("recursion", src);
+    assert!(status.success(), "non-zero: {:?}\nstdout: {}", status, stdout);
+    assert!(
+        stdout.contains("inner.y=4 m=107"),
+        "inner defaults resolve to Inner, outer to Outer; got: {:?}",
+        stdout
+    );
+}

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -143,6 +143,17 @@ plumbing.
 `LocusName { params }`:
 
 1. Compute params (overrides applied to declared defaults).
+   `self` resolves **lexically**: inside a *default* expression —
+   including the field inits of a nested locus literal written in
+   that default — `self.X` reads the locus being instantiated
+   (earlier-declared siblings only; a default that reads a
+   later-declared sibling is a compile error, since defaults run
+   in declaration order). Inside an *override* expression, `self`
+   belongs to the code that wrote the literal — the enclosing
+   method's locus, or the enclosing params block when the literal
+   itself sits in a default (F.4 call-site rule). This holds
+   regardless of where the instantiation executes (fn main, a
+   params-init, or another locus's method body — 2026-07-14 fix).
 2. The nearest enclosing ancestor that declares `accept(c: I)`
    for the child's interface is the **owner** (innermost-wins —
    interest-based ownership / accept bubbling; see below and


### PR DESCRIPTION
**4/6 of the downstream-handoff substrate fixes (2026-07-14).** Stacked on #205.

```hale
locus Conn {
    params {
        fd: Int = -1;
        conn: Ws = Ws { conn_fd: self.fd };
        // codegen error: no field `fd` on locus self
    }
}
```

Typecheck passed (it skips default exprs — the Milestone-2 cut), then codegen died — but only when `Conn` was instantiated from inside another locus's method body (a per-connection child born in an accept/dispatch handler). Root cause: the enclosing method's `current_self` took precedence over `params_init_self` in the `self.X` read, so the default's `self.fd` resolved against the wrong locus. The F.4 override-context swap itself was correct all along (`sibling_field_forward_ref.rs` proves it).

## Semantics, now pinned in `spec/semantics.md`

`self` resolves to the locus whose source text **lexically contains** the expression: default text (including nested-literal field inits written inside a default) → the declaring locus; a locus-literal field init written in a method body → that method's locus (the F.4 call-site rule); recursive defaults → each to its own innermost declaring locus.

## Mechanism

A `Cx.in_params_default` flag set while lowering a locus's own default text inverts the `current_self`/`params_init_self` precedence. Override expressions restore the flag saved at frame entry (mirroring the F.4 `prev_params_init_self` swap), and the three instantiation sites that lower *member* text with a deliberately-installed `current_self` — bus `where key == self.X` clauses (cooperative + pinned) and `birth_check` conds — clear it, so keyed subscriptions on loci born in defaults keep resolving against the new locus (`bus_routing_keys` pins this).

Also new: a declaration-order guard — a default reading a **later-declared** sibling is now a compile error ("reads `self.b` before it is initialized") instead of a silent GEP+load of an uninitialized slot, tracked by an initialized-fields set that travels with the params-init context.

## Tests

New `params_default_scalar_self_ref.rs`: the four instantiation quadrants (fn main / main params default / method body / field reassign), call-site-override-still-resolves-to-caller (F.4 pin), two-level recursion, forward-ref rejection. Must-stay-green all green: `sibling_field_forward_ref`, `ws1_ffi_handle_reassign`, `locus_let_lifecycle`, `bus_routing_keys`, `topic_phase2*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)