### PR TITLE
Compiler allocation enforcement: hot-path lint + @budget contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ behavior.
 
 ---
 
+## Unreleased — compiler allocation enforcement (2026-07-16)
+
+Make the allocation-free hot path the path of least resistance, and
+let a fn *certify* it. Two compiler additions, one advisory and one
+enforced.
+
+- **New default-on advisory: hot-path allocation lint.** `hale check`
+  now warns on two loop-scoped anti-patterns: a **locus** or a
+  `std::bytes::BytesBuilder` instantiated inside a loop (a fresh arena
+  / heap buffer every iteration — hoist it to a reused field), and an
+  **allocating `recv`** (`recv` / `recv_bytes` / `recv_with_source`)
+  in a loop (use `recv_into` with a reused `BytesBuilder`). Both
+  accumulate in the method scratch until the enclosing method returns,
+  and a `run()` read loop never returns. A plain value struct/type
+  literal isn't flagged, and an instantiation outside a loop isn't —
+  only the unambiguous per-iteration case. Warning, never a build
+  failure.
+- **New opt-in contract: `@budget(alloc_per_call = N)`.** The dual of
+  `@unbounded` — an explicit per-call allocation ceiling on a `fn`
+  (free or method), enforced as a **hard error**. The compiler counts
+  the arena allocations it can see (literals, `@form` inserts) —
+  transitively through resolved callees — plus the known-allocating
+  `recv` family, and errors if the fn allocates more than `N` per
+  call; a loop-nested allocation, a call to an allocating fn in a
+  loop, or recursion is unbounded per call. `N = 0` is the zero-alloc
+  certificate for a per-datagram handler or decode helper. fn-only;
+  mutually exclusive with `@unbounded`. A violation reports the
+  measured count and pinpoints every offending allocation with the
+  fast-path fix. Reuses the item-1 (`--dump-alloc-summary`) allocation
+  summary + call graph. See `spec/verification.md`,
+  `docs/src/systems/performance.md`.
+
 ## Unreleased — downstream-handoff substrate fixes (2026-07-14)
 
 Eight substrate findings from a downstream service built on hale

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -6825,6 +6825,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     ffi: None,
                     export: false,
                     unbounded: false,
