### PR TITLE
Deliver the iris observer handoff (P1 vec.set retire, P2 verify false positives, P3 docs)

### DIFF
--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - run: |
           if [ -z "$TOKEN" ]; then
-            echo "::notice::SITE_DEPLOY_TOKEN not set — site not redeployed"
+            echo "::warning::SITE_DEPLOY_TOKEN not set — the docs site is now STALE (create a fine-grained PAT with Actions rw on hale-lang/hale-lang.org and save it as this repo secret)"
             exit 0
           fi
           GH_TOKEN="$TOKEN" gh workflow run deploy -R hale-lang/hale-lang.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ behavior.
 
 ---
 
+## Unreleased
+
+- **`@form(vec).set` no longer leaks or slows down (iris handoff
+  P1).** Vec elements are pointer-storage; `set` deep-copied the
+  new element into the form owner's program-lifetime arena but
+  never retired the REPLACED one — ~33 B leaked per set, and the
+  growing arena made the per-set containment walk progressively
+  slower (the reported ~1µs/set, ~1000× `get`; ~1.4 MB/s in a
+  ~1M sets/s observer). Replaced elements (and their
+  non-surviving String fields, hashmap retire-cell discipline)
+  now retire straight onto the arena's reuse freelist and the
+  deep-copy alloc consults it: the iris repro went from 2.06 s /
+  70 MB to 0.01 s / 7.8 MB flat over 2M sets, ASan-clean.
+  Single-owner caveat spec'd in forms.md: a `.get` value is
+  invalidated by a later `set` to the same slot.
+
+- **`hale verify` unbounded-allocation analysis: three
+  false-positive shapes fixed (iris handoff P2).** (1) Loop
+  ceilings const-fold — `while i < NET_SLOTS * WINDOW` over
+  top-level consts ranks bounded. (2) Eager per-iteration
+  children are modeled: a bare-statement `Cycle { ... };`
+  dissolves at the statement, so neither the instantiation site
+  nor the child's own self-stores accumulate (let-bound and
+  subscription-bearing instantiations, and loci containing
+  `while true`, keep the conservative verdict) — the analysis
+  no longer flags the very idiom its advisory recommends.
+  (3) A vec `.set` is no longer an accumulation channel (see the
+  P1 retire). Both advisory texts now name `@unbounded` on the
+  enclosing fn/hook as the acknowledge mechanism for
+  domain-bounded shapes. fuse-hl: 26 findings → 0, with the
+  let-bound/while-true counterparts still flagged.
+
+- **Docs: takeover send timeouts.** `std::io::tcp::
+  set_send_timeout(fd, d)` already shipped but the takeover
+  chapter never mentioned it — a stalled SSE/WS peer blocks
+  `send` forever without it (iris handoff P3). The chapter now
+  says so next to the recv-timeout note.
+
 ## v0.11.11 — or wait + bounded topics (the backpressure contract), std::compress + std::tar, teardown delivery contract (2026-07-27)
 
 - **Bounded topics + consumer shed bounds (GH #255 phase 2).**

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -4570,6 +4570,91 @@ void lotus_hashmap_set_retire_desc(void *map_ptr,
  * is 9 bytes ⇒ 16-byte nodes need size >= 16; smaller blobs are
  * simply dropped back to the shell list without reuse — they cost
  * almost nothing to leak and can't hold a node). */
+/* GH iris-handoff P1 (2026-07-27): put one block on the reuse
+ * freelist IMMEDIATELY (no pending window). Used by the form
+ * pointer-storage replace paths (vec.set overwriting a slot),
+ * where the deep copy of the NEW value completed before the old
+ * pointer is unlinked — under the single-owner value rule no
+ * live alias may survive the overwrite, so the block is
+ * reclaimable now. Same size-16 split as the flush below. */
+int64_t lotus_bytes_len(const void *b); /* defined below */
+
+static void lotus_arena_free_block_now(lotus_arena_t *a, void *blob,
+                                       size_t size) {
+    if (!a || !blob) return;
+    if (size >= 16) {
+        char *b = (char *)blob;
+        memcpy(b, &size, sizeof(size_t));
+        memcpy(b + 8, &a->retire_free, sizeof(void *));
+        a->retire_free = b;
+    } else {
+        lotus_retire_shell_t *sh =
+            (lotus_retire_shell_t *)a->retire_shells;
+        if (sh) {
+            a->retire_shells = sh->next;
+        } else {
+            sh = (lotus_retire_shell_t *)lotus_arena_alloc(
+                a, sizeof(lotus_retire_shell_t), 8);
+            if (!sh) return;
+        }
+        sh->blob = blob;
+        sh->size = size;
+        sh->next = (lotus_retire_shell_t *)a->retire_free_small;
+        a->retire_free_small = sh;
+    }
+}
+
+/* GH iris-handoff P1: retire everything a REPLACED pointer-storage
+ * form element owned — its top-level String fields (surviving
+ * pointers excluded, intra-call aliasing deduped: the hashmap
+ * retire-cell discipline) and then the element block itself.
+ * `size` sentinels: -1 = old_blob is a NUL-terminated String
+ * (strlen+1); -2 = old_blob is a Bytes blob (8 + len); >= 0 =
+ * struct block of that many bytes. All guards live here so the
+ * publish-site IR is two loads + one call. */
+void lotus_form_retire_replaced(void *arena_ptr, void *old_blob,
+                                void *new_blob, int64_t size,
+                                const int32_t *str_offs,
+                                int64_t n_offs) {
+    lotus_arena_t *a = (lotus_arena_t *)arena_ptr;
+    if (!a || !old_blob || old_blob == new_blob) return;
+    if (!lotus_arena_contains_ptr(a, old_blob)) return;
+    const char *old_v = (const char *)old_blob;
+    const char *new_v = (const char *)new_blob;
+    for (int64_t i = 0; i < n_offs; i++) {
+        int32_t off = str_offs[i];
+        char *oldp;
+        memcpy(&oldp, old_v + off, sizeof(char *));
+        if (!oldp) continue;
+        if (new_v) {
+            char *newp;
+            memcpy(&newp, new_v + off, sizeof(char *));
+            if (oldp == newp) continue; /* survives into the new elem */
+        }
+        int dup = 0;
+        for (int64_t j = 0; j < i; j++) {
+            char *pj;
+            memcpy(&pj, old_v + str_offs[j], sizeof(char *));
+            if (pj == oldp) { dup = 1; break; }
+        }
+        if (dup) continue;
+        if (!lotus_arena_contains_ptr(a, oldp)) continue;
+        lotus_arena_free_block_now(a, oldp, strlen(oldp) + 1);
+    }
+    size_t block_size;
+    if (size == -1) {
+        block_size = strlen((const char *)old_blob) + 1;
+    } else if (size == -2) {
+        block_size =
+            (size_t)lotus_bytes_len(old_blob) + sizeof(int64_t);
+    } else if (size >= 0) {
+        block_size = (size_t)size;
+    } else {
+        return;
+    }
+    lotus_arena_free_block_now(a, old_blob, block_size);
+}
+
 void lotus_arena_flush_retired(void *arena_ptr) {
     lotus_arena_t *a = (lotus_arena_t *)arena_ptr;
     if (!a) return;
@@ -4671,7 +4756,11 @@ void *lotus_arena_alloc_reusable(void *arena_ptr, uint64_t size,
                                  uint64_t align) {
     lotus_arena_t *a = (lotus_arena_t *)arena_ptr;
     if (!a) return NULL;
-    if (align <= 8) {
+    /* GH iris-handoff P1: struct blocks alloc at align 16 (the
+     * i128/Decimal movdqa fix) — admit them; the pops match by
+     * candidate ADDRESS alignment, so a 16-align request simply
+     * skips under-aligned blocks. */
+    if (align <= 16) {
         void *b = size >= 16
             ? lotus_retire_free_pop(a, (size_t)size, (size_t)align)
             : lotus_retire_free_small_pop(a, (size_t)size, (size_t)align);

--- a/crates/hale-codegen/src/form/mod.rs
+++ b/crates/hale-codegen/src/form/mod.rs
@@ -510,6 +510,118 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         )
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
                 };
+                // iris handoff P1 (2026-07-27): retire the REPLACED
+                // element before the overwrite. Pointer-storage
+                // elements (structs / String / Bytes) each own an
+                // arena block that the old code simply orphaned in
+                // the form owner's program-lifetime arena — ~33B
+                // and one arena chunk-walk per set at fuse-hl's
+                // rates. All guards (NULL, old==new, containment,
+                // field-survival, intra-call aliasing dedup) live
+                // in the C helper; here it is one load + one call
+                // on the in-bounds path. Scalar-repr elements
+                // (Int/Float/Bool/enum-tag) store inline — nothing
+                // to retire.
+                let retire_spec: Option<(i64, Vec<u32>)> = match &elem_ty {
+                    CodegenTy::String => Some((-1, Vec::new())),
+                    CodegenTy::Bytes => Some((-2, Vec::new())),
+                    CodegenTy::TypeRef(tn) => {
+                        self.user_types.get(tn).map(|ti| {
+                            let sz = self
+                                .target_data
+                                .get_abi_size(&ti.struct_ty)
+                                as i64;
+                            let mut offs = Vec::new();
+                            for fname in &ti.field_order {
+                                if let Some((idx, fty)) =
+                                    ti.fields.get(fname)
+                                {
+                                    if matches!(fty, CodegenTy::String) {
+                                        if let Some(o) = self
+                                            .target_data
+                                            .offset_of_element(
+                                                &ti.struct_ty,
+                                                *idx,
+                                            )
+                                        {
+                                            offs.push(o as u32);
+                                        }
+                                    }
+                                }
+                            }
+                            (sz, offs)
+                        })
+                    }
+                    _ => None,
+                };
+                if let Some((size_sentinel, offs)) = retire_spec {
+                    let old_ptr = self
+                        .builder
+                        .build_load(
+                            ptr_t,
+                            elem_ptr,
+                            &format!("{}.vec.set.old", locus_name),
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    let (desc_ptr, n_offs) = if offs.is_empty() {
+                        (ptr_t.const_null(), 0i64)
+                    } else {
+                        let gname = format!(
+                            "__vec_retire_desc.{}",
+                            match &elem_ty {
+                                CodegenTy::TypeRef(tn) => tn.clone(),
+                                _ => unreachable!(),
+                            }
+                        );
+                        let g = match self.module.get_global(&gname) {
+                            Some(g) => g,
+                            None => {
+                                let vals: Vec<_> = offs
+                                    .iter()
+                                    .map(|o| {
+                                        i32_t.const_int(*o as u64, false)
+                                    })
+                                    .collect();
+                                let arr = i32_t.const_array(&vals);
+                                let g = self.module.add_global(
+                                    arr.get_type(),
+                                    None,
+                                    &gname,
+                                );
+                                g.set_initializer(&arr);
+                                g.set_constant(true);
+                                g.set_linkage(
+                                    inkwell::module::Linkage::Internal,
+                                );
+                                g
+                            }
+                        };
+                        (g.as_pointer_value(), offs.len() as i64)
+                    };
+                    let retire_fn = self
+                        .module
+                        .get_function("lotus_form_retire_replaced")
+                        .expect("lotus_form_retire_replaced declared");
+                    self.builder
+                        .build_call(
+                            retire_fn,
+                            &[
+                                dest_arena.into(),
+                                old_ptr.into(),
+                                val.into(),
+                                i64_t
+                                    .const_int(
+                                        size_sentinel as u64,
+                                        true,
+                                    )
+                                    .into(),
+                                desc_ptr.into(),
+                                i64_t.const_int(n_offs as u64, false).into(),
+                            ],
+                            &format!("{}.vec.set.retire", locus_name),
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                }
                 self.builder
                     .build_store(elem_ptr, val)
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;

--- a/crates/hale-codegen/src/locus/return_path.rs
+++ b/crates/hale-codegen/src/locus/return_path.rs
@@ -443,10 +443,14 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 let bytes = struct_ty
                     .size_of()
                     .expect("user-type struct has known size");
+                // iris handoff P1: consult the retire freelist so a
+                // steady-state form replace (vec.set) ping-pongs
+                // between reused blocks instead of growing the
+                // owner's arena ~sizeof(elem) per call.
                 let alloc_fn = self
                     .module
-                    .get_function("lotus_arena_alloc")
-                    .expect("lotus_arena_alloc declared");
+                    .get_function("lotus_arena_alloc_reusable")
+                    .expect("lotus_arena_alloc_reusable declared");
                 let i64_t = self.context.i64_type();
                 let new_struct = self
                     .builder

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -906,6 +906,33 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             i64_t2.fn_type(&[ptr_t.into(), ptr_t.into()], false),
             None,
         );
+        // iris handoff P1 — form pointer-storage replace retire:
+        // declare void @lotus_form_retire_replaced(ptr arena, ptr old,
+        //     ptr new, i64 size, ptr str_offs, i64 n_offs)
+        // declare ptr @lotus_arena_alloc_reusable(ptr, i64, i64)
+        self.module.add_function(
+            "lotus_form_retire_replaced",
+            self.context.void_type().fn_type(
+                &[
+                    ptr_t.into(),
+                    ptr_t.into(),
+                    ptr_t.into(),
+                    i64_t2.into(),
+                    ptr_t.into(),
+                    i64_t2.into(),
+                ],
+                false,
+            ),
+            None,
+        );
+        self.module.add_function(
+            "lotus_arena_alloc_reusable",
+            ptr_t.fn_type(
+                &[ptr_t.into(), i64_t2.into(), i64_t2.into()],
+                false,
+            ),
+            None,
+        );
         // declare i32 @lotus_process_wait(i32 pid,
         //                                 ptr out_code,
         //                                 ptr out_signal)

--- a/crates/hale-codegen/tests/form_vec_set_retire.rs
+++ b/crates/hale-codegen/tests/form_vec_set_retire.rs
@@ -1,0 +1,163 @@
+//! iris handoff P1 (2026-07-27) — `@form(vec).set` replaced-element
+//! retire.
+//!
+//! Pointer-storage vec elements each own an arena block; `.set`
+//! used to orphan the REPLACED element in the form owner's
+//! program-lifetime arena: ~33B leaked per set, and the growing
+//! arena made the deep-copy containment chunk-walk progressively
+//! slower (the reported ~1µs/set, ~1000× `.get`). The fix retires
+//! the old block (+ its non-surviving String fields, hashmap
+//! retire-cell discipline) straight onto the reuse freelist, and
+//! the deep-copy alloc consults that freelist — steady-state sets
+//! ping-pong between reused blocks.
+//!
+//! The assertion is an IN-PROGRAM RSS budget via
+//! `std::process::rss_bytes()`: after warmup, 2M churn sets may
+//! not grow peak RSS by more than 16MB (pre-fix growth at this
+//! scale: ~65MB and climbing linearly). Generous margin keeps CI
+//! load out of the verdict; the ASan corpus job covers the
+//! double-retire/UAF side.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+fn build(name: &str, src: &str) -> PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale_test_vecretire_{}", name));
+    build_executable(&program, &bin).expect("build");
+    bin
+}
+
+#[test]
+fn set_churn_is_flat_and_fast() {
+    let src = r#"
+        type Ent { seq: Int = 0; ts: Int = 0; seg: Int = -1; kind: Int = 0; }
+
+        @form(vec)
+        locus EntVec { capacity { heap items of Ent; } }
+
+        locus Setter {
+            params { v: EntVec; round: Int = 0; }
+            birth() {
+                let mut i = 0;
+                while i < 100000 {
+                    let e = self.v.get(i % 1024) or Ent { };
+                    self.v.set(i % 1024, Ent {
+                        seq: e.seq + 1, ts: self.round, seg: 0, kind: 1,
+                    }) or discard;
+                    i = i + 1;
+                }
+            }
+        }
+
+        main locus App {
+            params { v: EntVec = EntVec { }; }
+            birth() {
+                let mut i = 0;
+                while i < 1024 { self.v.push(Ent { }); i = i + 1; }
+            }
+            run() {
+                // Warmup round, then measure.
+                Setter { v: self.v, round: 0 };
+                let base = std::process::rss_bytes();
+                let mut n = 1;
+                while n < 20 {
+                    Setter { v: self.v, round: n };
+                    n = n + 1;
+                }
+                let grown = std::process::rss_bytes() - base;
+                if grown > 16777216 {
+                    println("LEAK: rss grew ", grown, " bytes over 1.9M sets");
+                    std::process::exit(1);
+                }
+                let probe = self.v.get(7) or Ent { };
+                if probe.seq != 1960 {
+                    println("BAD seq: ", probe.seq);
+                    std::process::exit(1);
+                }
+                println("flat, seq ok");
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let bin = build("churn", src);
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("flat, seq ok"),
+        "stdout: {:?}\nstderr: {:?}",
+        stdout,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn string_fields_retire_with_survivor_guard() {
+    // Replaced elements' String fields retire; a field that
+    // SURVIVES into the new element (tag aliasing) must not be
+    // retired out from under it. Correctness assertions +
+    // steady-state churn — corruption from a bad retire shows up
+    // as a wrong tag or an ASan hit in the sanitizer job.
+    let src = r#"
+        type Row { name: String = ""; tag: String = ""; n: Int = 0; }
+
+        @form(vec)
+        locus Rows { capacity { heap items of Row; } }
+
+        locus Churner {
+            params { v: Rows; }
+            birth() {
+                let mut i = 0;
+                while i < 200000 {
+                    let idx = i % 64;
+                    let old = self.v.get(idx) or Row { };
+                    self.v.set(idx, Row {
+                        name: "fresh",
+                        tag: old.tag,
+                        n: old.n + 1,
+                    }) or discard;
+                    i = i + 1;
+                }
+            }
+        }
+
+        main locus App {
+            params { v: Rows = Rows { }; }
+            birth() {
+                let mut i = 0;
+                while i < 64 {
+                    self.v.push(Row { name: "seed", tag: "keep-me", n: 0 });
+                    i = i + 1;
+                }
+            }
+            run() {
+                Churner { v: self.v };
+                let probe = self.v.get(3) or Row { };
+                if probe.tag != "keep-me" {
+                    println("SURVIVOR LOST: ", probe.tag);
+                    std::process::exit(1);
+                }
+                if probe.n != 3125 {
+                    println("BAD n: ", probe.n);
+                    std::process::exit(1);
+                }
+                println("survivor intact");
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let bin = build("strings", src);
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("survivor intact"),
+        "stdout: {:?}\nstderr: {:?}",
+        stdout,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -99,8 +99,22 @@ fn form_grows(form_name: &str) -> bool {
 /// Phase D / D2: the method names that *insert* into a collection (vs read
 /// it). Gated by `form_grows` on the receiver's form, so a `get`/`len`/`pop`
 /// never counts.
+///
+/// iris handoff P1 (2026-07-27): `set` no longer counts for VEC —
+/// a vec `.set` replaces in place and RETIRES the old element onto
+/// the reuse freelist (RSS-proven flat at 2M sets), so it is not an
+/// accumulation channel anymore. `hashmap.set` keeps counting: it
+/// can insert a NEW key (growth), and its replaced-value retirement
+/// already has its own retired_store modeling (Gap D).
 fn is_insert_method(method: &str) -> bool {
     matches!(method, "push" | "set" | "insert" | "add")
+}
+
+fn is_growing_insert(form_name: &str, method: &str) -> bool {
+    if form_name == "vec" && method == "set" {
+        return false;
+    }
+    form_grows(form_name) && is_insert_method(method)
 }
 
 /// The unqualified name of a `Named` type expression (`SegVec` from
@@ -432,6 +446,8 @@ pub struct FormShape {
 /// The bundle-wide allocation summary + call graph.
 #[derive(Debug, Clone, Default)]
 pub struct AllocSummary {
+    /// iris handoff P2.2: loci only ever instantiated eagerly.
+    pub eager_only_loci: BTreeSet<String>,
     pub fns: BTreeMap<FnKey, FnSummary>,
     /// GH #18 item 1: loci carrying `@bounded` — their leak sites are
     /// reported even without the `--warn-unbounded-alloc` survey flag
@@ -588,6 +604,39 @@ impl AllocSummary {
         callers: &BTreeMap<FnKey, BTreeSet<FnKey>>,
     ) -> SiteVerdict {
         let intra = site.verdict();
+        // iris handoff P2.2: EAGER-ONLY loci — every instantiation is
+        // a bare statement that dissolves (arena destroyed) at the
+        // statement itself.
+        //  (a) An instantiation SITE of such a locus in a parent
+        //      loop reclaims per iteration — the fresh instance
+        //      cannot outlive the statement.
+        //  (b) A site INSIDE such a locus's own frames whose value
+        //      stays in the instance (Local / StoredToSelf) is
+        //      bounded by that statement-scoped lifetime. Returned /
+        //      Sent escapes keep their normal analysis — they leave
+        //      the instance.
+        // `while true` inside the eager locus still disqualifies
+        // (the statement never completes).
+        // (a) applies regardless of the PARENT loop's kind — even
+        // under `while true`, the eager child drains/dissolves and
+        // its arena is destroyed at the statement, every iteration.
+        if let AllocKind::StructLit(n) = &site.kind {
+            if self.eager_only_loci.contains(n) {
+                return SiteVerdict::PerIterationReclaim;
+            }
+        }
+        if !site.in_infinite_loop {
+            if let Some(l) = &owner.locus {
+                if self.eager_only_loci.contains(l)
+                    && matches!(
+                        site.escape,
+                        Escape::Local | Escape::StoredToSelf
+                    )
+                {
+                    return SiteVerdict::PerIterationReclaim;
+                }
+            }
+        }
         let owner_scratchless = scratchless.contains(owner);
         match intra {
             SiteVerdict::AccumulatesUnbounded => {
@@ -876,6 +925,169 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
     let mut retirable_structs: BTreeSet<String> = BTreeSet::new();
     // 2026-07-01 — per-locus scalar-[T; N] param fields (inline layout).
     let mut locus_inline_arrays: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    // iris handoff P2.1 (2026-07-27): top-level `const` ints, so a
+    // `while i < NET_SLOTS * WINDOW` ceiling const-folds to a real
+    // bound instead of ranking as a runtime `while`.
+    let mut const_ints: BTreeMap<String, i64> = BTreeMap::new();
+    for program in programs {
+        for item in &program.items {
+            if let TopDecl::Const(c) = item {
+                if let Some(v) =
+                    const_int_eval(&c.value, &const_ints)
+                {
+                    const_ints.insert(c.name.name.clone(), v);
+                }
+            }
+        }
+    }
+
+    // iris handoff P2.2 (2026-07-27): loci whose every instantiation
+    // is EAGER — a bare statement `L { ... };` that drains/dissolves
+    // (arena destroyed) at the statement itself. Their per-instance
+    // region accumulation is bounded by one parent statement, and an
+    // instantiation site in a parent loop reclaims per iteration.
+    // Conservative subtraction: any subscription (defers to scope
+    // exit), any use as a param-field type (parent-owned lifetime),
+    // any let-binding of the literal (defers to method exit), any
+    // appearance as an accept() param type, or `main` status
+    // disqualifies.
+    let mut eager_only_loci: BTreeSet<String> = BTreeSet::new();
+    {
+        let mut all: BTreeSet<String> = BTreeSet::new();
+        let mut deferred: BTreeSet<String> = BTreeSet::new();
+        fn has_while_true(b: &Block) -> bool {
+            b.stmts.iter().any(|st| match st {
+                Stmt::While { cond, body, .. } => {
+                    matches!(cond, Expr::Literal(Literal::Bool(true), _))
+                        || has_while_true(body)
+                }
+                Stmt::For { body, .. } => has_while_true(body),
+                Stmt::If(i) => {
+                    fn hif(i: &IfStmt) -> bool {
+                        if has_while_true(&i.then_block) {
+                            return true;
+                        }
+                        match i.else_block.as_deref() {
+                            Some(ElseBranch::Else(b)) => has_while_true(b),
+                            Some(ElseBranch::ElseIf(i2)) => hif(i2),
+                            None => false,
+                        }
+                    }
+                    hif(i)
+                }
+                Stmt::Block(b2) => has_while_true(b2),
+                _ => false,
+            })
+        }
+        fn scan_lets_if(i: &IfStmt, out: &mut BTreeSet<String>) {
+            scan_lets(&i.then_block, out);
+            if let Some(e) = &i.else_block {
+                match e.as_ref() {
+                    ElseBranch::Else(b) => scan_lets(b, out),
+                    ElseBranch::ElseIf(i2) => scan_lets_if(i2, out),
+                }
+            }
+        }
+        fn scan_lets(b: &Block, out: &mut BTreeSet<String>) {
+            for st in &b.stmts {
+                match st {
+                    Stmt::Let { value, .. } => {
+                        if let Expr::Struct { path, .. } = value {
+                            if path.segments.len() == 1 {
+                                out.insert(
+                                    path.segments[0].name.clone(),
+                                );
+                            }
+                        }
+                    }
+                    Stmt::While { body, .. } => scan_lets(body, out),
+                    Stmt::For { body, .. } => scan_lets(body, out),
+                    Stmt::If(i) => scan_lets_if(i, out),
+                    Stmt::Block(b2) => scan_lets(b2, out),
+                    _ => {}
+                }
+            }
+        }
+        for program in programs {
+            for item in &program.items {
+                let TopDecl::Locus(l) = item else { continue };
+                all.insert(l.name.name.clone());
+                if l.is_main {
+                    deferred.insert(l.name.name.clone());
+                }
+                for member in &l.members {
+                    match member {
+                        LocusMember::Bus(_) => {
+                            let has_sub =
+                                l.members.iter().any(|m| match m {
+                                    LocusMember::Bus(bb) => {
+                                        bb.members.iter().any(|bm| {
+                                            matches!(
+                                                bm,
+                                                BusMember::Subscribe {
+                                                    ..
+                                                }
+                                            )
+                                        })
+                                    }
+                                    _ => false,
+                                });
+                            if has_sub {
+                                deferred.insert(l.name.name.clone());
+                            }
+                        }
+                        LocusMember::Params(pb) => {
+                            for p in &pb.params {
+                                if let Some(ty) = &p.ty {
+                                    if let Some(n) =
+                                        single_named_type_name(ty)
+                                    {
+                                        deferred.insert(n);
+                                    }
+                                }
+                            }
+                        }
+                        LocusMember::Lifecycle(lc) => {
+                            for p in &lc.params {
+                                if let Some(n) =
+                                    single_named_type_name(&p.ty)
+                                {
+                                    deferred.insert(n);
+                                }
+                            }
+                            scan_lets(&lc.body, &mut deferred);
+                            // A `while true` anywhere in the locus's
+                            // own bodies means an eager statement may
+                            // never complete — no statement-scoped
+                            // lifetime to lean on.
+                            if has_while_true(&lc.body) {
+                                deferred.insert(l.name.name.clone());
+                            }
+                        }
+                        LocusMember::Fn(f) => {
+                            scan_lets(&f.body, &mut deferred);
+                            if has_while_true(&f.body) {
+                                deferred.insert(l.name.name.clone());
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        for program in programs {
+            for item in &program.items {
+                if let TopDecl::Fn(f) = item {
+                    scan_lets(&f.body, &mut deferred);
+                }
+            }
+        }
+        for l in all {
+            if !deferred.contains(&l) {
+                eager_only_loci.insert(l);
+            }
+        }
+    }
 
     for program in programs {
         for item in &program.items {
@@ -977,6 +1189,7 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
 
     // Phase 2 — walk each body.
     let mut summary = AllocSummary::default();
+    summary.eager_only_loci = eager_only_loci;
     for (key, body, entry, enclosing_locus, param_types) in &bodies {
         let escaping = collect_escaping_names(body);
         let field_types = enclosing_locus
@@ -997,6 +1210,7 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
             loop_stack: Vec::new(),
             infinite_stack: Vec::new(),
             fn_body: body,
+            const_ints: &const_ints,
             store_target: None,
             var_types: param_types.iter().cloned().collect(),
             field_types,
@@ -1146,7 +1360,10 @@ pub fn unbounded_alloc_diags(programs: &[&Program], include_all: bool) -> Vec<Di
                 format!(
                     "unbounded allocation: this {} {} accumulates in `{}`'s region \
                      until the locus dissolves — it is never reclaimed per iteration, \
-                     so it grows without bound. Bound the loop; store it in a \
+                     so it grows without bound (or acknowledge an \
+                     intentionally-/domain-bounded shape with `@unbounded` \
+                     on the enclosing fn or lifecycle hook). Bound the loop; \
+                     store it in a \
                      capacity-bounded form (`@form(ring_buffer)` / `@form(lru_cache)` / \
                      a `capacity` slot) instead of a replaced field; mutate fixed state \
                      in place rather than rebuilding it; route the value over the bus \
@@ -1244,6 +1461,8 @@ struct Walker<'a> {
     /// `while v < N` counter is const-bounded (const init + only positive
     /// const increments anywhere in the fn).
     fn_body: &'a Block,
+    /// iris handoff P2.1: top-level const ints for ceiling folding.
+    const_ints: &'a BTreeMap<String, i64>,
     /// Phase D / D1: the `self.<field>` currently being assigned, set around
     /// the RHS walk of a `self.<field> = …` statement so an escaping
     /// allocation in that RHS records which field it lands in.
@@ -1435,7 +1654,8 @@ impl<'a> Walker<'a> {
                 // const-initialized and only ever incremented by positive
                 // consts is const-bounded; any other `while` is unbounded
                 // (its trip count is runtime, like a runtime `for`-iter).
-                let bounded = while_counter_bounded(cond, self.fn_body);
+                let bounded =
+                    while_counter_bounded(cond, self.fn_body, self.const_ints);
                 let kind = if bounded { LoopKind::WhileCounter } else { while_loop_kind(cond) };
                 let infinite = matches!(
                     cond,
@@ -1557,7 +1777,10 @@ impl<'a> Walker<'a> {
                 | Expr::Path2 { receiver, name, .. } = callee.as_ref()
                 {
                     if is_insert_method(&name.name) {
-                        if let Some(form) = self.growing_form_of_receiver(receiver) {
+                        if let Some(form) = self
+                            .growing_form_of_receiver(receiver)
+                            .filter(|f| is_growing_insert(f, &name.name))
+                        {
                             self.push_collection_insert(form, depth, *span);
                         }
                     }
@@ -1708,11 +1931,23 @@ fn while_loop_kind(cond: &Expr) -> LoopKind {
 /// a const ceiling → the trip count is bounded by a compile-time constant.
 /// Conservative: any non-increment mutation, shadowing, non-const init, or
 /// a `self.field` counter → false (never a false "bounded").
-fn while_counter_bounded(cond: &Expr, fn_body: &Block) -> bool {
+fn while_counter_bounded(
+    cond: &Expr,
+    fn_body: &Block,
+    const_ints: &BTreeMap<String, i64>,
+) -> bool {
+    // iris handoff P2.1: the ceiling may be any CONST-FOLDABLE int
+    // expression — a literal, a top-level `const` ident, or +/-/*
+    // arithmetic over those (`NET_SLOTS * WINDOW`). Runtime values
+    // still rank unbounded.
     let var = match cond {
         Expr::Binary { op: BinOp::Lt | BinOp::LtEq, left, right, .. } => {
-            match (left.as_ref(), right.as_ref()) {
-                (Expr::Ident(v), Expr::Literal(Literal::Int(_), _)) => v.name.as_str(),
+            match left.as_ref() {
+                Expr::Ident(v)
+                    if const_int_eval(right, const_ints).is_some() =>
+                {
+                    v.name.as_str()
+                }
                 _ => return false,
             }
         }
@@ -1734,6 +1969,42 @@ fn while_counter_bounded(cond: &Expr, fn_body: &Block) -> bool {
         && s.rebindings == 0
         && s.bad_assigns == 0
         && s.pos_increments >= 1
+}
+
+/// iris handoff P2.2: single-segment named type → its name.
+fn single_named_type_name(ty: &TypeExpr) -> Option<String> {
+    match ty {
+        TypeExpr::Named { path, generic_args, .. }
+            if path.segments.len() == 1 && generic_args.is_empty() =>
+        {
+            Some(path.segments[0].name.clone())
+        }
+        _ => None,
+    }
+}
+
+/// iris handoff P2.1: fold an int expression over literals,
+/// top-level `const` idents, and +/-/* arithmetic. None = not a
+/// compile-time constant.
+fn const_int_eval(
+    e: &Expr,
+    const_ints: &BTreeMap<String, i64>,
+) -> Option<i64> {
+    match e {
+        Expr::Literal(Literal::Int(v), _) => Some(*v),
+        Expr::Ident(id) => const_ints.get(&id.name).copied(),
+        Expr::Binary { op, left, right, .. } => {
+            let l = const_int_eval(left, const_ints)?;
+            let r = const_int_eval(right, const_ints)?;
+            match op {
+                BinOp::Add => l.checked_add(r),
+                BinOp::Sub => l.checked_sub(r),
+                BinOp::Mul => l.checked_mul(r),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
 }
 
 #[derive(Default)]
@@ -2447,6 +2718,105 @@ mod tests {
         assert!(
             !msgs.iter().any(|m| m.contains("struct Cell")),
             "retired struct replace must not be flagged, got: {:?}",
+            msgs
+        );
+    }
+
+    #[test]
+    fn const_expr_ceiling_ranks_bounded() {
+        // iris handoff P2.1: `while i < NET_SLOTS * WINDOW` with both
+        // top-level consts is a const-bounded counter, not a runtime
+        // while.
+        let src = r#"
+            const NET_SLOTS: Int = 16;
+            const WINDOW: Int = 4;
+            locus K {
+                params { seen: Int = 0; }
+                bus { subscribe "k" as on_k of type Int; }
+                birth() {
+                    let mut i = 0;
+                    while i < NET_SLOTS * WINDOW {
+                        let s = "x" + i;
+                        self.seen = self.seen + len(s);
+                        i = i + 1;
+                    }
+                }
+                fn on_k(n: Int) { self.seen = self.seen + n; }
+            }
+            fn main() { }
+        "#;
+        let msgs = leak_msgs(src);
+        assert!(
+            msgs.is_empty(),
+            "const-expr ceiling must rank bounded, got: {:?}",
+            msgs
+        );
+    }
+
+    #[test]
+    fn eager_child_in_run_loop_not_flagged() {
+        // iris handoff P2.2: a bare-statement child instantiated per
+        // iteration dissolves at the statement — neither the
+        // instantiation site nor the child's own self-stores
+        // accumulate, even under the parent's `while true`.
+        let src = r#"
+            locus Cycle {
+                params { n: Int = 0; work: String = ""; }
+                birth() {
+                    let mut i = 0;
+                    while i < 8 {
+                        self.work = self.work + "x";
+                        i = i + 1;
+                    }
+                }
+            }
+            locus Driver {
+                params { r: Int = 0; }
+                bus { subscribe "tick" as on_t of type Int; }
+                run() {
+                    while true {
+                        Cycle { n: self.r };
+                        self.r = self.r + 1;
+                    }
+                }
+                fn on_t(n: Int) { self.r = self.r + n; }
+            }
+            fn main() { }
+        "#;
+        let msgs = leak_msgs(src);
+        assert!(
+            !msgs.iter().any(|m| m.contains("Cycle")),
+            "eager per-iteration child must not flag, got: {:?}",
+            msgs
+        );
+    }
+
+    #[test]
+    fn let_bound_child_in_run_loop_still_flagged() {
+        // The counterpart: a LET-BOUND instantiation defers to method
+        // exit — under `while true` that is a real accumulation and
+        // must keep flagging.
+        let src = r#"
+            locus Cycle {
+                params { n: Int = 0; }
+            }
+            locus Driver {
+                params { r: Int = 0; }
+                bus { subscribe "tick" as on_t of type Int; }
+                run() {
+                    while true {
+                        let c = Cycle { n: self.r };
+                        self.r = self.r + c.n;
+                    }
+                }
+                fn on_t(n: Int) { self.r = self.r + n; }
+            }
+            fn main() { }
+        "#;
+        let msgs = leak_msgs(src);
+        assert!(
+            msgs.iter().any(|m| m.contains("Cycle")),
+            "let-bound child in while-true must stay flagged, got: {:?}",
             msgs
         );
     }

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -1616,7 +1616,35 @@ fn hot_walk_stmt(s: &Stmt, cx: &mut HotPathCx) {
         Stmt::Match(m) => hot_walk_match(m, cx),
         Stmt::Return(Some(e), _) => hot_walk_expr(e, cx),
         Stmt::Fail { value, .. } => hot_walk_expr(value, cx),
-        Stmt::Expr(e) => hot_walk_expr(e, cx),
+        Stmt::Expr(e) => {
+            // iris handoff P2.2: a BARE-STATEMENT instantiation of
+            // a subscription-less locus dissolves EAGERLY at the
+            // statement — its arena is destroyed every iteration,
+            // which is the documented per-iteration-child idiom
+            // (and the very fix this advisory's "hoist it"
+            // guidance competes with). Only let-bound and
+            // subscription-bearing instantiations defer to
+            // method exit, so only those keep the warning. The
+            // field inits still walk (a nested builder inside
+            // the child literal is still a finding).
+            if let Expr::Struct { path, inits, .. } = e {
+                let eager = hot_locus_name(path, cx.top)
+                    .map(|n| match cx.top.lookup(&n) {
+                        Some(TopSymbol::Locus(li)) => {
+                            li.bus_subscribes.is_empty()
+                        }
+                        _ => false,
+                    })
+                    .unwrap_or(false);
+                if eager {
+                    for init in inits {
+                        hot_walk_expr(&init.value, cx);
+                    }
+                    return;
+                }
+            }
+            hot_walk_expr(e, cx);
+        }
         _ => {}
     }
 }
@@ -1645,11 +1673,14 @@ fn hot_walk_expr(e: &Expr, cx: &mut HotPathCx) {
                         *span,
                         format!(
                             "hot-path allocation: locus `{}` is instantiated \
-                             {} and only reclaimed when the enclosing method \
+                             {} and, being let-bound or subscription-bearing, \
+                             is only reclaimed when the enclosing method \
                              returns (a `run()` read loop never returns). \
-                             Hoist it to a reused field, or `clear()` and \
-                             refill one builder, to keep the hot path \
-                             allocation-free.",
+                             Hoist it to a reused field, `clear()` and refill \
+                             one builder, use a bare-statement per-iteration \
+                             child (eagerly dissolved), or acknowledge an \
+                             intentional shape with `@unbounded` on the \
+                             enclosing fn/hook.",
                             name, where_
                         ),
                     );

--- a/docs/src/everyday/http.md
+++ b/docs/src/everyday/http.md
@@ -157,11 +157,15 @@ and write it through the raw-fd `std::io::tcp` functions
 (`send_fd(fd, bytes)` to write, `recv_into` to read, `close_fd`
 to hang up) or a borrowed
 `Stream { conn_fd: fd, owns_fd: false }`, and close it
-when the session ends. Two things to remember: the server's 5s
+when the session ends. Three things to remember: the server's 5s
 receive timeout is still set on the fd (clear it with
 `std::io::tcp::set_recv_timeout(fd, 0)` for a long-lived
-session), and a takeover response without stashing `req.conn_fd`
-leaks the connection.
+session); a stalled peer — a half-dead connection, a throttled
+browser tab — will block your sends *forever* unless you bound
+them, so set `std::io::tcp::set_send_timeout(fd, 200ms)` before
+entering a push loop (an SSE/WS fan-out stalls its whole loop on
+one dead client otherwise); and a takeover response without
+stashing `req.conn_fd` leaks the connection.
 
 ## Calling out
 

--- a/spec/forms.md
+++ b/spec/forms.md
@@ -392,6 +392,23 @@ vec.set(0, new_first) or raise;
 vec.set(i, x)         or noop(err);   # swallow OOB
 ```
 
+> **Replaced-element reclamation (iris handoff P1, 2026-07-27).**
+> Vec elements are pointer-storage: each `set` deep-copies the new
+> value into the form owner's arena. The REPLACED element (and its
+> non-surviving String fields, with aliasing dedup — the hashmap
+> retire-cell discipline) now retires onto the arena's reuse
+> freelist immediately, and the deep-copy allocation consults that
+> freelist — steady-state `set` churn ping-pongs between reused
+> blocks instead of growing the arena (~33 B/set and a
+> progressively slower containment walk, pre-fix). Single-owner
+> caveat: a value obtained from `.get` is invalidated by a later
+> `set` to the same slot — holding a get result across a mutation
+> of its slot is out of contract (the same single-owner rule the
+> hashmap forms document).
+
+```hale,fragment
+```
+
 ### `pop`
 
 ```


### PR DESCRIPTION
Works through `HANDOFF-iris-2026-07-27.md` (the fuse-hl port findings).

## P1 — `@form(vec).set` per-call leak + ~1000× slowdown: root-caused and fixed

Vec elements are pointer-storage: `.set` deep-copies the new element into the form owner's program-lifetime arena — and **orphaned the replaced one**. That's the ~33 B/set leak, and the growing arena made the deep-copy's `contains_ptr` chunk-walk progressively slower, which is the microsecond (the two symptoms are one bug, compounding). Fix mirrors the v0.11.2 hashmap anchor-retire: the replaced block + its non-surviving String fields (survive-guard + intra-call aliasing dedup) retire **immediately onto the reuse freelist**, and the struct deep-copy allocates through the freelist-consulting path (align gate widened to 16).

Numbers on the reporter's own repro3 (2M sets): **2.06 s / 70 MB → 0.01 s / 7.8 MB flat** — with-set and no-set RSS now identical, ASan corpus clean. fuse-hl's ~1.4 MB/s growth and drain-loop tax should be gone; no more periodic restarts. Contract note spec'd in forms.md: a `.get` value is invalidated by a later `set` to the same slot (the established single-owner rule). Ring-buffer push refuses when full (no overwrite path), hashmap already retired — vec.set was the only orphan site.

## P2 — `hale verify` false positives: **fuse-hl 26 findings → 0**

1. **Const-bounded ceilings**: `while i < NET_SLOTS * WINDOW` const-folds over top-level `const` ints (+/-/* arithmetic) and ranks bounded.
2. **Per-iteration children modeled**: a bare-statement `Cycle { ... };` dissolves at the statement — the instantiation site reclaims per iteration (even under the parent's `while true`), and the child's own Local/StoredToSelf sites are statement-bounded. Conservatively disqualified by subscriptions, param-field usage, let-binding, accept params, `main`, or a `while true` in the locus's own bodies — the let-bound-in-while-true counterpart test proves the real accumulation still flags. The analysis no longer flags the exact idiom its advisory recommends.
3. **The ack exists**: `@unbounded` on the enclosing fn/lifecycle hook has been the per-shape acknowledge all along — both advisory texts now *name* it, so domain-bounded growth (segments ≤16, topics ≤64) is acknowledgeable per-site without losing the gate's teeth.

Plus: vec `.set` is no longer classified as an accumulation channel (consequence of P1). Three new analysis regression tests; all 469 hale-types tests green.

## P3 — send timeout: already shipped, now documented

`std::io::tcp::set_send_timeout(fd, d)` exists and works (verified live) — iris's C-glue `SO_SNDTIMEO` workaround was unnecessary. The takeover chapter now tells servers to arm it before push loops, next to the recv-timeout note.

## Drive-by

`site-deploy`'s missing-token skip upgraded notice → warning naming the fix: every docs deploy since the workflow landed had silently no-opped (`SITE_DEPLOY_TOKEN` was never set — needs a fine-grained PAT, see the warning text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)