### PR TITLE
refactor: the #265/#262 substrate batch — callgraph engine, stdlib registry, DeploymentPlan, fanout core, obs test reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ behavior.
 
 ---
 
+## Unreleased
+
+- **Refactor batch (R1/R2/R3/R4/R6) — the substrate for #265 and
+  #262.** Behavior-neutral; full workspace suite + the dispatch
+  bench gate every piece.
+  - *R1*: `hale-types::callgraph` — the shared, witness-path-
+    preserving call-graph engine (extracted verbatim from
+    `budget_check`'s DFS, which is its first ported customer with
+    byte-identical diagnostics); `witness_path` renders the
+    `root -> mid -> leaf [alloc]` chains #265's diagnostics
+    specify. `PurityKey` unified onto `alloc_summary::FnKey`.
+  - *R2*: `stdlib_surface` is now the stdlib registry — structured
+    per-fn entries carrying an `EffectSet` column (UNCLASSIFIED
+    until #265 classifies the frontier) with `effects_for(path)`
+    as the query hook.
+  - *R3*: the deployment arrangement (placement, NUMA nodes,
+    pools, async_io set, pinned/pool locus types) is one
+    `DeploymentPlan` value on Cx instead of seven loose fields —
+    #262's seed artifact.
+  - *R4*: `lotus_bus_post_entry` — the one per-entry
+    mailbox/coop_pool/queue post, replacing 9 of 11 hand-copies
+    across dispatch flavors (the "fixed one flavor, missed
+    siblings" class from P5..P17); the two exceptions (_st
+    fast path, direct same-thread call) are annotated. Dispatch
+    bench unchanged (~173µs dormant).
+  - *R6*: one obs-segment reader for the three test files that
+    each carried a drifting copy of the PROTOCOL v0.1 decode; the
+    protocol.h-vendored decodes live in exactly one place.
+
 ## v0.11.21 — iris handoff-7: BUS w1 packed per PROTOCOL §8 (2026-07-29)
 
 - **BUS record w1 packed per PROTOCOL §8** (iris handoff-7 — the

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -718,7 +718,8 @@ fn run_doc_stdlib(json: bool, out_path: Option<PathBuf>) -> ExitCode {
         .map(|e| e.name.clone())
         .collect();
     for surface in hale_types::stdlib_surface::SURFACES {
-        for f in surface.fns {
+        for entry in surface.fns {
+            let f = entry.name;
             if f.starts_with("__") {
                 continue;
             }

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -8302,6 +8302,39 @@ static int lotus_bus_log_drop_enabled(void);
  * reader thread can dispatch recv'd bytes into the same local-
  * handler set without going through transport fanout (which
  * would re-emit them remotely and loop forever). */
+/* R4 (2026-07-29) — the ONE per-entry post. Every dispatch flavor
+ * used to hand-copy the mailbox / coop_pool / queue routing triple
+ * (11 copies), and every cross-cutting concern had to be stitched
+ * into each — the "fixed one flavor, missed siblings" bug class
+ * that recurred through P5/P11/P13/P14/P15/P17 (obs probes missing
+ * on keyed, direct, and adapter flavors across five releases).
+ * Routing decisions live HERE now: pinned subscribers take their
+ * mailbox, pool-placed subscribers post to their pool's worker
+ * (single-threaded-method invariant), everything else enqueues on
+ * the supplied cooperative queue. Returns 1 when the cell was
+ * posted, 0 when no target existed (caller decides whether that is
+ * a drop worth logging). The static-devirt _st enqueue variant
+ * (build #3 no-pinned fast path) is the one deliberate exception —
+ * it stays open-coded at its single site with a pointer here. */
+static inline int lotus_bus_post_entry(lotus_bus_entry_t *e,
+                                       lotus_bus_queue_t *queue,
+                                       const void *payload,
+                                       size_t size) {
+    if (e->mailbox) {
+        lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
+                           payload, size);
+    } else if (e->coop_pool) {
+        lotus_coop_pool_post(e->coop_pool, e->handler, e->self_ptr,
+                             payload, size);
+    } else if (queue) {
+        lotus_bus_queue_enqueue(queue, e->handler, e->self_ptr,
+                                payload, size);
+    } else {
+        return 0;
+    }
+    return 1;
+}
+
 void lotus_bus_local_dispatch(lotus_bus_queue_t *queue,
                               const char *subject,
                               const void *payload,
@@ -8329,23 +8362,8 @@ void lotus_bus_local_dispatch(lotus_bus_queue_t *queue,
          * would deliver to filtered subscribers regardless of the
          * filter — bypassing the routing-key contract. */
         if (e->key_filter_kind != 0) continue;
-        if (e->mailbox) {
-            lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
-                               payload, payload_size);
-            delivered++;
-        } else if (e->coop_pool) {
-            /* F.31 Phase 4: subscriber's locus is on a named
-             * non-main cooperative pool. Route to that pool's
-             * queue so the handler fires on the pool's worker
-             * thread (single-threaded-method invariant). */
-            lotus_coop_pool_post(e->coop_pool, e->handler, e->self_ptr,
-                                 payload, payload_size);
-            delivered++;
-        } else if (queue) {
-            lotus_bus_queue_enqueue(queue, e->handler, e->self_ptr,
-                                    payload, payload_size);
-            delivered++;
-        }
+        delivered += (size_t)lotus_bus_post_entry(
+            e, queue, payload, payload_size);
         if (lotus_obs_bus_deliver) {
             lotus_obs_bus_deliver(subject, e->self_ptr,
                                   (uint64_t)payload_size);
@@ -8467,16 +8485,8 @@ void lotus_bus_local_dispatch_keyed(lotus_bus_queue_t *queue,
              * pass; the fallback pass below would dispatch it. */
             continue;
         }
-        if (e->mailbox) {
-            lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
-                               payload, payload_size);
-        } else if (e->coop_pool) {
-            lotus_coop_pool_post(e->coop_pool, e->handler, e->self_ptr,
-                                 payload, payload_size);
-        } else if (queue) {
-            lotus_bus_queue_enqueue(queue, e->handler, e->self_ptr,
-                                    payload, payload_size);
-        }
+        (void)lotus_bus_post_entry(e, queue,
+            payload, payload_size);
         /* iris handoff-4 P15: BUS_DELIVER per matched keyed target
          * (sibling of the non-keyed local_dispatch probe — the keyed
          * flavor had none, so keyed deliveries never counted). */
@@ -8496,16 +8506,7 @@ void lotus_bus_local_dispatch_keyed(lotus_bus_queue_t *queue,
             if (!e->subject) continue;
             if (!lotus_subject_match(e->subject, subject)) continue;
             if (e->key_filter_kind != 2) continue;
-            if (e->mailbox) {
-                lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
-                                   payload, payload_size);
-            } else if (e->coop_pool) {
-                lotus_coop_pool_post(e->coop_pool, e->handler,
-                                     e->self_ptr, payload, payload_size);
-            } else if (queue) {
-                lotus_bus_queue_enqueue(queue, e->handler, e->self_ptr,
-                                        payload, payload_size);
-            }
+            (void)lotus_bus_post_entry(e, queue, payload, payload_size);
             if (lotus_obs_bus_deliver) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
                                       (uint64_t)payload_size);
@@ -14425,16 +14426,8 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
          * fn; the owner thread materializes at drain. */
         if (!lotus_bus_target_owner_is_current(e, g_bus_queue_for_remote)) {
             g_bus_pending_wire_deser = (void *)e->deserialize;
-            if (e->mailbox) {
-                lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
-                                   wire_bytes, wire_size);
-            } else if (e->coop_pool) {
-                lotus_coop_pool_post(e->coop_pool, e->handler, e->self_ptr,
-                                     wire_bytes, wire_size);
-            } else if (g_bus_queue_for_remote) {
-                lotus_bus_queue_enqueue(g_bus_queue_for_remote, e->handler,
-                                        e->self_ptr, wire_bytes, wire_size);
-            }
+            (void)lotus_bus_post_entry(e, g_bus_queue_for_remote,
+                wire_bytes, wire_size);
             g_bus_pending_wire_deser = NULL;
             if (lotus_obs_bus_deliver) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
@@ -14483,16 +14476,8 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
              * fn; the owner thread materializes at drain. */
             if (!lotus_bus_target_owner_is_current(e, g_bus_queue_for_remote)) {
                 g_bus_pending_wire_deser = (void *)e->deserialize;
-                if (e->mailbox) {
-                        lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
-                                                   wire_bytes, wire_size);
-                } else if (e->coop_pool) {
-                        lotus_coop_pool_post(e->coop_pool, e->handler, e->self_ptr,
-                                                     wire_bytes, wire_size);
-                } else if (g_bus_queue_for_remote) {
-                        lotus_bus_queue_enqueue(g_bus_queue_for_remote, e->handler,
-                                                            e->self_ptr, wire_bytes, wire_size);
-                }
+                (void)lotus_bus_post_entry(e, g_bus_queue_for_remote,
+                    wire_bytes, wire_size);
                 g_bus_pending_wire_deser = NULL;
                 if (lotus_obs_bus_deliver) {
                     lotus_obs_bus_deliver(subject, e->self_ptr,
@@ -14599,16 +14584,8 @@ void lotus_bus_dispatch_wire(const char *subject,
          * drain (lotus_bus_cell_materialize). */
         if (!lotus_bus_target_owner_is_current(e, g_bus_queue_for_remote)) {
             g_bus_pending_wire_deser = (void *)e->deserialize;
-            if (e->mailbox) {
-                lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
-                                   wire_bytes, wire_size);
-            } else if (e->coop_pool) {
-                lotus_coop_pool_post(e->coop_pool, e->handler, e->self_ptr,
-                                     wire_bytes, wire_size);
-            } else if (g_bus_queue_for_remote) {
-                lotus_bus_queue_enqueue(g_bus_queue_for_remote, e->handler,
-                                        e->self_ptr, wire_bytes, wire_size);
-            }
+            (void)lotus_bus_post_entry(e, g_bus_queue_for_remote,
+                wire_bytes, wire_size);
             g_bus_pending_wire_deser = NULL;
             delivered++;
             continue;
@@ -14723,25 +14700,17 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
                     lotus_obs_bus_deliver(subject, e->self_ptr,
                                           (uint64_t)struct_size);
                 }
-                if (e->mailbox) {
-                    lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
-                                       struct_payload, (size_t)struct_size);
+                /* R4 exception: the build #3 no-pinned fast path
+                 * takes the no-acquire-load _st enqueue; everything
+                 * else routes through lotus_bus_post_entry. */
+                if (no_pinned && !e->mailbox && !e->coop_pool && queue) {
+                    lotus_bus_queue_enqueue_st(queue, e->handler,
+                                               e->self_ptr, struct_payload,
+                                               (size_t)struct_size);
                     delivered++;
-                } else if (e->coop_pool) {
-                    lotus_coop_pool_post(e->coop_pool, e->handler, e->self_ptr,
-                                         struct_payload, (size_t)struct_size);
-                    delivered++;
-                } else if (queue) {
-                    if (no_pinned) {
-                        lotus_bus_queue_enqueue_st(queue, e->handler,
-                                                   e->self_ptr, struct_payload,
-                                                   (size_t)struct_size);
-                    } else {
-                        lotus_bus_queue_enqueue(queue, e->handler, e->self_ptr,
-                                                struct_payload,
-                                                (size_t)struct_size);
-                    }
-                    delivered++;
+                } else {
+                    delivered += (size_t)lotus_bus_post_entry(
+                        e, queue, struct_payload, (size_t)struct_size);
                 }
             }
         }
@@ -14779,25 +14748,17 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
                 lotus_bus_entry_t *e = &g_bus_entries[b->idx[k]];
                 if (!e->subject) continue;
                 if (e->key_filter_kind != 0) continue;
-                if (e->mailbox) {
-                    lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
-                                       struct_payload, (size_t)struct_size);
+                /* R4 exception: the build #3 no-pinned fast path
+                 * takes the no-acquire-load _st enqueue; everything
+                 * else routes through lotus_bus_post_entry. */
+                if (no_pinned && !e->mailbox && !e->coop_pool && queue) {
+                    lotus_bus_queue_enqueue_st(queue, e->handler,
+                                               e->self_ptr, struct_payload,
+                                               (size_t)struct_size);
                     delivered++;
-                } else if (e->coop_pool) {
-                    lotus_coop_pool_post(e->coop_pool, e->handler, e->self_ptr,
-                                         struct_payload, (size_t)struct_size);
-                    delivered++;
-                } else if (queue) {
-                    if (no_pinned) {
-                        lotus_bus_queue_enqueue_st(queue, e->handler,
-                                                   e->self_ptr, struct_payload,
-                                                   (size_t)struct_size);
-                    } else {
-                        lotus_bus_queue_enqueue(queue, e->handler, e->self_ptr,
-                                                struct_payload,
-                                                (size_t)struct_size);
-                    }
-                    delivered++;
+                } else {
+                    delivered += (size_t)lotus_bus_post_entry(
+                        e, queue, struct_payload, (size_t)struct_size);
                 }
             }
         }
@@ -14838,18 +14799,8 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
             if (!lotus_bus_target_owner_is_current(e,
                                                    g_bus_queue_for_remote)) {
                 g_bus_pending_wire_deser = (void *)e->deserialize;
-                if (e->mailbox) {
-                    lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
-                                       wire_buf, (size_t)wire_size);
-                } else if (e->coop_pool) {
-                    lotus_coop_pool_post(e->coop_pool, e->handler,
-                                         e->self_ptr, wire_buf,
-                                         (size_t)wire_size);
-                } else if (g_bus_queue_for_remote) {
-                    lotus_bus_queue_enqueue(g_bus_queue_for_remote,
-                                            e->handler, e->self_ptr,
-                                            wire_buf, (size_t)wire_size);
-                }
+                (void)lotus_bus_post_entry(e, g_bus_queue_for_remote,
+                                           wire_buf, (size_t)wire_size);
                 g_bus_pending_wire_deser = NULL;
                 delivered++;
                 continue;
@@ -14860,25 +14811,17 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
             ssize_t ssz = e->deserialize(wire_buf, (size_t)wire_size,
                                          struct_buf, LOTUS_PAYLOAD_MAX);
             if (ssz <= 0) continue;
-            if (e->mailbox) {
-                lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
-                                   struct_buf, (size_t)ssz);
+            /* R4 exception: build #3 no-pinned _st fast path; the
+             * rest routes through lotus_bus_post_entry. */
+            if (no_pinned && !e->mailbox && !e->coop_pool
+                && g_bus_queue_for_remote) {
+                lotus_bus_queue_enqueue_st(g_bus_queue_for_remote,
+                                           e->handler, e->self_ptr,
+                                           struct_buf, (size_t)ssz);
                 delivered++;
-            } else if (e->coop_pool) {
-                lotus_coop_pool_post(e->coop_pool, e->handler, e->self_ptr,
-                                     struct_buf, (size_t)ssz);
-                delivered++;
-            } else if (g_bus_queue_for_remote) {
-                if (no_pinned) {
-                    lotus_bus_queue_enqueue_st(g_bus_queue_for_remote,
-                                               e->handler, e->self_ptr,
-                                               struct_buf, (size_t)ssz);
-                } else {
-                    lotus_bus_queue_enqueue(g_bus_queue_for_remote, e->handler,
-                                            e->self_ptr, struct_buf,
-                                            (size_t)ssz);
-                }
-                delivered++;
+            } else {
+                delivered += (size_t)lotus_bus_post_entry(
+                    e, g_bus_queue_for_remote, struct_buf, (size_t)ssz);
             }
         }
     }
@@ -14945,6 +14888,10 @@ void lotus_bus_dispatch_static_direct(uint32_t id,
             lotus_bus_entry_t *e = &g_bus_entries[b->idx[k]];
             if (!e->subject) continue;           /* quarantined */
             if (e->key_filter_kind != 0) continue;
+            /* R4 note: deliberately NOT lotus_bus_post_entry — the
+             * direct flavor's identity is the same-thread handler
+             * CALL in the else branch (no queue). Off-thread targets
+             * (defensive; the gate excludes them) still enqueue. */
             if (e->mailbox) {
                 /* off-thread; gate should have excluded — enqueue. */
                 lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,

--- a/crates/hale-codegen/src/bus/runtime.rs
+++ b/crates/hale-codegen/src/bus/runtime.rs
@@ -175,7 +175,7 @@ impl<'ctx, 'p> BusRuntime<'ctx> for Cx<'ctx, 'p> {
         // F.31 Phase 4: free pool structs + ring buffers. Runs
         // after shutdown_all (workers joined) + router_destroy
         // (no more dispatch attempts).
-        if !self.main_cooperative_pools.is_empty() {
+        if !self.deployment.main_cooperative_pools.is_empty() {
             let destroy_all_fn = self
                 .module
                 .get_function("lotus_coop_pool_destroy_all")

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1250,20 +1250,14 @@ pub fn build_executable_with_options(
         instantiating_into_payload_arena: false,
         placement_for_next_locus_instantiation: None,
         numa_node_for_next_locus_instantiation: None,
-        main_placement_map: BTreeMap::new(),
-        main_placement_node: BTreeMap::new(),
         main_placement_replicas: BTreeMap::new(),
-        main_locus_name: None,
-        pinned_locus_types: BTreeSet::new(),
         params_init_self: None,
         in_params_default: false,
         params_init_initialized: None,
-        main_cooperative_pools: BTreeMap::new(),
-        async_io_pools: BTreeSet::new(),
         cooperative_pool_for_next_locus_instantiation: None,
         current_cooperative_pool: None,
-        coop_pool_locus_types: BTreeSet::new(),
         coop_pool_run_wrappers: BTreeMap::new(),
+        deployment: Default::default(),
         obs_live_cache: Vec::new(),
         reclaim_fns: BTreeMap::new(),
         handler_reclaim_wrappers: BTreeMap::new(),
@@ -3276,20 +3270,6 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// co-locates with its thread's node. Consumed via `mem::take`
     /// like its sibling.
     pub(crate) numa_node_for_next_locus_instantiation: Option<i64>,
-    /// F.31: per-main-locus map of `params` field name →
-    /// effective placement. Built once at codegen startup from
-    /// `main locus`'s `placement { }` block. Used by the
-    /// main-locus params-init loop to set
-    /// `placement_for_next_locus_instantiation` per field. An
-    /// absent field defaults to `Cooperative` (placement
-    /// pool routing comes in Phase 4).
-    pub(crate) main_placement_map: BTreeMap<String, ScheduleClass>,
-    /// Topology arena-on-node: per-main-locus map of `params`
-    /// field name → resolved NUMA node, for the `pinned(node/l3)`
-    /// entries whose arena binds to a node. Built alongside
-    /// `main_placement_map` in `collect_main_placement`; absent
-    /// fields (no node placement) simply don't appear.
-    pub(crate) main_placement_node: BTreeMap<String, i64>,
     /// Topology Phase 1c (replicas): per-main-locus map of `params`
     /// field name → `(count, cores)` for a `pinned(..., replicas =
     /// K)` entry with `K > 1`. `cores` is the resolved affinity set
@@ -3299,14 +3279,6 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// `K > 1`; `K <= 1` behaves as an ordinary single instance.
     pub(crate) main_placement_replicas:
         BTreeMap<String, (i64, Vec<i64>)>,
-    /// F.31: name of the main locus (if any) for the bundle.
-    /// Cached at startup so the params-init loop can detect
-    /// "we're instantiating main" without re-walking the
-    /// program. None when the bundle has no `main` locus
-    /// (free-fn-main shape with statement-position
-    /// instantiations) — placement entries have nowhere to live
-    /// in that case.
-    pub(crate) main_locus_name: Option<String>,
     /// F.31 Phase 3b (2026-05-23): transient parent context set
     /// during a locus's params-init loop. Children instantiated
     /// as field defaults consult this via
@@ -3343,31 +3315,6 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// lowering, frame exit). Typecheck currently skips default
     /// exprs entirely (Milestone-2 cut), so codegen owns this rule.
     pub(crate) params_init_initialized: Option<BTreeSet<String>>,
-    /// F.31 Phase 3b: set of locus type names that are
-    /// instantiated pinned-equivalent SOMEWHERE in the bundle.
-    /// Populated from: (a) `placement { field: pinned[(core=N)]; }`
-    /// entries on main locus — resolves the field's params-
-    /// declared locus type; (b) `bindings { Topic: AdapterLocus
-    /// { ... }; }` entries — adapter loci are pinned-equivalent
-    /// by construction (recv-loop on own thread).
-    ///
-    /// `declare_locus_struct` reads this set: any locus type
-    /// in the set gets the pinned-required struct fields
-    /// (mailbox slot for subscribers, etc.) regardless of the
-    /// locus's own `: schedule` annotation (which is gone in
-    /// F.31). Per-instance core affinity stays per-instance via
-    /// the placement_override mechanism in
-    /// `lower_locus_instantiation`.
-    pub(crate) pinned_locus_types: BTreeSet<String>,
-    /// F.31 Phase 4: cooperative pool name per main-locus
-    /// params field. Mirrors `main_placement_map` but carries
-    /// the pool name string for `PlacementSpec::Cooperative {
-    /// pool: Some(name) }` entries. Fields with explicit
-    /// pool-less cooperative placement, or no placement entry
-    /// at all, default to pool "main" and don't appear here —
-    /// the main thread's drain loop handles them via the
-    /// global cooperative queue.
-    pub(crate) main_cooperative_pools: BTreeMap<String, String>,
 
     /// iris handoff-5 P17 perf note: per-function cache of the
     /// `lotus_obs_live` gate check (`load i32, icmp ne 0`). The
@@ -3384,14 +3331,6 @@ pub(crate) struct Cx<'ctx, 'p> {
         inkwell::values::FunctionValue<'ctx>,
         inkwell::values::IntValue<'ctx>,
     )>,
-    /// F.35 Slice 2 (2026-05-28): cooperative pool names whose
-    /// placement entries declare `where async_io`. The prelude
-    /// emits one `lotus_coop_pool_enable_async_io(pool_ptr)` per
-    /// entry in this set, right after the pool's
-    /// `lotus_coop_pool_register` call. Typecheck has already
-    /// verified mode-consistency across same-pool entries; this
-    /// set carries the canonical truth for codegen.
-    pub(crate) async_io_pools: BTreeSet<String>,
     /// F.31 Phase 4: set by the parent's params-init loop
     /// before recursing into a child's
     /// `lower_locus_instantiation`. The recursion consumes it
@@ -3408,18 +3347,17 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// to the prior value at function exit. None means
     /// "default — main pool / global queue."
     pub(crate) current_cooperative_pool: Option<String>,
-    /// F.31 Phase 4b: set of locus types that need a
-    /// `__coop_pool_run_<L>` wrapper because they appear as
-    /// non-main-cooperative-pool main-locus params fields.
-    /// Populated in `collect_main_placement`; consumed by the
-    /// wrapper-synthesis pass (`synthesize_coop_pool_run_wrappers`)
-    /// before any locus instantiation runs.
-    coop_pool_locus_types: BTreeSet<String>,
     /// F.31 Phase 4b: synthesized `__coop_pool_run_<L>` fn ptrs.
     /// Each wrapper takes `(self_ptr, _payload_ptr)` matching
     /// the pool-handler signature and calls the locus's run()
     /// method. Indexed by locus type name.
     pub(crate) coop_pool_run_wrappers: BTreeMap<String, FunctionValue<'ctx>>,
+
+    /// R3 (2026-07-29): the reified deployment arrangement — see
+    /// `crate::deployment::DeploymentPlan`. Populated by
+    /// `collect_main_placement`; consumed by the prelude emission
+    /// and instantiation lowering. #262's seed artifact.
+    pub(crate) deployment: crate::deployment::DeploymentPlan,
     /// 2026-06-01: synthesized `__reclaim_<L>(self_ptr)` fns — the
     /// single per-child teardown spine. Idempotent (gated on the
     /// `__arena`-null latch at entry), so the three callers that can
@@ -5911,7 +5849,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// worker threads. Idempotent + no-op when no pools were
     /// registered.
     pub(crate) fn emit_coop_pool_shutdown_all(&mut self) -> Result<(), CodegenError> {
-        if !self.main_cooperative_pools.is_empty() {
+        if !self.deployment.main_cooperative_pools.is_empty() {
             let shutdown_fn = self
                 .module
                 .get_function("lotus_coop_pool_shutdown_all")
@@ -8115,7 +8053,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // happen here so worker threads exist by the time the
         // first bus dispatch posts a cell.
         let mut distinct_pools: BTreeSet<String> = BTreeSet::new();
-        for name in self.main_cooperative_pools.values() {
+        for name in self.deployment.main_cooperative_pools.values() {
             distinct_pools.insert(name.clone());
         }
         if !distinct_pools.is_empty() {
@@ -8158,7 +8096,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 // emission too guarantees codegen never references the
                 // async_io C path on a host where it's a -1 stub — a clean
                 // diagnostic instead of a surprising runtime no-op.
-                if self.async_io_pools.contains(name)
+                if self.deployment.async_io_pools.contains(name)
                     && !cfg!(target_os = "macos")
                 {
                     self.builder
@@ -8667,7 +8605,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             _ => None,
         });
         let Some(l) = main_locus else { return };
-        self.main_locus_name = Some(l.name.name.clone());
+        self.deployment.main_locus_name = Some(l.name.name.clone());
 
         // Build a name → locus-type-name map for main's params so
         // we can resolve placement entries' field references back
@@ -8741,7 +8679,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                             if let Some(node) =
                                 Self::resolve_pin_node(affinity, topology)
                             {
-                                self.main_placement_node.insert(
+                                self.deployment.main_placement_node.insert(
                                     entry.field.name.clone(),
                                     node,
                                 );
@@ -8781,7 +8719,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                             // queue handles main-pool subscribers).
                             if let Some(name) = pool {
                                 if name.name != "main" {
-                                    self.main_cooperative_pools.insert(
+                                    self.deployment.main_cooperative_pools.insert(
                                         entry.field.name.clone(),
                                         name.name.clone(),
                                     );
@@ -8792,7 +8730,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                                     if let Some(locus_ty) =
                                         params_locus_types.get(&entry.field.name)
                                     {
-                                        self.coop_pool_locus_types
+                                        self.deployment.coop_pool_locus_types
                                             .insert(locus_ty.clone());
                                     }
                                 }
@@ -8800,7 +8738,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                             ScheduleClass::Cooperative
                         }
                     };
-                    self.main_placement_map
+                    self.deployment.main_placement_map
                         .insert(entry.field.name.clone(), sc.clone());
                     // F.31 Phase 3b: if the entry pins the field,
                     // mark the field's locus TYPE as pinned-
@@ -8810,7 +8748,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         if let Some(locus_ty) =
                             params_locus_types.get(&entry.field.name)
                         {
-                            self.pinned_locus_types
+                            self.deployment.pinned_locus_types
                                 .insert(locus_ty.clone());
                         }
                     }
@@ -8829,7 +8767,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                             &entry.spec
                         {
                             if name.name != "main" {
-                                self.async_io_pools
+                                self.deployment.async_io_pools
                                     .insert(name.name.clone());
                             }
                         }
@@ -8850,7 +8788,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     if let TransportSpec::Adapter { locus, .. } =
                         &entry.transport
                     {
-                        self.pinned_locus_types.insert(locus.name.clone());
+                        self.deployment.pinned_locus_types.insert(locus.name.clone());
                     }
                 }
             }
@@ -9118,7 +9056,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // dispatcher needed.
         if any_connect_binding {
             let main_handler = self
-                .main_locus_name
+                .deployment.main_locus_name
                 .as_ref()
                 .and_then(|n| self.user_loci.get(n))
                 .and_then(|info| info.failure_handler.as_ref())

--- a/crates/hale-codegen/src/deployment.rs
+++ b/crates/hale-codegen/src/deployment.rs
@@ -1,0 +1,58 @@
+//! R3 (2026-07-29) — the deployment plan, reified.
+//!
+//! The committed arrangement of the system — which main-locus param
+//! fields are pinned where, which live on which cooperative pool,
+//! which pools are async_io, which NUMA node an arena binds to —
+//! used to exist only as seven loose fields on `Cx`, populated by
+//! `collect_main_placement` and consumed ad hoc by the prelude
+//! emission and instantiation lowering. Issue #262 (deployment
+//! elaboration / meta-scheduling) is premised on this arrangement
+//! being a *value*: constructible by an upstream phase, verifiable,
+//! submittable, diffable. This struct is that value's seed — one
+//! place holding the whole plan, `Debug`-renderable today,
+//! serializable when #262 needs it.
+//!
+//! Field semantics are unchanged from the Cx originals (the doc
+//! comments moved with them); `Cx::collect_main_placement` still
+//! populates it (path resolution needs `Cx`), and every consumer
+//! reads `self.deployment.<field>`.
+//!
+//! Not yet folded in (next #262 increments): the `bindings { }`
+//! block (emitted straight from the AST in the prelude), the
+//! `topology { }` domains (resolved inside collect), and replica
+//! counts (expanded inline at instantiation).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use hale_syntax::ast::ScheduleClass;
+
+/// The whole-program deployment arrangement, collected from the main
+/// locus's `placement { }` / `topology { }` declarations before any
+/// lowering runs.
+#[derive(Debug, Default, Clone)]
+pub struct DeploymentPlan {
+    /// The main locus's type name (None when the program has no main
+    /// locus — plain `fn main` programs).
+    pub main_locus_name: Option<String>,
+    /// Per-params-field placement override: field name →
+    /// schedule class (pinned with resolved core set, cooperative,
+    /// ...). Absent fields keep the locus's own default class.
+    pub main_placement_map: BTreeMap<String, ScheduleClass>,
+    /// Topology arena-on-node: field name → resolved NUMA node for
+    /// `pinned(node = ...)` / `pinned(l3 = ...)` entries; absent for
+    /// every other placement (arena stays unbound).
+    pub main_placement_node: BTreeMap<String, i64>,
+    /// Locus TYPE names that appear in any pinned placement entry —
+    /// consumed by struct-shape decisions (pinned loci get a
+    /// thread-id slot).
+    pub pinned_locus_types: BTreeSet<String>,
+    /// Field name → named cooperative pool, for
+    /// `cooperative(pool = X)` entries. Drives pool registration in
+    /// the prelude and the per-field pool override at instantiation.
+    pub main_cooperative_pools: BTreeMap<String, String>,
+    /// Pool names declared `where async_io` (green-I/O scheduling).
+    pub async_io_pools: BTreeSet<String>,
+    /// Locus TYPE names placed on a named cooperative pool —
+    /// consumed by the `__coop_pool_run_<L>` wrapper synthesis.
+    pub coop_pool_locus_types: BTreeSet<String>,
+}

--- a/crates/hale-codegen/src/lib.rs
+++ b/crates/hale-codegen/src/lib.rs
@@ -30,6 +30,7 @@
 //! lowered.
 
 pub(crate) mod bus;
+pub mod deployment;
 pub(crate) mod channels;
 pub mod codegen;
 pub(crate) mod form;

--- a/crates/hale-codegen/src/locus/decl.rs
+++ b/crates/hale-codegen/src/locus/decl.rs
@@ -427,7 +427,7 @@ impl<'ctx, 'p> LocusDeclare<'ctx> for Cx<'ctx, 'p> {
         // varies via the placement_override at instantiation
         // time; struct layout is type-level uniform.
         let is_pinned_locus_type =
-            self.pinned_locus_types.contains(&l.name.name);
+            self.deployment.pinned_locus_types.contains(&l.name.name);
         let has_subscribe = is_pinned_locus_type
             && l.members.iter().any(|m| match m {
                 LocusMember::Bus(b) => b.members.iter().any(|bm| {

--- a/crates/hale-codegen/src/locus/dissolve.rs
+++ b/crates/hale-codegen/src/locus/dissolve.rs
@@ -318,7 +318,7 @@ impl<'ctx, 'p> LocusDissolve<'ctx> for Cx<'ctx, 'p> {
         // pthread_join + arena_destroy happen via the
         // deferred-dissolve frame's flush at fn-scope exit.
         let is_main_locus = self
-            .main_locus_name
+            .deployment.main_locus_name
             .as_ref()
             .map(|n| n == locus_name)
             .unwrap_or(false);
@@ -338,7 +338,7 @@ impl<'ctx, 'p> LocusDissolve<'ctx> for Cx<'ctx, 'p> {
             // F.31 Phase 3b: skip cascade for pinned-placed fields.
             if is_main_locus
                 && matches!(
-                    self.main_placement_map.get(&fname),
+                    self.deployment.main_placement_map.get(&fname),
                     Some(ScheduleClass::Pinned(_))
                 )
             {
@@ -532,7 +532,7 @@ impl<'ctx, 'p> LocusDissolve<'ctx> for Cx<'ctx, 'p> {
         // F.31 Phase 3b: skip cascade drain for pinned-placed
         // fields. See emit_locus_field_dissolves's matching guard.
         let is_main_locus = self
-            .main_locus_name
+            .deployment.main_locus_name
             .as_ref()
             .map(|n| n == locus_name)
             .unwrap_or(false);
@@ -549,7 +549,7 @@ impl<'ctx, 'p> LocusDissolve<'ctx> for Cx<'ctx, 'p> {
             };
             if is_main_locus
                 && matches!(
-                    self.main_placement_map.get(&fname),
+                    self.deployment.main_placement_map.get(&fname),
                     Some(ScheduleClass::Pinned(_))
                 )
             {

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -772,7 +772,7 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                         coop_pool_for_hint
                     {
                         let hint = chunk_hint_for_coop_pool(
-                            &self.main_cooperative_pools,
+                            &self.deployment.main_cooperative_pools,
                             pool_name,
                         );
                         let sized_fn = self
@@ -1721,7 +1721,7 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
         // lower_expr, consumed by the recursive call to
         // lower_locus_instantiation).
         let is_main_locus = self
-            .main_locus_name
+            .deployment.main_locus_name
             .as_ref()
             .map(|n| n == locus_name)
             .unwrap_or(false);
@@ -1827,21 +1827,21 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
             // own schedule_class — Cooperative under F.31).
             if is_main_locus {
                 self.placement_for_next_locus_instantiation = self
-                    .main_placement_map
+                    .deployment.main_placement_map
                     .get(fname.as_str())
                     .cloned();
                 // F.31 Phase 4: parallel pool-name set. None when
                 // the field has no cooperative-pool entry (either
                 // pinned, default-pool main, or no placement).
                 self.cooperative_pool_for_next_locus_instantiation = self
-                    .main_cooperative_pools
+                    .deployment.main_cooperative_pools
                     .get(fname.as_str())
                     .cloned();
                 // Topology arena-on-node: parallel NUMA-node set for
                 // `pinned(node/l3)` fields; None for every other
                 // placement (arena stays unbound).
                 self.numa_node_for_next_locus_instantiation = self
-                    .main_placement_node
+                    .deployment.main_placement_node
                     .get(fname.as_str())
                     .copied();
             }
@@ -1863,7 +1863,7 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                     .cloned()
                 {
                     let node =
-                        self.main_placement_node.get(fname.as_str()).copied();
+                        self.deployment.main_placement_node.get(fname.as_str()).copied();
                     let DefaultInit::Expr(rep_expr) = default else {
                         return Err(CodegenError::Unsupported(format!(
                             "locus `{}` field `{}`: `replicas = K` needs a \
@@ -1898,7 +1898,7 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                     // Restore replica 0's overrides for the normal path
                     // below — the loop clobbered them.
                     self.placement_for_next_locus_instantiation = self
-                        .main_placement_map
+                        .deployment.main_placement_map
                         .get(fname.as_str())
                         .cloned();
                     self.numa_node_for_next_locus_instantiation = node;
@@ -4337,7 +4337,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             .expect("cross-pool owner is a declared locus");
         let owner_pinned =
             matches!(owner_info.schedule_class, ScheduleClass::Pinned(_))
-                || self.pinned_locus_types.contains(owner_name);
+                || self.deployment.pinned_locus_types.contains(owner_name);
         if owner_pinned {
             // Pinned A: post to A's mailbox (drained by A's pthread).
             let mb_idx = owner_info.mailbox_field_idx.ok_or_else(|| {

--- a/crates/hale-codegen/tests/obs_emission.rs
+++ b/crates/hale-codegen/tests/obs_emission.rs
@@ -17,6 +17,10 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/obs.rs"]
+mod obs;
+use obs::{obs_bus_locus, read_u32, read_u64};
+
 fn build(name: &str, src: &str) -> PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
     let mut bin = std::env::temp_dir();
@@ -50,20 +54,6 @@ const DEMO: &str = r#"
     }
     fn main() { App { }; }
 "#;
-
-/// Vendored from iris emitter/protocol.h (PROTOCOL §8): BUS w1 =
-/// locus:20 in bits 44..63, seq:44 low — see the handoff-7 note in
-/// obs_fleet_contract.rs.
-fn obs_bus_locus(w1: u64) -> u32 {
-    ((w1 >> 44) & 0xFFFFF) as u32
-}
-
-fn read_u64(seg: &[u8], off: usize) -> u64 {
-    u64::from_le_bytes(seg[off..off + 8].try_into().unwrap())
-}
-fn read_u32(seg: &[u8], off: usize) -> u32 {
-    u32::from_le_bytes(seg[off..off + 4].try_into().unwrap())
-}
 
 #[test]
 fn emits_protocol_segment_with_matching_counters() {

--- a/crates/hale-codegen/tests/obs_fleet_contract.rs
+++ b/crates/hale-codegen/tests/obs_fleet_contract.rs
@@ -31,167 +31,19 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/obs.rs"]
+mod obs;
+use obs::{
+    attach_observer, net_origin_seq, obs_bus_locus, records,
+    snapshot_shm, topic_counters, topic_id_and_line,
+};
+
 fn compile(tag: &str, src: &str) -> PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
     let mut bin = std::env::temp_dir();
     bin.push(format!("hale_obsfleet_{}_{}", tag, std::process::id()));
     build_executable(&program, &bin).expect("build");
     bin
-}
-
-fn read_u64(seg: &[u8], off: usize) -> u64 {
-    u64::from_le_bytes(seg[off..off + 8].try_into().unwrap())
-}
-fn read_u32(seg: &[u8], off: usize) -> u32 {
-    u32::from_le_bytes(seg[off..off + 4].try_into().unwrap())
-}
-
-unsafe fn mmap_ro(f: &std::fs::File, len: usize) -> *mut u8 {
-    use std::os::unix::io::AsRawFd;
-    extern "C" {
-        fn mmap(
-            addr: *mut core::ffi::c_void,
-            len: usize,
-            prot: i32,
-            flags: i32,
-            fd: i32,
-            off: i64,
-        ) -> *mut core::ffi::c_void;
-    }
-    let p = mmap(core::ptr::null_mut(), len, 0x1, 0x1, f.as_raw_fd(), 0);
-    if p as isize == -1 {
-        return core::ptr::null_mut();
-    }
-    p as *mut u8
-}
-
-/// Snapshot a live process's obs segment into an owned buffer (must
-/// run before the process exits — teardown shm_unlinks).
-unsafe fn snapshot_shm(pid: u32) -> Option<Vec<u8>> {
-    let f = std::fs::File::open(format!("/dev/shm/hale-obs-{}", pid))
-        .ok()?;
-    let len = f.metadata().ok()?.len() as usize;
-    let p = mmap_ro(&f, len);
-    if p.is_null() {
-        return None;
-    }
-    Some(std::slice::from_raw_parts(p as *const u8, len).to_vec())
-}
-
-/// Attach as an observer (bump observer_count so ring emission turns
-/// on) — requires a writable map.
-unsafe fn attach_observer(pid: u32) {
-    use std::os::unix::io::AsRawFd;
-    extern "C" {
-        fn mmap(
-            addr: *mut core::ffi::c_void,
-            len: usize,
-            prot: i32,
-            flags: i32,
-            fd: i32,
-            off: i64,
-        ) -> *mut core::ffi::c_void;
-    }
-    if let Ok(f) = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(format!("/dev/shm/hale-obs-{}", pid))
-    {
-        let len = f.metadata().unwrap().len() as usize;
-        let p = mmap(core::ptr::null_mut(), len, 0x3, 0x1, f.as_raw_fd(), 0);
-        if p as isize != -1 {
-            let seg = std::slice::from_raw_parts(p as *const u8, len);
-            let control_off = read_u64(seg, 0x38) as usize;
-            std::ptr::write_volatile(
-                (p as *mut u8).add(control_off) as *mut u32,
-                1,
-            );
-        }
-    }
-}
-
-/// The manifest topic id (join key) + counter line for a subject, or
-/// None if the topic never registered in this segment.
-fn topic_id_and_line(seg: &[u8], subject: &[u8]) -> Option<(u32, usize)> {
-    let manifest_off = read_u64(seg, 0x40) as usize;
-    let entry_count = read_u32(seg, manifest_off) as usize;
-    let pool_off = read_u32(seg, manifest_off + 8) as usize;
-    let entries = manifest_off + 16;
-    let mut line = 0usize;
-    for i in 0..entry_count {
-        let e = entries + i * 32;
-        let kind = seg[e + 28];
-        // topic (0) and binding (2) entries each occupy a counter line.
-        if kind == 0 || kind == 2 {
-            line += 1;
-            if kind == 0 {
-                let name_off = read_u32(seg, e + 20) as usize;
-                let name_len = seg[e + 24] as usize
-                    | ((seg[e + 25] as usize) << 8);
-                let base = manifest_off + pool_off + name_off;
-                if &seg[base..base + name_len] == subject {
-                    let id = read_u32(seg, e + 16);
-                    return Some((id, line));
-                }
-            }
-        }
-    }
-    None
-}
-
-/// (published, delivered, bytes) counters for a subject.
-fn topic_counters(seg: &[u8], subject: &[u8]) -> Option<(u64, u64, u64)> {
-    let (_, line) = topic_id_and_line(seg, subject)?;
-    let counters_off = read_u64(seg, 0x58) as usize;
-    let cline = counters_off + line * 64;
-    Some((
-        read_u64(seg, cline),
-        read_u64(seg, cline + 8),
-        read_u64(seg, cline + 16),
-    ))
-}
-
-/// All records of a given ekind as (w0-id, w1). NET (3/4): w0-id is
-/// the topic id, w1 = origin:16 | seq:48. BUS_PUBLISH (1): w1 =
-/// locus:20 | seq:44. LOCUS_BIRTH (5): w0-id = instance id.
-fn records(seg: &[u8], want_ekind: u32) -> Vec<(u32, u64)> {
-    let rings_off = read_u64(seg, 0x68) as usize;
-    let ring_count = read_u32(seg, 0x1C) as usize;
-    let ring_slots = read_u32(seg, 0x20) as usize;
-    let mut out = Vec::new();
-    for r in 0..ring_count {
-        let rdesc = rings_off + r * 64;
-        let data_off = read_u64(seg, rdesc) as usize;
-        let head = read_u64(seg, rdesc + 8) as usize;
-        let start = head.saturating_sub(ring_slots);
-        for i in start..head {
-            let slot = data_off + (i & (ring_slots - 1)) * 16;
-            let w0 = read_u64(seg, slot);
-            let w1 = read_u64(seg, slot + 8);
-            let id = (w0 & 0xFFFFF) as u32;
-            let ekind = ((w0 >> 20) & 0x1F) as u32;
-            if ekind == want_ekind {
-                out.push((id, w1));
-            }
-        }
-    }
-    out
-}
-
-/// Vendored from iris `emitter/protocol.h` (PROTOCOL §8, the
-/// executable reference): BUS_PUBLISH / BUS_DELIVER pack
-/// `w1 = locus:20 (bits 44..63) | seq:44 (low)`. The handoff-7 bug
-/// was the emitter transposing these fields while this test decoded
-/// with the emitter's own layout — self-consistent and green while
-/// every protocol-conformant consumer read locus 0. Emitter and
-/// tests now share THIS decode; if protocol.h changes, change both
-/// in one commit (PROTOCOL.md's own rule).
-fn obs_bus_locus(w1: u64) -> u32 {
-    ((w1 >> 44) & 0xFFFFF) as u32
-}
-
-fn net_origin_seq(w1: u64) -> (u32, u64) {
-    ((w1 & 0xFFFF) as u32, (w1 >> 16) & 0xFFFF_FFFF_FFFF)
 }
 
 const SUB: &str = r#"
@@ -276,15 +128,13 @@ fn fleet_multicast_full_contract() {
     let (pub_pid, s1_pid, s2_pid) = (pubc.id(), sub1.id(), sub2.id());
     // Attach as observer before the burst (starts at pub t+400ms).
     std::thread::sleep(Duration::from_millis(150));
-    unsafe {
-        attach_observer(pub_pid);
-        attach_observer(s1_pid);
-        attach_observer(s2_pid);
-    }
+    attach_observer(pub_pid);
+    attach_observer(s1_pid);
+    attach_observer(s2_pid);
     std::thread::sleep(Duration::from_millis(1000));
-    let pub_seg = unsafe { snapshot_shm(pub_pid) };
-    let s1_seg = unsafe { snapshot_shm(s1_pid) };
-    let s2_seg = unsafe { snapshot_shm(s2_pid) };
+    let pub_seg = snapshot_shm(pub_pid);
+    let s1_seg = snapshot_shm(s1_pid);
+    let s2_seg = snapshot_shm(s2_pid);
 
     let _ = pubc.kill();
     let _ = pubc.wait();
@@ -504,9 +354,9 @@ fn keyed_publish_records_bus_publish() {
             break;
         }
     }
-    unsafe { attach_observer(pid) };
+    attach_observer(pid);
     std::thread::sleep(Duration::from_millis(700));
-    let seg = unsafe { snapshot_shm(pid) };
+    let seg = snapshot_shm(pid);
     let _ = child.kill();
     let _ = child.wait();
     let _ = std::fs::remove_file(&bin);
@@ -603,9 +453,9 @@ fn attribution_on_fleet_publisher_shapes() {
             break;
         }
     }
-    unsafe { attach_observer(pid) };
+    attach_observer(pid);
     std::thread::sleep(Duration::from_millis(1100));
-    let seg = unsafe { snapshot_shm(pid) };
+    let seg = snapshot_shm(pid);
     let _ = child.kill();
     let _ = child.wait();
     let _ = std::fs::remove_file(&bin);
@@ -722,9 +572,9 @@ fn direct_devirt_flavor_emits_attributed_probes() {
             break;
         }
     }
-    unsafe { attach_observer(pid) };
+    attach_observer(pid);
     std::thread::sleep(Duration::from_millis(550));
-    let seg = unsafe { snapshot_shm(pid) };
+    let seg = snapshot_shm(pid);
     let _ = child.kill();
     let _ = child.wait();
     let _ = std::fs::remove_file(&bin);
@@ -802,9 +652,9 @@ fn quiet_process_replays_births_via_heartbeat() {
     // Attach AFTER the birth already happened; the process makes no
     // further probes, so only the heartbeat can notice us.
     std::thread::sleep(Duration::from_millis(300));
-    unsafe { attach_observer(pid) };
+    attach_observer(pid);
     std::thread::sleep(Duration::from_millis(800));
-    let seg = unsafe { snapshot_shm(pid) };
+    let seg = snapshot_shm(pid);
     let _ = child.kill();
     let _ = child.wait();
     let _ = std::fs::remove_file(&bin);
@@ -865,9 +715,9 @@ fn late_attach_still_attributes_publishes() {
     let pid = child.id();
     // Let the publisher run deep into steady state UNOBSERVED.
     std::thread::sleep(Duration::from_millis(1200));
-    unsafe { attach_observer(pid) };
+    attach_observer(pid);
     std::thread::sleep(Duration::from_millis(1200));
-    let seg = unsafe { snapshot_shm(pid) };
+    let seg = snapshot_shm(pid);
     let _ = child.kill();
     let _ = child.wait();
     let _ = std::fs::remove_file(&bin);
@@ -947,9 +797,9 @@ fn adapter_inbound_dispatch_is_not_a_publish() {
             break;
         }
     }
-    unsafe { attach_observer(pid) };
+    attach_observer(pid);
     std::thread::sleep(Duration::from_millis(900));
-    let seg = unsafe { snapshot_shm(pid) };
+    let seg = snapshot_shm(pid);
     let _ = child.kill();
     let _ = child.wait();
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/obs_net_seq.rs
+++ b/crates/hale-codegen/tests/obs_net_seq.rs
@@ -23,6 +23,10 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/obs.rs"]
+mod obs;
+use obs::{attach_observer, net_origin_seq, records, snapshot_shm};
+
 fn compile(tag: &str, src: &str) -> PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
     let mut bin = std::env::temp_dir();
@@ -31,94 +35,12 @@ fn compile(tag: &str, src: &str) -> PathBuf {
     bin
 }
 
-fn read_u64(seg: &[u8], off: usize) -> u64 {
-    u64::from_le_bytes(seg[off..off + 8].try_into().unwrap())
-}
-fn read_u32(seg: &[u8], off: usize) -> u32 {
-    u32::from_le_bytes(seg[off..off + 4].try_into().unwrap())
-}
-
-/// Snapshot a live process's obs segment into an owned buffer
-/// (must run before the process exits — teardown shm_unlinks).
-unsafe fn snapshot_shm(pid: u32) -> Option<Vec<u8>> {
-    use std::os::unix::io::AsRawFd;
-    extern "C" {
-        fn mmap(
-            addr: *mut core::ffi::c_void,
-            len: usize,
-            prot: i32,
-            flags: i32,
-            fd: i32,
-            off: i64,
-        ) -> *mut core::ffi::c_void;
-    }
-    let f = std::fs::File::open(format!("/dev/shm/hale-obs-{}", pid))
-        .ok()?;
-    let len = f.metadata().ok()?.len() as usize;
-    let p = mmap(core::ptr::null_mut(), len, 0x1, 0x1, f.as_raw_fd(), 0);
-    if p as isize == -1 {
-        return None;
-    }
-    let seg = std::slice::from_raw_parts(p as *const u8, len);
-    Some(seg.to_vec())
-}
-
-/// Attach as an observer (bump observer_count so ring emission
-/// turns on) — requires a writable map.
-unsafe fn attach_observer(pid: u32) {
-    use std::os::unix::io::AsRawFd;
-    extern "C" {
-        fn mmap(
-            addr: *mut core::ffi::c_void,
-            len: usize,
-            prot: i32,
-            flags: i32,
-            fd: i32,
-            off: i64,
-        ) -> *mut core::ffi::c_void;
-    }
-    if let Ok(f) = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(format!("/dev/shm/hale-obs-{}", pid))
-    {
-        let len = f.metadata().unwrap().len() as usize;
-        let p = mmap(core::ptr::null_mut(), len, 0x3, 0x1, f.as_raw_fd(), 0);
-        if p as isize != -1 {
-            let seg = std::slice::from_raw_parts(p as *const u8, len);
-            let control_off = read_u64(seg, 0x38) as usize;
-            std::ptr::write_volatile(
-                (p as *mut u8).add(control_off) as *mut u32,
-                1,
-            );
-        }
-    }
-}
-
 /// Collect (origin, seq) for a given ekind (3=NET_SEND, 4=NET_DELIVER).
 fn net_pairs(seg: &[u8], want_ekind: u32) -> Vec<(u32, u64)> {
-    let rings_off = read_u64(seg, 0x68) as usize;
-    let ring_count = read_u32(seg, 0x1C) as usize;
-    let ring_slots = read_u32(seg, 0x20) as usize;
-    let mut out = Vec::new();
-    for r in 0..ring_count {
-        let rdesc = rings_off + r * 64;
-        let data_off = read_u64(seg, rdesc) as usize;
-        let head = read_u64(seg, rdesc + 8) as usize;
-        let start = head.saturating_sub(ring_slots);
-        for i in start..head {
-            let slot = data_off + (i & (ring_slots - 1)) * 16;
-            let w0 = read_u64(seg, slot);
-            let w1 = read_u64(seg, slot + 8);
-            let ekind = ((w0 >> 20) & 0x1F) as u32;
-            if ekind == want_ekind {
-                let origin = (w1 & 0xFFFF) as u32;
-                let seq = (w1 >> 16) & 0xFFFF_FFFF_FFFF;
-                out.push((origin, seq));
-            }
-        }
-    }
-    out
+    records(seg, want_ekind)
+        .iter()
+        .map(|(_, w1)| net_origin_seq(*w1))
+        .collect()
 }
 
 const SUB: &str = r#"
@@ -204,13 +126,11 @@ fn framed_transport_net_pairs_on_origin_seq() {
     let pub_pid = pubc.id();
     let sub_pid = sub.id();
     std::thread::sleep(Duration::from_millis(150));
-    unsafe {
-        attach_observer(pub_pid);
-        attach_observer(sub_pid);
-    }
+    attach_observer(pub_pid);
+    attach_observer(sub_pid);
     std::thread::sleep(Duration::from_millis(900));
-    let pub_seg = unsafe { snapshot_shm(pub_pid) };
-    let sub_seg = unsafe { snapshot_shm(sub_pid) };
+    let pub_seg = snapshot_shm(pub_pid);
+    let sub_seg = snapshot_shm(sub_pid);
     let sends = pub_seg.as_ref().map(|s| net_pairs(s, 3)).unwrap_or_default();
     let delivers =
         sub_seg.as_ref().map(|s| net_pairs(s, 4)).unwrap_or_default();
@@ -286,16 +206,14 @@ fn net_send_and_deliver_pair_on_origin_seq() {
     // Attach as observer to both so ring emission is on for the
     // publish burst (starts at pub t+300ms).
     std::thread::sleep(Duration::from_millis(150));
-    unsafe {
-        attach_observer(pub_pid);
-        attach_observer(sub_pid);
-    }
+    attach_observer(pub_pid);
+    attach_observer(sub_pid);
     // Burst runs pub t+300..500ms; App.run keeps the process alive
     // ~2.5s. Snapshot BOTH segments while alive (teardown
     // shm_unlinks at exit).
     std::thread::sleep(Duration::from_millis(900));
-    let pub_seg = unsafe { snapshot_shm(pub_pid) };
-    let sub_seg = unsafe { snapshot_shm(sub_pid) };
+    let pub_seg = snapshot_shm(pub_pid);
+    let sub_seg = snapshot_shm(sub_pid);
 
     let sends = pub_seg
         .as_ref()

--- a/crates/hale-codegen/tests/support/obs.rs
+++ b/crates/hale-codegen/tests/support/obs.rs
@@ -1,0 +1,175 @@
+//! R6 (2026-07-29) — shared observation-segment reader for tests.
+//!
+//! The raw-consumer decoding of `/hale-obs-<pid>` segments (mmap,
+//! header offsets, manifest walk, counter lines, ring records) was
+//! copy-pasted across `obs_fleet_contract.rs`, `obs_net_seq.rs`, and
+//! `obs_emission.rs` — three drifting copies of PROTOCOL v0.1, one
+//! of which decoded BUS w1 with the emitter's own (wrong) layout for
+//! four releases (handoff-7). One copy now, with the protocol.h
+//! decodes vendored HERE and nowhere else.
+//!
+//! Usage from an integration test (each test file is its own crate):
+//!   #[path = "support/obs.rs"]
+//!   mod obs;
+#![allow(dead_code)]
+
+pub fn read_u64(seg: &[u8], off: usize) -> u64 {
+    u64::from_le_bytes(seg[off..off + 8].try_into().unwrap())
+}
+pub fn read_u32(seg: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes(seg[off..off + 4].try_into().unwrap())
+}
+
+unsafe fn mmap_raw(
+    f: &std::fs::File,
+    len: usize,
+    prot: i32,
+) -> *mut u8 {
+    use std::os::unix::io::AsRawFd;
+    extern "C" {
+        fn mmap(
+            addr: *mut core::ffi::c_void,
+            len: usize,
+            prot: i32,
+            flags: i32,
+            fd: i32,
+            off: i64,
+        ) -> *mut core::ffi::c_void;
+    }
+    let p = mmap(
+        core::ptr::null_mut(),
+        len,
+        prot,
+        0x1, /* MAP_SHARED */
+        f.as_raw_fd(),
+        0,
+    );
+    if p as isize == -1 {
+        core::ptr::null_mut()
+    } else {
+        p as *mut u8
+    }
+}
+
+/// Snapshot a live process's obs segment into an owned buffer (must
+/// run before the process exits — teardown shm_unlinks).
+pub fn snapshot_shm(pid: u32) -> Option<Vec<u8>> {
+    let f = std::fs::File::open(format!("/dev/shm/hale-obs-{}", pid))
+        .ok()?;
+    let len = f.metadata().ok()?.len() as usize;
+    let p = unsafe { mmap_raw(&f, len, 0x1) };
+    if p.is_null() {
+        return None;
+    }
+    Some(unsafe { std::slice::from_raw_parts(p as *const u8, len) }
+        .to_vec())
+}
+
+/// Attach as an observer: bump `observer_count` on the control page
+/// so ring emission turns on (requires a writable map).
+pub fn attach_observer(pid: u32) {
+    if let Ok(f) = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(format!("/dev/shm/hale-obs-{}", pid))
+    {
+        let len = f.metadata().unwrap().len() as usize;
+        let p = unsafe { mmap_raw(&f, len, 0x3) };
+        if !p.is_null() {
+            let seg =
+                unsafe { std::slice::from_raw_parts(p as *const u8, len) };
+            let control_off = read_u64(seg, 0x38) as usize;
+            unsafe {
+                std::ptr::write_volatile(
+                    p.add(control_off) as *mut u32,
+                    1,
+                )
+            };
+        }
+    }
+}
+
+/// The manifest topic id (join key) + counter line for a subject, or
+/// None if the topic never registered in this segment.
+pub fn topic_id_and_line(seg: &[u8], subject: &[u8]) -> Option<(u32, usize)> {
+    let manifest_off = read_u64(seg, 0x40) as usize;
+    let entry_count = read_u32(seg, manifest_off) as usize;
+    let pool_off = read_u32(seg, manifest_off + 8) as usize;
+    let entries = manifest_off + 16;
+    let mut line = 0usize;
+    for i in 0..entry_count {
+        let e = entries + i * 32;
+        let kind = seg[e + 28];
+        // topic (0) and binding (2) entries each occupy a counter line.
+        if kind == 0 || kind == 2 {
+            line += 1;
+            if kind == 0 {
+                let name_off = read_u32(seg, e + 20) as usize;
+                let name_len = seg[e + 24] as usize
+                    | ((seg[e + 25] as usize) << 8);
+                let base = manifest_off + pool_off + name_off;
+                if &seg[base..base + name_len] == subject {
+                    let id = read_u32(seg, e + 16);
+                    return Some((id, line));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// (published, delivered, bytes) counters for a subject.
+pub fn topic_counters(seg: &[u8], subject: &[u8]) -> Option<(u64, u64, u64)> {
+    let (_, line) = topic_id_and_line(seg, subject)?;
+    let counters_off = read_u64(seg, 0x58) as usize;
+    let cline = counters_off + line * 64;
+    Some((
+        read_u64(seg, cline),
+        read_u64(seg, cline + 8),
+        read_u64(seg, cline + 16),
+    ))
+}
+
+/// All records of a given ekind as (w0-id, w1). NET (3/4): w0-id is
+/// the topic id. BUS (1/2): decode w1 with [`obs_bus_locus`].
+/// LOCUS_BIRTH (5): w0-id = instance id.
+pub fn records(seg: &[u8], want_ekind: u32) -> Vec<(u32, u64)> {
+    let rings_off = read_u64(seg, 0x68) as usize;
+    let ring_count = read_u32(seg, 0x1C) as usize;
+    let ring_slots = read_u32(seg, 0x20) as usize;
+    let mut out = Vec::new();
+    for r in 0..ring_count {
+        let rdesc = rings_off + r * 64;
+        let data_off = read_u64(seg, rdesc) as usize;
+        let head = read_u64(seg, rdesc + 8) as usize;
+        let start = head.saturating_sub(ring_slots);
+        for i in start..head {
+            let slot = data_off + (i & (ring_slots - 1)) * 16;
+            let w0 = read_u64(seg, slot);
+            let w1 = read_u64(seg, slot + 8);
+            let id = (w0 & 0xFFFFF) as u32;
+            let ekind = ((w0 >> 20) & 0x1F) as u32;
+            if ekind == want_ekind {
+                out.push((id, w1));
+            }
+        }
+    }
+    out
+}
+
+/// Vendored from iris `emitter/protocol.h` (PROTOCOL §8, the
+/// executable reference): BUS_PUBLISH / BUS_DELIVER pack
+/// `w1 = locus:20 (bits 44..63) | seq:44 (low)`. The handoff-7 bug
+/// was the emitter transposing these fields while its tests decoded
+/// with the emitter's own layout — vendor THIS decode, never the
+/// emitter's. If protocol.h changes, change both in one commit
+/// (PROTOCOL.md's own rule).
+pub fn obs_bus_locus(w1: u64) -> u32 {
+    ((w1 >> 44) & 0xFFFFF) as u32
+}
+
+/// NET_SEND / NET_DELIVER w1 = origin:16 (low) | seq:48 (high) —
+/// PROTOCOL §8, handoff-3 amendment.
+pub fn net_origin_seq(w1: u64) -> (u32, u64) {
+    ((w1 & 0xFFFF) as u32, (w1 >> 16) & 0xFFFF_FFFF_FFFF)
+}

--- a/crates/hale-lsp/src/lib.rs
+++ b/crates/hale-lsp/src/lib.rs
@@ -1073,7 +1073,8 @@ fn complete_std_path(
     // Free fns in the exact namespace, with signatures as detail.
     for surface in surf::SURFACES {
         if surface.ns == ns_refs.as_slice() {
-            for f in surface.fns {
+            for entry in surface.fns {
+                let f = entry.name;
                 if !f.starts_with(partial) {
                     continue;
                 }

--- a/crates/hale-types/src/budget_check.rs
+++ b/crates/hale-types/src/budget_check.rs
@@ -38,9 +38,9 @@
 use hale_syntax::ast::*;
 use hale_syntax::{Diag, Span};
 
-use crate::alloc_summary::{
-    self, AllocKind, AllocSummary, Callee, FnKey, FnSummary,
-};
+use crate::alloc_summary::{self, AllocKind, AllocSite, AllocSummary,
+    CallEdge, FnKey};
+use crate::callgraph::{self, FactVisitor};
 
 /// A per-call allocation count that saturates at `Unbounded` (a
 /// loop-nested allocation, a call in a loop, or recursion).
@@ -119,138 +119,136 @@ fn describe_kind(kind: &AllocKind) -> String {
 
 /// A DFS-work ceiling. A pathological wide call graph could re-count a
 /// shared callee exponentially; past this many steps we stop and report
-/// the fn as uncertifiable (conservatively over budget) rather than
-/// spin. Real call graphs are nowhere near this.
-const MAX_STEPS: u32 = 20_000;
+/// R1 (2026-07-29): the DFS that used to live here (`count_fn`) is
+/// now the shared engine in [`crate::callgraph`]; this visitor
+/// supplies exactly the contributions the old traversal hard-coded.
+/// Semantics and diagnostic text are unchanged — the engine was
+/// extracted from this file and this file is its reference customer.
+struct BudgetVisitor {
+    offenders: Vec<Offender>,
+}
 
-/// Count the arena allocations one call of `key` performs, collecting
-/// offenders for diagnostics. `path` is the current DFS ancestor stack
-/// (for cycle → recursion detection); a diamond (a callee reached by two
-/// distinct paths) is *not* on the path and is correctly counted once
-/// per reaching call site.
-fn count_fn(
-    key: &FnKey,
-    summary: &AllocSummary,
-    path: &mut Vec<FnKey>,
-    offenders: &mut Vec<Offender>,
-    steps: &mut u32,
-) -> Count {
-    let fs: &FnSummary = match summary.fns.get(key) {
-        Some(fs) => fs,
-        // An unresolved / external target has no summary — nothing we can
-        // see. (Callers already special-case the known-allocating recv
-        // family before recursing here.)
-        None => return Count::zero(),
-    };
+impl FactVisitor for BudgetVisitor {
+    type Fact = Count;
 
-    let mut total = Count::zero();
+    fn identity(&self) -> Count {
+        Count::zero()
+    }
+    fn combine(&self, a: Count, b: Count) -> Count {
+        a.add(b)
+    }
+    fn saturated(&self) -> Count {
+        Count::Unbounded
+    }
+    fn is_zero(&self, f: &Count) -> bool {
+        !f.nonzero()
+    }
 
-    // Direct allocation sites in this body.
-    for site in &fs.sites {
-        *steps += 1;
-        if *steps > MAX_STEPS {
-            return Count::Unbounded;
-        }
+    fn site(&mut self, _key: &FnKey, site: &AllocSite, emit: bool) -> Count {
         if site.loop_depth > 0 {
-            offenders.push(Offender {
-                span: site.span,
+            if emit {
+                self.offenders.push(Offender {
+                    span: site.span,
+                    note: format!(
+                        "{} inside a loop — a fresh allocation every iteration",
+                        describe_kind(&site.kind)
+                    ),
+                });
+            }
+            Count::Unbounded
+        } else {
+            if emit {
+                self.offenders.push(Offender {
+                    span: site.span,
+                    note: describe_kind(&site.kind),
+                });
+            }
+            Count::Finite(1)
+        }
+    }
+
+    fn unresolved(
+        &mut self,
+        _key: &FnKey,
+        edge: &CallEdge,
+        name: &str,
+        in_loop: bool,
+        emit: bool,
+    ) -> Count {
+        if !opaque_recv_allocates(name) {
+            // Any other opaque call is outside what the budget can
+            // see (documented boundary).
+            return Count::zero();
+        }
+        if in_loop {
+            if emit {
+                self.offenders.push(Offender {
+                    span: edge.span,
+                    note: format!(
+                        "`{}` inside a loop allocates a fresh buffer \
+                         every iteration — use `recv_into` with a \
+                         reused `BytesBuilder`",
+                        name
+                    ),
+                });
+            }
+            Count::Unbounded
+        } else {
+            if emit {
+                self.offenders.push(Offender {
+                    span: edge.span,
+                    note: format!(
+                        "`{}` allocates a fresh result buffer — use \
+                         `recv_into` with a reused `BytesBuilder` for \
+                         a zero-alloc read",
+                        name
+                    ),
+                });
+            }
+            Count::Finite(1)
+        }
+    }
+
+    fn recursion(
+        &mut self,
+        _key: &FnKey,
+        edge: &CallEdge,
+        callee: &FnKey,
+        emit: bool,
+    ) -> Count {
+        if emit {
+            self.offenders.push(Offender {
+                span: edge.span,
                 note: format!(
-                    "{} inside a loop — a fresh allocation every iteration",
-                    describe_kind(&site.kind)
+                    "recursive call to `{}` — unbounded allocation \
+                     per call",
+                    callee.display()
                 ),
             });
-            total = total.add(Count::Unbounded);
-        } else {
-            offenders.push(Offender {
-                span: site.span,
-                note: describe_kind(&site.kind),
-            });
-            total = total.add(Count::Finite(1));
         }
+        Count::Unbounded
     }
 
-    // Call edges.
-    path.push(key.clone());
-    for edge in &fs.calls {
-        *steps += 1;
-        if *steps > MAX_STEPS {
-            path.pop();
-            return Count::Unbounded;
+    fn loop_call(
+        &mut self,
+        _key: &FnKey,
+        edge: &CallEdge,
+        callee: &FnKey,
+        _sub: Count,
+        emit: bool,
+    ) -> Count {
+        if emit {
+            self.offenders.push(Offender {
+                span: edge.span,
+                note: format!(
+                    "calls `{}` inside a loop — its allocations \
+                     repeat every iteration",
+                    callee.display()
+                ),
+            });
         }
-        let in_loop = edge.loop_depth > 0;
-        match &edge.callee {
-            Callee::Resolved(callee_key) => {
-                if path.contains(callee_key) {
-                    // A cycle on the current path = recursion = unbounded
-                    // per call.
-                    offenders.push(Offender {
-                        span: edge.span,
-                        note: format!(
-                            "recursive call to `{}` — unbounded allocation \
-                             per call",
-                            callee_key.display()
-                        ),
-                    });
-                    total = total.add(Count::Unbounded);
-                    continue;
-                }
-                if in_loop {
-                    // The callee runs many times per call. If it allocates
-                    // at all, that's unbounded per call.
-                    let mut probe = Vec::new();
-                    let sub = count_fn(callee_key, summary, path, &mut probe, steps);
-                    if sub.nonzero() {
-                        offenders.push(Offender {
-                            span: edge.span,
-                            note: format!(
-                                "calls `{}` inside a loop — its allocations \
-                                 repeat every iteration",
-                                callee_key.display()
-                            ),
-                        });
-                        total = total.add(Count::Unbounded);
-                    }
-                } else {
-                    // A once-per-call callee: its allocations fold in
-                    // directly (offenders point into its body).
-                    total = total.add(count_fn(
-                        callee_key, summary, path, offenders, steps,
-                    ));
-                }
-            }
-            Callee::Unresolved(name) => {
-                if opaque_recv_allocates(name) {
-                    if in_loop {
-                        offenders.push(Offender {
-                            span: edge.span,
-                            note: format!(
-                                "`{}` inside a loop allocates a fresh buffer \
-                                 every iteration — use `recv_into` with a \
-                                 reused `BytesBuilder`",
-                                name
-                            ),
-                        });
-                        total = total.add(Count::Unbounded);
-                    } else {
-                        offenders.push(Offender {
-                            span: edge.span,
-                            note: format!(
-                                "`{}` allocates a fresh result buffer — use \
-                                 `recv_into` with a reused `BytesBuilder` for \
-                                 a zero-alloc read",
-                                name
-                            ),
-                        });
-                        total = total.add(Count::Finite(1));
-                    }
-                }
-                // Any other opaque call is outside what the budget can
-                // see (documented boundary).
-            }
-        }
+        Count::Unbounded
     }
-    path.pop();
-    total
 }
 
 /// The public entry: check every `@budget(...)`-annotated fn/method in
@@ -301,10 +299,9 @@ fn check_one(
     summary: &AllocSummary,
     diags: &mut Vec<Diag>,
 ) {
-    let mut offenders = Vec::new();
-    let mut path = Vec::new();
-    let mut steps = 0u32;
-    let count = count_fn(key, summary, &mut path, &mut offenders, &mut steps);
+    let mut visitor = BudgetVisitor { offenders: Vec::new() };
+    let count = callgraph::walk(summary, key, &mut visitor);
+    let offenders = visitor.offenders;
 
     if !count.exceeds(budget) {
         return;

--- a/crates/hale-types/src/callgraph.rs
+++ b/crates/hale-types/src/callgraph.rs
@@ -1,0 +1,297 @@
+//! R1 (2026-07-29) — the shared call-graph walking substrate.
+//!
+//! `hale-types` grew four independent call-graph traversals
+//! (`alloc_summary`'s fixpoint, `budget_check`'s counting DFS,
+//! `purity`'s worklist, check.rs's blocking finder), none of which
+//! carried a witness path. Issue #265 (categoric effect assertions)
+//! needs exactly one engine: path-carrying reachability over the
+//! resolved call graph, parameterized by what a leaf contributes.
+//! This module is that engine, extracted from `budget_check`'s DFS
+//! (its semantics are the reference: ancestor-stack recursion
+//! detection, loop-context propagation, per-reaching-path diamond
+//! counting, a step cap) — `budget_check` is the first ported
+//! customer, and #265's effect classes are intended to be the next.
+//!
+//! Two entry points:
+//!
+//!  * [`walk`] — a fact-accumulating DFS. The [`FactVisitor`]
+//!    decides what an allocation site, an unresolved call, or a
+//!    recursive edge contributes; the engine handles traversal
+//!    order, loop context, cycle detection, and the step cap. The
+//!    `emit` flag on every visitor method distinguishes the real
+//!    walk (record diagnostics) from silent probes (loop-callee
+//!    pre-walks: contribute facts, discard diagnostics) — the same
+//!    split `budget_check` made with its throwaway offender vec.
+//!  * [`witness_path`] — the #265 primitive: the first call chain
+//!    from a root to a site/edge matching a predicate, returned as
+//!    the human-renderable `root -> f -> g [leaf]` path that
+//!    `@budget`'s fixpoint could never produce.
+
+use hale_syntax::Span;
+
+use crate::alloc_summary::{
+    AllocSite, AllocSummary, CallEdge, Callee, FnKey, FnSummary,
+};
+
+/// Runaway-graph guard, inherited from `budget_check`: a diamond-heavy
+/// graph revisits shared callees once per reaching path (correct for
+/// per-call counting), so pathological shapes could blow up. Past the
+/// cap the walk reports saturation rather than spinning. Real call
+/// graphs are nowhere near this.
+pub const MAX_STEPS: u32 = 20_000;
+
+/// What one traversal event contributes to the accumulated fact.
+///
+/// Facts accumulate via `identity` + `combine`; `saturated` is the
+/// conservative worst-case element used when the step cap trips. For
+/// `budget_check` the fact is a saturating count; for #265 effect
+/// classes it will be a lattice mask + quantity.
+///
+/// `emit` is false during silent probes (the pre-walk of a callee
+/// inside a loop): compute and return the fact as usual, but do not
+/// record diagnostics/offenders.
+pub trait FactVisitor {
+    type Fact: Clone;
+
+    fn identity(&self) -> Self::Fact;
+    fn combine(&self, a: Self::Fact, b: Self::Fact) -> Self::Fact;
+    /// The element returned when the step cap trips.
+    fn saturated(&self) -> Self::Fact;
+    /// Does this fact contribute anything? Drives the loop-call
+    /// policy: a loop callee whose probe `is_zero` produces no event.
+    fn is_zero(&self, f: &Self::Fact) -> bool;
+
+    /// An allocation site in `key`'s own body (`site.loop_depth > 0`
+    /// = every-iteration).
+    fn site(
+        &mut self,
+        key: &FnKey,
+        site: &AllocSite,
+        emit: bool,
+    ) -> Self::Fact;
+    /// An unresolved (external / stdlib / FFI) callee.
+    fn unresolved(
+        &mut self,
+        key: &FnKey,
+        edge: &CallEdge,
+        name: &str,
+        in_loop: bool,
+        emit: bool,
+    ) -> Self::Fact;
+    /// A cycle on the current ancestor path (recursion).
+    fn recursion(
+        &mut self,
+        key: &FnKey,
+        edge: &CallEdge,
+        callee: &FnKey,
+        emit: bool,
+    ) -> Self::Fact;
+    /// A resolved callee inside a loop whose silent probe (`sub`)
+    /// was non-zero: its work repeats every iteration.
+    fn loop_call(
+        &mut self,
+        key: &FnKey,
+        edge: &CallEdge,
+        callee: &FnKey,
+        sub: Self::Fact,
+        emit: bool,
+    ) -> Self::Fact;
+}
+
+/// Fact-accumulating DFS from `root`. Traversal semantics are
+/// `budget_check::count_fn`'s, verbatim:
+///
+///  * sites first, then call edges, in summary order;
+///  * a resolved callee NOT in a loop folds its walk in directly
+///    (offender spans point into the callee's body);
+///  * a resolved callee IN a loop is probed silently; only a
+///    non-`is_zero` probe produces a `loop_call` event;
+///  * an ancestor-path callee is `recursion`;
+///  * past [`MAX_STEPS`] the walk returns `saturated()`.
+pub fn walk<V: FactVisitor>(
+    summary: &AllocSummary,
+    root: &FnKey,
+    visitor: &mut V,
+) -> V::Fact {
+    let mut path = Vec::new();
+    let mut steps = 0u32;
+    walk_inner(summary, root, visitor, &mut path, &mut steps, true)
+}
+
+fn walk_inner<V: FactVisitor>(
+    summary: &AllocSummary,
+    key: &FnKey,
+    visitor: &mut V,
+    path: &mut Vec<FnKey>,
+    steps: &mut u32,
+    emit: bool,
+) -> V::Fact {
+    let fs: &FnSummary = match summary.fns.get(key) {
+        Some(fs) => fs,
+        // Unresolved target with no summary — nothing visible.
+        None => return visitor.identity(),
+    };
+
+    let mut total = visitor.identity();
+
+    for site in &fs.sites {
+        *steps += 1;
+        if *steps > MAX_STEPS {
+            return visitor.saturated();
+        }
+        let f = visitor.site(key, site, emit);
+        total = visitor.combine(total, f);
+    }
+
+    path.push(key.clone());
+    for edge in &fs.calls {
+        *steps += 1;
+        if *steps > MAX_STEPS {
+            path.pop();
+            return visitor.saturated();
+        }
+        let in_loop = edge.loop_depth > 0;
+        match &edge.callee {
+            Callee::Resolved(callee_key) => {
+                if path.contains(callee_key) {
+                    let f =
+                        visitor.recursion(key, edge, callee_key, emit);
+                    total = visitor.combine(total, f);
+                    continue;
+                }
+                if in_loop {
+                    let sub = walk_inner(
+                        summary, callee_key, visitor, path, steps, false,
+                    );
+                    if !visitor.is_zero(&sub) {
+                        let f = visitor
+                            .loop_call(key, edge, callee_key, sub, emit);
+                        total = visitor.combine(total, f);
+                    }
+                } else {
+                    let sub = walk_inner(
+                        summary, callee_key, visitor, path, steps, emit,
+                    );
+                    total = visitor.combine(total, sub);
+                }
+            }
+            Callee::Unresolved(name) => {
+                let f =
+                    visitor.unresolved(key, edge, name, in_loop, emit);
+                total = visitor.combine(total, f);
+            }
+        }
+    }
+    path.pop();
+    total
+}
+
+/// One step of a witness path: the fn whose body contains the hop,
+/// and the span of the site/edge that continues (or ends) the chain.
+#[derive(Debug, Clone)]
+pub struct WitnessStep {
+    pub in_fn: FnKey,
+    pub span: Span,
+    /// Human label: the callee display name for interior hops, or
+    /// the predicate's own label for the leaf.
+    pub label: String,
+}
+
+/// What [`witness_path`] tests at each traversal event.
+pub enum Probe<'a> {
+    /// An allocation site in the current fn's body.
+    Site(&'a AllocSite),
+    /// An unresolved callee by name (the classified frontier).
+    Unresolved(&'a str, &'a CallEdge),
+}
+
+/// The #265 primitive: the FIRST chain of calls from `root` to a
+/// site/unresolved-callee satisfying `pred` (which returns the leaf's
+/// label), as renderable steps. `None` when nothing reachable
+/// matches. Depth-first in summary order, ancestor cycles skipped —
+/// deterministic for stable summaries.
+pub fn witness_path(
+    summary: &AllocSummary,
+    root: &FnKey,
+    pred: &mut dyn FnMut(&Probe<'_>) -> Option<String>,
+) -> Option<Vec<WitnessStep>> {
+    let mut path = Vec::new();
+    let mut steps = 0u32;
+    witness_inner(summary, root, pred, &mut path, &mut steps)
+}
+
+fn witness_inner(
+    summary: &AllocSummary,
+    key: &FnKey,
+    pred: &mut dyn FnMut(&Probe<'_>) -> Option<String>,
+    path: &mut Vec<FnKey>,
+    steps: &mut u32,
+) -> Option<Vec<WitnessStep>> {
+    let fs = summary.fns.get(key)?;
+    for site in &fs.sites {
+        *steps += 1;
+        if *steps > MAX_STEPS {
+            return None;
+        }
+        if let Some(label) = pred(&Probe::Site(site)) {
+            return Some(vec![WitnessStep {
+                in_fn: key.clone(),
+                span: site.span,
+                label,
+            }]);
+        }
+    }
+    path.push(key.clone());
+    for edge in &fs.calls {
+        *steps += 1;
+        if *steps > MAX_STEPS {
+            break;
+        }
+        match &edge.callee {
+            Callee::Resolved(callee_key) => {
+                if path.contains(callee_key) {
+                    continue;
+                }
+                if let Some(mut tail) =
+                    witness_inner(summary, callee_key, pred, path, steps)
+                {
+                    let mut out = vec![WitnessStep {
+                        in_fn: key.clone(),
+                        span: edge.span,
+                        label: callee_key.display(),
+                    }];
+                    out.append(&mut tail);
+                    path.pop();
+                    return Some(out);
+                }
+            }
+            Callee::Unresolved(name) => {
+                if let Some(label) = pred(&Probe::Unresolved(name, edge))
+                {
+                    path.pop();
+                    return Some(vec![WitnessStep {
+                        in_fn: key.clone(),
+                        span: edge.span,
+                        label,
+                    }]);
+                }
+            }
+        }
+    }
+    path.pop();
+    None
+}
+
+/// Render a witness chain as `root -> hop -> hop [leaf-label]` — the
+/// diagnostic shape #265 specifies.
+pub fn render_witness(root: &FnKey, steps: &[WitnessStep]) -> String {
+    let mut s = root.display();
+    for (i, st) in steps.iter().enumerate() {
+        if i + 1 == steps.len() {
+            s.push_str(&format!(" [{}]", st.label));
+        } else {
+            s.push_str(&format!(" -> {}", st.label));
+        }
+    }
+    s
+}

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -24,6 +24,7 @@
 pub mod alloc_summary;
 pub mod budget_check;
 pub mod bus_graph;
+pub mod callgraph;
 pub mod check;
 pub mod stdlib_surface;
 pub mod ownership_graph;

--- a/crates/hale-types/src/purity.rs
+++ b/crates/hale-types/src/purity.rs
@@ -65,22 +65,12 @@ pub enum Impurity {
     ImpureCalleeCall { callee_name: String, span: Span },
 }
 
-/// Identifies a fn for purity lookup. Free fns have `locus: None`;
-/// locus methods carry the enclosing locus's name.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct PurityKey {
-    pub locus: Option<String>,
-    pub fn_name: String,
-}
-
-impl PurityKey {
-    pub fn free_fn(name: impl Into<String>) -> Self {
-        Self { locus: None, fn_name: name.into() }
-    }
-    pub fn method(locus: impl Into<String>, name: impl Into<String>) -> Self {
-        Self { locus: Some(locus.into()), fn_name: name.into() }
-    }
-}
+/// Identifies a fn for purity lookup. R1 (2026-07-29): this was a
+/// byte-identical duplicate of `alloc_summary::FnKey` — the walkers
+/// are converging on one key type (see `crate::callgraph`), so
+/// purity now shares it. `free_fn` / `method` constructors come
+/// with it.
+pub use crate::alloc_summary::FnKey as PurityKey;
 
 /// Bundle-wide purity result keyed by [`PurityKey`].
 pub type PurityMap = BTreeMap<PurityKey, Purity>;

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -1,6 +1,15 @@
 //! Typecheck M3 stage 1 (2026-07-02): the stdlib path-call NAME
 //! surface — typo detection for `std::<ns>::<fn>(...)` calls.
 //!
+//! R2 (2026-07-29): this table is becoming THE stdlib registry —
+//! the single row per fn that the four parallel structures (this
+//! surface, `signature_for`, the codegen dispatch arms, the docs)
+//! converge on. Each entry now carries an [`EffectSet`] column:
+//! the classified frontier #265's effect assertions query. Every
+//! entry starts `UNCLASSIFIED`; #265 step 4 classifies the
+//! surface, after which an unclassified entry becomes a build
+//! error (the "frontier stays true forever" discipline).
+//!
 //! Names only, deliberately: a wrong name entry here produces a
 //! cheap, obvious false "unknown stdlib function" that's fixed by
 //! adding the name; a wrong SIGNATURE entry (stage 2) produces an
@@ -157,14 +166,58 @@ impl FnSig {
 }
 
 /// One namespace's accepted surface.
+/// R2/#265: one effect-class bitmask per stdlib fn — the leaf
+/// lattice of the effect-assertion engine (`crate::callgraph`).
+/// Const-constructible so the registry stays a static table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EffectSet(pub u32);
+
+impl EffectSet {
+    pub const PURE: EffectSet = EffectSet(0);
+    pub const SYSCALL: EffectSet = EffectSet(1 << 0);
+    pub const BLOCK: EffectSet = EffectSet(1 << 1);
+    pub const PUBLISH: EffectSet = EffectSet(1 << 2);
+    pub const TIME: EffectSet = EffectSet(1 << 3);
+    pub const ENTROPY: EffectSet = EffectSet(1 << 4);
+    pub const ENV: EffectSet = EffectSet(1 << 5);
+    pub const ALLOC: EffectSet = EffectSet(1 << 6);
+    /// Not yet classified (#265 step 4 turns the surface; until
+    /// then queries must treat this as "may do anything").
+    pub const UNCLASSIFIED: EffectSet = EffectSet(u32::MAX);
+
+    pub const fn union(self, o: EffectSet) -> EffectSet {
+        EffectSet(self.0 | o.0)
+    }
+    pub fn contains(self, o: EffectSet) -> bool {
+        (self.0 & o.0) == o.0
+    }
+    pub fn is_unclassified(self) -> bool {
+        self.0 == u32::MAX
+    }
+}
+
+/// One registry row: the fn name plus its effect classification.
+#[derive(Debug, Clone, Copy)]
+pub struct FnEntry {
+    pub name: &'static str,
+    pub effects: EffectSet,
+}
+
+/// Row constructor for the (current) unclassified default — keeps
+/// the table visually close to the old bare-name lists.
+const fn f(name: &'static str) -> FnEntry {
+    FnEntry { name, effects: EffectSet::UNCLASSIFIED }
+}
+
 pub struct NsSurface {
     /// Path segments after `std` identifying the namespace
     /// (e.g. `["io", "fs"]` for `std::io::fs`). Longest match wins,
     /// so `std::io::fs` shadows a hypothetical `std::io` table for
     /// three-segment paths.
     pub ns: &'static [&'static str],
-    /// Accepted function names within the namespace.
-    pub fns: &'static [&'static str],
+    /// Accepted functions within the namespace (name + effect
+    /// classification).
+    pub fns: &'static [FnEntry],
     /// Prefixes the dispatch accepts open-endedly (rare). A name
     /// starting with one of these passes without being listed.
     pub open_prefixes: &'static [&'static str],
@@ -251,280 +304,280 @@ pub const SURFACES: &[NsSurface] = &[
     NsSurface {
         ns: &["bus"],
         fns: &[
-            "__local_dispatch",
+            f("__local_dispatch"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["bytes"],
         fns: &[
-            "__is_alloc_fail", "at", "clone", "concat", "find_byte",
-            "from_int", "from_string", "read_f32_le", "read_f64_be",
-            "read_f64_le", "read_i16_be", "read_i16_le", "read_i32_be",
-            "read_i32_le", "read_i64_be", "read_i64_le", "read_i8",
-            "read_u16_be", "read_u16_le", "read_u32_be", "read_u32_le",
-            "read_u64_be", "read_u64_le", "read_u8", "slice",
-            "write_f32_le", "write_f64_be", "write_f64_le", "write_i16_be",
-            "write_i16_le", "write_i32_be", "write_i32_le", "write_i64_be",
-            "write_i64_le", "write_i8", "write_u16_be", "write_u16_le",
-            "write_u32_be", "write_u32_le", "write_u64_be", "write_u64_le",
-            "write_u8",
+            f("__is_alloc_fail"), f("at"), f("clone"), f("concat"), f("find_byte"),
+            f("from_int"), f("from_string"), f("read_f32_le"), f("read_f64_be"),
+            f("read_f64_le"), f("read_i16_be"), f("read_i16_le"), f("read_i32_be"),
+            f("read_i32_le"), f("read_i64_be"), f("read_i64_le"), f("read_i8"),
+            f("read_u16_be"), f("read_u16_le"), f("read_u32_be"), f("read_u32_le"),
+            f("read_u64_be"), f("read_u64_le"), f("read_u8"), f("slice"),
+            f("write_f32_le"), f("write_f64_be"), f("write_f64_le"), f("write_i16_be"),
+            f("write_i16_le"), f("write_i32_be"), f("write_i32_le"), f("write_i64_be"),
+            f("write_i64_le"), f("write_i8"), f("write_u16_be"), f("write_u16_le"),
+            f("write_u32_be"), f("write_u32_le"), f("write_u64_be"), f("write_u64_le"),
+            f("write_u8"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["bytes", "builder"],
         fns: &[
-            "__append", "__append_f32", "__append_f64", "__append_pad",
-            "__append_scalar", "__append_slice", "__append_str", "__clear",
-            "__finish", "__free", "__len", "__new", "__shift_front",
-            "__snapshot", "__text_view", "__view", "__xor_mask_into",
+            f("__append"), f("__append_f32"), f("__append_f64"), f("__append_pad"),
+            f("__append_scalar"), f("__append_slice"), f("__append_str"), f("__clear"),
+            f("__finish"), f("__free"), f("__len"), f("__new"), f("__shift_front"),
+            f("__snapshot"), f("__text_view"), f("__view"), f("__xor_mask_into"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["tar"],
         fns: &[
-            "entries", "entry_data", "entry_name", "entry_size",
-            "entry_type", "finish", "pack", "pack_dir",
+            f("entries"), f("entry_data"), f("entry_name"), f("entry_size"),
+            f("entry_type"), f("finish"), f("pack"), f("pack_dir"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["compress"],
         fns: &[
-            "gunzip", "gzip", "unzstd", "zstd",
+            f("gunzip"), f("gzip"), f("unzstd"), f("zstd"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["crypto"],
         fns: &[
-            "crc32", "ecdsa_p256_sign", "ecdsa_p256_verify", "hmac_sha256",
-            "hmac_sha512", "sha1", "sha256", "sha512",
+            f("crc32"), f("ecdsa_p256_sign"), f("ecdsa_p256_verify"), f("hmac_sha256"),
+            f("hmac_sha512"), f("sha1"), f("sha256"), f("sha512"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["ring"],
         fns: &[
-            "__spsc_emit",
-            "__spsc_init",
-            "__spsc_note_drop",
-            "__spsc_read",
-            "__spsc_set_tag_b",
+            f("__spsc_emit"),
+            f("__spsc_init"),
+            f("__spsc_note_drop"),
+            f("__spsc_read"),
+            f("__spsc_set_tag_b"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["decimal"],
         fns: &[
-            "format",
-            "to_float",
+            f("format"),
+            f("to_float"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["diag"],
         fns: &[
-            "heap_alloc_count", "syscall_count",
+            f("heap_alloc_count"), f("syscall_count"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["env"],
         fns: &[
-            "arg", "arg_or", "args_count", "var", "var_exists",
+            f("arg"), f("arg_or"), f("args_count"), f("var"), f("var_exists"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["http"],
         fns: &[
-            "get", "header", "parse_request", "parse_url", "path_param",
-            "post", "query_param", "request", "write_response",
+            f("get"), f("header"), f("parse_request"), f("parse_url"), f("path_param"),
+            f("post"), f("query_param"), f("request"), f("write_response"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["io", "file"],
         fns: &[
-            "__at_eof", "__close", "__open", "__read_line", "__seek",
-            "__write_bytes", "at_eof", "open", "read_line", "seek",
-            "write_bytes", "write_line",
+            f("__at_eof"), f("__close"), f("__open"), f("__read_line"), f("__seek"),
+            f("__write_bytes"), f("at_eof"), f("open"), f("read_line"), f("seek"),
+            f("write_bytes"), f("write_line"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["io", "fs"],
         fns: &[
-            "extension", "file_exists", "file_size", "list_dir",
-            "list_dir_at", "list_dir_count", "mkdir", "mktemp",
-            "read_bytes", "read_file", "rename", "unlink", "write_bytes",
-            "write_file",
-            "write_file_append",
+            f("extension"), f("file_exists"), f("file_size"), f("list_dir"),
+            f("list_dir_at"), f("list_dir_count"), f("mkdir"), f("mktemp"),
+            f("read_bytes"), f("read_file"), f("rename"), f("unlink"), f("write_bytes"),
+            f("write_file"),
+            f("write_file_append"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["io", "stdin"],
         fns: &[
-            "read_byte", "read_line", "read_line_status",
+            f("read_byte"), f("read_line"), f("read_line_status"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["io", "stdout"],
         fns: &[
-            "write_bytes",
+            f("write_bytes"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["io", "tcp"],
         fns: &[
-            "__accept_one", "__close_fd", "__connect", "__io_error_kind",
-            "__last_io_status", "__listen_socket",
-            "__recv", "__recv_bytes", "__send", "__send_bytes",
-            "__set_recv_timeout_ns", "__shutdown_listen_socket",
-            "accept_one", "close_fd", "connect", "last_recv_kernel_ns",
-            "last_recv_user_ns", "listen_socket", "recv_into",
-            "recv_stamped_into", "send_fd", "set_nodelay",
-            "set_recv_timeout", "set_rx_timestamps", "set_send_timeout",
+            f("__accept_one"), f("__close_fd"), f("__connect"), f("__io_error_kind"),
+            f("__last_io_status"), f("__listen_socket"),
+            f("__recv"), f("__recv_bytes"), f("__send"), f("__send_bytes"),
+            f("__set_recv_timeout_ns"), f("__shutdown_listen_socket"),
+            f("accept_one"), f("close_fd"), f("connect"), f("last_recv_kernel_ns"),
+            f("last_recv_user_ns"), f("listen_socket"), f("recv_into"),
+            f("recv_stamped_into"), f("send_fd"), f("set_nodelay"),
+            f("set_recv_timeout"), f("set_rx_timestamps"), f("set_send_timeout"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["io", "tls"],
         fns: &[
-            "close", "connect", "last_recv_kernel_ns", "last_recv_user_ns",
-            "recv_bytes", "recv_into", "recv_stamped_into", "send_bytes",
-            "set_nodelay", "set_recv_timeout", "set_rx_timestamps",
-            "set_send_timeout", "upgrade",
+            f("close"), f("connect"), f("last_recv_kernel_ns"), f("last_recv_user_ns"),
+            f("recv_bytes"), f("recv_into"), f("recv_stamped_into"), f("send_bytes"),
+            f("set_nodelay"), f("set_recv_timeout"), f("set_rx_timestamps"),
+            f("set_send_timeout"), f("upgrade"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["io", "udp"],
         fns: &[
-            "__bind", "__close", "__recv", "__send", "bind", "close",
-            "get_option_int", "join_group", "last_source_host",
-            "last_source_port", "leave_group", "recv", "recv_into",
-            "recv_with_source", "send", "set_multicast_iface",
-            "set_multicast_loop", "set_multicast_ttl", "set_option_bool",
-            "set_option_int", "set_recv_timeout", "set_send_timeout",
+            f("__bind"), f("__close"), f("__recv"), f("__send"), f("bind"), f("close"),
+            f("get_option_int"), f("join_group"), f("last_source_host"),
+            f("last_source_port"), f("leave_group"), f("recv"), f("recv_into"),
+            f("recv_with_source"), f("send"), f("set_multicast_iface"),
+            f("set_multicast_loop"), f("set_multicast_ttl"), f("set_option_bool"),
+            f("set_option_int"), f("set_recv_timeout"), f("set_send_timeout"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["json"],
         fns: &[
-            "array_first", "array_first_span", "array_next",
-            "array_next_span", "escape_string", "find_bool_field",
-            "find_field_range_in", "find_field_raw", "find_field_raw_in",
-            "find_int_field", "find_string_field", "iter_find_bool_field",
-            "iter_find_field_range", "iter_find_field_raw",
-            "iter_find_int_field", "iter_find_string_field",
-            "iter_find_string_field_range", "iter_substring",
-            "next_non_ws", "next_quote_or_bs", "next_struct_or_quote",
-            "obj_key_eq", "obj_key_len", "obj_key_string", "obj_value_bool",
-            "obj_value_float", "obj_value_int", "obj_value_raw",
-            "obj_value_string", "object_first", "object_next",
-            "unescape_string",
+            f("array_first"), f("array_first_span"), f("array_next"),
+            f("array_next_span"), f("escape_string"), f("find_bool_field"),
+            f("find_field_range_in"), f("find_field_raw"), f("find_field_raw_in"),
+            f("find_int_field"), f("find_string_field"), f("iter_find_bool_field"),
+            f("iter_find_field_range"), f("iter_find_field_raw"),
+            f("iter_find_int_field"), f("iter_find_string_field"),
+            f("iter_find_string_field_range"), f("iter_substring"),
+            f("next_non_ws"), f("next_quote_or_bs"), f("next_struct_or_quote"),
+            f("obj_key_eq"), f("obj_key_len"), f("obj_key_string"), f("obj_value_bool"),
+            f("obj_value_float"), f("obj_value_int"), f("obj_value_raw"),
+            f("obj_value_string"), f("object_first"), f("object_next"),
+            f("unescape_string"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["math"],
         fns: &[
-            "acos", "asin", "atan", "atan2", "ceil", "cos", "exp",
-            "float_to_int", "floor", "inf", "int_to_float", "is_nan",
-            "log", "nan", "pow", "round", "sin", "sqrt", "tan", "tanh",
-            "trunc",
+            f("acos"), f("asin"), f("atan"), f("atan2"), f("ceil"), f("cos"), f("exp"),
+            f("float_to_int"), f("floor"), f("inf"), f("int_to_float"), f("is_nan"),
+            f("log"), f("nan"), f("pow"), f("round"), f("sin"), f("sqrt"), f("tan"), f("tanh"),
+            f("trunc"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["os"],
         fns: &[
-            "getrandom",
+            f("getrandom"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["process"],
         fns: &[
-            "__kill_escalate", "__pipe_read", "__pipe_write",
-            "__signal_pid", "__spawn", "__try_wait_pid", "__wait_pid",
-            "dump_arena_residency", "dump_pool_residency",
-            "exit", "kill", "pid", "read_stderr", "read_stdout",
-            "rss_bytes", "run", "signal", "spawn", "try_wait", "wait",
-            "write_stdin",
+            f("__kill_escalate"), f("__pipe_read"), f("__pipe_write"),
+            f("__signal_pid"), f("__spawn"), f("__try_wait_pid"), f("__wait_pid"),
+            f("dump_arena_residency"), f("dump_pool_residency"),
+            f("exit"), f("kill"), f("pid"), f("read_stderr"), f("read_stdout"),
+            f("rss_bytes"), f("run"), f("signal"), f("spawn"), f("try_wait"), f("wait"),
+            f("write_stdin"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["metrics"],
         fns: &[
-            "counter", "gauge", "histogram", "labels_append",
-            "labels_empty", "labels_one", "labels_two", "metric_key",
+            f("counter"), f("gauge"), f("histogram"), f("labels_append"),
+            f("labels_empty"), f("labels_one"), f("labels_two"), f("metric_key"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["rand"],
         fns: &[
-            "next_int", "seed_from_time",
+            f("next_int"), f("seed_from_time"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["str"],
         fns: &[
-            "builder_append", "builder_finish", "builder_len",
-            "builder_new", "byte_at_unchecked", "can_parse_decimal",
-            "can_parse_float", "can_parse_int", "clone", "from_bytes",
-            "index_of", "lower", "pad_left", "pad_right", "parse_decimal",
-            "parse_float", "parse_int", "range_eq", "range_parse_decimal",
-            "range_parse_int", "repeat", "replace", "substring", "trim",
-            "upper",
+            f("builder_append"), f("builder_finish"), f("builder_len"),
+            f("builder_new"), f("byte_at_unchecked"), f("can_parse_decimal"),
+            f("can_parse_float"), f("can_parse_int"), f("clone"), f("from_bytes"),
+            f("index_of"), f("lower"), f("pad_left"), f("pad_right"), f("parse_decimal"),
+            f("parse_float"), f("parse_int"), f("range_eq"), f("range_parse_decimal"),
+            f("range_parse_int"), f("repeat"), f("replace"), f("substring"), f("trim"),
+            f("upper"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["term"],
         fns: &[
-            "__raw_disable", "__raw_enable", "__size_packed", "is_tty",
-            "size",
+            f("__raw_disable"), f("__raw_enable"), f("__size_packed"), f("is_tty"),
+            f("size"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["test"],
         fns: &[
-            "assert", "assert_eq_int", "assert_eq_str",
+            f("assert"), f("assert_eq_int"), f("assert_eq_str"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["text"],
         fns: &[
-            "is_alnum", "is_alpha", "is_digit", "is_whitespace",
-            "is_word_char", "md_to_html", "tokenize_words_into",
+            f("is_alnum"), f("is_alpha"), f("is_digit"), f("is_whitespace"),
+            f("is_word_char"), f("md_to_html"), f("tokenize_words_into"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["text", "base64"],
         fns: &[
-            "decode", "encode", "url_encode",
+            f("decode"), f("encode"), f("url_encode"),
         ],
         open_prefixes: &[],
     },
     NsSurface {
         ns: &["time"],
         fns: &[
-            "monotonic", "monotonic_ns", "now", "sleep", "time_from_unix",
+            f("monotonic"), f("monotonic_ns"), f("now"), f("sleep"), f("time_from_unix"),
         ],
         open_prefixes: &[],
     },
@@ -562,7 +615,8 @@ pub fn is_locus_path(segs: &[&str]) -> bool {
 /// the name length (a distance-2 match on a 3-char name is noise).
 pub fn suggest(surface: &NsSurface, name: &str) -> Option<&'static str> {
     let mut best: Option<(&'static str, usize)> = None;
-    for cand in surface.fns {
+    for entry in surface.fns {
+        let cand = &entry.name;
         let d = edit_distance(name, cand);
         match best {
             Some((_, bd)) if bd <= d => {}
@@ -628,7 +682,7 @@ pub fn unknown_fn_error(segs: &[&str]) -> Option<String> {
     }
     let (surface, fn_idx) = lookup(segs)?;
     let name = segs[fn_idx];
-    if surface.fns.contains(&name) {
+    if surface.fns.iter().any(|e| e.name == name) {
         return None;
     }
     if surface
@@ -933,3 +987,28 @@ pub const SIGS: &[FnSig] = &[
     sig!(NS_DIAG, "syscall_count", [Str], Int),
     sig!(NS_OS, "getrandom", [Int], Bytes, "IoError"),
 ];
+
+
+/// R2/#265: the effect classification for a fully-qualified stdlib
+/// path (`["std", ns.., fn]`), or None when the path isn't in the
+/// registry. UNCLASSIFIED entries are exactly that — the caller
+/// must treat them as may-do-anything until #265 classifies the
+/// surface.
+pub fn effects_for(segs: &[&str]) -> Option<EffectSet> {
+    if segs.len() < 2 || segs[0] != "std" {
+        return None;
+    }
+    let (ns_segs, name) = (&segs[1..segs.len() - 1], segs[segs.len() - 1]);
+    let surface = SURFACES
+        .iter()
+        .filter(|s| {
+            s.ns.len() == ns_segs.len()
+                && s.ns.iter().zip(ns_segs).all(|(a, b)| a == b)
+        })
+        .next()?;
+    surface
+        .fns
+        .iter()
+        .find(|e| e.name == name)
+        .map(|e| e.effects)
+}

--- a/crates/hale-types/tests/callgraph_witness.rs
+++ b/crates/hale-types/tests/callgraph_witness.rs
@@ -1,0 +1,78 @@
+//! R1 — the path-carrying reachability primitive (#265 step 1).
+//!
+//! `budget_check`'s fixpoint could tell you a fn allocates; it could
+//! not tell you HOW the allocation is reached. `callgraph::
+//! witness_path` returns the call chain — the diagnostic shape #265
+//! specifies (`on_tick -> format_px -> lotus_str_builder_finish
+//! [alloc]`). This pins: a two-hop chain through a helper, the
+//! renderer, and the negative (nothing reachable matches).
+
+use hale_types::alloc_summary::{self, FnKey};
+use hale_types::callgraph::{self, Probe};
+
+const SRC: &str = r#"
+    type P { x: Int; }
+
+    fn leaf_alloc() -> P {
+        return P { x: 1 };
+    }
+
+    fn mid() -> P {
+        return leaf_alloc();
+    }
+
+    fn root() -> P {
+        return mid();
+    }
+
+    fn clean(n: Int) -> Int {
+        return n + 1;
+    }
+
+    fn main() {
+        let p = root();
+        let c = clean(2);
+        println(p.x + c);
+    }
+"#;
+
+#[test]
+fn witness_path_carries_the_call_chain() {
+    let program = hale_syntax::parse_source(SRC).expect("parse");
+    let summary = alloc_summary::summarize_programs(&[&program]);
+
+    let root = FnKey::free_fn("root");
+    let path = callgraph::witness_path(
+        &summary,
+        &root,
+        &mut |probe| match probe {
+            Probe::Site(_) => Some("alloc".to_string()),
+            Probe::Unresolved(..) => None,
+        },
+    )
+    .expect("an alloc is reachable from root");
+
+    // root's body -> mid -> leaf_alloc [alloc]
+    let rendered = callgraph::render_witness(&root, &path);
+    assert_eq!(rendered, "root -> mid -> leaf_alloc [alloc]");
+    // Every interior step names the fn whose body holds the hop.
+    assert_eq!(path[0].in_fn, FnKey::free_fn("root"));
+    assert_eq!(path[1].in_fn, FnKey::free_fn("mid"));
+    assert_eq!(path[2].in_fn, FnKey::free_fn("leaf_alloc"));
+}
+
+#[test]
+fn witness_path_negative_when_nothing_matches() {
+    let program = hale_syntax::parse_source(SRC).expect("parse");
+    let summary = alloc_summary::summarize_programs(&[&program]);
+    let root = FnKey::free_fn("clean");
+    let path = callgraph::witness_path(
+        &summary,
+        &root,
+        &mut |probe| match probe {
+            Probe::Site(_) => Some("alloc".to_string()),
+            Probe::Unresolved(..) => None,
+        },
+    );
+    assert!(path.is_none(), "clean must reach no allocation site");
+}

--- a/crates/hale-types/tests/callgraph_witness.rs
+++ b/crates/hale-types/tests/callgraph_witness.rs
@@ -76,3 +76,18 @@ fn witness_path_negative_when_nothing_matches() {
     );
     assert!(path.is_none(), "clean must reach no allocation site");
 }
+
+/// R2 — the registry's effect column is queryable by path; every
+/// entry is UNCLASSIFIED until #265 classifies the surface.
+#[test]
+fn stdlib_registry_effects_lookup() {
+    use hale_types::stdlib_surface::{effects_for, EffectSet};
+    let e = effects_for(&["std", "crypto", "sha256"])
+        .expect("sha256 in registry");
+    assert!(e.is_unclassified());
+    assert_eq!(effects_for(&["std", "crypto", "sha9000"]), None);
+    assert_eq!(
+        effects_for(&["std", "time", "sleep"]),
+        Some(EffectSet::UNCLASSIFIED)
+    );
+}


### PR DESCRIPTION
Five behavior-neutral refactors positioning the codebase for #265 (effect assertions) and #262 (deployment elaboration), one commit each. Full workspace suite (1847/1847) + the dispatch bench gate every piece.

## R1 — `hale-types::callgraph` (#265 step 1 as a refactor)
The shared, witness-path-preserving call-graph engine, extracted verbatim from `budget_check`'s DFS (ancestor-stack recursion detection, loop-context propagation, per-reaching-path diamond counting, step cap). `budget_check` is the first ported customer — diagnostics byte-identical, its tests pin the text. `witness_path`/`render_witness` add the primitive the fixpoint never had: the call chain to a violation in #265's diagnostic shape (`root -> mid -> leaf_alloc [alloc]`, pinned by `callgraph_witness.rs`). `PurityKey` (a byte-identical duplicate of `alloc_summary::FnKey`) is now a re-export. Follow-on customers: purity's worklist, check.rs's blocking finder.

## R2 — `stdlib_surface` becomes the stdlib registry
The fn surface lived as four hand-agreeing structures (surface lists, `signature_for`, codegen arms, docs) — adding one fn touched three files; builtin-only namespaces were invisible to search (Crumb 4-3/5-2). The lists are now structured `FnEntry` rows carrying an `EffectSet` column — the single place #265's frontier classification lives, with `effects_for(path)` as the query hook. Everything starts `UNCLASSIFIED`; when #265 classifies the surface that flips to a build error.

## R3 — `DeploymentPlan` (the #262 seed artifact)
The committed arrangement (placement, NUMA nodes, pools, async_io set, pinned/pool locus types, main locus name) was seven loose Cx fields; #262 is premised on it being a *value* — constructible, verifiable, submittable, diffable. It's now one `Debug`-renderable struct on Cx; collect + consumers unchanged semantically. Not yet folded in (documented): bindings, topology domains, replicas.

## R4 — `lotus_bus_post_entry` (kills the "missed siblings" class)
The mailbox/coop_pool/queue routing triple was hand-copied at 11 dispatch sites — the structural cause of P5/P11/P13/P14/P15/P17 across five releases. Nine sites now route through one static-inline helper; the two exceptions (`_st` no-pinned fast path, the direct flavor's same-thread call) are annotated with pointers at the helper. Dispatch bench unchanged (~173µs dormant).

## R6 — one obs-segment reader for tests
Three test files carried drifting copies of the PROTOCOL v0.1 decode (one decoded BUS w1 with the emitter's own wrong layout for four releases — handoff-7). `tests/support/obs.rs` is the single copy; the protocol.h-vendored decodes live exactly there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)