### PR TITLE
release: v0.11.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.14"
+version = "0.11.15"
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "hale-syntax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.14"
+version = "0.11.15"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for v0.11.15 — iris handoff-4 observation edge-emission fixes (#277): NET topic id (P14), publish counter un-gate + keyed probes (P15), `LOTUS_OBS_WIRE` opt-in (P16), field-shaped multicast acceptance test. CHANGELOG rolled in #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)