### PR TITLE
docs: playground links point at the live playground; homepage link in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,16 @@ behavior.
   fraction digits (0..=9, round half-up) for money-style
   fixed display.
 
+- **Per-binding transport telemetry counters (GH #236 item 2).**
+  Every remote binding maintains relaxed-atomic counters at the
+  transport choke points — messages/bytes sent and delivered,
+  send failures, `dropped_lost` (publishes made while a connect
+  binding was in the lost/reconnecting window), listener
+  re-arms, reconnects, and `seq_gaps`. `LOTUS_BUS_COUNTERS_DUMP=1`
+  prints one line per binding at teardown; this is the substrate
+  for the iris observer. (Entry restored — it was dropped in a
+  changelog merge during the release cycle; the feature shipped
+  in v0.11.10 as PR #237.)
 - **macOS unix-transport support via framed SOCK_STREAM + wire
   sequence numbers (GH #231 transport half, GH #236 item 1).**
   Darwin has no AF_UNIX `SOCK_SEQPACKET`, so the substrate unix

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ One primitive, the **locus**, scales from a single function to a fleet of
 services wired over a typed message bus. There's no translation layer
 between the sentence you'd say out loud and the code you write.
 
+**[hale-lang.org](https://hale-lang.org)** — docs, [playground](https://hale-lang.org/playground), packages, roadmap.
+
 [![Tests](https://github.com/hale-lang/hale/actions/workflows/tests.yml/badge.svg)](https://github.com/hale-lang/hale/actions/workflows/tests.yml)
-[![Docs](https://github.com/hale-lang/hale/actions/workflows/docs.yml/badge.svg)](https://hale-lang.github.io/hale/)
+[![Docs](https://github.com/hale-lang/hale/actions/workflows/docs.yml/badge.svg)](https://hale-lang.org/docs)
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](./LICENSE)
 [![LLVM](https://img.shields.io/badge/LLVM-18-red.svg)](https://llvm.org/)
 
@@ -60,7 +62,7 @@ them — dynamic subject creation is on the roadmap.)
 
 > GitHub can't syntax-highlight Hale yet, so the snippets here render in a
 > single color. For highlighted, runnable Hale, open the
-> [playground](https://hale-lang.github.io/hale/play/).
+> [playground](https://play.hale-lang.org/).
 
 ## One primitive, at any altitude
 
@@ -79,7 +81,7 @@ down is how much of it you choose to see.
 
 A function you wrote at the top still works at the bottom — you've just
 learned to see more of what was always there. The
-[docs](https://hale-lang.github.io/hale/) are organized as exactly this
+[docs](https://hale-lang.org/docs) are organized as exactly this
 descent, so you go only as deep as you need.
 
 ## Deploy the same system anywhere — by editing `main`
@@ -184,7 +186,7 @@ You don't get a "verified" sticker on your whole program. You get a
 foundation whose coordination can't silently race — and because messages are
 copies and loci never reach sideways, programs that are **data-race-free by
 construction**, with no GC and no borrow checker.
-[Verification →](https://hale-lang.github.io/hale/verification.html)
+[Verification →](https://hale-lang.org/docs/verification)
 
 ## Built for humans and models
 
@@ -202,14 +204,15 @@ system.
 
 ## Try it
 
-**No install — [run curated Hale examples in your browser](https://hale-lang.github.io/hale/play/).**
-Each playground example is real Hale, precompiled to WebAssembly and run
-on the page (the UI itself is a Hale `@export locus` — the same `.hl`
-source runs native or in the browser). You can read the source and run
-it; editing code in the browser isn't there yet — for that, install
-below.
+**No install — [write and run Hale in your browser](https://play.hale-lang.org/).**
+Your source is compiled to WebAssembly by a compile service written in
+Hale itself, and the result runs fully client-side — the same compiler
+you install locally. Prefer a guided start? The
+[example gallery](https://hale-lang.org/play/) walks curated programs,
+each precompiled from real Hale (the gallery UI is itself a Hale
+`@export locus` — the same `.hl` source runs native or in the browser).
 
-**Prebuilt Linux binaries** are on the
+**Prebuilt Linux and macOS binaries** are on the
 [releases page](https://github.com/hale-lang/hale/releases) — download,
 extract, put `hale` on your `PATH`. Or build from source:
 
@@ -341,7 +344,7 @@ They mean things, and they fit together:
 
 ## Where to go next
 
-- **[Docs site](https://hale-lang.github.io/hale/)** — the level-by-level
+- **[Docs site](https://hale-lang.org/docs)** — the level-by-level
   tour. Start here.
 - **[`spec/`](./spec/)** — the canonical reference; the compiler enforces
   what it describes.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -19,10 +19,11 @@ the bottom. There is one primitive — the **locus** — and the
 only thing that changes as you descend is how much of it you
 choose to see.
 
-> **Try it now:** the [playground](https://hale-lang.github.io/hale/play/) runs a set of
-> curated Hale examples, precompiled to WebAssembly, right in your
-> browser — no install. (Read the source and run it; in-browser
-> editing isn't there yet.)
+> **Try it now:** the [playground](https://play.hale-lang.org/) compiles
+> and runs your Hale right in the browser — no install, same compiler
+> you'd install locally. For a guided start, the
+> [example gallery](https://hale-lang.org/play/) walks curated programs
+> chapter by chapter.
 
 This guide is built around that idea. It introduces Hale at four
 levels, each one self-contained:

--- a/docs/src/tutorial/job-queue.md
+++ b/docs/src/tutorial/job-queue.md
@@ -4,7 +4,7 @@ In about thirty minutes, you'll build a small **job queue** and watch it
 descend the four altitudes — from a throwaway script to a service split
 across processes — changing almost nothing but `main` at the very end. The
 first three stages run in the browser at the
-[playground](https://hale-lang.github.io/hale/play/) (no install); to follow
+[playground](https://play.hale-lang.org/) (no install); to follow
 along locally, drop each program in a `.hl` file and `hale run` it.
 
 We'll keep the "work" trivial — squaring a number stands in for whatever a
@@ -129,7 +129,9 @@ job 3 done -> 81
 ```
 
 > **Run it:** this exact program is live in the
-> [playground](https://hale-lang.github.io/hale/play/?example=jobqueue) — no install.
+> [example gallery](https://hale-lang.org/play/?example=jobqueue) — no
+> install. Or paste it into the [playground](https://play.hale-lang.org/)
+> and edit as you go.
 
 Notice what you *didn't* write. The `Submitter` never calls the `Worker` —
 it publishes to a topic, and whoever subscribes gets the message. There's no
@@ -200,5 +202,5 @@ That last row is the point: a Hale program is a *design* of loci and topics;
 where and how it runs is a binding you change in one place. From here, the
 [concurrent services](../services/lifecycle.md) chapters go deeper on
 lifecycle, failure, and supervision — or open the
-[playground](https://hale-lang.github.io/hale/play/) and run the bus version
+[playground](https://play.hale-lang.org/) and run the bus version
 in your browser.


### PR DESCRIPTION
Playground-linkage audit across README + the book (the marketing site's own nav was already clean; its doc mirrors resync from this repo). Everything stale said 'curated, precompiled, no in-browser editing' and pointed at the github.io tour — the live compile playground (play.hale-lang.org) is now primary everywhere, with the example gallery (hale-lang.org/play/) kept as the guided start. README gains the hale-lang.org homepage link up top, all github.io doc links repoint to hale-lang.org/docs, and 'Prebuilt Linux binaries' becomes 'Linux and macOS' per v0.11.10. All target URLs verified 200; docs snippet gate green (prose-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)