### PR TITLE
fix(check): call arity validated at check phase with spans (#229)

### DIFF
--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -10116,7 +10116,35 @@ impl<'a> Checker<'a> {
                 // typing in general; this fires *only* when the
                 // param is an interface, so we don't widen the
                 // call-site checking surface beyond that.
+                // GH #229: arity UPPER bound at check phase. More
+                // args than params is always an error (defaults
+                // can only excuse omissions, never extras), and
+                // pre-#229 it sailed through check to die as a
+                // spanless codegen internal error. The LOWER bound
+                // needs default-param counts plumbed into
+                // FnSig/MethodInfo — follow-through on the issue.
                 if let Ty::Function { params, .. } = &callee_ty {
+                    if arg_tys.len() > params.len() {
+                        let display = match callee.as_ref() {
+                            Expr::Field { name, .. } => {
+                                format!("method `{}`", name.name)
+                            }
+                            Expr::Ident(id) => {
+                                format!("fn `{}`", id.name)
+                            }
+                            _ => "this callee".to_string(),
+                        };
+                        self.diags.push(Diag::ty(
+                            callee.span(),
+                            format!(
+                                "{} takes at most {} argument{}, got {}",
+                                display,
+                                params.len(),
+                                if params.len() == 1 { "" } else { "s" },
+                                arg_tys.len()
+                            ),
+                        ));
+                    }
                     for (i, (param_ty, arg_ty)) in
                         params.iter().zip(arg_tys.iter()).enumerate()
                     {

--- a/crates/hale-types/tests/call_arity.rs
+++ b/crates/hale-types/tests/call_arity.rs
@@ -1,0 +1,82 @@
+//! GH #229: arity mismatches are check-phase errors with spans —
+//! previously `a.go(7)` on a zero-arg method passed `hale check`
+//! and died at codegen as a locationless internal error. The
+//! check enforces the UPPER bound only (extra args are always
+//! wrong; omitted args may be excused by default params, whose
+//! counts aren't modeled in FnSig/MethodInfo yet — the lower
+//! bound is the issue's remaining follow-through).
+
+use hale_syntax::parse_source;
+use hale_types::symbol::Bundle;
+
+fn diags(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    let mut programs: std::collections::BTreeMap<
+        String,
+        &hale_syntax::ast::Program,
+    > = std::collections::BTreeMap::new();
+    programs.insert("test.hl".to_string(), &program);
+    let bundle = Bundle { programs };
+    let (scope, mut ds) = hale_types::resolve::build_top_scope(&bundle);
+    ds.extend(hale_types::check::check_bundle(&bundle, &scope, true));
+    ds.iter().map(|d| d.message.clone()).collect()
+}
+
+#[test]
+fn method_over_arity_is_a_check_error() {
+    let src = r#"
+        locus A {
+            fn go() { }
+        }
+        fn main() {
+            let a = A { };
+            a.go(7);
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("method `go`")
+            && m.contains("at most 0")
+            && m.contains("got 1")),
+        "expected over-arity diag; got: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn free_fn_over_arity_is_a_check_error() {
+    let src = r#"
+        fn add(a: Int, b: Int) -> Int { a + b }
+        fn main() {
+            let x = add(1, 2, 3);
+            println(x);
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("fn `add`")
+            && m.contains("at most 2")
+            && m.contains("got 3")),
+        "expected over-arity diag; got: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn exact_arity_stays_clean() {
+    let src = r#"
+        locus A {
+            fn go(n: Int) { println(n); }
+        }
+        fn main() {
+            let a = A { };
+            a.go(7);
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("at most")),
+        "unexpected arity diag on exact call; got: {:?}",
+        ds
+    );
+}


### PR DESCRIPTION
Fixes the filed repro of #229: `a.go(7)` on a zero-arg method now fails `hale check` (and therefore surfaces in the LSP) with a precise span, instead of sailing through to a locationless codegen internal error.

The gap: the general call fallthrough in hale-types typed the callee as `Ty::Function` but never compared arg count against params — its own comment noted positional typing wasn't enforced. This adds the **upper-bound** check (extra args are always wrong regardless of default params) at the callee's span, covering locus methods, free fns, and fn-typed values uniformly.

Deliberately not in this PR, left as checkboxes on the issue:
- **Lower bound** (too few args) — needs default-param counts plumbed into `FnSig`/`MethodInfo`; enforcing it blind would false-error every defaulted-param call.
- The broader **no-spanless-internal-error audit** of codegen error paths.
- The **did-you-mean** stretch.

Tests: `crates/hale-types/tests/call_arity.rs` (over-arity method + free fn, exact-arity negative). hale-types suite + corpus check sweep + codegen sanity green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)