### PR TITLE
fix(runtime): reclaim cross-thread bus payloads per-delivery (P0 leak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,21 @@ Eight substrate findings from a downstream service built on hale
   (TSan-verified race). Same-thread publishes keep the
   deserialize-at-dispatch fast path. See spec/runtime.md
   § Owner-executed handlers.
+- **Fixed: P0 memory leak on cross-thread bus dispatch to a
+  parked `async_io` subscriber** (downstream handoff 2026-07-15).
+  The owner-routed wire-cell path above deserialized each
+  delivery's payload straight into the subscriber's locus arena —
+  fine for a subscriber that dissolves, but a per-delivery leak on
+  a long-lived one whose `run()` is parked forever (the canonical
+  accept/recv server loop): the arena never dissolves, so every
+  message's String/Bytes fields accumulated unboundedly (~320 MiB
+  over 20k 16-KiB deliveries; flat afterward). Each wire cell now
+  deserializes into a per-delivery subregion destroyed the instant
+  the handler returns. Retention patterns are unchanged —
+  `self.saved = msg` still deep-copies into the locus arena. Only
+  the leaking cross-thread wire path is affected; same-thread and
+  main-pool delivery were never impacted. See spec/memory.md
+  § Cross-thread wire cell per-delivery reclaim.
 - Filed as an issue: implicit error propagation on tail-position
   `return` (finding 8).
 

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -5204,6 +5204,24 @@ typedef struct lotus_bus_cell {
      * the drain path calls lotus_bus_cell_materialize() on the
      * OWNER thread just before invoking the handler. */
     void  *deserialize;
+    /* Per-delivery payload arena (downstream handoff 2026-07-15,
+     * P0 leak). NULL for every non-wire cell and until materialize
+     * runs. When a wire cell is materialized, its deserializer
+     * allocates the payload's String/Bytes fields somewhere — and
+     * routing that into the subscriber's LOCUS arena (program-
+     * lifetime) leaks one payload's worth of heap PER DELIVERY on a
+     * long-lived subscriber. So materialize deserializes into a
+     * fresh subregion of the subscriber's arena instead, recorded
+     * here; each drain path destroys it right after the handler
+     * returns, exactly alongside the payload_heap free. This gives
+     * the deserialized payload the same lifetime the same-thread
+     * (inline) delivery path already gives it — alive for the
+     * handler, reclaimed after — so a handler that stashes a
+     * payload field into self still deep-copies into the locus
+     * arena (as it must for the inline path too). NULL region =>
+     * nothing to destroy (non-wire cell, or self_ptr was NULL and
+     * the deserialize fell back to the global arena). */
+    void  *payload_region;
     /* 16-byte aligned. The inline buffer holds a verbatim copy of a
      * bus payload struct, which may carry an i128 / Decimal (align-16)
      * field. A subscriber handler reads such a field with an aligned
@@ -5530,6 +5548,10 @@ static void bus_inline_drain_one(lotus_bus_queue_t *q) {
     void  *handler_self = cell->self_ptr;
     size_t psize        = cell->payload_size;
     void  *heap_ptr     = cell->payload_heap;
+    /* Snapshot the per-delivery region alongside heap_ptr — both must
+     * survive a handler-driven q->cells realloc. NULL on this
+     * single-threaded inline path (no wire cells); kept uniform. */
+    void  *region_ptr   = cell->payload_region;
     unsigned char stack_payload[LOTUS_PAYLOAD_INLINE]
         __attribute__((aligned(16)));
     void *payload_ptr = NULL;
@@ -5543,6 +5565,7 @@ static void bus_inline_drain_one(lotus_bus_queue_t *q) {
     ((lotus_handler_fn)handler_fn)(handler_self, payload_ptr);
     g_bus_inline_drain_depth--;
     if (heap_ptr) free(heap_ptr);
+    if (region_ptr) lotus_arena_destroy((lotus_arena_t *)region_ptr);
 }
 
 /* Re-entrancy guard: set while THIS THREAD is inside a drain. A nested
@@ -5603,6 +5626,8 @@ void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
             ((lotus_handler_fn)cell_copy.handler)(
                 cell_copy.self_ptr, payload_ptr);
             if (cell_copy.payload_heap) free(cell_copy.payload_heap);
+            if (cell_copy.payload_region)
+                lotus_arena_destroy(cell_copy.payload_region);
         }
     } else {
         /* Single-threaded cooperative path: no concurrent producer
@@ -5626,6 +5651,11 @@ void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
             void *handler_self = cell->self_ptr;
             size_t psize = cell->payload_size;
             void *heap_ptr = cell->payload_heap;
+            /* Snapshot the per-delivery region too: like heap_ptr it
+             * must survive a handler-driven q->cells realloc. Always
+             * NULL on this single-threaded path (no wire cells), but
+             * kept uniform with the concurrent drain. */
+            void *region_ptr = cell->payload_region;
             void *payload_ptr = NULL;
             if (heap_ptr) {
                 /* Heap pointer is stable across handler-driven
@@ -5642,6 +5672,7 @@ void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
             }
             ((lotus_handler_fn)handler_fn)(handler_self, payload_ptr);
             if (heap_ptr) free(heap_ptr);
+            if (region_ptr) lotus_arena_destroy((lotus_arena_t *)region_ptr);
         }
     }
 }
@@ -5917,6 +5948,7 @@ static void lotus_mailbox_dispatch_cell(lotus_bus_cell_t *cell) {
     }
     ((lotus_handler_fn)cell->handler)(cell->self_ptr, payload_ptr);
     if (cell->payload_heap) free(cell->payload_heap);
+    if (cell->payload_region) lotus_arena_destroy(cell->payload_region);
 }
 
 /* A ring slot just freed (the consumer dequeued). Wake any producer
@@ -6456,6 +6488,7 @@ static void lotus_coop_pool_dispatch_cell(lotus_bus_cell_t *cell) {
     }
     ((lotus_handler_fn)cell->handler)(cell->self_ptr, payload_ptr);
     if (cell->payload_heap) free(cell->payload_heap);
+    if (cell->payload_region) lotus_arena_destroy(cell->payload_region);
 }
 
 /* A ring slot just freed (the consumer dequeued). Wake any producer
@@ -7068,6 +7101,8 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
         ((lotus_handler_fn)cell_copy.handler)(
             cell_copy.self_ptr, payload_ptr);
         if (cell_copy.payload_heap) free(cell_copy.payload_heap);
+        if (cell_copy.payload_region)
+            lotus_arena_destroy(cell_copy.payload_region);
         return 1;
     }
     g_current_coro_tls = c;
@@ -7075,11 +7110,13 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
     g_current_coro_tls = NULL;
     if (c->done) {
         if (cell_copy.payload_heap) free(cell_copy.payload_heap);
+        if (cell_copy.payload_region)
+            lotus_arena_destroy(cell_copy.payload_region);
         lotus_coro_free(c);
     }
-    /* If c is not done (it parked), the cell's payload_heap is
-     * retained by the coro and freed when it resumes-and-completes
-     * (Slice 3 wiring). */
+    /* If c is not done (it parked), the cell's payload_heap and
+     * payload_region are retained by the coro and freed when it
+     * resumes-and-completes (Slice 3 wiring). */
     return 1;
 }
 #else /* !LOTUS_HAVE_ASYNC_IO — macOS / other BSDs */
@@ -7899,21 +7936,43 @@ extern __thread lotus_arena_t *lotus_current_caller_arena;
  * (deserializers do no I/O), so the shared TLS struct buffer is
  * safe even on async-pool workers. */
 static int lotus_bus_cell_materialize(lotus_bus_cell_t *c) {
-    if (!c->deserialize) return 1;
+    /* Defined for every cell the drain paths destroy after the
+     * handler: non-wire cells (the common case) carry no per-delivery
+     * region, so pin it NULL before the early return — the region
+     * destroy at each drain site reads this unconditionally. */
+    if (!c->deserialize) { c->payload_region = NULL; return 1; }
     void *wire = c->payload_heap ? c->payload_heap
                                  : (void *)c->payload_inline;
     char *sbuf = g_tls_bus_struct_buf;
-    lotus_arena_t *prev = lotus_current_caller_arena;
-    lotus_current_caller_arena =
+    lotus_arena_t *sub_arena =
         c->self_ptr ? *(lotus_arena_t **)c->self_ptr : NULL;
+    /* Deserialize the payload's owned fields (String / Bytes) into a
+     * fresh per-delivery subregion of the subscriber's arena, NOT the
+     * locus arena itself — otherwise every delivery's payload piles
+     * up in the program-lifetime locus arena (the P0 leak). The
+     * subregion is destroyed after the handler returns (see the drain
+     * paths); a self-field stash inside the handler deep-copies into
+     * the locus arena, just as it must on the inline path. If the
+     * subscriber has no arena (self_ptr NULL), fall back to the prior
+     * behavior (deserialize into the global arena) and leave
+     * payload_region NULL. */
+    lotus_arena_t *region =
+        sub_arena ? lotus_arena_create_subregion(sub_arena) : NULL;
+    lotus_arena_t *prev = lotus_current_caller_arena;
+    lotus_current_caller_arena = region ? region : sub_arena;
     ssize_t ssz = ((lotus_deserialize_fn)c->deserialize)(
         wire, c->payload_size, sbuf, LOTUS_PAYLOAD_MAX);
     lotus_current_caller_arena = prev;
     c->deserialize = NULL;
+    c->payload_region = region;
     if (ssz <= 0) {
         if (c->payload_heap) {
             free(c->payload_heap);
             c->payload_heap = NULL;
+        }
+        if (c->payload_region) {
+            lotus_arena_destroy(c->payload_region);
+            c->payload_region = NULL;
         }
         c->payload_size = 0;
         return 0;                       /* drop the cell */
@@ -7923,6 +7982,10 @@ static int lotus_bus_cell_materialize(lotus_bus_cell_t *c) {
         if (c->payload_heap) {
             free(c->payload_heap);
             c->payload_heap = NULL;
+        }
+        if (c->payload_region) {
+            lotus_arena_destroy(c->payload_region);
+            c->payload_region = NULL;
         }
         c->payload_size = 0;
         return 0;                       /* drop on OOM */

--- a/crates/hale-codegen/tests/bus_async_wire_payload_reclaim.rs
+++ b/crates/hale-codegen/tests/bus_async_wire_payload_reclaim.rs
@@ -1,0 +1,124 @@
+//! P0 leak regression (downstream handoff 2026-07-15) — a cross-thread
+//! bus payload delivered to a long-lived `where async_io` subscriber must
+//! be reclaimed PER DELIVERY, not accumulated in the subscriber's
+//! program-lifetime locus arena.
+//!
+//! Shape of the bug: a cross-thread publish posts a WIRE cell (serialized
+//! payload) that the owner thread deserializes just before the handler
+//! runs (`lotus_bus_cell_materialize`). The deserializer allocates the
+//! payload's owned fields (here a 16 KiB String) into an arena — and
+//! routing that into the subscriber's LOCUS arena leaked one payload's
+//! worth of heap on every delivery. On an async_io subscriber whose run()
+//! parks (the canonical server loop), that arena is never reclaimed until
+//! dissolve, so a steady publish stream grows RSS without bound. The fix
+//! deserializes into a per-delivery subregion destroyed right after the
+//! handler returns.
+//!
+//! This test pins the fix to measured RSS: an async_io subscriber flooded
+//! with LARGE (16 KiB) payloads must end near the same RSS as the
+//! identical subscriber flooded with TINY (1-byte) payloads. Pre-fix the
+//! large run accumulated ~320 MiB over 20k deliveries; the tiny run stayed
+//! at the floor. Comparing the two isolates the payload-reclaim path from
+//! the build's baseline arena (which the alloc-model RSS tests note sits
+//! tens of MB above the optimized CLI build), so the assertion is a
+//! relative delta, not a fragile absolute bound.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+/// A flood program parameterized by the per-payload body. An async_io
+/// subscriber (its run() parked forever on an accept — the server-loop
+/// shape) counts deliveries and, at the target count, prints final RSS and
+/// exits. The publisher is `pinned`, so every publish crosses a thread
+/// boundary and posts a wire cell that the subscriber's pool worker
+/// materializes — the exact path that leaked.
+fn flood_src(body_expr: &str, n: u32) -> String {
+    format!(
+        r#"
+        type Payload {{ seq: Int; body: String; }}
+        locus Sink {{
+            params {{ got: Int = 0; n: Int = {n}; acc: Int = 0; }}
+            bus {{ subscribe "flood" as on_msg of type Payload; }}
+            fn on_msg(m: Payload) {{
+                self.got = self.got + 1;
+                self.acc = self.acc + len(m.body);
+                if self.got == self.n {{
+                    print("acc="); println(self.acc);
+                    print("final_rss_mb="); println(std::process::rss_bytes() / 1048576);
+                    std::process::exit(0);
+                }}
+            }}
+            run() {{
+                // Park run() on an OS-chosen port (nobody connects) so the
+                // pool worker spends its life draining bus cells — the
+                // long-lived-subscriber shape where the leak accrued.
+                let lfd = std::io::tcp::__listen_socket("127.0.0.1", 0);
+                let _ = std::io::tcp::__accept_one(lfd);
+            }}
+        }}
+        locus Flood {{
+            params {{ n: Int = {n}; }}
+            bus {{ publish "flood" of type Payload; }}
+            run() {{
+                std::time::sleep(200ms);
+                let body = {body_expr};
+                let mut i = 0;
+                while i < self.n {{
+                    "flood" <- Payload {{ seq: i, body: body }};
+                    i = i + 1;
+                    // Yield periodically so the async subscriber drains and
+                    // publisher-side ring backpressure stays bounded.
+                    if i - (i / 200) * 200 == 0 {{ std::time::sleep(1ms); }}
+                }}
+            }}
+        }}
+        main locus App {{
+            params {{ sink: Sink = Sink {{ }}; flood: Flood = Flood {{ }}; }}
+            placement {{ sink: cooperative(pool = io) where async_io; flood: pinned; }}
+            run() {{ std::time::sleep(30s); }}
+        }}
+        fn main() {{ App {{ }}; }}
+        "#,
+    )
+}
+
+fn build_and_rss(name: &str, src: &str) -> i64 {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale_bus_async_reclaim_{}", name));
+    build_executable(&program, &bin).expect("build");
+    let output = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(output.status.success(), "{} crashed: {:?}", name, output.status);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .find(|l| l.starts_with("final_rss_mb="))
+        .and_then(|l| l.trim_start_matches("final_rss_mb=").trim().parse().ok())
+        .unwrap_or_else(|| panic!("no final_rss_mb in {} stdout: {:?}", name, stdout))
+}
+
+#[test]
+fn async_io_wire_payload_reclaimed_per_delivery() {
+    const N: u32 = 20_000;
+
+    // 16 KiB body per delivery: 20k × 16 KiB = 320 MiB of accumulation if
+    // the payload leaks into the locus arena (the pre-fix behavior).
+    let large_rss = build_and_rss("large", &flood_src(r#"std::str::repeat("0123456789abcdef", 1024)"#, N));
+    // 1-byte body: the same delivery machinery, negligible payload — the
+    // control that isolates baseline arena from payload accumulation.
+    let tiny_rss = build_and_rss("tiny", &flood_src(r#""x""#, N));
+
+    // Post-fix both sit at the runtime floor: the per-delivery region is
+    // destroyed after each handler, so the 16 KiB body never persists. A
+    // generous 96 MiB gate still fails hard on the pre-fix ~320 MiB leak
+    // while absorbing arena/allocator slack between the two builds.
+    assert!(
+        large_rss <= tiny_rss + 96,
+        "async_io subscriber flooded with 16 KiB payloads ended at {large_rss} MiB vs \
+         {tiny_rss} MiB for 1-byte payloads — a >96 MiB gap means the cross-thread \
+         wire payload is accumulating in the subscriber's locus arena again \
+         (per-delivery reclaim regressed in lotus_bus_cell_materialize / the drain paths).",
+    );
+}

--- a/spec/memory.md
+++ b/spec/memory.md
@@ -890,6 +890,37 @@ reclaim the global arena but to skip it entirely — the m20 spec
 holds by construction because the deserialize-time allocator IS
 the subscriber's arena.
 
+**Cross-thread wire cell per-delivery reclaim (2026-07-15;
+refines Task 9 for the owner-routed path).** Task 9 deserializes
+into the subscriber's arena on the *publisher's* thread. When the
+target subscriber lives on a *different* thread (a `pinned`
+publisher fanning out to a `where async_io` pool subscriber),
+that write races the subscriber's own unlocked arena mutations —
+so the owner-routed dispatch instead posts a *wire cell* carrying
+the payload's wire bytes plus its deserializer, and the
+subscriber's own thread deserializes it just before invoking the
+handler (`lotus_bus_cell_materialize`). The first cut of that
+path deserialized directly into the subscriber's locus arena —
+correct for lifetime, but a per-delivery **leak**: on a
+long-lived subscriber whose `run()` is parked (the canonical
+server loop — an accept / recv that never returns), the locus
+arena never dissolves, so every delivery's payload fields
+(String / Bytes) piled up unboundedly (~one payload's heap per
+message; measured ~320 MiB over 20k 16-KiB deliveries). The fix
+deserializes each wire cell into a fresh **per-delivery
+subregion** of the subscriber's arena, destroyed the instant the
+handler returns (alongside the existing per-cell payload free).
+This gives the deserialized payload exactly the lifetime the
+same-thread (inline) delivery path already gives it — alive for
+the handler, reclaimed after — and is safe for the
+`self.current_kernel = msg` retention pattern because a
+locus-field store deep-copies nested String / Bytes fields into
+the *locus* arena (the only way user code can retain payload
+data: address-taking is disallowed, so the payload pointer itself
+never escapes the handler). A subscriber on the same thread as
+its publisher, or a payload with no owned fields, is unaffected
+(no wire cell, no subregion).
+
 **Phase-2 (4) `g_bus_payload_arena` reclaim investigation
 (2026-05-19; superseded by Phase-3 Task 9).**
 The handoff posed: "should `lotus_bus_dispatch_wire`'s


### PR DESCRIPTION
## Summary

Fixes the P0 memory leak from the downstream handoff (2026-07-15, item 1): a cross-thread bus publish to a long-lived `where async_io` subscriber leaked one payload's worth of heap **per delivery**.

The owner-routed wire-cell path added for the cross-pool SIGSEGV fix (#212) deserializes each delivery's payload on the subscriber's own thread via `lotus_bus_cell_materialize` — but it deserialized straight into the subscriber's **locus arena**. That's correct for a subscriber that eventually dissolves; it's an unbounded leak on one whose `run()` is parked forever on an accept/recv (the canonical server loop), because the locus arena never dissolves. Every message's `String`/`Bytes` fields piled up.

- **Measured:** ~320 MiB accumulated over 20k × 16-KiB deliveries; flat afterward.
- **Scope:** cross-thread wire path only. Same-thread and main-pool delivery build no wire cell and were never affected.

## The fix

Each wire cell now deserializes into a fresh **per-delivery subregion** of the subscriber's arena, destroyed the instant the handler returns — alongside the existing per-cell `payload_heap` free, at all **seven** drain sites (queue locked / single-thread, `bus_inline_drain_one`, mailbox, coop classic, async OOM-direct, async coro-done). The region is snapshotted before the handler wherever the cell pointer can be reallocated by a re-publish.

This gives the deserialized payload exactly the lifetime the same-thread (inline) delivery path already gives it: **alive for the handler, reclaimed after.**

## Why it's safe

The documented `self.current_kernel = msg` retention pattern (spec/memory.md) still works: a locus-field store **deep-copies** nested `String`/`Bytes` into the locus arena. Address-taking is disallowed in Hale, so a field store is the only way user code can retain payload data — and it always deep-copies. Verified both a String-field stash (`self.last = m.body`) and a whole-struct stash (`self.saved = m`) survive 4000 deliveries of region churn, **clean under ASan** (no use-after-free).

## Verification

- Leak repro: subscriber arena went from 12.5 MiB / 200 chunks → **0 chunks / 0 bytes** at 3000 deliveries.
- New regression test `bus_async_wire_payload_reclaim.rs`: a 16-KiB-payload async subscriber ends at **52 MiB** vs **53 MiB** for a 1-byte control (`acc=327680000` confirms 320 MiB actually flowed through). Red test if per-delivery reclaim regresses.
- `corpus_oracle` **clean under ASan + LSan**.
- Full workspace suite green (only the pre-existing rustdoc `libLLVM.so` doctest-infra error, unrelated).

## Docs (same change set)

- `spec/memory.md` — new "Cross-thread wire cell per-delivery reclaim (2026-07-15)" note refining the Task 9 section.
- `CHANGELOG.md` — P0-leak bullet under the Unreleased downstream-handoff section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)