### PR TITLE
fix(obs): pack BUS w1 per PROTOCOL §8 — locus high, seq low (iris handoff-7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ behavior.
 
 ---
 
+## Unreleased
+
+- **BUS record w1 packed per PROTOCOL §8** (iris handoff-7 — the
+  one-liner). `BUS_PUBLISH`/`BUS_DELIVER` emitted `locus` in bits
+  0..19 with seq shifted high; the protocol (and every consumer)
+  puts **locus in bits 44..63, seq low**. Attribution has been
+  computed correctly since handoff-6 and packed unreadably —
+  consumers decoded `w1 >> 44` and read the top of a small seq
+  → 0. Both probes now pack `locus:20 << 44 | seq:44`, and the
+  contract tests vendor protocol.h's decode
+  (`obs_bus_locus = w1 >> 44`) instead of the emitter's own
+  layout, closing the self-consistent-but-wrong loophole that
+  kept them green.
+
 ## v0.11.20 — iris handoff-6: constructor-resolved obs gate, marked adapter inbound (2026-07-29)
 
 iris handoff-6 (P17/P19 — attribution in the field).

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -628,10 +628,17 @@ void lotus_obs_bus_publish(const char *subject, void *publisher_self,
   uint8_t mode = MODE[t->id & (OBS_ENTRY_CAP - 1)];
   if (mode < 2) return; /* OFF / COUNTERS */
   uint32_t locus = pub ? obs_inst_id_of(pub) : 0; /* best-effort */
+  /* iris handoff-7: w1 = locus:20 (HIGH bits 44..63) | seq:44
+   * (low) — PROTOCOL §8 / iris emitter/protocol.h `obs_bus_w1`.
+   * The original pack transposed the fields (locus low, seq<<20),
+   * so every protocol-conformant consumer decoded `w1 >> 44` and
+   * read the top of a small seq → 0: attribution was CORRECT all
+   * along and unreadable. protocol.h is the executable reference;
+   * the contract tests decode with these same shifts. */
   obs_emit(EK_BUS_PUBLISH, (uint32_t)t->id,
            obs_size_class(payload_bytes),
-           ((uint64_t)locus & 0xFFFFFu)
-               | ((seq & 0xFFFFFFFFFFFULL) << 20));
+           (((uint64_t)locus & 0xFFFFFu) << 44)
+               | (seq & 0xFFFFFFFFFFFULL));
 }
 
 void lotus_obs_bus_deliver(const char *subject, void *subscriber_self,
@@ -646,10 +653,11 @@ void lotus_obs_bus_deliver(const char *subject, void *subscriber_self,
   uint8_t mode = MODE[t->id & (OBS_ENTRY_CAP - 1)];
   if (mode < 2) return;
   uint32_t locus = subscriber_self ? obs_inst_id_of(subscriber_self) : 0;
+  /* handoff-7: same protocol packing as the publish probe. */
   obs_emit(EK_BUS_DELIVER, (uint32_t)t->id,
            obs_size_class(payload_bytes),
-           ((uint64_t)locus & 0xFFFFFu)
-               | (((seq ? seq - 1 : 0) & 0xFFFFFFFFFFFULL) << 20));
+           (((uint64_t)locus & 0xFFFFFu) << 44)
+               | ((seq ? seq - 1 : 0) & 0xFFFFFFFFFFFULL));
 }
 
 /* binding_obs_id: cached on the remote entry by the caller (the

--- a/crates/hale-codegen/tests/obs_emission.rs
+++ b/crates/hale-codegen/tests/obs_emission.rs
@@ -51,6 +51,13 @@ const DEMO: &str = r#"
     fn main() { App { }; }
 "#;
 
+/// Vendored from iris emitter/protocol.h (PROTOCOL §8): BUS w1 =
+/// locus:20 in bits 44..63, seq:44 low — see the handoff-7 note in
+/// obs_fleet_contract.rs.
+fn obs_bus_locus(w1: u64) -> u32 {
+    ((w1 >> 44) & 0xFFFFF) as u32
+}
+
 fn read_u64(seg: &[u8], off: usize) -> u64 {
     u64::from_le_bytes(seg[off..off + 8].try_into().unwrap())
 }
@@ -239,9 +246,10 @@ fn births_carry_parentage_and_publishes_attribute_locus() {
                     }
                 }
                 1 => {
-                    // BUS_PUBLISH: w1 = locus:20 | seq:44
+                    // BUS_PUBLISH: w1 = locus:20 (high, bits
+                    // 44..63) | seq:44 (low) — PROTOCOL §8.
                     publishes += 1;
-                    if (w1 & 0xFFFFF) != 0 {
+                    if obs_bus_locus(w1) != 0 {
                         attributed += 1;
                     }
                 }
@@ -284,7 +292,7 @@ fn births_carry_parentage_and_publishes_attribute_locus() {
     for rr in 0..ring_count {
         for (ekind, _id, w1) in drain_ring(seg, rings_off, ring_slots, rr) {
             if ekind == 1 {
-                let locus = (w1 & 0xFFFFF) as u32;
+                let locus = obs_bus_locus(w1);
                 assert!(
                     locus != 0,
                     "P13: a BUS_PUBLISH stamped locus=0 (unattributed \

--- a/crates/hale-codegen/tests/obs_fleet_contract.rs
+++ b/crates/hale-codegen/tests/obs_fleet_contract.rs
@@ -178,6 +178,18 @@ fn records(seg: &[u8], want_ekind: u32) -> Vec<(u32, u64)> {
     out
 }
 
+/// Vendored from iris `emitter/protocol.h` (PROTOCOL §8, the
+/// executable reference): BUS_PUBLISH / BUS_DELIVER pack
+/// `w1 = locus:20 (bits 44..63) | seq:44 (low)`. The handoff-7 bug
+/// was the emitter transposing these fields while this test decoded
+/// with the emitter's own layout — self-consistent and green while
+/// every protocol-conformant consumer read locus 0. Emitter and
+/// tests now share THIS decode; if protocol.h changes, change both
+/// in one commit (PROTOCOL.md's own rule).
+fn obs_bus_locus(w1: u64) -> u32 {
+    ((w1 >> 44) & 0xFFFFF) as u32
+}
+
 fn net_origin_seq(w1: u64) -> (u32, u64) {
     ((w1 & 0xFFFF) as u32, (w1 >> 16) & 0xFFFF_FFFF_FFFF)
 }
@@ -323,14 +335,14 @@ fn fleet_multicast_full_contract() {
     let attributed = publishes
         .iter()
         .filter(|(_, w1)| {
-            let locus = (*w1 & 0xFFFFF) as u32;
+            let locus = obs_bus_locus(*w1);
             locus != 0 && births.contains(&locus)
         })
         .count();
     assert!(
         attributed > 0,
         "BUS_PUBLISH must attribute a real birth instance (got loci {:?}, births {:?})",
-        publishes.iter().map(|(_, w1)| (*w1 & 0xFFFFF) as u32).collect::<Vec<_>>(),
+        publishes.iter().map(|(_, w1)| obs_bus_locus(*w1)).collect::<Vec<_>>(),
         births
     );
 
@@ -609,7 +621,7 @@ fn attribution_on_fleet_publisher_shapes() {
     let k_pubs: Vec<u32> = records(&seg, 1)
         .iter()
         .filter(|(id, _)| *id == k_id)
-        .map(|(_, w1)| (*w1 & 0xFFFFF) as u32)
+        .map(|(_, w1)| obs_bus_locus(*w1))
         .collect();
     assert!(!k_pubs.is_empty(), "no BUS_PUBLISH records for keyed topic");
     assert!(
@@ -624,7 +636,7 @@ fn attribution_on_fleet_publisher_shapes() {
     let out_pubs: Vec<u32> = records(&seg, 1)
         .iter()
         .filter(|(id, _)| *id == out_id)
-        .map(|(_, w1)| (*w1 & 0xFFFFF) as u32)
+        .map(|(_, w1)| obs_bus_locus(*w1))
         .collect();
     assert!(
         !out_pubs.is_empty(),
@@ -642,7 +654,7 @@ fn attribution_on_fleet_publisher_shapes() {
     let k_dlvs: Vec<u32> = records(&seg, 2)
         .iter()
         .filter(|(id, _)| *id == k_id)
-        .map(|(_, w1)| (*w1 & 0xFFFFF) as u32)
+        .map(|(_, w1)| obs_bus_locus(*w1))
         .collect();
     assert!(!k_dlvs.is_empty(), "no BUS_DELIVER records for keyed topic");
     assert!(
@@ -727,11 +739,11 @@ fn direct_devirt_flavor_emits_attributed_probes() {
         records(&seg, 5).iter().map(|(id, _)| *id).collect();
     let pubs: Vec<u32> = records(&seg, 1)
         .iter()
-        .map(|(_, w1)| (*w1 & 0xFFFFF) as u32)
+        .map(|(_, w1)| obs_bus_locus(*w1))
         .collect();
     let dlvs: Vec<u32> = records(&seg, 2)
         .iter()
-        .map(|(_, w1)| (*w1 & 0xFFFFF) as u32)
+        .map(|(_, w1)| obs_bus_locus(*w1))
         .collect();
     assert!(!pubs.is_empty(), "direct flavor emitted no BUS_PUBLISH");
     assert!(!dlvs.is_empty(), "direct flavor emitted no BUS_DELIVER");
@@ -864,7 +876,7 @@ fn late_attach_still_attributes_publishes() {
         records(&seg, 5).iter().map(|(id, _)| *id).collect();
     let pubs: Vec<u32> = records(&seg, 1)
         .iter()
-        .map(|(_, w1)| (*w1 & 0xFFFFF) as u32)
+        .map(|(_, w1)| obs_bus_locus(*w1))
         .collect();
     assert!(!pubs.is_empty(), "no post-attach BUS_PUBLISH records");
     assert!(
@@ -953,7 +965,7 @@ fn adapter_inbound_dispatch_is_not_a_publish() {
         records(&seg, 5).iter().map(|(id, _)| *id).collect();
     let pubs: Vec<u32> = records(&seg, 1)
         .iter()
-        .map(|(_, w1)| (*w1 & 0xFFFFF) as u32)
+        .map(|(_, w1)| obs_bus_locus(*w1))
         .collect();
     assert!(
         pubs.iter().all(|l| *l != 0 && births.contains(l)),

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1482,6 +1482,16 @@ v0.11.18):
   replay latency after attach is bounded at ~250ms even for a
   process that never probes again.
 
+BUS record w1 layout (iris handoff 7, v0.11.21): `BUS_PUBLISH` /
+`BUS_DELIVER` pack `w1 = locus:20 (bits 44..63) | seq:44 (low)` —
+PROTOCOL §8, executable reference `iris emitter/protocol.h`
+(`obs_bus_w1`). The emitter had these fields transposed (locus
+low, seq shifted) since handoff-3; attribution was computed
+correctly and packed unreadably, and the contract tests stayed
+green because they decoded with the emitter's own layout. The
+tests now vendor protocol.h's decode, so emitter and consumers
+cannot disagree silently.
+
 Attribution ordering + the adapter inbound path (iris handoff 6,
 v0.11.20):
 


### PR DESCRIPTION
The handoff-7 one-liner, plus the loophole close iris prescribed.

`lotus_obs_bus_publish`/`_deliver` packed `locus | (seq << 20)`; PROTOCOL §8 and `emitter/protocol.h` (`obs_bus_w1`) define `(locus & 0xFFFFF) << 44 | (seq & 0xFFFFFFFFFFF)`. Consumers decode `w1 >> 44` → read the top of a small seq → 0. Attribution has been *computed* correctly since the handoff-6 fixes — it was packed unreadably since handoff-3.

Why the contract tests never caught it: they decoded with the emitter's own layout — self-consistent and green while every protocol-conformant consumer read 0. Per iris's ask, the tests now vendor protocol.h's decode (`obs_bus_locus(w1) = (w1 >> 44) & 0xFFFFF`) with a comment pointing at PROTOCOL §8 and the fix-both-in-one-commit rule, so emitter and consumers can never disagree silently for this record kind again. All 13 obs tests pass against the corrected packing.

Spec `runtime.md` handoff-7 note; CHANGELOG under Unreleased. Full workspace nextest: **1844/1844**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)