### PR TITLE
fix(check): call arity lower bound with default-param awareness (closes #229)

### DIFF
--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -10145,6 +10145,75 @@ impl<'a> Checker<'a> {
                             ),
                         ));
                     }
+                    // GH #229: arity LOWER bound. Ty::Function
+                    // erases default-param info, so resolve the
+                    // callee's symbol directly; the receiver
+                    // re-check is speculative (diags rolled
+                    // back — the real check already ran above).
+                    let min_required: Option<(usize, String)> =
+                        match callee.as_ref() {
+                            Expr::Ident(id) => {
+                                match self.top.lookup(&id.name) {
+                                    Some(TopSymbol::Fn(sig)) => Some((
+                                        sig.required_params(),
+                                        format!("fn `{}`", id.name),
+                                    )),
+                                    _ => None,
+                                }
+                            }
+                            Expr::Field { receiver, name, .. } => {
+                                let mark = self.diags.len();
+                                let rt = self.check_expr(receiver);
+                                self.diags.truncate(mark);
+                                match rt {
+                                    Ty::Named(tn) => {
+                                        match self.top.symbols.get(&tn) {
+                                            Some(TopSymbol::Locus(li)) => li
+                                                .methods
+                                                .iter()
+                                                .find(|m| m.name == name.name)
+                                                .map(|m| (
+                                                    m.required_params(),
+                                                    format!(
+                                                        "method `{}`",
+                                                        name.name
+                                                    ),
+                                                )),
+                                            Some(TopSymbol::Perspective(
+                                                pi,
+                                            )) => pi
+                                                .methods
+                                                .iter()
+                                                .find(|m| m.name == name.name)
+                                                .map(|m| (
+                                                    m.required_params(),
+                                                    format!(
+                                                        "method `{}`",
+                                                        name.name
+                                                    ),
+                                                )),
+                                            _ => None,
+                                        }
+                                    }
+                                    _ => None,
+                                }
+                            }
+                            _ => None,
+                        };
+                    if let Some((min, display)) = min_required {
+                        if arg_tys.len() < min {
+                            self.diags.push(Diag::ty(
+                                callee.span(),
+                                format!(
+                                    "{} takes at least {} argument{}, got {}",
+                                    display,
+                                    min,
+                                    if min == 1 { "" } else { "s" },
+                                    arg_tys.len()
+                                ),
+                            ));
+                        }
+                    }
                     for (i, (param_ty, arg_ty)) in
                         params.iter().zip(arg_tys.iter()).enumerate()
                     {

--- a/crates/hale-types/src/resolve.rs
+++ b/crates/hale-types/src/resolve.rs
@@ -794,6 +794,11 @@ fn register_locus(
                         .iter()
                         .map(|p| resolve_type_expr(&p.ty, known))
                         .collect(),
+                    // Mode params are projection inputs the
+                    // SUBSTRATE may supply (50-mode-defaults
+                    // calls `self.x.bulk()` bare) — exempt from
+                    // the GH #229 lower bound.
+                    min_params: Some(0),
                     ret,
                     fallible: None,
                 });
@@ -814,6 +819,11 @@ fn register_locus(
                         .iter()
                         .map(|p| resolve_type_expr(&p.ty, known))
                         .collect(),
+                    // GH #229: see FnSig::min_params.
+                    min_params: f
+                        .params
+                        .iter()
+                        .position(|p| p.default.is_some()),
                     ret,
                     fallible,
                 });
@@ -1062,6 +1072,11 @@ fn register_perspective(
                         .iter()
                         .map(|p| resolve_type_expr(&p.ty, known))
                         .collect(),
+                    // GH #229: see FnSig::min_params.
+                    min_params: f
+                        .params
+                        .iter()
+                        .position(|p| p.default.is_some()),
                     ret,
                     fallible,
                 });
