### PR TITLE
release: v0.11.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.11.12 — the iris handoff: native observation emission, vec.set retire, verify modeling (2026-07-27)
 
 - **Native observation emission (iris handoff P4).** `LOTUS_OBS=1`
   makes any hale binary publish an iris-protocol observation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.11"
+version = "0.11.12"
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "hale-syntax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.11"
+version = "0.11.12"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
CHANGELOG rollup + workspace version bump for v0.11.12 — the iris handoff release.

Since v0.11.11 (merged to main): #263 (P1 `vec.set` replaced-element retire, P2 `hale verify` false-positive modeling, P3 takeover send-timeout docs, site-deploy warning) and #264 (P4 native observation emission with late-attach birth replay).

Tag `v0.11.12` follows on merge → release.yml builds Linux x86_64/arm64 + macOS arm64 artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)