### PR TITLE
Native observation: iris handoff-2 field-report fixes (P5–P10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ behavior.
 
 ## Unreleased
 
+- **Native observation emission: field-report hardening (iris
+  handoff 2).** Six fixes from a ~16-binary production fleet run:
+  NET_SEND now fires on the **UDP multicast fanout** (it was
+  `continue`-skipped before the stream probe, so multicast
+  publishers emitted no send-side records and the cross-process
+  seq matcher rendered zero edges); LOCUS_BIRTH carries real
+  **parentage** (emitted before field-default init so a child
+  finds its parent registered — every tree was rendering flat)
+  and **pinned children register on the spawning thread**
+  (previously a pinned reader that parked before its first probe
+  emitted nothing); BUS_PUBLISH **stamps the publishing locus**
+  (per-locus perimeter pulses); topic **shape_hash is subject +
+  canonical payload structure**, never the declaring type's local
+  name, so two binaries sharing a subject fuse into one manifest
+  row; and rings **re-emit EPOCH every 1024 records** so a
+  high-rate ring that wraps its anchor stops reconstructing ~2^64
+  ns timestamps. `obs_emission.rs` gains ring-walking assertions
+  for parentage + attribution.
+
 - **Direct `std::io::tcp::listen_socket` path-call fixed (Crumb
   batch-2 item 2).** The direct user-code lowering truncated the
   port to i32 against the C primitive's declared `(ptr, i16)`

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -13961,8 +13961,25 @@ void lotus_bus_remote_fanout(const char *subject,
                 LOTUS_CTR_BUMP(e->ctr_send_failures);
                 lotus_bus_udp_log_sendto_error(e->subject, errno);
             } else {
-                LOTUS_CTR_BUMP(e->ctr_msgs_sent);
+                uint64_t useq = LOTUS_CTR_BUMP(e->ctr_msgs_sent);
                 LOTUS_CTR_ADD(e->ctr_bytes_sent, payload_size);
+                /* iris handoff-2 P5: NET_SEND for the UDP fanout —
+                 * this branch `continue`s before the stream-
+                 * transport probe below, so the fleet's multicast
+                 * publishes emitted no send-side records and the
+                 * seq matcher had nothing to pair (0 edges).
+                 * Mirrors the deliver-side placement. */
+                if (lotus_obs_net_send && lotus_obs_binding_register) {
+                    if (e->obs_binding_id == 0) {
+                        int64_t id = lotus_obs_binding_register(
+                            e->subject ? e->subject : "?", 1);
+                        e->obs_binding_id = (id > 0) ? id : -1;
+                    }
+                    if (e->obs_binding_id > 0) {
+                        lotus_obs_net_send(e->obs_binding_id, useq,
+                                           (uint64_t)payload_size);
+                    }
+                }
             }
             continue;
         }

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -111,6 +111,49 @@ void lotus_spsc_note_drop(void *desc);
 /* 0 = unchecked, 1 = disabled, 2 = enabled. */
 static _Atomic int g_obs_state = 0;
 
