### PR TITLE
release: v0.11.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.11.21 — iris handoff-7: BUS w1 packed per PROTOCOL §8 (2026-07-29)
 
 - **BUS record w1 packed per PROTOCOL §8** (iris handoff-7 — the
   one-liner). `BUS_PUBLISH`/`BUS_DELIVER` emitted `locus` in bits

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.20"
+version = "0.11.21"
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "hale-syntax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.20"
+version = "0.11.21"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for v0.11.21 — iris handoff-7 (#289): BUS record w1 packed per PROTOCOL §8 (locus in bits 44..63, seq low); contract tests vendor protocol.h's decode. CHANGELOG rolled from Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)