### PR TITLE
C→Hale re-entry: @export fn as native C-ABI symbol (Crumb batch 2, item 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ behavior.
 
 ---
 
+## Unreleased
+
+- **C→Hale re-entry: `@export fn` emits a native C-ABI symbol
+  (Crumb batch-2 item 1 — the port's critical path).** The same
+  annotation wasm entry-inversion uses now works on native: the
+  exported fn's literal name becomes an unmangled C-callable
+  symbol (FFI-portable marshalling both ways), and codegen
+  publishes the call-site arena in the caller-arena TLS around
+  every `@ffi` call so a callback fired during an in-flight call
+  re-enters with a live context — bus publishes and eager locus
+  instantiation from inside the callback work (CI-proven).
+  Same-thread contract at v1: foreign-thread/idle entry aborts
+  with a pointed diagnostic; typecheck rejects non-portable
+  types, defaults, and fallible exports. spec/ffi.md § "C→Hale
+  re-entry". This is what lets QuickJS host functions land in
+  Hale — `serve()`/`fetch()` from JS backed by `std::http` and
+  the bus.
+
 ## v0.11.12 — the iris handoff: native observation emission, vec.set retire, verify modeling (2026-07-27)
 
 - **Native observation emission (iris handoff P4).** `LOTUS_OBS=1`

--- a/HANDOFF-iris-2-native-obs.md
+++ b/HANDOFF-iris-2-native-obs.md
@@ -1,0 +1,100 @@
+# Handoff 2: native observation emission (P4) — field report from a production fleet
+
+P4 (`455563b`, v0.11.12) was deployed against a real ~16-binary
+multicast-bus fleet under `LOTUS_OBS=1` with the iris fuse
+attached. **It fundamentally works** — every rebuilt binary
+registered, birthed typed loci, and bus counters flowed with
+correct multicast fan-out accounting (one subject showed pub=8
+dlv=16 across two listeners — exactly right). The findings
+below are ordered by impact on iris's marquee feature
+(seq-matched cross-process edges), which currently renders
+zero edges.
+
+Live evidence on this machine: segments under `/tmp/hale-obs/`
+(fleet still running), raw dumps `/tmp/peek-dash.txt`,
+`/tmp/peek-rg.txt`, `/tmp/peek-sp.txt` (from
+`iris-observer/emitter/peek`, run with `env -u XDG_RUNTIME_DIR`).
+Keep fleet-specific subject/binary names out of any committed
+test cases — synthesize neutral fixtures.
+
+## P5 — NET_SEND never fires (the zero-edges cause)
+
+Every segment dumped shows `net<` (NET_DELIVER, with monotonic
+seqs, at the transport reader) and **zero `net>`** (NET_SEND).
+A binary that publishes heavily over the UDP transport emits
+pub records for each message but no send-side NET record. With
+no sends, iris's seq matcher has nothing to pair — delivers
+park forever, 0 edges.
+
+Suspect: the fanout probe is on a transport path this fleet
+doesn't take (or is ordered after an early-continue in the
+fanout loop). The deliver-side probe placement is correct —
+mirror it.
+
+## P6 — shape_hash splits topics that share a subject
+
+Two binaries declaring the same subject via *different local
+topic type names* (producer declares its own `topic X {
+subject: "s" }`, consumer declares `topic Y { subject: "s" }`)
+get different shape_hashes. iris joins topics on
+(shape_hash, subject) per PROTOCOL §5, so one subject splits
+into two rows — observed live: a high-rate subject showed its
+~266k publishes on one row (dlv 0) and its consumers' ~20k
+delivers on another. Subjects declared once in a shared lib
+fuse correctly.
+
+This is PROTOCOL §13's open canonicalization item, now with a
+concrete rule proposal: **hash the subject string + canonical
+payload structure (field names/types in declaration order),
+never the declaring type's name.** iris will adopt whatever
+rule lands; today's split also breaks edge matching for those
+subjects independently of P5.
+
+## P7 — timestamp reconstruction ≈ 2^64 on some segments
+
+One segment's reconstructed event timestamps read
+`18446625687.x` seconds (u64 wrap territory: 2^64 ns ≈
+18446744073 s) while a sibling segment reconstructs sane
+values (`390.x` s) under the same consumer. Suspect the EPOCH
+base or ts_delta encoding on one emission path (cross-thread
+wire flavor?) — a negative delta stored into the u31 ts_delta
+field would do this. Latency math survives only because both
+sides of a pair usually share the broken base.
+
+## P8 — five binaries register but emit nothing
+
+Segments exist (registration + manifest), but zero records —
+no births, and the observer-attach birth replay also produces
+nothing (fuse attached long after start; replay contract says
+tree reconstruction). The silent five in this fleet are the
+ones whose work is a single pinned/main read loop. Possibly
+the main-locus / pinned-reader lifecycle path skips both the
+birth probe and the replay registry. The chatty binaries (many
+cooperative children) all birth fine.
+
+## P9 — births carry no parentage
+
+Every birth record says `parent=(root)` — 22 loci in one
+binary, all flat. LOCUS_BIRTH w1 packs parent:32|type:20;
+the instantiation-site probe apparently doesn't thread the
+spawning locus. Without it iris renders a flat fan instead of
+the supervision tree (the flower's whole layout is the tree).
+
+## P10 — BUS records: confirm locus attribution
+
+PROTOCOL §8 (2026-07-27 amendment): BUS_PUBLISH/BUS_DELIVER
+`w1 = locus:20 | seq:44`, 0 = unattributed. Petals in the live
+fleet don't pulse, which suggests w1's locus bits are 0 —
+stamp the current locus at dispatch (the runtime knows it;
+that's the point of native emission). iris already renders it
+(per-locus pub/dlv -> perimeter pulses) the moment it's
+nonzero.
+
+---
+
+Verification loop once fixed: rebuild fleet binaries, restart
+under the observe overlay, then `curl :8787/snapshot` — edges
+non-empty with plausible µs latencies, one row per subject,
+loci parented, petals pulsing. The iris side needs no changes
+for P5/P7/P9/P10; P6 may need the fuse join updated to the
+final canonicalization rule.

--- a/crates/hale-cli/tests/ffi_export_reentry.rs
+++ b/crates/hale-cli/tests/ffi_export_reentry.rs
@@ -1,0 +1,147 @@
+//! Crumb batch-2 item 1 — C→Hale re-entry (`@export fn`, native).
+//!
+//! The port's critical-path shape: Hale calls into C through
+//! `@ffi("c")` (QuickJS in Crumb; a plain driver here), and the C
+//! code calls BACK into Hale through `@export fn` symbols — same
+//! thread, during the in-flight `@ffi` call (the v1 contract).
+//! The re-entered fns marshal Int and String both ways AND
+//! publish onto the bus, proving the re-entry composes with the
+//! established runtime context rather than just returning
+//! scalars.
+
+use std::process::Command;
+
+#[test]
+fn c_calls_back_into_exported_hale_fns() {
+    let root = std::env::temp_dir().join(format!(
+        "hale_reentry_{}",
+        std::process::id()
+    ));
+    let lib = root.join("vendor/cb");
+    let app = root.join("app");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&lib).expect("mkdir lib");
+    std::fs::create_dir_all(&app).expect("mkdir app");
+    std::fs::write(root.join("hale.toml"), "").expect("marker");
+
+    std::fs::write(
+        lib.join("glue.c"),
+        r#"
+long long hale_add(long long a, long long b);
+const char *hale_tag(const char *s);
+long long hale_emit(long long n);
+
+long long c_driver(long long x) {
+  const char *t = hale_tag("from-c");
+  if (!t || t[0] != 't') return -1;
+  /* re-enter three times; each publishes on the bus */
+  for (int i = 0; i < 3; i++) {
+    if (hale_emit(i) != i) return -2;
+  }
+  return hale_add(x, 22);
+}
+"#,
+    )
+    .expect("write glue.c");
+    std::fs::write(
+        lib.join("hale.toml"),
+        "[ffi]\ncsrc = [\"glue.c\"]\nlink = []\n",
+    )
+    .expect("write lib toml");
+    std::fs::write(
+        lib.join("cb.hl"),
+        r#"@ffi("c") fn c_driver(x: Int) -> Int;
+
+fn drive(x: Int) -> Int {
+    return c_driver(x);
+}
+"#,
+    )
+    .expect("write cb.hl");
+
+    std::fs::write(
+        app.join("main.hl"),
+        r#"import "vendor/cb" as cb;
+
+type Ping { n: Int = 0; }
+
+locus Sink {
+    params { seen: Int = 0; sum: Int = 0; }
+    bus { subscribe "reentry.ping" as on_p of type Ping; }
+    fn on_p(p: Ping) {
+        self.seen = self.seen + 1;
+        self.sum = self.sum + p.n;
+    }
+    fn report() -> Int { return self.seen * 100 + self.sum; }
+}
+
+@export fn hale_add(a: Int, b: Int) -> Int {
+    return a + b;
+}
+
+@export fn hale_tag(s: String) -> String {
+    return "tagged:" + s;
+}
+
+locus Emitter {
+    params { n: Int = 0; }
+    bus { publish "reentry.ping" of type Ping; }
+    birth() {
+        "reentry.ping" <- Ping { n: self.n };
+    }
+}
+
+@export fn hale_emit(n: Int) -> Int {
+    // Locus instantiation from re-entered code — the eager child
+    // births, publishes, and dissolves inside the callback.
+    Emitter { n: n };
+    return n;
+}
+
+main locus App {
+    params { sink: Sink = Sink { }; }
+    run() {
+        let r = cb::drive(20);
+        // main-thread publishes from re-entry enqueue to the coop
+        // queue; a sliced sleep drains them before we assert.
+        std::time::sleep(150ms);
+        if r != 42 {
+            println("BAD r=", r);
+            std::process::exit(1);
+        }
+        // 3 pings, sum 0+1+2 = 3 -> 303
+        if self.sink.report() != 303 {
+            println("BAD sink=", self.sink.report());
+            std::process::exit(1);
+        }
+        println("reentry ok");
+    }
+}
+
+fn main() { App { }; }
+"#,
+    )
+    .expect("write main.hl");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("build")
+        .arg(&app)
+        .output()
+        .expect("hale build");
+    assert!(
+        out.status.success(),
+        "build failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let bin = app.join("app");
+    let run = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_dir_all(&root);
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert!(
+        run.status.success() && stdout.contains("reentry ok"),
+        "stdout: {:?}\nstderr: {:?}",
+        stdout,
+        String::from_utf8_lossy(&run.stderr)
+    );
+}

--- a/crates/hale-codegen/examples/dbg_export.rs
+++ b/crates/hale-codegen/examples/dbg_export.rs
@@ -1,0 +1,14 @@
+fn main() {
+    let src = r#"
+@export fn hale_add(a: Int, b: Int) -> Int {
+    return a + b;
+}
+fn main() { println("ok"); }
+"#;
+    let p = hale_syntax::parse_source(src).expect("parse");
+    for item in &p.items {
+        if let hale_syntax::ast::TopDecl::Fn(f) = item {
+            eprintln!("fn {} export={}", f.name.name, f.export);
+        }
+    }
+}

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -14813,6 +14813,12 @@ void lotus_set_caller_arena(lotus_arena_t *a) {
     lotus_current_caller_arena = a;
 }
 
+/* Crumb batch-2 (C→Hale re-entry): read the TLS so codegen can
+ * save/restore it around @ffi calls. */
+lotus_arena_t *lotus_caller_arena_get(void) {
+    return lotus_current_caller_arena;
+}
+
 lotus_arena_t *lotus_caller_arena_or_global(void) {
     if (lotus_current_caller_arena) return lotus_current_caller_arena;
     pthread_mutex_lock(&g_bus_payload_arena_mutex);
@@ -14832,6 +14838,29 @@ lotus_arena_t *lotus_caller_arena_or_global(void) {
  * with the mutex when no TLS. Returns NULL on either alloc
  * failure (cap or malloc); callers' existing NULL handling
  * surfaces it. */
+/* Crumb batch-2 item 1 — C→Hale re-entry (native `@export fn`).
+ * The export wrapper's prologue: hand back the arena the re-
+ * entered Hale body should treat as its caller's. v1 contract =
+ * SAME-THREAD re-entry only: the callback fires while Hale is
+ * inside an in-flight `@ffi` call on this thread, so the
+ * caller-arena TLS is live and the re-entered fn composes with
+ * the established context (bus publishes, locus instantiation —
+ * all on the thread that already owns them). Entry from a
+ * foreign thread (TLS unset) is rejected loudly rather than
+ * left undefined; cross-thread entry is the documented
+ * follow-up. */
+void *lotus_reentry_arena(const char *fn_name) {
+    if (lotus_current_caller_arena) return lotus_current_caller_arena;
+    fprintf(stderr,
+            "hale: @export fn `%s` re-entered outside an in-flight "
+            "@ffi call on a Hale thread — cross-thread / idle C->Hale "
+            "entry is not supported yet (spec/ffi.md § C->Hale "
+            "re-entry). Register the callback so it fires during the "
+            "@ffi call that installed it.\n",
+            fn_name ? fn_name : "?");
+    abort();
+}
+
 void *lotus_caller_or_global_bytes_create(int64_t len) {
     if (lotus_current_caller_arena) {
         return lotus_bytes_create(lotus_current_caller_arena, len);

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1172,6 +1172,7 @@ pub fn build_executable_with_options(
         target_data,
         is_wasm,
         wasm_exports: Vec::new(),
+        native_exports: Vec::new(),
         instantiating_persistent_singleton: false,
         cell_owned_clone: false,
         program: &merged,
@@ -1560,7 +1561,15 @@ pub fn build_executable_with_options(
                     .to_str()
                     .unwrap_or("")
                     .to_string();
-                if func.count_basic_blocks() > 0 && name != "main" {
+                // Crumb batch-2: `@export` wrappers are external
+                // API — a C caller links them by name, so they must
+                // survive internalize+globaldce like `main` does
+                // (their `__hale_impl_*` bodies survive through the
+                // wrapper's call edge).
+                if func.count_basic_blocks() > 0
+                    && name != "main"
+                    && !cx.native_exports.contains(&name)
+                {
                     func.set_linkage(inkwell::module::Linkage::Internal);
                 }
                 f = func.get_next_function();
@@ -2766,6 +2775,10 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// arena-less wrappers were emitted; passed to `wasm-ld
     /// --export=`. Empty on native builds.
     pub(crate) wasm_exports: Vec<String>,
+    /// Crumb batch-2: native `@export` wrapper symbols — preserved
+    /// through the internalize+globaldce prepass (they're exactly
+    /// the symbols an external C caller links by name).
+    pub(crate) native_exports: Vec<String>,
     /// WASM entry-inversion: set while `_hale_start` instantiates the
     /// `@export locus` singleton, so `lower_locus_instantiation`
     /// allocates its struct in the persistent program arena (not a
@@ -7841,6 +7854,10 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // `@export` fns + the `_hale_start` setup entry. No-op on native.
         if self.is_wasm {
             self.synthesize_wasm_export_wrappers(&user_fn_decls)?;
+        } else {
+            // Crumb batch-2 item 1: native C-ABI export wrappers
+            // (C→Hale re-entry).
+            self.synthesize_native_export_wrappers(&user_fn_decls)?;
         }
 
         // Pass 3: the C entry point — i32 @main(i32 argc, ptr argv).
@@ -11719,7 +11736,11 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // resolve through `user_fns[name].func` (the SSA value), so the
         // symbol rename is invisible to them. Native builds keep the
         // literal name (no wrapper, `@export` is a no-op).
-        let impl_symbol = if self.is_wasm && f.export {
+        // Crumb batch-2: the rename applies on NATIVE too — the
+        // literal name is claimed by the C-ABI export wrapper
+        // (synthesize_native_export_wrappers); internal callers
+        // resolve through user_fns[name].func either way.
+        let impl_symbol = if f.export {
             format!("__hale_impl_{}", f.name.name)
         } else {
             f.name.name.clone()
@@ -11783,6 +11804,104 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     ///     implementation (`__hale_impl_<name>`, arena-ABI). The JS host
     ///     calls these with just the declared args.
     /// Collected names are handed to `wasm-ld --export=`.
+    /// Crumb batch-2 item 1 — C→Hale re-entry, native side. Each
+    /// `@export fn` gets a C-ABI wrapper under its LITERAL name
+    /// (the arena-ABI implementation was renamed to
+    /// `__hale_impl_<name>`): prologue = `lotus_reentry_arena`
+    /// (same-thread contract: the caller-arena TLS must be live —
+    /// i.e. the callback fires during an in-flight `@ffi` call;
+    /// foreign-thread entry aborts with a pointed diagnostic),
+    /// then a straight call through the existing marshalling
+    /// (Int↔int64_t, Float↔double, Bool↔bool, String↔const char*,
+    /// Bytes↔lotus blob ptr). Fallibility and defaults are
+    /// rejected at typecheck; wasm keeps its own wrapper flavor.
+    fn synthesize_native_export_wrappers(
+        &mut self,
+        user_fn_decls: &[FnDecl],
+    ) -> Result<(), CodegenError> {
+        let void_t = self.context.void_type();
+        let emit = |s: String| CodegenError::LlvmEmit(s);
+        for f in user_fn_decls {
+            if !f.export {
+                continue;
+            }
+            let name = &f.name.name;
+            let sig = self
+                .user_fns
+                .get(name)
+                .cloned()
+                .expect("@export fn declared in pass B");
+            if sig.fallible.is_some() {
+                return Err(CodegenError::Unsupported(format!(
+                    "@export fn `{}`: fallible exports are not \
+                     supported (no C error channel)",
+                    name
+                )));
+            }
+            let mut wparam_tys: Vec<
+                inkwell::types::BasicMetadataTypeEnum,
+            > = Vec::with_capacity(sig.params.len());
+            for p in &sig.params {
+                wparam_tys.push(self.llvm_basic_type(p).into());
+            }
+            let wrapper_ty = match &sig.ret {
+                Some(rt) => {
+                    self.llvm_basic_type(rt).fn_type(&wparam_tys, false)
+                }
+                None => void_t.fn_type(&wparam_tys, false),
+            };
+            let wrapper = self.module.add_function(name, wrapper_ty, None);
+            self.native_exports.push(name.clone());
+            let wentry = self.context.append_basic_block(wrapper, "entry");
+            self.builder.position_at_end(wentry);
+            let arena_fn = self
+                .module
+                .get_function("lotus_reentry_arena")
+                .expect("lotus_reentry_arena declared");
+            let name_g = self.global_string(name);
+            let arena = self
+                .builder
+                .build_call(arena_fn, &[name_g.into()], "reentry.arena")
+                .map_err(|e| emit(e.to_string()))?
+                .try_as_basic_value()
+                .left()
+                .expect("returns ptr");
+            let mut call_args: Vec<
+                inkwell::values::BasicMetadataValueEnum,
+            > = Vec::with_capacity(sig.params.len() + 1);
+            call_args.push(arena.into());
+            for i in 0..sig.params.len() {
+                call_args.push(
+                    wrapper
+                        .get_nth_param(i as u32)
+                        .expect("wrapper param")
+                        .into(),
+                );
+            }
+            let call = self
+                .builder
+                .build_call(sig.func, &call_args, "reentry.call")
+                .map_err(|e| emit(e.to_string()))?;
+            match &sig.ret {
+                Some(_) => {
+                    let rv = call
+                        .try_as_basic_value()
+                        .left()
+                        .expect("non-void export returns a value");
+                    self.builder
+                        .build_return(Some(&rv))
+                        .map_err(|e| emit(e.to_string()))?;
+                }
+                None => {
+                    self.builder
+                        .build_return(None)
+                        .map_err(|e| emit(e.to_string()))?;
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn synthesize_wasm_export_wrappers(
         &mut self,
         user_fn_decls: &[FnDecl],
@@ -13300,10 +13419,38 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 };
             lowered_args.push(coerced.into());
         }
+        // Crumb batch-2 (C→Hale re-entry): publish the call
+        // site's arena in the caller-arena TLS for the duration
+        // of the @ffi call, so an `@export fn` the C code calls
+        // back into (same thread, in-flight call — the v1
+        // contract) finds a live context. Saved/restored around
+        // the call for nesting.
+        let tls_get = self
+            .module
+            .get_function("lotus_caller_arena_get")
+            .expect("lotus_caller_arena_get declared");
+        let tls_set = self
+            .module
+            .get_function("lotus_set_caller_arena")
+            .expect("lotus_set_caller_arena declared");
+        let tls_prev = self
+            .builder
+            .build_call(tls_get, &[], "ffi.tls.prev")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .expect("returns ptr");
+        let site_arena = self.current_arena_ptr()?;
+        self.builder
+            .build_call(tls_set, &[site_arena.into()], "ffi.tls.set")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         let call = self
             .builder
             .build_call(sig.func, &lowered_args, &format!("{}.ffi.call", name))
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder
+                .build_call(tls_set, &[tls_prev.into()], "ffi.tls.restore")
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         let ret_ty_opt = sig.ret.clone();
         // sret-style struct return: the LLVM call returned void
         // (the C glue wrote into the slot we passed); yield the

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -944,6 +944,19 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ),
             None,
         );
+        // Crumb batch-2: C→Hale re-entry prologue.
+        // declare ptr @lotus_reentry_arena(ptr fn_name)
+        self.module.add_function(
+            "lotus_reentry_arena",
+            ptr_t.fn_type(&[ptr_t.into()], false),
+            None,
+        );
+        // declare ptr @lotus_caller_arena_get()
+        self.module.add_function(
+            "lotus_caller_arena_get",
+            ptr_t.fn_type(&[], false),
+            None,
+        );
         self.module.add_function(
             "lotus_obs_locus_dissolve",
             self.context

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -8297,6 +8297,66 @@ impl<'a> Checker<'a> {
         // Locus context is forbidden — @ffi only valid on top-level
         // free fns at Stage 1; the parser dispatch in
         // parse_top_decl enforces this, but defend in depth here.
+        // Crumb batch-2 item 1 (C→Hale re-entry): an `@export fn` is
+        // a C-ABI symbol on native (and a wasm export) — its params
+        // and return must sit in the same FFI-portable set the
+        // `@ffi` import direction validates, and it can't be
+        // fallible (no C error channel) or take defaults (fixed
+        // C arity).
+        if decl.export && locus.is_none() {
+            for p in &decl.params {
+                let ty = resolve_type_expr(&p.ty, self.known);
+                if let Some(reason) = ffi_type_unportable(&ty) {
+                    self.diags.push(Diag::ty(
+                        p.ty.span(),
+                        format!(
+                            "`@export` fn `{}` parameter `{}` has type {} \
+                             — {} (the export is a C-ABI symbol; only the \
+                             FFI-portable set crosses)",
+                            decl.name.name,
+                            p.name.name,
+                            ty.display(),
+                            reason,
+                        ),
+                    ));
+                }
+                if p.default.is_some() {
+                    self.diags.push(Diag::ty(
+                        p.ty.span(),
+                        format!(
+                            "`@export` fn `{}`: defaulted params aren't \
+                             exportable — a C caller has fixed arity",
+                            decl.name.name
+                        ),
+                    ));
+                }
+            }
+            if let Some(ret_te) = &decl.ret {
+                let ret_ty = resolve_type_expr(ret_te, self.known);
+                if let Some(reason) = ffi_type_unportable(&ret_ty) {
+                    self.diags.push(Diag::ty(
+                        ret_te.span(),
+                        format!(
+                            "`@export` fn `{}` return type {} — {}",
+                            decl.name.name,
+                            ret_ty.display(),
+                            reason,
+                        ),
+                    ));
+                }
+            }
+            if decl.fallible.is_some() {
+                self.diags.push(Diag::ty(
+                    decl.span,
+                    format!(
+                        "`@export` fn `{}`: fallible fns aren't \
+                         exportable (no C error channel) — return a \
+                         sentinel or split the error out",
+                        decl.name.name
+                    ),
+                ));
+            }
+        }
         if let Some(ffi) = &decl.ffi {
             if locus.is_some() {
                 self.diags.push(Diag::ty(

--- a/spec/ffi.md
+++ b/spec/ffi.md
@@ -496,3 +496,45 @@ Bytes;` (Hale reads them and parses with `std::json` / `std::bytes`).
 - `docs/src/systems/webassembly.md` — the pedagogical companion to
   the WASM host interface above (the browser-client walkthrough:
   loader `run(glue)`, the inbox, the `@export locus` game loop).
+
+
+## C→Hale re-entry: `@export fn` on native (Crumb batch 2, 2026-07-27)
+
+The inverse direction of `@ffi`: an `@export fn` free fn is
+emitted as an **unmangled C-ABI symbol** on native targets (the
+same annotation wasm entry-inversion already used; the internal
+arena-ABI implementation is renamed `__hale_impl_<name>` and the
+literal name is claimed by a C-callable wrapper). C code — an
+engine registering host functions, a callback-taking library —
+links the symbol and calls straight into Hale.
+
+**Marshalling** is the same FFI-portable set as imports, in the
+same C shapes: `Int` ↔ `int64_t`, `Float` ↔ `double`, `Bool` ↔
+`bool`, `String` ↔ `const char*`, `Bytes` ↔ lotus blob pointer
+(`lotus_bytes_len`/`lotus_bytes_data` are linkable for C-side
+access). Typecheck rejects non-portable params/returns, defaulted
+params (fixed C arity), and fallible exports (no C error
+channel).
+
+**The v1 contract is same-thread re-entry**: the callback must
+fire while Hale is inside an in-flight `@ffi` call on that same
+thread (the engine-host-function shape — JS calls a host fn
+during `crumb_js_run_file`). Codegen publishes the call site's
+arena in the caller-arena TLS around every `@ffi` call
+(save/set/restore, nesting-safe); the export wrapper's prologue
+picks it up, so the re-entered body composes with the established
+context — bus publishes dispatch, eager loci instantiate and
+dissolve, all on the thread that owns them. Entry from a foreign
+thread (or outside any in-flight `@ffi` call) aborts with a
+pointed diagnostic naming this section; cross-thread entry is the
+documented follow-up.
+
+**Invariants the re-entered code inherits** (spelled out per the
+Crumb request): re-entry runs on the calling thread's context —
+the same single-threaded interiority as the locus/fn that made
+the `@ffi` call. Publishes enqueue exactly as they would from
+that caller; a re-entered export must not assume it runs on main
+unless the `@ffi` call site does. `JSValue`-style by-value
+foreign structs never cross — trampolines convert to the
+marshalling set C-side (the pond/sqlite handles-in/scalars-out
+pattern).


### PR DESCRIPTION
Crumb batch-2 item 1 — the port's critical path (PORT.md milestone 2: JS calls `serve()`/`fetch()` and the implementation is Hale).

Went with the handoff's **option 1**, spelled as the existing annotation: `@export fn` (wasm entry-inversion's annotation) now emits an **unmangled C-ABI symbol on native** too. QuickJS trampolines (`JS_NewCFunction` → C glue) link the symbol and call straight into Hale.

- **Symbol plumbing**: internal impl renames to `__hale_impl_<name>` on both targets; a synthesized wrapper claims the literal name; export wrappers are exempted from the internalize+globaldce prepass (they're exactly what a C caller links by name).
- **Re-entry prologue**: codegen saves/sets/restores the caller-arena TLS around every `@ffi` call, so a callback fired during the in-flight call (the engine-host-function shape) finds a live context. Foreign-thread/idle entry aborts with a diagnostic naming the spec section — the requested "cross-thread stays rejected clearly" v1.
- **Marshalling**: the same FFI-portable set as imports (`Int`↔`int64_t`, `String`↔`const char*`, …); typecheck rejects non-portable types, defaulted params, fallible exports.
- **Composition proven, not assumed**: the E2E (`ffi_export_reentry.rs`) re-enters from C with Int + String marshalling, instantiates an eager locus, and publishes on the bus from inside the callback — all delivered and asserted. The inherited-invariants section the handoff asked for ("save the first user a debugging week") is in spec/ffi.md.
- wasm exports untouched (15/15 green); corpus, ffi-pickup, hale-types all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)