### PR TITLE
docs(spec): F.31 cross-pool pool is per-instance, not per-type

### DIFF
--- a/docs/src/systems/forms.md
+++ b/docs/src/systems/forms.md
@@ -51,8 +51,15 @@ buffer/slot walk, not per-element method calls. (Don't mutate the
 form inside the body — a grow would rehash under the cursor.)
 
 By default a `@form(hashmap)` is single-pool: its densest layout
-has no synchronization, and a cross-pool call into it is rejected.
-Opt into concurrent access with the `sync = …` parameter —
+has no synchronization, and a *cross-pool* call into one instance
+is rejected. "Cross-pool" is judged per instance, at the call
+site: two loci that each hold their own form field on different
+pools are two separate, single-threaded maps — each touched only
+by its owner's pool — so neither is flagged and neither needs a
+discipline. (You don't need byte-identical twin types to place
+two same-type forms on two pools.) The rejection is for genuine
+sharing: reaching one instance from a pool other than the one it
+lives on. Opt into that with the `sync = …` parameter —
 `@form(hashmap, sync = serialized)` (per-map mutex),
 `sync = striped` (concurrent readers), or `sync = lockfree`
 (CAS-only steady state) — trading layout density for the sharing

--- a/spec/types.md
+++ b/spec/types.md
@@ -613,12 +613,19 @@ from the `main locus`'s `placement { }` entries:
 2. Each nested locus inherits its containing tower's pool
    (see `spec/semantics.md` § "Nested instantiation"). Methods
    on a nested locus run on the parent's pool's thread.
-3. For each method-call expression `recv.foo(args)`, the
-   typechecker determines `recv`'s pool from its static type
-   and the surrounding pool context.
-4. If `recv`'s pool differs from the caller's pool, the call
-   is rejected with a diagnostic naming both pools and
-   pointing at the `placement { }` entries that picked them.
+3. For a method-call expression `self.field.foo(args)`, the
+   receiver's pool is the pool of the *field instance*,
+   inferred at the call site: the enclosing locus's own
+   `placement { }` entry for `field` if it names one (e.g. a
+   `db: pinned` field on the main locus), otherwise the field
+   co-locates with its owner (the caller's pool). The pool is a
+   property of the **instance**, not the field's type — the
+   same locus type used as a field in two loci on two pools is
+   two independent instances, one per owner, each single-pool.
+4. If the receiver instance's pool differs from the caller's
+   pool, the call is rejected with a diagnostic naming both
+   pools and pointing at the `placement { }` entries that
+   picked them.
 5. Bus sends (`Topic <- v;` / `"subj" <- v;`) are unrestricted
    — the runtime's cross-thread dispatch (m28b condvar+memcpy)
    handles the boundary safely.
@@ -674,6 +681,18 @@ the substrate's chosen discipline carries the safety
 contract. Plain `@form(...)` (no sync kwarg) gets the same
 cross-pool diagnostic as any other locus, extended with an
 upgrade-path hint naming the sync kwargs.
+
+Because a form field's pool is its instance's (rule 3 above),
+two loci that each hold their own `@form` field of the same
+type on different pools are two **separate**, single-threaded
+structures — each accessed only by its owner's pool. Neither
+is a cross-pool access, so neither is flagged, and neither
+needs a `sync` discipline (there is no sharing to synchronize).
+The diagnostic fires only on a genuine cross-pool access —
+reaching one instance from a pool other than the one it lives
+on, e.g. a form field explicitly placed off its owner. (This
+is why two same-type form instances on two pools do **not**
+require byte-identical twin types.)
 
 Concrete shape: a `Registry @form(hashmap, sync = striped)
 of Counter indexed_by name` shared across producer pools


### PR DESCRIPTION
Follow-up to #219, which changed the F.31 cross-pool-method check to infer a form field's pool **per instance** at the call site (enclosing placement, else owner co-location) instead of a type-global assignment — but only updated the CHANGELOG. This syncs the canonical contract to the shipped behavior:

- **`spec/types.md` § Single-threaded-method invariant (F.31)** — rule 3 now states the receiver's pool is the field *instance's* (call-site inferred), not "from its static type"; the `@form` subsection spells out that two separate per-owner form instances on two pools are each single-pool (not flagged, no `sync` needed), so byte-identical twin types are **not** required. The diagnostic is for genuine cross-pool access to one instance.
- **`docs/src/systems/forms.md`** — same clarification on the `@form` single-pool default.

Documents already-shipped behavior; no code or behavior change. (`concurrency.md` already described per-field placement, so it needed nothing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)