### PR TITLE
release: v0.11.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.11.22 — iris handoff-8: adapter ingest lit + the refactor batch (2026-07-29)
 
 - **The adapter ingest path carries the full observation trio**
   (iris handoff-8 P21 — "the last dark ingestion path"). The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.21"
+version = "0.11.22"
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "hale-syntax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.21"
+version = "0.11.22"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for v0.11.22 — iris handoff-8 (#292): adapter ingest trio (NET_DELIVER + header peel + plain-wire BUS_DELIVER), P20 pinned-not-reproduced; plus the #291 refactor batch (callgraph engine, stdlib registry, DeploymentPlan, fanout core, obs test reader). CHANGELOG rolled from Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)