+/* iris handoff-2 P10: publisher attribution. Codegen notes the
+ * publishing locus's self in this TLS right before lowering a
+ * `<-` dispatch from inside a locus body (NULL from free-fn
+ * contexts), and bus_publish falls back to it when its explicit
+ * arg is NULL. */
+static __thread void *g_obs_tls_publisher = NULL;
+void lotus_obs_note_publisher(void *self) {
+  g_obs_tls_publisher = self;
+}
+
+/* iris handoff-2 P6: canonical topic shapes, registered by
+ * codegen at program start (before the segment exists — obs
+ * init is lazy). shape_hash = fnv(subject, canonical payload
+ * structure), NEVER the declaring type's name, so two binaries
+ * declaring the same subject under different local topic names
+ * fuse into one row (the PROTOCOL §13 canonicalization rule
+ * proposed by the field report). */
+typedef struct { const char *subject; const char *shape; } obs_shape_t;
+static obs_shape_t g_shapes[OBS_ENTRY_CAP];
+static _Atomic int g_shape_count = 0;
+
+void lotus_obs_topic_shape(const char *subject, const char *shape) {
+  if (!subject || !shape) return;
+  int n = atomic_load(&g_shape_count);
+  if (n >= OBS_ENTRY_CAP) return;
+  for (int i = 0; i < n; i++) {
+    if (strcmp(g_shapes[i].subject, subject) == 0) return;
+  }
+  g_shapes[n].subject = strdup(subject);
+  g_shapes[n].shape = strdup(shape);
+  atomic_store_explicit(&g_shape_count, n + 1, memory_order_release);
+}
+
+static const char *obs_shape_for(const char *subject) {
+  int n = atomic_load_explicit(&g_shape_count, memory_order_acquire);
+  for (int i = 0; i < n; i++) {
+    if (strcmp(g_shapes[i].subject, subject) == 0) {
+      return g_shapes[i].shape;
+    }
+  }
+  return "";
+}
+
 static void *g_seg; static size_t g_seg_len;
 static obs_hdr_t *H; static obs_ctrl_t *C; static obs_mh_t *MH;
 static obs_me_t *ME; static char *POOL; static uint8_t *MODE;
@@ -137,6 +180,14 @@ static _Atomic uint32_t g_next_inst_id = 1;
 static _Atomic int g_ring_next = 0;
 static __thread int t_ring = -1;          /* -1 unassigned, -2 none free */
 static __thread uint64_t t_epoch_ns = 0;  /* ring epoch anchor */
