### PR TITLE
release: v0.11.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.11.10 — the publish contract + loss supervision, macOS unix transport, SPSC observation ring, diagnostics overhaul (2026-07-22)
 
 - **Diamond imports fixed (GH #249, iris friction F.10).** A lib
   reached a second time — by the entry and by another lib, or by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.9"
+version = "0.11.10"
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "hale-syntax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.9"
+version = "0.11.10"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
CHANGELOG rollup + workspace version bump for v0.11.10 — the session's full arc: publish contract + loss supervision (F.37), macOS unix transport + self-contained artifacts, wire seq + counters + SPSC observation ring, diagnostics overhaul, per-assertion tests, decimal format, docs snippet gate, diamond imports. Tag lands on the merge commit; the release workflow's new dylib vendoring gets its first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)