### PR TITLE
fix(types): infer @form field pool per-instance at the call site (F.31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,20 @@ Eight substrate findings from a downstream service built on hale
   typecheck-time diagnostic would need stdlib handle loci in the
   type table (a larger follow-on); this removes the ICE, which was
   the defect.
+- **Fixed: two `@form` instances on two pools no longer need twin
+  types** (downstream handoff 2026-07-15, item 5). The F.31
+  cross-pool-method check pinned a `@form` (or any) locus **type**
+  to one pool (first placement seen), so two loci that each held
+  their own field of that type on different pools false-flagged
+  every owner but the first with a "cross-pool method call" error —
+  forcing byte-identical twin types as a workaround. The receiver's
+  pool is now inferred per **instance** at the call site: the
+  enclosing locus's own placement of the field, else the field
+  co-locates with its owner. Two separate `self.<field>` maps, each
+  touched only by its owner's pool, are single-threaded and no
+  longer flagged (they never needed a sync discipline). A genuine
+  cross-pool access — a form field explicitly placed off its owner —
+  still flags and still carries the sync-discipline hint.
 - Filed as an issue: implicit error propagation on tail-position
   `return` (finding 8).
 

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -2332,8 +2332,35 @@ fn walk_expr_pool(expr: &Expr, cx: &mut PoolCheckCx) {
                 cx.enclosing_locus,
                 cx.top,
             ) {
+                // F.31 (downstream handoff 2026-07-15): the receiver's
+                // pool is the pool of THIS field INSTANCE, inferred at
+                // the call site — not a type-global property. A locus
+                // type used as a plain field in two loci on two pools
+                // yields two independent instances, one co-located with
+                // each owner; `pool_of_locus_type` collapses the type to
+                // a single (first-seen) pool and would false-flag every
+                // other owner's own `self.<field>` call (two separate
+                // `@form` maps each touched by a single pool need no sync
+                // — flagging them was never sound). Compute it
+                // owner-relative: the enclosing locus's OWN placement of
+                // the field if it names one (e.g. `db: pinned` on the
+                // main locus — a genuine off-owner cross-pool access),
+                // else the field co-locates with its owner (the caller's
+                // pool → same pool → not flagged).
+                let field_name = match receiver.as_ref() {
+                    Expr::Field { name, .. } => name.name.clone(),
+                    _ => String::new(),
+                };
+                let instance_pool: Option<PoolId> =
+                    cx.caller_pool.map(|caller| {
+                        enclosing_field_placement(
+                            cx.enclosing_locus,
+                            &field_name,
+                        )
+                        .unwrap_or_else(|| caller.clone())
+                    });
                 if let (Some(callee_pool), Some(caller_pool_val)) = (
-                    cx.pool_of_locus_type.get(&field_locus),
+                    instance_pool.as_ref(),
                     cx.caller_pool,
                 ) {
                     // F.32-0: receivers with an explicit
@@ -2493,6 +2520,24 @@ fn receiver_field_locus_type(
     let param = params.params.iter().find(|p| p.name.name == name.name)?;
     let ty = param.ty.as_ref()?;
     type_expr_locus_name(ty, top)
+}
+
+/// The pool a field is EXPLICITLY placed on by its owning locus's
+/// own `placement { }` block, if any. `None` means the field carries
+/// no explicit placement, so its instance co-locates with its owner's
+/// pool. (F.31: a field instance's pool is owner-relative, not a
+/// type-global property — the same locus type used as a field in two
+/// loci on two pools yields two instances, one per owner.)
+fn enclosing_field_placement(
+    enclosing_locus: &LocusDecl,
+    field_name: &str,
+) -> Option<PoolId> {
+    let pb = enclosing_locus.members.iter().find_map(|m| match m {
+        LocusMember::Placement(pb) => Some(pb),
+        _ => None,
+    })?;
+    let entry = pb.entries.iter().find(|e| e.field.name == field_name)?;
+    Some(placement_spec_to_pool(&entry.spec, &entry.field.name))
 }
 
 fn receiver_display(e: &Expr) -> String {

--- a/crates/hale-types/tests/placement.rs
+++ b/crates/hale-types/tests/placement.rs
@@ -403,17 +403,26 @@ fn main() { App { }; }
     );
 }
 
-// F.32-1∞ (2026-05-25): when the offending cross-pool call IS
-// one of the synthesized hashmap methods, the diagnostic should
-// substitute the inference-specific hint (naming the picked
-// discipline + the observed writer/reader pools) for the
-// generic "choose serialized or striped" hint.
+// F.31 (downstream handoff 2026-07-15): the cross-pool-form check
+// infers the receiver's pool per INSTANCE at the call site — the
+// enclosing locus's own placement of the field, else the field
+// co-locates with its owner. Two loci that each hold their OWN
+// `@form` field are two independent, single-threaded maps; each is
+// only ever touched by its owner's pool, so there is no shared
+// access to synchronize and the check must NOT flag them (the old
+// type-global pool assignment collapsed the type to one pool and
+// false-flagged every owner but the first — forcing byte-identical
+// twin types as a workaround). A genuine cross-pool access — a form
+// field explicitly placed off its owner — still flags, and still
+// carries the sync-discipline hint.
 
 #[test]
-fn cross_pool_set_call_carries_inferred_sync_hint() {
-    // Two pools (io + compute) each fire `self.reg.set(...)`
-    // inside a bus handler (`on_tick`). Inference: 2 writer
-    // pools, hot-path (in `on_*` handlers) → striped.
+fn separate_per_owner_form_fields_on_distinct_pools_build_clean() {
+    // Two workers on two pools, each with its OWN `reg` field, each
+    // calling `self.reg.set(...)` on its own instance. These are
+    // separate maps, each single-threaded — no cross-pool sharing,
+    // so no diagnostic. (Pre-F.31 this false-flagged the second
+    // worker because `Registry` was pinned type-globally to `io`.)
     let src = r#"
 type Entry { k: Int; v: Int; }
 type Tick { n: Int; }
@@ -458,83 +467,34 @@ fn main() { App { }; }
     let cross_pool: Vec<_> =
         msgs.iter().filter(|m| m.contains("cross-pool")).collect();
     assert!(
-        !cross_pool.is_empty(),
-        "expected cross-pool diagnostic; got: {:?}",
-        msgs
-    );
-    let msg = cross_pool[0];
-    assert!(
-        msg.contains("inferred sync (F.32-1∞)"),
-        "diagnostic should carry the inferred-sync banner: {}",
-        msg
-    );
-    assert!(
-        msg.contains("sync = striped"),
-        "inference should pick striped (2 writer pools, hot-path): {}",
-        msg
-    );
-    assert!(
-        msg.contains("hot-path: yes"),
-        "hot-path detection should fire (call inside on_tick): {}",
-        msg
-    );
-    // Should NOT carry the generic "choose serialized or striped"
-    // fallback hint — the inference picked one, the diagnostic
-    // names it specifically.
-    assert!(
-        !msg.contains("sync = serialized")
-            || msg.contains("`sync = striped` for `Registry`"),
-        "diagnostic should not fall back to the generic both-options hint: {}",
-        msg
+        cross_pool.is_empty(),
+        "separate per-owner `@form` fields (each single-threaded) must \
+         NOT be flagged cross-pool; got: {:?}",
+        cross_pool
     );
 }
 
 #[test]
-fn cross_pool_set_call_one_writer_picks_serialized() {
-    // 1 writer pool (io), 2 reader pools (io, compute) → the
-    // 2-vs-1 rule fires `serialized`. Concrete shape: each
-    // worker holds its own `reg` field; pool propagation
-    // first-wins puts Registry on `io` (from IoWriter).
-    // CompReader on `compute` calling `self.reg.has(...)` is
-    // the cross-pool call site; the diagnostic includes the
-    // inference banner.
+fn off_owner_placed_form_field_flags_cross_pool_with_sync_hint() {
+    // A GENUINE cross-pool access: `reg` is a field of `App` (on the
+    // main pool) but is explicitly PLACED on `io`, so its instance
+    // lives on a different pool than the enclosing locus that calls
+    // into it. The direct `self.reg.set(...)` crosses pools and must
+    // flag, carrying the sync-discipline upgrade hint.
     let src = r#"
 type Entry { k: Int; v: Int; }
-type Tick { n: Int; }
 
 @form(hashmap)
 locus Registry {
     capacity { pool entries of Entry indexed_by k; }
 }
 
-locus IoWriter {
-    params { reg: Registry = Registry { }; }
-    bus { subscribe "tick" as on_tick of type Tick; }
-    fn on_tick(t: Tick) {
-        self.reg.set(Entry { k: t.n, v: 1 });
-        let _ = self.reg.has(t.n);
-    }
-}
-
-locus CompReader {
-    params { reg: Registry = Registry { }; }
-    bus { subscribe "tick" as on_tick of type Tick; }
-    fn on_tick(t: Tick) {
-        let _ = self.reg.has(t.n);
-    }
-}
-
 main locus App {
-    params {
-        io: IoWriter = IoWriter { };
-        cpu: CompReader = CompReader { };
+    params { reg: Registry = Registry { }; }
+    placement { reg: cooperative(pool = io); }
+    run() {
+        self.reg.set(Entry { k: 1, v: 1 });
     }
-    placement {
-        io: cooperative(pool = io);
-        cpu: cooperative(pool = compute);
-    }
-    bus { publish "tick" of type Tick; }
-    run() { }
 }
 
 fn main() { App { }; }
@@ -544,7 +504,7 @@ fn main() { App { }; }
         msgs.iter().filter(|m| m.contains("cross-pool")).collect();
     assert!(
         !cross_pool.is_empty(),
-        "expected cross-pool diagnostic; got: {:?}",
+        "off-owner-placed `@form` field access must flag cross-pool; got: {:?}",
         msgs
     );
     let combined = cross_pool
@@ -553,8 +513,10 @@ fn main() { App { }; }
         .collect::<Vec<&str>>()
         .join("\n");
     assert!(
-        combined.contains("sync = serialized"),
-        "inference should pick serialized (1 writer, multi reader): {}",
+        combined.contains("sync = serialized")
+            || combined.contains("sync = striped"),
+        "genuine cross-pool `@form` access should carry the sync-discipline \
+         hint: {}",
         combined
     );
 }


### PR DESCRIPTION
## Summary

Item 5 of the downstream handoff (the F.31 leftover). Two `@form` instances on two pools no longer need byte-identical twin types.

The F.31 cross-pool-method check compared a `self.<field>` form receiver's pool against `pool_of_locus_type[field_type]` — a type-global assignment that **first-wins-collapses** a locus type used as a field in multiple loci to one pool. So two loci that each held their own `@form` field of that type on different pools false-flagged every owner but the first with a `cross-pool method call` error (and a nonsensical "add a sync discipline" hint — those maps are single-threaded), forcing byte-identical twin types as the workaround.

## Fix

A `self.<field>` instance is owned by the enclosing locus, so its pool is inferred **per-instance at the call site**:
- the enclosing locus's own placement of the field if it names one (e.g. a `db: pinned` field on the main locus — a genuine off-owner cross-pool access), else
- the field co-locates with its owner (same pool as the caller → not flagged).

Two separate per-owner maps, each touched only by its owner's pool, are single-threaded and need no sync discipline — flagging them was never sound. A genuine cross-pool access (a form field explicitly placed off its owner) still flags and still carries the sync-discipline hint. The existing `db: pinned` / different-named-pool rejections are unchanged.

Per the maintainer's direction: the detection is call-site/per-instance inference, not a type-decl annotation. (A call-site opt-out *marker* for the genuine off-owner case is a separate, parser-touching pass, deferred until a real off-owner-shared-form workload wants it.)

## Tests

Two F.32 tests asserted the separate-per-owner-fields shape gets the inferred-sync hint — that shape was the type-global false positive. Replaced with:
- `separate_per_owner_form_fields_on_distinct_pools_build_clean` — the reported case, now builds clean (no cross-pool diagnostic).
- `off_owner_placed_form_field_flags_cross_pool_with_sync_hint` — a genuine off-owner-placed form still flags with the sync-discipline hint.

Placement suite green (57), form/hashmap suites green, full workspace suite green (286 result-lines ok, 0 failed). The SME two-pool repro builds and runs (`A 1` / `B 1`).

## Docs

- `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)