### PR TITLE
release: v0.11.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.11.11 — or wait + bounded topics (the backpressure contract), std::compress + std::tar, teardown delivery contract (2026-07-27)
 
 - **Bounded topics + consumer shed bounds (GH #255 phase 2).**
   Topic-level `bounded(N); on_full: fail;` makes publishes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.10"
+version = "0.11.11"
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "hale-syntax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.10"
+version = "0.11.11"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
CHANGELOG rollup + workspace version bump for v0.11.11.

Since v0.11.10 (all merged to main): #256 playground links, #257 hale-bun handoff (conditional-instantiation dominance fix, diagnostics, `send_fd`, ENOENT hint) + the devirt publisher-placement soundness fix, #258/#259/#260 — the #253 teardown delivery contract, `std::compress`/`std::tar`/`fs::write_bytes` (#254), and the full #255 backpressure contract (`or wait` + bounded topics).

Tag `v0.11.11` follows on merge → release.yml builds the Linux x86_64/arm64 + macOS arm64 artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)