### PR TITLE
feat(diag): caret snippets, did-you-mean, spanless-error audit fixes (closes #241)

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -3182,7 +3182,15 @@ fn run_build(target: &Path) -> ExitCode {
             ExitCode::SUCCESS
         }
         Err(e) => {
-            eprintln!("codegen error: {}", e);
+            // GH #241: span-carrying codegen errors render like
+            // check diagnostics (file:line:col + source caret);
+            // everything else keeps the bare line.
+            if let hale_codegen::CodegenError::UnsupportedAt(msg, span) = &e {
+                let d = hale_syntax::Diag::codegen(*span, msg.clone());
+                eprintln!("{}", render_located(&d, &file_bases, &sources));
+            } else {
+                eprintln!("codegen error: {}", e);
+            }
             ExitCode::from(1)
         }
     }

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -517,6 +517,12 @@ fn bce_call_safe(
 #[derive(Debug)]
 pub enum CodegenError {
     Unsupported(String),
+    /// GH #241: an unsupported-construct error that can name the
+    /// user source location that produced it. Prefer this for any
+    /// raise a user program can reach; the CLI renders it through
+    /// the standard diagnostic formatter (file:line:col + caret)
+    /// instead of a bare `codegen error:` line.
+    UnsupportedAt(String, hale_syntax::Span),
     LlvmInit(String),
     LlvmEmit(String),
     Link(String),
@@ -526,6 +532,9 @@ impl std::fmt::Display for CodegenError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CodegenError::Unsupported(s) => write!(f, "unsupported in codegen v0: {}", s),
+            CodegenError::UnsupportedAt(s, _) => {
+                write!(f, "unsupported in codegen v0: {}", s)
+            }
             CodegenError::LlvmInit(s) => write!(f, "LLVM init failed: {}", s),
             CodegenError::LlvmEmit(s) => write!(f, "LLVM emit failed: {}", s),
             CodegenError::Link(s) => write!(f, "link failed: {}", s),
@@ -10119,7 +10128,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// generic ref recurses through `mangle_generic_name`.
     fn type_expr_mangle_token(t: &TypeExpr) -> Result<String, CodegenError> {
         match t {
-            TypeExpr::Primitive(p, _) => match p {
+            TypeExpr::Primitive(p, span) => match p {
                 PrimType::Int => Ok("Int".into()),
                 PrimType::Float => Ok("Float".into()),
                 PrimType::Bool => Ok("Bool".into()),
@@ -10127,10 +10136,14 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 PrimType::Duration => Ok("Duration".into()),
                 PrimType::Decimal => Ok("Decimal".into()),
                 PrimType::Time => Ok("Time".into()),
-                other => Err(CodegenError::Unsupported(format!(
-                    "primitive `{:?}` as generic arg (m61 v0.1)",
-                    other
-                ))),
+                // GH #241: user-reachable — carry the arg's span.
+                other => Err(CodegenError::UnsupportedAt(
+                    format!(
+                        "primitive `{:?}` as a generic argument                          (v0 supports Int / Float / Bool / String                          / Duration / Decimal / Time)",
+                        other
+                    ),
+                    *span,
+                )),
             },
             TypeExpr::Named { path, generic_args, .. }
                 if path.segments.len() == 1 =>
@@ -10144,11 +10157,15 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     )
                 }
             }
-            other => Err(CodegenError::Unsupported(format!(
-                "type form `{:?}` as generic arg (m61 v0.1 only \
-                 supports primitives + named types)",
-                other
-            ))),
+            // GH #241: user-reachable — carry the arg's span.
+            other => Err(CodegenError::UnsupportedAt(
+                format!(
+                    "type form `{:?}` as a generic argument (v0 \
+                     supports primitives and named types)",
+                    other
+                ),
+                other.span(),
+            )),
         }
     }
 

