### PR TITLE
release: v0.11.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.11.14 — iris observation NET seq pairing (edges), transport-branch parity (2026-07-28)
 
 - **Native observation: NET (origin,seq) on the transport branch
   too (iris handoff-3 field re-test).** The handoff-3 fix landed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.13"
+version = "0.11.14"
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "hale-syntax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.13"
+version = "0.11.14"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"

--- a/docs/src/systems/operations.md
+++ b/docs/src/systems/operations.md
@@ -38,7 +38,7 @@ own once you know which class you're chasing:
 | `LOTUS_BUS_LOG_DROP=1` | everything below, plus serialize-fail and no-post-target |
 | `LOTUS_BUS_LOG_UNMATCHED=1` | a keyed publish (`where key == …`) that matched no subscriber — prints subject, key, and the per-topic subscriber counts |
 | `LOTUS_BUS_LOG_DESERIALIZE_DROP=1` | the `udp://` reader thread dropping a frame (no deserializer registered, or a size-mismatched read) |
-| `LOTUS_BUS_COUNTERS_DUMP=1` | one line per remote binding at exit: messages/bytes sent and delivered, send failures, publishes dropped while a link was down, listener re-arms, reconnects |
+| `LOTUS_BUS_COUNTERS_DUMP=1` | one line per remote binding at exit: messages/bytes sent and delivered, send failures, publishes dropped while a link was down, publishes that parked on `or wait`, listener re-arms, reconnects |
 
 **The shape that produces no line at all.** If `LOTUS_BUS_LOG_DROP`
 is silent but the handler still never fires, the message *was*
@@ -214,6 +214,35 @@ RSS — see [Memory](#memory-my-rss-is-growing) above).
    (`self.f.x = v`) over whole-value replace (`self.f = T{…}`), which
    bump-allocates fresh each time. `--dump-alloc-summary` names the
    site at compile time.
+
+## Observing a running system
+
+Set `LOTUS_OBS=1` and any hale binary publishes an observation
+segment — a shared-memory ring of records emitted from the
+runtime's own choke points: bus publishes and deliveries (each
+attributed to the publishing/subscribing locus), transport
+sends and deliveries (paired across processes by a
+`(sender-origin, sequence)` key so a message's send and its
+deliveries line up into a cross-process edge), and locus
+lifecycle (birth with parentage, dissolve, restart). It is
+**dormant by default**: with the env var unset every probe is a
+single predictable branch, and even enabled it writes only
+counters until an observer attaches (`observer_count` on the
+segment's control page). One SPSC ring per emitting thread; a
+late-attaching observer gets the live locus tree replayed as
+births so it can reconstruct the supervision graph.
+
+The segment lives at `/hale-obs-<pid>` with a registration file
+under `$XDG_RUNTIME_DIR/hale/` (or `/tmp/hale-obs/`). The wire
+layout is the iris observation protocol — the canonical contract
+is `spec/runtime.md` § *Native observation emission*; the iris
+project is the reference consumer. Knobs: `LOTUS_OBS_RINGS`
+(default 8), `LOTUS_OBS_SLOTS` (default 4096). Cross-process
+edge pairing needs a framed transport (`udp://` carries the
+`(origin, seq)` header inline; `unix://` under
+`LOTUS_UNIX_STREAM=1` carries it in the frame header) — a
+non-framed unicast transport falls back to a local delivery
+count.
 
 ## Debugging with the native toolchain
 


### PR DESCRIPTION
CHANGELOG rollup + workspace version bump for v0.11.14, with a docs/spec sweep.

Since v0.11.13 (merged to main): #273 (iris handoff-3 NET origin/seq semantics P11–P13) and #274 (transport-branch NET parity). Both close the iris cross-process-edge blocker across the raw-udp and transport dispatch branches.

**Docs/spec sweep** (part of this PR):
- Audited spec/ coverage of everything shipped since v0.11.10 — observation, `or wait` + bounded topics, `std::compress`/`std::tar`, C→Hale re-entry (`@export fn`), `send_fd` — all present in the canonical spec.
- Added a **"Observing a running system"** section to `docs/src/systems/operations.md`: `LOTUS_OBS=1`, the segment + iris protocol, dormant-by-default cost, cross-process edge pairing (framed transports), and the `LOTUS_OBS_RINGS`/`LOTUS_OBS_SLOTS` knobs — native observation had spec coverage but no book page.
- Completed the `LOTUS_BUS_COUNTERS_DUMP` counters line with the `or wait` parks counter.

Tag `v0.11.14` follows on merge → artifacts + container image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)