### PR TITLE
fix(parser): name the reserved keyword when it lands in a binding position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Eight substrate findings from a downstream service built on hale
   longer flag.** Both diverge — the payload allocates at most once
   per invocation. Removes the false-positive class on strict
   parsers (`fail E { … }` inside `while`).
+- **Parser: reserved keywords in binding position are named.**
+  `let accept = …` now says ``expected variable name, but `accept`
+  is a reserved lifecycle keyword in Hale — pick another name``.
 - Filed as issues: migrating `Stream.send`/`recv` to
   `fallible(IoError)` (finding 5) and implicit error propagation
   on tail-position `return` (finding 8).

--- a/crates/hale-syntax/src/lexer.rs
+++ b/crates/hale-syntax/src/lexer.rs
@@ -260,6 +260,91 @@ pub enum TokenKind {
     Eof,
 }
 
+impl TokenKind {
+    /// The source lexeme for a reserved-keyword token (`Some("accept")`
+    /// for [`TokenKind::Accept`]), or `None` for any token that isn't a
+    /// keyword. The reverse of the keyword match in
+    /// `lex_ident_or_keyword`; `tests/keyword_sync.rs` keeps the two in
+    /// sync via `keywords::HARD_KEYWORDS`.
+    pub fn keyword_lexeme(&self) -> Option<&'static str> {
+        Some(match self {
+            TokenKind::Locus => "locus",
+            TokenKind::Perspective => "perspective",
+            TokenKind::Type => "type",
+            TokenKind::Const => "const",
+            TokenKind::Fn => "fn",
+            TokenKind::Import => "import",
+            TokenKind::Export => "export",
+            TokenKind::Module => "module",
+            TokenKind::Params => "params",
+            TokenKind::Contract => "contract",
+            TokenKind::Bus => "bus",
+            TokenKind::Capacity => "capacity",
+            TokenKind::AsParentFor => "as_parent_for",
+            TokenKind::IndexedBy => "indexed_by",
+            TokenKind::Birth => "birth",
+            TokenKind::Accept => "accept",
+            TokenKind::Run => "run",
+            TokenKind::Drain => "drain",
+            TokenKind::Dissolve => "dissolve",
+            TokenKind::OnFailure => "on_failure",
+            TokenKind::Bulk => "bulk",
+            TokenKind::Harmonic => "harmonic",
+            TokenKind::Resolution => "resolution",
+            TokenKind::Projection => "projection",
+            TokenKind::Rich => "rich",
+            TokenKind::Chunked => "chunked",
+            TokenKind::Recognition => "recognition",
+            TokenKind::Closure => "closure",
+            TokenKind::Epoch => "epoch",
+            TokenKind::PersistsThrough => "persists_through",
+            TokenKind::ResetsOn => "resets_on",
+            TokenKind::ResetsPerEpoch => "resets_per_epoch",
+            TokenKind::Restart => "restart",
+            TokenKind::RestartInPlace => "restart_in_place",
+            TokenKind::Quarantine => "quarantine",
+            TokenKind::Reorganize => "reorganize",
+            TokenKind::Bubble => "bubble",
+            TokenKind::Expose => "expose",
+            TokenKind::Consume => "consume",
+            TokenKind::Inferred => "inferred",
+            TokenKind::Subscribe => "subscribe",
+            TokenKind::Publish => "publish",
+            TokenKind::On => "on",
+            TokenKind::Of => "of",
+            TokenKind::StableWhen => "stable_when",
+            TokenKind::SerializeAs => "serialize_as",
+            TokenKind::Let => "let",
+            TokenKind::Mut => "mut",
+            TokenKind::If => "if",
+            TokenKind::Else => "else",
+            TokenKind::Match => "match",
+            TokenKind::For => "for",
+            TokenKind::In => "in",
+            TokenKind::While => "while",
+            TokenKind::Return => "return",
+            TokenKind::Break => "break",
+            TokenKind::Continue => "continue",
+            TokenKind::True => "true",
+            TokenKind::False => "false",
+            TokenKind::Nil => "nil",
+            TokenKind::Tier => "tier",
+            TokenKind::KwSelf => "self",
+            TokenKind::Interface => "interface",
+            TokenKind::Trait => "trait",
+            TokenKind::Impl => "impl",
+            TokenKind::Async => "async",
+            TokenKind::Await => "await",
+            TokenKind::Yield => "yield",
+            TokenKind::Terminate => "terminate",
+            TokenKind::Release => "release",
+            TokenKind::Macro => "macro",
+            TokenKind::Where => "where",
+            _ => return None,
+        })
+    }
+}
+
 /// Lex a source string into tokens. Returns either a token stream
 /// (with [`TokenKind::Eof`] appended) or one or more diagnostics.
 pub fn lex(source: &str) -> Result<Vec<Token>, Vec<Diag>> {

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -149,6 +149,24 @@ impl Parser {
             }
             other => {
                 let span = self.peek_token().span;
+                if let Some(kw) = other.keyword_lexeme() {
+                    let category = match other {
+                        TokenKind::Birth
+                        | TokenKind::Accept
+                        | TokenKind::Run
+                        | TokenKind::Drain
+                        | TokenKind::Dissolve
+                        | TokenKind::OnFailure => "a reserved lifecycle keyword",
+                        _ => "a reserved keyword",
+                    };
+                    return Err(Diag::parse(
+                        span,
+                        format!(
+                            "expected {}, but `{}` is {} in Hale — pick another name",
+                            what, kw, category
+                        ),
+                    ));
+                }
                 Err(Diag::parse(
                     span,
                     format!("expected {}, got {:?}", what, other),
@@ -5183,6 +5201,31 @@ fn main() {
             }
             _ => panic!("expected fn"),
         }
+    }
+
+    #[test]
+    fn let_with_lifecycle_keyword_names_the_keyword() {
+        let errs = parse_str("fn main() { let accept = 1; }").unwrap_err();
+        let msg = &errs[0].message;
+        assert!(msg.contains("`accept`"), "got: {msg}");
+        assert!(msg.contains("reserved lifecycle keyword"), "got: {msg}");
+    }
+
+    #[test]
+    fn let_with_reserved_keyword_names_the_keyword() {
+        let errs = parse_str("fn main() { let match = 1; }").unwrap_err();
+        let msg = &errs[0].message;
+        assert!(msg.contains("`match`"), "got: {msg}");
+        assert!(msg.contains("is a reserved keyword"), "got: {msg}");
+        assert!(!msg.contains("lifecycle"), "got: {msg}");
+    }
+
+    #[test]
+    fn let_with_non_keyword_token_keeps_debug_fallback() {
+        let errs = parse_str("fn main() { let 5 = 1; }").unwrap_err();
+        let msg = &errs[0].message;
+        assert!(msg.contains("got"), "got: {msg}");
+        assert!(!msg.contains("reserved"), "got: {msg}");
     }
 
     // === v1.x-FORM-1 PR1 tests ============================

--- a/crates/hale-syntax/tests/keyword_sync.rs
+++ b/crates/hale-syntax/tests/keyword_sync.rs
@@ -42,6 +42,20 @@ fn keyword_lists_match_the_lexer() {
     }
 }
 
+#[test]
+fn keyword_lexeme_round_trips_every_hard_keyword() {
+    for kw in keywords::HARD_KEYWORDS {
+        let toks = lex(kw).unwrap_or_else(|e| panic!("lex `{kw}`: {e:?}"));
+        assert_eq!(
+            toks[0].kind.keyword_lexeme(),
+            Some(*kw),
+            "TokenKind::keyword_lexeme is out of sync with the lexer for \
+             `{kw}` (token {:?}) — update the match in lexer.rs.",
+            toks[0].kind
+        );
+    }
+}
+
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
**6/6 of the downstream-handoff substrate fixes (2026-07-14).** Stacked on #207.

`let accept = …;` errored with `expected variable name, got Accept` — technically true, but the Debug variant name sends users on a grammar hunt instead of saying the word is reserved.

Now: ``expected variable name, but `accept` is a reserved lifecycle keyword in Hale — pick another name``. The lifecycle wording covers `birth`/`accept`/`run`/`drain`/`dissolve`/`on_failure`; every other hard keyword gets "a reserved keyword"; the Debug fallback stays for non-keyword tokens. Implemented in shared `expect_ident`, so all 62 call sites (param names, field names, …) inherit it. The keyword-name mapping is a new `TokenKind::keyword_lexeme()` — the reverse of the lexer's keyword match — kept honest by a round-trip test against `keywords::HARD_KEYWORDS` in `keyword_sync.rs` (the same sync discipline the highlighter lists use).

No spec change (diagnostic texts aren't pinned in spec); CHANGELOG line included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)