### PR TITLE
feat(bus): connection loss is structural; restart reconnects (#233 steps 3–4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ behavior.
 
 ## Unreleased
 
+- **Connection loss is structural; `restart` reconnects
+  (GH #233 steps 3–4, closes #233).** A send failure on a
+  source-declared connect binding now marks the binding lost
+  (publishes during the window are dropped, never falsely
+  "delivered") and routes a synthetic `link_lost`
+  `ClosureViolation` through the main locus's `on_failure` at
+  the next queue drain. Declare
+  `on_failure(t: std::bus::UnixTransport, err: ClosureViolation)
+  { restart (t); }` on `main` to reconnect — the runtime re-runs
+  the connect-with-retry and publishing resumes (the new
+  public name `std::bus::UnixTransport` names the connect-side
+  substrate transport locus). Without a handler (or when
+  reconnect fails), the process exits non-zero with a
+  diagnostic naming the subject — completing the publish
+  contract: the broker never accepts what it cannot deliver, at
+  boot (#227) or mid-run. `LOTUS_BUS_CONFIG` routes sit outside
+  the supervision tree and keep logged-only send failures.
 - **Substrate unix transports are loci; listen bindings re-arm
   (GH #233 steps 1–2).** A `bindings { T: unix(...) }` entry now
   desugars to a stdlib transport locus

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -5657,6 +5657,9 @@ static void bus_inline_drain_one(lotus_bus_queue_t *q) {
  * (TSAN-flagged). A __thread flag is per-thread, so neither happens. */
 static __thread int g_bus_drain_active = 0;
 
+/* GH #233: defined with the remote-transport machinery below. */
+void lotus_bus_drain_lost_transports(void);
+
 void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
     if (!q) return;
     /* Owner-only handler execution (see the `owner` field comment).
@@ -5667,6 +5670,11 @@ void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
      * the owner's next drain point. */
     if (!pthread_equal(pthread_self(), q->owner)) return;
     if (g_bus_drain_active) return;
+    /* GH #233 steps 3-4: dispatch pending transport-loss events
+     * first — we're on the owner thread here, the only place
+     * failure handlers may run. Defined with the transport
+     * machinery below; cheap flag check when nothing is lost. */
+    lotus_bus_drain_lost_transports();
     g_bus_drain_active = 1;
     int locked = __atomic_load_n(&g_bus_has_pinned, __ATOMIC_ACQUIRE);
     if (locked) {
@@ -12365,15 +12373,25 @@ typedef struct lotus_bus_remote_entry {
     void             *(*codec_encode_fn)(void *self, void *value);
     void             *(*codec_decode_fn)(void *self, void *bytes);
     /* GH #233 step 1 (transports-as-loci): entries owned by a
-     * __StdBusUnixTransport locus instead of the register-time
+     * __StdBusUnix*Transport locus instead of the register-time
      * reader thread. `locus_served` entries are realized by the
-     * locus's birth(), served by its pinned run() (LISTEN role),
-     * and reclaimed by its dissolve() — destroy_all only frees
-     * the husk. `closing` is the serve-loop stop flag, set by
-     * lotus_bus_transport_interrupt before the pinned join (the
-     * transport analog of lotus_mailbox_shutdown). */
+     * locus's birth(), served by a birth-spawned thread (LISTEN
+     * role), and reclaimed by its dissolve() — destroy_all only
+     * frees the husk. `closing` is the serve-loop stop flag set
+     * at reclaim. */
     int                locus_served;
     volatile int       closing;
+    /* GH #233 steps 3-4 (loss supervision): `lost` is set by
+     * publish fanout when a locus-served CONNECT transport's
+     * send fails with a connection-class errno; fanout skips
+     * lost entries, and the main-thread drain routes the loss
+     * into main's on_failure (or the structural fallback).
+     * `path` (owned) is kept for restart-as-reconnect;
+     * `locus_self` is the owning transport locus, bound by
+     * codegen right after instantiation. */
+    volatile int       lost;
+    char              *path;
+    void              *locus_self;
 } lotus_bus_remote_entry_t;
 
 /* 2026-05-27 — array-of-pointers shape (was array-of-structs).
@@ -13041,6 +13059,15 @@ int64_t lotus_bus_transport_realize(const char *subject,
     if (!e) return 0;
     e->role         = (int)role;
     e->locus_served = 1;
+    /* Kept for restart-as-reconnect (steps 3-4): reconnect
+     * re-runs the connect-with-retry against this path. */
+    e->path = strdup(path);
+    if (!e->path) {
+        g_bus_remote_count--;
+        free(e->subject);
+        free(e);
+        return 0;
+    }
     if (role == LOTUS_TRANSPORT_LISTEN) {
         e->transport = lotus_transport_listener_create(path);
     } else {
@@ -13048,6 +13075,7 @@ int64_t lotus_bus_transport_realize(const char *subject,
     }
     if (!e->transport) {
         g_bus_remote_count--;
+        free(e->path);
         free(e->subject);
         free(e);
         return 0;
@@ -13074,6 +13102,119 @@ int64_t lotus_bus_transport_spawn_server(int64_t handle) {
     }
     e->has_reader_thread = 1;
     return 0;
+}
+
+/*
+ * GH #233 steps 3-4 — connection-loss supervision.
+ *
+ * Loss detection happens at publish fanout (any thread); failure
+ * handlers run only on the queue owner thread. The bridge is a
+ * small mutex'd pending list drained at the top of
+ * lotus_bus_queue_drain: each lost entry is handed to the
+ * codegen-registered loss handler (emitted only when the main
+ * locus declares `on_failure(t: std::bus::UnixTransport, err:
+ * ClosureViolation)`), which invokes the handler and — if it
+ * called `restart(t)` — asks for a reconnect. With no handler
+ * registered (or a handler that declined), the loss is the
+ * structural exit, same seat as lotus_bus_binding_fail.
+ */
+#define LOTUS_BUS_LOST_MAX 16
+static pthread_mutex_t g_transport_lost_lock = PTHREAD_MUTEX_INITIALIZER;
+static lotus_bus_remote_entry_t *g_transport_lost[LOTUS_BUS_LOST_MAX];
+static int g_transport_lost_count = 0;
+volatile int g_transport_lost_pending = 0;
+static void (*g_transport_loss_handler)(int64_t) = NULL;
+
+void lotus_bus_set_loss_handler(void (*fn)(int64_t)) {
+    g_transport_loss_handler = fn;
+}
+
+void lotus_bus_transport_mark_lost(lotus_bus_remote_entry_t *e) {
+    pthread_mutex_lock(&g_transport_lost_lock);
+    if (g_transport_lost_count < LOTUS_BUS_LOST_MAX) {
+        g_transport_lost[g_transport_lost_count++] = e;
+        g_transport_lost_pending = 1;
+    }
+    pthread_mutex_unlock(&g_transport_lost_lock);
+}
+
+static void lotus_bus_binding_lost_fail(const char *subject,
+                                        const char *path) {
+    dprintf(2,
+            "Hale structural failure: bus binding for subject `%s` "
+            "(unix://%s) lost its connection — the broker can no "
+            "longer honor this binding's guarantee and no restart "
+            "policy is in place (spec/semantics.md, \"The publish "
+            "contract\"; declare `on_failure(t: "
+            "std::bus::UnixTransport, err: ClosureViolation)` on "
+            "the main locus with `restart (t);` to reconnect)\n",
+            subject ? subject : "<unknown>",
+            path ? path : "<unknown>");
+    exit(1);
+}
+
+void lotus_bus_transport_lost_fallback(int64_t handle) {
+    lotus_bus_remote_entry_t *e =
+        (lotus_bus_remote_entry_t *)(intptr_t)handle;
+    lotus_bus_binding_lost_fail(e ? e->subject : NULL,
+                                e ? e->path : NULL);
+}
+
+void lotus_bus_transport_bind_self(int64_t handle, void *locus_self) {
+    lotus_bus_remote_entry_t *e =
+        (lotus_bus_remote_entry_t *)(intptr_t)handle;
+    if (e) e->locus_self = locus_self;
+}
+
+void *lotus_bus_transport_locus_self(int64_t handle) {
+    lotus_bus_remote_entry_t *e =
+        (lotus_bus_remote_entry_t *)(intptr_t)handle;
+    return e ? e->locus_self : NULL;
+}
+
+const char *lotus_bus_transport_subject(int64_t handle) {
+    lotus_bus_remote_entry_t *e =
+        (lotus_bus_remote_entry_t *)(intptr_t)handle;
+    return (e && e->subject) ? e->subject : "<unknown>";
+}
+
+/* Re-run the connect-with-retry against the stored path. 0 on
+ * success (entry live again, fanout resumes), -1 on failure.
+ * Runs on the main thread from the loss-dispatch path only. */
+int64_t lotus_bus_transport_reconnect(int64_t handle) {
+    lotus_bus_remote_entry_t *e =
+        (lotus_bus_remote_entry_t *)(intptr_t)handle;
+    if (!e || !e->path || e->role != LOTUS_TRANSPORT_CONNECT) return -1;
+    if (e->transport) {
+        lotus_transport_destroy(e->transport);
+        e->transport = NULL;
+    }
+    e->transport = lotus_transport_create(e->path, LOTUS_TRANSPORT_CONNECT);
+    if (!e->transport) return -1;
+    e->lost = 0;
+    return 0;
+}
+
+void lotus_bus_drain_lost_transports(void) {
+    if (!g_transport_lost_pending) return;
+    /* Snapshot under the lock, dispatch outside it — the handler
+     * may publish (re-entering fanout) or exit the process. */
+    lotus_bus_remote_entry_t *batch[LOTUS_BUS_LOST_MAX];
+    int n;
+    pthread_mutex_lock(&g_transport_lost_lock);
+    n = g_transport_lost_count;
+    memcpy(batch, g_transport_lost, sizeof(batch[0]) * (size_t)n);
+    g_transport_lost_count   = 0;
+    g_transport_lost_pending = 0;
+    pthread_mutex_unlock(&g_transport_lost_lock);
+    for (int i = 0; i < n; i++) {
+        int64_t h = (int64_t)(intptr_t)batch[i];
+        if (g_transport_loss_handler) {
+            g_transport_loss_handler(h);
+        } else {
+            lotus_bus_transport_lost_fallback(h);
+        }
+    }
 }
 
 void lotus_bus_transport_reclaim(int64_t handle) {
@@ -13318,13 +13459,31 @@ void lotus_bus_remote_fanout(const char *subject,
         if (!e->transport) continue;
         /* CONNECT role only fans out at this milestone. LISTEN
          * role transports exist on the receive side and are
-         * driven by the (future) reader thread, not by publish-
-         * site dispatch. */
+         * driven by the reader thread, not by publish-site
+         * dispatch. */
         if (e->role != LOTUS_TRANSPORT_CONNECT) continue;
-        (void)lotus_transport_send(e->transport, payload, payload_size);
-        /* Errors are logged inside lotus_transport_send; we don't
-         * abort dispatch on transport failure — local subscribers
-         * already received their copy. */
+        /* GH #233 steps 3-4: a lost binding accepts nothing —
+         * fanout skips it until the loss is dispatched on the
+         * main thread (on_failure restart → reconnect, or the
+         * structural exit). Publishes during the window are
+         * dropped-and-counted, never falsely "delivered". */
+        if (e->lost) continue;
+        if (lotus_transport_send(e->transport, payload, payload_size) != 0
+            && e->locus_served) {
+            /* Connection-class failure on a locus-owned
+             * transport: the broker can no longer honor this
+             * binding's guarantee. Mark lost and queue the loss
+             * event for the main-thread drain (failure handlers
+             * only run on the queue owner thread; fanout may be
+             * running anywhere). Non-locus (LOTUS_BUS_CONFIG)
+             * entries keep the logged-only behavior — they sit
+             * outside the supervision tree. */
+            e->lost = 1;
+            lotus_bus_transport_mark_lost(e);
+        }
+        /* Send errors are also logged inside lotus_transport_send;
+         * dispatch continues — local subscribers already received
+         * their copy. */
     }
 }
 
@@ -16546,6 +16705,9 @@ void lotus_bus_remote_destroy_all(void) {
         }
         if (e->subject) {
             free(e->subject);
+        }
+        if (e->path) {
+            free(e->path);
         }
         free(e);
     }

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -2407,6 +2407,12 @@ pub fn stdlib_path_renames() -> &'static [(&'static [&'static str], &'static str
 
 const STDLIB_PATH_RENAMES: &[(&[&str], &str)] = &[
     (&["std", "bus", "Adapter"], "__StdBusAdapter"),
+    // GH #233 steps 3-4: the connect-side substrate transport is
+    // user-nameable so main can declare
+    // `on_failure(t: std::bus::UnixTransport, err: ClosureViolation)`.
+    // (The listen side re-arms instead of getting lost, so it
+    // stays internal.)
+    (&["std", "bus", "UnixTransport"], "__StdBusUnixConnectTransport"),
     (&["std", "bytes", "BytesBuilder"], "__StdBytesBytesBuilder"),
     (&["std", "cli", "Resolver"], "__StdCliResolver"),
     (&["std", "http", "Handler"], "__StdHttpHandler"),
@@ -8300,6 +8306,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         }
 
         let i32_t = self.context.i32_type();
+        let mut any_connect_binding = false;
 
         for block in bindings {
             for entry in block.entries {
@@ -8337,6 +8344,9 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                                 )));
                             }
                         };
+                        if !listen {
+                            any_connect_binding = true;
+                        }
                         self.emit_unix_transport_binding(
                             &subject,
                             &entry.topic.name,
@@ -8521,6 +8531,23 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 };
             }
         }
+        // GH #233 steps 3-4: when connect bindings exist and the
+        // main locus declares the matching on_failure, register
+        // the loss dispatcher. Without the handler, the C drain
+        // falls straight through to the structural exit — no
+        // dispatcher needed.
+        if any_connect_binding {
+            let main_handler = self
+                .main_locus_name
+                .as_ref()
+                .and_then(|n| self.user_loci.get(n))
+                .and_then(|info| info.failure_handler.as_ref())
+                .filter(|(child, _)| child == "__StdBusUnixConnectTransport")
+                .map(|(_, f)| *f);
+            if let Some(handler) = main_handler {
+                self.emit_transport_loss_dispatch(handler)?;
+            }
+        }
         Ok(())
     }
 