+/* iris handoff-2 P7: records emitted since the last EPOCH. A
+ * high-rate ring wraps and OVERWRITES its EPOCH record; a
+ * consumer that attaches (or falls behind) then reconstructs
+ * from base 0 — observed as ~2^64 ns timestamps on the fleet's
+ * hottest segment. Re-emit EPOCH every OBS_EPOCH_EVERY records
+ * so every ring window contains at least one anchor. */
+#define OBS_EPOCH_EVERY 1024
+static __thread uint32_t t_since_epoch = 0;
 
 static uint64_t obs_mono_ns(void) {
   struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -274,7 +325,12 @@ static uint64_t obs_fnv(const char *a, const char *b) {
   return h;
 }
 
-static int64_t g_next_id[4] = {1, 1, 0, 0};
+/* iris handoff-2: binding ids start at 1 here (reference glue
+ * started them at 0, which collided with the arena-side
+ * `obs_binding_id == 0` = unregistered sentinel and produced
+ * records the consumer showed as `unknown:0`). Consumers read
+ * ids from manifest entries, so the numbering start is free. */
+static int64_t g_next_id[4] = {1, 1, 1, 0};
 
 /* Under g_obs_lock. */
 static int64_t obs_manifest_add(uint8_t kind, uint8_t flg,
@@ -336,11 +392,14 @@ static void obs_emit(uint32_t ekind, uint32_t id, uint32_t size_class,
                      uint64_t w1) {
   uint64_t now = obs_mono_ns();
   uint64_t delta = (now - t_epoch_ns) >> H->ts_shift;
-  if (t_epoch_ns == 0 || delta > OBS_TS_DELTA_MAX) {
+  if (t_epoch_ns == 0 || delta > OBS_TS_DELTA_MAX ||
+      t_since_epoch >= OBS_EPOCH_EVERY) {
     t_epoch_ns = now;
+    t_since_epoch = 0;
     obs_emit_raw((uint64_t)EK_EPOCH << 20, now);
     delta = 0;
   }
+  t_since_epoch++;
   uint64_t w0 = ((uint64_t)(id & 0xFFFFFu))
       | ((uint64_t)(ekind & 0x1Fu) << 20)
       | ((uint64_t)(size_class & 0xFFu) << 25)
@@ -391,7 +450,9 @@ static obs_topic_slot_t *obs_topic_slot(const char *subject,
   obs_topic_slot_t *slot = NULL;
   if (n < OBS_ENTRY_CAP) {
     int64_t id = obs_manifest_add(MK_TOPIC, networked ? 1 : 0, subject,
-                                  0, obs_fnv(subject, ""), 0);
+                                  0,
+                                  obs_fnv(subject, obs_shape_for(subject)),
+                                  0);
     if (id >= 0) {
       char *copy = strdup(subject);
       if (copy) {
@@ -432,6 +493,7 @@ void lotus_obs_bus_publish(const char *subject, void *publisher_self,
   if (!obs_gate()) return;
   uint8_t mode = MODE[t->id & (OBS_ENTRY_CAP - 1)];
   if (mode < 2) return; /* OFF / COUNTERS */
+  if (!publisher_self) publisher_self = g_obs_tls_publisher;
   uint32_t locus = publisher_self ? obs_inst_id_of(publisher_self) : 0;
   obs_emit(EK_BUS_PUBLISH, (uint32_t)t->id,
            obs_size_class(payload_bytes),

--- a/crates/hale-codegen/src/bus/dispatch.rs
+++ b/crates/hale-codegen/src/bus/dispatch.rs
@@ -190,6 +190,27 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
             )));
         }
         let subj_val = self.unpack_view_if_needed(subj_val, &subj_ty)?;
+        // iris handoff-2 P10: note the publishing locus in the obs
+        // TLS so BUS_PUBLISH records carry locus attribution (the
+        // C dispatch doesn't know self; petals don't pulse
+        // without it). Null from free-fn contexts. One relaxed
+        // TLS store per publish; the obs fn is a no-op branch
+        // when observation is off.
+        {
+            let ptr_t = self.context.ptr_type(AddressSpace::default());
+            let note_fn = self
+                .module
+                .get_function("lotus_obs_note_publisher")
+                .expect("lotus_obs_note_publisher declared");
+            let pub_self: inkwell::values::BasicValueEnum = self
+                .current_self
+                .as_ref()
+                .map(|cs| cs.self_ptr.into())
+                .unwrap_or_else(|| ptr_t.const_null().into());
+            self.builder
+                .build_call(note_fn, &[pub_self.into()], "obs.note_pub")
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        }
         // GH #255 phase 1: `or wait` — park through the binding's
         // loss window BEFORE the dispatch fanout, so the publish
         // that follows lands on a live transport instead of

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -411,6 +411,24 @@ fn bce_ifstmt_safe(ifs: &IfStmt, vkey: &BceVecKey, var: &str) -> bool {
 
 /// True iff evaluating `expr` cannot mutate vec `vkey` (nor pass
 /// `self`/V by-reference somewhere that could). Default-bail.
+/// iris handoff-2 P6: coarse, stable field-type tags for the
+/// canonical topic shape string. Deliberately name-free for
+/// nested user types ("struct") so the hash never depends on a
+/// declaring binary's local type names.
+fn obs_shape_tag(ty: &CodegenTy) -> &'static str {
+    match ty {
+        CodegenTy::Int => "i",
+        CodegenTy::Float => "f",
+        CodegenTy::Bool => "b",
+        CodegenTy::Decimal => "d",
+        CodegenTy::Time => "t",
+        CodegenTy::Duration => "u",
+        CodegenTy::String | CodegenTy::StringView => "s",
+        CodegenTy::Bytes | CodegenTy::BytesView => "y",
+        _ => "struct",
+    }
+}
+
 fn bce_expr_safe(expr: &Expr, vkey: &BceVecKey, var: &str) -> bool {
     // A bare occurrence of V anywhere OTHER than as the receiver of a
     // read-only method call (handled in `bce_call_safe`, which does
@@ -1173,6 +1191,7 @@ pub fn build_executable_with_options(
         is_wasm,
         wasm_exports: Vec::new(),
         native_exports: Vec::new(),
+        current_instantiation_parent: None,
         instantiating_persistent_singleton: false,
         cell_owned_clone: false,
         program: &merged,
@@ -2779,6 +2798,13 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// through the internalize+globaldce prepass (they're exactly
     /// the symbols an external C caller links by name).
     pub(crate) native_exports: Vec<String>,
+    /// iris handoff-2 P9: the self pointer of the locus currently
+    /// being INSTANTIATED, so children created during its
+    /// param-init register LOCUS_BIRTH with real parentage
+    /// (current_self is None in that context — param defaults
+    /// lower in the instantiating fn's scope).
+    pub(crate) current_instantiation_parent:
+        Option<PointerValue<'ctx>>,
     /// WASM entry-inversion: set while `_hale_start` instantiates the
     /// `@export locus` singleton, so `lower_locus_instantiation`
     /// allocates its struct in the persistent program arena (not a
@@ -8097,6 +8123,80 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // reachable from `main`) would otherwise survive gc-sections and
         // become host imports. The browser bus is in-memory / WebSocket-
         // adapter-driven (a later slice), never cross-process sockets.
+        // iris handoff-2 P6: register every declared topic's
+        // canonical shape (subject + field structure, never the
+        // declaring type's name) before any traffic — two
+        // binaries sharing a subject under different local topic
+        // names then hash identically and fuse into one manifest
+        // row on the consumer. Cheap: one strdup'd table entry
+        // per topic, consulted lazily if/when observation
+        // initializes.
+        if !self.is_wasm {
+            let shapes: Vec<(String, String)> = self
+                .program
+                .items
+                .iter()
+                .filter_map(|it| match it {
+                    TopDecl::Topic(t) => {
+                        let subj = t
+                            .subject
+                            .clone()
+                            .unwrap_or_else(|| t.name.name.clone());
+                        let shape = match &t.payload {
+                            TypeExpr::Named { path, generic_args, .. }
+                                if path.segments.len() == 1
+                                    && generic_args.is_empty() =>
+                            {
+                                self.user_types
+                                    .get(&path.segments[0].name)
+                                    .map(|ti| {
+                                        ti.field_order
+                                            .iter()
+                                            .filter_map(|f| {
+                                                ti.fields.get(f).map(
+                                                    |(_, fty)| {
+                                                        format!(
+                                                            "{}:{}",
+                                                            f,
+                                                            obs_shape_tag(
+                                                                fty
+                                                            )
+                                                        )
+                                                    },
+                                                )
+                                            })
+                                            .collect::<Vec<_>>()
+                                            .join(";")
+                                    })
+                                    .unwrap_or_default()
+                            }
+                            _ => String::new(),
+                        };
+                        Some((subj, shape))
+                    }
+                    _ => None,
+                })
+                .collect();
+            if !shapes.is_empty() {
+                let shape_fn = self
+                    .module
+                    .get_function("lotus_obs_topic_shape")
+                    .expect("lotus_obs_topic_shape declared");
+                for (subj, shape) in shapes {
+                    let sg = self.global_string(&subj);
+                    let hg = self.global_string(&shape);
+                    self.builder
+                        .build_call(
+                            shape_fn,
+                            &[sg.into(), hg.into()],
+                            "obs.topic_shape",
+                        )
+                        .map_err(|e| {
+                            CodegenError::LlvmEmit(e.to_string())
+                        })?;
+                }
+            }
+        }
         if !self.is_wasm {
             let load_cfg_fn = self
                 .module

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -1783,6 +1783,42 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                 .build_store(g.as_pointer_value(), self_ptr)
                 .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         }
+        // iris P4 + handoff-2 P8/P9: register THIS instance's
+        // LOCUS_BIRTH *before* field-default init, so a child
+        // born during that init finds this locus already in the
+        // instance table for its parent lookup (post-birth()
+        // placement rendered every parent as root). Parent = the
+        // OUTER context (the locus/instantiation that created us),
+        // null/root from `fn main`.
+        {
+            let ptr_t = self.context.ptr_type(AddressSpace::default());
+            let obs_fn = self
+                .module
+                .get_function("lotus_obs_locus_birth")
+                .expect("lotus_obs_locus_birth declared");
+            let tname = self.global_string(locus_name);
+            let parent: inkwell::values::BasicValueEnum = self
+                .current_instantiation_parent
+                .map(|p| p.into())
+                .or_else(|| {
+                    self.current_self.as_ref().map(|cs| cs.self_ptr.into())
+                })
+                .unwrap_or_else(|| ptr_t.const_null().into());
+            self.builder
+                .build_call(
+                    obs_fn,
+                    &[self_ptr.into(), tname.into(), parent.into()],
+                    &format!("{}.obs.birth", locus_name),
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        }
+        // iris handoff-2 P9: every child instantiated during THIS
+        // locus's field-default init records this locus as its
+        // LOCUS_BIRTH parent — now registered above.
+        let prev_obs_parent = std::mem::replace(
+            &mut self.current_instantiation_parent,
+            Some(self_ptr),
+        );
         for (fname, default) in info.defaults.iter() {
             // F.31: per-field placement override for main-locus
             // params. Looked up by field name in
@@ -2252,6 +2288,8 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
             }
         }
         self.current_arena_override = prev_arena_override;
+        // iris handoff-2 P9: restore the obs-parent context.
+        self.current_instantiation_parent = prev_obs_parent;
         // F.31 Phase 3b: restore params-init-parent context.
         // The placement-pinned children we instantiated above
         // have already stored their __parent_self values via
@@ -3161,31 +3199,6 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                     )
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
             }
-            // iris P4: LOCUS_BIRTH for pinned loci — their birth
-            // runs on the spawned thread, so the cooperative-path
-            // probe never sees them. Parent is unattributed here
-            // (the spawning locus's self isn't marshaled into the
-            // thread-main); v0 accepts the root-parent rendering.
-            {
-                let ptr_t2 =
-                    self.context.ptr_type(AddressSpace::default());
-                let obs_fn = self
-                    .module
-                    .get_function("lotus_obs_locus_birth")
-                    .expect("lotus_obs_locus_birth declared");
-                let tname = self.global_string(locus_name);
-                self.builder
-                    .build_call(
-                        obs_fn,
-                        &[
-                            thread_self.into(),
-                            tname.into(),
-                            ptr_t2.const_null().into(),
-                        ],
-                        &format!("{}.obs.birth.pinned", locus_name),
-                    )
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-            }
             for kind in &["birth", "run"] {
                 if let Some(method) = info.methods.get(*kind) {
                     let skip = info.empty_lifecycle.contains(*kind);
@@ -3328,6 +3341,7 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
             // session's fix for the locus .self struct alloca).
             let tid_alloca = self
                 .alloca_in_entry(i64_t.into(), &format!("{}.tid", locus_name))?;
+
             let thread_main_ptr =
                 thread_main.as_global_value().as_pointer_value();
             let null_attr = ptr_t.const_null();
@@ -3468,30 +3482,6 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                     )
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
             }
-        }
-        // iris P4: LOCUS_BIRTH probe (no-op unless LOTUS_OBS=1;
-        // one predictable branch inside the C fn otherwise).
-        // Parent = the instantiating locus's self when inside a
-        // lifecycle/method body, null from free fns.
-        {
-            let ptr_t = self.context.ptr_type(AddressSpace::default());
-            let obs_fn = self
-                .module
-                .get_function("lotus_obs_locus_birth")
-                .expect("lotus_obs_locus_birth declared");
-            let tname = self.global_string(locus_name);
-            let parent: inkwell::values::BasicValueEnum = self
-                .current_self
-                .as_ref()
-                .map(|cs| cs.self_ptr.into())
-                .unwrap_or_else(|| ptr_t.const_null().into());
-            self.builder
-                .build_call(
-                    obs_fn,
-                    &[self_ptr.into(), tname.into(), parent.into()],
-                    &format!("{}.obs.birth", locus_name),
-                )
-                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         }
         if let Some(birth_closures_fn) = info.birth_closures_fn {
             let (parent_self, handler_ptr) =

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -957,6 +957,21 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ptr_t.fn_type(&[], false),
             None,
         );
+        // iris handoff-2: publisher-attribution TLS + topic shapes.
+        // declare void @lotus_obs_note_publisher(ptr self)
+        // declare void @lotus_obs_topic_shape(ptr subject, ptr shape)
+        self.module.add_function(
+            "lotus_obs_note_publisher",
+            self.context.void_type().fn_type(&[ptr_t.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "lotus_obs_topic_shape",
+            self.context
+                .void_type()
+                .fn_type(&[ptr_t.into(), ptr_t.into()], false),
+            None,
+        );
         self.module.add_function(
             "lotus_obs_locus_dissolve",
             self.context

--- a/crates/hale-codegen/tests/obs_emission.rs
+++ b/crates/hale-codegen/tests/obs_emission.rs
@@ -154,6 +154,121 @@ fn emits_protocol_segment_with_matching_counters() {
     );
 }
 
+/// Walk a ring's slots, collecting decoded (ekind, w0-id, w1)
+/// tuples. Consumer-side: read head, scan the live window.
+fn drain_ring(
+    seg: &[u8],
+    rings_off: usize,
+    ring_slots: usize,
+    ring: usize,
+) -> Vec<(u32, u32, u64)> {
+    // ring descriptor: {u64 data_off, u64 head, ...} at rings_off
+    // + ring * 64 (sizeof rdesc). Descriptors precede data.
+    let rdesc = rings_off + ring * 64;
+    let data_off = read_u64(seg, rdesc) as usize;
+    let head = read_u64(seg, rdesc + 8) as usize;
+    let mut out = Vec::new();
+    let start = head.saturating_sub(ring_slots);
+    for i in start..head {
+        let slot = data_off + (i & (ring_slots - 1)) * 16;
+        let w0 = read_u64(seg, slot);
+        let w1 = read_u64(seg, slot + 8);
+        let id = (w0 & 0xFFFFF) as u32;
+        let ekind = ((w0 >> 20) & 0x1F) as u32;
+        out.push((ekind, id, w1));
+    }
+    out
+}
+
+#[test]
+fn births_carry_parentage_and_publishes_attribute_locus() {
+    let bin = build("attrib", DEMO);
+    let mut child = Command::new(&bin)
+        .env("LOTUS_OBS", "1")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    let pid = child.id();
+    let shm_path = format!("/dev/shm/hale-obs-{}", pid);
+    let mut seg_file = None;
+    for _ in 0..40 {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        if let Ok(f) = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&shm_path)
+        {
+            seg_file = Some(f);
+            break;
+        }
+    }
+    let seg_file = seg_file.unwrap_or_else(|| {
+        let _ = child.kill();
+        panic!("segment never appeared")
+    });
+    let seg_len = seg_file.metadata().expect("meta").len() as usize;
+    let map = unsafe { libc_mmap(&seg_file, seg_len) };
+    let seg = unsafe { std::slice::from_raw_parts(map, seg_len) };
+    let control_off = read_u64(seg, 0x38) as usize;
+    let rings_off = read_u64(seg, 0x68) as usize;
+    let ring_count = read_u32(seg, 0x1C) as usize;
+    let ring_slots = read_u32(seg, 0x20) as usize;
+    // Attach BEFORE the publish burst (starts at t+400ms).
+    unsafe {
+        let oc = map.add(control_off) as *mut u32;
+        std::ptr::write_volatile(oc, 1);
+    }
+    let out = child.wait_with_output().expect("wait");
+    assert!(out.status.success(), "demo exited nonzero");
+
+    let mut births = 0usize;
+    let mut parented = 0usize;
+    let mut publishes = 0usize;
+    let mut attributed = 0usize;
+    for r in 0..ring_count {
+        for (ekind, _id, w1) in
+            drain_ring(seg, rings_off, ring_slots, r)
+        {
+            match ekind {
+                5 => {
+                    // LOCUS_BIRTH: w1 = parent:32 | type:20
+                    births += 1;
+                    if (w1 & 0xFFFFFFFF) != 0 {
+                        parented += 1;
+                    }
+                }
+                1 => {
+                    // BUS_PUBLISH: w1 = locus:20 | seq:44
+                    publishes += 1;
+                    if (w1 & 0xFFFFF) != 0 {
+                        attributed += 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    // Sink + Pub (+ App itself) all birth; at least the two
+    // children must carry a non-root parent (P9).
+    assert!(births >= 2, "expected births, got {}", births);
+    assert!(
+        parented >= 2,
+        "births must carry parentage (P9): {}/{} parented",
+        parented,
+        births
+    );
+    // The publisher is the pinned Pub locus — its publishes must
+    // attribute it (P10).
+    assert!(publishes >= 1, "expected publishes, got {}", publishes);
+    assert!(
+        attributed >= 1,
+        "BUS_PUBLISH must attribute the publishing locus (P10):          {}/{} attributed",
+        attributed,
+        publishes
+    );
+}
+
 #[test]
 fn dormant_by_default() {
     let bin = build("dormant", DEMO);

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1354,7 +1354,24 @@ late-attaching observer reconstructs the tree. Knobs:
 locus attribution on BUS_PUBLISH is unattributed (0); pinned
 births render parent=root. `lotus_obs.c` is its own TU; the
 arena TU's probes are weak-guarded so helper binaries compiling
-`lotus_arena.c` alone still link.
+`lotus_arena.c` alone  still link.
+
+Field-hardening (iris handoff 2, 2026-07-27, v0.11.13): NET_SEND
+now fires on the UDP multicast fanout path (it `continue`s before
+the stream-transport probe, so multicast publishers emitted only
+deliver-side records — the seq matcher had nothing to pair);
+LOCUS_BIRTH is emitted BEFORE a locus's field-default init and
+carries real parentage (the parent registers before its children
+look it up — post-birth placement rendered every tree flat), and
+pinned children register on the spawning thread so a park before
+their first probe doesn't hide them; BUS_PUBLISH stamps the
+publishing locus from a codegen-set TLS (the C dispatch doesn't
+know `self`); topic shape_hash is `fnv(subject, canonical payload
+structure)` — field names + coarse type tags in declared order,
+never the declaring type's local name — so two binaries sharing a
+subject fuse into one manifest row; and each ring re-emits EPOCH
+every 1024 records so a high-rate ring that wraps its anchor never
+reconstructs timestamps from a stale base (the ~2^64 ns readings).
 
 ### Time
 


### PR DESCRIPTION
Six fixes from a real ~16-binary multicast-bus fleet run of P4 (v0.11.12), ordered by the field report's impact on iris's marquee feature (seq-matched cross-process edges, which rendered zero).

- **P5 — the zero-edges cause.** NET_SEND never fired on the UDP multicast path: that branch `continue`s before the stream-transport probe, so every multicast publisher emitted `net<` (deliver) but no `net>` (send), and the seq matcher had nothing to pair. Probe added on the UDP send success, mirroring the deliver placement, using the per-binding counter seq.
- **P6 — subject canonicalization.** `shape_hash` was `fnv(subject, "")` effectively keyed by the declaring type; two binaries declaring the same subject under different local topic names split into two manifest rows (the field report saw 266k pubs on one, 20k delivers on another). Now `fnv(subject, canonical payload structure)` — field names + coarse type tags in declared order, name-free for nested types — registered at the main prologue. Adopts the PROTOCOL §13 rule the report proposed.
- **P7 — 2^64 timestamps.** A high-rate ring wraps and overwrites its EPOCH anchor; a late/behind consumer then reconstructs from base 0. Rings now re-emit EPOCH every 1024 records so every window carries an anchor.
- **P8/P9 — silent binaries + flat trees.** LOCUS_BIRTH now emits *before* field-default init (a child born during init finds its parent already registered) with real parentage, and pinned children register on the spawning thread rather than inside thread-main (a pinned reader that parks before its first probe was invisible, and its parent was out of scope). Every fleet birth had been `parent=(root)`.
- **P10 — petals don't pulse.** BUS_PUBLISH's locus bits were 0. Codegen now stamps the publishing locus in a TLS before each `<-` (the C dispatch doesn't know `self`).

Verified with a ring-walking extension to `obs_emission.rs`: births carry non-root parents (incl. the pinned publisher) and BUS_PUBLISH attributes the publishing locus — deterministic via the raw-mmap consumer. iris needs no changes for P5/P7/P9/P10; P6 may need its fuse join updated to the final rule (spec'd in runtime.md). Fleet subject/binary names kept out — neutral fixtures only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)