### PR TITLE
Native observation: NET (origin,seq) on the transport branch (iris handoff-3 field re-test)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ behavior.
 
 ## Unreleased
 
+- **Native observation: NET (origin,seq) on the transport branch
+  too (iris handoff-3 field re-test).** The handoff-3 fix landed
+  on the raw-udp `sendto` branch, but a fleet whose bindings flow
+  through `lotus_transport_send` still stamped origin 0 + a local
+  receive counter (the field's still-zero edges). The framed
+  transport wire header now carries `origin:16 | seq:48` (was
+  seq-only), and both the fanout NET_SEND and the reader
+  NET_DELIVER emit the wire `(origin, seq)` instead of `(0, local
+  ctr)` — verified cross-segment over a framed unix transport
+  (`obs_net_seq.rs`). The parity audit that found this is in the
+  commit; the adapter branch (user transport loci) still has no
+  NET probe and is a separate gap. Non-framed transports carry no
+  wire seq and fall back to the local count.
+
 - **Native observation: NET seq semantics + publish attribution
   (iris handoff 3).** The last cross-process-edge blocker.
   `NET_SEND`/`NET_DELIVER` now carry `origin:16 | seq:48` where

--- a/HANDOFF-iris-3-net-seq.md
+++ b/HANDOFF-iris-3-net-seq.md
@@ -96,3 +96,36 @@ Ships in the next release; a fresh `cargo build -p hale-cli` off
 main has it now. Acceptance should now go green: fleet up under
 the overlay → `curl :8787/snapshot` → non-empty edges with µs
 latencies, per-locus pub/dlv nonzero.
+
+---
+
+## Field re-test of the dispositions (iris side, same evening)
+
+Uniform fleet rebuilt on main (incl. `ff70ef6`), full acceptance
+run: **P11/P12/P13 do not yet manifest in the field** — origin
+still exactly 0, receiver seqs still local counts (sender 1490 vs
+receiver 3085 on the same subject), attribution still zero. The
+unit tests pass because they exercise the paths that were fixed.
+
+Root cause hypothesis, from reading the send fanout: the
+header-prepend + origin/wire-seq code landed on the **raw-udp
+branch** (`e->udp_fd >= 0`, direct `sendto`), but the fleet's
+multicast entries flow through the **generic
+`lotus_transport_send` branch** immediately below it, which
+still passes literal `origin 0`, uses `ctr_msgs_sent` locally,
+and prepends nothing. Every field symptom follows from that
+branch: origin == 0 exactly, no wire header for the reader to
+peel, local-count fallback at the receiver.
+
+P13 likely rhymes: the publisher-TLS stamp may be consumed on
+one BUS_PUBLISH emit flavor while the fleet's publishes take
+another (devirt/static/cross-thread). Suggest auditing every
+`lotus_obs_net_send`/`BUS_PUBLISH` emit site for parity with the
+fixed one — the recurring shape across P5, P11, and P13 is
+"fixed on one dispatch flavor, missed on its siblings." A grep
+inventory of emit sites with a checklist beats fixing the one a
+test happens to exercise.
+
+Evidence: /tmp/pk-mk2.txt, /tmp/pk-pv2.txt; acceptance snapshot
+showed 0 edges, 0 attributed, 449 loci / 418 parented (P8/P9
+still good), no duplicate rows (P6 still good).

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -9858,8 +9858,24 @@ typedef struct lotus_transport {
     int      framed;
     uint64_t send_seq;    /* stamped then incremented per send */
     uint64_t recv_seq;    /* last seq seen (0 = none yet) */
+    uint64_t recv_origin; /* iris handoff-3: sender origin read off the wire */
     uint64_t seq_gaps;    /* recv'd seq != last+1 occurrences */
 } lotus_transport_t;
+
+/* iris handoff-3 (transport branch): expose the framed wire seq +
+ * the sender origin the receiver read, so the fanout / reader emit
+ * NET_SEND/NET_DELIVER on the SAME (origin, seq) — the transport
+ * path was stamping origin 0 + a local counter (the field's
+ * unpaired-edges symptom). Non-framed transports leave these 0. */
+uint64_t lotus_transport_send_seq(const lotus_transport_t *t) {
+    return t ? t->send_seq : 0;
+}
+uint64_t lotus_transport_recv_seq(const lotus_transport_t *t) {
+    return t ? t->recv_seq : 0;
+}
+uint64_t lotus_transport_recv_origin(const lotus_transport_t *t) {
+    return t ? t->recv_origin : 0;
+}
 
 #define LOTUS_UNIX_MAX_MSG_BYTES (8u * 1024u * 1024u)
 
@@ -10108,7 +10124,14 @@ int lotus_transport_send(lotus_transport_t *t,
         /* GH #231/#236: [u64 LE len][u64 LE seq][payload]. */
         uint64_t hdr[2];
         hdr[0] = (uint64_t)len;
-        hdr[1] = ++t->send_seq;   /* first frame = 1; 0 = sentinel */
+        /* iris handoff-3: [len][origin:16 | seq:48]. origin = this
+         * process's obs identity (0 when unobserved); seq is the
+         * per-connection frame counter (first = 1). Both ends are
+         * the same build after a uniform rebuild, so widening the
+         * seq word is safe; gap accounting masks to the low 48. */
+        uint64_t o = lotus_obs_origin ? lotus_obs_origin() : 0;
+        ++t->send_seq;
+        hdr[1] = (t->send_seq & 0xFFFFFFFFFFFFULL) | ((o & 0xFFFFULL) << 48);
         if (lotus__transport_write_full(t->conn_fd, hdr, sizeof(hdr)) != 0
             || lotus__transport_write_full(t->conn_fd, buf, len) != 0) {
             perror("lotus_transport_send");
@@ -10140,7 +10163,8 @@ ssize_t lotus_transport_recv(lotus_transport_t *t,
             return 0;
         }
         uint64_t len = hdr[0];
-        uint64_t seq = hdr[1];
+        uint64_t seq = hdr[1] & 0xFFFFFFFFFFFFULL;
+        t->recv_origin = (hdr[1] >> 48) & 0xFFFFULL;
         if (len > LOTUS_UNIX_MAX_MSG_BYTES || len > (uint64_t)cap) {
             fprintf(stderr,
                     "lotus_transport_recv: framed length %llu exceeds "
@@ -13019,12 +13043,20 @@ static void lotus_bus_unix_serve(lotus_bus_remote_entry_t *entry) {
                     entry->obs_binding_id = (id > 0) ? id : -1;
                 }
                 if (entry->obs_binding_id > 0) {
-                    /* Stream is unicast (one sender per connection),
-                     * so origin 0 + the local seq pairs correctly;
-                     * the (origin, seq) fix is UDP-multicast-specific
-                     * (handoff-3 P11). */
-                    lotus_obs_net_deliver(entry->obs_binding_id, 0,
-                                          dseq, (uint64_t)n);
+                    /* iris handoff-3: echo the SENDER's (origin,
+                     * seq) read off the framed wire — the same
+                     * pair the transport-branch NET_SEND stamped.
+                     * Falls back to (0, local dseq) only for a
+                     * non-framed transport (no wire seq). */
+                    uint64_t wo =
+                        lotus_transport_recv_origin(entry->transport);
+                    uint64_t ws =
+                        lotus_transport_recv_seq(entry->transport);
+                    lotus_obs_net_deliver(
+                        entry->obs_binding_id,
+                        ws ? wo : 0,
+                        ws ? ws : dseq,
+                        (uint64_t)n);
                 }
             }
         }
@@ -14093,8 +14125,15 @@ void lotus_bus_remote_fanout(const char *subject,
                     e->obs_binding_id = (id > 0) ? id : -1;
                 }
                 if (e->obs_binding_id > 0) {
-                    lotus_obs_net_send(e->obs_binding_id, 0, sent_seq,
-                                       (uint64_t)payload_size);
+                    /* iris handoff-3: pair on (origin, wire seq),
+                     * not (0, local ctr) — the transport-branch
+                     * field bug. send_seq is the framed wire seq
+                     * the receiver echoes; origin is this process. */
+                    lotus_obs_net_send(
+                        e->obs_binding_id,
+                        lotus_obs_origin ? lotus_obs_origin() : 0,
+                        lotus_transport_send_seq(e->transport),
+                        (uint64_t)payload_size);
                 }
             }
         } else {

--- a/crates/hale-codegen/tests/obs_net_seq.rs
+++ b/crates/hale-codegen/tests/obs_net_seq.rs
@@ -152,6 +152,93 @@ const PUB: &str = r#"
     fn main() { App { }; }
 "#;
 
+/// Same cross-segment (origin, seq) pairing, but over a FRAMED
+/// unix transport — the `lotus_transport_send` branch (distinct
+/// from the raw-udp branch above). iris handoff-3 field re-test:
+/// the transport branch was stamping origin 0 + a local counter;
+/// this asserts it now carries the wire (origin, seq).
+#[test]
+fn framed_transport_net_pairs_on_origin_seq() {
+    let sub_bin = compile("fsub", SUB);
+    let pub_bin = compile("fpub", PUB);
+    let dir = std::env::temp_dir().join(format!(
+        "hale_obsnet_f_{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let sock = dir.join("evt.sock");
+    let sub_cfg = dir.join("sub.conf");
+    let pub_cfg = dir.join("pub.conf");
+    std::fs::write(
+        &sub_cfg,
+        format!("evt = unix://{}:listen
+", sock.display()),
+    )
+    .unwrap();
+    std::fs::write(
+        &pub_cfg,
+        format!("evt = unix://{}:connect
+", sock.display()),
+    )
+    .unwrap();
+
+    let mut sub = Command::new(&sub_bin)
+        .env("LOTUS_BUS_CONFIG", &sub_cfg)
+        .env("LOTUS_OBS", "1")
+        .env("LOTUS_UNIX_STREAM", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sub");
+    std::thread::sleep(Duration::from_millis(200));
+    let mut pubc = Command::new(&pub_bin)
+        .env("LOTUS_BUS_CONFIG", &pub_cfg)
+        .env("LOTUS_OBS", "1")
+        .env("LOTUS_UNIX_STREAM", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn pub");
+    let pub_pid = pubc.id();
+    let sub_pid = sub.id();
+    std::thread::sleep(Duration::from_millis(150));
+    unsafe {
+        attach_observer(pub_pid);
+        attach_observer(sub_pid);
+    }
+    std::thread::sleep(Duration::from_millis(900));
+    let pub_seg = unsafe { snapshot_shm(pub_pid) };
+    let sub_seg = unsafe { snapshot_shm(sub_pid) };
+    let sends = pub_seg.as_ref().map(|s| net_pairs(s, 3)).unwrap_or_default();
+    let delivers =
+        sub_seg.as_ref().map(|s| net_pairs(s, 4)).unwrap_or_default();
+    let _ = pubc.kill();
+    let _ = pubc.wait();
+    let _ = sub.kill();
+    let _ = sub.wait();
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(!sends.is_empty(), "framed publisher emitted no NET_SEND");
+    assert!(
+        sends.iter().all(|(o, _)| *o != 0),
+        "transport-branch NET_SEND origin is 0 (the field bug): {:?}",
+        sends
+    );
+    assert!(!delivers.is_empty(), "framed sub emitted no NET_DELIVER");
+    let send_set: std::collections::HashSet<_> =
+        sends.iter().copied().collect();
+    let paired = delivers.iter().filter(|d| send_set.contains(d)).count();
+    assert!(
+        paired > 0,
+        "transport branch: no NET_SEND/NET_DELIVER pairs on \
+         (origin, seq).\nsends: {:?}\ndelivers: {:?}",
+        sends,
+        delivers
+    );
+}
+
 #[test]
 fn net_send_and_deliver_pair_on_origin_seq() {
     let sub_bin = compile("sub", SUB);


### PR DESCRIPTION
The iris field re-test of handoff-3 (#273) found the NET fix landed on the wrong branch: it targeted the raw-udp `sendto` path (`LOTUS_BUS_CONFIG udp://`), but the fleet's bindings flow through the generic `lotus_transport_send` branch, which still stamped **origin 0** + a local counter — so the field still saw `origin=0`, receiver seqs as local counts (sender 1490 vs receiver 3085), and zero edges. This is exactly the "fixed one dispatch flavor, missed its siblings" pattern the handoff called out.

## Parity audit (every NET/BUS emit site)

| site | path | before |
|---|---|---|
| NET_SEND | raw-udp | fixed in #273 |
| **NET_SEND** | **transport** | **origin 0 + ctr → fixed here** |
| NET_DELIVER | udp reader | fixed in #273 |
| **NET_DELIVER** | **transport reader** | **origin 0 + ctr → fixed here** |
| BUS_PUBLISH | local/wire/static | consume-once TLS (P13) ✓ |
| adapter branch | user transport locus | **no NET probe** — separate gap, noted |

## Fix

The framed transport wire header grows origin: `[u64 len][u64 origin:16 | seq:48]` (was seq-only); recv unpacks both into `t->recv_seq` / `t->recv_origin` (gap accounting masks to the low 48). New getters (`lotus_transport_send_seq`/`recv_seq`/`recv_origin`) let the fanout `NET_SEND` stamp `(obs_origin, wire send_seq)` and the reader `NET_DELIVER` echo the wire `(origin, seq)` — the same pair, so they cross-segment match. Non-framed transports carry no wire seq and fall back to `(0, local count)` (old behavior — no regression, no pairing).

## Verification

`obs_net_seq.rs` gains a framed-unix-transport variant (`LOTUS_UNIX_STREAM=1`, two real processes) asserting the transport branch pairs on exact `(origin, seq)` with nonzero origin — the branch the field symptom (origin *exactly* 0) pinned. Full obs/transport/udp/counters sweep green (the framed wire round-trips through `transport_tcp` + `transport_counters`).

## Honest boundary

The field symptom (origin literally 0 with `net>` present) points at the transport branch, and that's now fixed + tested. Two things I couldn't close from here: (1) the **adapter** branch has no NET probe at all (a fleet using a user/stdlib udp transport *locus* would need it, and its wire is Hale-owned so seq-echo needs the header in the Hale layer); (2) a **non-framed** transport carries no wire seq. If the field re-test still shows unpaired edges, the fleet's exact binding config (the `LOTUS_BUS_CONFIG` line or source `bindings {}` block, + framed vs non-framed) will say which of these remains — and I'll add a matching real-transport test.

Part of the iris handoff-3 acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)