--- a/crates/hale-syntax/src/error.rs
+++ b/crates/hale-syntax/src/error.rs
@@ -17,6 +17,10 @@ pub enum DiagKind {
     Parse,
     /// Type-checker errors.
     Type,
+    /// GH #241: codegen-raised errors that carry a source span
+    /// (CodegenError::UnsupportedAt) — rendered with the same
+    /// location + caret treatment as check diagnostics.
+    Codegen,
     /// Non-fatal advisories — the program still compiles. The first
     /// is the blocking-syscall-on-a-cooperative-pool smell: legal,
     /// but it stalls co-scheduled loci, so it's surfaced rather than
@@ -37,6 +41,14 @@ impl Diag {
     pub fn parse(span: Span, msg: impl Into<String>) -> Self {
         Diag {
             kind: DiagKind::Parse,
+            span,
+            message: msg.into(),
+        }
+    }
+
+    pub fn codegen(span: Span, msg: impl Into<String>) -> Self {
+        Diag {
+            kind: DiagKind::Codegen,
             span,
             message: msg.into(),
         }
@@ -78,6 +90,7 @@ impl Diag {
             DiagKind::Lex => "lex error",
             DiagKind::Parse => "parse error",
             DiagKind::Type => "type error",
+            DiagKind::Codegen => "codegen error",
             DiagKind::Warn => "warning",
         }
     }

--- a/crates/hale-syntax/src/error.rs
+++ b/crates/hale-syntax/src/error.rs
@@ -84,14 +84,66 @@ impl Diag {
 
     pub fn render(&self, source: &str) -> String {
         let (line, col) = self.span.line_col(source);
-        format!("{}:{}: {}: {}", line, col, self.kind_str(), self.message)
+        format!(
+            "{}:{}: {}: {}{}",
+            line,
+            col,
+            self.kind_str(),
+            self.message,
+            Self::context_snippet(self.span, source, line, col)
+        )
     }
 
     /// Render as `path:line:col: kind: message`, un-shifting the span by
     /// the file's virtual `base` (from `parse_source_at`) so the line/col
     /// are relative to the file's own source — for multi-file builds.
     pub fn render_located(&self, path: &str, source: &str, base: u32) -> String {
-        let (line, col) = self.span.shifted(base.wrapping_neg()).line_col(source);
-        format!("{}:{}:{}: {}: {}", path, line, col, self.kind_str(), self.message)
+        let span = self.span.shifted(base.wrapping_neg());
+        let (line, col) = span.line_col(source);
+        format!(
+            "{}:{}:{}: {}: {}{}",
+            path,
+            line,
+            col,
+            self.kind_str(),
+            self.message,
+            Self::context_snippet(span, source, line, col)
+        )
+    }
+
+    /// GH #241: two extra lines under every rendered diagnostic —
+    /// the offending source line and a caret underline at the
+    /// span. Tab alignment: the padding reuses the line's own
+    /// prefix characters (tabs stay tabs) so the caret lands
+    /// where the terminal renders the column. Empty when the
+    /// span's line can't be recovered (synthetic spans).
+    fn context_snippet(
+        span: Span,
+        source: &str,
+        line: usize,
+        col: usize,
+    ) -> String {
+        let Some(src_line) = source.lines().nth(line.saturating_sub(1))
+        else {
+            return String::new();
+        };
+        if src_line.trim().is_empty() {
+            return String::new();
+        }
+        let caret_at = col.saturating_sub(1);
+        let span_len = span.end.as_usize().saturating_sub(span.start.as_usize());
+        let rest = src_line.chars().count().saturating_sub(caret_at);
+        let width = span_len.clamp(1, rest.max(1));
+        let pad: String = src_line
+            .chars()
+            .take(caret_at)
+            .map(|c| if c == '\t' { '\t' } else { ' ' })
+            .collect();
+        format!(
+            "\n    {}\n    {}{}",
+            src_line,
+            pad,
+            "^".repeat(width)
+        )
     }
 }

--- a/crates/hale-syntax/tests/parse_source_at.rs
+++ b/crates/hale-syntax/tests/parse_source_at.rs
@@ -31,5 +31,16 @@ fn render_located_unshifts_to_file_line_col() {
     // Demux: rendering against the file's own source + base recovers the
     // real location (line 1 — `fn main` is the first line).
     let out = d.render_located("lib/foo.hl", src, base);
-    assert_eq!(out, "lib/foo.hl:1:1: type error: boom");
+    // GH #241: rendered diagnostics carry a source-context
+    // snippet (offending line + caret underline).
+    assert!(
+        out.starts_with("lib/foo.hl:1:1: type error: boom\n"),
+        "got: {:?}",
+        out
+    );
+    assert!(
+        out.contains("\n    fn main() {\n    ^"),
+        "expected context snippet with caret; got: {:?}",
+        out
+    );
 }

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -10332,14 +10332,52 @@ impl<'a> Checker<'a> {
                         // through. Strict when the receiver
                         // is a known type and the field
                         // doesn't exist on it: catches typos
-                        // statically.
+                        // statically. GH #241: with a nearest-
+                        // name suggestion drawn from the
+                        // receiver's fields + methods.
                         if !matches!(rt, Ty::Unknown) {
+                            let mut candidates: Vec<String> = Vec::new();
+                            if let Ty::Named(tn) = &rt {
+                                match self.top.symbols.get(tn) {
+                                    Some(TopSymbol::Locus(li)) => {
+                                        candidates.extend(
+                                            li.params.iter().map(|p| p.name.clone()),
+                                        );
+                                        candidates.extend(
+                                            li.methods.iter().map(|m| m.name.clone()),
+                                        );
+                                    }
+                                    Some(TopSymbol::Perspective(pi)) => {
+                                        candidates.extend(
+                                            pi.params.iter().map(|p| p.name.clone()),
+                                        );
+                                        candidates.extend(
+                                            pi.methods.iter().map(|m| m.name.clone()),
+                                        );
+                                    }
+                                    Some(TopSymbol::Type(ti)) => {
+                                        if let TypeKind::Struct(fields) = &ti.kind {
+                                            candidates.extend(
+                                                fields.iter().map(|f| f.name.clone()),
+                                            );
+                                        }
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            let hint = crate::stdlib_surface::nearest_name(
+                                &name.name,
+                                candidates.iter().map(|s| s.as_str()),
+                            )
+                            .map(|s| format!(" — did you mean `{}`?", s))
+                            .unwrap_or_default();
                             self.diags.push(Diag::ty(
                                 *span,
                                 format!(
-                                    "no field `{}` on `{}`",
+                                    "no field `{}` on `{}`{}",
                                     name.name,
-                                    rt.display()
+                                    rt.display(),
+                                    hint
                                 ),
                             ));
                         }

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -9713,6 +9713,62 @@ impl<'a> Checker<'a> {
                         }
                     }
                 }
+                // GH #241 (audit items 1+3): bare-builtin arg
+                // validation. println/print/to_string accept only
+                // printable types (primitives + enums — structs
+                // and loci have no rendering and previously died
+                // as spanless codegen errors); abs/min/max accept
+                // numerics (Int/Float/Duration/Decimal). Guarded
+                // on the name NOT resolving to a user fn, so user
+                // shadowing keeps its own signature.
+                if let Expr::Ident(id) = callee.as_ref() {
+                    let shadowed = self.top.lookup(&id.name).is_some()
+                        || self.locals.lookup(&id.name).is_some();
+                    if !shadowed {
+                        match id.name.as_str() {
+                            "println" | "print" | "to_string" => {
+                                for a in args {
+                                    let at = self.check_expr_addressed(a);
+                                    if !self.ty_is_printable(&at) {
+                                        self.diags.push(Diag::ty(
+                                            a.span(),
+                                            format!(
+                                                "`{}` cannot render a value of                                                  type `{}` — printable types are                                                  the scalar primitives, String,                                                  and enums (render struct/locus                                                  fields individually)",
+                                                id.name,
+                                                at.display()
+                                            ),
+                                        ));
+                                    }
+                                }
+                            }
+                            "abs" | "min" | "max" => {
+                                for a in args {
+                                    let at = self.check_expr_addressed(a);
+                                    let numeric = matches!(
+                                        &at,
+                                        Ty::Prim(
+                                            PrimType::Int
+                                                | PrimType::Float
+                                                | PrimType::Duration
+                                                | PrimType::Decimal
+                                        ) | Ty::Unknown
+                                    );
+                                    if !numeric {
+                                        self.diags.push(Diag::ty(
+                                            a.span(),
+                                            format!(
+                                                "`{}` takes numeric operands                                                  (Int / Float / Duration /                                                  Decimal), got `{}`",
+                                                id.name,
+                                                at.display()
+                                            ),
+                                        ));
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
                 // bounded[T; N] intrinsics (2026-07-02):
                 // push/at/count/clear over a bounded-typed first
                 // arg. Probed speculatively — when arg0 isn't
@@ -10818,7 +10874,7 @@ impl<'a> Checker<'a> {
     /// `value_to_string_supports` set: every primitive that
     /// `to_string(...)` accepts, plus enums (which render as their
     /// variant name).
-    fn ty_is_printable(t: &Ty) -> bool {
+    fn ty_is_printable(&self, t: &Ty) -> bool {
         match t {
             Ty::Prim(p) => matches!(
                 p,
@@ -10829,14 +10885,27 @@ impl<'a> Checker<'a> {
                     | PrimType::Decimal
                     | PrimType::Duration
                     | PrimType::Time
+                    | PrimType::StringView
             ),
-            // Named types: enums render via to_string at codegen.
-            // The typechecker doesn't distinguish enum vs struct
-            // here without more lookup work; permit and let
-            // codegen reject if the type isn't actually printable
-            // (struct with no Display rendering would still error
-            // there).
-            Ty::Named(_) => true,
+            // GH #241 (audit item 1): enums render via to_string
+            // (variant name); structs / loci / perspectives do
+            // NOT — pre-#241 this deferred to a spanless codegen
+            // error ("`to_string` not supported for type ...").
+            // Resolve the name: enum printable, everything else
+            // known is not. Unresolved names stay permissive
+            // (imports / synthesized types).
+            Ty::Named(n) => match self.top.symbols.get(n) {
+                Some(TopSymbol::Type(ti)) => {
+                    matches!(ti.kind, TypeKind::Enum(_))
+                }
+                Some(
+                    TopSymbol::Locus(_)
+                    | TopSymbol::Perspective(_)
+                    | TopSymbol::Interface(_),
+                ) => false,
+                _ => true,
+            },
+            Ty::Unknown => true,
             _ => false,
         }
     }
@@ -10850,8 +10919,8 @@ impl<'a> Checker<'a> {
         if matches!(op, Add) {
             let l_str = matches!(lt, Ty::Prim(PrimType::String));
             let r_str = matches!(rt, Ty::Prim(PrimType::String));
-            if (l_str && Self::ty_is_printable(rt))
-                || (r_str && Self::ty_is_printable(lt))
+            if (l_str && self.ty_is_printable(rt))
+                || (r_str && self.ty_is_printable(lt))
             {
                 return Ty::Prim(PrimType::String);
             }

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -549,6 +549,31 @@ pub fn suggest(surface: &NsSurface, name: &str) -> Option<&'static str> {
     }
 }
 
+/// GH #241: generic nearest-name suggestion for user-scope
+/// diagnostics (unknown field/method/type names), same threshold
+/// policy as the stdlib `suggest` above: distance ≤ 2 on names of
+/// length ≥ 4, or distance 1 on anything.
+pub fn nearest_name<'a, I>(name: &str, candidates: I) -> Option<String>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut best: Option<(&'a str, usize)> = None;
+    for cand in candidates {
+        let d = edit_distance(name, cand);
+        match best {
+            Some((_, bd)) if bd <= d => {}
+            _ => best = Some((cand, d)),
+        }
+    }
+    match best {
+        Some((cand, d)) if d <= 2 && name.len() >= 4 => {
+            Some(cand.to_string())
+        }
+        Some((cand, 1)) => Some(cand.to_string()),
+        _ => None,
+    }
+}
+
 fn edit_distance(a: &str, b: &str) -> usize {
     let a: Vec<char> = a.chars().collect();
     let b: Vec<char> = b.chars().collect();

--- a/crates/hale-types/tests/diag_quality.rs
+++ b/crates/hale-types/tests/diag_quality.rs
@@ -1,0 +1,102 @@
+//! GH #241: diagnostic-quality checks — user errors that
+//! previously escaped to spanless codegen internal errors now
+//! die at check phase, and typo diags carry did-you-mean hints.
+
+use hale_syntax::parse_source;
+use hale_types::symbol::Bundle;
+
+fn diags(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    let mut programs: std::collections::BTreeMap<
+        String,
+        &hale_syntax::ast::Program,
+    > = std::collections::BTreeMap::new();
+    programs.insert("test.hl".to_string(), &program);
+    let bundle = Bundle { programs };
+    let (scope, mut ds) = hale_types::resolve::build_top_scope(&bundle);
+    ds.extend(hale_types::check::check_bundle(&bundle, &scope, true));
+    ds.iter().map(|d| d.message.clone()).collect()
+}
+
+#[test]
+fn printing_a_struct_is_a_check_error() {
+    let src = r#"
+        type P { x: Int = 0; }
+        fn main() {
+            let p = P { x: 1 };
+            println("p=", p);
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("cannot render") && m.contains("`P`")),
+        "expected printable diag; got: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn string_plus_struct_is_a_check_error() {
+    let src = r#"
+        type P { x: Int = 0; }
+        fn main() {
+            let p = P { x: 1 };
+            let s = "v: " + p;
+            println(s);
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        !ds.is_empty(),
+        "expected a diag for String + struct; got none"
+    );
+}
+
+#[test]
+fn printing_an_enum_stays_legal() {
+    let src = r#"
+        type Light = enum { Red, Green };
+        fn main() {
+            let l = Light::Red;
+            println("light: ", l);
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("cannot render")),
+        "enum printing must stay legal; got: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn abs_on_string_is_a_check_error() {
+    let src = r#"
+        fn main() {
+            println(abs("hi"));
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("`abs` takes numeric")),
+        "expected numeric-builtin diag; got: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn field_typo_gets_did_you_mean() {
+    let src = r#"
+        type Order { quantity: Int = 0; }
+        fn main() {
+            let o = Order { quantity: 2 };
+            println(o.quantty);
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("did you mean `quantity`")),
+        "expected did-you-mean; got: {:?}",
+        ds
+    );
+}


### PR DESCRIPTION
Closes #241 — all three checkboxes.

**Source-context snippets.** Every rendered diagnostic now shows the offending line + a caret underline sized to the span (tab-preserving alignment; suppressed for synthetic spans):

```
t.hl:6:5: type error: method `go` takes at most 0 arguments, got 1
    a.go(7);
    ^^^^
```

**Did-you-mean for user scope.** The strict no-field diagnostic suggests the nearest name from the receiver's own surface (locus params+methods, perspective, struct fields), via a generalized `nearest_name` with the stdlib suggester's threshold policy: ``no field `quantty` on `Order` — did you mean `quantity`?``

**The audit** (full inventory posted on the issue). ~973 `CodegenError` raises; the user-reachable spanless band is now closed from both ends:
- *Check-phase catches*: printing a struct/locus (`println`/`print`/`to_string`/`String + x`) — previously an explicit `ty_is_printable` deferral to a spanless codegen death, now resolved enum-vs-struct through the symbol table; `abs`/`min`/`max` on non-numerics. Both guarded against user shadowing.
- *Plumbing for whatever escapes next*: `CodegenError::UnsupportedAt(msg, span)` + `DiagKind::Codegen` — codegen raises can carry a location and the CLI renders them with the same file:line:col + caret treatment; the generic-arg mangle raises are converted as the first users.

Tests: `diag_quality.rs` (5 cases incl. enum-print-stays-legal) + updated render test; hale-types/syntax/lsp/cli suites + corpus green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)