+                    budget: None,
                     body: Block {
                         stmts: Vec::new(),
                         tail: None,
@@ -9848,6 +9849,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 ffi: fd.ffi.clone(),
                 export: fd.export,
                 unbounded: fd.unbounded,
+                budget: fd.budget,
                 body: Self::substitute_block_type_ascriptions(
                     &fd.body, subst,
                 ),
@@ -10093,6 +10095,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ffi: template.ffi.clone(),
             export: template.export,
             unbounded: template.unbounded,
+            budget: template.budget,
             body: new_body,
             span: template.span.clone(),
         })

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -1458,6 +1458,16 @@ pub struct FnDecl {
     /// silence under `--warn-unbounded-alloc`. Applies to free fns and
     /// locus methods alike.
     pub unbounded: bool,
+    /// Lever 2 (2026-07-16): `@budget(alloc_per_call = N)` — an opt-in
+    /// hot-path contract asserting this fn performs at most `N` arena
+    /// allocations per call (counting the literals/collection inserts the
+    /// compiler sees, transitively through resolved callees, plus the
+    /// known-allocating stdlib recv family; a loop-nested allocation is
+    /// "unbounded per call"). Enforced as a hard error in
+    /// [`crate`](hale-types)`::budget_check`. `@budget(alloc_per_call = 0)`
+    /// is the zero-alloc certificate. Mutually exclusive with `@unbounded`
+    /// (only one fn-prefix annotation parses).
+    pub budget: Option<u32>,
     pub body: Block,
     pub span: Span,
 }

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -370,6 +370,8 @@ impl Parser {
                 matches!(&kind_tok, TokenKind::Ident(s) if s == "bounded");
             let is_unbounded =
                 matches!(&kind_tok, TokenKind::Ident(s) if s == "unbounded");
+            let is_budget =
+                matches!(&kind_tok, TokenKind::Ident(s) if s == "budget");
             if is_export {
                 // WASM entry-inversion. `@export fn …` is a free-fn
                 // module export; `@export locus …` is the persistent
@@ -478,6 +480,31 @@ impl Parser {
                 fn_decl.span = at.span.merge(fn_decl.span);
                 return Ok(TopDecl::Fn(fn_decl));
             }
+            if is_budget {
+                // fn-only, like `@unbounded` / `@ffi` / `@export fn`.
+                if form.is_some() || locality.is_some() || export_locus
+                    || bounded_locus
+                {
+                    return Err(Diag::parse(
+                        self.peek_token().span,
+                        "`@budget(...)` is fn-only; it can't stack with \
+                         `@form(...)` / `@locality(...)` / `@bounded` / \
+                         `@export locus` (those precede `locus`)",
+                    ));
+                }
+                let (budget, bspan) = self.parse_budget_annotation()?;
+                if !matches!(self.peek(), TokenKind::Fn) {
+                    return Err(Diag::parse(
+                        self.peek_token().span,
+                        "expected `fn` after `@budget(alloc_per_call = N)` — \
+                         it is a per-call allocation contract on a fn",
+                    ));
+                }
+                let mut fn_decl = self.parse_fn_decl_with_ffi(None, false)?;
+                fn_decl.budget = Some(budget);
+                fn_decl.span = bspan.merge(fn_decl.span);
+                return Ok(TopDecl::Fn(fn_decl));
+            }
             if is_form {
                 if form.is_some() {
                     return Err(Diag::parse(
@@ -512,8 +539,8 @@ impl Parser {
             }
             return Err(Diag::parse(
                 self.peek_token().span,
-                "expected `form`, `locality`, `bounded`, `unbounded`, or \
-                 `ffi` after `@`",
+                "expected `form`, `locality`, `bounded`, `unbounded`, \
+                 `budget`, or `ffi` after `@`",
             ));
         }
         if form.is_some() || locality.is_some() || export_locus || bounded_locus {
@@ -1033,6 +1060,56 @@ impl Parser {
         })
     }
 
+    /// Lever 2 (2026-07-16): `@budget(alloc_per_call = N)` — an opt-in
+    /// hot-path contract on a free fn or locus method. Returns the
+    /// per-call allocation budget `N` and the annotation span. The
+    /// contract is enforced in `hale-types::budget_check`.
+    ///
+    /// Grammar: `'@' 'budget' '(' 'alloc_per_call' '=' INT ')'`.
+    fn parse_budget_annotation(&mut self) -> Result<(u32, Span), Diag> {
+        let at = self.expect(TokenKind::At, "@")?;
+        let next = self.peek_token().clone();
+        let is_budget = matches!(&next.kind, TokenKind::Ident(s) if s == "budget");
+        if !is_budget {
+            return Err(Diag::parse(next.span, "expected `budget` after `@`"));
+        }
+        self.bump();
+        self.expect(TokenKind::LParen, "(")?;
+        let key_tok = self.peek_token().clone();
+        let key_ok =
+            matches!(&key_tok.kind, TokenKind::Ident(s) if s == "alloc_per_call");
+        if !key_ok {
+            return Err(Diag::parse(
+                key_tok.span,
+                "expected `alloc_per_call` inside `@budget(...)` — the only \
+                 budget dimension in v0.1 (per-call arena allocations)",
+            ));
+        }
+        self.bump();
+        self.expect(TokenKind::Eq, "=")?;
+        let n_tok = self.peek_token().clone();
+        let n = match &n_tok.kind {
+            TokenKind::IntLit(v) if *v >= 0 => *v as u32,
+            TokenKind::IntLit(_) => {
+                return Err(Diag::parse(
+                    n_tok.span,
+                    "`@budget(alloc_per_call = N)` needs a non-negative \
+                     integer (0 = the zero-alloc certificate)",
+                ));
+            }
+            _ => {
+                return Err(Diag::parse(
+                    n_tok.span,
+                    "expected an integer after `alloc_per_call =` (e.g. \
+                     `@budget(alloc_per_call = 0)`)",
+                ));
+            }
+        };
+        self.bump();
+        let close = self.expect(TokenKind::RParen, ")")?;
+        Ok((n, at.span.merge(close.span)))
+    }
+
     /// Stage-1 FFI (2026-05-22): parse `@ffi("c")` — the
     /// annotation prefix that marks the following `fn` declaration
     /// as an external C-ABI binding. Stage 1 accepts only the
@@ -1458,12 +1535,32 @@ impl Parser {
             // member.
             TokenKind::At => {
                 let kind_tok = self.peek_at(1);
+                // `@budget(alloc_per_call = N)` on a method — the hot-path
+                // allocation contract. fn-only (a lifecycle `run()` is
+                // one-shot; the contract is about per-call cost).
+                if matches!(&kind_tok, TokenKind::Ident(s) if s == "budget") {
+                    let (budget, bspan) = self.parse_budget_annotation()?;
+                    if !matches!(self.peek(), TokenKind::Fn) {
+                        return Err(Diag::parse(
+                            self.peek_token().span,
+                            "expected `fn` after `@budget(alloc_per_call = N)` \
+                             — it is a per-call allocation contract on a \
+                             method",
+                        ));
+                    }
+                    let mut fn_decl = self.parse_fn_decl()?;
+                    fn_decl.budget = Some(budget);
+                    fn_decl.span = bspan.merge(fn_decl.span);
+                    return Ok(LocusMember::Fn(fn_decl));
+                }
                 if !matches!(&kind_tok, TokenKind::Ident(s) if s == "unbounded") {
                     return Err(Diag::parse(
                         self.peek_token().span,
-                        "the only `@` annotation valid on a locus member is \
+                        "the only `@` annotations valid on a locus member are \
                          `@unbounded` (on a `fn` or a lifecycle hook — \
-                         acknowledge an intentionally-unbounded body)",
+                         acknowledge an intentionally-unbounded body) and \
+                         `@budget(alloc_per_call = N)` (on a `fn` — a per-call \
+                         allocation contract)",
                     ));
                 }
                 let at = self.expect(TokenKind::At, "@")?;
@@ -3450,6 +3547,7 @@ impl Parser {
                 ffi,
                 export: false,
                 unbounded: false,
+                budget: None,
                 span: kw.span.merge(semi.span),
                 body,
             });
@@ -3474,6 +3572,7 @@ impl Parser {
                 ffi,
                 export: false,
                 unbounded: false,
+                budget: None,
                 span: kw.span.merge(semi.span),
                 body,
             });
@@ -3494,6 +3593,7 @@ impl Parser {
             ffi,
             export: false,
             unbounded: false,
+            budget: None,
             span: kw.span.merge(body.span),
             body,
         })
@@ -5521,6 +5621,81 @@ main locus App {
             msg.contains("opts in with `@bounded`"),
             "wrong error: {msg}"
         );
+    }
+
+    // === Lever 2: @budget(alloc_per_call = N) =============
+
+    #[test]
+    fn parse_budget_free_fn() {
+        let src = "@budget(alloc_per_call = 0) fn hot() { }";
+        let prog = parse_str(src).expect("parse failed");
+        match &prog.items[0] {
+            TopDecl::Fn(f) => assert_eq!(f.budget, Some(0)),
+            _ => panic!("expected fn"),
+        }
+    }
+
+    #[test]
+    fn parse_budget_nonzero_free_fn() {
+        let src = "@budget(alloc_per_call = 3) fn warm() { }";
+        let prog = parse_str(src).expect("parse failed");
+        match &prog.items[0] {
+            TopDecl::Fn(f) => assert_eq!(f.budget, Some(3)),
+            _ => panic!("expected fn"),
+        }
+    }
+
+    #[test]
+    fn parse_budget_method() {
+        let src = r#"
+locus L {
+    @budget(alloc_per_call = 0) fn on_msg() { }
+    fn plain() { }
+}
+"#;
+        let prog = parse_str(src).expect("parse failed");
+        let TopDecl::Locus(l) = &prog.items[0] else {
+            panic!("expected locus");
+        };
+        let mut saw_budgeted = false;
+        let mut saw_plain = false;
+        for m in &l.members {
+            if let LocusMember::Fn(f) = m {
+                match f.name.name.as_str() {
+                    "on_msg" => {
+                        assert_eq!(f.budget, Some(0));
+                        saw_budgeted = true;
+                    }
+                    "plain" => {
+                        assert_eq!(f.budget, None);
+                        saw_plain = true;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        assert!(saw_budgeted && saw_plain);
+    }
+
+    #[test]
+    fn parse_budget_rejects_unknown_dimension() {
+        let err = parse_str("@budget(bytes_per_call = 8) fn f() { }")
+            .expect_err("expected parse error");
+        assert!(format!("{:?}", err).contains("alloc_per_call"));
+    }
+
+    #[test]
+    fn parse_budget_requires_integer() {
+        let err = parse_str("@budget(alloc_per_call = foo) fn f() { }")
+            .expect_err("expected parse error");
+        assert!(format!("{:?}", err).contains("integer"));
+    }
+
+    #[test]
+    fn parse_budget_rejects_locus_target() {
+        let err = parse_str("@budget(alloc_per_call = 0) locus L { }")
+            .expect_err("expected parse error");
+        assert!(format!("{:?}", err).contains("fn"));
     }
 
     #[test]

--- a/crates/hale-types/src/budget_check.rs
+++ b/crates/hale-types/src/budget_check.rs
@@ -1,0 +1,344 @@
+//! Lever 2 (2026-07-16) — `@budget(alloc_per_call = N)`, an opt-in
+//! hot-path allocation contract.
+//!
+//! `@unbounded` says "this fn allocates without a static bound, on
+//! purpose" and silences the leak lint. `@budget` is its dual: an
+//! explicit *ceiling*. `@budget(alloc_per_call = N)` on a free fn or a
+//! locus method asserts the fn performs **at most `N` arena allocations
+//! per call**, and the compiler enforces it as a hard error. `N = 0` is
+//! the zero-alloc certificate — the strongest, most useful form: a
+//! per-datagram handler or a decode helper the runtime can call on the
+//! hot path with a guarantee it touches no arena.
+//!
+//! ## What counts
+//!
+//! It reuses [`crate::alloc_summary`] — the same per-fn allocation-site +
+//! call-graph IR the memory-bound proofs and the leak lint consume. Per
+//! call of the annotated fn, the check counts:
+//!
+//!   * each arena-allocating literal / collection insert the summary sees
+//!     (`Struct` / array / bytes / `@form` vec/hashmap insert), in the fn
+//!     body **and transitively through resolved (bundle-local) callees**;
+//!   * each known-allocating stdlib `recv` (the `recv` family returns a
+//!     fresh result buffer — the exact set the hot-path lint flags);
+//!
+//! and any of those **inside a loop** (or reached via a call inside a
+//! loop) counts as *unbounded per call* — a per-call budget is a
+//! statement about one invocation, and a loop runs its body many times
+//! per invocation. Recursion is likewise unbounded.
+//!
+//! ## What it can't see
+//!
+//! Opaque calls other than the known-allocating `recv` set (foreign
+//! receivers, most stdlib, FFI) are not counted — the budget bounds "the
+//! allocations the compiler can see," and is meant to be paired with
+//! `recv_into` + the hot-path lint, not to model the whole heap. This is
+//! the same soundness boundary `alloc_summary`'s escape tagging draws.
+
+use hale_syntax::ast::*;
+use hale_syntax::{Diag, Span};
+
+use crate::alloc_summary::{
+    self, AllocKind, AllocSummary, Callee, FnKey, FnSummary,
+};
+
+/// A per-call allocation count that saturates at `Unbounded` (a
+/// loop-nested allocation, a call in a loop, or recursion).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Count {
+    Finite(u64),
+    Unbounded,
+}
+
+impl Count {
+    fn zero() -> Count {
+        Count::Finite(0)
+    }
+    fn add(self, other: Count) -> Count {
+        match (self, other) {
+            (Count::Finite(a), Count::Finite(b)) => Count::Finite(a.saturating_add(b)),
+            _ => Count::Unbounded,
+        }
+    }
+    fn nonzero(self) -> bool {
+        !matches!(self, Count::Finite(0))
+    }
+    fn exceeds(self, budget: u32) -> bool {
+        match self {
+            Count::Finite(n) => n > budget as u64,
+            Count::Unbounded => true,
+        }
+    }
+    fn render(self) -> String {
+        match self {
+            Count::Finite(n) => n.to_string(),
+            Count::Unbounded => "an unbounded number of".to_string(),
+        }
+    }
+}
+
+/// A single allocation counted against a budget — its source span and a
+/// human note. Collected so an over-budget error can point at every
+/// offending line, not just report a total.
+struct Offender {
+    span: Span,
+    note: String,
+}
+
+/// The known-allocating opaque stdlib calls: the `recv` family, which
+/// each return a freshly-allocated result buffer. `recv_into` is the
+/// zero-alloc alternative. This is exactly the set the hot-path lint
+/// (`check_hot_path_alloc`) flags in a loop — the two levers agree on
+/// what "allocating recv" means. Path-call form carries the full
+/// `std::io::udp::recv` path; method-call form carries just the bare
+/// name (the receiver types as Unknown).
+fn opaque_recv_allocates(name: &str) -> bool {
+    matches!(
+        name,
+        "std::io::tcp::recv"
+            | "std::io::tcp::recv_bytes"
+            | "std::io::udp::recv"
+            | "std::io::udp::recv_with_source"
+            | "std::io::tls::recv_bytes"
+            | "recv_bytes"
+            | "recv_with_source"
+    )
+}
+
+fn describe_kind(kind: &AllocKind) -> String {
+    match kind {
+        AllocKind::StructLit(n) => format!("a `{}` instantiation", n),
+        AllocKind::ArrayLit => "an array literal".to_string(),
+        AllocKind::ArrayRepeat => "an array-repeat literal".to_string(),
+        AllocKind::BytesLit => "a bytes literal".to_string(),
+        AllocKind::CollectionInsert(form) => {
+            format!("an insert into a growing `@form({})` slot", form)
+        }
+    }
+}
+
+/// A DFS-work ceiling. A pathological wide call graph could re-count a
+/// shared callee exponentially; past this many steps we stop and report
+/// the fn as uncertifiable (conservatively over budget) rather than
+/// spin. Real call graphs are nowhere near this.
+const MAX_STEPS: u32 = 20_000;
+
+/// Count the arena allocations one call of `key` performs, collecting
+/// offenders for diagnostics. `path` is the current DFS ancestor stack
+/// (for cycle → recursion detection); a diamond (a callee reached by two
+/// distinct paths) is *not* on the path and is correctly counted once
+/// per reaching call site.
+fn count_fn(
+    key: &FnKey,
+    summary: &AllocSummary,
+    path: &mut Vec<FnKey>,
+    offenders: &mut Vec<Offender>,
+    steps: &mut u32,
+) -> Count {
+    let fs: &FnSummary = match summary.fns.get(key) {
+        Some(fs) => fs,
+        // An unresolved / external target has no summary — nothing we can
+        // see. (Callers already special-case the known-allocating recv
+        // family before recursing here.)
+        None => return Count::zero(),
+    };
+
+    let mut total = Count::zero();
+
+    // Direct allocation sites in this body.
+    for site in &fs.sites {
+        *steps += 1;
+        if *steps > MAX_STEPS {
+            return Count::Unbounded;
+        }
+        if site.loop_depth > 0 {
+            offenders.push(Offender {
+                span: site.span,
+                note: format!(
+                    "{} inside a loop — a fresh allocation every iteration",
+                    describe_kind(&site.kind)
+                ),
+            });
+            total = total.add(Count::Unbounded);
+        } else {
+            offenders.push(Offender {
+                span: site.span,
+                note: describe_kind(&site.kind),
+            });
+            total = total.add(Count::Finite(1));
+        }
+    }
+
+    // Call edges.
+    path.push(key.clone());
+    for edge in &fs.calls {
+        *steps += 1;
+        if *steps > MAX_STEPS {
+            path.pop();
+            return Count::Unbounded;
+        }
+        let in_loop = edge.loop_depth > 0;
+        match &edge.callee {
+            Callee::Resolved(callee_key) => {
+                if path.contains(callee_key) {
+                    // A cycle on the current path = recursion = unbounded
+                    // per call.
+                    offenders.push(Offender {
+                        span: edge.span,
+                        note: format!(
+                            "recursive call to `{}` — unbounded allocation \
+                             per call",
+                            callee_key.display()
+                        ),
+                    });
+                    total = total.add(Count::Unbounded);
+                    continue;
+                }
+                if in_loop {
+                    // The callee runs many times per call. If it allocates
+                    // at all, that's unbounded per call.
+                    let mut probe = Vec::new();
+                    let sub = count_fn(callee_key, summary, path, &mut probe, steps);
+                    if sub.nonzero() {
+                        offenders.push(Offender {
+                            span: edge.span,
+                            note: format!(
+                                "calls `{}` inside a loop — its allocations \
+                                 repeat every iteration",
+                                callee_key.display()
+                            ),
+                        });
+                        total = total.add(Count::Unbounded);
+                    }
+                } else {
+                    // A once-per-call callee: its allocations fold in
+                    // directly (offenders point into its body).
+                    total = total.add(count_fn(
+                        callee_key, summary, path, offenders, steps,
+                    ));
+                }
+            }
+            Callee::Unresolved(name) => {
+                if opaque_recv_allocates(name) {
+                    if in_loop {
+                        offenders.push(Offender {
+                            span: edge.span,
+                            note: format!(
+                                "`{}` inside a loop allocates a fresh buffer \
+                                 every iteration — use `recv_into` with a \
+                                 reused `BytesBuilder`",
+                                name
+                            ),
+                        });
+                        total = total.add(Count::Unbounded);
+                    } else {
+                        offenders.push(Offender {
+                            span: edge.span,
+                            note: format!(
+                                "`{}` allocates a fresh result buffer — use \
+                                 `recv_into` with a reused `BytesBuilder` for \
+                                 a zero-alloc read",
+                                name
+                            ),
+                        });
+                        total = total.add(Count::Finite(1));
+                    }
+                }
+                // Any other opaque call is outside what the budget can
+                // see (documented boundary).
+            }
+        }
+    }
+    path.pop();
+    total
+}
+
+/// The public entry: check every `@budget(...)`-annotated fn/method in
+/// `programs` against its declared per-call allocation ceiling. Returns
+/// hard-error diagnostics (opt-in: you asked for the contract, so a
+/// violation fails the build) — empty when every contract holds.
+pub fn budget_diags(programs: &[&Program]) -> Vec<Diag> {
+    let summary = alloc_summary::summarize_programs(programs);
+    let mut diags = Vec::new();
+
+    for program in programs {
+        for item in &program.items {
+            match item {
+                TopDecl::Fn(fd) => {
+                    if let Some(budget) = fd.budget {
+                        let key = FnKey::free_fn(fd.name.name.clone());
+                        check_one(&key, budget, fd, &summary, &mut diags);
+                    }
+                }
+                TopDecl::Locus(l) => {
+                    for m in &l.members {
+                        if let LocusMember::Fn(fd) = m {
+                            if let Some(budget) = fd.budget {
+                                let key = FnKey::method(
+                                    l.name.name.clone(),
+                                    fd.name.name.clone(),
+                                );
+                                check_one(&key, budget, fd, &summary, &mut diags);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    diags
+}
+
+/// The cap on how many offender pinpoints one violation emits, so a
+/// wildly-over-budget fn doesn't bury the build in notes.
+const MAX_OFFENDERS: usize = 6;
+
+fn check_one(
+    key: &FnKey,
+    budget: u32,
+    fd: &FnDecl,
+    summary: &AllocSummary,
+    diags: &mut Vec<Diag>,
+) {
+    let mut offenders = Vec::new();
+    let mut path = Vec::new();
+    let mut steps = 0u32;
+    let count = count_fn(key, summary, &mut path, &mut offenders, &mut steps);
+
+    if !count.exceeds(budget) {
+        return;
+    }
+
+    let advice = if budget == 0 {
+        "For a zero-alloc hot path: hoist per-iteration allocations to \
+         reused fields, read with `recv_into` into a reused \
+         `std::bytes::BytesBuilder`, and keep locus instantiation out of \
+         the fn. If the allocation is intentional, drop `@budget` for \
+         `@unbounded fn`."
+    } else {
+        "Reduce per-call allocations (hoist to reused fields, use \
+         `recv_into`), raise the budget, or drop `@budget` for \
+         `@unbounded fn` if the allocation is intentional."
+    };
+
+    diags.push(Diag::ty(
+        fd.name.span,
+        format!(
+            "hot-path budget exceeded: `{}` declares \
+             `@budget(alloc_per_call = {})` but the compiler counts {} \
+             arena allocation(s) per call. {}",
+            key.display(),
+            budget,
+            count.render(),
+            advice,
+        ),
+    ));
+
+    for off in offenders.into_iter().take(MAX_OFFENDERS) {
+        diags.push(Diag::ty(
+            off.span,
+            format!("counts against `{}`'s alloc budget: {}", key.display(), off.note),
+        ));
+    }
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -378,6 +378,19 @@ pub fn check_bundle(
     // Long-running cooperative children`.
     check_nested_long_running_child(bundle, &mut diags);
     check_cooperative_pool_blocking(bundle, &mut diags);
+    // Perf lint (2026-07-16): hot-path allocation anti-patterns — a
+    // locus instantiated per loop iteration, an allocating recv in a
+    // loop. Warnings that steer toward the allocation-free shape
+    // (hoisted field / `recv_into`).
+    check_hot_path_alloc(bundle, top, &mut diags);
+    // Lever 2 (2026-07-16): `@budget(alloc_per_call = N)` — an opt-in
+    // hot-path allocation contract. A hard error when an annotated fn
+    // allocates more than its declared per-call ceiling (0 = zero-alloc
+    // certificate). Reuses the `alloc_summary` call graph.
+    {
+        let programs_vec: Vec<&Program> = bundle.programs.values().copied().collect();
+        diags.extend(crate::budget_check::budget_diags(&programs_vec));
+    }
     // 2026-05-29: a bus-subscribing locus instantiated non-owned
     // inside another locus's method/handler body dissolves at that
     // method's scope exit, so its subscription can never fire.
@@ -1403,6 +1416,258 @@ fn external_subscription_handlers(decl: &LocusDecl) -> Vec<String> {
         .filter(|(subj, _)| !published.contains(subj))
         .map(|(_, h)| h)
         .collect()
+}
+
+// ===================================================================
+// Perf lint (downstream handoff 2026-07-16): hot-path allocation
+// anti-patterns. Steer the naive shape toward the allocation-free one
+// so the fast path is the path of least resistance rather than expert
+// folklore. Two loop-scoped patterns, both warnings:
+//   1. a locus (its own arena / heap buffer) instantiated per loop
+//      iteration — hoist to a reused field;
+//   2. an allocating `recv` in a loop — use `recv_into` with a reused
+//      buffer.
+// Both accumulate in the method scratch until the enclosing method
+// returns, and a `run()` read loop never returns, so under load they
+// dominate the p50 tax and (per the recv_bytes-in-a-loop footgun) can
+// grow unboundedly. Loop-scoped keeps the signal clean (per-iteration
+// is the unambiguous case); a handler-scratch instantiation reclaims
+// per invocation and isn't flagged.
+// ===================================================================
+
+struct HotPathCx<'a> {
+    top: &'a TopScope,
+    diags: &'a mut Vec<Diag>,
+    loop_depth: u32,
+}
+
+/// A locus literal worth hoisting out of a loop: a user locus (carries
+/// its own arena) or a heap-bearing stdlib builder. Plain struct/type
+/// literals are values and don't allocate, so they're not flagged.
+fn hot_locus_name(path: &QualifiedName, top: &TopScope) -> Option<String> {
+    let segs: Vec<&str> = path.segments.iter().map(|s| s.name.as_str()).collect();
+    if segs == ["std", "bytes", "BytesBuilder"] {
+        return Some("std::bytes::BytesBuilder".to_string());
+    }
+    if segs.len() == 1 && matches!(top.lookup(segs[0]), Some(TopSymbol::Locus(_))) {
+        return Some(segs[0].to_string());
+    }
+    None
+}
+
+/// An allocating recv path-call (the result Bytes/String lands in the
+/// caller's scratch). `recv_into` is the zero-alloc alternative.
+fn allocating_recv_name(callee: &Expr) -> Option<String> {
+    match callee {
+        // Path-call form: `std::io::udp::recv(fd, n)`.
+        Expr::Path(qn) => {
+            let segs: Vec<&str> =
+                qn.segments.iter().map(|s| s.name.as_str()).collect();
+            match segs.as_slice() {
+                ["std", "io", "tcp", "recv"]
+                | ["std", "io", "tcp", "recv_bytes"]
+                | ["std", "io", "udp", "recv"]
+                | ["std", "io", "udp", "recv_with_source"]
+                | ["std", "io", "tls", "recv_bytes"] => Some(segs.join("::")),
+                _ => None,
+            }
+        }
+        // Method-call form: `stream.recv_bytes(n)`. The Stream receiver
+        // types as Unknown in the checker (stdlib handle locus), so key
+        // off the method name. `recv_bytes` / `recv_with_source` are
+        // stdlib-specific enough that false positives are rare; plain
+        // `recv` (a common user-method name) is only flagged in the
+        // path-call form above.
+        Expr::Field { name, .. } => match name.name.as_str() {
+            "recv_bytes" | "recv_with_source" => Some(name.name.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn hot_walk_block(b: &Block, cx: &mut HotPathCx) {
+    for s in &b.stmts {
+        hot_walk_stmt(s, cx);
+    }
+    if let Some(t) = &b.tail {
+        hot_walk_expr(t, cx);
+    }
+}
+
+fn hot_walk_if(i: &IfStmt, cx: &mut HotPathCx) {
+    hot_walk_expr(&i.cond, cx);
+    hot_walk_block(&i.then_block, cx);
+    if let Some(eb) = &i.else_block {
+        match eb.as_ref() {
+            ElseBranch::Else(b) => hot_walk_block(b, cx),
+            ElseBranch::ElseIf(i2) => hot_walk_if(i2, cx),
+        }
+    }
+}
+
+fn hot_walk_match(m: &MatchStmt, cx: &mut HotPathCx) {
+    hot_walk_expr(&m.scrutinee, cx);
+    for arm in &m.arms {
+        if let Some(g) = &arm.guard {
+            hot_walk_expr(g, cx);
+        }
+        match &arm.body {
+            MatchArmBody::Expr(e) => hot_walk_expr(e, cx),
+            MatchArmBody::Block(b) => hot_walk_block(b, cx),
+        }
+    }
+}
+
+fn hot_walk_stmt(s: &Stmt, cx: &mut HotPathCx) {
+    match s {
+        Stmt::While { cond, body, .. } => {
+            hot_walk_expr(cond, cx);
+            cx.loop_depth += 1;
+            hot_walk_block(body, cx);
+            cx.loop_depth -= 1;
+        }
+        Stmt::For { iter, body, .. } => {
+            hot_walk_expr(iter, cx);
+            cx.loop_depth += 1;
+            hot_walk_block(body, cx);
+            cx.loop_depth -= 1;
+        }
+        Stmt::Let { value, .. }
+        | Stmt::LetTuple { value, .. }
+        | Stmt::Assign { value, .. } => hot_walk_expr(value, cx),
+        Stmt::If(i) => hot_walk_if(i, cx),
+        Stmt::Match(m) => hot_walk_match(m, cx),
+        Stmt::Return(Some(e), _) => hot_walk_expr(e, cx),
+        Stmt::Fail { value, .. } => hot_walk_expr(value, cx),
+        Stmt::Expr(e) => hot_walk_expr(e, cx),
+        _ => {}
+    }
+}
+
+fn hot_walk_expr(e: &Expr, cx: &mut HotPathCx) {
+    match e {
+        Expr::Struct { path, inits, span } => {
+            for init in inits {
+                hot_walk_expr(&init.value, cx);
+            }
+            if cx.loop_depth > 0 {
+                if let Some(name) = hot_locus_name(path, cx.top) {
+                    cx.diags.push(Diag::warn(
+                        *span,
+                        format!(
+                            "hot-path allocation: locus `{}` is instantiated \
+                             inside a loop — a fresh instance (its own arena / \
+                             heap buffer) is allocated every iteration and only \
+                             reclaimed when the enclosing method returns (a \
+                             `run()` read loop never returns). Hoist it to a \
+                             reused field, or `clear()` and refill one builder, \
+                             to keep the hot path allocation-free.",
+                            name
+                        ),
+                    ));
+                }
+            }
+        }
+        Expr::Call { callee, args, span } => {
+            hot_walk_expr(callee, cx);
+            for a in args {
+                hot_walk_expr(a, cx);
+            }
+            if cx.loop_depth > 0 {
+                if let Some(disp) = allocating_recv_name(callee) {
+                    cx.diags.push(Diag::warn(
+                        *span,
+                        format!(
+                            "hot-path allocation: `{}` in a loop allocates a \
+                             fresh result buffer each iteration (it accumulates \
+                             in the method scratch until the method returns). \
+                             Use `recv_into(fd, buf, max)` with a reused \
+                             `std::bytes::BytesBuilder` for a zero-alloc hot \
+                             path.",
+                            disp
+                        ),
+                    ));
+                }
+            }
+        }
+        Expr::Binary { left, right, .. } => {
+            hot_walk_expr(left, cx);
+            hot_walk_expr(right, cx);
+        }
+        Expr::Unary { operand, .. } => hot_walk_expr(operand, cx),
+        Expr::Field { receiver, .. } | Expr::Path2 { receiver, .. } => {
+            hot_walk_expr(receiver, cx)
+        }
+        Expr::Index { receiver, index, .. } => {
+            hot_walk_expr(receiver, cx);
+            hot_walk_expr(index, cx);
+        }
+        Expr::Tuple(es, _) | Expr::Array(es, _) => {
+            for e in es {
+                hot_walk_expr(e, cx);
+            }
+        }
+        Expr::Sum(e, _) | Expr::Prod(e, _) => hot_walk_expr(e, cx),
+        Expr::Approx { left, right, tolerance, .. } => {
+            hot_walk_expr(left, cx);
+            hot_walk_expr(right, cx);
+            hot_walk_expr(tolerance, cx);
+        }
+        Expr::Range { lo, hi, .. } => {
+            hot_walk_expr(lo, cx);
+            hot_walk_expr(hi, cx);
+        }
+        Expr::ArrayRepeat { val, .. } => hot_walk_expr(val, cx),
+        Expr::Block(b) => hot_walk_block(b, cx),
+        Expr::If(i) => hot_walk_if(i, cx),
+        Expr::Match(m) => hot_walk_match(m, cx),
+        Expr::Or { inner, disposition, .. } => {
+            hot_walk_expr(inner, cx);
+            match disposition {
+                OrDisposition::Substitute(e) | OrDisposition::Fail(e, _) => {
+                    hot_walk_expr(e, cx)
+                }
+                _ => {}
+            }
+        }
+        _ => {}
+    }
+}
+
+fn check_hot_path_alloc(bundle: &Bundle<'_>, top: &TopScope, diags: &mut Vec<Diag>) {
+    for program in bundle.programs.values() {
+        for item in &program.items {
+            match item {
+                TopDecl::Locus(l) => {
+                    for m in &l.members {
+                        let body = match m {
+                            LocusMember::Fn(fd) => Some(&fd.body),
+                            LocusMember::Lifecycle(ld) => Some(&ld.body),
+                            _ => None,
+                        };
+                        if let Some(b) = body {
+                            let mut cx = HotPathCx {
+                                top,
+                                diags: &mut *diags,
+                                loop_depth: 0,
+                            };
+                            hot_walk_block(b, &mut cx);
+                        }
+                    }
+                }
+                TopDecl::Fn(fd) => {
+                    let mut cx = HotPathCx {
+                        top,
+                        diags: &mut *diags,
+                        loop_depth: 0,
+                    };
+                    hot_walk_block(&fd.body, &mut cx);
+                }
+                _ => {}
+            }
+        }
+    }
 }
 
 /// Flag blocking calls on cooperative pools. Two outcomes:

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -22,6 +22,7 @@
 //! against built-ins.
 
 pub mod alloc_summary;
+pub mod budget_check;
 pub mod bus_graph;
 pub mod check;
 pub mod stdlib_surface;

--- a/crates/hale-types/tests/budget_contract.rs
+++ b/crates/hale-types/tests/budget_contract.rs
@@ -1,0 +1,230 @@
+//! Lever 2 (2026-07-16) — `@budget(alloc_per_call = N)`, the opt-in
+//! hot-path allocation contract. A hard error when an annotated fn/method
+//! allocates more than its declared per-call ceiling; silent when the
+//! contract holds. Enforced in `hale_types::budget_check`.
+
+use hale_syntax::parse_source;
+use hale_types::check_program;
+
+/// Budget-contract diagnostics only (the check emits hard `Type` errors;
+/// unrelated diagnostics from the rest of the checker are filtered out).
+fn budget_errors(src: &str) -> Vec<String> {
+    let prog = parse_source(src).expect("parse failed");
+    check_program(&prog)
+        .into_iter()
+        .filter(|d| {
+            d.message.contains("budget exceeded")
+                || d.message.contains("alloc budget")
+        })
+        .map(|d| d.message)
+        .collect()
+}
+
+// ---- clean: the contract holds ---------------------------------------
+
+#[test]
+fn zero_alloc_fn_with_no_allocation_is_clean() {
+    let src = r#"
+@budget(alloc_per_call = 0)
+fn tick(x: Int) -> Int {
+    x + 1
+}
+
+fn main() { }
+"#;
+    assert!(
+        budget_errors(src).is_empty(),
+        "a genuinely zero-alloc fn must satisfy `= 0`, got: {:?}",
+        budget_errors(src)
+    );
+}
+
+#[test]
+fn budget_of_two_with_two_allocations_is_clean() {
+    let src = r#"
+type P { a: Int; }
+
+@budget(alloc_per_call = 2)
+fn two() -> P {
+    let x = P { a: 1 };
+    let y = P { a: 2 };
+    y
+}
+
+fn main() { }
+"#;
+    assert!(
+        budget_errors(src).is_empty(),
+        "two allocations under a budget of 2 must be clean, got: {:?}",
+        budget_errors(src)
+    );
+}
+
+#[test]
+fn zero_alloc_method_is_clean() {
+    let src = r#"
+locus Handler {
+    @budget(alloc_per_call = 0)
+    fn on_msg(x: Int) -> Int {
+        x + 1
+    }
+}
+
+fn main() { }
+"#;
+    assert!(
+        budget_errors(src).is_empty(),
+        "a zero-alloc method must satisfy `= 0`, got: {:?}",
+        budget_errors(src)
+    );
+}
+
+// ---- violations: the contract bites ----------------------------------
+
+#[test]
+fn zero_alloc_fn_that_instantiates_is_rejected() {
+    let src = r#"
+type P { a: Int; }
+
+@budget(alloc_per_call = 0)
+fn make() -> P {
+    P { a: 1 }
+}
+
+fn main() { }
+"#;
+    let errs = budget_errors(src);
+    assert!(
+        errs.iter().any(|m| m.contains("budget exceeded") && m.contains("make")),
+        "an allocation under `= 0` must be rejected, got: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn budget_counts_transitively_through_resolved_callees() {
+    // `caller` itself allocates nothing, but the fn it calls does —
+    // the budget sees through resolved (bundle-local) calls.
+    let src = r#"
+type P { a: Int; }
+
+fn helper() -> P {
+    P { a: 1 }
+}
+
+@budget(alloc_per_call = 0)
+fn caller() -> P {
+    helper()
+}
+
+fn main() { }
+"#;
+    let errs = budget_errors(src);
+    assert!(
+        errs.iter().any(|m| m.contains("budget exceeded") && m.contains("caller")),
+        "a transitive allocation must count against the budget, got: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn allocation_in_a_loop_is_unbounded_per_call() {
+    let src = r#"
+type P { a: Int; }
+
+@budget(alloc_per_call = 4)
+fn spin() {
+    let mut n = 0;
+    while n < 10 {
+        let x = P { a: n };
+        n = n + 1;
+    }
+}
+
+fn main() { }
+"#;
+    let errs = budget_errors(src);
+    assert!(
+        errs.iter().any(|m| m.contains("budget exceeded")
+            && m.contains("unbounded")),
+        "a loop-nested allocation must read as unbounded per call, got: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn allocating_recv_in_a_loop_is_rejected_under_zero_budget() {
+    // The known-allocating `recv` family is counted like a visible
+    // allocation; in a loop it's unbounded per call.
+    let src = r#"
+@budget(alloc_per_call = 0)
+fn pump(fd: Int) {
+    let mut n = 0;
+    while n < 10 {
+        let msg = std::io::udp::recv(fd, 2048) or discard;
+        n = n + 1;
+    }
+}
+
+fn main() { }
+"#;
+    let errs = budget_errors(src);
+    assert!(
+        errs.iter().any(|m| m.contains("budget exceeded")),
+        "an allocating recv in a loop must bust a zero budget, got: {:?}",
+        errs
+    );
+    // And the pinpoint should steer toward recv_into.
+    assert!(
+        errs.iter().any(|m| m.contains("recv_into")),
+        "expected a recv_into pinpoint, got: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn budget_of_one_with_two_allocations_is_rejected() {
+    let src = r#"
+type P { a: Int; }
+
+@budget(alloc_per_call = 1)
+fn two() -> P {
+    let x = P { a: 1 };
+    let y = P { a: 2 };
+    y
+}
+
+fn main() { }
+"#;
+    let errs = budget_errors(src);
+    assert!(
+        errs.iter().any(|m| m.contains("budget exceeded")),
+        "two allocations must bust a budget of 1, got: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn unannotated_fn_is_never_checked() {
+    // No `@budget` = no contract = no diagnostic, however much it
+    // allocates. The check is strictly opt-in.
+    let src = r#"
+type P { a: Int; }
+
+fn allocates_freely() -> P {
+    let mut n = 0;
+    while n < 10 {
+        let x = P { a: n };
+        n = n + 1;
+    }
+    P { a: 0 }
+}
+
+fn main() { }
+"#;
+    assert!(
+        budget_errors(src).is_empty(),
+        "an unannotated fn must never trip the budget check, got: {:?}",
+        budget_errors(src)
+    );
+}

--- a/crates/hale-types/tests/hot_path_alloc.rs
+++ b/crates/hale-types/tests/hot_path_alloc.rs
@@ -1,0 +1,224 @@
+//! Hot-path allocation lint (2026-07-16) — Lever 3.
+//!
+//! Two loop-scoped anti-patterns get a warning, so the fast path is
+//! the path of least resistance rather than expert folklore:
+//!   1. a locus (its own arena / heap buffer) instantiated per loop
+//!      iteration — hoist to a reused field;
+//!   2. an allocating `recv` in a loop — use `recv_into` with a reused
+//!      buffer.
+//! The zero-alloc equivalents (reused field, `recv_into`) stay silent.
+
+use hale_syntax::parse_source;
+use hale_types::check_program;
+
+fn warnings(src: &str) -> Vec<String> {
+    let prog = parse_source(src).expect("parse failed");
+    check_program(&prog)
+        .into_iter()
+        .map(|d| d.message)
+        .filter(|m| m.contains("hot-path allocation"))
+        .collect()
+}
+
+// ---- positives: the anti-patterns fire -------------------------------
+
+#[test]
+fn locus_instantiated_in_loop_is_flagged() {
+    let src = r#"
+locus Conn { run() { } }
+
+locus Server {
+    run() {
+        let mut n = 0;
+        while n < 100 {
+            let c = Conn { };
+            n = n + 1;
+        }
+    }
+}
+
+fn main() { }
+"#;
+    let ws = warnings(src);
+    assert!(
+        ws.iter().any(|m| m.contains("locus `Conn`") && m.contains("loop")),
+        "expected loop-scoped locus-instantiation warning, got: {:?}",
+        ws
+    );
+}
+
+#[test]
+fn bytesbuilder_in_loop_is_flagged() {
+    let src = r#"
+locus Server {
+    run() {
+        let mut n = 0;
+        while n < 100 {
+            let b = std::bytes::BytesBuilder { initial_cap: 4096 };
+            n = n + 1;
+        }
+    }
+}
+
+fn main() { }
+"#;
+    let ws = warnings(src);
+    assert!(
+        ws.iter().any(|m| m.contains("std::bytes::BytesBuilder")),
+        "expected loop-scoped BytesBuilder warning, got: {:?}",
+        ws
+    );
+}
+
+#[test]
+fn allocating_recv_path_call_in_loop_is_flagged() {
+    let src = r#"
+locus Reader {
+    params { fd: Int = 0; }
+    run() {
+        let mut n = 0;
+        while n < 100 {
+            let msg = std::io::udp::recv(self.fd, 2048) or discard;
+            n = n + 1;
+        }
+    }
+}
+
+fn main() { }
+"#;
+    let ws = warnings(src);
+    assert!(
+        ws.iter().any(|m| m.contains("std::io::udp::recv") && m.contains("recv_into")),
+        "expected loop-scoped allocating-recv warning, got: {:?}",
+        ws
+    );
+}
+
+#[test]
+fn allocating_recv_method_call_in_loop_is_flagged() {
+    // Method-call form `stream.recv_bytes(n)` — the receiver types as
+    // Unknown (stdlib handle locus), so the lint keys off the method
+    // name.
+    let src = r#"
+locus Sink {
+    params { s: Int = 0; }
+    run() {
+        let mut n = 0;
+        while n < 100 {
+            let chunk = self.s.recv_bytes(4096) or discard;
+            n = n + 1;
+        }
+    }
+}
+
+fn main() { }
+"#;
+    let ws = warnings(src);
+    assert!(
+        ws.iter().any(|m| m.contains("recv_bytes")),
+        "expected method-form allocating-recv warning, got: {:?}",
+        ws
+    );
+}
+
+#[test]
+fn for_loop_body_is_a_hot_loop_too() {
+    let src = r#"
+locus Conn { run() { } }
+
+locus Server {
+    run() {
+        for i in 0..100 {
+            let c = Conn { };
+        }
+    }
+}
+
+fn main() { }
+"#;
+    let ws = warnings(src);
+    assert!(
+        ws.iter().any(|m| m.contains("locus `Conn`")),
+        "expected for-loop body to count as a hot loop, got: {:?}",
+        ws
+    );
+}
+
+// ---- negatives: the fast path (and non-loop code) stays silent -------
+
+#[test]
+fn hoisted_reused_field_is_silent() {
+    // The fast path: the builder is a field (allocated once at birth),
+    // reused per iteration via recv_into. Nothing instantiated in the
+    // loop, nothing flagged.
+    let src = r#"
+locus Reader {
+    params {
+        fd: Int = 0;
+        buf: std::bytes::BytesBuilder = std::bytes::BytesBuilder { initial_cap: 4096 };
+    }
+    run() {
+        let mut n = 0;
+        while n < 100 {
+            let got = std::io::udp::recv_into(self.fd, self.buf, 2048) or discard;
+            n = n + 1;
+        }
+    }
+}
+
+fn main() { }
+"#;
+    assert!(
+        warnings(src).is_empty(),
+        "fast path must be silent, got: {:?}",
+        warnings(src)
+    );
+}
+
+#[test]
+fn instantiation_outside_a_loop_is_silent() {
+    // A per-invocation instantiation reclaims when the method returns;
+    // only loop-scoped allocation is the unambiguous hot-path case.
+    let src = r#"
+locus Conn { run() { } }
+
+locus Server {
+    run() {
+        let c = Conn { };
+    }
+}
+
+fn main() { }
+"#;
+    assert!(
+        warnings(src).is_empty(),
+        "non-loop instantiation must be silent, got: {:?}",
+        warnings(src)
+    );
+}
+
+#[test]
+fn plain_struct_literal_in_loop_is_silent() {
+    // A plain struct/type literal is a value — no arena, no heap
+    // buffer — so it's not flagged even in a loop.
+    let src = r#"
+type Point { x: Int; y: Int; }
+
+locus Server {
+    run() {
+        let mut n = 0;
+        while n < 100 {
+            let p = Point { x: 1, y: 2 };
+            n = n + 1;
+        }
+    }
+}
+
+fn main() { }
+"#;
+    assert!(
+        warnings(src).is_empty(),
+        "plain struct literal must be silent, got: {:?}",
+        warnings(src)
+    );
+}

--- a/docs/src/systems/performance.md
+++ b/docs/src/systems/performance.md
@@ -119,6 +119,39 @@ These are advisory warnings, not build failures:
   loop) is the fix. (Detection reads the receiver's *declared* type, so
   it sees `fn f(v: IntVec)` and `self.buf: IntVec` but not an untyped
   `let`.)
+- It also flags two **loop-scoped hot-path allocations** (also advisory):
+  a **locus** or a `std::bytes::BytesBuilder` instantiated *inside a loop*
+  (a fresh arena / heap buffer every iteration — hoist it to a reused
+  field), and an **allocating `recv`** (`recv` / `recv_bytes` /
+  `recv_with_source`) in a loop (use `recv_into` with a reused
+  `BytesBuilder`). A plain value struct/type literal isn't flagged, and an
+  instantiation outside a loop reclaims at method exit — only the
+  per-iteration case, the unambiguous one, warns.
+
+Once the loop is clean, you can **certify** it and have the compiler hold
+the line. `@budget(alloc_per_call = N)` on a fn (free or method) is an
+opt-in contract: the fn allocates at most `N` times per call, enforced as
+a **hard error** (this is the one allocation check that fails the build —
+because you asked for it).
+
+```hale
+@budget(alloc_per_call = 0)
+fn decode(buf: Bytes) -> Tick {
+    // no arena allocation reachable from here — the compiler proves it.
+    // reads via reused fields / recv_into; parses in place.
+}
+```
+
+`N = 0` is the zero-alloc certificate — exactly what you want on a
+per-datagram handler or decode helper. The check counts the arena
+allocations it can see (literals, `@form` inserts) transitively through
+resolved callees, plus the known-allocating `recv` family; a loop-nested
+allocation or a call to an allocating fn in a loop is unbounded per call
+and busts any finite budget. On a violation it reports the count and
+points at every offending line. It's the dual of `@unbounded` — one
+acknowledges intentional allocation, the other forbids it — and the two
+are mutually exclusive on a fn.
+
 The same idea extends to file descriptors and resource budgets. The
 full diagnostic surface — runtime residency dumps,
 `--dump-alloc-summary`, the fd-leak and resource-budget checks, and

--- a/docs/src/verification.md
+++ b/docs/src/verification.md
@@ -106,7 +106,20 @@ and no bus handler) warn nothing — a script owes no bound proof.
 `@unbounded fn` is the in-source carve-out for an acknowledged
 site; `--no-warn-unbounded-alloc` opts a run out. Advisory today; a
 hard error contract is the intended end state once the remaining
-documented false-positive classes get their annotations.
+documented false-positive classes get their annotations. A separate
+advisory also flags two **loop-scoped hot-path allocations** — a locus
+or `BytesBuilder` instantiated per iteration, and an allocating `recv`
+in a loop — steering toward a hoisted field / `recv_into`.
+
+**Hot-path allocation budget** *(opt-in, hard error).* `@budget(alloc_per_call
+= N)` on a fn is the dual of `@unbounded`: an explicit per-call
+allocation ceiling the compiler enforces. It counts the arena
+allocations it can see — literals, `@form` inserts, transitively
+through resolved callees, plus the known-allocating `recv` family — and
+**fails the build** if the fn allocates more than `N` per call (a
+loop-nested allocation is unbounded per call). `N = 0` is the zero-alloc
+certificate for a hot-path handler. The one allocation check that gates
+the build, because you opted into it.
 
 **Resource budgets** *(opt-in).* Static counts of file descriptors, OS
 threads, cooperative pools, and bus subjects, with a

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -754,12 +754,25 @@ function_decl     = [ function_decorator ] ,
    survey). It also prefixes a locus member — a `function_decl` or a
    `lifecycle_decl` (e.g. `@unbounded run { … }`) — inside a locus
    body; `unbounded` is contextual, recognized only after `@`. See
-   `spec/verification.md`. *)
+   `spec/verification.md`.
+
+   `@budget(alloc_per_call = N)` (2026-07-16) is `@unbounded`'s dual:
+   an opt-in per-call allocation ceiling on a `fn` (free or method).
+   The compiler counts the arena allocations it can see — literals /
+   `@form` inserts, transitively through resolved callees, plus the
+   known-allocating `recv` family — and errors if the fn allocates
+   more than `N` per call; a loop-nested allocation is unbounded per
+   call. `N = 0` is the zero-alloc certificate. fn-only; mutually
+   exclusive with `@unbounded` (only one fn decorator parses).
+   `budget` / `alloc_per_call` are contextual, recognized only in
+   this annotation. See `spec/verification.md`. *)
 function_decorator = ffi_annotation | export_annotation
-                   | unbounded_annotation ;
+                   | unbounded_annotation | budget_annotation ;
 ffi_annotation    = "@" , "ffi" , "(" , STRING_LIT , ")" ;
 export_annotation = "@" , "export" ;
 unbounded_annotation = "@" , "unbounded" ;
+budget_annotation = "@" , "budget" , "(" , "alloc_per_call" ,
+                    "=" , INT_LIT , ")" ;
 
 (* v1.x-FORM-1: a fallible fn's return type is "value of T, or
    an error has occurred with payload P." Callers MUST address

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -131,6 +131,39 @@ assume the others in a build:
   param fields — not inferred ones.) Zero corpus false positives. Type-aware
   String-concat sites and untyped-receiver collection inserts remain
   deferred. See `notes/memory-bound-proofs.md`.
+- **Hot-path allocation contract — `@budget(alloc_per_call = N)`** (2026-07-16).
+  The dual of `@unbounded`: where `@unbounded` acknowledges intentional
+  unbounded allocation, `@budget` declares an *opt-in per-call ceiling* and
+  the compiler **enforces it as a hard error**. On a `fn` (free or method),
+  `@budget(alloc_per_call = N)` asserts the fn performs at most `N` arena
+  allocations per call. The check reuses the item-1 allocation summary +
+  call graph: it counts the arena-allocating literals / `@form` inserts it
+  can see, **transitively through resolved (bundle-local) callees**, plus
+  the known-allocating `recv` family (`recv` / `recv_bytes` /
+  `recv_with_source` — the same set the hot-path lint flags); a
+  loop-nested allocation, or a call to an allocating fn inside a loop, or
+  recursion, is **unbounded per call**. `N = 0` is the zero-alloc
+  certificate — the strongest form, for a per-datagram handler or decode
+  helper the runtime calls on the hot path with a guarantee it touches no
+  arena. Opaque calls other than the `recv` family are outside what the
+  budget sees (the same boundary the escape analysis draws); pair the
+  contract with `recv_into` + a reused `BytesBuilder`. fn-only; mutually
+  exclusive with `@unbounded`. A violation reports the measured count and
+  points at every offending allocation with the fast-path fix.
+- **Hot-path allocation lint — default-on advisory** (2026-07-16). Two
+  loop-scoped anti-patterns get a **warning** (never a build failure), so
+  the allocation-free shape is the path of least resistance rather than
+  expert folklore: (1) a **locus** (its own arena / heap buffer) or a
+  `std::bytes::BytesBuilder` instantiated inside a loop — hoist it to a
+  reused field; (2) an **allocating `recv`** (the `recv` family) in a loop
+  — use `recv_into` with a reused `BytesBuilder`. Both accumulate in the
+  method scratch until the enclosing method returns, and a `run()` read
+  loop never returns. Loop-scoped keeps the signal clean (per-iteration is
+  the unambiguous case); a plain value struct/type literal is not flagged
+  (only loci and heap-bearing builders), and a per-invocation
+  instantiation outside a loop reclaims at method exit. This is the
+  conservative default advisory; `@budget` is the strict opt-in contract
+  built on the same intent.
 - **Resource-budget tracking (item 5)** — fully shipped, opt-in. A static
   **count** of pinned threads / cooperative pools / bus subjects /
   fd-acquisition sites (fd-opening calls *and* held-fd `Listener` /
@@ -158,8 +191,11 @@ assume the others in a build:
   built. Closures still verify their (runtime-observing) invariants at
   *runtime*. See `notes/closure-lifting.md`.
 
-Nothing here yet *proves* allocation, fd, or thread bounds as a
-build-failing gate; the item-1 warnings are advisory.
+The item-1 whole-program survey and the hot-path lint are advisory
+(warnings). The one build-failing *allocation* gate is opt-in:
+`@budget(alloc_per_call = N)` on a fn — you ask for the ceiling, and a
+violation is a hard error. fd and thread bounds remain advisory / CI-gated
+(item 5), not automatic build failures.
 
 Item 2 (race-completeness for substrate primitives) is a *substrate*
 quality bar, not a user-facing check: it model-checks the runtime's own


### PR DESCRIPTION
**Stack 1 of 3** — base for the hot-path enforcement series (base `main`).

Make the allocation-free hot path the path of least resistance, and let a fn *certify* it. Two additions built on the existing `alloc_summary` call graph.

### Hot-path allocation lint (default-on advisory)
Warns on two loop-scoped anti-patterns: a locus or `std::bytes::BytesBuilder` instantiated inside a loop, and an allocating `recv` (`recv`/`recv_bytes`/`recv_with_source`) in a loop — steering toward a hoisted field / `recv_into`. Plain value literals and non-loop instantiations stay silent; a warning, never a build failure. Clean across all 77 example fixtures.

### `@budget(alloc_per_call = N)` (opt-in hard error)
The dual of `@unbounded` — an explicit per-call allocation ceiling on a `fn` (free or method). Counts the visible arena allocations (literals, `@form` inserts) transitively through resolved callees plus the known-allocating `recv` family; a loop-nested allocation, a call to an allocating fn in a loop, or recursion is unbounded per call. `N = 0` is the zero-alloc certificate. A violation reports the count and pinpoints every offending allocation. fn-only, mutually exclusive with `@unbounded`.

### Tests
- `crates/hale-types/tests/hot_path_alloc.rs` (8) — positives + fast-path silence
- `crates/hale-types/tests/budget_contract.rs` (9) — clean/violation, transitive, loop=unbounded, opt-in
- `parser.rs` inline (6) — annotation shapes + rejections

### Spec + docs (same change)
`spec/grammar.ebnf` (`budget_annotation`), `spec/verification.md`, `docs/src/verification.md`, `docs/src/systems/performance.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)