### PR TITLE
release: v0.11.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## v0.11.19 — Crumb batch-5: sleep parks on async_io, stdlib builtin-namespace README (2026-07-28)
+## v0.11.20 — iris handoff-6: constructor-resolved obs gate, marked adapter inbound (2026-07-29)
 
 iris handoff-6 (P17/P19 — attribution in the field).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.19"
+version = "0.11.20"
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "hale-syntax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.19"
+version = "0.11.20"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for v0.11.20 — iris handoff-6 (#287): `lotus_obs_live` resolved in a constructor (the fn-entry hoist is now genuinely sound), adapter inbound path redispatch-marked (deliveries no longer stamp locus=0 publishes or inflate counters). CHANGELOG rolled from Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)