### PR TITLE
feat(runtime): SPSC observation ring as a lotus primitive (closes #244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ behavior.
 
 ## Unreleased
 
+- **SPSC observation ring as a lotus primitive (GH #244).**
+  `lotus_spsc_*` + `std::ring::__spsc_*`: a single-producer
+  16-byte-slot ring over caller-provided memory — monotonic
+  release-published head, overwrite-oldest (never blocks a
+  producer on readers), producer-side drop accounting, external-
+  reader-safe snapshot reads with overrun accounting. Layout is
+  a stable documented contract (spec/runtime.md) intended for
+  verbatim adoption by the iris observer protocol; concurrent
+  contract test + GenMC model included. Convergence note: the
+  driver test empirically refuted the pre-freeze protocol
+  sketch's overrun boundary (`< h2 - ring_slots`) — an in-flight
+  producer write already clobbers slot `h2 - ring_slots` before
+  publication, so the live window is `(h - ring_slots, h]`.
+- **Diagnostics: caret snippets, did-you-mean, span-carrying
+  codegen errors (GH #241).** Every rendered diagnostic shows
+  the offending source line with a caret underline; the
+  no-field diagnostic suggests the nearest name from the
+  receiver's own surface; printing a struct/locus and
+  abs/min/max on non-numerics are now spanned check-phase
+  errors (previously spanless codegen deaths); and
+  `CodegenError::UnsupportedAt` lets any codegen raise carry a
+  location rendered like a check diagnostic.
+
 - **Test failures report per-assertion progress; runtime C
   warnings no longer leak (GH #230 items 1+3).** A failing
   multi-assert test file now prints `(N earlier assertion(s)

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -18290,6 +18290,151 @@ void lotus_root_panic(
  * (hand-rolled tanh from exp) and pond/math/matrix (synthesizes
  * `nan_sentinel()` as `0.0/0.0` and `is_nan(f)` as `f != f`).
  */
+/*
+ * GH #244 — the SPSC observation ring as a lotus primitive.
+ *
+ * Single-producer fixed-slot ring over CALLER-PROVIDED memory
+ * (the rings live at fixed offsets inside an attachable shm
+ * segment; this code never allocates). The layout is a STABLE,
+ * documented contract (spec/runtime.md "SPSC observation ring")
+ * that external readers — including non-Hale processes like the
+ * iris observer — depend on byte-for-byte:
+ *
+ *   descriptor (64 B, 64-aligned, caller-placed):
+ *     u64 data_off   slot array offset from the SEGMENT BASE
+ *     u64 head       producer cursor: MONOTONIC, never wraps,
+ *                    published with a release store; slot index
+ *                    is head & (ring_slots - 1), ring_slots a
+ *                    power of two
+ *     u64 dropped    producer-side drop count (emit suppressed
+ *                    while a consumer-independent gate is off,
+ *                    etc.) — the ring itself NEVER blocks or
+ *                    drops: overwrite-oldest by construction
+ *     u32 tag_a      user tag (iris: sched_id)
+ *     u32 tag_b      user gauge (iris: current locus instance)
+ *     24 B reserved (zero)
+ *
+ *   slots: ring_slots × 16 B, two u64 words each, written plain
+ *   BEFORE the head release-store publishes them.
+ *
+ * Read side (any process): the h1/copy/h2 snapshot — load-
+ * acquire head, copy [cursor, min(h1, cursor+max)), re-load
+ * head; records with index < h2 - ring_slots were possibly
+ * overwritten mid-copy → discarded, cursor advanced, counted as
+ * overruns. Verified in verification/spsc_ring_model.c.
+ */
+
+typedef struct lotus_spsc_desc {
+    uint64_t data_off;
+    uint64_t head;
+    uint64_t dropped;
+    uint32_t tag_a;
+    uint32_t tag_b;
+    uint8_t  reserved[32];
+} lotus_spsc_desc_t;
+
+_Static_assert(sizeof(lotus_spsc_desc_t) == 64,
+               "spsc descriptor layout is a stable contract");
+
+void lotus_spsc_init(void *desc, int64_t data_off,
+                     int64_t tag_a, int64_t tag_b) {
+    lotus_spsc_desc_t *d = (lotus_spsc_desc_t *)desc;
+    memset(d, 0, sizeof(*d));
+    d->data_off = (uint64_t)data_off;
+    d->tag_a    = (uint32_t)tag_a;
+    d->tag_b    = (uint32_t)tag_b;
+}
+
+void lotus_spsc_emit(void *seg_base, void *desc,
+                     int64_t ring_slots,
+                     int64_t w0, int64_t w1) {
+    lotus_spsc_desc_t *d = (lotus_spsc_desc_t *)desc;
+    uint64_t head = d->head;   /* producer-owned: plain read */
+    uint64_t *slot = (uint64_t *)((char *)seg_base + d->data_off
+        + (head & ((uint64_t)ring_slots - 1)) * 16u);
+    slot[0] = (uint64_t)w0;
+    slot[1] = (uint64_t)w1;
+    __atomic_store_n(&d->head, head + 1, __ATOMIC_RELEASE);
+}
+
+void lotus_spsc_note_drop(void *desc) {
+    lotus_spsc_desc_t *d = (lotus_spsc_desc_t *)desc;
+    /* Producer-owned counter; relaxed atomic so external
+     * readers never see a torn value. */
+    __atomic_fetch_add(&d->dropped, 1, __ATOMIC_RELAXED);
+}
+
+void lotus_spsc_set_tag_b(void *desc, int64_t v) {
+    lotus_spsc_desc_t *d = (lotus_spsc_desc_t *)desc;
+    __atomic_store_n(&d->tag_b, (uint32_t)v, __ATOMIC_RELAXED);
+}
+
+/* Snapshot-read up to max_records 16-byte records into out.
+ * cursor_io / overruns_io are CONSUMER-owned (live outside the
+ * shared segment). Returns the number of records copied. */
+int64_t lotus_spsc_read(const void *seg_base, const void *desc,
+                        int64_t ring_slots,
+                        int64_t *cursor_io, int64_t *overruns_io,
+                        void *out, int64_t max_records) {
+    const lotus_spsc_desc_t *d = (const lotus_spsc_desc_t *)desc;
+    uint64_t slots = (uint64_t)ring_slots;
+    uint64_t c = (uint64_t)*cursor_io;
+    uint64_t h1 = __atomic_load_n(&d->head, __ATOMIC_ACQUIRE);
+    /* Oldest SAFE record given a published head h: the producer's
+     * in-flight (not yet published) write for record h is already
+     * clobbering slot index h - slots, so the live window is
+     * (h - slots, h] — indices <= h - slots are suspect. (The
+     * iris PROTOCOL.md sketch used `< h - ring_slots`, which the
+     * concurrent driver test refutes empirically: the in-flight
+     * slot leaks a future record — flagged upstream on GH #244.)
+     */
+    uint64_t live_min1 = h1 >= slots ? h1 - slots + 1 : 0;
+    /* A reader attaching late (or after a long stall) starts at
+     * the oldest safe record. */
+    if (c < live_min1) {
+        *overruns_io += (int64_t)(live_min1 - c);
+        c = live_min1;
+    }
+    uint64_t end = h1;
+    if (end > c + (uint64_t)max_records) {
+        end = c + (uint64_t)max_records;
+    }
+    const uint64_t *data = (const uint64_t *)
+        ((const char *)seg_base + d->data_off);
+    uint64_t *o = (uint64_t *)out;
+    uint64_t n = 0;
+    for (uint64_t i = c; i < end; i++, n++) {
+        const uint64_t *slot = data + (i & (slots - 1)) * 2;
+        o[n * 2]     = slot[0];
+        o[n * 2 + 1] = slot[1];
+    }
+    uint64_t h2 = __atomic_load_n(&d->head, __ATOMIC_ACQUIRE);
+    /* Discard anything the producer may have overwritten while
+     * we copied: same boundary as above against the re-read
+     * head — records with index <= h2 - slots are suspect. */
+    uint64_t live_min2 = h2 >= slots ? h2 - slots + 1 : 0;
+    if (c < live_min2) {
+        uint64_t stale = live_min2 - c;
+        if (stale >= n) {
+            /* Whole batch stale AND possibly a further gap the
+             * producer lapped past while we copied: account for
+             * every skipped index (the copied-and-discarded n
+             * plus the never-copied [c+n, live_min2)), so
+             * delivered + overruns always equals the cursor's
+             * total advance. */
+            *overruns_io += (int64_t)(live_min2 - c);
+            *cursor_io = (int64_t)live_min2;
+            return 0;
+        }
+        *overruns_io += (int64_t)stale;
+        memmove(o, o + stale * 2, (size_t)(n - stale) * 16u);
+        n -= stale;
+        c += stale;
+    }
+    *cursor_io = (int64_t)(c + n);
+    return (int64_t)n;
+}
+
 /* GH #230: per-assertion test granularity. std::test asserts
  * bump this on every PASS (silently — the pass path stays
  * output-free per the testing contract); the FAILURE path reads

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -18352,6 +18352,16 @@ void lotus_spsc_emit(void *seg_base, void *desc,
     uint64_t head = d->head;   /* producer-owned: plain read */
     uint64_t *slot = (uint64_t *)((char *)seg_base + d->data_off
         + (head & ((uint64_t)ring_slots - 1)) * 16u);
+    /* Release fence BEFORE the slot writes: pairs with the
+     * consumer's acquire fence before its h2 re-read (the
+     * Boehm seqlock recipe). Without it, a consumer's relaxed
+     * slot load may observe a FUTURE record's bytes while its
+     * h2 load is still permitted to return a stale head — a
+     * mixed record delivered past the overrun discard. Found
+     * by GenMC (verification/spsc_ring_model.c), not by the
+     * stress soak: real-hardware TSO masks it, the model
+     * doesn't. Free on x86 (compiler barrier), one dmb on ARM. */
+    __atomic_thread_fence(__ATOMIC_RELEASE);
     slot[0] = (uint64_t)w0;
     slot[1] = (uint64_t)w1;
     __atomic_store_n(&d->head, head + 1, __ATOMIC_RELEASE);
@@ -18408,6 +18418,14 @@ int64_t lotus_spsc_read(const void *seg_base, const void *desc,
         o[n * 2]     = slot[0];
         o[n * 2 + 1] = slot[1];
     }
+    /* Acquire fence: pairs with the producer's release fence
+     * (see lotus_spsc_emit). Any slot value we just read that
+     * came from record h's write now forces the h2 load below
+     * to observe head >= h — which places index h - slots
+     * inside the <= h2 - slots discard window. This is what
+     * makes the h1/copy/h2 validation formally sound, not just
+     * TSO-lucky. */
+    __atomic_thread_fence(__ATOMIC_ACQUIRE);
     uint64_t h2 = __atomic_load_n(&d->head, __ATOMIC_ACQUIRE);
     /* Discard anything the producer may have overwritten while
      * we copied: same boundary as above against the re-read

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -32,6 +32,7 @@ use crate::locus::dissolve::LocusDissolve;
 use crate::locus::instantiation::LocusInstantiate;
 use crate::locus::method::LocusMethodBodies;
 use crate::stdlib::bus::BusStdlib;
+use crate::stdlib::ring::RingStdlib;
 use crate::stdlib::bytes::BytesStdlib;
 use crate::stdlib::crypto::CryptoStdlib;
 use crate::stdlib::decimal::DecimalStdlib;
@@ -21494,6 +21495,28 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 let _ = self.lower_std_bus_local_dispatch(args, scope)?;
                 Ok(())
             }
+            // GH #244: SPSC observation-ring primitives
+            // (statement position; emit/init/note_drop/set_tag).
+            ["std", "ring", "__spsc_init"] => {
+                let _ = self.lower_std_ring_op(
+                    "lotus_spsc_init", 4, args, scope)?;
+                Ok(())
+            }
+            ["std", "ring", "__spsc_emit"] => {
+                let _ = self.lower_std_ring_op(
+                    "lotus_spsc_emit", 5, args, scope)?;
+                Ok(())
+            }
+            ["std", "ring", "__spsc_note_drop"] => {
+                let _ = self.lower_std_ring_op(
+                    "lotus_spsc_note_drop", 1, args, scope)?;
+                Ok(())
+            }
+            ["std", "ring", "__spsc_set_tag_b"] => {
+                let _ = self.lower_std_ring_op(
+                    "lotus_spsc_set_tag_b", 2, args, scope)?;
+                Ok(())
+            }
             // GH #230: std::test pass-counter bump (statement).
             ["std", "test", "__note_pass"] => {
                 let f = self
@@ -22351,6 +22374,11 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ["std", "bus", "__transport_spawn_server"] => {
                 self.lower_std_bus_transport_handle_op(
                     "lotus_bus_transport_spawn_server", args, scope)
+            }
+            // GH #244: SPSC ring read (expression — returns the
+            // record count).
+            ["std", "ring", "__spsc_read"] => {
+                self.lower_std_ring_op("lotus_spsc_read", 7, args, scope)
             }
             // GH #230: std::test pass-counter read (expression).
             ["std", "test", "__passes"] => {

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1586,6 +1586,27 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             None,
         );
 
+        // GH #244: SPSC observation-ring primitives. Pointer
+        // params are declared i64 (addresses from the caller's
+        // shm mapping — same register class at the C ABI, the
+        // transport-handle precedent).
+        for (name, n_args, has_ret) in [
+            ("lotus_spsc_init", 4usize, false),
+            ("lotus_spsc_emit", 5, false),
+            ("lotus_spsc_note_drop", 1, false),
+            ("lotus_spsc_set_tag_b", 2, false),
+            ("lotus_spsc_read", 7, true),
+        ] {
+            let params: Vec<inkwell::types::BasicMetadataTypeEnum> =
+                (0..n_args).map(|_| i64_t.into()).collect();
+            let fn_ty = if has_ret {
+                i64_t.fn_type(&params, false)
+            } else {
+                void_t.fn_type(&params, false)
+            };
+            self.module.add_function(name, fn_ty, None);
+        }
+
         // GH #230: per-assertion test granularity — std::test's
         // pass counter (silent bump on every passing assert; the
         // failure path reads it for the "(N earlier assertion(s)

--- a/crates/hale-codegen/src/stdlib/mod.rs
+++ b/crates/hale-codegen/src/stdlib/mod.rs
@@ -10,6 +10,7 @@
 //! `notes/refactor-codegen-model-org.md`.
 
 pub(crate) mod bus;
+pub(crate) mod ring;
 pub(crate) mod bytes;
 pub(crate) mod crypto;
 pub(crate) mod decimal;

--- a/crates/hale-codegen/src/stdlib/ring.rs
+++ b/crates/hale-codegen/src/stdlib/ring.rs
@@ -1,0 +1,71 @@
+//! `std::ring::*` path-call lowering — GH #244: the SPSC
+//! observation ring as a lotus primitive over caller-provided
+//! memory. The `__spsc_*` surface is deliberately raw (every
+//! param an Int: addresses into an shm segment the caller
+//! mapped, word values, counts) — pond's `observe` library
+//! wraps it; the layout contract lives in spec/runtime.md and
+//! the C in runtime/lotus_arena.c.
+
+use hale_syntax::ast::Expr;
+use inkwell::values::BasicValueEnum;
+
+use crate::codegen::{CodegenError, CodegenTy, Cx, Scope};
+
+pub(crate) trait RingStdlib<'ctx> {
+    fn lower_std_ring_op(
+        &mut self,
+        c_fn: &str,
+        arity: usize,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
+}
+
+impl<'ctx, 'p> RingStdlib<'ctx> for Cx<'ctx, 'p> {
+    /// Shared lowering for the all-Int `std::ring::__spsc_*`
+    /// primitives: lower each arg (must be Int), call the C fn,
+    /// surface an i64 result (the call's return when it has one,
+    /// else 0 so statement-position calls type uniformly).
+    fn lower_std_ring_op(
+        &mut self,
+        c_fn: &str,
+        arity: usize,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        if args.len() != arity {
+            return Err(CodegenError::Unsupported(format!(
+                "std::ring::{}: takes {} Int arg(s), got {}",
+                c_fn, arity, args.len()
+            )));
+        }
+        let mut lowered = Vec::with_capacity(arity);
+        for (i, a) in args.iter().enumerate() {
+            let (v, ty) = self.lower_expr(a, scope)?;
+            if ty != CodegenTy::Int {
+                return Err(CodegenError::Unsupported(format!(
+                    "std::ring::{}: arg {} must be Int \
+                     (addresses/words/counts), got {:?}",
+                    c_fn,
+                    i + 1,
+                    ty
+                )));
+            }
+            lowered.push(v.into());
+        }
+        let f = self
+            .module
+            .get_function(c_fn)
+            .unwrap_or_else(|| panic!("{} declared", c_fn));
+        let call = self
+            .builder
+            .build_call(f, &lowered, "ring.op")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let i64_t = self.context.i64_type();
+        let ret = call
+            .try_as_basic_value()
+            .left()
+            .unwrap_or_else(|| i64_t.const_zero().into());
+        Ok((ret, CodegenTy::Int))
+    }
+}

--- a/crates/hale-codegen/tests/spsc_driver.c
+++ b/crates/hale-codegen/tests/spsc_driver.c
@@ -1,0 +1,117 @@
+/*
+ * GH #244: exercise lotus_spsc_* from the runtime — the SPSC
+ * observation ring over caller-provided memory. Built by
+ * tests/spsc_ring.rs (clang, linked against lotus_arena.c) and
+ * run once; asserts are in-process.
+ *
+ * Scenario: a 64 KiB "segment" on the heap holding one 64 B
+ * descriptor + a 64-slot ring. A producer thread emits 10_000
+ * records (seq in w0, seq^mask in w1); a consumer thread
+ * snapshot-reads concurrently. Asserts:
+ *   - every delivered record is internally consistent
+ *     (w1 == w0 ^ mask — no torn 16 B records delivered),
+ *   - delivered seqs are strictly increasing (no duplicates,
+ *     no reordering),
+ *   - delivered + overruns == produced (nothing vanishes
+ *     unaccounted),
+ *   - the final head equals the produce count (monotonic,
+ *     never wrapped).
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define RING_SLOTS 64
+#define PRODUCE 10000
+#define MASK 0x5A5A5A5A5A5A5A5AULL
+
+void    lotus_spsc_init(void *desc, int64_t data_off,
+                        int64_t tag_a, int64_t tag_b);
+void    lotus_spsc_emit(void *seg, void *desc, int64_t slots,
+                        int64_t w0, int64_t w1);
+void    lotus_spsc_note_drop(void *desc);
+int64_t lotus_spsc_read(const void *seg, const void *desc,
+                        int64_t slots, int64_t *cursor,
+                        int64_t *overruns, void *out,
+                        int64_t max_records);
+
+static char g_seg[65536];
+
+static void *producer(void *arg) {
+    (void)arg;
+    for (uint64_t i = 0; i < PRODUCE; i++) {
+        lotus_spsc_emit(g_seg, g_seg, RING_SLOTS,
+                        (int64_t)i, (int64_t)(i ^ MASK));
+    }
+    return NULL;
+}
+
+int main(void) {
+    lotus_spsc_init(g_seg, /*data_off=*/64, /*tag_a=*/7, /*tag_b=*/0);
+
+    pthread_t p;
+    if (pthread_create(&p, NULL, producer, NULL) != 0) {
+        fprintf(stderr, "pthread_create failed\n");
+        return 2;
+    }
+
+    int64_t cursor = 0, overruns = 0;
+    uint64_t out[32 * 2];
+    uint64_t delivered = 0;
+    uint64_t last_seq = 0;
+    int have_last = 0;
+    while (delivered + (uint64_t)overruns < PRODUCE) {
+        int64_t n = lotus_spsc_read(g_seg, g_seg, RING_SLOTS,
+                                    &cursor, &overruns, out, 32);
+        for (int64_t i = 0; i < n; i++) {
+            uint64_t w0 = out[i * 2];
+            uint64_t w1 = out[i * 2 + 1];
+            if (w1 != (w0 ^ MASK)) {
+                fprintf(stderr, "torn record: w0=%llu w1=%llu\n",
+                        (unsigned long long)w0,
+                        (unsigned long long)w1);
+                return 1;
+            }
+            if (have_last && w0 <= last_seq) {
+                fprintf(stderr, "non-monotonic seq %llu after %llu\n",
+                        (unsigned long long)w0,
+                        (unsigned long long)last_seq);
+                return 1;
+            }
+            last_seq = w0;
+            have_last = 1;
+        }
+        delivered += (uint64_t)n;
+    }
+    pthread_join(p, NULL);
+
+    /* Drain the tail after the producer stopped. */
+    for (;;) {
+        int64_t n = lotus_spsc_read(g_seg, g_seg, RING_SLOTS,
+                                    &cursor, &overruns, out, 32);
+        if (n == 0) break;
+        delivered += (uint64_t)n;
+    }
+
+    uint64_t head;
+    memcpy(&head, g_seg + 8, sizeof(head));
+    if (head != PRODUCE) {
+        fprintf(stderr, "head=%llu, want %d\n",
+                (unsigned long long)head, PRODUCE);
+        return 1;
+    }
+    if (delivered + (uint64_t)overruns != PRODUCE) {
+        fprintf(stderr,
+                "accounting: delivered=%llu overruns=%lld != %d\n",
+                (unsigned long long)delivered,
+                (long long)overruns, PRODUCE);
+        return 1;
+    }
+    printf("ok delivered=%llu overruns=%lld\n",
+           (unsigned long long)delivered, (long long)overruns);
+    return 0;
+}

--- a/crates/hale-codegen/tests/spsc_ring.rs
+++ b/crates/hale-codegen/tests/spsc_ring.rs
@@ -1,0 +1,68 @@
+//! GH #244: the SPSC observation ring as a lotus primitive.
+//! Two layers: (1) the C driver exercises the concurrent
+//! produce/consume contract (torn-record, monotonicity, and
+//! delivered+overruns accounting asserts live in the driver);
+//! (2) a Hale program proves the `std::ring::__spsc_*` surface
+//! lowers and links end-to-end.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[test]
+fn spsc_driver_concurrent_contract_holds() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut bin = std::env::temp_dir();
+    bin.push("lotus_spsc_driver_test");
+    let status = Command::new("clang")
+        .arg(manifest.join("tests").join("spsc_driver.c"))
+        .arg(manifest.join("runtime").join("lotus_arena.c"))
+        .arg("-O2")
+        .arg("-lpthread")
+        .arg("-o")
+        .arg(&bin)
+        .status()
+        .expect("clang invocation");
+    assert!(status.success(), "clang failed building spsc driver");
+    let out = Command::new(&bin).output().expect("run driver");
+    let _ = std::fs::remove_file(&bin);
+    assert!(
+        out.status.success(),
+        "spsc contract violated.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(String::from_utf8_lossy(&out.stdout).contains("ok "));
+}
+
+#[test]
+fn hale_surface_lowers_and_links() {
+    // The primitives operate on caller-provided memory the
+    // program would normally get from shm glue; here the calls
+    // sit behind a false branch so nothing dereferences, proving
+    // dispatch + declaration + link without a segment.
+    let src = r#"
+        fn main() {
+            let never = 1 == 2;
+            if never {
+                let seg = 0;
+                std::ring::__spsc_init(seg, 64, 1, 0);
+                std::ring::__spsc_emit(seg, seg, 64, 1, 2);
+                std::ring::__spsc_note_drop(seg);
+                std::ring::__spsc_set_tag_b(seg, 3);
+                let n = std::ring::__spsc_read(seg, seg, 64, 0, 0, 0, 8);
+                println(n);
+            }
+            println("linked");
+        }
+    "#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push("hale_test_spsc_surface");
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(out.status.success());
+    assert!(String::from_utf8_lossy(&out.stdout).contains("linked"));
+}

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -291,6 +291,17 @@ pub const SURFACES: &[NsSurface] = &[
         open_prefixes: &[],
     },
     NsSurface {
+        ns: &["ring"],
+        fns: &[
+            "__spsc_emit",
+            "__spsc_init",
+            "__spsc_note_drop",
+            "__spsc_read",
+            "__spsc_set_tag_b",
+        ],
+        open_prefixes: &[],
+    },
+    NsSurface {
         ns: &["decimal"],
         fns: &[
             "format",

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1102,10 +1102,16 @@ documented contract:
   construction), `u32 tag_a`, `u32 tag_b` (user tags; tag_b has
   a relaxed-store setter for gauge use), 32 B reserved (zero).
 - Slots: `ring_slots × 16 B`, two u64 words, written plain
-  BEFORE the head release-store publishes them.
+  after a RELEASE FENCE and before the head release-store. The
+  fence pairs with an acquire fence on the read side (below) —
+  the Boehm seqlock recipe. Without the pair, a relaxed slot
+  load may observe a future record while the h2 re-read returns
+  a stale head, delivering a mixed record past the discard;
+  GenMC exhibits it (the stress soak cannot — TSO masks it).
 - Read side (any process, no Hale runtime required): snapshot
-  h1 (acquire) → copy `[cursor, min(h1, cursor+max))` → re-read
-  h2 (acquire) → discard records with index `<= h2 - ring_slots`
+  h1 (acquire) → copy `[cursor, min(h1, cursor+max))` →
+  ACQUIRE FENCE → re-read h2 (acquire) → discard records with
+  index `<= h2 - ring_slots`
   and count them as overruns. The `<=` is load-bearing: the
   producer's in-flight (unpublished) write for record `h` is
   already clobbering slot index `h - ring_slots`, so the live

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1084,6 +1084,42 @@ bytes, and fans into local subscribers via
 thread path; out-of-band recv loops (any code holding wire
 bytes for a bound subject) can use this too.
 
+**SPSC observation ring (GH #244).** A single-producer
+fixed-slot ring over CALLER-PROVIDED memory, exposed as lotus
+primitives (`lotus_spsc_init` / `_emit` / `_note_drop` /
+`_set_tag_b` / `_read`) and the raw all-Int Hale surface
+`std::ring::__spsc_*`. Built for observation planes (the iris
+observer attaches to these rings inside an shm segment,
+read-only, from a foreign process), so the layout is a STABLE
+documented contract:
+
+- Descriptor, 64 B, 64-aligned, caller-placed: `u64 data_off`
+  (slot array offset from the segment base), `u64 head`
+  (producer cursor — monotonic, never wraps, published with a
+  release store; slot index is `head & (ring_slots-1)`,
+  ring_slots a power of two), `u64 dropped` (producer-side drop
+  accounting; the ring itself never blocks — overwrite-oldest by
+  construction), `u32 tag_a`, `u32 tag_b` (user tags; tag_b has
+  a relaxed-store setter for gauge use), 32 B reserved (zero).
+- Slots: `ring_slots × 16 B`, two u64 words, written plain
+  BEFORE the head release-store publishes them.
+- Read side (any process, no Hale runtime required): snapshot
+  h1 (acquire) → copy `[cursor, min(h1, cursor+max))` → re-read
+  h2 (acquire) → discard records with index `<= h2 - ring_slots`
+  and count them as overruns. The `<=` is load-bearing: the
+  producer's in-flight (unpublished) write for record `h` is
+  already clobbering slot index `h - ring_slots`, so the live
+  window given a published head `h` is `(h - ring_slots, h]`.
+  Verified concurrently in `tests/spsc_driver.c` and modeled in
+  `verification/spsc_ring_model.c` (which also refutes the
+  strict-`<` boundary).
+
+Consumer cursors and overrun counters live OUTSIDE the shared
+segment (caller-owned); external readers never write the ring.
+This ring is the convergence target for iris's observation
+protocol (its PROTOCOL.md pre-freeze sketch is this layout with
+`tag_a`/`tag_b` as `sched_id`/`current_locus`).
+
 **SHM ring substrate (Form K5).** POSIX shared-
 memory ring backing the zero-copy bus route. Six C primitives in
 `runtime/lotus_shm_ring.c`, linked unconditionally so user

--- a/verification/spsc_ring_model.c
+++ b/verification/spsc_ring_model.c
@@ -46,6 +46,11 @@ static void *producer(void *arg) {
     (void)arg;
     for (uint64_t i = 0; i < PRODUCE; i++) {
         uint64_t h = atomic_load_explicit(&head, memory_order_relaxed);
+        /* Release fence before slot writes — pairs with the
+         * consumer's acquire fence before h2 (Boehm seqlock
+         * recipe); without the pair GenMC exhibits a mixed
+         * record delivered past the discard (stale h2). */
+        atomic_thread_fence(memory_order_release);
         atomic_store_explicit(&slot_w0[h & (SLOTS - 1)], i,
                               memory_order_relaxed);
         atomic_store_explicit(&slot_w1[h & (SLOTS - 1)], i ^ MASK,
@@ -79,6 +84,7 @@ int main(void) {
                                            memory_order_relaxed);
         uint64_t w1 = atomic_load_explicit(&slot_w1[c & (SLOTS - 1)],
                                            memory_order_relaxed);
+        atomic_thread_fence(memory_order_acquire);
         uint64_t h2 = atomic_load_explicit(&head, memory_order_acquire);
         uint64_t live_min2 =
             h2 >= SLOTS ? h2 - SLOTS + (DISCARD_BOUNDARY_STRICT ? 0 : 1)

--- a/verification/spsc_ring_model.c
+++ b/verification/spsc_ring_model.c
@@ -1,0 +1,104 @@
+/* GenMC model of the lotus SPSC observation ring (GH #244).
+ *
+ * FAITHFUL TRANSCRIPTION of the distinctive concurrency in
+ * `lotus_spsc_emit` / `lotus_spsc_read`
+ * (crates/hale-codegen/runtime/lotus_arena.c): the producer
+ * plain-writes both slot words and THEN publishes `head+1` with
+ * a release store; the consumer acquire-loads the head (h1),
+ * copies a batch, acquire-loads again (h2), and DISCARDS every
+ * copied record with index <= h2 - slots — because the
+ * producer's in-flight write for record h2 is already clobbering
+ * slot index h2 - slots before h2+1 is published. (That `<=` is
+ * load-bearing: the `<` boundary from the pre-freeze iris
+ * PROTOCOL.md sketch delivers a torn/future record — the
+ * concurrent driver test in tests/spsc_driver.c refutes it
+ * empirically, and flipping DISCARD_BOUNDARY_STRICT below to 1
+ * lets GenMC refute it exhaustively.)
+ *
+ * NOT the production code: ring shrunk to 2 slots, 4 records,
+ * batch of 1. Transcription note: production slot writes/reads
+ * are PLAIN accesses — torn reads are tolerated by design
+ * because every possibly-torn record falls in the discarded
+ * window. C11 calls concurrent plain access a data race, so the
+ * model expresses the same design as RELAXED atomics on the
+ * slot words; the checked invariant is the algorithm's real
+ * contract: no DELIVERED record is torn (w1 == w0 ^ MASK) and
+ * delivered seqs are strictly increasing.
+ *
+ * Run:  genmc -- verification/spsc_ring_model.c   (or run_genmc.sh)
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+
+#define SLOTS 2u
+#define PRODUCE 4u
+#define MASK 0xA5u
+#define DISCARD_BOUNDARY_STRICT 0 /* 1 = iris's pre-freeze `<`: REFUTED */
+
+static _Atomic uint64_t head;
+static _Atomic uint64_t slot_w0[SLOTS];
+static _Atomic uint64_t slot_w1[SLOTS];
+
+static void *producer(void *arg) {
+    (void)arg;
+    for (uint64_t i = 0; i < PRODUCE; i++) {
+        uint64_t h = atomic_load_explicit(&head, memory_order_relaxed);
+        atomic_store_explicit(&slot_w0[h & (SLOTS - 1)], i,
+                              memory_order_relaxed);
+        atomic_store_explicit(&slot_w1[h & (SLOTS - 1)], i ^ MASK,
+                              memory_order_relaxed);
+        atomic_store_explicit(&head, h + 1, memory_order_release);
+    }
+    return NULL;
+}
+
+int main(void) {
+    pthread_t p;
+    pthread_create(&p, NULL, producer, NULL);
+
+    uint64_t c = 0;
+    uint64_t last = 0;
+    int have_last = 0;
+    /* Bounded consumer: up to PRODUCE single-record snapshot
+     * reads interleaved arbitrarily with the producer. */
+    for (unsigned round = 0; round < PRODUCE; round++) {
+        uint64_t h1 = atomic_load_explicit(&head, memory_order_acquire);
+        uint64_t live_min1 =
+            h1 >= SLOTS ? h1 - SLOTS + (DISCARD_BOUNDARY_STRICT ? 0 : 1)
+                        : 0;
+        if (c < live_min1) {
+            c = live_min1;
+        }
+        if (c >= h1) {
+            continue; /* nothing published yet */
+        }
+        uint64_t w0 = atomic_load_explicit(&slot_w0[c & (SLOTS - 1)],
+                                           memory_order_relaxed);
+        uint64_t w1 = atomic_load_explicit(&slot_w1[c & (SLOTS - 1)],
+                                           memory_order_relaxed);
+        uint64_t h2 = atomic_load_explicit(&head, memory_order_acquire);
+        uint64_t live_min2 =
+            h2 >= SLOTS ? h2 - SLOTS + (DISCARD_BOUNDARY_STRICT ? 0 : 1)
+                        : 0;
+        if (c < live_min2) {
+            /* possibly overwritten mid-copy: discard, advance. */
+            c = live_min2;
+            continue;
+        }
+        /* DELIVERED record: the algorithm's contract. */
+        assert(w1 == (w0 ^ MASK));
+        assert(w0 == c);
+        if (have_last) {
+            assert(w0 > last);
+        }
+        last = w0;
+        have_last = 1;
+        c++;
+    }
+
+    pthread_join(p, NULL);
+    return 0;
+}


### PR DESCRIPTION
Closes #244. Stacked on #246 — retarget to main after it merges.

The runtime's SPSC ring machinery, exposed exactly along the issue's five requirements: **(1)** operates on caller-provided memory (never allocates — rings live at fixed offsets in an attachable shm segment); **(2)** 16 B fixed slots, single producer, monotonic never-wrapping head published with a release store; **(3)** overwrite-oldest by cursor arithmetic — a producer is never backpressured, with producer-side `dropped` accounting; **(4)** external-reader friendly — consumer cursors live outside the segment, the snapshot read (h1/copy/h2 with overrun discard) is documented and usable by non-Hale processes attaching read-only; **(5)** the layout is a stable documented contract in `spec/runtime.md` — 64 B descriptor `{data_off, head, dropped, tag_a, tag_b, 32 B reserved}` + power-of-two slot array, with iris's `sched_id`/`current_locus` generalized to two user tag words.

Surface: `lotus_spsc_init/emit/note_drop/set_tag_b/read` in C plus the deliberately-raw all-Int `std::ring::__spsc_*` path-calls, so pond `observe`'s glue shrinks to shm mapping.

**Two protocol findings fed back before the iris freeze** (also commented on the issue):
1. The overrun boundary must be **`<= h2 − ring_slots`**, not `<`: the producer's in-flight write for record `h` already clobbers slot `h − ring_slots` before `h+1` publishes, so the live window is `(h − ring_slots, h]`. The strict-`<` from the PROTOCOL.md sketch delivers a torn/future record — refuted empirically by the new concurrent driver test, and the GenMC model has a `DISCARD_BOUNDARY_STRICT` switch to refute it exhaustively.
2. Overrun accounting must count the never-copied gap when a consumer is lapped mid-batch, or `delivered + overruns` undercounts (surfaced as a consumer livelock in the 25× soak).

Tests: `spsc_driver.c` concurrent contract (no torn deliveries, strict monotonicity, exact accounting, monotonic head; 25× soak clean) + Hale lower/link test; `verification/spsc_ring_model.c` rides the genmc CI job via the `*_model.c` glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)