### PR TITLE
perf: branch-gate the obs publisher-attribution note (publish hot path -28%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ behavior.
 
 ---
 
+## Unreleased
+
+- **perf: publish hot path back to baseline — the obs
+  publisher-attribution note is now branch-gated.** v0.11.13's
+  iris P10 fix made `lower_send` emit an UNCONDITIONAL
+  `lotus_obs_note_publisher` call (a call + TLS store) before
+  every `<-`, violating the "dormant = one predictable branch"
+  observation cost contract: ~0.8ns on a ~1.9ns devirtualized
+  publish, +39% on the `bus_dispatch` microbench and +34% on
+  `stream_aggregator`, shipped unnoticed in v0.11.13–v0.11.16.
+  Codegen now branches on `lotus_obs_note_publisher_wanted` (an
+  i32 the obs TU sets when `LOTUS_OBS` resolves enabled), so an
+  unobserved publish pays one predictable load+branch — LLVM
+  hoists the check and the dormant publish loop is
+  instruction-identical to the pre-v0.11.13 one. Bench restored:
+  `bus_dispatch` 268→192µs, `stream_aggregator` ~600→~440µs
+  (baselines met). Attribution under `LOTUS_OBS=1` is unchanged
+  (the flag is set by the first probe — always a locus birth —
+  before any publish).
+
 ## v0.11.16 — Crumb batch-3: main-return teardown fix, takeover_raw, Duration scalars (2026-07-28)
 
 Crumb batch-3 handoff (UPSTREAM3.md): two design asks, one

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -330,6 +330,20 @@ static int obs_create(int64_t rings, int64_t slots) {
   return 1;
 }
 
+/* Dormant-cost gate for the codegen-emitted publisher-attribution
+ * note (bench regression, v0.11.13→ found 2026-07-28). lower_send
+ * used to emit an UNCONDITIONAL `lotus_obs_note_publisher` call
+ * before every `<-` — a call + TLS store even with LOTUS_OBS
+ * unset, ~1ns on a ~1.7ns devirtualized publish (+55% on the
+ * bus_dispatch microbench). Codegen now loads this flag and only
+ * calls when observation is live, restoring the "dormant = one
+ * predictable branch" cost contract. Written once, under
+ * g_obs_lock, when the env gate resolves; plain int is fine (the
+ * transition happens before any publish that could care, and a
+ * momentarily-stale 0 only skips attribution on the first
+ * publishes of a not-yet-probed thread). */
+int lotus_obs_note_publisher_wanted = 0;
+
 /* Enable check + lazy init. Fast path after first call: one
  * relaxed load + compare. */
 static int obs_on(void) {
@@ -351,6 +365,7 @@ static int obs_on(void) {
     } else {
       st = 1;
     }
+    if (st == 2) lotus_obs_note_publisher_wanted = 1;
     atomic_store(&g_obs_state, st);
   }
   pthread_mutex_unlock(&g_obs_lock);

--- a/crates/hale-codegen/src/bus/dispatch.rs
+++ b/crates/hale-codegen/src/bus/dispatch.rs
@@ -193,11 +193,54 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
         // iris handoff-2 P10: note the publishing locus in the obs
         // TLS so BUS_PUBLISH records carry locus attribution (the
         // C dispatch doesn't know self; petals don't pulse
-        // without it). Null from free-fn contexts. One relaxed
-        // TLS store per publish; the obs fn is a no-op branch
-        // when observation is off.
+        // without it). Null from free-fn contexts.
+        //
+        // Dormant-cost gate (bench regression, 2026-07-28): the
+        // original emission called note_publisher UNCONDITIONALLY —
+        // a call + TLS store per `<-` even with LOTUS_OBS unset,
+        // ~1ns on a ~1.7ns devirtualized publish (+55% on
+        // bus_dispatch). Branch on the obs TU's
+        // `lotus_obs_note_publisher_wanted` flag instead: an
+        // unobserved publish pays one predictable load+branch,
+        // and the call only fires when observation is live.
         {
             let ptr_t = self.context.ptr_type(AddressSpace::default());
+            let i32_t = self.context.i32_type();
+            let flag_global = self
+                .module
+                .get_global("lotus_obs_note_publisher_wanted")
+                .expect("lotus_obs_note_publisher_wanted declared");
+            let flag = self
+                .builder
+                .build_load(
+                    i32_t,
+                    flag_global.as_pointer_value(),
+                    "obs.note_pub.wanted",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                .into_int_value();
+            let wanted = self
+                .builder
+                .build_int_compare(
+                    inkwell::IntPredicate::NE,
+                    flag,
+                    i32_t.const_zero(),
+                    "obs.note_pub.on",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let func = self
+                .builder
+                .get_insert_block()
+                .and_then(|bb| bb.get_parent())
+                .expect("inside a function");
+            let note_bb =
+                self.context.append_basic_block(func, "obs.note_pub.do");
+            let cont_bb =
+                self.context.append_basic_block(func, "obs.note_pub.cont");
+            self.builder
+                .build_conditional_branch(wanted, note_bb, cont_bb)
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder.position_at_end(note_bb);
             let note_fn = self
                 .module
                 .get_function("lotus_obs_note_publisher")
@@ -210,6 +253,10 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
             self.builder
                 .build_call(note_fn, &[pub_self.into()], "obs.note_pub")
                 .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder
+                .build_unconditional_branch(cont_bb)
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder.position_at_end(cont_bb);
         }
         // GH #255 phase 1: `or wait` — park through the binding's
         // loss window BEFORE the dispatch fanout, so the publish

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -965,6 +965,20 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             self.context.void_type().fn_type(&[ptr_t.into()], false),
             None,
         );
+        // Dormant-cost gate for the note above (bench regression,
+        // 2026-07-28): an i32 the obs TU sets to 1 when LOTUS_OBS
+        // resolves enabled. lower_send branches on it so an
+        // unobserved publish pays one load+branch, not a call +
+        // TLS store. External declaration — defined in lotus_obs.c,
+        // which every codegen-linked binary carries.
+        {
+            let i32_t = self.context.i32_type();
+            self.module.add_global(
+                i32_t,
+                None,
+                "lotus_obs_note_publisher_wanted",
+            );
+        }
         self.module.add_function(
             "lotus_obs_topic_shape",
             self.context


### PR DESCRIPTION
Investigation of the two bench-baseline drifts (`bus_dispatch` +39%, `stream_aggregator` +34%) found a real regression, not env drift: release-binary bisection pins it to **v0.11.12 → v0.11.13**, where the iris P10 attribution fix made `lower_send` emit an **unconditional** `lotus_obs_note_publisher` call (call + TLS store) before every `<-` — ~0.8ns on a ~1.9ns devirtualized publish, violating the "dormant = one predictable branch" observation cost contract.

Fix: codegen branches on `lotus_obs_note_publisher_wanted`, an i32 the obs TU sets (under `g_obs_lock`) when `LOTUS_OBS` resolves enabled. LLVM hoists the check and emits two loop versions — the dormant one is **instruction-identical to the pre-v0.11.13 loop** (verified by disassembly).

Numbers (direct A/B, 100k-publish bench):
- `bus_dispatch`: v0.11.16 release 268µs → gated 192µs (baseline 193.8µs — met)
- `stream_aggregator`: ~600µs → ~440µs (baseline 417µs, in band)
- v0.11.3/.5/.8 release binaries measure 192µs on this machine today, confirming environment is not a factor.

Attribution under `LOTUS_OBS=1` is unchanged: the flag is set by the first probe (always a locus birth, which precedes any publish). obs_emission / obs_fleet_contract / obs_net_seq / coop_pool / routing-keys suites green.

Also of note for the harness: `bench/run.sh` prefers `hale` on PATH over the sibling checkout, so earlier same-machine A/Bs silently measured the installed v0.11.13 — that masked this from the v0.11.14/.15 sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)