### PR TITLE
feat(bus): substrate unix transports as loci + listen re-arm (#233 steps 1–2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ behavior.
 
 ## Unreleased
 
+- **Substrate unix transports are loci; listen bindings re-arm
+  (GH #233 steps 1–2).** A `bindings { T: unix(...) }` entry now
+  desugars to a stdlib transport locus
+  (`__StdBusUnixListenTransport` / `__StdBusUnixConnectTransport`)
+  instantiated as a cooperative child at the main prelude —
+  converging with the adapter path, per F.37's
+  transports-as-loci direction. birth() realizes synchronously
+  on the boot path (behavior of GH #227 preserved verbatim);
+  dissolve() interrupts, joins, and reclaims. The listen serve
+  loop now **re-arms on peer EOF** — it closes the dead
+  connection and accepts the next peer instead of silently going
+  deaf for the rest of the process — so rolling restarts of the
+  connect-side binary just work (`LOTUS_BUS_CONFIG` unix
+  listeners share the same loop and re-arm too). The hot path is
+  unchanged: publish fanout still writes the C remote table
+  directly (locus for flow, C for bytes). Loss-is-structural +
+  restart-as-reconnect are GH #233 steps 3–4.
 - **Bus binding failure is now structural (F.37, GH #227).** A
   `bindings { }` entry or `LOTUS_BUS_CONFIG` route whose
   transport cannot be realized — socket/bind/listen/addr

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -12364,6 +12364,16 @@ typedef struct lotus_bus_remote_entry {
     void              *codec_self;
     void             *(*codec_encode_fn)(void *self, void *value);
     void             *(*codec_decode_fn)(void *self, void *bytes);
+    /* GH #233 step 1 (transports-as-loci): entries owned by a
+     * __StdBusUnixTransport locus instead of the register-time
+     * reader thread. `locus_served` entries are realized by the
+     * locus's birth(), served by its pinned run() (LISTEN role),
+     * and reclaimed by its dissolve() — destroy_all only frees
+     * the husk. `closing` is the serve-loop stop flag, set by
+     * lotus_bus_transport_interrupt before the pinned join (the
+     * transport analog of lotus_mailbox_shutdown). */
+    int                locus_served;
+    volatile int       closing;
 } lotus_bus_remote_entry_t;
 
 /* 2026-05-27 — array-of-pointers shape (was array-of-structs).
@@ -12398,6 +12408,39 @@ static inline int lotus_bus_has_remote_entries(void) {
 
 #define LOTUS_BUS_REMOTE_INITIAL_CAP 4
 
+/* Grow the slot-array (of pointers, post-2026-05-27) and push a
+ * zero-initialized entry. The realloc can move the array of
+ * pointers, but the individual entries it points to are stable
+ * malloc'd allocations — no dangling reader-thread/locus
+ * `entry` pointers from prior registrations. Returns NULL on
+ * allocation failure. Registration runs single-threaded on the
+ * boot path; a failed caller pops via g_bus_remote_count--. */
+static lotus_bus_remote_entry_t *lotus_bus_remote_entry_push(
+    const char *subject, int kind)
+{
+    if (g_bus_remote_count == g_bus_remote_cap) {
+        size_t new_cap = g_bus_remote_cap == 0
+            ? LOTUS_BUS_REMOTE_INITIAL_CAP
+            : g_bus_remote_cap * 2;
+        lotus_bus_remote_entry_t **grown = (lotus_bus_remote_entry_t **)
+            realloc(g_bus_remote_entries,
+                    new_cap * sizeof(lotus_bus_remote_entry_t *));
+        if (!grown) return NULL;
+        g_bus_remote_entries = grown;
+        g_bus_remote_cap     = new_cap;
+    }
+    char *subject_copy = strdup(subject);
+    if (!subject_copy) return NULL;
+    lotus_bus_remote_entry_t *e = (lotus_bus_remote_entry_t *)
+        calloc(1, sizeof(lotus_bus_remote_entry_t));
+    if (!e) { free(subject_copy); return NULL; }
+    e->subject = subject_copy;
+    e->kind    = kind;
+    e->udp_fd  = -1;
+    g_bus_remote_entries[g_bus_remote_count++] = e;
+    return e;
+}
+
 /* m59: queue pointer published by the codegen prelude (via
  * lotus_bus_set_queue) so reader threads can dispatch into the
  * cooperative-subscriber path without plumbing the queue through
@@ -12420,66 +12463,75 @@ typedef struct lotus_bus_reader_args {
     lotus_bus_remote_entry_t *entry;
 } lotus_bus_reader_args_t;
 
-static void *lotus_bus_reader_thread_main(void *arg) {
-    lotus_bus_reader_args_t *args = (lotus_bus_reader_args_t *)arg;
-    /* Accept HERE, on the reader thread, so the block-until-peer
-     * wait doesn't stall main's boot path (m59). The listener
-     * socket itself was already bound in register_remote, so a
-     * peer's connect-with-retry succeeds as soon as this binary
-     * boots, whether or not this thread has reached accept yet. */
-    lotus_transport_t *t = args->entry->transport;
-    if (lotus_transport_listener_accept(t) != 0) {
-        /* Teardown shut the listener down before any peer
-         * arrived (or accept genuinely failed). Destroy and
-         * hand the slot back as "no transport". */
-        args->entry->transport = NULL;
-        lotus_transport_destroy(t);
-        free(args);
-        return NULL;
-    }
-
+/* GH #233: the LISTEN-role serve loop, shared between the
+ * config-route reader thread below and the transport locus's
+ * pinned run() (lotus_bus_transport_serve). Accepts a peer,
+ * dispatches its messages until EOF, then RE-ARMS — peer EOF is
+ * not connection loss (the listener is still bound; a restarted
+ * connect-side binary's connect-with-retry lands on the next
+ * accept). Exits when `closing` is set or accept refuses
+ * (teardown shuts the listener down via
+ * lotus_bus_transport_interrupt / destroy_all). */
+static void lotus_bus_unix_serve(lotus_bus_remote_entry_t *entry) {
+    lotus_transport_t *t = entry->transport;
+    if (!t) return;
     char wire_buf[LOTUS_PAYLOAD_MAX];
     char struct_buf[LOTUS_PAYLOAD_MAX];
-    while (1) {
-        ssize_t n = lotus_transport_recv(t, wire_buf, sizeof(wire_buf));
-        if (n <= 0) break;     /* peer closed (0) or error (-1) */
+    while (!entry->closing) {
+        /* The listener socket was bound at realization, so a
+         * peer's connect-with-retry succeeds as soon as this
+         * binary boots, whether or not this thread has reached
+         * accept yet (m59's no-hang-at-boot property). */
+        if (lotus_transport_listener_accept(t) != 0) break;
+        while (!entry->closing) {
+            ssize_t n = lotus_transport_recv(t, wire_buf, sizeof(wire_buf));
+            if (n <= 0) break;     /* peer closed (0) or error (-1) */
 
-        /* m60: deserialize wire bytes into struct-layout bytes
-         * before handing them to local dispatch. Look up the
-         * deserialize_fn from the FIRST local entry matching
-         * this subject — by language constraint all entries on
-         * the same subject share the payload type, so any one
-         * works. Skip dispatch if the type-checker mismatches
-         * or there are no local subscribers (the recv'd bytes
-         * have nowhere to go locally; that's not an error in
-         * relay-shaped programs). */
-        lotus_deserialize_fn deserialize = NULL;
-        for (size_t i = 0; i < g_bus_count; i++) {
-            lotus_bus_entry_t *e = &g_bus_entries[i];
-            if (!e->subject) continue;
-            /* m94: wildcard locals (e.g. "log.**") need to match
-             * concrete remote-bound subjects too, so use the same
-             * pattern-matching as the dispatch path. By language
-             * constraint, all subscribers on the same subject
-             * share the payload type, so the deserialize_fn from
-             * any matching entry is the right one. */
-            if (!lotus_subject_match(e->subject, args->entry->subject)) continue;
-            deserialize = e->deserialize;
-            break;
+            /* m60: deserialize wire bytes into struct-layout bytes
+             * before handing them to local dispatch. Look up the
+             * deserialize_fn from the FIRST local entry matching
+             * this subject — by language constraint all entries on
+             * the same subject share the payload type, so any one
+             * works. Skip dispatch if the type-checker mismatches
+             * or there are no local subscribers (the recv'd bytes
+             * have nowhere to go locally; that's not an error in
+             * relay-shaped programs). */
+            lotus_deserialize_fn deserialize = NULL;
+            for (size_t i = 0; i < g_bus_count; i++) {
+                lotus_bus_entry_t *e = &g_bus_entries[i];
+                if (!e->subject) continue;
+                /* m94: wildcard locals (e.g. "log.**") need to
+                 * match concrete remote-bound subjects too, so use
+                 * the same pattern-matching as the dispatch path. */
+                if (!lotus_subject_match(e->subject, entry->subject)) continue;
+                deserialize = e->deserialize;
+                break;
+            }
+            if (!deserialize) continue;
+            ssize_t struct_size = deserialize(
+                wire_buf, (size_t)n, struct_buf, sizeof(struct_buf));
+            if (struct_size <= 0) continue;
+            lotus_bus_local_dispatch(g_bus_queue_for_remote,
+                                     entry->subject,
+                                     struct_buf, (size_t)struct_size);
         }
-        if (!deserialize) continue;
-        ssize_t struct_size = deserialize(
-            wire_buf, (size_t)n, struct_buf, sizeof(struct_buf));
-        if (struct_size <= 0) continue;
-        lotus_bus_local_dispatch(g_bus_queue_for_remote,
-                                 args->entry->subject,
-                                 struct_buf, (size_t)struct_size);
+        /* GH #233 step 2: re-arm. Close the dead connection and
+         * loop back into accept for the next peer. */
+        if (t->conn_fd >= 0) {
+            close(t->conn_fd);
+            t->conn_fd = -1;
+        }
     }
+}
 
+static void *lotus_bus_reader_thread_main(void *arg) {
+    lotus_bus_reader_args_t *args = (lotus_bus_reader_args_t *)arg;
+    lotus_transport_t *t = args->entry->transport;
+    lotus_bus_unix_serve(args->entry);
     /* NULL the entry's pointer BEFORE destroying so destroy_all
      * never reads a freed transport — at worst it sees NULL and
      * skips its shutdown, which is fine because this thread is
-     * already past the recv loop and exiting. */
+     * already past the serve loop and exiting. */
     args->entry->transport = NULL;
     lotus_transport_destroy(t);
     free(args);
@@ -12812,48 +12864,11 @@ int lotus_bus_register_remote(const char *subject,
         return -1;
     }
 
-    /* Grow the slot-array (of pointers, post-2026-05-27) so we
-     * have room to stash the new entry's pointer. The
-     * realloc here can move the array of pointers, but the
-     * individual entries it points to are stable malloc'd
-     * allocations — no dangling reader-thread `args->entry`
-     * pointers from prior registrations. */
-    if (g_bus_remote_count == g_bus_remote_cap) {
-        size_t new_cap = g_bus_remote_cap == 0
-            ? LOTUS_BUS_REMOTE_INITIAL_CAP
-            : g_bus_remote_cap * 2;
-        lotus_bus_remote_entry_t **grown = (lotus_bus_remote_entry_t **)
-            realloc(g_bus_remote_entries,
-                    new_cap * sizeof(lotus_bus_remote_entry_t *));
-        if (!grown) return -1;
-        g_bus_remote_entries = grown;
-        g_bus_remote_cap     = new_cap;
-    }
-
-    char *subject_copy = strdup(subject);
-    if (!subject_copy) return -1;
-
-    lotus_bus_remote_entry_t *e = (lotus_bus_remote_entry_t *)
-        malloc(sizeof(lotus_bus_remote_entry_t));
-    if (!e) { free(subject_copy); return -1; }
-    g_bus_remote_entries[g_bus_remote_count++] = e;
-    e->subject           = subject_copy;
-    e->kind              = is_udp
-        ? LOTUS_BUS_REMOTE_KIND_UDP
-        : LOTUS_BUS_REMOTE_KIND_UNIX;
-    e->transport         = NULL;
-    e->role              = role;
-    e->has_reader_thread = 0;
-    e->adapter_self      = NULL;
-    e->adapter_send_fn   = NULL;
-    e->udp_fd            = -1;
-    memset(&e->udp_dest, 0, sizeof(e->udp_dest));
-    e->udp_is_multicast  = 0;
-    /* F.36 Slice 3: codec fields default NULL (m70 path). The
-     * register_codec call below zero-or-overwrites them. */
-    e->codec_self        = NULL;
-    e->codec_encode_fn   = NULL;
-    e->codec_decode_fn   = NULL;
+    lotus_bus_remote_entry_t *e = lotus_bus_remote_entry_push(
+        subject,
+        is_udp ? LOTUS_BUS_REMOTE_KIND_UDP : LOTUS_BUS_REMOTE_KIND_UNIX);
+    if (!e) return -1;
+    e->role = role;
 
     /* #227: every failure below pops the just-pushed entry and
      * returns -1 so the caller can fail the declaring locus's
@@ -12993,6 +13008,103 @@ void lotus_bus_binding_fail(const char *subject, const char *url) {
     exit(1);
 }
 
+/*
+ * GH #233 step 1 — the locus-facing transport surface. A source
+ * `bindings { T: unix(...) }` entry no longer emits a raw
+ * lotus_bus_register_remote call; codegen instantiates a
+ * __StdBusUnixTransport locus (stdlib bus.hl) whose lifecycle
+ * drives these four primitives:
+ *
+ *   birth()    -> lotus_bus_transport_realize (synchronous;
+ *                 failure = birth failure of the locus), then
+ *                 for LISTEN role lotus_bus_transport_spawn_server
+ *                 (starts the accept/dispatch/re-arm thread)
+ *   dissolve() -> lotus_bus_transport_reclaim  (interrupt the
+ *                 serve thread, join it, destroy the transport)
+ *
+ * Publish fanout is untouched: realized entries land in the
+ * same g_bus_remote_entries table the fanout walks (locus for
+ * flow, C for bytes — F.37). The serve thread is the same
+ * machinery the LOTUS_BUS_CONFIG reader path uses; it belongs
+ * to the data plane, not the locus placement machinery.
+ *
+ * The handle is the entry pointer as i64. Entries stay in the
+ * table after reclaim (subject intact, transport NULL) so
+ * destroy_all can free the husk uniformly.
+ */
+int64_t lotus_bus_transport_realize(const char *subject,
+                                    const char *path,
+                                    int64_t role) {
+    if (!subject || !path || *path == '\0') return 0;
+    lotus_bus_remote_entry_t *e = lotus_bus_remote_entry_push(
+        subject, LOTUS_BUS_REMOTE_KIND_UNIX);
+    if (!e) return 0;
+    e->role         = (int)role;
+    e->locus_served = 1;
+    if (role == LOTUS_TRANSPORT_LISTEN) {
+        e->transport = lotus_transport_listener_create(path);
+    } else {
+        e->transport = lotus_transport_create(path, (int)role);
+    }
+    if (!e->transport) {
+        g_bus_remote_count--;
+        free(e->subject);
+        free(e);
+        return 0;
+    }
+    return (int64_t)(intptr_t)e;
+}
+
+int64_t lotus_bus_transport_spawn_server(int64_t handle) {
+    lotus_bus_remote_entry_t *e =
+        (lotus_bus_remote_entry_t *)(intptr_t)handle;
+    if (!e || e->role != LOTUS_TRANSPORT_LISTEN || !e->transport) {
+        return -1;
+    }
+    lotus_bus_reader_args_t *args =
+        (lotus_bus_reader_args_t *)malloc(sizeof(*args));
+    if (!args) return -1;
+    args->entry = e;
+    lotus_mark_multithreaded();
+    if (pthread_create(&e->reader_thread, NULL,
+                       lotus_bus_reader_thread_main, args) != 0) {
+        perror("lotus_bus_transport_spawn_server: pthread_create");
+        free(args);
+        return -1;
+    }
+    e->has_reader_thread = 1;
+    return 0;
+}
+
+void lotus_bus_transport_reclaim(int64_t handle) {
+    lotus_bus_remote_entry_t *e =
+        (lotus_bus_remote_entry_t *)(intptr_t)handle;
+    if (!e) return;
+    e->closing = 1;
+    if (e->transport) {
+        /* Unblock the serve thread wherever it's parked: a
+         * shutdown connection recv returns EOF; a shutdown
+         * listener makes a parked accept() refuse. */
+        if (e->transport->conn_fd >= 0) {
+            shutdown(e->transport->conn_fd, SHUT_RDWR);
+        }
+        if (e->transport->listen_fd >= 0) {
+            shutdown(e->transport->listen_fd, SHUT_RDWR);
+        }
+    }
+    if (e->has_reader_thread) {
+        pthread_join(e->reader_thread, NULL);
+        /* The thread destroyed the transport and NULLed the
+         * entry's pointer on its way out. Clear the flag so
+         * destroy_all doesn't double-join. */
+        e->has_reader_thread = 0;
+    }
+    if (e->transport) {
+        lotus_transport_destroy(e->transport);
+        e->transport = NULL;
+    }
+}
+
 /* Wave B: register an adapter binding. The adapter locus has
  * already been instantiated by codegen with program-lifetime
  * allocation, and its `send(subject, bytes)` method's fn pointer
@@ -13019,36 +13131,11 @@ void lotus_bus_register_remote_adapter(
                 "self_data, or send_fn\n");
         return;
     }
-    if (g_bus_remote_count == g_bus_remote_cap) {
-        size_t new_cap = g_bus_remote_cap == 0
-            ? LOTUS_BUS_REMOTE_INITIAL_CAP
-            : g_bus_remote_cap * 2;
-        lotus_bus_remote_entry_t **grown = (lotus_bus_remote_entry_t **)
-            realloc(g_bus_remote_entries,
-                    new_cap * sizeof(lotus_bus_remote_entry_t *));
-        if (!grown) return;
-        g_bus_remote_entries = grown;
-        g_bus_remote_cap     = new_cap;
-    }
-    char *subject_copy = strdup(subject);
-    if (!subject_copy) return;
-    lotus_bus_remote_entry_t *e = (lotus_bus_remote_entry_t *)
-        malloc(sizeof(lotus_bus_remote_entry_t));
-    if (!e) { free(subject_copy); return; }
-    g_bus_remote_entries[g_bus_remote_count++] = e;
-    e->subject           = subject_copy;
-    e->kind              = LOTUS_BUS_REMOTE_KIND_ADAPTER;
-    e->transport         = NULL;
-    e->role              = 0;
-    e->has_reader_thread = 0;
-    e->adapter_self      = self_data;
-    e->adapter_send_fn   = send_fn;
-    e->udp_fd            = -1;
-    memset(&e->udp_dest, 0, sizeof(e->udp_dest));
-    e->udp_is_multicast  = 0;
-    e->codec_self        = NULL;
-    e->codec_encode_fn   = NULL;
-    e->codec_decode_fn   = NULL;
+    lotus_bus_remote_entry_t *e = lotus_bus_remote_entry_push(
+        subject, LOTUS_BUS_REMOTE_KIND_ADAPTER);
+    if (!e) return;
+    e->adapter_self    = self_data;
+    e->adapter_send_fn = send_fn;
 }
 
 /* F.36 Slice 3 (2026-05-28): attach a pluggable codec to an

--- a/crates/hale-codegen/runtime/stdlib/bus.hl
+++ b/crates/hale-codegen/runtime/stdlib/bus.hl
@@ -53,3 +53,78 @@
 interface __StdBusAdapter {
     fn send(subject: String, bytes: Bytes);
 }
+
+// GH #233 (F.37): the substrate unix transports, expressed as
+// what they always were — loci with lifecycle. A source-level
+// `bindings { T: unix("/path", role: ...) }` entry is sugar that
+// instantiates one of these as a child of the main locus
+// (converging with the adapter path above). The locus is the
+// control plane; the data plane stays in C — publish fanout
+// writes through the realized entry directly, and the listen
+// serve loop (accept → dispatch → re-arm on peer EOF) runs in
+// `lotus_bus_unix_serve` on the listen locus's pinned thread.
+//
+// birth() realizes the transport synchronously on the boot path
+// — a binding the broker cannot honor fails the declaring
+// locus's birth (the publish contract, spec/semantics.md). Both
+// types are cooperative: birth runs inline at the prelude (the
+// codec-locus precedent), so realization failure refuses the
+// boot before any user code runs. The listen side's serve
+// thread (accept → dispatch → re-arm on peer EOF) is spawned by
+// birth and joined by dissolve — the byte-pump thread belongs
+// to the C data plane, not the locus placement machinery (a
+// pinned run() would move birth onto the spawned thread and
+// make realization asynchronous again).
+
+/// Listen-side substrate transport: `unix(..., role: listen)`.
+locus __StdBusUnixListenTransport {
+    params {
+        subject: String = "";
+        url: String = "";
+        path: String = "";
+        handle: Int = 0;    // remote-entry handle, set by birth
+    }
+
+    birth() {
+        self.handle = std::bus::__transport_realize(
+            self.subject, self.path, 0);
+        if self.handle == 0 {
+            // Structural refusal: diagnostic + non-zero exit.
+            // (The handled route — violate → main's on_failure —
+            // is GH #233 steps 3/4.)
+            std::bus::__binding_fail(self.subject, self.url);
+        }
+        let spawned = std::bus::__transport_spawn_server(self.handle);
+        if spawned != 0 {
+            std::bus::__binding_fail(self.subject, self.url);
+        }
+    }
+
+    dissolve() {
+        // Interrupts the serve thread (closing flag + fd
+        // shutdown), joins it, destroys the transport.
+        std::bus::__transport_reclaim(self.handle);
+    }
+}
+
+/// Connect-side substrate transport: `unix(..., role: connect)`.
+locus __StdBusUnixConnectTransport {
+    params {
+        subject: String = "";
+        url: String = "";
+        path: String = "";
+        handle: Int = 0;    // remote-entry handle, set by birth
+    }
+
+    birth() {
+        self.handle = std::bus::__transport_realize(
+            self.subject, self.path, 1);
+        if self.handle == 0 {
+            std::bus::__binding_fail(self.subject, self.url);
+        }
+    }
+
+    dissolve() {
+        std::bus::__transport_reclaim(self.handle);
+    }
+}

--- a/crates/hale-codegen/runtime/stdlib/bus.hl
+++ b/crates/hale-codegen/runtime/stdlib/bus.hl
@@ -82,7 +82,7 @@ locus __StdBusUnixListenTransport {
         subject: String = "";
         url: String = "";
         path: String = "";
-        handle: Int = 0;    // remote-entry handle, set by birth
+        handle: Int = 0; // remote-entry handle, set by birth
     }
 
     birth() {
@@ -113,7 +113,7 @@ locus __StdBusUnixConnectTransport {
         subject: String = "";
         url: String = "";
         path: String = "";
-        handle: Int = 0;    // remote-entry handle, set by birth
+        handle: Int = 0; // remote-entry handle, set by birth
     }
 
     birth() {

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -8253,7 +8253,11 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         }
 
         // Walk binding entries: adapter loci instantiated inline
-        // are pinned-equivalent by construction.
+        // are pinned-equivalent by construction. (The GH #233
+        // stdlib transport loci are deliberately NOT pinned —
+        // birth must run inline on the boot path so realization
+        // failure refuses the boot synchronously; their serve
+        // thread is C-spawned by birth, not placement-spawned.)
         for m in &l.members {
             if let LocusMember::Bindings(bb) = m {
                 for entry in &bb.entries {
@@ -8296,10 +8300,6 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         }
 
         let i32_t = self.context.i32_type();
-        let register_fn = self
-            .module
-            .get_function("lotus_bus_register_remote")
-            .expect("lotus_bus_register_remote declared");
 
         for block in bindings {
             for entry in block.entries {
@@ -8312,9 +8312,11 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     .cloned()
                     .unwrap_or_else(|| entry.topic.name.clone());
 
-                // Build URL + role from the transport spec, or
-                // dispatch to the adapter-binding path.
-                let (url, role) = match &entry.transport {
+                // Emit per transport spec: unix entries become
+                // __StdBusUnix{Listen,Connect}Transport locus
+                // children (GH #233); adapter / shm_ring keep
+                // their dedicated paths.
+                match &entry.transport {
                     TransportSpec::Unix { path, role, .. } => {
                         // Role inference filled this in during desugar
                         // (publish-only → connect, subscribe-only →
@@ -8322,9 +8324,9 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         // binding was ambiguous or unused; in that
                         // path role stays None and we fall through to
                         // the error arm below.
-                        let r = match role {
-                            Some(TransportRole::Listen) => 0_i64,
-                            Some(TransportRole::Connect) => 1_i64,
+                        let listen = match role {
+                            Some(TransportRole::Listen) => true,
+                            Some(TransportRole::Connect) => false,
                             None => {
                                 return Err(CodegenError::Unsupported(format!(
                                     "binding for topic `{}`: role could not be \
@@ -8335,7 +8337,24 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                                 )));
                             }
                         };
-                        (format!("unix://{}", path), r)
+                        self.emit_unix_transport_binding(
+                            &subject,
+                            &entry.topic.name,
+                            path,
+                            listen,
+                            entry.topic.span,
+                        )?;
+                        // F.36 Slice 3a (2026-05-28): codec
+                        // attachment rides the unix binding.
+                        if let Some(codec) = &entry.codec {
+                            self.emit_codec_binding_register(
+                                &subject,
+                                &entry.topic.name,
+                                &codec.locus,
+                                &codec.inits,
+                            )?;
+                        }
+                        continue;
                     }
                     TransportSpec::Adapter { locus, inits, .. } => {
                         self.emit_adapter_binding_register(
@@ -8500,101 +8519,79 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         continue;
                     }
                 };
-
-                let subj_ptr = self
-                    .builder
-                    .build_global_string_ptr(
-                        &subject,
-                        &format!("lotus.binding.subject.{}", entry.topic.name),
-                    )
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
-                    .as_pointer_value();
-                let url_ptr = self
-                    .builder
-                    .build_global_string_ptr(
-                        &url,
-                        &format!("lotus.binding.url.{}", entry.topic.name),
-                    )
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
-                    .as_pointer_value();
-                let role_val = i32_t.const_int(role as u64, false);
-                let status = self
-                    .builder
-                    .build_call(
-                        register_fn,
-                        &[subj_ptr.into(), url_ptr.into(), role_val.into()],
-                        "lotus.binding.register",
-                    )
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
-                    .try_as_basic_value()
-                    .left()
-                    .expect("register_remote returns i32")
-                    .into_int_value();
-                // #227: a binding that cannot be realized is a
-                // birth failure of the declaring (main) locus —
-                // route non-zero status into the structural
-                // failure sink instead of running with a broker
-                // that would accept messages it cannot deliver.
-                let is_fail = self
-                    .builder
-                    .build_int_compare(
-                        inkwell::IntPredicate::NE,
-                        status,
-                        i32_t.const_zero(),
-                        "lotus.binding.register.failed",
-                    )
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                let cur_fn = self
-                    .builder
-                    .get_insert_block()
-                    .expect("builder positioned")
-                    .get_parent()
-                    .expect("block has parent fn");
-                let fail_bb = self
-                    .context
-                    .append_basic_block(cur_fn, "binding.fail");
-                let cont_bb = self
-                    .context
-                    .append_basic_block(cur_fn, "binding.ok");
-                self.builder
-                    .build_conditional_branch(is_fail, fail_bb, cont_bb)
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                self.builder.position_at_end(fail_bb);
-                let binding_fail_fn = self
-                    .module
-                    .get_function("lotus_bus_binding_fail")
-                    .expect("lotus_bus_binding_fail declared");
-                self.builder
-                    .build_call(
-                        binding_fail_fn,
-                        &[subj_ptr.into(), url_ptr.into()],
-                        "lotus.binding.fail",
-                    )
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                self.builder
-                    .build_unreachable()
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                self.builder.position_at_end(cont_bb);
-                // F.36 Slice 3a (2026-05-28): codec attachment.
-                // When the binding entry carries a `codec(L { ... })`
-                // clause, instantiate L into program-lifetime memory
-                // (same m90-routed shape as the adapter path) and
-                // call `lotus_bus_register_codec` so the runtime
-                // entry knows which method ptrs to invoke at
-                // publish / receive. Slice 3b will wire the actual
-                // publish + receive dispatch through these ptrs;
-                // today the registration completes but dispatch
-                // falls through to m70.
-                if let Some(codec) = &entry.codec {
-                    self.emit_codec_binding_register(
-                        &subject,
-                        &entry.topic.name,
-                        &codec.locus,
-                        &codec.inits,
-                    )?;
-                }
             }
         }
+        Ok(())
+    }
+
+    /// GH #233: emit a `bindings { T: unix(...) }` entry as a
+    /// substrate-transport locus instantiation — the sugar view
+    /// of "transports are loci, children of main." Listen-role
+    /// entries instantiate `__StdBusUnixListenTransport` on the
+    /// pinned path (its run() serves the accept/recv/re-arm loop
+    /// on a dedicated thread); connect-role entries instantiate
+    /// `__StdBusUnixConnectTransport` cooperatively (no thread —
+    /// fanout drives the transport). Both realize synchronously
+    /// in birth(), which routes an unrealizable binding into
+    /// `std::bus::__binding_fail` — same observable behavior as
+    /// the #227 register-call shape this replaces.
+    fn emit_unix_transport_binding(
+        &mut self,
+        subject: &str,
+        topic_name: &str,
+        path: &str,
+        listen: bool,
+        span: hale_syntax::Span,
+    ) -> Result<(), CodegenError> {
+        let locus_name = if listen {
+            "__StdBusUnixListenTransport"
+        } else {
+            "__StdBusUnixConnectTransport"
+        };
+        let url = format!("unix://{}", path);
+        let str_init = |name: &str, value: &str| StructInit {
+            name: Ident { name: name.to_string(), span },
+            value: Expr::Literal(Literal::String(value.to_string()), span),
+            span,
+        };
+        let locus_lit = Expr::Struct {
+            path: QualifiedName {
+                segments: vec![Ident {
+                    name: locus_name.to_string(),
+                    span,
+                }],
+                span,
+            },
+            inits: vec![
+                str_init("subject", subject),
+                str_init("url", &url),
+                str_init("path", path),
+            ],
+            span,
+        };
+        if self.user_loci.get(locus_name).is_none() {
+            return Err(CodegenError::Unsupported(format!(
+                "binding for topic `{}`: stdlib transport locus `{}` \
+                 missing from the merged program (stdlib bus.hl not \
+                 loaded?)",
+                topic_name, locus_name
+            )));
+        }
+        // m90 routing → program-lifetime payload arena, exactly
+        // like the adapter path — but NO pinned override: a
+        // pinned locus runs its whole lifecycle (birth included)
+        // on the spawned thread, which would make realization
+        // asynchronous again. Both transport loci are
+        // cooperative; birth runs inline right here on the boot
+        // path, and the listen serve thread is C-spawned by
+        // birth itself (lotus_bus_transport_spawn_server).
+        let saved_ret = self.current_user_fn_ret.clone();
+        self.current_user_fn_ret =
+            Some(Some(CodegenTy::LocusRef(locus_name.to_string())));
+        let mut scope = Scope::default();
+        let result = self.lower_expr(&locus_lit, &mut scope);
+        self.current_user_fn_ret = saved_ret;
+        result?;
         Ok(())
     }
 
@@ -21165,6 +21162,16 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 let _ = self.lower_std_bus_local_dispatch(args, scope)?;
                 Ok(())
             }
+            // GH #233: __StdBusUnix*Transport lifecycle primitives.
+            ["std", "bus", "__transport_reclaim"] => {
+                let _ = self.lower_std_bus_transport_handle_op(
+                    "lotus_bus_transport_reclaim", args, scope)?;
+                Ok(())
+            }
+            ["std", "bus", "__binding_fail"] => {
+                let _ = self.lower_std_bus_binding_fail(args, scope)?;
+                Ok(())
+            }
             ["std", "str", "from_bytes"] => {
                 let _ = self.lower_std_str_from_bytes(args, scope)?;
                 Ok(())
@@ -21991,6 +21998,16 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             }
             ["std", "bus", "__local_dispatch"] => {
                 self.lower_std_bus_local_dispatch(args, scope)
+            }
+            // GH #233: expression-position transport primitives
+            // (realize is assigned to self.handle in birth();
+            // spawn_server's status is checked there too).
+            ["std", "bus", "__transport_realize"] => {
+                self.lower_std_bus_transport_realize(args, scope)
+            }
+            ["std", "bus", "__transport_spawn_server"] => {
+                self.lower_std_bus_transport_handle_op(
+                    "lotus_bus_transport_spawn_server", args, scope)
             }
             ["std", "str", "from_bytes"] => {
                 self.lower_std_str_from_bytes(args, scope)

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1520,6 +1520,30 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             None,
         );
 
+        // GH #233 step 1: the locus-facing transport surface
+        // driven by the __StdBusUnix*Transport lifecycles
+        // (stdlib bus.hl). realize returns the entry handle as
+        // i64 (0 on failure); spawn_server starts the listen
+        // serve thread (0 ok / -1 fail); reclaim interrupts +
+        // joins the serve thread and destroys the transport at
+        // dissolve.
+        let i64_t = self.context.i64_type();
+        self.module.add_function(
+            "lotus_bus_transport_realize",
+            i64_t.fn_type(&[ptr_t.into(), ptr_t.into(), i64_t.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "lotus_bus_transport_spawn_server",
+            i64_t.fn_type(&[i64_t.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "lotus_bus_transport_reclaim",
+            void_t.fn_type(&[i64_t.into()], false),
+            None,
+        );
+
         // Wave B (bus-transport redesign): adapter-binding
         // registration. The runtime stores the (self, send_fn)
         // pair in lotus_bus_remote_entry_t's adapter slot and

--- a/crates/hale-codegen/src/stdlib/bus.rs
+++ b/crates/hale-codegen/src/stdlib/bus.rs
@@ -13,6 +13,22 @@ pub(crate) trait BusStdlib<'ctx> {
         args: &[Expr],
         scope: &Scope<'ctx>,
     ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
+    fn lower_std_bus_transport_realize(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
+    fn lower_std_bus_transport_handle_op(
+        &mut self,
+        c_fn: &str,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
+    fn lower_std_bus_binding_fail(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
 }
 
 impl<'ctx, 'p> BusStdlib<'ctx> for Cx<'ctx, 'p> {
@@ -88,4 +104,137 @@ impl<'ctx, 'p> BusStdlib<'ctx> for Cx<'ctx, 'p> {
         Ok((i64_t.const_zero().into(), CodegenTy::Int))
     }
 
+    /// GH #233: `std::bus::__transport_realize(subject: String,
+    /// path: String, role: Int) -> Int` — realize a unix bus
+    /// transport (socket + bind + listen, or connect-with-retry)
+    /// and register it with the fanout table. Returns the entry
+    /// handle, 0 on failure. Called from
+    /// __StdBusUnixTransport.birth() only.
+    fn lower_std_bus_transport_realize(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        if args.len() != 3 {
+            return Err(CodegenError::Unsupported(format!(
+                "std::bus::__transport_realize takes 3 args \
+                 (subject, path, role), got {}",
+                args.len()
+            )));
+        }
+        let (subj_val, subj_ty) = self.lower_expr(&args[0], scope)?;
+        let (path_val, path_ty) = self.lower_expr(&args[1], scope)?;
+        for (name, ty) in [("subject", &subj_ty), ("path", &path_ty)] {
+            if !matches!(ty, CodegenTy::String | CodegenTy::StringView) {
+                return Err(CodegenError::Unsupported(format!(
+                    "std::bus::__transport_realize: {} must be String, got {:?}",
+                    name, ty
+                )));
+            }
+        }
+        let subj_val = self.unpack_view_if_needed(subj_val, &subj_ty)?;
+        let path_val = self.unpack_view_if_needed(path_val, &path_ty)?;
+        let (role_val, role_ty) = self.lower_expr(&args[2], scope)?;
+        if !matches!(role_ty, CodegenTy::Int) {
+            return Err(CodegenError::Unsupported(format!(
+                "std::bus::__transport_realize: role must be Int, got {:?}",
+                role_ty
+            )));
+        }
+        let f = self
+            .module
+            .get_function("lotus_bus_transport_realize")
+            .expect("lotus_bus_transport_realize declared");
+        let handle = self
+            .builder
+            .build_call(
+                f,
+                &[subj_val.into(), path_val.into(), role_val.into()],
+                "bus.transport.realize",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .expect("realize returns i64");
+        Ok((handle, CodegenTy::Int))
+    }
+
+    /// GH #233: shared lowering for the 1-arg handle ops —
+    /// `std::bus::__transport_serve(h)` / `__transport_reclaim(h)`.
+    fn lower_std_bus_transport_handle_op(
+        &mut self,
+        c_fn: &str,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        if args.len() != 1 {
+            return Err(CodegenError::Unsupported(format!(
+                "{} takes 1 arg (handle), got {}",
+                c_fn,
+                args.len()
+            )));
+        }
+        let (h_val, h_ty) = self.lower_expr(&args[0], scope)?;
+        if !matches!(h_ty, CodegenTy::Int) {
+            return Err(CodegenError::Unsupported(format!(
+                "{}: handle must be Int, got {:?}",
+                c_fn, h_ty
+            )));
+        }
+        let f = self
+            .module
+            .get_function(c_fn)
+            .unwrap_or_else(|| panic!("{} declared", c_fn));
+        let call = self
+            .builder
+            .build_call(f, &[h_val.into()], "bus.transport.op")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let i64_t = self.context.i64_type();
+        // i64-returning ops (spawn_server) surface their status;
+        // void ops (reclaim) type as Int 0 so statement-position
+        // calls stay uniform.
+        let ret = call
+            .try_as_basic_value()
+            .left()
+            .unwrap_or_else(|| i64_t.const_zero().into());
+        Ok((ret, CodegenTy::Int))
+    }
+
+    /// #227/#233: `std::bus::__binding_fail(subject: String,
+    /// url: String)` — the structural-failure sink (stderr +
+    /// exit(1)); called from __StdBusUnixTransport.birth() when
+    /// realization fails and no handled route exists.
+    fn lower_std_bus_binding_fail(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        if args.len() != 2 {
+            return Err(CodegenError::Unsupported(format!(
+                "std::bus::__binding_fail takes 2 args (subject, url), got {}",
+                args.len()
+            )));
+        }
+        let (subj_val, subj_ty) = self.lower_expr(&args[0], scope)?;
+        let (url_val, url_ty) = self.lower_expr(&args[1], scope)?;
+        for (name, ty) in [("subject", &subj_ty), ("url", &url_ty)] {
+            if !matches!(ty, CodegenTy::String | CodegenTy::StringView) {
+                return Err(CodegenError::Unsupported(format!(
+                    "std::bus::__binding_fail: {} must be String, got {:?}",
+                    name, ty
+                )));
+            }
+        }
+        let subj_val = self.unpack_view_if_needed(subj_val, &subj_ty)?;
+        let url_val = self.unpack_view_if_needed(url_val, &url_ty)?;
+        let f = self
+            .module
+            .get_function("lotus_bus_binding_fail")
+            .expect("lotus_bus_binding_fail declared");
+        self.builder
+            .build_call(f, &[subj_val.into(), url_val.into()], "bus.binding.fail")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let i64_t = self.context.i64_type();
+        Ok((i64_t.const_zero().into(), CodegenTy::Int))
+    }
 }

--- a/crates/hale-codegen/tests/binding_listen_rearm.rs
+++ b/crates/hale-codegen/tests/binding_listen_rearm.rs
@@ -1,0 +1,135 @@
+//! GH #233 step 2: listen-side re-arm. Peer EOF on a listen
+//! binding is not connection *loss* — the listener socket is
+//! still bound (bound at registration since #232), so the reader
+//! loops back into accept() and serves the next peer. This is
+//! what makes rolling restarts of the connect-side binary work:
+//! publisher restarts, reconnects, and the subscriber keeps
+//! receiving. Pre-#233 the reader thread exited at first EOF and
+//! inbound silently stopped for the rest of the process.
+//!
+//! Shape: one subscriber binary (listen role) outlives TWO
+//! sequential runs of the same publisher binary (connect role).
+//! Each publisher run connects, publishes once, exits (EOF).
+//! The subscriber must observe both deliveries.
+
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::build_executable;
+
+fn build(name: &str, src: &str) -> std::path::PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale_test_listen_rearm_{}", name));
+    build_executable(&program, &bin).expect("build");
+    bin
+}
+
+fn unique_socket_path() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!(
+        "{}/hale-233-rearm-{}-{}.sock",
+        std::env::temp_dir().display(),
+        std::process::id(),
+        nanos
+    )
+}
+
+#[test]
+fn listen_binding_serves_sequential_peers() {
+    let sock = unique_socket_path();
+    // Sub is a params child of App so it stays born for the whole
+    // of App's run() (a statement-position `Sub { };` after
+    // `App { };` would only be born after App's lifecycle ends).
+    let sub_src = format!(
+        r#"
+        type T {{ n: Int = 0; }}
+        topic Evt {{ payload: T; subject: "evt"; }}
+        locus Sub {{
+            params {{ seen: Int = 0; }}
+            bus {{ subscribe Evt as on_evt; }}
+            fn on_evt(t: T) {{
+                self.seen = self.seen + 1;
+                println("got=", self.seen);
+            }}
+        }}
+        main locus App {{
+            params {{ sub: Sub = Sub {{ }}; }}
+            bindings {{ Evt: unix("{}", role: listen); }}
+            run() {{
+                std::time::sleep(4000ms);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock
+    );
+    let pub_src = format!(
+        r#"
+        type T {{ n: Int = 0; }}
+        topic Evt {{ payload: T; subject: "evt"; }}
+        main locus App {{
+            bus {{ publish Evt; }}
+            bindings {{ Evt: unix("{}", role: connect); }}
+            run() {{
+                Evt <- T {{ n: 7 }};
+                std::time::sleep(200ms);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock
+    );
+    let sub_bin = build("sub", &sub_src);
+    let pub_bin = build("pub", &pub_src);
+
+    let mut sub = Command::new(&sub_bin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn subscriber");
+
+    // First peer: connects (retry covers the subscriber's boot),
+    // publishes once, exits — EOF on the subscriber side.
+    let p1 = Command::new(&pub_bin).output().expect("run publisher 1");
+    assert!(
+        p1.status.success(),
+        "publisher 1 failed: {:?}",
+        String::from_utf8_lossy(&p1.stderr)
+    );
+
+    // Second peer: the re-armed listener must accept it. The
+    // publisher's own connect-with-retry (~1s) absorbs the gap
+    // between peer-1 EOF and the subscriber re-reaching accept.
+    let p2 = Command::new(&pub_bin).output().expect("run publisher 2");
+    assert!(
+        p2.status.success(),
+        "publisher 2 failed (listener did not re-arm?): {:?}",
+        String::from_utf8_lossy(&p2.stderr)
+    );
+
+    let out = sub.wait().and_then(|_| {
+        use std::io::Read;
+        let mut s = String::new();
+        sub.stdout.take().unwrap().read_to_string(&mut s)?;
+        Ok(s)
+    });
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+    let _ = std::fs::remove_file(&sock);
+    let stdout = out.expect("collect subscriber stdout");
+    assert!(
+        stdout.contains("got=1"),
+        "first delivery missing.\nstdout: {:?}",
+        stdout
+    );
+    assert!(
+        stdout.contains("got=2"),
+        "second delivery missing — listener did not re-arm after \
+         peer EOF.\nstdout: {:?}",
+        stdout
+    );
+}

--- a/docs/src/services/multi-binary.md
+++ b/docs/src/services/multi-binary.md
@@ -85,6 +85,14 @@ dropped. Per-datagram loss on `udp://` is different — that
 transport's guarantee is best-effort by declaration, so downstream
 loss is within contract and won't kill the process.
 
+And a peer *disconnecting* from a `unix(...)` listener isn't a
+failure at all: the listener stays bound and simply accepts the
+next connection. Restart the publishing binary and it reconnects
+— the subscriber never notices. (Under the hood each binding is
+a real locus, a child of your `main` locus, whose lifecycle
+opens the transport at birth and tears it down at dissolve —
+the same shape as a custom adapter.)
+
 The same rule covers routes added at deploy time through the
 `LOTUS_BUS_CONFIG` file: a route that's asked for but can't be
 opened refuses the boot.

--- a/spec/decisions.md
+++ b/spec/decisions.md
@@ -3126,14 +3126,22 @@ directly against the handle the locus owns (the `@form`
 pattern: locus for flow, C for bytes).
 
 **Sequencing:** (1) transports-as-loci restructure, behavior
-unchanged (the regression tests above pass verbatim); (2)
-listen-side re-arm — peer EOF loops back into `accept()` on the
+unchanged (the regression tests above pass verbatim) —
+**SHIPPED 2026-07-22** (GH #233 PR: `bindings { T: unix(...) }`
+desugars to `__StdBusUnix{Listen,Connect}Transport`
+instantiation; both cooperative — pinned placement was tried
+and rejected because a pinned locus runs birth on its spawned
+thread, making realization asynchronous; the serve thread is
+C-spawned by birth and joined by dissolve); (2) listen-side
+re-arm — peer EOF loops back into `accept()` on the
 already-bound listener, no policy needed, unblocks rolling
-restarts of connect-side binaries; (3) loss → `violate` with
-default bubble, landing **in the same change as** (4) the
-`on_failure`-on-main routing (`lotus_root_panic`'s documented
-seat) + `restart`-as-reconnect — per the guardrail: do not ship
-loss-is-fatal without the reconnect policy in the same change.
+restarts of connect-side binaries — **SHIPPED 2026-07-22**
+(`lotus_bus_unix_serve`, shared with `LOTUS_BUS_CONFIG` reader
+threads); (3) loss → `violate` with default bubble, landing
+**in the same change as** (4) the `on_failure`-on-main routing
+(`lotus_root_panic`'s documented seat) + `restart`-as-reconnect
+— per the guardrail: do not ship loss-is-fatal without the
+reconnect policy in the same change.
 
 ---
 

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -990,27 +990,53 @@ optimization that elides bus dispatch for unambiguous
 intra-locus and single-hop parent→child tower patterns when no
 binding is declared.
 
-**Binding realization failure (GH #227, 2026-07-22).**
+**Binding realization failure (GH #227) + transports-as-loci
+(GH #233 steps 1–2, 2026-07-22).** Source-level
+`bindings { T: unix(...) }` entries are sugar: codegen
+instantiates a stdlib transport locus
+(`__StdBusUnixListenTransport` / `__StdBusUnixConnectTransport`,
+`runtime/stdlib/bus.hl`) as a cooperative child at the main
+prelude — converging with the adapter path. The locus is the
+control plane; the data plane stays in C:
+
+- `birth()` calls `lotus_bus_transport_realize(subject, path,
+  role)` synchronously on the boot path (unix `socket + bind +
+  listen` via `lotus_transport_listener_create` for listen,
+  connect-with-retry for connect). Realization failure routes
+  into `lotus_bus_binding_fail(subject, url)` — the
+  structural-failure shape (stderr diagnostic + `exit(1)`), the
+  same seat as `lotus_root_panic`. The listen locus's birth then
+  spawns the serve thread (`lotus_bus_transport_spawn_server`).
+  The transport loci are deliberately NOT pinned: a pinned locus
+  runs birth on its spawned thread, which would make realization
+  asynchronous; the serve thread belongs to the C data plane.
+- The serve loop (`lotus_bus_unix_serve`) accepts a peer,
+  dispatches its messages, and on peer EOF **re-arms** — closes
+  the dead connection and loops back into `accept()` for the
+  next peer (GH #233 step 2; peer EOF is not connection loss,
+  and a rolling restart of the connect-side binary just works).
+- `dissolve()` calls `lotus_bus_transport_reclaim`: sets the
+  serve loop's `closing` flag, shuts down both fds to unblock a
+  parked accept/recv, joins the serve thread, destroys the
+  transport. The husk entry stays in the remote table for
+  `lotus_bus_remote_destroy_all` to free uniformly.
+
+Publish fanout is untouched — realized entries land in the same
+`g_bus_remote_entries` table the fanout walks.
+
+Env-configured routes (`LOTUS_BUS_CONFIG`) have no source-level
+declaration to hang a locus on and keep the direct C path:
 `lotus_bus_register_remote(subject, url, role)` returns an i32
-status: 0 on success, -1 when the route cannot be realized
-(scheme/addr validation, socket/bind/listen, connect-retry
-timeout, thread spawn). Listener-side work that can fail is done
-synchronously at registration — unix: `socket + bind + listen`
-(`lotus_transport_listener_create`); udp: parse + bind +
-multicast join (`lotus_bus_udp_listener_setup`) — and only the
-blocking accept/recv loop runs on the reader thread, so a
-failure always surfaces on the boot path, never on a detached
-thread. On failure the entry is popped from the remote table
-(no dead slot for fanout to silently skip) and the caller —
-codegen's bindings prelude, or `lotus_bus_load_config` for
-env-configured routes — routes the failure into
-`lotus_bus_binding_fail(subject, url)`: the structural-failure
-shape (stderr diagnostic + `exit(1)`), the same seat as
-`lotus_root_panic`. Normative contract: spec/semantics.md,
-"The publish contract". Teardown note: because the listener is
-bound at registration, `lotus_bus_remote_destroy_all` also
-shuts down `listen_fd` so a reader thread parked in `accept()`
-(peer never connected) joins instead of hanging.
+status (0 ok / -1 unrealizable — scheme/addr validation,
+socket/bind/listen, connect-retry timeout, thread spawn), with
+listener-side work done synchronously at registration (udp:
+parse + bind + multicast join via
+`lotus_bus_udp_listener_setup`). On failure the entry is popped
+(no dead slot for fanout to silently skip) and
+`lotus_bus_load_config` routes into `lotus_bus_binding_fail`.
+Config-route unix listeners share `lotus_bus_unix_serve`, so
+they re-arm identically. Normative contract: spec/semantics.md,
+"The publish contract".
 
 **Adapter dispatch.** At codegen, an adapter binding
 instantiates the adapter locus into the program-lifetime

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -931,12 +931,15 @@ acted on. Consequences, all normative:
 - **Per-send transient errors on a lossy transport are not
   structural.** A UDP `sendto` failure is logged (once per errno
   class), not fatal: the binding's guarantee is best-effort by
-  declaration, so downstream loss is within contract. An
-  established *stream* transport dying mid-run is currently
-  logged at send and EOF-terminates the reader; making binding
-  *loss* structural (with reconnection as a supervision policy,
-  not a transport feature) is an open decision — see GH #227's
-  follow-up discussion.
+  declaration, so downstream loss is within contract.
+- **Peer EOF on a listen binding is not loss.** The listener is
+  still bound; the serve loop re-arms and accepts the next peer
+  (GH #233 step 2), so rolling restarts of connect-side
+  binaries work without policy. An established *connect-side*
+  transport dying mid-run is currently logged at send; making
+  that *loss* structural (with reconnection as a supervision
+  policy via `restart` in main's `on_failure`, not a transport
+  feature) is GH #233 steps 3–4 — see F.37's deferred section.
 - **Malformed `LOTUS_BUS_CONFIG` lines stay warn-and-skip**
   (the file is an operator-layered override and the diagnostic
   names the line); a well-formed line whose route cannot be
@@ -945,18 +948,25 @@ acted on. Consequences, all normative:
 Transport surface:
 
 - `unix("/path")` or `unix("/path", role: connect|listen)` —
-  AF_UNIX framed-byte transport. Substrate-provided: the
-  runtime's `lotus_transport_*` owns the delivery contract
-  directly. `role: listen` binds + listens synchronously at
-  registration (so a dead binding fails the boot, per the
-  publish contract above), then spawns a reader thread that
-  accepts the peer and fans recv'd payloads into the local
-  handler set; `role: connect` opens a write-side transport
-  that publish-site dispatch sends to. When `role:` is omitted,
-  the typechecker infers it from the bus block (`publish` only
-  → connect, `subscribe` only → listen); if both publish and
-  subscribe touch the topic, the binding is rejected with a
-  "specify `role:`" diagnostic.
+  AF_UNIX framed-byte transport. Substrate-provided as a
+  **locus** (GH #233 / F.37): the entry is sugar that
+  instantiates `__StdBusUnixListenTransport` /
+  `__StdBusUnixConnectTransport` (stdlib `bus.hl`) as a
+  cooperative child of the main locus, converging with the
+  adapter path. `birth()` realizes the transport synchronously
+  on the boot path (so a dead binding fails the boot, per the
+  publish contract above); the listen side's birth spawns the C
+  serve thread, whose loop accepts a peer, fans recv'd payloads
+  into the local handler set, and **re-arms on peer EOF**
+  (closes the dead connection and accepts the next peer — a
+  restarted connect-side binary reconnects without the
+  subscriber noticing); `dissolve()` interrupts + joins the
+  serve thread and destroys the transport. `role: connect`
+  opens a write-side transport that publish-site dispatch sends
+  to. When `role:` is omitted, the typechecker infers it from
+  the bus block (`publish` only → connect, `subscribe` only →
+  listen); if both publish and subscribe touch the topic, the
+  binding is rejected with a "specify `role:`" diagnostic.
 
 - `LocusName { field: value, ... }` — user-supplied
   protocol-layer adapter. Any locus that declares


### PR DESCRIPTION
First half of #233 (checkboxes 1 and 2).

**Step 1 — transports-as-loci (behavior unchanged).** `bindings { T: unix(...) }` now desugars to a stdlib transport locus (`__StdBusUnixListenTransport` / `__StdBusUnixConnectTransport` in `runtime/stdlib/bus.hl`) instantiated as a cooperative child at the main prelude — converging with the adapter path per F.37. `birth()` realizes synchronously (`lotus_bus_transport_realize`); `dissolve()` interrupts + joins + reclaims (`lotus_bus_transport_reclaim`). #227's regression suite passes **verbatim**, diagnostics included.

Design note recorded in F.37: both loci are deliberately **cooperative**, not pinned — a pinned locus runs its whole lifecycle (birth included) on the spawned thread, which made realization asynchronous again (caught by the #227 suite mid-development). The listen serve thread is C-spawned by birth (`lotus_bus_transport_spawn_server`); the byte-pump is data plane. Publish fanout is untouched — locus for flow, C for bytes.

**Step 2 — listen-side re-arm.** The serve loop (`lotus_bus_unix_serve`, extracted and shared with the `LOTUS_BUS_CONFIG` reader threads) re-arms on peer EOF: close the dead connection, loop back into `accept()`. Peer EOF is not connection loss; rolling restarts of connect-side binaries now just work. Previously the reader exited at first EOF and inbound went silently deaf for the rest of the process.

**Tests.** New `binding_listen_rearm.rs`: one subscriber lifetime serves two sequential publisher runs. Full affected suite green locally (binding_birth_fail verbatim, codec ×2, bus_subscriber/config/udp, transport, topic_phase2 ×2, adapter, shm, corpus_oracle).

**Spec/docs.** `spec/runtime.md` bus-router section rewritten for the locus path; `spec/semantics.md` unix bullet + publish-contract loss bullet updated (peer-EOF-is-not-loss); F.37 sequencing marked steps 1–2 shipped with the pinned-birth rationale; CHANGELOG; `docs/src/services/multi-binary.md` gets the reconnect paragraph.

Steps 3–4 (loss → structural with `on_failure`-on-main + `restart`-as-reconnect, landing together per the F.37 guardrail) are the next change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)