### PR TITLE
fix(codegen): reject unaddressed fallible Stream call, not LLVM ICE (item 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,22 @@ Eight substrate findings from a downstream service built on hale
   accidental-dual-bind case; a single server is unchanged.
   Intentional multi-process port sharing would need an explicit
   opt-in (none today). See spec/stdlib.md `std::io::tcp`.
+- **Fixed: unaddressed fallible `Stream` call is a clean error, not
+  an LLVM ICE** (downstream handoff 2026-07-15, item 5). After #209
+  made `Stream.send` / `send_bytes` / `recv` / `recv_bytes`
+  `fallible(IoError)`, a call site that omitted the `or` clause (a
+  bare statement or a plain value-binding) reached codegen's
+  non-fallible method-call lowering and emitted a call to the
+  fallible callee with the wrong arity — surfacing only as `module
+  verification failed … Incorrect number of arguments passed to
+  called function`. The typechecker can't catch it because a
+  `std::io::tcp::Stream` literal types as `Unknown` there (stdlib
+  handle loci aren't in the type table), so codegen now rejects the
+  call by name: `error not addressed: \`std::io::tcp::Stream.send_bytes\`
+  is fallible — handle its error with an \`or\` clause`. A
+  typecheck-time diagnostic would need stdlib handle loci in the
+  type table (a larger follow-on); this removes the ICE, which was
+  the defect.
 - Filed as an issue: implicit error propagation on tail-position
   `return` (finding 8).
 

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -23102,6 +23102,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         struct MethodSig {
             params: Vec<Param>,
             ret: Option<TypeExpr>,
+            fallible: Option<TypeExpr>,
         }
         let sig: MethodSig = self
             .program
@@ -23116,6 +23117,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                             Some(MethodSig {
                                 params: fd.params.clone(),
                                 ret: fd.ret.clone(),
+                                fallible: fd.fallible.clone(),
                             })
                         }
                         // B11 / G25: external `g.bulk(...)` /
@@ -23138,6 +23140,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                                 Some(MethodSig {
                                     params: md.params.clone(),
                                     ret: md.ret.clone(),
+                                    fallible: None,
                                 })
                             } else {
                                 None
@@ -23153,6 +23156,35 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     method_name, locus_name
                 ))
             })?;
