### PR TITLE
fix(image): zlib headers in the runtime stage + dispatch re-publish input

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -13,6 +13,15 @@ on:
   push:
     tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          Publish as this semver (e.g. 0.11.12) + latest. For
+          re-publishing an image whose tag-triggered build failed
+          on image plumbing (Dockerfile) rather than release
+          content — main must equal the tag's toolchain content.
+        required: false
+        default: ""
 
 concurrency:
   group: image-${{ github.ref }}
@@ -46,6 +55,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+            type=raw,value=latest,enable=${{ inputs.version != '' }}
 
       - name: Build + push
         uses: docker/build-push-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ FROM ubuntu:24.04 AS runtime
 # libtinfo, libzstd, zlib, libstdc++.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       clang-18 lld-18 libc6-dev libssl-dev \
-      libffi8 libtinfo6 libzstd1 zlib1g libstdc++6 \
+      libffi8 libtinfo6 libzstd1 zlib1g-dev libstdc++6 \
     && ln -s /usr/bin/clang-18 /usr/bin/clang \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The v0.11.11 and v0.11.12 tag-triggered image builds failed their in-image smoke test: `hale build` now compiles `lotus_compress.c` (#254) which includes `<zlib.h>`, and the runtime stage installed only `zlib1g` (runtime .so) — not the headers. Swap to `zlib1g-dev`. (zstd stays dlopen'd — `libzstd1` alone is correct.)

Also adds a `workflow_dispatch` `version` input to image.yml so a tag build that failed on image plumbing can be re-published from main without moving the tag; after merge, dispatching with `version=0.11.12` publishes the `0.11.12` + `latest` images (main's toolchain content == the tag's — only Dockerfile/workflow changed since).

🤖 Generated with [Claude Code](https://claude.com/claude-code)