### PR TITLE
fix(obs): light the adapter ingest path — the last dark ingestion path (iris handoff-8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ behavior.
 
 ## Unreleased
 
+- **The adapter ingest path carries the full observation trio**
+  (iris handoff-8 P21 — "the last dark ingestion path"). The
+  Hale-owned-wire ingest (`std::bus::__local_dispatch`) emitted no
+  NET_DELIVER and its fanout no per-target BUS_DELIVER — a
+  dynamically-subscribed plane was invisible (zero `net<`, zero
+  dlv) while the same segment's statically-configured listens
+  paired fully. The inbound wrapper now peels the magic-guarded
+  obs wire header when present (which also FIXES headered
+  datagrams reaching a Hale adapter — they previously failed
+  deserialization), emits NET_DELIVER echoing the wire
+  (origin, seq), and plain `dispatch_wire` gains the per-target
+  BUS_DELIVER its keyed sibling got in v0.11.18. Pinned by a
+  two-process producer→adapter-consumer test asserting paired
+  net records, attributed deliveries, and published == 0.
+
+- iris handoff-8 P20 (remote-only publishes show CT_PUBLISHED=0)
+  **did not reproduce** on any of four flavors (adapter binding,
+  udp config, framed transport, keyed) — the counter is correct on
+  all; likely a carry from the pre-v0.11.15 keyed-probe-gap era.
+  The keyed+udp shape is pinned as a regression test.
+
 - **Refactor batch (R1/R2/R3/R4/R6) — the substrate for #265 and
   #262.** Behavior-neutral; full workspace suite + the dispatch
   bench gate every piece.

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -5580,6 +5580,11 @@ int lotus_obs_active(void) __attribute__((weak));
  * so the published counter isn't inflated by deliveries. */
 void lotus_obs_begin_redispatch(void) __attribute__((weak));
 void lotus_obs_end_redispatch(void) __attribute__((weak));
+/* iris handoff-8 P21: adapter-ingest NET_DELIVER (binding dedupe +
+ * counters + record live in the obs TU). */
+void lotus_obs_adapter_net_deliver(const char *subject, uint64_t origin,
+                                   uint64_t seq, uint64_t bytes)
+    __attribute__((weak));
 /* iris handoff-3 P11: observation seq header on the UDP wire.
  * Self-describing so a headerless (unobserved / older) sender is
  * still delivered correctly — the reader checks the magic and a
@@ -14587,6 +14592,13 @@ void lotus_bus_dispatch_wire(const char *subject,
             (void)lotus_bus_post_entry(e, g_bus_queue_for_remote,
                 wire_bytes, wire_size);
             g_bus_pending_wire_deser = NULL;
+            /* handoff-8 P21: BUS_DELIVER per matched target — the
+             * plain wire flavor was the one fanout without it (its
+             * keyed sibling gained the probe in handoff-4). */
+            if (lotus_obs_bus_deliver) {
+                lotus_obs_bus_deliver(subject, e->self_ptr,
+                                      (uint64_t)wire_size);
+            }
             delivered++;
             continue;
         }
@@ -14608,24 +14620,14 @@ void lotus_bus_dispatch_wire(const char *subject,
             }
             continue;
         }
