### PR TITLE
Native observation emission (iris handoff P4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ behavior.
 
 ## Unreleased
 
+- **Native observation emission (iris handoff P4).** `LOTUS_OBS=1`
+  makes any hale binary publish an iris-protocol observation
+  segment and emit records from the runtime's own choke points —
+  BUS_PUBLISH/BUS_DELIVER at dispatch, NET_SEND/NET_DELIVER with
+  per-binding seqs at the transport layer, LOCUS_BIRTH/DISSOLVE/
+  RESTART from the lifecycle paths — lighting up a whole deployed
+  stack with zero app changes. Dormant = one branch per probe;
+  observed-but-unattached = counters only; SPSC ring per emitting
+  thread; live-locus birth replay on observer attach (late-attach
+  tree reconstruction). Verified end-to-end against iris's own
+  `peek` consumer (pub=dlv 1:1, manifest-resolved names, births
+  incl. pinned loci). spec/runtime.md § "Native observation
+  emission"; `obs_emission.rs` pins the segment contract +
+  dormant default.
+
 - **`@form(vec).set` no longer leaks or slows down (iris handoff
   P1).** Vec elements are pointer-storage; `set` deep-copied the
   new element into the form owner's program-lifetime arena but

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -5552,6 +5552,25 @@ static void bus_inline_drain_one(lotus_bus_queue_t *q);
  * because codegen proved the whole program has no pinned / cross-pool
  * placement, so g_bus_has_pinned is provably 0 and the acquire-load is
  * dead work. */
+/* iris P4 — native observation probes, defined in lotus_obs.c.
+ * WEAK: helper binaries that compile this TU alone (transport
+ * drivers, model checkers) link without the obs TU; every call
+ * site guards on the symbol's presence. */
+void lotus_obs_bus_publish(const char *subject, void *publisher_self,
+                           uint64_t payload_bytes)
+    __attribute__((weak));
+void lotus_obs_bus_deliver(const char *subject, void *subscriber_self,
+                           uint64_t payload_bytes)
+    __attribute__((weak));
+int64_t lotus_obs_binding_register(const char *subject,
+                                   int64_t transport_kind)
+    __attribute__((weak));
+void lotus_obs_net_send(int64_t binding_id, uint64_t seq,
+                        uint64_t bytes) __attribute__((weak));
+void lotus_obs_net_deliver(int64_t binding_id, uint64_t seq,
+                           uint64_t bytes) __attribute__((weak));
+void lotus_obs_restart(const char *subject) __attribute__((weak));
+
 /* GH #255 phase 2 — forward decls: the bound-enforcement hooks
  * are defined with the registry machinery further down. */
 int lotus_subject_match(const char *pattern, const char *subject);
@@ -8209,6 +8228,13 @@ void lotus_bus_local_dispatch(lotus_bus_queue_t *queue,
                               const void *payload,
                               size_t payload_size) {
     if (!subject) return;
+    /* iris P4: BUS_PUBLISH once per dispatch; BUS_DELIVER per
+     * matched target below (enqueue-time — see lotus_obs.c v0
+     * scope notes). Publisher attribution rides the caller-arena
+     * TLS owner when available; v0 passes NULL (unattributed). */
+    if (lotus_obs_bus_publish) {
+        lotus_obs_bus_publish(subject, NULL, (uint64_t)payload_size);
+    }
     size_t delivered = 0;
     for (size_t i = 0; i < g_bus_count; i++) {
         lotus_bus_entry_t *e = &g_bus_entries[i];
@@ -8240,6 +8266,10 @@ void lotus_bus_local_dispatch(lotus_bus_queue_t *queue,
             lotus_bus_queue_enqueue(queue, e->handler, e->self_ptr,
                                     payload, payload_size);
             delivered++;
+        }
+        if (lotus_obs_bus_deliver) {
+            lotus_obs_bus_deliver(subject, e->self_ptr,
+                                  (uint64_t)payload_size);
         }
     }
     if (delivered == 0 && lotus_bus_log_drop_enabled()) {
@@ -12818,6 +12848,7 @@ typedef struct lotus_bus_remote_entry {
     uint64_t           ctr_reconnects;
     uint64_t           ctr_seq_gaps;   /* framed mode: recv'd seq != last+1 */
     uint64_t           ctr_waits;      /* GH #255: publishes that parked in `or wait` */
+    int64_t            obs_binding_id; /* iris P4: manifest id; 0 = unregistered, -1 = declined */
 } lotus_bus_remote_entry_t;
 
 #define LOTUS_CTR_BUMP(field) \
@@ -12963,9 +12994,23 @@ static void lotus_bus_unix_serve(lotus_bus_remote_entry_t *entry) {
             lotus_bus_local_dispatch(g_bus_queue_for_remote,
                                      entry->subject,
                                      struct_buf, (size_t)struct_size);
-            LOTUS_CTR_BUMP(entry->ctr_msgs_delivered);
+            uint64_t dseq = LOTUS_CTR_BUMP(entry->ctr_msgs_delivered);
             LOTUS_CTR_ADD(entry->ctr_bytes_delivered, n);
             entry->ctr_seq_gaps = t->seq_gaps;   /* framed mode */
+            /* iris P4: NET_DELIVER — framed mode carries the wire
+             * seq (t->last_seq); datagram/legacy falls back to the
+             * local deliver count. */
+            if (lotus_obs_net_deliver && lotus_obs_binding_register) {
+                if (entry->obs_binding_id == 0) {
+                    int64_t id = lotus_obs_binding_register(
+                        entry->subject ? entry->subject : "?", 0);
+                    entry->obs_binding_id = (id > 0) ? id : -1;
+                }
+                if (entry->obs_binding_id > 0) {
+                    lotus_obs_net_deliver(entry->obs_binding_id, dseq,
+                                          (uint64_t)n);
+                }
+            }
         }
         /* GH #233 step 2: re-arm. Close the dead connection and
          * loop back into accept for the next peer. */
@@ -13276,8 +13321,20 @@ static void *lotus_bus_udp_reader_thread_main(void *arg) {
         lotus_bus_local_dispatch(g_bus_queue_for_remote,
                                  args->entry->subject,
                                  struct_buf, (size_t)struct_size);
-        LOTUS_CTR_BUMP(args->entry->ctr_msgs_delivered);
+        uint64_t dseq2 = LOTUS_CTR_BUMP(args->entry->ctr_msgs_delivered);
         LOTUS_CTR_ADD(args->entry->ctr_bytes_delivered, n);
+        if (lotus_obs_net_deliver && lotus_obs_binding_register) {
+            if (args->entry->obs_binding_id == 0) {
+                int64_t id = lotus_obs_binding_register(
+                    args->entry->subject ? args->entry->subject : "?",
+                    1);
+                args->entry->obs_binding_id = (id > 0) ? id : -1;
+            }
+            if (args->entry->obs_binding_id > 0) {
+                lotus_obs_net_deliver(args->entry->obs_binding_id,
+                                      dseq2, (uint64_t)n);
+            }
+        }
     }
     free(args);
     return NULL;
@@ -13633,6 +13690,10 @@ int64_t lotus_bus_transport_reconnect(int64_t handle) {
     if (!e->transport) return -1;
     e->lost = 0;
     LOTUS_CTR_BUMP(e->ctr_reconnects);
+    /* iris P4: RESTART record for the reconnected binding. */
+    if (lotus_obs_restart) {
+        lotus_obs_restart(e->subject);
+    }
     return 0;
 }
 
@@ -13921,8 +13982,21 @@ void lotus_bus_remote_fanout(const char *subject,
             continue;
         }
         if (lotus_transport_send(e->transport, payload, payload_size) == 0) {
-            LOTUS_CTR_BUMP(e->ctr_msgs_sent);
+            uint64_t sent_seq = LOTUS_CTR_BUMP(e->ctr_msgs_sent);
             LOTUS_CTR_ADD(e->ctr_bytes_sent, payload_size);
+            /* iris P4: NET_SEND with the per-binding monotonic seq.
+             * Lazy binding registration on first observed send. */
+            if (lotus_obs_net_send && lotus_obs_binding_register) {
+                if (e->obs_binding_id == 0) {
+                    int64_t id = lotus_obs_binding_register(
+                        e->subject ? e->subject : "?", 0);
+                    e->obs_binding_id = (id > 0) ? id : -1;
+                }
+                if (e->obs_binding_id > 0) {
+                    lotus_obs_net_send(e->obs_binding_id, sent_seq,
+                                       (uint64_t)payload_size);
+                }
+            }
         } else {
             LOTUS_CTR_BUMP(e->ctr_send_failures);
             if (e->locus_served) {
@@ -14183,6 +14257,11 @@ void lotus_bus_dispatch_wire(const char *subject,
                              const void *wire_bytes,
                              size_t wire_size) {
     if (!subject || !wire_bytes || wire_size == 0) return;
+    /* iris P4: BUS_PUBLISH for the cross-thread wire path (the
+     * deliver probe rides the per-subscriber fanout below). */
+    if (lotus_obs_bus_publish) {
+        lotus_obs_bus_publish(subject, NULL, (uint64_t)wire_size);
+    }
     /* Phase-3 Task 9 (2026-05-20): per-subscriber arena routing.
      * Previously this deserialize-once-then-fanout shape parked
      * the deserialized String/Bytes pointers in the program-
@@ -14346,11 +14425,19 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
     if (flat) {
         /* Verbatim local fanout (mirror lotus_bus_local_dispatch). */
         size_t delivered = 0;
+        /* iris P4 (mirrors the dynamic path). */
+        if (lotus_obs_bus_publish) {
+            lotus_obs_bus_publish(subject, NULL, (uint64_t)struct_size);
+        }
         if (b) {
             for (size_t k = 0; k < b->count; k++) {
                 lotus_bus_entry_t *e = &g_bus_entries[b->idx[k]];
                 if (!e->subject) continue;           /* quarantined */
                 if (e->key_filter_kind != 0) continue;
+                if (lotus_obs_bus_deliver) {
+                    lotus_obs_bus_deliver(subject, e->self_ptr,
+                                          (uint64_t)struct_size);
+                }
                 if (e->mailbox) {
                     lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
                                        struct_payload, (size_t)struct_size);

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -1,0 +1,561 @@
+/*
+ * Hale native observation emission — iris handoff P4 (2026-07-27).
+ *
+ * Implements the iris observation protocol (PROTOCOL.md v0.1 on
+ * the iris-observer `observer` branch) as a runtime capability:
+ * with `LOTUS_OBS=1` in the environment, the process publishes a
+ * `/hale-obs-<pid>` shm segment + registration file, and the
+ * runtime's own choke points emit protocol records — NET_SEND /
+ * NET_DELIVER at the transport layer (with real per-binding
+ * seqs, the records iris seq-matches into cross-process edges),
+ * BUS_PUBLISH / BUS_DELIVER at dispatch (locus-attributed),
+ * LOCUS_BIRTH / DISSOLVE / RESTART from the lifecycle paths —
+ * lighting up every binary of a stack with zero app changes.
+ *
+ * Segment machinery adapted from the protocol's reference
+ * implementation (iris-observer/observe/glue.c + emitter/
+ * protocol.h — layouts pinned there by static_asserts; where
+ * this file and PROTOCOL.md disagree, that is a bug).
+ *
+ * Own TU (the lotus_tls.c rationale): helper binaries including
+ * lotus_arena.c directly don't pick up the probe surface; the
+ * arena TU calls into these hooks through weak-ref-shaped
+ * always-defined externs instead.
+ *
+ * Cost contract: LOTUS_OBS unset → `g_obs_state` stays 0 and
+ * every probe is one predictable branch. Enabled but no observer
+ * attached (`observer_count == 0`) → counters only, no ring
+ * writes (§5 dormant rule). Ring emission is SPSC per the #247
+ * primitive: each emitting THREAD owns one ring (TLS
+ * assignment, first-come; threads beyond ring_count count into
+ * ring_drops_total rather than corrupting a ring).
+ *
+ * v0 scope notes (each is a PROTOCOL §13 conversation):
+ *   - BUS_DELIVER is emitted at fanout/enqueue time per target
+ *     (the subject + target locus are in scope there); consumer
+ *     -side dispatch latency is therefore not in the deliver
+ *     record. Counter `delivered` matches enqueue too.
+ *   - Manifest ids are registration-order (the protocol's
+ *     "library" rule); `.hale.topo` native ordering lands with
+ *     that metadata section.
+ *   - On the observer_count 0→1 rising edge the live locus
+ *     table is replayed as LOCUS_BIRTH records (late-attach
+ *     tree reconstruction, §13 candidate) from whichever
+ *     probe thread notices the edge.
+ */
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+#define OBS_MAGIC 0x4F42534948414C45ULL
+#define OBS_PAGE 4096
+#define OBS_ENTRY_CAP 256
+#define OBS_INSTANCE_CAP 4096
+#define OBS_TS_DELTA_MAX 0x7FFFFFFFULL
+
+/* ekinds (PROTOCOL §8) */
+#define EK_EPOCH 0
+#define EK_BUS_PUBLISH 1
+#define EK_BUS_DELIVER 2
+#define EK_NET_SEND 3
+#define EK_NET_DELIVER 4
+#define EK_LOCUS_BIRTH 5
+#define EK_LOCUS_DISSOLVE 6
+#define EK_RESTART 7
+#define EK_DROP_MARK 14
+
+/* manifest kinds */
+#define MK_TOPIC 0
+#define MK_LOCUS_TYPE 1
+#define MK_BINDING 2
+
+typedef struct {
+  uint64_t magic;
+  uint16_t proto_major, proto_minor;
+  uint32_t header_len;
+  uint64_t total_len;
+  uint32_t pid, ring_count, ring_slots, ts_shift;
+  uint64_t started_mono_ns, started_wall_ns;
+  uint64_t control_off, manifest_off, manifest_len, modemask_off,
+           counters_off, counters_len, rings_off;
+  _Atomic uint64_t flags;
+  _Atomic uint64_t manifest_gen;
+} obs_hdr_t;
+
+typedef struct { _Atomic uint32_t observer_count, sample_n; } obs_ctrl_t;
+typedef struct { _Atomic uint32_t entry_count; uint32_t entry_cap, pool_off;
+                 _Atomic uint32_t pool_used; } obs_mh_t;
+typedef struct { uint64_t shape_hash, aux_b; uint32_t id, name_off;
+                 uint16_t name_len, aux_a; uint8_t kind, flags;
+                 uint16_t _pad; } obs_me_t;
+typedef struct { _Atomic uint64_t c[8]; } obs_cline_t;
+/* MUST match lotus_spsc_desc_t (lotus_arena.c) and PROTOCOL §9. */
+typedef struct { uint64_t data_off; _Atomic uint64_t head, dropped;
+                 uint32_t tag_a; _Atomic uint32_t tag_b;
+                 uint8_t reserved[32]; } obs_rdesc_t;
+
+/* #247 primitives (lotus_arena.c). */
+void lotus_spsc_emit(void *seg_base, void *desc, int64_t ring_slots,
+                     int64_t w0, int64_t w1);
+void lotus_spsc_note_drop(void *desc);
+
+/* 0 = unchecked, 1 = disabled, 2 = enabled. */
+static _Atomic int g_obs_state = 0;
+
+static void *g_seg; static size_t g_seg_len;
+static obs_hdr_t *H; static obs_ctrl_t *C; static obs_mh_t *MH;
+static obs_me_t *ME; static char *POOL; static uint8_t *MODE;
+static obs_cline_t *CNT; static obs_rdesc_t *RD;
+static char g_shm_name[64], g_reg_path[280];
+static int g_cnt_line_for[4][OBS_ENTRY_CAP];
+static pthread_mutex_t g_obs_lock = PTHREAD_MUTEX_INITIALIZER;
+
+/* subject → topic id cache (linear; manifest is <= 256). */
+typedef struct { const char *subject; int64_t id;
+                 _Atomic uint64_t seq; } obs_topic_slot_t;
+static obs_topic_slot_t g_topics[OBS_ENTRY_CAP];
+static _Atomic int g_topic_count = 0;
+
+/* locus instance table: self_ptr → u20 instance id + liveness
+ * (for the 0→1 birth replay). */
+typedef struct { void *self; uint32_t id, type_id, parent; int live; }
+    obs_inst_t;
+static obs_inst_t g_inst[OBS_INSTANCE_CAP];
+static _Atomic int g_inst_count = 0;
+static _Atomic uint32_t g_next_inst_id = 1;
+
+/* per-thread ring assignment (SPSC: one producer per ring). */
+static _Atomic int g_ring_next = 0;
+static __thread int t_ring = -1;          /* -1 unassigned, -2 none free */
+static __thread uint64_t t_epoch_ns = 0;  /* ring epoch anchor */
+
+static uint64_t obs_mono_ns(void) {
+  struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+static uint64_t obs_wall_ns(void) {
+  struct timespec ts; clock_gettime(CLOCK_REALTIME, &ts);
+  return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+static size_t obs_page_up(size_t n) {
+  return (n + OBS_PAGE - 1) & ~((size_t)OBS_PAGE - 1);
+}
+
+void lotus_obs_teardown(void) {
+  if (!g_seg) return;
+  atomic_store(&H->flags, 0);
+  unlink(g_reg_path);
+  munmap(g_seg, g_seg_len);
+  shm_unlink(g_shm_name);
+  g_seg = NULL;
+  atomic_store(&g_obs_state, 1);
+}
+
+static int obs_create(int64_t rings, int64_t slots) {
+  size_t manifest_len =
+      obs_page_up(sizeof(obs_mh_t) + OBS_ENTRY_CAP * 32 + 8192);
+  size_t modemask_len = obs_page_up(OBS_ENTRY_CAP);
+  size_t counters_len = obs_page_up((1 + OBS_ENTRY_CAP) * 64);
+  size_t rings_hdr = obs_page_up((size_t)rings * sizeof(obs_rdesc_t));
+  size_t ring_bytes = (size_t)slots * 16;
+  size_t off = 0;
+  size_t control_off  = (off += OBS_PAGE);
+  size_t manifest_off = (off += OBS_PAGE);
+  size_t modemask_off = (off += manifest_len);
+  size_t counters_off = (off += modemask_len);
+  size_t rings_off    = (off += counters_len);
+  g_seg_len = rings_off + rings_hdr + (size_t)rings * ring_bytes;
+
+  snprintf(g_shm_name, sizeof g_shm_name, "/hale-obs-%d", (int)getpid());
+  shm_unlink(g_shm_name);
+  int fd = shm_open(g_shm_name, O_CREAT | O_EXCL | O_RDWR, 0600);
+  if (fd < 0) return 0;
+  if (ftruncate(fd, (off_t)g_seg_len) < 0) { close(fd); return 0; }
+  g_seg = mmap(NULL, g_seg_len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  close(fd);
+  if (g_seg == MAP_FAILED) { g_seg = NULL; return 0; }
+
+  H = (obs_hdr_t *)g_seg;
+  C = (obs_ctrl_t *)((char *)g_seg + control_off);
+  MH = (obs_mh_t *)((char *)g_seg + manifest_off);
+  ME = (obs_me_t *)((char *)MH + sizeof(obs_mh_t));
+  MH->entry_cap = OBS_ENTRY_CAP;
+  MH->pool_off = (uint32_t)(sizeof(obs_mh_t) + OBS_ENTRY_CAP * 32);
+  POOL = (char *)MH + MH->pool_off;
+  MODE = (uint8_t *)g_seg + modemask_off;
+  CNT = (obs_cline_t *)((char *)g_seg + counters_off);
+  RD = (obs_rdesc_t *)((char *)g_seg + rings_off);
+  memset(MODE, 2 /* PACKED */, OBS_ENTRY_CAP);
+  memset(g_cnt_line_for, -1, sizeof g_cnt_line_for);
+
+  *H = (obs_hdr_t){ .magic = OBS_MAGIC, .proto_major = 0, .proto_minor = 1,
+    .header_len = sizeof(obs_hdr_t), .total_len = g_seg_len,
+    .pid = (uint32_t)getpid(), .ring_count = (uint32_t)rings,
+    .ring_slots = (uint32_t)slots, .ts_shift = 4,
+    .started_mono_ns = obs_mono_ns(), .started_wall_ns = obs_wall_ns(),
+    .control_off = control_off, .manifest_off = manifest_off,
+    .manifest_len = manifest_len, .modemask_off = modemask_off,
+    .counters_off = counters_off, .counters_len = counters_len,
+    .rings_off = rings_off };
+  for (int64_t i = 0; i < rings; i++)
+    RD[i] = (obs_rdesc_t){
+        .data_off = rings_off + rings_hdr + (uint64_t)i * ring_bytes,
+        .tag_a = (uint32_t)i };
+  atomic_store(&H->flags, 1);
+
+  const char *xdg = getenv("XDG_RUNTIME_DIR");
+  char dir[192];
+  if (xdg) snprintf(dir, sizeof dir, "%s/hale", xdg);
+  else snprintf(dir, sizeof dir, "/tmp/hale-obs");
+  mkdir(dir, 0700);
+  snprintf(g_reg_path, sizeof g_reg_path, "%s/%d.json", dir,
+           (int)getpid());
+  char tmp[300]; snprintf(tmp, sizeof tmp, "%s.tmp", g_reg_path);
+  FILE *f = fopen(tmp, "w");
+  if (f) {
+    char exe[128] = "hale-app";
+    ssize_t n = readlink("/proc/self/exe", exe, sizeof exe - 1);
+    if (n > 0) exe[n] = 0;
+    fprintf(f,
+      "{\n  \"proto\": \"0.1\",\n  \"pid\": %d,\n  \"exe\": \"%s\",\n"
+      "  \"shm\": \"%s\",\n  \"started_mono_ns\": %llu,\n"
+      "  \"started_wall_ns\": %llu,\n  \"rings\": %d\n}\n",
+      (int)getpid(), exe, g_shm_name,
+      (unsigned long long)H->started_mono_ns,
+      (unsigned long long)H->started_wall_ns, (int)rings);
+    fclose(f);
+    rename(tmp, g_reg_path);
+  }
+  atexit(lotus_obs_teardown);
+  return 1;
+}
+
+/* Enable check + lazy init. Fast path after first call: one
+ * relaxed load + compare. */
+static int obs_on(void) {
+  int st = atomic_load_explicit(&g_obs_state, memory_order_relaxed);
+  if (st == 2) return 1;
+  if (st == 1) return 0;
+  pthread_mutex_lock(&g_obs_lock);
+  st = atomic_load(&g_obs_state);
+  if (st == 0) {
+    const char *e = getenv("LOTUS_OBS");
+    if (e && e[0] == '1') {
+      const char *rs = getenv("LOTUS_OBS_RINGS");
+      const char *ss = getenv("LOTUS_OBS_SLOTS");
+      int64_t rings = rs ? atoll(rs) : 8;
+      int64_t slots = ss ? atoll(ss) : 4096;
+      if (rings < 1 || rings > 64) rings = 8;
+      if (slots < 64 || (slots & (slots - 1))) slots = 4096;
+      st = obs_create(rings, slots) ? 2 : 1;
+    } else {
+      st = 1;
+    }
+    atomic_store(&g_obs_state, st);
+  }
+  pthread_mutex_unlock(&g_obs_lock);
+  return st == 2;
+}
+
+static uint64_t obs_fnv(const char *a, const char *b) {
+  uint64_t h = 0xcbf29ce484222325ull;
+  for (const char *p = a; *p; p++) { h ^= (uint8_t)*p; h *= 0x100000001b3ull; }
+  h ^= ':'; h *= 0x100000001b3ull;
+  for (const char *p = b; p && *p; p++) { h ^= (uint8_t)*p; h *= 0x100000001b3ull; }
+  return h;
+}
+
+static int64_t g_next_id[4] = {1, 1, 0, 0};
+
+/* Under g_obs_lock. */
+static int64_t obs_manifest_add(uint8_t kind, uint8_t flg,
+                                const char *name, uint16_t aux_a,
+                                uint64_t shape, uint64_t aux_b) {
+  uint32_t i = atomic_load(&MH->entry_count);
+  if (i >= OBS_ENTRY_CAP) {
+    atomic_fetch_add(&CNT[0].c[1], 1); /* manifest_overflow */
+    return -1;
+  }
+  int64_t id = g_next_id[kind]++;
+  if (id >= OBS_ENTRY_CAP) return -1;
+  uint32_t len = (uint32_t)strlen(name);
+  uint32_t noff = atomic_fetch_add(&MH->pool_used, len);
+  memcpy(POOL + noff, name, len);
+  ME[i] = (obs_me_t){ .shape_hash = shape, .aux_b = aux_b,
+                      .id = (uint32_t)id, .name_off = noff,
+                      .name_len = (uint16_t)len, .aux_a = aux_a,
+                      .kind = kind, .flags = flg, ._pad = 0 };
+  if (kind == MK_TOPIC || kind == MK_BINDING) {
+    int line = 1;
+    for (uint32_t j = 0; j < i; j++)
+      if (ME[j].kind == MK_TOPIC || ME[j].kind == MK_BINDING) line++;
+    g_cnt_line_for[kind][id] = line;
+  }
+  atomic_store_explicit(&MH->entry_count, i + 1, memory_order_release);
+  atomic_fetch_add_explicit(&H->manifest_gen, 1, memory_order_release);
+  return id;
+}
+
+static void obs_count(int kind, int64_t id, int cell, uint64_t delta) {
+  if (id < 0 || id >= OBS_ENTRY_CAP) return;
+  int line = g_cnt_line_for[kind][id];
+  if (line > 0)
+    atomic_fetch_add_explicit(&CNT[line].c[cell], delta,
+                              memory_order_relaxed);
+}
+
+/* ---- record emission (per-thread ring, EPOCH-anchored) -------- */
+
+static void obs_emit_raw(uint64_t w0, uint64_t w1) {
+  if (t_ring == -2) return;
+  if (t_ring == -1) {
+    int r = atomic_fetch_add(&g_ring_next, 1);
+    if ((uint32_t)r >= H->ring_count) {
+      t_ring = -2;
+      atomic_fetch_add_explicit(&CNT[0].c[0], 1, memory_order_relaxed);
+      return;
+    }
+    t_ring = r;
+    RD[r].tag_b = (uint32_t)(uintptr_t)pthread_self();
+  }
+  lotus_spsc_emit(g_seg, &RD[t_ring], H->ring_slots, (int64_t)w0,
+                  (int64_t)w1);
+  atomic_fetch_add_explicit(&CNT[0].c[2], 1, memory_order_relaxed);
+}
+
+static void obs_emit(uint32_t ekind, uint32_t id, uint32_t size_class,
+                     uint64_t w1) {
+  uint64_t now = obs_mono_ns();
+  uint64_t delta = (now - t_epoch_ns) >> H->ts_shift;
+  if (t_epoch_ns == 0 || delta > OBS_TS_DELTA_MAX) {
+    t_epoch_ns = now;
+    obs_emit_raw((uint64_t)EK_EPOCH << 20, now);
+    delta = 0;
+  }
+  uint64_t w0 = ((uint64_t)(id & 0xFFFFFu))
+      | ((uint64_t)(ekind & 0x1Fu) << 20)
+      | ((uint64_t)(size_class & 0xFFu) << 25)
+      | ((delta & OBS_TS_DELTA_MAX) << 33);
+  obs_emit_raw(w0, w1);
+}
+
+static uint32_t obs_size_class(uint64_t bytes) {
+  if (bytes == 0) return 0;
+  uint32_t c = 1;
+  while ((1ull << c) < bytes && c < 255) c++;
+  return c;
+}
+
+/* dormant gate + 0→1 birth replay */
+static _Atomic uint32_t g_last_observed = 0;
+
+static void obs_replay_births(void);
+
+static int obs_gate(void) {
+  uint32_t oc = atomic_load_explicit(&C->observer_count,
+                                     memory_order_relaxed);
+  uint32_t last = atomic_load_explicit(&g_last_observed,
+                                       memory_order_relaxed);
+  if (oc != last) {
+    atomic_store_explicit(&g_last_observed, oc, memory_order_relaxed);
+    if (last == 0 && oc > 0) obs_replay_births();
+  }
+  return oc > 0;
+}
+
+/* ---- topics ---------------------------------------------------- */
+
+static obs_topic_slot_t *obs_topic_slot(const char *subject,
+                                        int networked) {
+  int n = atomic_load_explicit(&g_topic_count, memory_order_acquire);
+  for (int i = 0; i < n; i++) {
+    if (strcmp(g_topics[i].subject, subject) == 0) return &g_topics[i];
+  }
+  pthread_mutex_lock(&g_obs_lock);
+  n = atomic_load(&g_topic_count);
+  for (int i = 0; i < n; i++) {
+    if (strcmp(g_topics[i].subject, subject) == 0) {
+      pthread_mutex_unlock(&g_obs_lock);
+      return &g_topics[i];
+    }
+  }
+  obs_topic_slot_t *slot = NULL;
+  if (n < OBS_ENTRY_CAP) {
+    int64_t id = obs_manifest_add(MK_TOPIC, networked ? 1 : 0, subject,
+                                  0, obs_fnv(subject, ""), 0);
+    if (id >= 0) {
+      char *copy = strdup(subject);
+      if (copy) {
+        g_topics[n].subject = copy;
+        g_topics[n].id = id;
+        atomic_store(&g_topics[n].seq, 0);
+        slot = &g_topics[n];
+        atomic_store_explicit(&g_topic_count, n + 1,
+                              memory_order_release);
+      }
+    }
+  }
+  pthread_mutex_unlock(&g_obs_lock);
+  return slot;
+}
+
+/* ---- instance table -------------------------------------------- */
+
+static uint32_t obs_inst_id_of(void *self) {
+  int n = atomic_load_explicit(&g_inst_count, memory_order_acquire);
+  for (int i = 0; i < n; i++) {
+    if (g_inst[i].self == self && g_inst[i].live) return g_inst[i].id;
+  }
+  return 0; /* unattributed */
+}
+
+/* ---- public probes (called from lotus_arena.c + codegen) ------- */
+
+void lotus_obs_bus_publish(const char *subject, void *publisher_self,
+                           uint64_t payload_bytes) {
+  if (!obs_on() || !subject) return;
+  obs_topic_slot_t *t = obs_topic_slot(subject, 0);
+  if (!t) return;
+  uint64_t seq =
+      atomic_fetch_add_explicit(&t->seq, 1, memory_order_relaxed);
+  obs_count(MK_TOPIC, t->id, 0, 1);              /* published */
+  obs_count(MK_TOPIC, t->id, 2, payload_bytes);  /* bytes */
+  if (!obs_gate()) return;
+  uint8_t mode = MODE[t->id & (OBS_ENTRY_CAP - 1)];
+  if (mode < 2) return; /* OFF / COUNTERS */
+  uint32_t locus = publisher_self ? obs_inst_id_of(publisher_self) : 0;
+  obs_emit(EK_BUS_PUBLISH, (uint32_t)t->id,
+           obs_size_class(payload_bytes),
+           ((uint64_t)locus & 0xFFFFFu)
+               | ((seq & 0xFFFFFFFFFFFULL) << 20));
+}
+
+void lotus_obs_bus_deliver(const char *subject, void *subscriber_self,
+                           uint64_t payload_bytes) {
+  if (!obs_on() || !subject) return;
+  obs_topic_slot_t *t = obs_topic_slot(subject, 0);
+  if (!t) return;
+  uint64_t seq =
+      atomic_load_explicit(&t->seq, memory_order_relaxed);
+  obs_count(MK_TOPIC, t->id, 1, 1); /* delivered */
+  if (!obs_gate()) return;
+  uint8_t mode = MODE[t->id & (OBS_ENTRY_CAP - 1)];
+  if (mode < 2) return;
+  uint32_t locus = subscriber_self ? obs_inst_id_of(subscriber_self) : 0;
+  obs_emit(EK_BUS_DELIVER, (uint32_t)t->id,
+           obs_size_class(payload_bytes),
+           ((uint64_t)locus & 0xFFFFFu)
+               | (((seq ? seq - 1 : 0) & 0xFFFFFFFFFFFULL) << 20));
+}
+
+/* binding_obs_id: cached on the remote entry by the caller (the
+ * arena TU stores the id we return on first use; -1 = not yet
+ * registered). */
+int64_t lotus_obs_binding_register(const char *subject,
+                                   int64_t transport_kind) {
+  if (!obs_on() || !subject) return -1;
+  pthread_mutex_lock(&g_obs_lock);
+  int64_t id = obs_manifest_add(MK_BINDING, 1, subject,
+                                (uint16_t)transport_kind, 0, 0);
+  pthread_mutex_unlock(&g_obs_lock);
+  return id;
+}
+
+void lotus_obs_net_send(int64_t binding_id, uint64_t seq,
+                        uint64_t bytes) {
+  if (binding_id < 0 || !obs_on()) return;
+  obs_count(MK_BINDING, binding_id, 0, 1);
+  obs_count(MK_BINDING, binding_id, 2, bytes);
+  if (!obs_gate()) return;
+  obs_emit(EK_NET_SEND, 0, obs_size_class(bytes),
+           ((uint64_t)binding_id & 0xFFFFu)
+               | ((seq & 0xFFFFFFFFFFFFULL) << 16));
+}
+
+void lotus_obs_net_deliver(int64_t binding_id, uint64_t seq,
+                           uint64_t bytes) {
+  if (binding_id < 0 || !obs_on()) return;
+  obs_count(MK_BINDING, binding_id, 1, 1);
+  if (!obs_gate()) return;
+  obs_emit(EK_NET_DELIVER, 0, obs_size_class(bytes),
+           ((uint64_t)binding_id & 0xFFFFu)
+               | ((seq & 0xFFFFFFFFFFFFULL) << 16));
+}
+
+void lotus_obs_locus_birth(void *self, const char *type_name,
+                           void *parent_self) {
+  if (!obs_on() || !self || !type_name) return;
+  pthread_mutex_lock(&g_obs_lock);
+  /* type id: manifest lookup-or-add by name */
+  uint32_t type_id = 0;
+  uint32_t mc = atomic_load(&MH->entry_count);
+  for (uint32_t i = 0; i < mc; i++) {
+    if (ME[i].kind == MK_LOCUS_TYPE &&
+        strncmp(POOL + ME[i].name_off, type_name, ME[i].name_len) == 0 &&
+        type_name[ME[i].name_len] == 0) {
+      type_id = ME[i].id;
+      break;
+    }
+  }
+  if (type_id == 0) {
+    int64_t id = obs_manifest_add(MK_LOCUS_TYPE, 0, type_name, 0, 0, 0);
+    if (id > 0) type_id = (uint32_t)id;
+  }
+  uint32_t inst_id =
+      atomic_fetch_add(&g_next_inst_id, 1) & 0xFFFFFu;
+  uint32_t parent = parent_self ? obs_inst_id_of(parent_self) : 0;
+  int n = atomic_load(&g_inst_count);
+  if (n < OBS_INSTANCE_CAP) {
+    g_inst[n] = (obs_inst_t){ .self = self, .id = inst_id,
+                              .type_id = type_id, .parent = parent,
+                              .live = 1 };
+    atomic_store_explicit(&g_inst_count, n + 1, memory_order_release);
+  }
+  pthread_mutex_unlock(&g_obs_lock);
+  if (!obs_gate()) return;
+  obs_emit(EK_LOCUS_BIRTH, inst_id, 0,
+           ((uint64_t)parent) | ((uint64_t)(type_id & 0xFFFFFu) << 32));
+}
+
+void lotus_obs_locus_dissolve(void *self, int64_t reason) {
+  if (!obs_on() || !self) return;
+  uint32_t inst_id = 0;
+  pthread_mutex_lock(&g_obs_lock);
+  int n = atomic_load(&g_inst_count);
+  for (int i = 0; i < n; i++) {
+    if (g_inst[i].self == self && g_inst[i].live) {
+      g_inst[i].live = 0;
+      inst_id = g_inst[i].id;
+      break;
+    }
+  }
+  pthread_mutex_unlock(&g_obs_lock);
+  if (inst_id == 0 || !obs_gate()) return;
+  obs_emit(EK_LOCUS_DISSOLVE, inst_id, 0, (uint64_t)reason);
+}
+
+void lotus_obs_restart(const char *subject) {
+  if (!obs_on()) return;
+  if (!obs_gate()) return;
+  obs_emit(EK_RESTART, 0, 0, 0);
+  (void)subject;
+}
+
+static void obs_replay_births(void) {
+  int n = atomic_load_explicit(&g_inst_count, memory_order_acquire);
+  for (int i = 0; i < n; i++) {
+    if (!g_inst[i].live) continue;
+    obs_emit(EK_LOCUS_BIRTH, g_inst[i].id, 0,
+             ((uint64_t)g_inst[i].parent)
+                 | ((uint64_t)(g_inst[i].type_id & 0xFFFFFu) << 32));
+  }
+}

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1746,6 +1746,14 @@ pub fn build_executable_with_options(
         "compress",
         &rt_cflags,
     )?;
+    // iris P4: native observation emission (PROTOCOL v0.1). Own TU;
+    // probes in lotus_arena.c are weak-guarded so helper binaries
+    // that compile the arena TU alone still link.
+    let obs_o = compile_cached_runtime_object(
+        RUNTIME_OBS_C_SOURCE,
+        "obs",
+        &rt_cflags,
+    )?;
 
     // m96: locate the tree-sitter shim staticlib produced by the
     // sibling `hale-ts-shim` workspace crate. We don't try to
@@ -1765,7 +1773,8 @@ pub fn build_executable_with_options(
         .arg(&arena_o)
         .arg(&tls_o)
         .arg(&shm_ring_o)
-        .arg(&compress_o);
+        .arg(&compress_o)
+        .arg(&obs_o);
     if lto_active {
         // Full-LTO link: -flto pulls the Hale bitcode + the runtime
         // bitcode TUs through the LTO backend at -O3, inlining the arena
@@ -1959,6 +1968,8 @@ const RUNTIME_C_SOURCE: &str = include_str!("../runtime/lotus_arena.c");
 const RUNTIME_TLS_C_SOURCE: &str = include_str!("../runtime/lotus_tls.c");
 const RUNTIME_COMPRESS_C_SOURCE: &str =
     include_str!("../runtime/lotus_compress.c");
+const RUNTIME_OBS_C_SOURCE: &str =
+    include_str!("../runtime/lotus_obs.c");
 /// Form K5 (2026-05-20) — POSIX SHM ring substrate for zero-copy
 /// bus payload routing. Independent translation unit; pulled in
 /// unconditionally so user programs that bind a topic to a

--- a/crates/hale-codegen/src/locus/dissolve.rs
+++ b/crates/hale-codegen/src/locus/dissolve.rs
@@ -865,6 +865,23 @@ impl<'ctx, 'p> LocusDissolve<'ctx> for Cx<'ctx, 'p> {
         self_ptr: PointerValue<'ctx>,
         locus_name: &str,
     ) -> Result<(), CodegenError> {
+        // iris P4: LOCUS_DISSOLVE probe at THE teardown
+        // chokepoint (every dissolve path funnels here). No-op
+        // unless LOTUS_OBS=1.
+        {
+            let obs_fn = self
+                .module
+                .get_function("lotus_obs_locus_dissolve")
+                .expect("lotus_obs_locus_dissolve declared");
+            let i64_t = self.context.i64_type();
+            self.builder
+                .build_call(
+                    obs_fn,
+                    &[self_ptr.into(), i64_t.const_zero().into()],
+                    &format!("{}.obs.dissolve", locus_name),
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        }
         // Arena-elision counterpart: when `__arena` was pointed
         // at the caller's arena at instantiation (see
         // `locus_arena_elidable` + the matching branch in

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -3161,6 +3161,31 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                     )
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
             }
+            // iris P4: LOCUS_BIRTH for pinned loci — their birth
+            // runs on the spawned thread, so the cooperative-path
+            // probe never sees them. Parent is unattributed here
+            // (the spawning locus's self isn't marshaled into the
+            // thread-main); v0 accepts the root-parent rendering.
+            {
+                let ptr_t2 =
+                    self.context.ptr_type(AddressSpace::default());
+                let obs_fn = self
+                    .module
+                    .get_function("lotus_obs_locus_birth")
+                    .expect("lotus_obs_locus_birth declared");
+                let tname = self.global_string(locus_name);
+                self.builder
+                    .build_call(
+                        obs_fn,
+                        &[
+                            thread_self.into(),
+                            tname.into(),
+                            ptr_t2.const_null().into(),
+                        ],
+                        &format!("{}.obs.birth.pinned", locus_name),
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            }
             for kind in &["birth", "run"] {
                 if let Some(method) = info.methods.get(*kind) {
                     let skip = info.empty_lifecycle.contains(*kind);

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -3444,6 +3444,30 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
             }
         }
+        // iris P4: LOCUS_BIRTH probe (no-op unless LOTUS_OBS=1;
+        // one predictable branch inside the C fn otherwise).
+        // Parent = the instantiating locus's self when inside a
+        // lifecycle/method body, null from free fns.
+        {
+            let ptr_t = self.context.ptr_type(AddressSpace::default());
+            let obs_fn = self
+                .module
+                .get_function("lotus_obs_locus_birth")
+                .expect("lotus_obs_locus_birth declared");
+            let tname = self.global_string(locus_name);
+            let parent: inkwell::values::BasicValueEnum = self
+                .current_self
+                .as_ref()
+                .map(|cs| cs.self_ptr.into())
+                .unwrap_or_else(|| ptr_t.const_null().into());
+            self.builder
+                .build_call(
+                    obs_fn,
+                    &[self_ptr.into(), tname.into(), parent.into()],
+                    &format!("{}.obs.birth", locus_name),
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        }
         if let Some(birth_closures_fn) = info.birth_closures_fn {
             let (parent_self, handler_ptr) =
                 self.resolve_failure_route(&locus_name);

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -933,6 +933,24 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ),
             None,
         );
+        // iris P4 — lifecycle observation probes (lotus_obs.c):
+        // declare void @lotus_obs_locus_birth(ptr self, ptr type_name, ptr parent)
+        // declare void @lotus_obs_locus_dissolve(ptr self, i64 reason)
+        self.module.add_function(
+            "lotus_obs_locus_birth",
+            self.context.void_type().fn_type(
+                &[ptr_t.into(), ptr_t.into(), ptr_t.into()],
+                false,
+            ),
+            None,
+        );
+        self.module.add_function(
+            "lotus_obs_locus_dissolve",
+            self.context
+                .void_type()
+                .fn_type(&[ptr_t.into(), i64_t2.into()], false),
+            None,
+        );
         // declare i32 @lotus_process_wait(i32 pid,
         //                                 ptr out_code,
         //                                 ptr out_signal)

--- a/crates/hale-codegen/tests/obs_emission.rs
+++ b/crates/hale-codegen/tests/obs_emission.rs
@@ -1,0 +1,197 @@
+//! iris handoff P4 — native observation emission (PROTOCOL v0.1).
+//!
+//! With LOTUS_OBS=1 the runtime publishes a /hale-obs-<pid> shm
+//! segment and its own choke points emit protocol records. This
+//! test attaches as a minimal consumer (mmap the segment via
+//! /dev/shm, bump observer_count on the control page like a real
+//! observer) and asserts:
+//!   - header magic/proto/layout sanity,
+//!   - the topic manifest entry appears with pub == dlv == N and
+//!     the byte count,
+//!   - records were emitted to the rings (records_total > 0),
+//!   - dormant default: without LOTUS_OBS the segment does not
+//!     exist.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+fn build(name: &str, src: &str) -> PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bin = std::env::temp_dir();
+    bin.push(format!("hale_test_obs_{}", name));
+    build_executable(&program, &bin).expect("build");
+    bin
+}
+
+const DEMO: &str = r#"
+    type Tick { n: Int = 0; }
+    locus Sink {
+        params { seen: Int = 0; }
+        bus { subscribe "obs.test" as on_t of type Tick; }
+        fn on_t(t: Tick) { self.seen = self.seen + 1; }
+    }
+    locus Pub {
+        bus { publish "obs.test" of type Tick; }
+        run() {
+            std::time::sleep(400ms);
+            let mut i = 0;
+            while i < 50 {
+                "obs.test" <- Tick { n: i };
+                i = i + 1;
+            }
+        }
+    }
+    main locus App {
+        params { s: Sink = Sink { }; p: Pub = Pub { }; }
+        placement { p: pinned(core = 0); }
+        run() { std::time::sleep(1200ms); }
+    }
+    fn main() { App { }; }
+"#;
+
+fn read_u64(seg: &[u8], off: usize) -> u64 {
+    u64::from_le_bytes(seg[off..off + 8].try_into().unwrap())
+}
+fn read_u32(seg: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes(seg[off..off + 4].try_into().unwrap())
+}
+
+#[test]
+fn emits_protocol_segment_with_matching_counters() {
+    let bin = build("emit", DEMO);
+    let mut child = Command::new(&bin)
+        .env("LOTUS_OBS", "1")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    let pid = child.id();
+    let shm_path = format!("/dev/shm/hale-obs-{}", pid);
+
+    // Wait for the segment (lazy init on first probe), then act
+    // like an attached observer: bump observer_count so ring
+    // emission turns on before the publish burst (which starts
+    // at t+400ms).
+    let mut seg_file = None;
+    for _ in 0..40 {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        if let Ok(f) = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&shm_path)
+        {
+            seg_file = Some(f);
+            break;
+        }
+    }
+    let seg_file = seg_file.unwrap_or_else(|| {
+        let _ = child.kill();
+        panic!("segment {} never appeared", shm_path)
+    });
+    let seg_len = seg_file.metadata().expect("meta").len() as usize;
+    let map = unsafe {
+        libc_mmap(&seg_file, seg_len)
+    };
+    let seg = unsafe { std::slice::from_raw_parts(map, seg_len) };
+
+    assert_eq!(read_u64(seg, 0x00), 0x4F42534948414C45, "magic");
+    assert_eq!(read_u32(seg, 0x1C).count_ones() >= 1, true, "rings");
+    let control_off = read_u64(seg, 0x38) as usize;
+    let manifest_off = read_u64(seg, 0x40) as usize;
+    let counters_off = read_u64(seg, 0x58) as usize;
+
+    // observer attach (control page is the consumer-writable one).
+    unsafe {
+        let oc = map.add(control_off) as *mut u32;
+        std::ptr::write_volatile(oc, 1);
+    }
+
+    let out = child.wait_with_output().expect("wait");
+    assert!(out.status.success(), "demo exited nonzero");
+
+    // The emitter tears the segment down at exit; we still hold
+    // the mapping (POSIX shm semantics).
+    // Manifest: find the obs.test topic entry (kind 0).
+    let entry_count = read_u32(seg, manifest_off) as usize;
+    let entries = manifest_off + 16;
+    let pool_off = read_u32(seg, manifest_off + 8) as usize;
+    let mut topic_line: Option<usize> = None;
+    let mut line = 0usize;
+    for i in 0..entry_count {
+        let e = entries + i * 32;
+        let kind = seg[e + 28];
+        if kind == 0 || kind == 2 {
+            line += 1;
+            if kind == 0 {
+                let name_off = read_u32(seg, e + 20) as usize;
+                let name_len = seg[e + 24] as usize
+                    | ((seg[e + 25] as usize) << 8);
+                let name = &seg
+                    [manifest_off + pool_off + name_off
+                        ..manifest_off + pool_off + name_off + name_len];
+                if name == b"obs.test" {
+                    topic_line = Some(line);
+                }
+            }
+        }
+    }
+    let topic_line = topic_line.expect("obs.test in manifest");
+
+    let cline = counters_off + topic_line * 64;
+    let published = read_u64(seg, cline);
+    let delivered = read_u64(seg, cline + 8);
+    let bytes = read_u64(seg, cline + 16);
+    let records_total = read_u64(seg, counters_off + 16);
+    assert_eq!(published, 50, "published");
+    assert_eq!(delivered, 50, "delivered (one subscriber)");
+    assert!(bytes > 0, "payload bytes counted");
+    assert!(
+        records_total > 100,
+        "ring records emitted while observed (got {})",
+        records_total
+    );
+}
+
+#[test]
+fn dormant_by_default() {
+    let bin = build("dormant", DEMO);
+    let mut child = Command::new(&bin)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn");
+    let pid = child.id();
+    std::thread::sleep(std::time::Duration::from_millis(600));
+    let exists =
+        std::path::Path::new(&format!("/dev/shm/hale-obs-{}", pid))
+            .exists();
+    let _ = child.kill();
+    let _ = child.wait();
+    assert!(!exists, "no segment without LOTUS_OBS");
+}
+
+unsafe fn libc_mmap(f: &std::fs::File, len: usize) -> *mut u8 {
+    use std::os::unix::io::AsRawFd;
+    extern "C" {
+        fn mmap(
+            addr: *mut core::ffi::c_void,
+            len: usize,
+            prot: i32,
+            flags: i32,
+            fd: i32,
+            off: i64,
+        ) -> *mut core::ffi::c_void;
+    }
+    let p = mmap(
+        core::ptr::null_mut(),
+        len,
+        0x1 | 0x2, /* PROT_READ|WRITE */
+        0x1,       /* MAP_SHARED */
+        f.as_raw_fd(),
+        0,
+    );
+    assert!(p as isize != -1, "mmap failed");
+    p as *mut u8
+}

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1327,6 +1327,35 @@ zero_copy binding produces.
   the runtime's only value-error escape valve. See
   `spec/semantics.md` § "Process exit".
 
+### Native observation emission (iris P4, 2026-07-27)
+
+With `LOTUS_OBS=1` the runtime publishes an iris-protocol
+observation segment (`/hale-obs-<pid>` + registration file per
+PROTOCOL v0.1 — the contract lives in the iris-observer repo;
+layouts mirrored from its reference implementation) and the
+runtime's own choke points emit records: `BUS_PUBLISH` /
+`BUS_DELIVER` at every dispatch flavor (dynamic, static-devirt,
+cross-thread wire; deliver is enqueue-time at v0),
+`NET_SEND` / `NET_DELIVER` at the transport fanout/reader with
+per-binding monotonic seqs (what iris seq-matches into
+cross-process edges), `LOCUS_BIRTH` / `LOCUS_DISSOLVE` (both
+cooperative and pinned lifecycle paths; dissolve rides the
+`emit_locus_arena_destroy` chokepoint) and `RESTART` at
+reconnect. Cost contract: env unset = one predictable branch
+per probe (`g_obs_state`); enabled-but-unobserved
+(`observer_count == 0`) = counters only, no ring writes; ring
+emission is SPSC via the #247 primitive with one ring per
+emitting thread (TLS assignment; overflow threads count into
+`ring_drops_total`). On the observer-count 0→1 rising edge the
+live-locus table replays as `LOCUS_BIRTH` records so a
+late-attaching observer reconstructs the tree. Knobs:
+`LOTUS_OBS_RINGS` (default 8), `LOTUS_OBS_SLOTS` (default
+4096). v0 notes: manifest ids are registration-order; publisher
+locus attribution on BUS_PUBLISH is unattributed (0); pinned
+births render parent=root. `lotus_obs.c` is its own TU; the
+arena TU's probes are weak-guarded so helper binaries compiling
+`lotus_arena.c` alone still link.
+
 ### Time
 
 - **Monotonic + wall-clock.** `time::now()` and


### PR DESCRIPTION
Implements the iris observation protocol (PROTOCOL v0.1, iris-observer `observer` branch) as a runtime capability — the hale side of the observation contract per iris DESIGN §13.

`LOTUS_OBS=1` → the process publishes `/hale-obs-<pid>` + registration file, and the runtime's own choke points emit protocol records with **zero app changes**:

- `BUS_PUBLISH` / `BUS_DELIVER` at all three dispatch flavors (dynamic, static-devirt, cross-thread wire) — deliver at enqueue time at v0, noted in the TU header
- `NET_SEND` / `NET_DELIVER` at the transport fanout/reader with per-binding monotonic seqs — the records iris seq-matches into cross-process edges
- `LOCUS_BIRTH` / `LOCUS_DISSOLVE` from both cooperative and pinned lifecycle paths, `RESTART` at reconnect
- **Late-attach replay**: on the `observer_count` 0→1 edge the live-locus table replays as births (the PROTOCOL §13 candidate — an observer attaching mid-run reconstructs the tree)

Cost contract held: env unset = one predictable branch per probe; enabled-but-unobserved = counters only (§5 dormant rule); ring emission is SPSC per emitting thread over the #247 primitive (the ring descriptor layouts were designed to match). `lotus_obs.c` is its own TU with weak-guarded arena-side probes, so helper binaries compiling `lotus_arena.c` alone still link.

**Verified against iris's own `peek.c` consumer**: attach mid-run shows `birth Sink#1 / App#2 / Pub#3` (pinned included) with parent attribution, per-record `dlv obs.tick` stream, and `--summary-only` reports `pub=300 dlv=300 bytes=2400` — exact 1:1. `obs_emission.rs` pins the segment contract from a raw-mmap consumer (magic/layout, manifest lookup, counter equality, records_total) plus the dormant default. Corpus + bus/transport suites green with obs off.

v0 scope notes (each flagged in the TU header for the PROTOCOL §13 conversation): enqueue-time deliver, registration-order manifest ids (`.hale.topo` ordering lands with that metadata section), unattributed publisher locus on BUS_PUBLISH, pinned births render parent=root.

Closes the last open item of `HANDOFF-iris-2026-07-27.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)