### PR TITLE
Bounded topics + consumer shed bounds (GH #255 phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ behavior.
 
 ## Unreleased
 
+- **Bounded topics + consumer shed bounds (GH #255 phase 2).**
+  Topic-level `bounded(N); on_full: fail;` makes publishes
+  refusal-fallible: every send site carries a disposition —
+  `or raise` (synchronous BusFull refusal), `or discard`
+  (at-capacity registrations shed the newcomer, counted), or
+  `or wait` (park until the drain frees space — queue-full is
+  the second wake source for the phase-1 disposition, no new
+  surface). Subscriber-level `bounded(N, drop_new|drop_old)` is
+  that consumer's private cap; `drop_old` keeps the newest N
+  (ring semantics — right for reload/telemetry events), and a
+  consumer bound below the topic bound sheds privately before
+  refusal ever fires (min governs). v1 scope: main-queue
+  subscribers only — pool queues and pinned mailboxes are
+  already bounded MPSC rings with producer-blocking
+  backpressure (GH #125), so declared bounds there are
+  typecheck-rejected with that explanation; err-payload
+  dispositions on full-fail topics land in a follow-up slice.
+  Self-checking corpus fixture `73-bounded-bus`; contracts
+  pinned by `bus_bounded_topics.rs`.
+
 - **`or wait` — park a publish through the loss window
   (GH #255 phase 1).** A send to a transport-bound topic can
   attach `or wait`: instead of the counted `dropped_lost` drop

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -5463,6 +5463,17 @@ static void bus_inline_drain_one(lotus_bus_queue_t *q);
  * because codegen proved the whole program has no pinned / cross-pool
  * placement, so g_bus_has_pinned is provably 0 and the acquire-load is
  * dead work. */
+/* GH #255 phase 2 — forward decls: the bound-enforcement hooks
+ * are defined with the registry machinery further down. */
+int lotus_subject_match(const char *pattern, const char *subject);
+struct lotus_bus_entry;
+static struct lotus_bus_entry *lotus_bus_bound_entry_for(void *handler,
+                                                         void *self_ptr);
+static int lotus_bus_shed_check(struct lotus_bus_entry *reg,
+                                lotus_bus_queue_t *q);
+static void lotus_bus_note_enqueued(struct lotus_bus_entry *reg);
+static void lotus_bus_note_dispatched(void *handler, void *self_ptr);
+
 static void bus_queue_enqueue_inner(lotus_bus_queue_t *q,
                                     void *handler,
                                     void *self_ptr,
@@ -5483,6 +5494,18 @@ static void bus_queue_enqueue_inner(lotus_bus_queue_t *q,
         }
     }
     if (locked) pthread_mutex_lock(&q->lock);
+    /* GH #255 phase 2: per-registration bound. Checked under the
+     * lock (drop_old tombstones in-queue cells). */
+    {
+        struct lotus_bus_entry *reg =
+            lotus_bus_bound_entry_for(handler, self_ptr);
+        if (reg && !lotus_bus_shed_check(reg, q)) {
+            if (locked) pthread_mutex_unlock(&q->lock);
+            if (heap_buf) free(heap_buf);
+            return; /* shed the newcomer */
+        }
+        if (reg) lotus_bus_note_enqueued(reg);
+    }
     /* Ensure a free tail slot, applying the bounded-queue backpressure
      * policy (GH #125). */
     while (q->tail == q->cap) {
@@ -5616,6 +5639,8 @@ typedef void (*lotus_handler_fn)(void *self, void *payload);
  * at the cap). */
 static void bus_inline_drain_one(lotus_bus_queue_t *q) {
     lotus_bus_cell_t *cell = &q->cells[q->head++];
+    if (!cell->handler) return; /* GH #255: tombstoned (drop_old) */
+    lotus_bus_note_dispatched(cell->handler, cell->self_ptr);
     if (!lotus_bus_cell_materialize(cell)) return;
     void  *handler_fn   = cell->handler;
     void  *handler_self = cell->self_ptr;
@@ -5697,6 +5722,9 @@ void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
             /* Wire cell from a cross-thread publisher: deserialize
              * into the subscriber's arena here, on the queue's
              * owner thread (bug 3). */
+            if (!cell_copy.handler) continue; /* GH #255 tombstone */
+            lotus_bus_note_dispatched(cell_copy.handler,
+                                      cell_copy.self_ptr);
             if (!lotus_bus_cell_materialize(&cell_copy)) continue;
             void *payload_ptr = NULL;
             if (cell_copy.payload_size > 0) {
@@ -5725,6 +5753,8 @@ void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
                 return;
             }
             lotus_bus_cell_t *cell = &q->cells[q->head++];
+            if (!cell->handler) continue; /* GH #255 tombstone */
+            lotus_bus_note_dispatched(cell->handler, cell->self_ptr);
             /* Single-threaded programs never build wire cells, but
              * keep the drain paths uniform (one NULL check). */
             if (!lotus_bus_cell_materialize(cell)) continue;
@@ -7571,11 +7601,149 @@ typedef struct lotus_bus_entry {
      * (a concurrent dispatch walk past the subject gate may still
      * read it). */
     const char           *key_str;
+    /* GH #255 phase 2: per-registration capacity on MAIN-queue
+     * deliveries. `shed_bound` (>0) with `shed_policy` (1 =
+     * drop_new, 2 = drop_old) is the subscriber's private cap;
+     * `refuse_bound` (>0) is the topic-level `on_full: fail`
+     * threshold consulted by the publish-site refusal pre-check.
+     * `in_flight` counts this registration's queued-but-not-yet-
+     * dispatched main-queue cells. Pool/mailbox registrations
+     * carry no bounds at v1 — their MPSC rings are already
+     * bounded with producer-blocking backpressure (GH #125);
+     * the typechecker rejects declared bounds off-main. */
+    int64_t               shed_bound;
+    uint8_t               shed_policy;
+    int64_t               refuse_bound;
+    volatile int64_t      in_flight;
+    uint64_t              ctr_dropped_full;
 } lotus_bus_entry_t;
 
 static lotus_bus_entry_t *g_bus_entries = NULL;
 static size_t             g_bus_count   = 0;
 static size_t             g_bus_cap     = 0;
+
+/* GH #255 phase 2: find the registration a queued cell belongs
+ * to. Linear scan — dispatch already walks this array, and the
+ * scan only runs for programs that declared bounds (guarded by
+ * g_bus_any_bounds). */
+static int g_bus_any_bounds = 0;
+
+static lotus_bus_entry_t *lotus_bus_bound_entry_for(void *handler,
+                                                    void *self_ptr) {
+    if (!g_bus_any_bounds) return NULL;
+    for (size_t i = 0; i < g_bus_count; i++) {
+        lotus_bus_entry_t *e = &g_bus_entries[i];
+        if (e->handler == handler && e->self_ptr == self_ptr &&
+            (e->shed_bound > 0 || e->refuse_bound > 0)) {
+            return e;
+        }
+    }
+    return NULL;
+}
+
+/* Enqueue-side policy, called with q's lock held (locked path)
+ * or single-threaded (st path). Returns 1 = proceed with the
+ * enqueue, 0 = shed the newcomer (drop_new, or drop_old that
+ * found nothing to tombstone in-queue). drop_old tombstones the
+ * registration's oldest queued cell (handler = NULL; drain
+ * paths skip) and frees its payload storage in place. */
+static int lotus_bus_shed_check(lotus_bus_entry_t *reg,
+                                lotus_bus_queue_t *q) {
+    if (!reg) return 1;
+    int64_t inflight =
+        __atomic_load_n(&reg->in_flight, __ATOMIC_RELAXED);
+    /* Refuse bound doubles as the hard enqueue cap: the publish-
+     * site pre-check is the synchronous signal, this is the
+     * backstop that also gives `or discard` its semantics (the
+     * dispatch proceeds; at-capacity registrations shed the
+     * newcomer, counted). */
+    if (reg->refuse_bound > 0 && inflight >= reg->refuse_bound &&
+        (reg->shed_bound <= 0 || reg->refuse_bound <= reg->shed_bound)) {
+        __atomic_fetch_add(&reg->ctr_dropped_full, 1, __ATOMIC_RELAXED);
+        return 0;
+    }
+    if (reg->shed_bound <= 0 || inflight < reg->shed_bound) return 1;
+    if (reg->shed_policy == 2 /* drop_old */) {
+        for (size_t i = q->head; i < q->tail; i++) {
+            lotus_bus_cell_t *c = &q->cells[i];
+            if (c->handler == reg->handler &&
+                c->self_ptr == reg->self_ptr) {
+                if (c->payload_heap) {
+                    free(c->payload_heap);
+                    c->payload_heap = NULL;
+                }
+                if (c->payload_region) {
+                    lotus_arena_destroy(
+                        (lotus_arena_t *)c->payload_region);
+                    c->payload_region = NULL;
+                }
+                c->handler = NULL; /* tombstone */
+                __atomic_fetch_sub(&reg->in_flight, 1,
+                                   __ATOMIC_RELAXED);
+                __atomic_fetch_add(&reg->ctr_dropped_full, 1,
+                                   __ATOMIC_RELAXED);
+                return 1; /* room made — enqueue the newcomer */
+            }
+        }
+        /* Nothing tombstonable (cells mid-dispatch): shed new. */
+    }
+    __atomic_fetch_add(&reg->ctr_dropped_full, 1, __ATOMIC_RELAXED);
+    return 0;
+}
+
+static void lotus_bus_note_enqueued(lotus_bus_entry_t *reg) {
+    if (reg) {
+        __atomic_fetch_add(&reg->in_flight, 1, __ATOMIC_RELAXED);
+    }
+}
+
+/* Called by codegen right after lotus_bus_register for a bounded
+ * subscriber: attaches the effective bounds to the registration
+ * (matched by subject + self so multi-topic subscribers
+ * disambiguate). */
+void lotus_bus_set_sub_bound(const char *subject,
+                             void *self_ptr,
+                             int64_t shed_bound,
+                             int64_t shed_policy,
+                             int64_t refuse_bound) {
+    for (size_t i = 0; i < g_bus_count; i++) {
+        lotus_bus_entry_t *e = &g_bus_entries[i];
+        if (!e->subject || e->self_ptr != self_ptr) continue;
+        if (strcmp(e->subject, subject) != 0) continue;
+        e->shed_bound   = shed_bound;
+        e->shed_policy  = (uint8_t)shed_policy;
+        e->refuse_bound = refuse_bound;
+        g_bus_any_bounds = 1;
+    }
+}
+
+/* Post-dispatch accounting: a main-queue cell for this
+ * registration completed (or was tombstoned/discarded). */
+static void lotus_bus_note_dispatched(void *handler, void *self_ptr) {
+    lotus_bus_entry_t *e = lotus_bus_bound_entry_for(handler, self_ptr);
+    if (e) {
+        __atomic_fetch_sub(&e->in_flight, 1, __ATOMIC_RELAXED);
+    }
+}
+
+/* Publish-site refusal pre-check for `on_full: fail` topics:
+ * 1 when any registration matching `subject` is at its refuse
+ * bound. Concurrent publishers may interleave past this check —
+ * the enqueue-side shed is the hard backstop; the refusal is the
+ * best-effort synchronous signal (documented in spec). */
+int64_t lotus_bus_subject_would_refuse(const char *subject) {
+    if (!g_bus_any_bounds || !subject) return 0;
+    for (size_t i = 0; i < g_bus_count; i++) {
+        lotus_bus_entry_t *e = &g_bus_entries[i];
+        if (!e->subject || e->refuse_bound <= 0) continue;
+        if (!lotus_subject_match(e->subject, subject)) continue;
+        if (__atomic_load_n(&e->in_flight, __ATOMIC_RELAXED) >=
+            e->refuse_bound) {
+            return 1;
+        }
+    }
+    return 0;
+}
 
 /* === Static-devirt per-subject buckets (build #1b) ================
  *
@@ -13755,6 +13923,25 @@ int64_t lotus_bus_binding_wait_ready(lotus_bus_queue_t *queue,
         /* Owner-guarded internally: pumps loss dispatch + coop
          * queue (incl. tick-driven retry handlers) on main,
          * no-ops elsewhere. */
+        lotus_bus_queue_drain(queue);
+        struct timespec ts = {0, 1000000}; /* 1ms slice */
+        nanosleep(&ts, NULL);
+    }
+}
+
+/* GH #255 phase 2 — `or wait` on a bounded `on_full: fail`
+ * topic: park until no registration for `subject` sits at its
+ * refuse bound. Same loop discipline as the binding wait above
+ * (main pumps its own drain — which is also what empties the
+ * queue and closes the window; teardown abort raises). */
+int64_t lotus_bus_subject_wait_space(lotus_bus_queue_t *queue,
+                                     const char *subject) {
+    if (!subject) return 0;
+    for (;;) {
+        if (!lotus_bus_subject_would_refuse(subject)) return 0;
+        if (__atomic_load_n(&g_bus_wait_abort, __ATOMIC_ACQUIRE)) {
+            return -1;
+        }
         lotus_bus_queue_drain(queue);
         struct timespec ts = {0, 1000000}; /* 1ms slice */
         nanosleep(&ts, NULL);

--- a/crates/hale-codegen/src/bus/dispatch.rs
+++ b/crates/hale-codegen/src/bus/dispatch.rs
@@ -275,6 +275,133 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
                 .build_unreachable()
                 .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
             self.builder.position_at_end(cont_bb);
+            // GH #255 phase 2: also wait for queue space on an
+            // `on_full: fail` topic (no-op when no registration
+            // carries a refuse bound). Same abort semantics.
+            let space_fn = self
+                .module
+                .get_function("lotus_bus_subject_wait_space")
+                .expect("lotus_bus_subject_wait_space declared");
+            let sret = self
+                .builder
+                .build_call(
+                    space_fn,
+                    &[queue_ptr.into(), subj_val.into()],
+                    "bus.wait.space",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                .try_as_basic_value()
+                .left()
+                .expect("returns i64")
+                .into_int_value();
+            let saborted = self
+                .builder
+                .build_int_compare(
+                    inkwell::IntPredicate::SLT,
+                    sret,
+                    i64_t.const_zero(),
+                    "bus.wait.space.aborted",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let spanic_bb = self
+                .context
+                .append_basic_block(current_fn, "bus.wait.space.raise");
+            let scont_bb = self
+                .context
+                .append_basic_block(current_fn, "bus.wait.space.cont");
+            self.builder
+                .build_conditional_branch(saborted, spanic_bb, scont_bb)
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder.position_at_end(spanic_bb);
+            self.builder
+                .build_call(
+                    panic_fn,
+                    &[
+                        ptr_t.const_null().into(),
+                        i64_t.const_zero().into(),
+                        typename_str.into(),
+                    ],
+                    "bus.wait.space.raise.call",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder
+                .build_unreachable()
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder.position_at_end(scont_bb);
+        }
+        // GH #255 phase 2: `or raise` on an `on_full: fail` topic —
+        // synchronous refusal at the publish site. `or discard`
+        // needs no publish-site code: the enqueue-side cap sheds
+        // (counted) and the dispatch proceeds for everyone else.
+        let full_fail_hit = match subject {
+            Expr::Literal(Literal::String(s), _) => {
+                self.full_fail_subjects.contains_key(s)
+            }
+            _ => false,
+        };
+        if full_fail_hit
+            && matches!(or_disposition, Some(OrDisposition::Raise(_)))
+        {
+            let ptr_t = self.context.ptr_type(AddressSpace::default());
+            let i64_t = self.context.i64_type();
+            let refuse_fn = self
+                .module
+                .get_function("lotus_bus_subject_would_refuse")
+                .expect("lotus_bus_subject_would_refuse declared");
+            let r = self
+                .builder
+                .build_call(refuse_fn, &[subj_val.into()], "bus.full.check")
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                .try_as_basic_value()
+                .left()
+                .expect("returns i64")
+                .into_int_value();
+            let refused = self
+                .builder
+                .build_int_compare(
+                    inkwell::IntPredicate::NE,
+                    r,
+                    i64_t.const_zero(),
+                    "bus.full.refused",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let current_fn = self
+                .builder
+                .get_insert_block()
+                .and_then(|bb| bb.get_parent())
+                .expect("inside a function");
+            let panic_bb = self
+                .context
+                .append_basic_block(current_fn, "bus.full.raise");
+            let cont_bb = self
+                .context
+                .append_basic_block(current_fn, "bus.full.cont");
+            self.builder
+                .build_conditional_branch(refused, panic_bb, cont_bb)
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder.position_at_end(panic_bb);
+            let panic_fn = self
+                .module
+                .get_function("lotus_root_panic")
+                .expect("lotus_root_panic declared");
+            let msg = self.global_string(
+                "BusFull (publish refused: a subscriber is at the topic's `bounded` capacity under `on_full: fail`)",
+            );
+            self.builder
+                .build_call(
+                    panic_fn,
+                    &[
+                        ptr_t.const_null().into(),
+                        i64_t.const_zero().into(),
+                        msg.into(),
+                    ],
+                    "bus.full.raise.call",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder
+                .build_unreachable()
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder.position_at_end(cont_bb);
         }
         // v1.x-FRAMEWORK: ephemeral-payload fast path. When the
         // value is a bare struct literal, the publisher-side

--- a/crates/hale-codegen/src/bus/runtime.rs
+++ b/crates/hale-codegen/src/bus/runtime.rs
@@ -12,6 +12,12 @@ use crate::codegen::{CodegenError, Cx};
 pub(crate) trait BusRuntime<'ctx> {
     fn emit_bus_drain(&mut self) -> Result<(), CodegenError>;
     fn emit_bus_wait_abort_all(&mut self) -> Result<(), CodegenError>;
+    fn emit_sub_bound_if_any(
+        &mut self,
+        locus_name: &str,
+        subject: &str,
+        self_ptr: PointerValue<'ctx>,
+    ) -> Result<(), CodegenError>;
     fn emit_bus_queue_destroy(&mut self) -> Result<(), CodegenError>;
     fn emit_bus_register_shm_ring(
         &mut self,
@@ -57,6 +63,47 @@ impl<'ctx, 'p> BusRuntime<'ctx> for Cx<'ctx, 'p> {
             .expect("lotus_bus_wait_abort_all declared");
         self.builder
             .build_call(f, &[], "bus.wait.abort_all")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        Ok(())
+    }
+
+    /// GH #255 phase 2: attach shed/refuse bounds to the
+    /// registration just emitted (no-op when neither the
+    /// subscribe declaration nor the topic declared capacity).
+    fn emit_sub_bound_if_any(
+        &mut self,
+        locus_name: &str,
+        subject: &str,
+        self_ptr: PointerValue<'ctx>,
+    ) -> Result<(), CodegenError> {
+        let shed = self
+            .sub_bounds
+            .get(&(locus_name.to_string(), subject.to_string()))
+            .copied();
+        let refuse = self.full_fail_subjects.get(subject).copied();
+        if shed.is_none() && refuse.is_none() {
+            return Ok(());
+        }
+        let (cap, policy) = shed.unwrap_or((0, 0));
+        let refuse_bound = refuse.unwrap_or(0);
+        let i64_t = self.context.i64_type();
+        let subj_g = self.global_string(subject);
+        let f = self
+            .module
+            .get_function("lotus_bus_set_sub_bound")
+            .expect("lotus_bus_set_sub_bound declared");
+        self.builder
+            .build_call(
+                f,
+                &[
+                    subj_g.into(),
+                    self_ptr.into(),
+                    i64_t.const_int(cap as u64, false).into(),
+                    i64_t.const_int(policy as u64, false).into(),
+                    i64_t.const_int(refuse_bound as u64, false).into(),
+                ],
+                "bus.set_sub_bound",
+            )
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         Ok(())
     }

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1199,6 +1199,8 @@ pub fn build_executable_with_options(
         bus_state: None,
         shm_ring_subjects: std::collections::BTreeMap::new(),
         routing_key_subjects: std::collections::BTreeMap::new(),
+        full_fail_subjects: std::collections::BTreeMap::new(),
+        sub_bounds: std::collections::BTreeMap::new(),
         bus_devirt_ids,
         bus_devirt_direct,
         bus_devirt_direct_subs,
@@ -2895,6 +2897,15 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// topic declarations before any user-code lowering. Unkeyed
     /// topics are NOT present in this map; absence ⇒ "route
     /// through the legacy lotus_bus_dispatch path."
+    /// GH #255 phase 2: wire subjects of `on_full: fail` topics
+    /// (value = the topic's refuse bound). Publishes to these get
+    /// the would-refuse pre-check + disposition branch.
+    pub(crate) full_fail_subjects:
+        std::collections::BTreeMap<String, i64>,
+    /// GH #255 phase 2: (locus name, wire subject) → subscriber
+    /// shed bound (cap, policy: 1 = drop_new, 2 = drop_old).
+    pub(crate) sub_bounds:
+        std::collections::BTreeMap<(String, String), (i64, u8)>,
     pub(crate) routing_key_subjects:
         std::collections::BTreeMap<String, RoutingKeySubjectInfo>,
     /// Static-bus-dispatch devirtualization (build #1b). Maps each
@@ -8302,6 +8313,16 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         Self::collect_topic_wire_subjects(&self.program.items, &mut wire_subjects);
         for item in &self.program.items {
             if let TopDecl::Topic(t) = item {
+                // GH #255 phase 2: record on_full-fail capacities.
+                if let (Some((cap, _)), Some(_)) =
+                    (t.bounded, t.on_full_fail)
+                {
+                    let wire = wire_subjects
+                        .get(&t.name.name)
+                        .cloned()
+                        .unwrap_or_else(|| t.name.name.clone());
+                    self.full_fail_subjects.insert(wire, cap);
+                }
                 let keyed_field = match &t.keyed_by {
                     Some(f) => f.name.clone(),
                     None => continue,
@@ -8326,6 +8347,42 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         policy: t.on_unmatched,
                     },
                 );
+            }
+        }
+        // GH #255 phase 2: subscriber shed bounds, keyed by
+        // (locus, wire subject).
+        let mut wire_subjects2: BTreeMap<String, String> = BTreeMap::new();
+        Self::collect_topic_wire_subjects(
+            &self.program.items,
+            &mut wire_subjects2,
+        );
+        for item in &self.program.items {
+            let TopDecl::Locus(l) = item else { continue };
+            for member in &l.members {
+                let LocusMember::Bus(bb) = member else { continue };
+                for bm in &bb.members {
+                    let BusMember::Subscribe {
+                        subject,
+                        bound: Some(b),
+                        ..
+                    } = bm
+                    else {
+                        continue;
+                    };
+                    let canon = subject.canonical().to_string();
+                    let wire = wire_subjects2
+                        .get(&canon)
+                        .cloned()
+                        .unwrap_or(canon);
+                    let policy = match b.policy {
+                        hale_syntax::ast::ShedPolicy::DropNew => 1u8,
+                        hale_syntax::ast::ShedPolicy::DropOld => 2u8,
+                    };
+                    self.sub_bounds.insert(
+                        (l.name.name.clone(), wire),
+                        (b.cap, policy),
+                    );
+                }
             }
         }
     }
@@ -10587,7 +10644,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     .members
                     .iter()
                     .map(|bm| match bm {
-                        BusMember::Subscribe { subject, handler, ty, key_filter, span } => {
+                        BusMember::Subscribe { subject, handler, ty, key_filter, bound, span } => {
                             BusMember::Subscribe {
                                 subject: subject.clone(),
                                 handler: handler.clone(),
@@ -10595,6 +10652,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                                     Self::substitute_type_expr(t, subst)
                                 }),
                                 key_filter: key_filter.clone(),
+                                bound: *bound,
                                 span: span.clone(),
                             }
                         }

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -2953,6 +2953,10 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                         key_filter.as_ref(),
                         owned_beyond_scope,
                     )?;
+                    // GH #255 phase 2: attach declared capacity.
+                    self.emit_sub_bound_if_any(
+                        locus_name, subject, self_ptr,
+                    )?;
                 }
             }
             self.in_params_default = prev_ipd_sub;

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -877,6 +877,35 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             self.context.void_type().fn_type(&[], false),
             None,
         );
+        // GH #255 phase 2 — bounded topics:
+        // declare void @lotus_bus_set_sub_bound(ptr subject, ptr self,
+        //     i64 shed_bound, i64 shed_policy, i64 refuse_bound)
+        // declare i64 @lotus_bus_subject_would_refuse(ptr subject)
+        // declare i64 @lotus_bus_subject_wait_space(ptr queue, ptr subject)
+        self.module.add_function(
+            "lotus_bus_set_sub_bound",
+            self.context.void_type().fn_type(
+                &[
+                    ptr_t.into(),
+                    ptr_t.into(),
+                    i64_t2.into(),
+                    i64_t2.into(),
+                    i64_t2.into(),
+                ],
+                false,
+            ),
+            None,
+        );
+        self.module.add_function(
+            "lotus_bus_subject_would_refuse",
+            i64_t2.fn_type(&[ptr_t.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "lotus_bus_subject_wait_space",
+            i64_t2.fn_type(&[ptr_t.into(), ptr_t.into()], false),
+            None,
+        );
         // declare i32 @lotus_process_wait(i32 pid,
         //                                 ptr out_code,
         //                                 ptr out_signal)

--- a/crates/hale-codegen/tests/bus_bounded_topics.rs
+++ b/crates/hale-codegen/tests/bus_bounded_topics.rs
@@ -1,0 +1,209 @@
+//! GH #255 phase 2 — bounded topics + consumer shed bounds.
+//!
+//! Three contracts:
+//!   1. `bounded(N, drop_old)` on a main-queue subscriber keeps
+//!      the NEWEST N queued deliveries when a burst outruns the
+//!      drain (ring semantics — the last event must survive).
+//!   2. A topic `bounded(N) on_full: fail` publish with
+//!      `or raise` refuses synchronously (BusFull panic) when a
+//!      subscriber sits at capacity.
+//!   3. The same burst with `or wait` parks the publisher until
+//!      the drain frees space — nothing is shed, all events
+//!      arrive.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+fn build(name: &str, src: &str) -> PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale_test_busbound_{}", name));
+    build_executable(&program, &bin).expect("build");
+    bin
+}
+
+#[test]
+fn drop_old_keeps_newest_under_burst() {
+    // Pinned publisher bursts 100 events while main sleeps (no
+    // drain); the bounded(4, drop_old) subscriber must see the
+    // TAIL of the burst — event 99 — and strictly fewer than
+    // 100 total. (A drain slice may land mid-burst, so the exact
+    // count is timing-dependent; the ring property is not.)
+    let src = r#"
+        type E { n: Int = 0; }
+        topic Evt { payload: E; subject: "evt"; }
+        locus Tally {
+            params { seen: Int = 0; last: Int = -1; }
+            bus {
+                subscribe Evt as on_e bounded(4, drop_old);
+            }
+            dissolve() {
+                if self.last != 99 {
+                    println("BAD last=", self.last);
+                    std::process::exit(1);
+                }
+                if self.seen > 60 {
+                    println("BAD no shedding, seen=", self.seen);
+                    std::process::exit(1);
+                }
+                println("ok seen=", self.seen, " last=", self.last);
+            }
+            fn on_e(e: E) {
+                self.seen = self.seen + 1;
+                self.last = e.n;
+            }
+        }
+        locus Pusher {
+            bus { publish Evt; }
+            run() {
+                std::time::sleep(250ms);
+                let mut i = 0;
+                while i < 100 {
+                    Evt <- E { n: i };
+                    i = i + 1;
+                }
+            }
+        }
+        main locus App {
+            params {
+                tally: Tally = Tally { };
+                p: Pusher = Pusher { };
+            }
+            placement { p: pinned(core = 0); }
+            run() {
+                std::time::sleep(600ms);
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let bin = build("dropold", src);
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("ok seen="),
+        "stdout: {:?}\nstderr: {:?}",
+        stdout,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn on_full_fail_or_raise_refuses() {
+    let src = r#"
+        type E { n: Int = 0; }
+        topic Evt {
+            payload: E;
+            subject: "evt";
+            bounded(2);
+            on_full: fail;
+        }
+        locus Tally {
+            params { seen: Int = 0; }
+            bus { subscribe Evt as on_e; }
+            fn on_e(e: E) { self.seen = self.seen + 1; }
+        }
+        locus Pusher {
+            bus { publish Evt; }
+            run() {
+                std::time::sleep(250ms);
+                let mut i = 0;
+                while i < 10 {
+                    Evt <- E { n: i } or raise;
+                    i = i + 1;
+                }
+                println("BURST SURVIVED (should have raised)");
+            }
+        }
+        main locus App {
+            params {
+                tally: Tally = Tally { };
+                p: Pusher = Pusher { };
+            }
+            placement { p: pinned(core = 0); }
+            run() {
+                std::time::sleep(600ms);
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let bin = build("fullraise", src);
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success() && !stdout.contains("BURST SURVIVED"),
+        "expected a BusFull raise.\nstdout: {:?}\nstderr: {:?}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stderr.contains("BusFull"),
+        "expected the BusFull diagnostic.\nstderr: {:?}",
+        stderr
+    );
+}
+
+#[test]
+fn on_full_or_wait_delivers_everything() {
+    // Same shape, but the publisher waits for space: main's
+    // sliced sleep drains between bursts, the parked publisher
+    // resumes, and every event arrives — nothing shed, nothing
+    // refused.
+    let src = r#"
+        type E { n: Int = 0; }
+        topic Evt {
+            payload: E;
+            subject: "evt";
+            bounded(10);
+            on_full: fail;
+        }
+        locus Tally {
+            params { seen: Int = 0; }
+            bus { subscribe Evt as on_e; }
+            dissolve() {
+                if self.seen != 50 {
+                    println("MISSED: saw ", self.seen, " of 50");
+                    std::process::exit(1);
+                }
+                println("all 50 delivered");
+            }
+            fn on_e(e: E) { self.seen = self.seen + 1; }
+        }
+        locus Pusher {
+            bus { publish Evt; }
+            run() {
+                std::time::sleep(200ms);
+                let mut i = 0;
+                while i < 50 {
+                    Evt <- E { n: i } or wait;
+                    i = i + 1;
+                }
+            }
+        }
+        main locus App {
+            params {
+                tally: Tally = Tally { };
+                p: Pusher = Pusher { };
+            }
+            placement { p: pinned(core = 0); }
+            run() {
+                std::time::sleep(1500ms);
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let bin = build("fullwait", src);
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("all 50 delivered"),
+        "stdout: {:?}\nstderr: {:?}",
+        stdout,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/crates/hale-codegen/tests/fixtures/examples/73-bounded-bus/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/73-bounded-bus/main.hl
@@ -1,0 +1,82 @@
+// GH #255 phase 2: the two capacity knobs, exercised through the
+// full CLI. A bounded(12) on_full: fail topic with an `or wait`
+// publisher delivers everything (the park absorbs the burst); a
+// sibling drop_old subscriber sheds to its own smaller window.
+
+type E {
+    n: Int = 0;
+}
+
+topic Evt {
+    payload: E;
+    subject: "evt";
+    bounded(12);
+    on_full: fail;
+}
+
+locus Full {
+    params { seen: Int = 0; }
+    bus {
+        subscribe Evt as on_e;
+    }
+    dissolve() {
+        if self.seen != 40 {
+            println("MISSED: full saw ", self.seen, " of 40");
+            std::process::exit(1);
+        }
+        println("full saw all 40");
+    }
+    fn on_e(e: E) {
+        self.seen = self.seen + 1;
+    }
+}
+
+locus Sampler {
+    params { seen: Int = 0; last: Int = -1; }
+    bus {
+        subscribe Evt as on_e bounded(4, drop_old);
+    }
+    dissolve() {
+        if self.last != 39 {
+            println("MISSED: sampler last=", self.last);
+            std::process::exit(1);
+        }
+        println("sampler kept the newest, saw ", self.seen);
+    }
+    fn on_e(e: E) {
+        self.seen = self.seen + 1;
+        self.last = e.n;
+    }
+}
+
+locus Pusher {
+    bus {
+        publish Evt;
+    }
+    run() {
+        std::time::sleep(200ms);
+        let mut i = 0;
+        while i < 40 {
+            Evt <- E { n: i } or wait;
+            i = i + 1;
+        }
+    }
+}
+
+main locus App {
+    params {
+        full: Full = Full { };
+        sampler: Sampler = Sampler { };
+        p: Pusher = Pusher { };
+    }
+    placement {
+        p: pinned(core = 0);
+    }
+    run() {
+        std::time::sleep(1200ms);
+    }
+}
+
+fn main() {
+    App { };
+}

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -101,6 +101,19 @@ pub struct TopicDecl {
     /// typecheck. When `None`, the topic is unkeyed and behaves
     /// as it has since Phase 1.
     pub keyed_by: Option<Ident>,
+    /// GH #255 phase 2: `bounded(N);` — the publisher-facing
+    /// refusal capacity. Uniform per-subscriber in-flight cap on
+    /// this topic's queued deliveries. Requires `on_full:` (v1:
+    /// `fail`) — a topic bound without a declared policy is
+    /// rejected at typecheck.
+    pub bounded: Option<(i64, Span)>,
+    /// GH #255 phase 2: `on_full: fail;` — publishes to this
+    /// topic become refusal-fallible: every send site must carry
+    /// an `or` disposition (raise / discard / handler(err) /
+    /// fail <p> / wait). v1 has exactly one topic-level policy
+    /// (`fail`); consumer-side shedding lives on the subscribe
+    /// declaration instead.
+    pub on_full_fail: Option<Span>,
     /// Behavior when a keyed publish finds no subscriber whose
     /// `where key == X` filter matches. `None` is equivalent to
     /// `Some(Swallow)` (the default; matches today's no-subscriber
@@ -1216,6 +1229,13 @@ pub enum BusMember {
         /// = filter at dispatch time. See `spec/semantics.md` §
         /// "Phase 3: routing keys".
         key_filter: Option<KeyFilter>,
+        /// GH #255 phase 2: `bounded(N, drop_old|drop_new)` — this
+        /// subscriber's private in-flight cap + shed policy on its
+        /// queued deliveries. The policy is mandatory with the
+        /// bound (no silent default). Affects nobody but the
+        /// declaring subscriber; composes with a topic-level
+        /// `bounded(N)` as min(topic, consumer).
+        bound: Option<SubBound>,
         span: Span,
     },
     Publish {
@@ -1225,6 +1245,30 @@ pub enum BusMember {
         alias: Option<Ident>,
         span: Span,
     },
+}
+
+/// GH #255 phase 2: a subscribe declaration's private capacity.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SubBound {
+    pub cap: i64,
+    pub policy: ShedPolicy,
+    pub span: Span,
+}
+
+/// GH #255 phase 2: what a bounded subscriber sheds when its
+/// in-flight cap is reached. Applies only to queues the core
+/// owns (main coop queue / pool queues); pinned subscribers'
+/// mailboxes keep their existing bounded-ring block-producer
+/// contract (GH #125).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShedPolicy {
+    /// Reject the newcomer; the arriving message is dropped
+    /// (counted).
+    DropNew,
+    /// Ring semantics: tombstone this subscriber's oldest queued
+    /// delivery to make room (right for telemetry / reload-style
+    /// events where stale beats lost-freshest).
+    DropOld,
 }
 
 /// `where key == EXPR` clause on `subscribe`. See

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -742,6 +742,8 @@ impl Parser {
         let mut subject: Option<String> = None;
         let mut keyed_by: Option<Ident> = None;
         let mut on_unmatched: Option<UnmatchedPolicy> = None;
+        let mut bounded: Option<(i64, Span)> = None;
+        let mut on_full_fail: Option<Span> = None;
         while !matches!(self.peek(), TokenKind::RBrace) {
             let field_name = self.expect_ident("topic field name")?;
             match field_name.name.as_str() {
@@ -820,13 +822,66 @@ impl Parser {
                     }
                     on_unmatched = Some(policy);
                 }
+                // GH #255 phase 2: `bounded(N);`
+                "bounded" => {
+                    self.expect(TokenKind::LParen, "(")?;
+                    let tok = self.peek_token().clone();
+                    let n = match tok.kind {
+                        TokenKind::IntLit(v) if v > 0 => {
+                            self.bump();
+                            v
+                        }
+                        _ => {
+                            return Err(Diag::parse(
+                                tok.span,
+                                "topic `bounded(N)` takes a positive \
+                                 integer capacity",
+                            ));
+                        }
+                    };
+                    let close_p = self.expect(TokenKind::RParen, ")")?;
+                    if bounded.is_some() {
+                        return Err(Diag::parse(
+                            field_name.span,
+                            "duplicate `bounded(...)` in topic declaration",
+                        ));
+                    }
+                    bounded = Some((n, field_name.span.merge(close_p.span)));
+                }
+                // GH #255 phase 2: `on_full: fail;`
+                "on_full" => {
+                    self.expect(TokenKind::Colon, ":")?;
+                    let policy_ident =
+                        self.expect_ident("on_full policy")?;
+                    if policy_ident.name != "fail" {
+                        return Err(Diag::parse(
+                            policy_ident.span,
+                            format!(
+                                "unknown on_full policy `{}` (v1 has \
+                                 exactly one topic-level policy: `fail`; \
+                                 consumer-side shedding is declared on \
+                                 the subscribe: `bounded(N, drop_old)`)",
+                                policy_ident.name
+                            ),
+                        ));
+                    }
+                    if on_full_fail.is_some() {
+                        return Err(Diag::parse(
+                            field_name.span,
+                            "duplicate `on_full:` in topic declaration",
+                        ));
+                    }
+                    on_full_fail =
+                        Some(field_name.span.merge(policy_ident.span));
+                }
                 other => {
                     return Err(Diag::parse(
                         field_name.span,
                         format!(
                             "unknown topic field `{}` (recognized: \
                              `payload:`, `subject:`, `keyed_by`, \
-                             `on_unmatched:`)",
+                             `on_unmatched:`, `bounded(...)`, \
+                             `on_full:`)",
                             other
                         ),
                     ));
@@ -848,6 +903,8 @@ impl Parser {
             subject,
             keyed_by,
             on_unmatched,
+            bounded,
+            on_full_fail,
             span: kw.span.merge(close.span),
         })
     }
@@ -2872,6 +2929,55 @@ impl Parser {
                 } else {
                     None
                 };
+                // GH #255 phase 2: optional
+                // `bounded(N, drop_old|drop_new)` — contextual
+                // (`bounded` is an ordinary ident here).
+                let bound = if matches!(
+                    self.peek(), TokenKind::Ident(s) if s == "bounded")
+                {
+                    let b_tok = self.bump();
+                    self.expect(TokenKind::LParen, "(")?;
+                    let cap_tok = self.peek_token().clone();
+                    let cap = match cap_tok.kind {
+                        TokenKind::IntLit(v) if v > 0 => {
+                            self.bump();
+                            v
+                        }
+                        _ => {
+                            return Err(Diag::parse(
+                                cap_tok.span,
+                                "subscribe `bounded(N, policy)` takes a \
+                                 positive integer capacity",
+                            ));
+                        }
+                    };
+                    self.expect(TokenKind::Comma, ",")?;
+                    let pol_ident =
+                        self.expect_ident("shed policy")?;
+                    let policy = match pol_ident.name.as_str() {
+                        "drop_new" => ShedPolicy::DropNew,
+                        "drop_old" => ShedPolicy::DropOld,
+                        other => {
+                            return Err(Diag::parse(
+                                pol_ident.span,
+                                format!(
+                                    "unknown shed policy `{}` (expected \
+                                     `drop_new` or `drop_old`; the policy \
+                                     is mandatory with a subscriber bound)",
+                                    other
+                                ),
+                            ));
+                        }
+                    };
+                    let close_p = self.expect(TokenKind::RParen, ")")?;
+                    Some(SubBound {
+                        cap,
+                        policy,
+                        span: b_tok.span.merge(close_p.span),
+                    })
+                } else {
+                    None
+                };
                 // Optional `where key == EXPR` (Phase 3).
                 // `where` is already a reserved keyword (used in
                 // form annotations); reuse the same TokenKind.
@@ -2919,6 +3025,7 @@ impl Parser {
                     handler,
                     ty,
                     key_filter,
+                    bound,
                     span: kw.span.merge(semi.span),
                 })
             }

--- a/crates/hale-types/src/bus_graph.rs
+++ b/crates/hale-types/src/bus_graph.rs
@@ -520,7 +520,7 @@ fn resolve_payload(top: &TopScope, locus: &str, key: &str) -> String {
 /// First-placement-wins when a type is placed in multiple fields
 /// (the multi-instance case); placement is informational for the
 /// gate, so a conservative single label suffices.
-fn collect_subscriber_placements(bundle: &Bundle<'_>) -> BTreeMap<String, Placement> {
+pub(crate) fn collect_subscriber_placements(bundle: &Bundle<'_>) -> BTreeMap<String, Placement> {
     let mut out: BTreeMap<String, Placement> = BTreeMap::new();
 
     fn walk(items: &[TopDecl], out: &mut BTreeMap<String, Placement>) {

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -380,6 +380,9 @@ pub fn check_bundle(
     //     `where key == _` subscriber program-wide.
     //   - `where key == _` is only legal on fallback topics.
     check_phase3_fallback_subscribers(bundle, &mut diags);
+    // GH #255 phase 2: bounded-topic pairing + subscriber-bound
+    // placement rules.
+    check_bounded_bus(bundle, &mut diags);
     // F.31 Phase 5: single-threaded-method invariant. Walks
     // method bodies looking for cross-pool `self.X.foo()` calls
     // where X's locus type is placed on a different pool than
@@ -3614,6 +3617,75 @@ fn transport_satisfies(
 /// h`) or literal subject (`subscribe "k" as h of type T`). We
 /// validate both forms; for literal subjects we look up the topic
 /// by its wire subject string.
+/// GH #255 phase 2 bundle checks:
+/// * a topic `bounded(N)` requires `on_full: fail` (v1's only
+///   topic-level policy) and vice versa;
+/// * a subscribe-site `bounded(N, policy)` is only legal on a
+///   MAIN-queue subscriber: pool queues and pinned mailboxes are
+///   already bounded MPSC rings with producer-blocking
+///   backpressure (GH #125), so shed bounds there would
+///   misdescribe the actual contract.
+fn check_bounded_bus(bundle: &Bundle<'_>, diags: &mut Vec<Diag>) {
+    for program in bundle.programs.values() {
+        for item in &program.items {
+            if let TopDecl::Topic(t) = item {
+                match (t.bounded, t.on_full_fail) {
+                    (Some((_, bspan)), None) => diags.push(Diag::ty(
+                        bspan,
+                        "topic `bounded(N)` requires `on_full: fail;` \
+                         — a capacity with no declared policy is \
+                         meaningless (consumer-side shedding is \
+                         declared on the subscribe instead: \
+                         `bounded(N, drop_old)`)",
+                    )),
+                    (None, Some(fspan)) => diags.push(Diag::ty(
+                        fspan,
+                        "topic `on_full: fail;` requires `bounded(N);` \
+                         — a refusal policy with no capacity never \
+                         fires",
+                    )),
+                    _ => {}
+                }
+            }
+        }
+    }
+    let placements = crate::bus_graph::collect_subscriber_placements(bundle);
+    for program in bundle.programs.values() {
+        for item in &program.items {
+            let TopDecl::Locus(l) = item else { continue };
+            for member in &l.members {
+                let LocusMember::Bus(bb) = member else { continue };
+                for bm in &bb.members {
+                    let BusMember::Subscribe {
+                        bound: Some(b), ..
+                    } = bm
+                    else {
+                        continue;
+                    };
+                    let placed = placements
+                        .get(&l.name.name)
+                        .cloned()
+                        .unwrap_or(crate::bus_graph::Placement::SameThread);
+                    if placed != crate::bus_graph::Placement::SameThread {
+                        diags.push(Diag::ty(
+                            b.span,
+                            format!(
+                                "subscriber `bounded(N, ...)` is only \
+                                 supported on main-queue subscribers at \
+                                 v1, and `{}` is placed off-main — its \
+                                 pool/mailbox ring is already bounded \
+                                 with producer-blocking backpressure \
+                                 (GH #125)",
+                                l.name.name
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn check_phase3_fallback_subscribers(
     bundle: &Bundle<'_>,
     diags: &mut Vec<Diag>,
@@ -8817,7 +8889,7 @@ impl<'a> Checker<'a> {
         // or-disposition leaves the no-match err unhandled. We
         // resolve the topic by name/literal-subject and validate
         // both directions.
-        let target_topic: Option<(String, Option<UnmatchedPolicy>)> =
+        let target_topic: Option<(String, Option<UnmatchedPolicy>, bool)> =
             match subject {
                 Expr::Literal(Literal::String(s), _) => self
                     .top
@@ -8829,19 +8901,55 @@ impl<'a> Checker<'a> {
                                 || ti.wire_subject == *s
                                 || ti.name == *s =>
                         {
-                            Some((ti.name.clone(), ti.on_unmatched))
+                            Some((
+                                ti.name.clone(),
+                                ti.on_unmatched,
+                                ti.on_full_fail,
+                            ))
                         }
                         _ => None,
                     }),
                 Expr::Ident(id) => match self.top.lookup(&id.name) {
-                    Some(TopSymbol::Topic(ti)) => {
-                        Some((ti.name.clone(), ti.on_unmatched))
-                    }
+                    Some(TopSymbol::Topic(ti)) => Some((
+                        ti.name.clone(),
+                        ti.on_unmatched,
+                        ti.on_full_fail,
+                    )),
                     _ => None,
                 },
                 _ => None,
             };
-        let target_policy = target_topic.as_ref().map(|(_, p)| *p);
+        let target_policy = target_topic.as_ref().map(|(_, p, _)| *p);
+        let target_full_fail =
+            target_topic.as_ref().map_or(false, |(_, _, f)| *f);
+        // GH #255 phase 2: an `on_full: fail` topic's publishes are
+        // refusal-fallible — every send site carries a disposition.
+        // v1 wires raise / discard / wait; the err-payload
+        // dispositions (`or handler(err)` / `or fail <p>`) land in
+        // the follow-up slice and are rejected with a pointer.
+        if target_full_fail {
+            match or_disposition {
+                None => self.diags.push(Diag::ty(
+                    span,
+                    "publish to a topic with `on_full: fail` must \
+                     carry an `or` disposition — e.g. \
+                     `Subject <- value or raise` (or `or discard` / \
+                     `or wait`)",
+                )),
+                Some(OrDisposition::Substitute(_))
+                | Some(OrDisposition::Fail(_, _)) => {
+                    self.diags.push(Diag::ty(
+                        span,
+                        "`or handler(err)` / `or fail <payload>` on an \
+                         `on_full: fail` topic aren't wired yet — use \
+                         `or raise`, `or discard`, or `or wait` (the \
+                         err-payload dispositions land in the next \
+                         slice)",
+                    ));
+                }
+                _ => {}
+            }
+        }
         // GH #255 phase 1: `or wait` is its own disposition kind —
         // a delivery-mode modifier on a NON-fallible publish, only
         // meaningful when the topic has a declared transport
@@ -8864,16 +8972,16 @@ impl<'a> Checker<'a> {
             } else {
                 let is_bound = target_topic
                     .as_ref()
-                    .map_or(false, |(name, _)| {
-                        self.bound_topics.contains(name)
+                    .map_or(false, |(name, _, full_fail)| {
+                        *full_fail || self.bound_topics.contains(name)
                     });
                 if !is_bound {
                     self.diags.push(Diag::ty(
                         *wsp,
                         "`or wait` requires the topic to have a declared \
-                         transport binding (a `bindings { }` entry) — \
-                         an unbound in-process publish has no loss \
-                         window to wait out",
+                         transport binding (a loss window to wait \
+                         out) or `on_full: fail` capacity (queue \
+                         space to wait for)",
                     ));
                 }
             }

--- a/crates/hale-types/src/resolve.rs
+++ b/crates/hale-types/src/resolve.rs
@@ -589,6 +589,8 @@ fn register_topic(
         wire_subject: r.wire_subject,
         keyed_by: decl.keyed_by.as_ref().map(|i| i.name.clone()),
         on_unmatched: decl.on_unmatched,
+        bounded: decl.bounded.map(|(n, _)| n),
+        on_full_fail: decl.on_full_fail.is_some(),
         span: decl.span,
     };
     register_symbol(

--- a/crates/hale-types/src/symbol.rs
+++ b/crates/hale-types/src/symbol.rs
@@ -90,6 +90,12 @@ pub struct TopicInfo {
     /// policy. Codegen treats None as Swallow at lowering
     /// time.
     pub on_unmatched: Option<hale_syntax::ast::UnmatchedPolicy>,
+    /// GH #255 phase 2: `bounded(N)` — topic-level refusal
+    /// capacity (requires `on_full: fail`).
+    pub bounded: Option<i64>,
+    /// GH #255 phase 2: `on_full: fail` — publishes are
+    /// refusal-fallible; send sites must carry a disposition.
+    pub on_full_fail: bool,
     pub span: Span,
 }
 

--- a/docs/src/services/bus.md
+++ b/docs/src/services/bus.md
@@ -93,6 +93,39 @@ for a completion signal ("exit when done") before returning.
 Set `LOTUS_BUS_LOG_DROP=1` to see any such drop while
 debugging.
 
+## When a consumer can't keep up
+
+Unbounded by default: most topics are low-rate control flow and
+a queue that grows briefly is fine. When a fast publisher meets
+a slow consumer, two opt-in knobs bound the damage — one for
+each side of the contract:
+
+```hale,fragment
+topic Frame {
+    payload: Reading;
+    bounded(1024);
+    on_full: fail;
+}
+```
+
+The topic bound is the *publisher's* contract: at capacity the
+broker refuses, and every send site must say what it does about
+that — `or raise` (a full queue is a bug), `or discard` (shed at
+the source, counted), or `or wait` (run at the consumer's pace).
+
+```hale,fragment
+subscribe Frame as on_frame bounded(64, drop_old);
+```
+
+The subscriber bound is that consumer's *private* coping
+strategy: `drop_old` keeps the newest 64 (right for reload-style
+events, where stale beats losing the freshest), `drop_new`
+rejects arrivals. A consumer bound below the topic bound sheds
+quietly before the publisher ever sees refusal. Pool- and
+pinned-placed subscribers don't take these bounds — their queues
+are already fixed-size rings that push back on producers
+directly.
+
 ## Why this doesn't break the tower
 
 In the [parent/child model](./parents-children.md), flow is

--- a/spec/decisions.md
+++ b/spec/decisions.md
@@ -3186,9 +3186,28 @@ a transport-bound topic. Semantics:
   drops, not exactly-once.
 - Per-binding `waits` counter (GH #236 family) records parks.
 
-Phase 2 (bounded topics / consumer shed bounds, designed on
-GH #255) will feed queue-full as a second transient-refusal
-condition into this same disposition — no surface change.
+**Phase 2 SHIPPED (2026-07-27, same day):** the two capacity
+knobs from the GH #255 design. Topic-level `bounded(N)` +
+`on_full: fail` is the publisher-facing refusal contract —
+publishes to such a topic must carry a disposition (`or raise`
+= synchronous BusFull refusal at the send site; `or discard` =
+proceed, at-capacity registrations shed the newcomer counted;
+`or wait` = park until the drain frees space — queue-full is
+the second transient-refusal condition feeding the same
+disposition, exactly as designed). Subscriber-level
+`bounded(N, drop_new|drop_old)` is that consumer's private cap:
+drop_old tombstones its oldest queued cell (ring semantics),
+and a consumer bound below the topic bound converts would-be
+refusal into private shedding. Scope facts: bounds apply to
+MAIN-queue registrations only at v1 (pool/pinned rings are
+already bounded MPSC rings with producer-blocking backpressure
+— GH #125 — so declared bounds there are typecheck-rejected
+with that explanation); the publish-site refusal pre-check is
+best-effort under concurrent publishers with the enqueue-side
+cap as the hard backstop; the err-payload dispositions
+(`or handler(err)` / `or fail <p>`) on full-fail topics are
+rejected with a pointer until the BusFull-payload slice lands.
+Per-registration `dropped_full` counting rides the entry.
 
 ---
 

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -80,7 +80,14 @@ topic_field       = "payload" , ":" , type_expr , ";"
                   | "subject" , ":" , STRING_LIT , ";"
                   | "keyed_by" , IDENTIFIER , ";"
                   | "on_unmatched" , ":" , unmatched_policy , ";"
+                  | "bounded" , "(" , INT_LIT , ")" , ";"
+                  | "on_full" , ":" , "fail" , ";"
                   ;
+(* GH #255 phase 2: `bounded(N)` + `on_full: fail` pair up (each
+   requires the other) — the publisher-facing refusal capacity.
+   Every send site of such a topic must carry an `or` disposition
+   (raise / discard / wait at v1; the err-payload dispositions
+   land in a follow-up slice). *)
 
 (* `ring_layout Name { ... }` — declares the byte layout of an
    externally-defined SHM broadcast ring so a
@@ -453,7 +460,15 @@ bus_member        = bus_subscribe
 bus_subject       = STRING_LIT | qualified_name ;
 bus_subscribe     = "subscribe" , bus_subject , "as" , IDENTIFIER ,
                     [ "of" , "type" , type_expr ] ,
+                    [ "bounded" , "(" , INT_LIT , "," , shed_policy , ")" ] ,
                     [ key_filter ] , ";" ;
+shed_policy       = "drop_new" | "drop_old" ;
+(* GH #255 phase 2: the subscriber's private in-flight cap +
+   mandatory shed policy. Main-queue subscribers only at v1 —
+   pool/pinned rings are already bounded with producer-blocking
+   backpressure (GH #125). Composes with a topic bound as
+   min(topic, consumer): a smaller consumer bound sheds privately
+   below the topic's refusal threshold. *)
 bus_publish       = "publish" , bus_subject ,
                     [ "of" , "type" , type_expr ] ,
                     [ "as" , IDENTIFIER ] , ";" ;


### PR DESCRIPTION
Phase 2 of the settled #255 design, stacked on #259 (phase 1). Closes #255 once both land.

The two capacity knobs, exactly as designed and validated by Crumb's mapping:
- **Topic `bounded(N); on_full: fail;`** — the publisher-facing refusal contract. Send sites must dispose: `or raise` (synchronous BusFull refusal), `or discard` (proceed; at-capacity registrations shed the newcomer, counted — the refuse bound doubles as the enqueue-side hard backstop, which is also what makes the pre-check race-safe under concurrent publishers), `or wait` (queue-full feeds the phase-1 disposition as its second wake source — zero new surface).
- **Subscriber `bounded(N, drop_new|drop_old)`** — private coping: `drop_old` tombstones the oldest queued cell (ring semantics), min(topic, consumer) governs, and a smaller consumer bound sheds privately below the refusal threshold (proven composing in fixture 73: the strict subscriber gets all 40 through the publisher's wait while the `drop_old` sampler sheds to its own window).

**v1 scope, spec'd:** bounds apply to main-queue registrations only — pool queues and pinned mailboxes are already bounded MPSC rings with producer-blocking backpressure (GH #125), so declared bounds there are typecheck-rejected with exactly that explanation. Err-payload dispositions (`or handler(err)` / `or fail <p>`, the Crumb 503 shape) are rejected with a pointer until the BusFull-payload follow-up slice.

Surface tally for both phases matches the design comment: `or wait`, topic `bounded`, topic `on_full:`, subscribe `bounded(N, policy)` — four grammar touches, everything else runtime/diagnostics/spec.

Tests: `bus_bounded_topics.rs` (drop_old keeps newest under a 100-event burst; or-raise refuses with BusFull; or-wait delivers all 50), corpus fixture `73-bounded-bus` (self-checking, both knobs composing), all bus/teardown suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)