### PR TITLE
fix(runtime): move udp recv kernel buffer off the coro stack

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -10239,15 +10239,23 @@ void *lotus_udp_recv_bytes_with_source(int fd, int max_bytes) {
         errno = EINVAL;
         return NULL;
     }
-    char stack_buf[65536];
     size_t cap = (size_t)max_bytes;
-    if (cap > sizeof(stack_buf)) cap = sizeof(stack_buf);
+    if (cap > 65536) cap = 65536;
+    /* Kernel handoff buffer on the HEAP, not a 64 KiB stack local:
+     * this runs inside bus handlers / child run() bodies on 64 KiB
+     * async coro stacks (LOTUS_CORO_STACK_BYTES), where a 64 KiB stack
+     * buffer overflows the coro stack — a latent corruption that
+     * becomes a hard crash the moment the stack layout shifts
+     * (downstream handoff 2026-07-16). Freed before every return. */
+    char *tmp = (char *)malloc(cap);
+    if (!tmp) { errno = ENOMEM; return NULL; }
     struct sockaddr_in src;
     socklen_t src_len = sizeof(src);
     memset(&src, 0, sizeof(src));
-    ssize_t n = lotus_udp_recvfrom_async(fd, stack_buf, cap,
+    ssize_t n = lotus_udp_recvfrom_async(fd, tmp, cap,
                                          (struct sockaddr *)&src, &src_len);
     if (n < 0) {
+        free(tmp);
         /* Reset source TLS so a stale value isn't read by a
          * caller that ignores the err path. */
         g_udp_last_source_host[0] = '0';
@@ -10275,11 +10283,12 @@ void *lotus_udp_recv_bytes_with_source(int fd, int max_bytes) {
     /* Build the Bytes blob in the bus payload arena. */
     size_t blob_size = sizeof(int64_t) + (size_t)n;
     void *blob = lotus_bus_payload_arena_alloc(blob_size, 8);
-    if (!blob) return NULL;
+    if (!blob) { free(tmp); return NULL; }
     *(int64_t *)blob = (int64_t)n;
     if (n > 0) {
-        memcpy((char *)blob + sizeof(int64_t), stack_buf, (size_t)n);
+        memcpy((char *)blob + sizeof(int64_t), tmp, (size_t)n);
     }
+    free(tmp);
     return blob;
 }
 
@@ -10421,26 +10430,32 @@ void *lotus_udp_recv_bytes_global(int fd, int max_bytes) {
         errno = EINVAL;
         return NULL;
     }
-    /* Use a stack buffer for the kernel handoff; the result is
-     * copied into a Bytes blob in the payload arena. UDP max
-     * packet size is ~65507 bytes on IPv4, so a 64KB stack
-     * buffer covers anything. */
-    char stack_buf[65536];
+    /* Kernel handoff buffer on the HEAP, not a 64 KiB stack local.
+     * UDP max packet is ~65507 bytes on IPv4, so cap covers anything,
+     * but this runs inside bus handlers / child run() bodies on 64 KiB
+     * async coro stacks (LOTUS_CORO_STACK_BYTES) — a 64 KiB stack
+     * buffer overflows the coro stack (latent corruption, hard crash
+     * once the layout shifts; downstream handoff 2026-07-16). The
+     * result is copied into a Bytes blob in the payload arena; the temp
+     * is freed before every return. */
     size_t cap = (size_t)max_bytes;
-    if (cap > sizeof(stack_buf)) cap = sizeof(stack_buf);
-    ssize_t n = lotus_udp_recvfrom_async(fd, stack_buf, cap, NULL, NULL);
-    if (n < 0) return NULL;
+    if (cap > 65536) cap = 65536;
+    char *tmp = (char *)malloc(cap);
+    if (!tmp) { errno = ENOMEM; return NULL; }
+    ssize_t n = lotus_udp_recvfrom_async(fd, tmp, cap, NULL, NULL);
+    if (n < 0) { free(tmp); return NULL; }
     /* Hand-build a Bytes blob ([i64 len][body]) in the global
      * payload arena via the public alloc helper. Mirrors the
      * lotus_bytes_create shape (without needing a direct
      * lotus_arena_t handle to the static g_bus_payload_arena). */
     size_t blob_size = sizeof(int64_t) + (size_t)n;
     void *blob = lotus_bus_payload_arena_alloc(blob_size, 8);
-    if (!blob) return NULL;
+    if (!blob) { free(tmp); return NULL; }
     *(int64_t *)blob = (int64_t)n;
     if (n > 0) {
-        memcpy((char *)blob + sizeof(int64_t), stack_buf, (size_t)n);
+        memcpy((char *)blob + sizeof(int64_t), tmp, (size_t)n);
     }
+    free(tmp);
     return blob;
 }
 
@@ -14299,9 +14314,16 @@ const char *lotus_process_pipe_read_nonblocking(int32_t fd) {
         errno = EBADF;
         return NULL;
     }
-    char buf[65536];
-    ssize_t r = read((int)fd, buf, sizeof(buf) - 1);
+    /* Heap, not a 64 KiB stack local: a handler that reads a child's
+     * pipe can run on a 64 KiB async coro stack, where this buffer
+     * overflows it (downstream handoff 2026-07-16). Freed before every
+     * return. */
+    const size_t bufcap = 65536;
+    char *buf = (char *)malloc(bufcap);
+    if (!buf) { errno = ENOMEM; return NULL; }
+    ssize_t r = read((int)fd, buf, bufcap - 1);
     if (r < 0) {
+        free(buf);
         if (errno == EAGAIN
 #if defined(EWOULDBLOCK) && (EWOULDBLOCK != EAGAIN)
             || errno == EWOULDBLOCK
@@ -14313,15 +14335,18 @@ const char *lotus_process_pipe_read_nonblocking(int32_t fd) {
     }
     if (r == 0) {
         /* EOF — surface as empty. */
+        free(buf);
         return empty;
     }
     buf[r] = '\0';
     char *out = (char *)lotus_bus_payload_arena_alloc((size_t)r + 1, 1);
     if (!out) {
+        free(buf);
         errno = ENOMEM;
         return NULL;
     }
     memcpy(out, buf, (size_t)r + 1);
+    free(buf);
     return out;
 }
 

--- a/crates/hale-codegen/tests/async_io_udp_recv_in_handler.rs
+++ b/crates/hale-codegen/tests/async_io_udp_recv_in_handler.rs
@@ -1,0 +1,109 @@
+//! Downstream handoff 2026-07-16 — a udp recv inside a BUS HANDLER on a
+//! `where async_io` pool must not overflow the coroutine stack.
+//!
+//! `lotus_udp_recv_bytes_global` / `_with_source` used to declare a
+//! 64 KiB `char stack_buf[65536]` local. A bus handler runs on a
+//! per-invocation coroutine whose stack is 64 KiB
+//! (`LOTUS_CORO_STACK_BYTES`), so calling udp recv from a handler put a
+//! 64 KiB buffer on a 64 KiB stack — a latent overflow that corrupts
+//! adjacent memory and becomes a hard SIGSEGV the moment the coro
+//! struct layout shifts (it did, on a since-discarded candidate). The
+//! buffer now lives on the heap; this pins that a handler-side udp recv
+//! on an async pool runs to completion and delivers correct data
+//! instead of smashing the stack.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale-async-udp-handler-{}-{}", name, std::process::id()));
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (String::from_utf8_lossy(&out.stdout).to_string(), out.status)
+}
+
+fn free_udp_port() -> u16 {
+    let s = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind probe");
+    s.local_addr().expect("local_addr").port()
+}
+
+#[test]
+fn udp_recv_in_async_bus_handler_does_not_smash_the_coro_stack() {
+    // A `pinned` sender publishes "tick" cells to an async_io
+    // subscriber. Each on_tick handler recvs one datagram (arriving on
+    // the subscriber's bound udp socket) and echoes its length. The
+    // handler doing udp recv is the exact path that overflowed the coro
+    // stack. Success = it runs to completion (no crash) and the handler
+    // saw the payloads.
+    let rport = free_udp_port();
+    let src = format!(
+        r#"
+        type Tick {{ n: Int; }}
+        fn __empty(e: IoError) -> Bytes {{ return b""; }}
+
+        locus Reader {{
+            params {{ sock: Int = -1; seen: Int = 0; }}
+            bus {{ subscribe "tick" as on_tick of type Tick; }}
+            fn on_tick(t: Tick) {{
+                // udp recv INSIDE the handler, on the async coro stack —
+                // used to overflow it with a 64 KiB stack buffer. The
+                // overflow is exercised whether or not a datagram is
+                // waiting (the buffer is allocated either way), so we
+                // count handler invocations, not successful recvs.
+                let _ = std::io::udp::recv(self.sock, 2048) or __empty(err);
+                self.seen = self.seen + 1;
+                if self.seen == 4 {{ println("reader saw 4"); }}
+            }}
+            run() {{
+                self.sock = std::io::udp::bind("127.0.0.1", {rport}) or raise;
+                std::io::udp::set_recv_timeout(self.sock, 200ms) or discard;
+                let mut n = 0;
+                while n < 1000000 {{
+                    let _ = std::io::udp::recv(self.sock, 64) or __empty(err);
+                    n = n + 1;
+                }}
+            }}
+        }}
+
+        locus Sender {{
+            bus {{ publish "tick" of type Tick; }}
+            run() {{
+                std::time::sleep(300ms);
+                let fd = std::io::udp::bind("", 0) or raise;
+                let mut i = 0;
+                while i < 8 {{
+                    std::io::udp::send(fd, "127.0.0.1", {rport}, "payload-xyz") or discard;
+                    "tick" <- Tick {{ n: i }};
+                    std::time::sleep(20ms);
+                    i = i + 1;
+                }}
+                std::io::udp::close(fd);
+            }}
+        }}
+
+        main locus App {{
+            params {{ r: Reader = Reader {{ }}; tx: Sender = Sender {{ }}; }}
+            placement {{ r: cooperative(pool = io) where async_io; tx: pinned; }}
+            run() {{ std::time::sleep(2s); std::process::exit(0); }}
+        }}
+        fn main() {{ App {{ }}; }}
+        "#,
+    );
+    let (out, status) = build_and_run("recv_in_handler", &src);
+    // The crash was a SIGSEGV; assert a clean exit (not signalled).
+    assert!(
+        status.success(),
+        "udp recv in an async bus handler must not crash the coro stack; \
+         status: {:?}\nstdout: {}",
+        status, out
+    );
+    assert!(
+        out.contains("reader saw 4"),
+        "handler-side udp recv should have delivered the datagrams; got:\n{}",
+        out
+    );
+}


### PR DESCRIPTION
## Summary

`lotus_udp_recv_bytes_global` / `_with_source` (and the subprocess `lotus_process_pipe_read_nonblocking`) declared a 64 KiB `char stack_buf[65536]` local for the kernel handoff. Those functions run inside bus handlers and child `run()` bodies, which on a `where async_io` pool execute on a per-invocation coroutine whose stack is **64 KiB** (`LOTUS_CORO_STACK_BYTES`). So a udp recv from a handler put a 64 KiB buffer on a 64 KiB stack and **overflowed it** — a latent corruption that survives by luck on the current layout but becomes a hard SIGSEGV the moment the coro struct layout shifts.

## Fix

Allocate the handoff buffer on the **heap** (freed before every return), the same way the tcp recv family avoids a stack buffer. Behavior is otherwise identical — same cap, same exact-sized Bytes blob, same source capture.

## Proof (deterministic A/B)

At a shrunk 40 KiB coro stack, so the overflow is guaranteed with a 64 KiB buffer:
- 64 KiB stack buffer → **SIGSEGV ×3**
- heap buffer → **rc=0, clean ×3**

Regression test `async_io_udp_recv_in_handler` exercises the exact path (udp recv inside an async bus handler). Full workspace suite (286) + corpus ASan green.

Found while validating (and rejecting) the WS-dispatch-leak candidate; independent of that leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)