### PR TITLE
fix(imports): register every alias to an already-resolved lib (closes #249, iris F.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ behavior.
 
 ## Unreleased
 
+- **Diamond imports fixed (GH #249, iris friction F.10).** A lib
+  reached a second time — by the entry and by another lib, or by
+  two libs — now registers the second importer's alias against
+  the shared mangled names (seed-rename cache keyed by canonical
+  lib path). Previously the resolver's visited-set dedup skipped
+  the registration, so `alias::Name` references in the second
+  importer leaked into codegen as "qualified type not in stdlib
+  path-renames table" / "unknown type name in signature" while
+  `hale check` passed — with which alias broke depending on
+  import order. This was the bug gating iris's reuse of its
+  spike rendering libs.
+
 - **SPSC observation ring as a lotus primitive (GH #244).**
   `lotus_spsc_*` + `std::ring::__spsc_*`: a single-producer
   16-byte-slot ring over caller-provided memory — monotonic

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -1679,6 +1679,15 @@ fn resolve_imports(
     errors: &mut Vec<(PathBuf, hale_syntax::Diag, String)>,
     merged_items: &mut Vec<hale_syntax::ast::TopDecl>,
     renames: &mut ImportRenames,
+    // iris F.10: per-canonical-lib seed_renames cache. A lib
+    // reached a SECOND time (another importer, its own alias)
+    // has all files in `visited`, so the parse+mangle work is
+    // rightly skipped — but the new alias must still register
+    // against the lib's mangled names, or every `alias::Name`
+    // in the second importer leaks unrenamed into codegen
+    // ("qualified type `g::Rect` not in stdlib path-renames
+    // table" / "unknown type name in signature").
+    seed_cache: &mut BTreeMap<PathBuf, std::collections::HashMap<String, String>>,
 ) -> Result<(), ()> {
     // Defensive guards + env-gated tracing. The guards bound the
     // resolver's accumulators so a future bug (or pathological
@@ -1826,6 +1835,28 @@ fn resolve_imports(
             });
         }
         if parsed_files.is_empty() {
+            // Every file already visited: the lib was resolved
+            // earlier under some other alias. Its decls are
+            // merged and mangled; only THIS alias's rename rows
+            // are missing. lib_canonical_id keys mangled names
+            // off the canonical path, so both aliases map to the
+            // same single compiled copy.
+            let cache_key = match &target {
+                ImportTarget::Directory(d) => {
+                    d.canonicalize().unwrap_or_else(|_| d.clone())
+                }
+                ImportTarget::SingleFile(f) => {
+                    f.canonicalize().unwrap_or_else(|_| f.clone())
+                }
+            };
+            if let Some(cached) = seed_cache.get(&cache_key) {
+                for (name, mangled) in cached {
+                    renames.push((
+                        vec![alias.clone(), name.clone()],
+                        mangled.clone(),
+                    ));
+                }
+            }
             continue;
         }
         // Build the unified rename map across every file in this
@@ -1850,6 +1881,17 @@ fn resolve_imports(
         let lib_id = lib_canonical_id(&target, workspace_root);
         let seed_renames =
             hale_codegen::mangle::build_seed_renames(&stem_prog_refs, &lib_id);
+        {
+            let cache_key = match &target {
+                ImportTarget::Directory(d) => {
+                    d.canonicalize().unwrap_or_else(|_| d.clone())
+                }
+                ImportTarget::SingleFile(f) => {
+                    f.canonicalize().unwrap_or_else(|_| f.clone())
+                }
+            };
+            seed_cache.insert(cache_key, seed_renames.clone());
+        }
         if trace {
             eprintln!("[import]     build_seed_renames done (n={})", seed_renames.len());
         }
@@ -1910,6 +1952,7 @@ fn resolve_imports(
                 errors,
                 merged_items,
                 renames,
+                seed_cache,
             )?;
         }
         // Move mangled items into the merged program; stash sources.
@@ -1992,6 +2035,7 @@ fn parse_with_imports(
     let entry_imports = entry_program.imports.clone();
     let mut merged_items = entry_program.items;
     let mut renames: ImportRenames = Vec::new();
+    let mut seed_cache: BTreeMap<PathBuf, std::collections::HashMap<String, String>> = BTreeMap::new();
 
     if resolve_imports(
         &entry_program.imports,
@@ -2003,6 +2047,7 @@ fn parse_with_imports(
         &mut errors,
         &mut merged_items,
         &mut renames,
+        &mut seed_cache,
     )
     .is_err()
     {
@@ -2740,6 +2785,7 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
     let workspace_root = find_workspace_root(target);
     let mut merged_items = merged.items;
     let mut renames: ImportRenames = Vec::new();
+    let mut seed_cache: BTreeMap<PathBuf, std::collections::HashMap<String, String>> = BTreeMap::new();
     let mut path_sources: BTreeMap<PathBuf, String> = sources.into_iter().collect();
     let mut visited: std::collections::BTreeSet<PathBuf> =
         std::collections::BTreeSet::new();
@@ -2760,6 +2806,7 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         &mut import_errors,
         &mut merged_items,
         &mut renames,
+        &mut seed_cache,
     )
     .is_err()
         || !import_errors.is_empty()
@@ -2876,6 +2923,7 @@ fn run_build(target: &Path) -> ExitCode {
         let workspace_root = find_workspace_root(target);
         let mut merged_items = merged.items;
         let mut renames: ImportRenames = Vec::new();
+    let mut seed_cache: BTreeMap<PathBuf, std::collections::HashMap<String, String>> = BTreeMap::new();
         let mut path_sources: BTreeMap<PathBuf, String> =
             sources.into_iter().collect();
         let mut visited: std::collections::BTreeSet<PathBuf> =
@@ -2898,6 +2946,7 @@ fn run_build(target: &Path) -> ExitCode {
             &mut import_errors,
             &mut merged_items,
             &mut renames,
+            &mut seed_cache,
         )
         .is_err()
         {

--- a/crates/hale-cli/tests/diamond_import.rs
+++ b/crates/hale-cli/tests/diamond_import.rs
@@ -1,0 +1,117 @@
+//! iris friction F.10 (GH #249): diamond imports — a lib reached
+//! a SECOND time (by the entry AND by another lib, or by two
+//! libs) must still register the second importer's alias against
+//! the shared mangled names. Pre-fix, the resolver's visited-set
+//! dedup skipped the alias registration entirely on revisit, so
+//! every `alias::Name` in the second importer leaked unrenamed
+//! into codegen: `hale check` passed (imports aren't
+//! deep-checked) and `hale build` died with "qualified type
+//! `g::Rect` not in stdlib path-renames table" (or the mangled
+//! unknown-type-in-signature variant). The iris shape: iris and
+//! lib/lotus_viz both import lib/raylib.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn write_project(order_viz_first: bool) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "hale_diamond_{}_{}",
+        if order_viz_first { "vf" } else { "gf" },
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("lib/geom")).expect("mkdir");
+    std::fs::create_dir_all(dir.join("lib/viz")).expect("mkdir");
+    std::fs::write(
+        dir.join("lib/geom/types.hl"),
+        r#"type Rect {
+    x: Float = 0.0;
+    w: Float = 0.0;
+}
+"#,
+    )
+    .expect("write geom");
+    // viz reaches geom under its OWN alias `g`, and uses it in a
+    // fn SIGNATURE — the position that leaked.
+    std::fs::write(
+        dir.join("lib/viz/draw.hl"),
+        r#"import "../geom" as g;
+
+fn area(r: g::Rect) -> Float {
+    return r.x * r.w;
+}
+"#,
+    )
+    .expect("write viz");
+    // Both import orders exercised: whichever resolves second
+    // hits the visited-dedup path.
+    let imports = if order_viz_first {
+        "import \"lib/viz\" as viz;\nimport \"lib/geom\" as geo;"
+    } else {
+        "import \"lib/geom\" as geo;\nimport \"lib/viz\" as viz;"
+    };
+    std::fs::write(
+        dir.join("main.hl"),
+        format!(
+            r#"{}
+
+type Panel {{
+    bounds: geo::Rect;
+}}
+
+fn pick() -> geo::Rect {{
+    return geo::Rect {{ x: 2.0, w: 3.0 }};
+}}
+
+fn main() {{
+    let r = pick();
+    let p = Panel {{ bounds: r }};
+    println(viz::area(p.bounds));
+}}
+"#,
+            imports
+        ),
+    )
+    .expect("write main");
+    dir
+}
+
+fn build_and_run(dir: &PathBuf) -> (bool, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("build")
+        .arg(dir)
+        .output()
+        .expect("hale build");
+    if !out.status.success() {
+        return (
+            false,
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        );
+    }
+    let bin = dir.join(dir.file_name().unwrap());
+    let run = Command::new(&bin).output().expect("run built binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).into_owned(),
+        String::from_utf8_lossy(&run.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn diamond_import_geom_first_builds_and_runs() {
+    let dir = write_project(false);
+    let (ok, stdout, stderr) = build_and_run(&dir);
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(ok, "stdout: {}\nstderr: {}", stdout, stderr);
+    assert!(stdout.contains('6'), "got: {:?}", stdout);
+}
+
+#[test]
+fn diamond_import_viz_first_builds_and_runs() {
+    let dir = write_project(true);
+    let (ok, stdout, stderr) = build_and_run(&dir);
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(ok, "stdout: {}\nstderr: {}", stdout, stderr);
+    assert!(stdout.contains('6'), "got: {:?}", stdout);
+}


### PR DESCRIPTION
Closes #249 — the iris F.10 friction (`codegen-unknown-cross-seed-type-in-signature`), upstreamed and root-caused.

**The bug:** `resolve_imports`' visited-set dedup skipped alias registration when a lib was reached a second time (the diamond — entry + another lib both importing it, iris's exact raylib/lotus_viz shape). The second importer's `alias::Name` references then leaked past the rename pass into codegen, failing `hale build` while `hale check` stayed green (imported seeds aren't deep-checked). Which alias broke depended on resolution order — hence the reported Color-works/Rect-fails asymmetry from the same file.

**The fix:** a seed-rename cache keyed by canonical lib path; revisits register the new alias against the cached map. Sound because `lib_canonical_id` already keys mangled names off the canonical path — one compiled copy per lib, every alias mapping to it (the code's actual behavior; a stale comment claiming per-importer copies is now wrong in the other direction and worth a later tidy).

**Verification:** minimal diamond repro fails pre-fix and passes post-fix; `diamond_import.rs` covers both import orders; hale-cli + cross-seed suites green. Against iris@main the F.10 error is gone — the build now runs into the *newer* CQRS locus-return diagnostics on its spike-era libs (spanned type errors with migration guidance; iris-side work, noted on the issue).

Two adjacent observations recorded on #249 for future passes: the check/build asymmetry (imports not deep-checked is *why* this class ships as a build error), and `fn ... falls through without returning a value` is a user-reachable spanless codegen error (a #241-class candidate for `UnsupportedAt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)