@@ -8591,7 +8618,270 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         let mut scope = Scope::default();
         let result = self.lower_expr(&locus_lit, &mut scope);
         self.current_user_fn_ret = saved_ret;
-        result?;
+        let (self_val, _self_ty) = result?;
+        // GH #233 steps 3-4: bind the connect locus's self onto
+        // its remote entry so the loss-dispatch fn can hand it to
+        // main's on_failure. Birth already ran (cooperative,
+        // inline), so the handle field is populated.
+        if !listen {
+            let info = self
+                .user_loci
+                .get(locus_name)
+                .cloned()
+                .expect("transport locus checked above");
+            let (h_idx, _) = *info
+                .fields
+                .get("handle")
+                .expect("transport locus has handle field");
+            let i64_t = self.context.i64_type();
+            let self_ptr = self_val.into_pointer_value();
+            let h_slot = self
+                .builder
+                .build_struct_gep(
+                    info.struct_ty,
+                    self_ptr,
+                    h_idx,
+                    "transport.handle.slot",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let h = self
+                .builder
+                .build_load(i64_t, h_slot, "transport.handle")
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let bind_fn = self
+                .module
+                .get_function("lotus_bus_transport_bind_self")
+                .expect("lotus_bus_transport_bind_self declared");
+            self.builder
+                .build_call(
+                    bind_fn,
+                    &[h.into(), self_ptr.into()],
+                    "transport.bind_self",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// GH #233 steps 3-4: emit `__hale_transport_loss_dispatch(h)`
+    /// and register it with the runtime — only called when the
+    /// main locus declares
+    /// `on_failure(t: std::bus::UnixTransport, err: ClosureViolation)`.
+    /// The fn runs on the queue owner thread (from
+    /// lotus_bus_drain_lost_transports): it invokes main's
+    /// handler with a synthetic link_lost ClosureViolation, then
+    /// reconnects if the handler called `restart (t)` (observed
+    /// as a bumped `__restart_count`), else falls back to the
+    /// structural exit.
+    fn emit_transport_loss_dispatch(
+        &mut self,
+        main_handler: inkwell::values::FunctionValue<'ctx>,
+    ) -> Result<(), CodegenError> {
+        let i64_t = self.context.i64_type();
+        let ptr_t = self.context.ptr_type(AddressSpace::default());
+        let void_t = self.context.void_type();
+        let info = self
+            .user_loci
+            .get("__StdBusUnixConnectTransport")
+            .cloned()
+            .expect("connect transport locus declared");
+
+        let fn_ty = void_t.fn_type(&[i64_t.into()], false);
+        let f = self.module.add_function(
+            "__hale_transport_loss_dispatch",
+            fn_ty,
+            None,
+        );
+        let saved_block = self.builder.get_insert_block();
+
+        let entry_bb = self.context.append_basic_block(f, "entry");
+        let have_main_bb = self.context.append_basic_block(f, "have_main");
+        let reconnect_bb = self.context.append_basic_block(f, "reconnect");
+        let fallback_bb = self.context.append_basic_block(f, "fallback");
+        let done_bb = self.context.append_basic_block(f, "done");
+
+        self.builder.position_at_end(entry_bb);
+        let h = f.get_nth_param(0).expect("handle param").into_int_value();
+        let locus_self_fn = self
+            .module
+            .get_function("lotus_bus_transport_locus_self")
+            .expect("locus_self declared");
+        let tself = self
+            .builder
+            .build_call(locus_self_fn, &[h.into()], "loss.tself")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .expect("returns ptr")
+            .into_pointer_value();
+        let main_global = self
+            .module
+            .get_global("lotus.main.self")
+            .unwrap_or_else(|| {
+                let g = self.module.add_global(ptr_t, None, "lotus.main.self");
+                g.set_initializer(&ptr_t.const_null());
+                g.set_linkage(inkwell::module::Linkage::Internal);
+                g
+            });
+        let mself = self
+            .builder
+            .build_load(ptr_t, main_global.as_pointer_value(), "loss.mself")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .into_pointer_value();
+        let tnull = self
+            .builder
+            .build_is_null(tself, "loss.tnull")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let mnull = self
+            .builder
+            .build_is_null(mself, "loss.mnull")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let any_null = self
+            .builder
+            .build_or(tnull, mnull, "loss.any_null")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_conditional_branch(any_null, fallback_bb, have_main_bb)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+
+        self.builder.position_at_end(have_main_bb);
+        // Synthetic ClosureViolation {locus, closure, diff} —
+        // static, never freed; matches the registered layout.
+        let viol_struct_ty = self.context.struct_type(
+            &[ptr_t.into(), ptr_t.into(), i64_t.into()],
+            false,
+        );
+        let locus_str = self
+            .builder
+            .build_global_string_ptr(
+                "__StdBusUnixConnectTransport",
+                "loss.viol.locus",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .as_pointer_value();
+        let closure_str = self
+            .builder
+            .build_global_string_ptr("link_lost", "loss.viol.closure")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .as_pointer_value();
+        let viol_g = self.module.add_global(viol_struct_ty, None, "loss.viol");
+        viol_g.set_initializer(&viol_struct_ty.const_named_struct(&[
+            ptr_t.const_null().into(),
+            ptr_t.const_null().into(),
+            i64_t.const_zero().into(),
+        ]));
+        viol_g.set_linkage(inkwell::module::Linkage::Internal);
+        let viol_ptr = viol_g.as_pointer_value();
+        let f0 = self
+            .builder
+            .build_struct_gep(viol_struct_ty, viol_ptr, 0, "loss.viol.f0")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_store(f0, locus_str)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let f1 = self
+            .builder
+            .build_struct_gep(viol_struct_ty, viol_ptr, 1, "loss.viol.f1")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_store(f1, closure_str)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        // restart-count before/after the handler call.
+        let rc_slot = self
+            .builder
+            .build_struct_gep(
+                info.struct_ty,
+                tself,
+                info.restart_count_field_idx,
+                "loss.rc.slot",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let pre = self
+            .builder
+            .build_load(i64_t, rc_slot, "loss.rc.pre")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .into_int_value();
+        self.builder
+            .build_call(
+                main_handler,
+                &[mself.into(), tself.into(), viol_ptr.into()],
+                "loss.on_failure",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let post = self
+            .builder
+            .build_load(i64_t, rc_slot, "loss.rc.post")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .into_int_value();
+        let bumped = self
+            .builder
+            .build_int_compare(
+                inkwell::IntPredicate::SGT,
+                post,
+                pre,
+                "loss.rc.bumped",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_conditional_branch(bumped, reconnect_bb, fallback_bb)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+
+        self.builder.position_at_end(reconnect_bb);
+        let reconnect_fn = self
+            .module
+            .get_function("lotus_bus_transport_reconnect")
+            .expect("reconnect declared");
+        let r = self
+            .builder
+            .build_call(reconnect_fn, &[h.into()], "loss.reconnect")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .expect("returns i64")
+            .into_int_value();
+        let r_ok = self
+            .builder
+            .build_int_compare(
+                inkwell::IntPredicate::EQ,
+                r,
+                i64_t.const_zero(),
+                "loss.reconnect.ok",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_conditional_branch(r_ok, done_bb, fallback_bb)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+
+        self.builder.position_at_end(fallback_bb);
+        let fallback_fn = self
+            .module
+            .get_function("lotus_bus_transport_lost_fallback")
+            .expect("lost_fallback declared");
+        self.builder
+            .build_call(fallback_fn, &[h.into()], "loss.fallback")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        // lost_fallback exits the process.
+        self.builder
+            .build_unreachable()
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+
+        self.builder.position_at_end(done_bb);
+        self.builder
+            .build_return(None)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+
+        // Back to the prelude position; register the dispatcher.
+        if let Some(bb) = saved_block {
+            self.builder.position_at_end(bb);
+        }
+        let set_fn = self
+            .module
+            .get_function("lotus_bus_set_loss_handler")
+            .expect("set_loss_handler declared");
+        let f_ptr = f.as_global_value().as_pointer_value();
+        self.builder
+            .build_call(set_fn, &[f_ptr.into()], "loss.set_handler")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         Ok(())
     }
 

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -1750,6 +1750,29 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
             self_ptr,
             fields: info.fields.clone(),
         });
+        // GH #233 steps 3-4: publish the main locus's self ptr to
+        // `lotus.main.self` so the transport loss-dispatch fn
+        // (registered at the prelude, firing from the queue
+        // drain) can invoke main's on_failure. NULL until the
+        // main locus is born; the dispatch fn falls back to the
+        // structural exit in that window.
+        if is_main_locus {
+            let ptr_t = self.context.ptr_type(AddressSpace::default());
+            let g = self
+                .module
+                .get_global("lotus.main.self")
+                .unwrap_or_else(|| {
+                    let g = self
+                        .module
+                        .add_global(ptr_t, None, "lotus.main.self");
+                    g.set_initializer(&ptr_t.const_null());
+                    g.set_linkage(inkwell::module::Linkage::Internal);
+                    g
+                });
+            self.builder
+                .build_store(g.as_pointer_value(), self_ptr)
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        }
         for (fname, default) in info.defaults.iter() {
             // F.31: per-field placement override for main-locus
             // params. Looked up by field name in

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1544,6 +1544,39 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             None,
         );
 
+        // GH #233 steps 3-4: connection-loss supervision. The
+        // prelude binds each connect transport locus's self to
+        // its entry; the queue drain routes loss events through
+        // the registered dispatch fn (emitted only when main
+        // declares the matching on_failure); restart-as-reconnect
+        // re-runs the connect-with-retry; the fallback is the
+        // structural exit.
+        self.module.add_function(
+            "lotus_bus_transport_bind_self",
+            void_t.fn_type(&[i64_t.into(), ptr_t.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "lotus_bus_transport_locus_self",
+            ptr_t.fn_type(&[i64_t.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "lotus_bus_set_loss_handler",
+            void_t.fn_type(&[ptr_t.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "lotus_bus_transport_reconnect",
+            i64_t.fn_type(&[i64_t.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "lotus_bus_transport_lost_fallback",
+            void_t.fn_type(&[i64_t.into()], false),
+            None,
+        );
+
         // Wave B (bus-transport redesign): adapter-binding
         // registration. The runtime stores the (self, send_fn)
         // pair in lotus_bus_remote_entry_t's adapter slot and

--- a/crates/hale-codegen/tests/binding_loss_supervision.rs
+++ b/crates/hale-codegen/tests/binding_loss_supervision.rs
@@ -1,0 +1,195 @@
+//! GH #233 steps 3-4: connection loss on a connect-role binding
+//! is structural. Default (no handler): the process exits with
+//! the loss diagnostic — never accept-and-drop. With
+//! `on_failure(t: std::bus::UnixTransport, err: ClosureViolation)`
+//! on the main locus calling `restart (t);`, the runtime re-runs
+//! the connect-with-retry and publishing resumes — reconnection
+//! as supervision policy, not transport feature (F.37).
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::build_executable;
+
+fn build(name: &str, src: &str) -> PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale_test_loss_{}", name));
+    build_executable(&program, &bin).expect("build");
+    bin
+}
+
+/// transport_driver.c listener: accepts one peer, recvs ONE
+/// message, exits — which closes the connection and induces
+/// EPIPE on the publisher's next send.
+fn build_peer_driver(tag: &str) -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale_loss_peer_{}", tag));
+    let status = Command::new("clang")
+        .arg(manifest.join("tests").join("transport_driver.c"))
+        .arg(manifest.join("runtime").join("lotus_arena.c"))
+        .arg("-O2")
+        .arg("-lpthread")
+        .arg("-o")
+        .arg(&bin)
+        .status()
+        .expect("clang invocation");
+    assert!(status.success(), "clang failed building peer driver");
+    bin
+}
+
+fn unique_socket_path(tag: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!(
+        "{}/hale-233-loss-{}-{}-{}.sock",
+        std::env::temp_dir().display(),
+        tag,
+        std::process::id(),
+        nanos
+    )
+}
+
+#[test]
+fn connection_loss_without_handler_is_structural_exit() {
+    let sock = unique_socket_path("fatal");
+    let src = format!(
+        r#"
+        type T {{ n: Int = 0; }}
+        topic Evt {{ payload: T; subject: "evt"; }}
+        main locus App {{
+            bus {{ publish Evt; }}
+            bindings {{ Evt: unix("{}", role: connect); }}
+            run() {{
+                Evt <- T {{ n: 1 }};
+                std::time::sleep(400ms);
+                Evt <- T {{ n: 2 }};
+                std::time::sleep(300ms);
+                println("survived loss");
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock
+    );
+    let bin = build("fatal", &src);
+    let driver = build_peer_driver("fatal");
+    let listener = Command::new(&driver)
+        .arg("listen")
+        .arg(&sock)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn listener peer");
+    let out = Command::new(&bin).output().expect("run publisher");
+    let _ = listener.wait_with_output();
+    let _ = std::fs::remove_file(&bin);
+    let _ = std::fs::remove_file(&driver);
+    let _ = std::fs::remove_file(&sock);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "connection loss with no restart policy must exit non-zero.\n\
+         stdout: {:?}\nstderr: {:?}",
+        stdout,
+        stderr
+    );
+    assert!(
+        !stdout.contains("survived loss"),
+        "program ran past a lost binding with no policy.\nstdout: {:?}",
+        stdout
+    );
+    assert!(
+        stderr.contains("lost its connection") && stderr.contains("evt"),
+        "expected the loss diagnostic naming the subject.\nstderr: {:?}",
+        stderr
+    );
+}
+
+#[test]
+fn on_failure_restart_reconnects_and_resumes() {
+    let sock = unique_socket_path("restart");
+    let src = format!(
+        r#"
+        type T {{ n: Int = 0; }}
+        topic Evt {{ payload: T; subject: "evt"; }}
+        main locus App {{
+            bus {{ publish Evt; }}
+            bindings {{ Evt: unix("{}", role: connect); }}
+            on_failure(t: std::bus::UnixTransport, err: ClosureViolation) {{
+                println("[sup] link lost — restarting");
+                restart (t);
+            }}
+            run() {{
+                Evt <- T {{ n: 1 }};
+                std::time::sleep(500ms);
+                Evt <- T {{ n: 2 }};
+                std::time::sleep(500ms);
+                Evt <- T {{ n: 3 }};
+                std::time::sleep(200ms);
+                println("recovered");
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock
+    );
+    let bin = build("restart", &src);
+    let driver = build_peer_driver("restart");
+
+    // Peer 1: takes the first message, exits → EPIPE on send 2.
+    let peer1 = Command::new(&driver)
+        .arg("listen")
+        .arg(&sock)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn peer 1");
+    let mut publisher = Command::new(&bin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn publisher");
+    let _ = peer1.wait_with_output();
+    // Peer 2 binds while the publisher is between send 2 (loss)
+    // and send 3; the reconnect's connect-with-retry (~1s)
+    // absorbs the gap.
+    let peer2 = Command::new(&driver)
+        .arg("listen")
+        .arg(&sock)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn peer 2");
+    let pub_out = publisher.wait_with_output().expect("publisher output");
+    let peer2_out = peer2.wait_with_output().expect("peer 2 output");
+    let _ = std::fs::remove_file(&bin);
+    let _ = std::fs::remove_file(&driver);
+    let _ = std::fs::remove_file(&sock);
+    let stdout = String::from_utf8_lossy(&pub_out.stdout);
+    let stderr = String::from_utf8_lossy(&pub_out.stderr);
+    assert!(
+        pub_out.status.success(),
+        "publisher with a restart policy must survive the loss.\n\
+         stdout: {:?}\nstderr: {:?}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("[sup] link lost") && stdout.contains("recovered"),
+        "expected the supervision handler + recovery to run.\nstdout: {:?}",
+        stdout
+    );
+    assert!(
+        !peer2_out.stdout.is_empty(),
+        "peer 2 received nothing — reconnect did not resume delivery.\n\
+         publisher stdout: {:?}\nstderr: {:?}",
+        stdout,
+        stderr
+    );
+}

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -177,6 +177,7 @@ pub const LOCUS_PATHS: &[&[&str]] = &[
     &["std", "bytes", "BytesBuilder"],
     &["std", "cli", "Resolver"],
     &["std", "http", "Client"],
+    &["std", "bus", "UnixTransport"],
     &["std", "http", "ClientRequest"],
     &["std", "http", "ClientResponse"],
     &["std", "http", "Context"],

--- a/docs/src/services/multi-binary.md
+++ b/docs/src/services/multi-binary.md
@@ -93,6 +93,31 @@ a real locus, a child of your `main` locus, whose lifecycle
 opens the transport at birth and tears it down at dissolve —
 the same shape as a custom adapter.)
 
+The *connect* side is the one that can genuinely lose its link —
+the peer it sends to goes away mid-run. That loss is structural:
+by default the process exits with a diagnostic naming the
+subject, because a broker that kept "accepting" messages it can
+no longer deliver would be lying to you. If you'd rather
+reconnect, say so — as a supervision decision on `main`:
+
+```hale
+main locus App {
+    bindings { Evt: unix("/tmp/evt.sock", role: connect); }
+    on_failure(t: std::bus::UnixTransport, err: ClosureViolation) {
+        restart (t);     // re-run the connect-with-retry
+    }
+    run() { /* ... */ }
+}
+```
+
+`restart` re-dials with the same retry window the boot connect
+uses, and publishing resumes on success. No hidden retry loops
+in the transport, no policy kwargs on the binding — the same
+`on_failure` + recovery-primitive vocabulary you already use for
+child loci. (Messages published while the link is down are
+dropped, and the drop is visible in the supervision flow — the
+broker never pretends they were delivered.)
+
 The same rule covers routes added at deploy time through the
 `LOTUS_BUS_CONFIG` file: a route that's asked for but can't be
 opened refuses the boot.

--- a/spec/decisions.md
+++ b/spec/decisions.md
@@ -3137,11 +3137,26 @@ re-arm — peer EOF loops back into `accept()` on the
 already-bound listener, no policy needed, unblocks rolling
 restarts of connect-side binaries — **SHIPPED 2026-07-22**
 (`lotus_bus_unix_serve`, shared with `LOTUS_BUS_CONFIG` reader
-threads); (3) loss → `violate` with default bubble, landing
-**in the same change as** (4) the `on_failure`-on-main routing
-(`lotus_root_panic`'s documented seat) + `restart`-as-reconnect
-— per the guardrail: do not ship loss-is-fatal without the
-reconnect policy in the same change.
+threads); (3)+(4) loss-is-structural + `on_failure`-on-main +
+`restart`-as-reconnect — **SHIPPED 2026-07-22 together**, per
+the guardrail. Implementation notes: loss is detected at
+publish fanout (any thread), marshaled through a mutex'd
+pending list, and dispatched at the top of
+`lotus_bus_queue_drain` (the owner thread — the only place
+failure handlers may run); the dispatcher is a codegen-emitted
+fn registered only when main declares
+`on_failure(t: std::bus::UnixTransport, err: ClosureViolation)`
+(the connect locus's public name via the rename tables), passes
+a synthetic `link_lost` ClosureViolation, detects `restart (t)`
+by the `__restart_count` bump, and reconnects via the stored
+path; no handler / no restart / failed reconnect all take the
+structural exit. Down-window sends are dropped (fanout skips
+lost entries) — the broker never falsely accepts. The
+loss-as-`violate`-statement spelling inside the transport locus
+body was NOT used — the violation is synthesized at the
+dispatch site instead, since the locus body isn't executing
+when fanout detects the loss; the observable semantics
+(ClosureViolation through on_failure) are as specified.
 
 ---
 

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1024,6 +1024,27 @@ control plane; the data plane stays in C:
 Publish fanout is untouched — realized entries land in the same
 `g_bus_remote_entries` table the fanout walks.
 
+**Connection-loss supervision (GH #233 steps 3–4).** Publish
+fanout marks a locus-served connect entry `lost` on send
+failure (skipping it thereafter — down-window publishes drop,
+never falsely succeed) and pushes it onto a mutex'd pending
+list (`lotus_bus_transport_mark_lost`). The top of
+`lotus_bus_queue_drain` — owner thread, the only place failure
+handlers may run — drains the list
+(`lotus_bus_drain_lost_transports`): each handle goes to the
+codegen-registered dispatcher (`lotus_bus_set_loss_handler`,
+emitted only when main declares the matching `on_failure`) or
+straight to the structural exit
+(`lotus_bus_transport_lost_fallback`). The dispatcher invokes
+`main.on_failure(main_self, transport_self, link_lost_violation)`
+and, when the handler bumped `__restart_count` via
+`restart (t)`, calls `lotus_bus_transport_reconnect` (re-runs
+connect-with-retry against the entry's stored path; success
+clears `lost`). Codegen support: `lotus.main.self` global
+(stored at main-locus instantiation),
+`lotus_bus_transport_bind_self` (entry ↔ locus self, emitted
+after each connect instantiation).
+
 Env-configured routes (`LOTUS_BUS_CONFIG`) have no source-level
 declaration to hang a locus on and keep the direct C path:
 `lotus_bus_register_remote(subject, url, role)` returns an i32

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -935,11 +935,23 @@ acted on. Consequences, all normative:
 - **Peer EOF on a listen binding is not loss.** The listener is
   still bound; the serve loop re-arms and accepts the next peer
   (GH #233 step 2), so rolling restarts of connect-side
-  binaries work without policy. An established *connect-side*
-  transport dying mid-run is currently logged at send; making
-  that *loss* structural (with reconnection as a supervision
-  policy via `restart` in main's `on_failure`, not a transport
-  feature) is GH #233 steps 3–4 — see F.37's deferred section.
+  binaries work without policy.
+- **Connect-side loss is structural, with reconnection as
+  supervision policy (GH #233 steps 3–4).** A send failure on a
+  source-declared connect binding marks the entry *lost*
+  (fanout skips it — publishes during the window are dropped,
+  never falsely "delivered") and queues a loss event dispatched
+  on the owner thread at the next queue drain. Default: the
+  structural exit, diagnostic naming the subject. Handled: the
+  main locus declares
+  `on_failure(t: std::bus::UnixTransport, err: ClosureViolation)`
+  — the handler receives a synthetic `link_lost` violation, and
+  `restart (t);` re-runs the connect-with-retry; on success the
+  binding resumes, on failure (or a handler that declines) the
+  structural exit fires. Reconnection is a supervision decision,
+  not a transport feature. `LOTUS_BUS_CONFIG` connect routes sit
+  outside the supervision tree (no locus to route through) and
+  keep logged-only send failures.
 - **Malformed `LOTUS_BUS_CONFIG` lines stay warn-and-skip**
   (the file is an operator-layered override and the diagnostic
   names the line); a well-formed line whose route cannot be


### PR DESCRIPTION
Second half of #233 (checkboxes 3 and 4, landing together per F.37's guardrail). Stacked on #234 — retarget to main after it merges.

**Loss is structural.** A send failure on a source-declared connect binding marks the entry lost: fanout skips it (down-window publishes drop — the broker never falsely accepts), and a loss event is marshaled from the failing thread to the queue owner thread (the only place failure handlers may run), dispatched at the top of `lotus_bus_queue_drain`. Default: structural exit with a diagnostic naming the subject and pointing at the restart recipe.

**Reconnection is supervision policy.** Zero new syntax:

```hale
on_failure(t: std::bus::UnixTransport, err: ClosureViolation) {
    restart (t);
}
```

on `main`. The codegen-emitted dispatcher (registered only when this handler exists) invokes it with a synthetic `link_lost` ClosureViolation, detects `restart` via the `__restart_count` bump, and re-runs the connect-with-retry against the stored path. `std::bus::UnixTransport` is the new public name for the connect-side transport locus (rename table + hale-types known-types). `LOTUS_BUS_CONFIG` routes sit outside the supervision tree and keep logged-only behavior (spec-noted).

**Plumbing:** `lotus.main.self` global stored at main-locus instantiation; `lotus_bus_transport_bind_self` after each connect instantiation; `lotus_bus_transport_mark_lost` / `drain_lost_transports` / `reconnect` / `lost_fallback` in the runtime. One honest deviation recorded in F.37: the violation is synthesized at the dispatch site rather than spelled as a `violate` in the locus body (the locus isn't executing when fanout detects loss); observable semantics are as specified.

**Tests:** `binding_loss_supervision.rs` — default-fatal (peer exits; next publish must kill the process with the loss diagnostic, never print the post-loss line) and restart-reconnects (peer #1 dies → handler restarts → peer #2 receives the post-reconnect publish; publisher exits 0). Full affected sweep + corpus_oracle + `hale fmt --check` green locally.

**Spec/docs:** publish-contract loss bullet rewritten, F.37 steps 3–4 marked shipped with implementation notes, runtime.md loss-supervision paragraph, CHANGELOG, `multi-binary.md` reconnect recipe (compile-shape verified by the restart test).

Closes #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)