### PR TITLE
test(bus): rearm-scenario subscribers wait-until-delivered (main CI flake)

### DIFF
--- a/crates/hale-codegen/tests/binding_listen_rearm.rs
+++ b/crates/hale-codegen/tests/binding_listen_rearm.rs
@@ -60,7 +60,19 @@ fn listen_binding_serves_sequential_peers() {
             params {{ sub: Sub = Sub {{ }}; }}
             bindings {{ Evt: unix("{}", role: listen); }}
             run() {{
-                std::time::sleep(4000ms);
+                // Wait-until-delivered (cap ~12s), then settle so
+                // the final peer EOF re-arms before teardown — a
+                // fixed sleep flaked on loaded CI (window expired
+                // mid-exchange; teardown ate a queued message).
+                let mut waited = 0;
+                while self.sub.seen < 2 {{
+                    std::time::sleep(100ms);
+                    waited = waited + 1;
+                    if waited > 120 {{
+                        std::process::exit(3);
+                    }}
+                }}
+                std::time::sleep(500ms);
             }}
         }}
         fn main() {{ App {{ }}; }}

--- a/crates/hale-codegen/tests/binding_stream_framing.rs
+++ b/crates/hale-codegen/tests/binding_stream_framing.rs
@@ -52,7 +52,19 @@ fn framed_stream_delivers_and_rearms_without_seq_gaps() {
             params {{ sub: Sub = Sub {{ }}; }}
             bindings {{ Evt: unix("{}", role: listen); }}
             run() {{
-                std::time::sleep(4000ms);
+                // Wait-until-delivered (cap ~12s), then settle so
+                // the final peer EOF re-arms before teardown — a
+                // fixed sleep flaked on loaded CI (window expired
+                // mid-exchange; teardown ate a queued message).
+                let mut waited = 0;
+                while self.sub.seen < 4 {{
+                    std::time::sleep(100ms);
+                    waited = waited + 1;
+                    if waited > 120 {{
+                        std::process::exit(3);
+                    }}
+                }}
+                std::time::sleep(500ms);
             }}
         }}
         fn main() {{ App {{ }}; }}

--- a/crates/hale-codegen/tests/transport_counters.rs
+++ b/crates/hale-codegen/tests/transport_counters.rs
@@ -39,14 +39,27 @@ fn counters_dump_reflects_rearm_scenario() {
         type T {{ n: Int = 0; }}
         topic Evt {{ payload: T; subject: "evt"; }}
         locus Sub {{
+            params {{ seen: Int = 0; }}
             bus {{ subscribe Evt as on_evt; }}
-            fn on_evt(t: T) {{ }}
+            fn on_evt(t: T) {{ self.seen = self.seen + 1; }}
         }}
         main locus App {{
             params {{ sub: Sub = Sub {{ }}; }}
             bindings {{ Evt: unix("{}", role: listen); }}
             run() {{
-                std::time::sleep(4000ms);
+                // Wait-until-delivered (cap ~12s), then settle so
+                // the final peer EOF re-arms before teardown — a
+                // fixed sleep flaked on loaded CI (window expired
+                // mid-exchange; teardown ate a queued message).
+                let mut waited = 0;
+                while self.sub.seen < 2 {{
+                    std::time::sleep(100ms);
+                    waited = waited + 1;
+                    if waited > 120 {{
+                        std::process::exit(3);
+                    }}
+                }}
+                std::time::sleep(500ms);
             }}
         }}
         fn main() {{ App {{ }}; }}


### PR DESCRIPTION
Fixes the `transport_counters::counters_dump_reflects_rearm_scenario` failure on main's post-#247 run — a load-timing flake, not a product bug: the subscriber's fixed 4 s window expired mid-exchange on the loaded runner, teardown's fd shutdown discarded publisher 2's queued message, and the EOF still bumped `rearms` → `delivered=1 rearms=2`.

All three tests sharing the fixed-sleep pattern (`transport_counters`, `binding_listen_rearm`, `binding_stream_framing`) now wait-until-delivered: loop on the subscriber child's `seen` counter in 100 ms slices (~12 s cap, distinct exit code on timeout), then settle 500 ms so the final peer EOF re-arms before teardown. Deterministic under load and faster in the common case (0.9–2.5 s vs the fixed 4 s). 5× local soak clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)