@@ -1072,6 +1087,7 @@ fn register_perspective(
                 methods.push(MethodInfo {
                     name: "is_stable".to_string(),
                     params: Vec::new(),
+                    min_params: None,
                     ret: Ty::Prim(PrimType::Bool),
                     fallible: None,
                 });
@@ -1133,6 +1149,13 @@ fn register_fn(
     let sig = FnSig {
         name: decl.name.name.clone(),
         params,
+        // GH #229: lower arity bound — index of the first
+        // defaulted param; callers may omit only trailing
+        // defaulted params.
+        min_params: decl
+            .params
+            .iter()
+            .position(|p| p.default.is_some()),
         ret,
         fallible,
         span: decl.span,
@@ -1368,36 +1391,42 @@ fn synthesize_form_vec_methods(methods: &mut Vec<MethodInfo>, cell_ty: &Ty) {
     methods.push(MethodInfo {
         name: "push".to_string(),
         params: vec![cell_ty.clone()],
+        min_params: None,
         ret: Ty::Unit,
         fallible: None,
     });
     methods.push(MethodInfo {
         name: "get".to_string(),
         params: vec![Ty::Prim(PrimType::Int)],
+        min_params: None,
         ret: cell_ty.clone(),
         fallible: Some(index_err.clone()),
     });
     methods.push(MethodInfo {
         name: "set".to_string(),
         params: vec![Ty::Prim(PrimType::Int), cell_ty.clone()],
+        min_params: None,
         ret: Ty::Unit,
         fallible: Some(index_err.clone()),
     });
     methods.push(MethodInfo {
         name: "pop".to_string(),
         params: Vec::new(),
+        min_params: None,
         ret: cell_ty.clone(),
         fallible: Some(index_err),
     });
     methods.push(MethodInfo {
         name: "len".to_string(),
         params: Vec::new(),
+        min_params: None,
         ret: Ty::Prim(PrimType::Int),
         fallible: None,
     });
     methods.push(MethodInfo {
         name: "is_empty".to_string(),
         params: Vec::new(),
+        min_params: None,
         ret: Ty::Prim(PrimType::Bool),
         fallible: None,
     });
@@ -1413,18 +1442,21 @@ fn synthesize_form_vec_methods(methods: &mut Vec<MethodInfo>, cell_ty: &Ty) {
     methods.push(MethodInfo {
         name: "sort".to_string(),
         params: Vec::new(),
+        min_params: None,
         ret: Ty::Unit,
         fallible: None,
     });
     methods.push(MethodInfo {
         name: "sort_by".to_string(),
         params: vec![cmp_ty.clone()],
+        min_params: None,
         ret: Ty::Unit,
         fallible: None,
     });
     methods.push(MethodInfo {
         name: "sort_desc_by".to_string(),
         params: vec![cmp_ty],
+        min_params: None,
         ret: Ty::Unit,
         fallible: None,
     });
@@ -1457,36 +1489,42 @@ fn synthesize_form_hashmap_methods(
     methods.push(MethodInfo {
         name: "get".to_string(),
         params: vec![key_ty.clone()],
+        min_params: None,
         ret: value_ty.clone(),
         fallible: Some(key_err.clone()),
     });
     methods.push(MethodInfo {
         name: "set".to_string(),
         params: vec![value_ty.clone()],
+        min_params: None,
         ret: Ty::Unit,
         fallible: None,
     });
     methods.push(MethodInfo {
         name: "has".to_string(),
         params: vec![key_ty.clone()],
+        min_params: None,
         ret: Ty::Prim(PrimType::Bool),
         fallible: None,
     });
     methods.push(MethodInfo {
         name: "remove".to_string(),
         params: vec![key_ty.clone()],
+        min_params: None,
         ret: Ty::Unit,
         fallible: Some(key_err),
     });
     methods.push(MethodInfo {
         name: "len".to_string(),
         params: Vec::new(),
+        min_params: None,
         ret: Ty::Prim(PrimType::Int),
         fallible: None,
     });
     methods.push(MethodInfo {
         name: "is_empty".to_string(),
         params: Vec::new(),
+        min_params: None,
         ret: Ty::Prim(PrimType::Bool),
         fallible: None,
     });
@@ -1501,18 +1539,21 @@ fn synthesize_form_hashmap_methods(
     methods.push(MethodInfo {
         name: "key_at".to_string(),
         params: vec![Ty::Prim(PrimType::Int)],
+        min_params: None,
         ret: key_ty.clone(),
         fallible: Some(idx_err.clone()),
     });
     methods.push(MethodInfo {
         name: "entry_at".to_string(),
         params: vec![Ty::Prim(PrimType::Int)],
+        min_params: None,
         ret: value_ty.clone(),
         fallible: Some(idx_err),
     });
     methods.push(MethodInfo {
         name: "bump".to_string(),
         params: vec![key_ty.clone()],
+        min_params: None,
         ret: Ty::Unit,
         fallible: None,
     });
@@ -1556,24 +1597,28 @@ fn synthesize_form_ring_buffer_methods(
     methods.push(MethodInfo {
         name: "push".to_string(),
         params: vec![cell_ty.clone()],
+        min_params: None,
         ret: Ty::Prim(PrimType::Bool),
         fallible: None,
     });
     methods.push(MethodInfo {
         name: "pop".to_string(),
         params: Vec::new(),
+        min_params: None,
         ret: cell_ty.clone(),
         fallible: Some(empty_err),
     });
     methods.push(MethodInfo {
         name: "len".to_string(),
         params: Vec::new(),
+        min_params: None,
         ret: Ty::Prim(PrimType::Int),
         fallible: None,
     });
     methods.push(MethodInfo {
         name: "is_full".to_string(),
         params: Vec::new(),
+        min_params: None,
         ret: Ty::Prim(PrimType::Bool),
         fallible: None,
     });
@@ -1604,24 +1649,28 @@ fn synthesize_form_lru_cache_methods(
     methods.push(MethodInfo {
         name: "put".to_string(),
         params: vec![value_ty.clone()],
+        min_params: None,
         ret: Ty::Unit,
         fallible: None,
     });
     methods.push(MethodInfo {
         name: "get".to_string(),
         params: vec![key_ty.clone()],
+        min_params: None,
         ret: value_ty.clone(),
         fallible: Some(key_err),
     });
     methods.push(MethodInfo {
         name: "contains".to_string(),
         params: vec![key_ty.clone()],
+        min_params: None,
         ret: Ty::Prim(PrimType::Bool),
         fallible: None,
     });
     methods.push(MethodInfo {
         name: "len".to_string(),
         params: Vec::new(),
+        min_params: None,
         ret: Ty::Prim(PrimType::Int),
         fallible: None,
     });

--- a/crates/hale-types/src/symbol.rs
+++ b/crates/hale-types/src/symbol.rs
@@ -167,6 +167,11 @@ pub struct ClosureSymInfo {
 pub struct MethodInfo {
     pub name: String,
     pub params: Vec<Ty>,
+    /// GH #229: arity lower bound — index of the first
+    /// defaulted param (callers may omit trailing defaulted
+    /// params, never required ones). None = no defaults, every
+    /// param required.
+    pub min_params: Option<usize>,
     pub ret: Ty,
     /// v1.x-FORM-1: payload type when the method was declared
     /// (or synthesized) `fallible(E)`. Mirrors `FnSig.fallible`
@@ -272,6 +277,8 @@ pub struct ConstInfo {
 pub struct FnSig {
     pub name: String,
     pub params: Vec<(String, Ty)>,
+    /// GH #229: arity lower bound (see MethodInfo::min_params).
+    pub min_params: Option<usize>,
     pub ret: Ty,
     /// v1.x-FORM-1: payload type when the fn was declared
     /// `-> T fallible(E)`. Calls to fallible fns produce a
@@ -280,3 +287,18 @@ pub struct FnSig {
     pub fallible: Option<Ty>,
     pub span: Span,
 }
+
+impl MethodInfo {
+    /// Required-argument count: params before the first default.
+    pub fn required_params(&self) -> usize {
+        self.min_params.unwrap_or(self.params.len())
+    }
+}
+
+impl FnSig {
+    /// Required-argument count: params before the first default.
+    pub fn required_params(&self) -> usize {
+        self.min_params.unwrap_or(self.params.len())
+    }
+}
+

--- a/crates/hale-types/tests/call_arity.rs
+++ b/crates/hale-types/tests/call_arity.rs
@@ -80,3 +80,62 @@ fn exact_arity_stays_clean() {
         ds
     );
 }
+
+#[test]
+fn method_under_arity_is_a_check_error() {
+    let src = r#"
+        locus A {
+            fn go(a: Int, b: Int) { println(a + b); }
+        }
+        fn main() {
+            let a = A { };
+            a.go(1);
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("method `go`")
+            && m.contains("at least 2")
+            && m.contains("got 1")),
+        "expected under-arity diag; got: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn defaulted_params_may_be_omitted() {
+    let src = r#"
+        fn greet(name: String, punct: String = "!") -> String {
+            name + punct
+        }
+        fn main() {
+            println(greet("hale"));
+            println(greet("hale", "?"));
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("at least") || m.contains("at most")),
+        "defaulted call must not trip arity diags; got: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn free_fn_under_arity_is_a_check_error() {
+    let src = r#"
+        fn add(a: Int, b: Int) -> Int { a + b }
+        fn main() {
+            let x = add(1);
+            println(x);
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("fn `add`")
+            && m.contains("at least 2")
+            && m.contains("got 1")),
+        "expected under-arity diag; got: {:?}",
+        ds
+    );
+}


### PR DESCRIPTION
The other half of check-phase arity (upper bound: #239) — closes #229.

`FnSig`/`MethodInfo` now carry `min_params` (index of the first defaulted param; `None` = all required), populated from the AST at the free-fn, locus-fn, and perspective-fn resolution sites. The call fallthrough enforces the lower bound with a spanned diagnostic, resolving the callee's symbol directly (Ty::Function erases default info; the receiver re-check is speculative with diag rollback).

One deliberate exemption the corpus caught immediately: **mode methods** (`bulk`/`harmonic`/`resolution`) take `min 0` — mode params are projection inputs the substrate may supply, and `50-mode-defaults` calls `self.x.bulk()` bare by design.

Tests: `call_arity.rs` grows under-arity (method + free fn) and defaulted-omission cases; full hale-types suite + corpus + fmt green locally.

The no-spanless-internal-error audit and did-you-mean stretch live in #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)