+        // Reaching here with a fallible method means the call site did
+        // NOT address the error with an `or` clause — the addressed
+        // path routes through lower_fallible_method_call and never
+        // gets here. For a USER locus the typechecker already rejects
+        // this (its method fallibility is known), but a STDLIB handle
+        // locus (`std::io::tcp::Stream`) types as `Unknown` there, so
+        // the check slips through to codegen. Historically this then
+        // emitted a plain (non-fallible-ABI) call to the fallible
+        // callee — whose declared signature carries the extra
+        // error-channel params — an arity mismatch that surfaced only
+        // as an LLVM verifier ICE ("Incorrect number of arguments
+        // passed to called function"). Reject it here with an
+        // actionable message (downstream handoff 2026-07-15, item 5).
+        if sig.fallible.is_some() {
+            // Demangle the stdlib handle name for the message
+            // (`__StdIoTcpStream` → `std::io::tcp::Stream`); user loci
+            // pass through unchanged.
+            let display_locus = STDLIB_PATH_RENAMES
+                .iter()
+                .find(|(_, mangled)| *mangled == locus_name)
+                .map(|(segs, _)| segs.join("::"))
+                .unwrap_or_else(|| locus_name.clone());
+            return Err(CodegenError::Unsupported(format!(
+                "error not addressed: `{}.{}` is fallible — handle its \
+                 error with an `or` clause (`or raise`, `or discard`, \
+                 `or <fallback>`, or `or handler(err)`)",
+                display_locus, method_name
+            )));
+        }
         if args.len() > sig.params.len() {
             return Err(CodegenError::Unsupported(format!(
                 "{}.{}: expected at most {} args, got {}",

--- a/crates/hale-codegen/tests/stream_fallible_unaddressed_rejects.rs
+++ b/crates/hale-codegen/tests/stream_fallible_unaddressed_rejects.rs
@@ -1,0 +1,103 @@
+//! Item 5 (downstream handoff 2026-07-15) — an UNADDRESSED fallible
+//! stdlib `Stream` method call must be rejected with a clean,
+//! actionable error, NOT an LLVM verifier ICE.
+//!
+//! After #209 migrated `Stream.send` / `send_bytes` / `recv` /
+//! `recv_bytes` to `fallible(IoError)`, a call site that omits the
+//! `or` clause (a bare statement, or a plain value-binding) reached
+//! codegen's non-fallible method-call lowering and emitted a call to
+//! the fallible callee with the wrong arity — surfacing only as
+//! `module verification failed ... Incorrect number of arguments
+//! passed to called function`. The typechecker can't catch it because
+//! a `std::io::tcp::Stream` literal types as `Unknown` there (stdlib
+//! handle loci aren't in the type table), so codegen is the backstop.
+//! It now rejects the call by name instead of emitting invalid IR.
+
+use hale_codegen::build_executable;
+
+fn build_err(src: &str) -> Option<String> {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale-stream-unaddr-{}", std::process::id()));
+    match build_executable(&program, &bin) {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&bin);
+            None
+        }
+        Err(e) => Some(e.to_string()),
+    }
+}
+
+#[test]
+fn bare_fallible_send_bytes_statement_rejected_cleanly() {
+    let err = build_err(
+        r#"
+        fn main() {
+            let s = std::io::tcp::Stream { conn_fd: 0 - 1, owns_fd: false };
+            s.send_bytes(std::bytes::from_string("x"));
+        }
+    "#,
+    )
+    .expect("bare fallible send_bytes must not build");
+    assert!(
+        err.contains("error not addressed") && err.contains("send_bytes"),
+        "expected an actionable 'error not addressed' message naming the \
+         method; got: {}",
+        err
+    );
+    // The whole point: it must NOT be the raw LLVM verifier dump.
+    assert!(
+        !err.contains("module verification failed")
+            && !err.contains("Incorrect number of arguments"),
+        "regressed to the LLVM verifier ICE instead of a clean error: {}",
+        err
+    );
+}
+
+#[test]
+fn bare_fallible_recv_value_binding_rejected_cleanly() {
+    // recv has a String success value, so the "returns no value" guard
+    // doesn't catch it — it too used to ICE.
+    let err = build_err(
+        r#"
+        fn main() {
+            let s = std::io::tcp::Stream { conn_fd: 0 - 1, owns_fd: false };
+            let got = s.recv(64);
+            println(got);
+        }
+    "#,
+    )
+    .expect("unaddressed fallible recv must not build");
+    assert!(
+        err.contains("error not addressed") && err.contains("recv"),
+        "expected 'error not addressed' naming recv; got: {}",
+        err
+    );
+    assert!(
+        !err.contains("module verification failed"),
+        "regressed to the LLVM verifier ICE: {}",
+        err
+    );
+}
+
+#[test]
+fn addressed_fallible_calls_still_build() {
+    // The `or`-addressed path routes through a different lowering and
+    // must be unaffected by the reject above.
+    let err = build_err(
+        r#"
+        fn main() {
+            let s = std::io::tcp::Stream { conn_fd: 0 - 1, owns_fd: false };
+            s.send("x") or discard;
+            s.send_bytes(std::bytes::from_string("y")) or discard;
+            let got = s.recv(64) or "FB";
+            println("ok ", got);
+        }
+    "#,
+    );
+    assert!(
+        err.is_none(),
+        "addressed fallible Stream calls must still build; got error: {:?}",
+        err
+    );
+}


### PR DESCRIPTION
## Summary

Item 5 of the downstream handoff — the LLVM-verifier ICE (the only hard crash in the P3 batch).

After #209 made `Stream.send` / `send_bytes` / `recv` / `recv_bytes` `fallible(IoError)`, a call site that **omits the `or` clause** — a bare statement `s.send_bytes(x);` or a plain value-binding `let n = s.recv(64);` — reached codegen's non-fallible method-call lowering and emitted a call to the fallible callee with the wrong arity. It surfaced only as:

```
codegen error: LLVM emit failed: module verification failed ...
Incorrect number of arguments passed to called function!
  %__StdIoTcpStream.send_bytes.call = call i1 @__StdIoTcpStream.send_bytes(ptr, ptr)
```

## Why the typechecker doesn't catch it

`check_struct_literal` returns `Ty::Unknown` for **any multi-segment path**, so a `std::io::tcp::Stream { ... }` literal types as `Unknown`. With the receiver Unknown, `callee_fallible_payload` can't resolve the method's fallibility, so `check_expr_addressed` never flags the bare call. (User loci *are* in the type table, so their unaddressed fallible calls are already caught at typecheck — this gap is stdlib-handle-locus specific.)

## Fix

Codegen is the backstop. `lower_external_method_call` — the lowering both unaddressed paths (bare stmt + value-binding) go through, and which the `or`-addressed path does **not** — now captures the resolved method's `fallible` marker and, when set, returns a clean actionable error (demangling `__StdIoTcpStream` → `std::io::tcp::Stream`) instead of emitting invalid IR:

```
error not addressed: `std::io::tcp::Stream.send_bytes` is fallible — handle its
error with an `or` clause (`or raise`, `or discard`, `or <fallback>`, or `or handler(err)`)
```

Reaching this lowering with a fallible method *means* the call was unaddressed (the `or` path routes through `lower_fallible_method_call`), so the check is precise. The self-method path is untouched — `self` is always a user locus, already typecheck-guarded.

A full typecheck-time diagnostic would require putting stdlib handle loci in the type table (a larger follow-on); this removes the ICE, which was the defect.

## Verification

- New `stream_fallible_unaddressed_rejects`: bare `send_bytes` statement + value-bound `recv` reject cleanly (asserting the message names the method **and** is not the verifier dump); the `or`-addressed forms still build.
- Full tcp/stream/fallible suites green; full workspace suite green (286 result-lines ok, 0 failed).

## Docs

- `CHANGELOG.md` (the fallible-must-be-addressed contract itself is unchanged — spec already states it; only the diagnostic improved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)