### PR TITLE
fix(obs): constructor-resolved gate flag + marked adapter inbound (iris handoff-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ behavior.
 
 ---
 
+## Unreleased
+
+iris handoff-6 (P17/P19 — attribution in the field).
+
+- **The obs gate flag is resolved in a constructor** (P19). The
+  fn-entry hoist of `lotus_obs_live` claimed the flag was final
+  before any user publish; it was set at the FIRST PROBE (a locus
+  birth inside main's body), so a publish lowered into `fn main`
+  itself snapshotted a stale dormant flag forever. `LOTUS_OBS` is
+  now read in a `__attribute__((constructor))` before `main` — the
+  flag is genuinely process-constant, which is the exact property
+  the hoist's soundness requires. The field's ordering shape
+  (publishers deep in steady-state loops, observer attaching much
+  later) is pinned in `obs_fleet_contract.rs`.
+
+- **The adapter inbound path no longer stamps `locus=0` publishes**
+  (the fleet's remaining attribution zero). `std::bus::
+  __local_dispatch` — the Hale-owned-wire ingest adapters use —
+  called the UNMARKED `lotus_bus_dispatch_wire`: every inbound
+  message recorded a spurious unattributed BUS_PUBLISH and
+  inflated the published counter (measured: 2 genuine publishes +
+  2 adapter relays = `pub=4` on v0.11.19; now exactly 2, all
+  attributed). It now lowers to `lotus_bus_dispatch_wire_inbound`,
+  which brackets the dispatch with the P15 redispatch marking —
+  deliveries deliver, publishes publish.
+
 ## v0.11.19 — Crumb batch-5: sleep parks on async_io, stdlib builtin-namespace README (2026-07-28)
 
 Crumb batch-5 (UPSTREAM5.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.11.19 — Crumb batch-5: sleep parks on async_io, stdlib builtin-namespace README (2026-07-28)
 
 Crumb batch-5 (UPSTREAM5.md).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.18"
+version = "0.11.19"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.18"
+version = "0.11.19"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.18"
+version = "0.11.19"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.18"
+version = "0.11.19"
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.18"
+version = "0.11.19"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.18"
+version = "0.11.19"
 dependencies = [
  "hale-syntax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.18"
+version = "0.11.19"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -8552,6 +8552,19 @@ void lotus_bus_dispatch_wire(const char *subject,
                              const void *wire_bytes,
                              size_t wire_size);
 
+/* iris handoff-6: the adapter-driven inbound entry. An adapter
+ * locus dispatching received wire bytes is a DELIVERY, not a local
+ * publish — exactly like the reader-thread path, which brackets its
+ * re-dispatch so the BUS_PUBLISH probe skips it (P15 negative
+ * marking). This entry was unmarked, so every adapter-inbound
+ * message stamped a spurious locus=0 BUS_PUBLISH and inflated the
+ * published counter — a fleet whose gateways ingest via the std
+ * adapter surface read as "everything publishes unattributed."
+ * `std::bus::__local_dispatch` lowers to this wrapper. */
+void lotus_bus_dispatch_wire_inbound(const char *subject,
+                                     const void *wire_bytes,
+                                     size_t wire_size);
+
 /* Phase-3 Task 9 (2026-05-20): forward decl of the caller-arena
  * TLS pointer. Defined further down alongside the other
  * caller_arena helpers; needed here because lotus_bus_dispatch_wire
@@ -19251,4 +19264,15 @@ double lotus_math_inf(void) {
  * pattern lotus_fs_file_exists uses for its 0/1 -> Bool. */
 int lotus_math_is_nan(double f) {
     return f != f ? 1 : 0;
+}
+
+
+/* iris handoff-6: marked adapter-inbound entry — see the forward
+ * declaration's comment near lotus_bus_dispatch_wire. */
+void lotus_bus_dispatch_wire_inbound(const char *subject,
+                                     const void *wire_bytes,
+                                     size_t wire_size) {
+    if (lotus_obs_begin_redispatch) lotus_obs_begin_redispatch();
+    lotus_bus_dispatch_wire(subject, wire_bytes, wire_size);
+    if (lotus_obs_end_redispatch) lotus_obs_end_redispatch();
 }

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -391,6 +391,21 @@ static int obs_create(int64_t rings, int64_t slots) {
  * publishes of a not-yet-probed thread). */
 int lotus_obs_live = 0;
 
+/* iris handoff-6 P19: codegen snapshots this flag at FUNCTION ENTRY
+ * (the dormant-cost hoist), so it must be final before ANY user code
+ * — including `fn main`'s own body, whose entry block runs BEFORE
+ * the first locus-birth probe that used to set it. A publish lowered
+ * into main's body therefore snapshotted 0 forever. Resolve the env
+ * in a constructor instead: the flag is process-constant from before
+ * main, which is the exact property the hoist's soundness argument
+ * claimed. (Segment creation stays lazy at the first probe; if it
+ * later fails, the flag stays 1 and the probes early-out on
+ * !obs_on() — a few dead branches in a broken-obs process.) */
+__attribute__((constructor)) static void obs_live_ctor(void) {
+  const char *e = getenv("LOTUS_OBS");
+  if (e && e[0] == '1') lotus_obs_live = 1;
+}
+
 /* Enable check + lazy init. Fast path after first call: one
  * relaxed load + compare. */
 static int obs_on(void) {

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -2030,6 +2030,14 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             bus_dispatch_wire_ty,
             None,
         );
+        // iris handoff-6: the redispatch-marked adapter-inbound
+        // entry (a delivery, not a publish) —
+        // `std::bus::__local_dispatch` lowers to this.
+        self.module.add_function(
+            "lotus_bus_dispatch_wire_inbound",
+            bus_dispatch_wire_ty,
+            None,
+        );
 
         // m59: subscriber-side reader threads need access to the
         // cooperative bus queue to dispatch incoming bytes into

--- a/crates/hale-codegen/src/stdlib/bus.rs
+++ b/crates/hale-codegen/src/stdlib/bus.rs
@@ -86,10 +86,15 @@ impl<'ctx, 'p> BusStdlib<'ctx> for Cx<'ctx, 'p> {
                 )
                 .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
         };
+        // iris handoff-6: route through the redispatch-MARKED inbound
+        // entry. An adapter dispatching received wire bytes is a
+        // delivery — the unmarked entry stamped a spurious locus=0
+        // BUS_PUBLISH per inbound message and inflated the published
+        // counter (the fleet's "everything publishes unattributed").
         let f = self
             .module
-            .get_function("lotus_bus_dispatch_wire")
-            .expect("lotus_bus_dispatch_wire declared");
+            .get_function("lotus_bus_dispatch_wire_inbound")
+            .expect("lotus_bus_dispatch_wire_inbound declared");
         self.builder
             .build_call(
                 f,

--- a/crates/hale-codegen/tests/obs_fleet_contract.rs
+++ b/crates/hale-codegen/tests/obs_fleet_contract.rs
@@ -804,3 +804,160 @@ fn quiet_process_replays_births_via_heartbeat() {
          attach (heartbeat missing?)"
     );
 }
+
+/// iris handoff-6 (P19 companion) — the ORDERING case the field has:
+/// publishers reach steady-state publish loops FIRST, the observer
+/// attaches minutes later. Every prior test attached before the
+/// burst. Asserts BUS_PUBLISH records captured AFTER a late attach
+/// carry nonzero locus == a birth instance (the fn-entry gate hoist
+/// must not have snapshotted a stale dormant flag — `lotus_obs_live`
+/// is resolved in a constructor, before any function entry).
+#[test]
+fn late_attach_still_attributes_publishes() {
+    const SRC: &str = r#"
+        type Ev { id: Int; v: Int; }
+        topic K { payload: Ev; subject: "k.late"; keyed_by id; }
+        locus KeySub {
+            params { my_id: Int = 1; }
+            bus { subscribe K as on_k where key == self.my_id; }
+            fn on_k(e: Ev) { }
+        }
+        locus Reader {
+            bus { publish K; }
+            run() {
+                let mut i = 0;
+                while i < 300 {
+                    K <- Ev { id: 1, v: i };
+                    std::time::sleep(10ms);
+                    i = i + 1;
+                }
+            }
+        }
+        main locus App {
+            params {
+                s: KeySub = KeySub { my_id: 1 };
+                r: Reader = Reader { };
+            }
+            placement { r: pinned(core = 0); }
+            run() { std::time::sleep(3500ms); }
+        }
+        fn main() { App { }; }
+    "#;
+    let bin = compile("lateattach", SRC);
+    let mut child = Command::new(&bin)
+        .env("LOTUS_OBS", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    let pid = child.id();
+    // Let the publisher run deep into steady state UNOBSERVED.
+    std::thread::sleep(Duration::from_millis(1200));
+    unsafe { attach_observer(pid) };
+    std::thread::sleep(Duration::from_millis(1200));
+    let seg = unsafe { snapshot_shm(pid) };
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_file(&bin);
+    let seg = seg.expect("segment");
+    let births: std::collections::HashSet<u32> =
+        records(&seg, 5).iter().map(|(id, _)| *id).collect();
+    let pubs: Vec<u32> = records(&seg, 1)
+        .iter()
+        .map(|(_, w1)| (*w1 & 0xFFFFF) as u32)
+        .collect();
+    assert!(!pubs.is_empty(), "no post-attach BUS_PUBLISH records");
+    assert!(
+        pubs.iter().all(|l| *l != 0 && births.contains(l)),
+        "P19: post-late-attach publishes unattributed: loci {:?} \
+         (births {:?})",
+        pubs,
+        births
+    );
+}
+
+/// iris handoff-6 — the ADAPTER inbound path (`std::bus::
+/// __local_dispatch`, the Hale-owned-wire ingest) is a DELIVERY:
+/// it must not stamp locus=0 BUS_PUBLISH records or inflate the
+/// published counter (the reader-thread path has marked its
+/// re-dispatch since P15; this entry was unmarked). Loopback
+/// adapter: 2 genuine publishes, each relayed once → published
+/// counter must be exactly 2 and every publish record attributed.
+#[test]
+fn adapter_inbound_dispatch_is_not_a_publish() {
+    const SRC: &str = r#"
+        type Tick { n: Int; }
+        topic Beat { payload: Tick; subject: "beat"; }
+        locus Loopback {
+            fn send(subject: String, bytes: Bytes) {
+                std::bus::__local_dispatch(subject, bytes);
+            }
+        }
+        locus Receiver {
+            bus { subscribe Beat as on_beat; }
+            fn on_beat(t: Tick) { }
+        }
+        locus Producer {
+            bus { publish Beat; }
+            run() {
+                std::time::sleep(300ms);
+                Beat <- Tick { n: 7 };
+                Beat <- Tick { n: 42 };
+            }
+        }
+        main locus App {
+            bindings { Beat: Loopback { }; }
+            // NOTE: App is the main locus and its run() executes
+            // INLINE at the `App { }` statement — keep it short or
+            // Producer never instantiates until it returns.
+            run() { std::time::sleep(50ms); }
+        }
+        fn main() {
+            App { };
+            Receiver { };
+            Producer { };
+            std::time::sleep(1200ms);
+        }
+    "#;
+    let bin = compile("adapterobs", SRC);
+    let mut child = Command::new(&bin)
+        .env("LOTUS_OBS", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    let pid = child.id();
+    for _ in 0..40 {
+        std::thread::sleep(Duration::from_millis(25));
+        if std::path::Path::new(&format!("/dev/shm/hale-obs-{}", pid))
+            .exists()
+        {
+            break;
+        }
+    }
+    unsafe { attach_observer(pid) };
+    std::thread::sleep(Duration::from_millis(900));
+    let seg = unsafe { snapshot_shm(pid) };
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_file(&bin);
+    let seg = seg.expect("segment");
+    let (published, _, _) =
+        topic_counters(&seg, b"beat").expect("beat topic");
+    assert_eq!(
+        published, 2,
+        "adapter inbound re-dispatch inflated the published counter \
+         (2 genuine publishes, each relayed once)"
+    );
+    let births: std::collections::HashSet<u32> =
+        records(&seg, 5).iter().map(|(id, _)| *id).collect();
+    let pubs: Vec<u32> = records(&seg, 1)
+        .iter()
+        .map(|(_, w1)| (*w1 & 0xFFFFF) as u32)
+        .collect();
+    assert!(
+        pubs.iter().all(|l| *l != 0 && births.contains(l)),
+        "adapter inbound stamped locus=0 publish records: {:?}",
+        pubs
+    );
+}

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1482,6 +1482,29 @@ v0.11.18):
   replay latency after attach is bounded at ~250ms even for a
   process that never probes again.
 
+Attribution ordering + the adapter inbound path (iris handoff 6,
+v0.11.20):
+
+- **`lotus_obs_live` is resolved in a constructor**, before
+  `main`. The fn-entry gate hoist's soundness argument requires
+  the flag to be final before ANY function entry — previously it
+  was set at the first probe (a locus birth inside main's body),
+  so a publish lowered into `fn main` itself would snapshot a
+  stale dormant flag forever. Constructor resolution makes the
+  flag genuinely process-constant. The field-shaped ordering case
+  (publishers deep in steady-state loops, observer attaching much
+  later) is pinned in `obs_fleet_contract.rs`.
+- **`std::bus::__local_dispatch` (the adapter-inbound ingest) is
+  redispatch-MARKED.** An adapter locus dispatching received wire
+  bytes is a delivery, exactly like the reader-thread path — the
+  unmarked entry stamped a spurious `locus=0` BUS_PUBLISH per
+  inbound message and inflated the published counter, so a fleet
+  ingesting via the std adapter surface read as "everything
+  publishes unattributed." Lowers to
+  `lotus_bus_dispatch_wire_inbound`, which brackets the dispatch
+  with the P15 negative marking. Per-subscriber BUS_DELIVER and
+  the topic registration are unchanged.
+
 ### Time
 
 - **Monotonic + wall-clock.** `time::now()` and


### PR DESCRIPTION
Delivers iris HANDOFF-6 (P17-still-zero / P19).

## P19 — the hoist is now actually sound
iris's ordering test (steady-state publish loops first, observer attaching later) **passes on HEAD** — the flag iris hypothesized flips at attach is actually set at `LOTUS_OBS` env resolution, which happens at the first probe. But their instinct found a real hole one step away: the first probe is a locus birth *inside main's body*, so a publish lowered into `fn main` itself snapshots the flag at main's entry — **before** obs init — and stays dormant forever. `LOTUS_OBS` is now resolved in a `__attribute__((constructor))` before `main`: the flag is genuinely process-constant before any function entry, which is the exact property the hoist's soundness argument claimed. The asked-for ordering case is pinned as `late_attach_still_attributes_publishes`.

## The fleet's actual attribution zero: the adapter inbound path
`std::bus::__local_dispatch` — the Hale-owned-wire ingest the fleet's gateways use (the open item from handoff-3's parity audit) — called the **unmarked** `lotus_bus_dispatch_wire`: every inbound message stamped a spurious `locus=0` BUS_PUBLISH and inflated the published counter. Measured on the v0.11.19 release binary with a loopback adapter: 2 genuine publishes + 2 relays = **pub=4, all records locus=0**. It now lowers to `lotus_bus_dispatch_wire_inbound` (brackets the dispatch with the P15 redispatch marking): **pub=2, every record attributed to a birth instance**. Deliver probes and topic registration unchanged. Pinned as `adapter_inbound_dispatch_is_not_a_publish`.

This matches the field signature exactly: segments dominated by inbound traffic show "everything publishes, nothing attributed" — those records were deliveries wearing publish records.

Spec `runtime.md` handoff-6 amendment; CHANGELOG under Unreleased. Full workspace nextest: **1844/1844**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)