### PR TITLE
release: v0.11.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.11.13 — C→Hale re-entry, iris observation field-hardening, Crumb bug fixes (2026-07-27)
 
 - **Native observation emission: field-report hardening (iris
   handoff 2).** Six fixes from a ~16-binary production fleet run:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.12"
+version = "0.11.13"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.12"
+version = "0.11.13"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.12"
+version = "0.11.13"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.12"
+version = "0.11.13"
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.12"
+version = "0.11.13"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.12"
+version = "0.11.13"
 dependencies = [
  "hale-syntax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.12"
+version = "0.11.13"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
CHANGELOG rollup + workspace version bump for v0.11.13.

Since v0.11.12 (all merged to main): #268 (Crumb listen_socket port width), #270 (C→Hale re-entry — `@export fn` native C-ABI symbol, the port's critical path), #271 (iris observation field-report fixes P5–P10). Image plumbing (#267 zlib) already shipped its own image.

Tag `v0.11.13` follows on merge → release.yml builds Linux x86_64/arm64 + macOS arm64 artifacts; the tag also triggers the container image build (zlib fix in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)