-        if (e->mailbox) {
-            lotus_mailbox_post(
-                e->mailbox, e->handler, e->self_ptr,
-                struct_buf, (size_t)struct_size);
-            delivered++;
-        } else if (e->coop_pool) {
-            /* F.31 Phase 4 (2026-05-28): same fix as the keyed
-             * variant above — wire-dispatch was missing the
-             * coop_pool branch that lotus_bus_local_dispatch ships
-             * with, so subscribers on non-main cooperative pools
-             * silently routed to the global queue. */
-            lotus_coop_pool_post(e->coop_pool, e->handler, e->self_ptr,
-                                 struct_buf, (size_t)struct_size);
-            delivered++;
-        } else if (g_bus_queue_for_remote) {
-            lotus_bus_queue_enqueue(
-                g_bus_queue_for_remote, e->handler, e->self_ptr,
-                struct_buf, (size_t)struct_size);
+        if (lotus_bus_post_entry(e, g_bus_queue_for_remote,
+                                 struct_buf, (size_t)struct_size)) {
+            /* handoff-8 P21: BUS_DELIVER per matched target (see the
+             * cross-thread branch above). */
+            if (lotus_obs_bus_deliver) {
+                lotus_obs_bus_deliver(subject, e->self_ptr,
+                                      (uint64_t)wire_size);
+            }
             delivered++;
         } else if (lotus_bus_log_drop_enabled()) {
             fprintf(stderr,
@@ -19219,7 +19221,37 @@ int lotus_math_is_nan(double f) {
 void lotus_bus_dispatch_wire_inbound(const char *subject,
                                      const void *wire_bytes,
                                      size_t wire_size) {
+    /* iris handoff-8 P21: the last dark ingestion path. Peel the
+     * self-describing obs wire header when the producer emitted one
+     * (a C-fanout sender under LOTUS_OBS_WIRE=1) and echo its
+     * (origin, seq) into NET_DELIVER so adapter-ingested messages
+     * pair into cross-process edges exactly like the C reader's.
+     * Headerless bytes probe with (0, local seq) — countable, not
+     * pairable, the non-framed-transport contract. The peel is
+     * magic-guarded, so non-Hale and unobserved producers are
+     * byte-for-byte unaffected; it also FIXES the previously-broken
+     * case of headered bytes reaching a Hale adapter (deserialize
+     * saw 16 stray bytes and dropped). */
+    const unsigned char *b = (const unsigned char *)wire_bytes;
+    size_t sz = wire_size;
+    uint64_t origin = 0, seq = 0;
+    if (sz >= 16) {
+        uint64_t magic;
+        memcpy(&magic, b, 8);
+        if (magic == LOTUS_OBS_WIRE_MAGIC) {
+            uint64_t w;
+            memcpy(&w, b + 8, 8);
+            origin = w & 0xFFFFULL;
+            seq = (w >> 16) & 0xFFFFFFFFFFFFULL;
+            b += 16;
+            sz -= 16;
+        }
+    }
+    if (lotus_obs_adapter_net_deliver) {
+        lotus_obs_adapter_net_deliver(subject, origin, seq,
+                                      (uint64_t)sz);
+    }
     if (lotus_obs_begin_redispatch) lotus_obs_begin_redispatch();
-    lotus_bus_dispatch_wire(subject, wire_bytes, wire_size);
+    lotus_bus_dispatch_wire(subject, b, sz);
     if (lotus_obs_end_redispatch) lotus_obs_end_redispatch();
 }

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -713,6 +713,67 @@ void lotus_obs_net_deliver(const char *subject, int64_t binding_id,
                | ((seq & 0xFFFFFFFFFFFFULL) << 16));
 }
 
+/* iris handoff-8 P21: the adapter (Hale-owned-wire) ingest probe.
+ * The C reader threads cache their obs binding id on the transport
+ * entry struct; adapter inbound has no such struct, so the dedupe
+ * cache lives here: subject -> (binding id, local seq). Called once
+ * per inbound message from lotus_bus_dispatch_wire_inbound with the
+ * wire (origin, seq) when the self-describing obs header was
+ * present, or (0, 0) when headerless — the local per-subject
+ * counter then supplies a monotonic seq so per-binding counting
+ * still works (it just won't cross-process pair, same contract as
+ * a non-framed transport). */
+typedef struct {
+  char *subject;
+  int64_t id;
+  uint64_t local_seq;
+} obs_adapter_binding_t;
+static obs_adapter_binding_t g_adapter_bindings[256];
+static _Atomic int g_adapter_binding_count = 0;
+
+void lotus_obs_adapter_net_deliver(const char *subject, uint64_t origin,
+                                   uint64_t seq, uint64_t bytes) {
+  if (!obs_on() || !subject) return;
+  int n = atomic_load_explicit(&g_adapter_binding_count,
+                               memory_order_acquire);
+  obs_adapter_binding_t *row = NULL;
+  for (int i = 0; i < n; i++) {
+    if (strcmp(g_adapter_bindings[i].subject, subject) == 0) {
+      row = &g_adapter_bindings[i];
+      break;
+    }
+  }
+  if (!row) {
+    pthread_mutex_lock(&g_obs_lock);
+    n = atomic_load(&g_adapter_binding_count);
+    for (int i = 0; i < n; i++) {
+      if (strcmp(g_adapter_bindings[i].subject, subject) == 0) {
+        row = &g_adapter_bindings[i];
+        break;
+      }
+    }
+    if (!row && n < 256) {
+      int64_t id = obs_manifest_add(MK_BINDING, 1, subject,
+                                    2 /* adapter */, 0, 0);
+      char *copy = strdup(subject);
+      if (id >= 0 && copy) {
+        g_adapter_bindings[n].subject = copy;
+        g_adapter_bindings[n].id = id;
+        g_adapter_bindings[n].local_seq = 0;
+        row = &g_adapter_bindings[n];
+        atomic_store_explicit(&g_adapter_binding_count, n + 1,
+                              memory_order_release);
+      } else if (copy) {
+        free(copy);
+      }
+    }
+    pthread_mutex_unlock(&g_obs_lock);
+  }
+  if (!row) return;
+  uint64_t use_seq = seq ? seq : ++row->local_seq;
+  lotus_obs_net_deliver(subject, row->id, origin, use_seq, bytes);
+}
+
 void lotus_obs_locus_birth(void *self, const char *type_name,
                            void *parent_self) {
   if (!obs_on() || !self || !type_name) return;

--- a/crates/hale-codegen/tests/obs_fleet_contract.rs
+++ b/crates/hale-codegen/tests/obs_fleet_contract.rs
@@ -823,3 +823,233 @@ fn adapter_inbound_dispatch_is_not_a_publish() {
         pubs
     );
 }
+
+/// iris handoff-8 P21 — the adapter (Hale-owned-wire) ingest path
+/// gets the full trio. A producer fans out over the C udp path
+/// under LOTUS_OBS_WIRE=1 (headered datagrams); the consumer does
+/// NOT use LOTUS_BUS_CONFIG — its own Hale code reads the socket
+/// and hands bytes to `std::bus::__local_dispatch` (the adapter
+/// ingest). Before this fix that path was dark: no NET_DELIVER, no
+/// BUS_DELIVER, and a headered datagram didn't even deserialize.
+/// Asserts on the consumer's segment: NET_DELIVER records carrying
+/// the producer's wire (origin, seq); BUS_DELIVER attributed to the
+/// subscriber's birth instance; published == 0 (ingest is not a
+/// publish).
+#[test]
+fn adapter_ingest_pairs_and_attributes() {
+    const PRODUCER: &str = r#"
+        type Sig { v: Int; }
+        locus Pub {
+            bus { publish "sig.plane" of type Sig; }
+            run() {
+                std::time::sleep(600ms);
+                let mut i = 0;
+                while i < 20 {
+                    "sig.plane" <- Sig { v: i };
+                    std::time::sleep(10ms);
+                    i = i + 1;
+                }
+            }
+        }
+        main locus App {
+            params { p: Pub = Pub { }; }
+            placement { p: pinned(core = 0); }
+            run() { std::time::sleep(2500ms); }
+        }
+        fn main() { App { }; }
+    "#;
+    const CONSUMER: &str = r#"
+        type Sig { v: Int; }
+        fn __empty(e: IoError) -> Bytes { return b""; }
+        locus Sub {
+            params { got: Int = 0; }
+            bus { subscribe "sig.plane" as on_s of type Sig; }
+            fn on_s(s: Sig) { self.got = self.got + 1; }
+        }
+        locus Ingest {
+            params { port: Int = 0; }
+            bus { publish "sig.plane" of type Sig; }
+            run() {
+                let fd = std::io::udp::bind("127.0.0.1", self.port) or -1;
+                if fd < 0 { return; }
+                std::io::udp::set_recv_timeout(fd, 200ms) or discard;
+                let mut i = 0;
+                while i < 200 {
+                    let b = std::io::udp::recv(fd, 4096) or __empty(err);
+                    if len(b) > 0 {
+                        std::bus::__local_dispatch("sig.plane", b);
+                    }
+                    i = i + 1;
+                }
+                std::io::udp::close(fd);
+            }
+        }
+        fn main() {
+            Sub { };
+            Ingest { port: 57845 };
+            std::time::sleep(200ms);
+        }
+    "#;
+    let pub_bin = compile("adppub", PRODUCER);
+    let sub_bin = compile("adpsub", CONSUMER);
+    let dir = std::env::temp_dir()
+        .join(format!("hale_obsadp_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let cfg = dir.join("pub.conf");
+    std::fs::write(&cfg, "sig.plane = udp://127.0.0.1:57845:connect\n")
+        .unwrap();
+
+    // Consumer first (its Ingest loop binds the port), NO bus config
+    // — its only ingest is the adapter path.
+    let mut sub = Command::new(&sub_bin)
+        .env("LOTUS_OBS", "1")
+        .env("LOTUS_OBS_WIRE", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn consumer");
+    std::thread::sleep(Duration::from_millis(200));
+    let mut pubc = Command::new(&pub_bin)
+        .env("LOTUS_BUS_CONFIG", &cfg)
+        .env("LOTUS_OBS", "1")
+        .env("LOTUS_OBS_WIRE", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn producer");
+    let (pub_pid, sub_pid) = (pubc.id(), sub.id());
+    std::thread::sleep(Duration::from_millis(150));
+    attach_observer(pub_pid);
+    attach_observer(sub_pid);
+    // Burst runs pub t+600..800ms; snapshot both while alive.
+    std::thread::sleep(Duration::from_millis(1300));
+    let pub_seg = snapshot_shm(pub_pid);
+    let sub_seg = snapshot_shm(sub_pid);
+    let _ = pubc.kill();
+    let _ = pubc.wait();
+    let _ = sub.kill();
+    let _ = sub.wait();
+    let _ = std::fs::remove_file(&pub_bin);
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_dir_all(&dir);
+    let pub_seg = pub_seg.expect("producer segment");
+    let sub_seg = sub_seg.expect("consumer segment");
+
+    // Producer side: headered NET_SENDs with nonzero origin.
+    let sends: std::collections::HashSet<(u32, u64)> = records(&pub_seg, 3)
+        .iter()
+        .map(|(_, w1)| net_origin_seq(*w1))
+        .collect();
+    assert!(!sends.is_empty(), "producer emitted no NET_SEND");
+
+    // Consumer side: the adapter ingest trio.
+    let delivers: Vec<(u32, u64)> = records(&sub_seg, 4)
+        .iter()
+        .map(|(_, w1)| net_origin_seq(*w1))
+        .collect();
+    assert!(
+        !delivers.is_empty(),
+        "P21: adapter ingest emitted no NET_DELIVER (dark path)"
+    );
+    let paired = delivers.iter().filter(|d| sends.contains(d)).count();
+    assert!(
+        paired > 0,
+        "P21: adapter NET_DELIVER did not echo the wire (origin, seq): \
+         sends {:?} delivers {:?}",
+        sends,
+        delivers
+    );
+    let births: std::collections::HashSet<u32> =
+        records(&sub_seg, 5).iter().map(|(id, _)| *id).collect();
+    let dlvs: Vec<u32> = records(&sub_seg, 2)
+        .iter()
+        .map(|(_, w1)| obs_bus_locus(*w1))
+        .collect();
+    assert!(
+        !dlvs.is_empty(),
+        "P21: adapter ingest produced no BUS_DELIVER"
+    );
+    assert!(
+        dlvs.iter().all(|l| *l != 0 && births.contains(l)),
+        "P21: adapter BUS_DELIVER unattributed: {:?} (births {:?})",
+        dlvs,
+        births
+    );
+    // Ingest is a delivery, not a publish.
+    let (published, delivered, _) =
+        topic_counters(&sub_seg, b"sig.plane").expect("topic on consumer");
+    assert_eq!(
+        published, 0,
+        "adapter ingest inflated the published counter"
+    );
+    assert!(delivered > 0, "delivered counter is 0");
+}
+
+/// iris handoff-8 P20 — remote-only publishes MUST count. The field
+/// report ("every purely-remote subject shows CT_PUBLISHED = 0")
+/// did not reproduce on any of four flavors (adapter binding, udp
+/// config, framed transport, keyed); this pins the keyed+udp shape
+/// (their signal plane's) so the counter can never regress to the
+/// pre-v0.11.15 keyed-probe-gap behavior the report likely carried.
+#[test]
+fn remote_only_publish_counts() {
+    const SRC: &str = r#"
+        type Out { id: Int; v: Int; }
+        type Keep { n: Int; }
+        topic Sig { payload: Out; subject: "sig.keyed"; keyed_by id; }
+        locus KeepAlive {
+            bus { subscribe "keep" as on_k of type Keep; }
+            fn on_k(k: Keep) { }
+        }
+        locus Pub {
+            bus { publish Sig; }
+            run() {
+                std::time::sleep(100ms);
+                let mut i = 0;
+                while i < 20 { Sig <- Out { id: 1, v: i }; i = i + 1; }
+            }
+        }
+        fn main() {
+            KeepAlive { };
+            Pub { };
+            std::time::sleep(700ms);
+        }
+    "#;
+    let bin = compile("remoteonly", SRC);
+    let dir = std::env::temp_dir()
+        .join(format!("hale_obsro_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let cfg = dir.join("bus.conf");
+    std::fs::write(&cfg, "sig.keyed = udp://127.0.0.1:57849:connect\n")
+        .unwrap();
+    let mut child = Command::new(&bin)
+        .env("LOTUS_BUS_CONFIG", &cfg)
+        .env("LOTUS_OBS", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    let pid = child.id();
+    for _ in 0..40 {
+        std::thread::sleep(Duration::from_millis(25));
+        if std::path::Path::new(&format!("/dev/shm/hale-obs-{}", pid))
+            .exists()
+        {
+            break;
+        }
+    }
+    attach_observer(pid);
+    std::thread::sleep(Duration::from_millis(500));
+    let seg = snapshot_shm(pid);
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_file(&bin);
+    let _ = std::fs::remove_dir_all(&dir);
+    let seg = seg.expect("segment");
+    let (published, _, _) =
+        topic_counters(&seg, b"sig.keyed").expect("remote-only topic");
+    assert_eq!(
+        published, 20,
+        "P20: remote-only keyed publishes must bump CT_PUBLISHED"
+    );
+}

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1492,6 +1492,22 @@ green because they decoded with the emitter's own layout. The
 tests now vendor protocol.h's decode, so emitter and consumers
 cannot disagree silently.
 
+Adapter ingest completeness (iris handoff 8, v0.11.22): the
+Hale-owned-wire ingest (`std::bus::__local_dispatch` →
+`lotus_bus_dispatch_wire_inbound`) now carries the full probe trio
+the C reader threads have. The wrapper peels the self-describing
+obs wire header when the producer emitted one (magic-guarded — a
+headerless or non-Hale producer is byte-for-byte unaffected, and
+headered bytes reaching a Hale adapter previously failed
+deserialization outright), emits `NET_DELIVER` echoing the wire
+`(origin, seq)` (or `(0, local per-subject seq)` when headerless —
+countable, not pairable), and the plain `dispatch_wire` fanout
+gains the per-target `BUS_DELIVER` its keyed sibling received in
+v0.11.18. Adapter bindings register lazily in the manifest
+(`aux = 2`). Dynamically-ingested planes now form producer→consumer
+edges and attribute subscriber loci exactly like statically
+configured listens.
+
 Attribution ordering + the adapter inbound path (iris handoff 6,
 v0.11.20):
 


### PR DESCRIPTION
Delivers iris HANDOFF-8.

## P21 — the adapter ingest trio
`std::bus::__local_dispatch` (the Hale-owned-wire ingest) was dark: no NET_DELIVER, and plain `dispatch_wire`'s fanout had no per-target BUS_DELIVER — its **keyed** sibling got probes in v0.11.18 while the plain flavor's comment claimed probes it never had (the sibling class, one more time; found instantly by grepping `lotus_bus_post_entry` — R4 doing its job).

The inbound wrapper now:
1. **Peels the magic-guarded obs wire header** when the producer emitted one and emits **NET_DELIVER echoing the wire (origin, seq)** — adapter-ingested messages pair into producer→consumer edges exactly like the C reader's. Headerless bytes probe `(0, local per-subject seq)`. Bonus: this *fixes delivery itself* for headered datagrams reaching a Hale adapter (16 stray bytes previously failed deserialization silently).
2. Registers adapter bindings lazily in the manifest (`aux=2`) via a dedupe cache in the obs TU.
3. Plain `dispatch_wire` gains per-target **BUS_DELIVER with subscriber attribution** on both branches (same-thread triple also converted to `lotus_bus_post_entry`).

Pinned by `adapter_ingest_pairs_and_attributes`: a real two-process shape — headered C-fanout producer, consumer whose *only* ingest is its own Hale read-loop calling `__local_dispatch` — asserting paired net records, attributed deliveries, and `published == 0`.

## P20 — could not reproduce; pinned anyway
`CT_PUBLISHED` counts correctly for remote-only subjects on all four constructible flavors (adapter binding, udp config, framed transport, keyed). Best theory: the carry predates the v0.11.15 keyed-probe fix. The keyed+udp shape is pinned as `remote_only_publish_counts`; the disposition asks iris for one concrete field detail (subject + binding line + the counter-line reading) if it persists on v0.11.22.

Spec `runtime.md` handoff-8 amendment; CHANGELOG. Full workspace nextest: **1849/1849**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)