### PR TITLE
feat(#265): make effect assertions a system — general @effects form, syntactic effects, placement-implied contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,8 +294,14 @@ innocent at the call site can leak into a locus's lifetime arena
 — but the substrate closes more of those shapes than you'd
 expect, and the "What's already free" list preempts overcautious
 code. The compiler backs the rules with a layered enforcement
-ladder (default warnings → `@hot` → `@budget`); see styleguide
-§5.
+ladder (default warnings → `@hot` → `@budget` → `@effects`); see
+styleguide §5. `@effects(none: {…})` — with the `@no_block` /
+`@no_syscall` / `@deterministic` / `@no_publish` / `@no_spawn` /
+`@no_ffi` / `@no_recursion` shorthands — asserts what a fn may
+*reach*, checked transitively with the offending call chain in
+the diagnostic. And a handler on a `where async_io` locus is
+checked for blocking calls with no annotation at all: the
+placement is the contract.
 
 ## Binding an external C library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,37 +8,48 @@ behavior.
 
 ## Unreleased
 
-- **GH #265 phase 1: categoric effect assertions —
-  `@no_recursion`, `@no_ffi`, `@no_block`.** `@budget`'s discipline
-  generalized from allocation *count* to effect *classes*: an opt-in
-  contract at a root, inferred everywhere else, enforced as a hard
-  error. Bare `@`-flags before a `fn` (free or method), stackable
-  with each other and with `@hot` / `@budget(...)`. Violations
-  report the **witness chain** — `on_tick -> helper -> nap
-  [std::time::sleep — …]` — the diagnostic shape `@budget`'s
-  fixpoint structurally could not produce, now available because
-  both run on the shared `hale-types::callgraph` engine (shipped in
-  the v0.11.22 refactor batch). `@no_block`'s leaf set is the
-  closed blocking-stdlib family; `@no_ffi` matches bundle-local
-  `@ffi` declarations; `@no_recursion` is call-graph acyclicity
-  (diamonds pass). Later phases — `@no_panic` (a different
-  analysis), `@no_syscall` / `@deterministic` (need the full
-  `lotus_*` frontier classification) — are unchanged in the issue's
-  build order.
-
-- **GH #265 phase 2: the frontier is classified —
-  `@no_syscall`, `@deterministic`.** All 327 stdlib registry entries
-  now carry a real `EffectSet` (SYSCALL / BLOCK / PUBLISH / TIME /
-  ENTROPY / ENV / ALLOC / PURE) — zero unclassified residue — and the
-  two new assertions are predicates over that column rather than
-  hand-lists. The classification distinguishes reading an effect
-  source from operating on a supplied value (`time_from_unix(n)` is
-  deterministic, `monotonic_ns()` is not; `http::parse_request` is
-  pure, `http::get` is blocking I/O). An unclassified entry would
-  violate every assertion by construction, so incompleteness can never
-  silently pass. The full certificate composes and is checked in one
-  pass: `@no_block @no_syscall @deterministic @no_recursion @hot
-  @budget(alloc_per_call = 0)`.
+- **GH #265: effect assertions — one surface, one engine, one
+  classified frontier.** `@budget`'s discipline generalized from
+  allocation *count* to effect *classes*, delivered as a system
+  rather than a family of flags.
+  - **The general form**: `@effects(none: {syscall, block, time,
+    entropy, env, ffi, publish, spawn, recursion})` and
+    `@effects(publish: {Topic, …})` (the allowed publish set —
+    exact, because the topic set is closed). The `@no_syscall` /
+    `@no_block` / `@no_ffi` / `@no_publish` / `@no_spawn` /
+    `@no_recursion` / `@deterministic` family is **documented
+    sugar**, desugared at parse time so the checker has one shape to
+    interpret and a flag can never drift from the general form. The
+    general form also expresses contracts the sugar can't name —
+    `@effects(none: {time})` forbids the clock while allowing
+    jitter.
+  - **The frontier is classified**: all 327 stdlib registry entries
+    carry an `EffectSet`, zero unclassified residue (pinned by a
+    test). Reading an effect source is distinguished from operating
+    on a supplied value — `time_from_unix(n)` is deterministic,
+    `monotonic_ns()` is not. An unclassified entry violates every
+    assertion by construction, so incompleteness can't silently
+    pass.
+  - **Syntactic effects**: `publish` and `spawn` are carried by
+    `Topic <- v` and `Child { … }`, not by any call, so the summary
+    now records effect *sites* alongside allocation sites.
+  - **Diagnostics carry the witness path** — the call chain from the
+    asserting root to the offending leaf, which `@budget`'s fixpoint
+    structurally could not produce.
+  - **Placement-implied contracts — the assertion you don't write.**
+    A handler on a `cooperative(pool = X) where async_io` locus that
+    reaches a blocking call stalls every other locus on that pool;
+    the placement already declared the intent, so the compiler warns
+    with **no annotation at all**, naming the chain and both fixes.
+    Writing `@no_block` upgrades it to an enforced error and
+    suppresses the advisory. This is the class of bug that shipped
+    as a downstream latency mystery (a sleeping handler holding an
+    engine pool), now visible at compile time.
+  - Docs: `spec/verification.md` rewritten as one systematic entry,
+    `spec/tokens.md` gains an annotation inventory,
+    `spec/styleguide.md`'s enforcement ladder gains the `@effects`
+    and placement-implied tiers, `AGENTS.md` updated, and
+    `docs/src/systems/performance.md` documents the surface.
 
 ## v0.11.22 — iris handoff-8: adapter ingest lit + the refactor batch (2026-07-29)
 

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -1467,30 +1467,70 @@ pub struct ConstDecl {
     pub span: Span,
 }
 
+/// GH #265: the effect classes an assertion can name — the leaf
+/// lattice the classified stdlib frontier is labelled with, plus
+/// the two Hale expresses syntactically (publish / spawn) and the
+/// graph property (recursion).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffectClass {
+    Syscall,
+    Block,
+    Time,
+    Entropy,
+    Env,
+    Ffi,
+    Publish,
+    Spawn,
+    Recursion,
+}
+
+impl EffectClass {
+    pub fn from_ident(s: &str) -> Option<EffectClass> {
+        Some(match s {
+            "syscall" => EffectClass::Syscall,
+            "block" => EffectClass::Block,
+            "time" => EffectClass::Time,
+            "entropy" => EffectClass::Entropy,
+            "env" => EffectClass::Env,
+            "ffi" => EffectClass::Ffi,
+            "publish" => EffectClass::Publish,
+            "spawn" => EffectClass::Spawn,
+            "recursion" => EffectClass::Recursion,
+            _ => return None,
+        })
+    }
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EffectClass::Syscall => "syscall",
+            EffectClass::Block => "block",
+            EffectClass::Time => "time",
+            EffectClass::Entropy => "entropy",
+            EffectClass::Env => "env",
+            EffectClass::Ffi => "ffi",
+            EffectClass::Publish => "publish",
+            EffectClass::Spawn => "spawn",
+            EffectClass::Recursion => "recursion",
+        }
+    }
+}
+
 /// #265 (2026-07-29): one asserted effect-class contract
 /// (`@no_recursion` / `@no_ffi` / `@no_block` before a fn). Checked
 /// in `hale-types::effects` over the callgraph witness engine; a
 /// violation is a hard error carrying the offending call chain.
 /// Extensible — the set grows with the frontier classification.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EffectAssert {
-    /// Call-graph acyclicity under this root (static stack story).
-    NoRecursion,
-    /// No `@ffi` fn transitively reachable ("pure managed Hale").
-    NoFfi,
-    /// No blocking stdlib operation reachable — the contract an
-    /// `async_io`-placed handler needs (a blocking call there stalls
-    /// the pool's single worker).
-    NoBlock,
-    /// #265 phase 2: no syscall-class stdlib operation reachable
-    /// (filesystem, sockets, process, terminal, stdio). The
-    /// compute-only contract.
-    NoSyscall,
-    /// #265 phase 2: no nondeterminism reachable — no clock read, no
-    /// entropy, no environment. The contract replicated/replayable
-    /// workloads need; combined with a message log it buys exact
-    /// replay debugging.
-    Deterministic,
+    /// GH #265: the GENERAL form — `@effects(none: {syscall, block})`
+    /// / `@effects(publish: {A, B})` / `@effects(none: {publish})`.
+    /// Every `@no_*` flag below is documented sugar over this; the
+    /// general form exists so a contract the sugar doesn't name
+    /// (e.g. "no clock, but entropy is fine") is still expressible.
+    Forbid(Vec<EffectClass>),
+    /// `@effects(publish: {A, B})` — the allowed publish set. A
+    /// publish to any subject outside the set is a violation; the
+    /// closed topic set makes this exact.
+    PublishSet(Vec<String>),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -378,7 +378,8 @@ impl Parser {
             // flags before a fn, stackable with each other and with
             // `@hot` / `@budget(...)`.
             let is_effect = matches!(&kind_tok,
-                TokenKind::Ident(s) if Self::effect_assert_for(s).is_some());
+                TokenKind::Ident(s) if Self::effect_assert_for(s).is_some()
+                    || Self::is_effects_form(s));
             if is_export {
                 // WASM entry-inversion. `@export fn …` is a free-fn
                 // module export; `@export locus …` is the persistent
@@ -1203,14 +1204,126 @@ impl Parser {
     /// assertions? They are bare `@`-flags before a `fn`, stackable
     /// with each other and with `@hot` / `@budget(...)`.
     fn effect_assert_for(name: &str) -> Option<EffectAssert> {
-        match name {
-            "no_recursion" => Some(EffectAssert::NoRecursion),
-            "no_ffi" => Some(EffectAssert::NoFfi),
-            "no_block" => Some(EffectAssert::NoBlock),
-            "no_syscall" => Some(EffectAssert::NoSyscall),
-            "deterministic" => Some(EffectAssert::Deterministic),
-            _ => None,
+        // GH #265: the `@no_*` family is documented SUGAR over
+        // `@effects(none: {...})` — desugared here so the checker has
+        // exactly one shape to interpret. `@deterministic` is the
+        // named bundle (no clock, no entropy, no environment).
+        let classes = match name {
+            "no_recursion" => vec![EffectClass::Recursion],
+            "no_ffi" => vec![EffectClass::Ffi],
+            "no_block" => vec![EffectClass::Block],
+            "no_syscall" => vec![EffectClass::Syscall],
+            "no_publish" => vec![EffectClass::Publish],
+            "no_spawn" => vec![EffectClass::Spawn],
+            "deterministic" => vec![
+                EffectClass::Time,
+                EffectClass::Entropy,
+                EffectClass::Env,
+            ],
+            _ => return None,
+        };
+        Some(EffectAssert::Forbid(classes))
+    }
+
+    /// Is this the general `@effects(...)` form?
+    fn is_effects_form(name: &str) -> bool {
+        name == "effects"
+    }
+
+    /// GH #265: `@effects(none: {a, b})` / `@effects(publish: {A, B})`.
+    /// The general surface the `@no_*` flags are sugar for.
+    fn parse_effects_annotation(&mut self) -> Result<(Vec<EffectAssert>, Span), Diag> {
+        let at = self.expect(TokenKind::At, "@")?;
+        self.bump(); // `effects`
+        self.expect(TokenKind::LParen, "(")?;
+        let mut out = Vec::new();
+        loop {
+            let key_tok = self.peek_token().clone();
+            let key = match &key_tok.kind {
+                TokenKind::Ident(s) => s.clone(),
+                // `publish` is a bus keyword elsewhere in the grammar;
+                // inside `@effects(...)` it is the key name.
+                TokenKind::Publish => "publish".to_string(),
+                _ => {
+                    return Err(Diag::parse(
+                        key_tok.span,
+                        "expected `none:` or `publish:` inside `@effects(...)`",
+                    ))
+                }
+            };
+            self.bump();
+            self.expect(TokenKind::Colon, ":")?;
+            self.expect(TokenKind::LBrace, "{")?;
+            let mut items: Vec<String> = Vec::new();
+            loop {
+                if matches!(self.peek(), TokenKind::RBrace) {
+                    break;
+                }
+                let t = self.peek_token().clone();
+                match &t.kind {
+                    TokenKind::Ident(s) => {
+                        items.push(s.clone());
+                        self.bump();
+                    }
+                    TokenKind::StringLit(s) => {
+                        items.push(s.clone());
+                        self.bump();
+                    }
+                    _ => {
+                        return Err(Diag::parse(
+                            t.span,
+                            "expected an effect class / topic name",
+                        ))
+                    }
+                }
+                if matches!(self.peek(), TokenKind::Comma) {
+                    self.bump();
+                }
+            }
+            self.expect(TokenKind::RBrace, "}")?;
+            match key.as_str() {
+                "none" => {
+                    let mut classes = Vec::new();
+                    for it in &items {
+                        match EffectClass::from_ident(it) {
+                            Some(c) => classes.push(c),
+                            None => {
+                                return Err(Diag::parse(
+                                    key_tok.span,
+                                    format!(
+                                        "unknown effect class `{}` — expected \
+                                         one of syscall, block, time, entropy, \
+                                         env, ffi, publish, spawn, recursion",
+                                        it
+                                    ),
+                                ))
+                            }
+                        }
+                    }
+                    out.push(EffectAssert::Forbid(classes));
+                }
+                "publish" => {
+                    out.push(EffectAssert::PublishSet(items));
+                }
+                _ => {
+                    return Err(Diag::parse(
+                        key_tok.span,
+                        format!(
+                            "unknown `@effects` key `{}` — expected `none:` \
+                             or `publish:`",
+                            key
+                        ),
+                    ))
+                }
+            }
+            if matches!(self.peek(), TokenKind::Comma) {
+                self.bump();
+                continue;
+            }
+            break;
         }
+        let close = self.expect(TokenKind::RParen, ")")?;
+        Ok((out, at.span.merge(close.span)))
     }
 
     /// Consume a run of stacked `@no_*` effect assertions, returning
@@ -1228,6 +1341,15 @@ impl Parser {
                 TokenKind::Ident(s) => s.clone(),
                 _ => break,
             };
+            if Self::is_effects_form(&name) {
+                let (mut asserts, aspan) = self.parse_effects_annotation()?;
+                out.append(&mut asserts);
+                span = Some(match span {
+                    Some(prev) => prev.merge(aspan),
+                    None => aspan,
+                });
+                continue;
+            }
             let Some(eff) = Self::effect_assert_for(&name) else {
                 break;
             };
@@ -1752,7 +1874,8 @@ impl Parser {
                 // #265: effect assertions on a method/handler (the
                 // common placement — a bus handler is a member fn).
                 if matches!(&kind_tok,
-                    TokenKind::Ident(s) if Self::effect_assert_for(s).is_some())
+                    TokenKind::Ident(s) if Self::effect_assert_for(s).is_some()
+                        || Self::is_effects_form(s))
                 {
                     let (effects, espan) = self.parse_effect_asserts()?;
                     let espan = espan.expect("at least one assertion parsed");

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -403,6 +403,34 @@ pub struct FnSummary {
     pub sites: Vec<AllocSite>,
     pub calls: Vec<CallEdge>,
     pub loops: Vec<LoopInfo>,
+    /// GH #265: non-call effect sites in this fn's own body — effects
+    /// carried by SYNTAX rather than by a stdlib call, so a leaf
+    /// predicate over call edges alone can never see them. Today:
+    /// `Topic <- value` publishes and locus instantiations.
+    pub effect_sites: Vec<EffectSite>,
+}
+
+/// GH #265: an effect a fn performs directly in its own body,
+/// syntactically. The classified stdlib frontier covers effects
+/// reached by CALLING something; these are the ones Hale expresses
+/// as language constructs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectSite {
+    pub kind: EffectSiteKind,
+    pub loop_depth: u32,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EffectSiteKind {
+    /// `Topic <- value` / `"subject" <- value`. Carries the subject
+    /// as written when it is a compile-time-constant string or a
+    /// declared topic name (the closed topic set makes publish-set
+    /// assertions exact); None for a computed subject.
+    Publish(Option<String>),
+    /// A locus instantiation (`Child { ... }`) — an arena creation
+    /// plus, depending on placement, a thread spawn or a pool post.
+    Spawn(String),
 }
 
 /// A distilled view of a locus's storage shape (GH #18 item 1, Phase D —
@@ -912,6 +940,15 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
     let mut bodies: Vec<BodyEntry> = Vec::new();
     let mut known: BTreeSet<FnKey> = BTreeSet::new();
     // GH #18 item 1 — the `@bounded` / `@unbounded` opt-in/carve-out sets.
+    // GH #265: every declared locus type name (spawn-site detection).
+    let mut locus_type_names: BTreeSet<String> = BTreeSet::new();
+    for p in programs {
+        for item in &p.items {
+            if let TopDecl::Locus(l) = item {
+                locus_type_names.insert(l.name.name.clone());
+            }
+        }
+    }
     let mut bounded_loci: BTreeSet<String> = BTreeSet::new();
     let mut unbounded_fns: BTreeSet<FnKey> = BTreeSet::new();
     // Phase D / D1 — the per-locus storage shape.
@@ -1202,6 +1239,8 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
             .unwrap_or(&empty_inline_arrays);
         let mut w = Walker {
             sites: Vec::new(),
+            effect_sites: Vec::new(),
+            locus_types: &locus_type_names,
             calls: Vec::new(),
             loops: Vec::new(),
             escaping: &escaping,
@@ -1227,6 +1266,7 @@ pub fn summarize_programs(programs: &[&Program]) -> AllocSummary {
                 sites: w.sites,
                 calls: w.calls,
                 loops: w.loops,
+                effect_sites: w.effect_sites,
             },
         );
     }
@@ -1444,6 +1484,12 @@ fn init_is_scalar_or_static(e: &Expr) -> bool {
 
 struct Walker<'a> {
     sites: Vec<AllocSite>,
+    /// GH #265: syntactic effect sites (publish / spawn).
+    effect_sites: Vec<EffectSite>,
+    /// GH #265: declared locus type names — a struct literal of one
+    /// of these is a locus INSTANTIATION (arena create + possibly a
+    /// thread spawn / pool post), not a plain data allocation.
+    locus_types: &'a BTreeSet<String>,
     calls: Vec<CallEdge>,
     loops: Vec<LoopInfo>,
     escaping: &'a BTreeMap<String, Escape>,
@@ -1488,6 +1534,21 @@ struct Walker<'a> {
 }
 
 impl<'a> Walker<'a> {
+    /// GH #265: record a syntactic effect site (publish / spawn) in
+    /// the fn currently being summarized.
+    fn push_effect_site(
+        &mut self,
+        kind: EffectSiteKind,
+        depth: u32,
+        span: Span,
+    ) {
+        self.effect_sites.push(EffectSite {
+            kind,
+            loop_depth: depth,
+            span,
+        });
+    }
+
     fn push_site(&mut self, kind: AllocKind, escape: Escape, depth: u32, span: Span) {
         // Only a StoredToSelf escape carries a target field — that's the
         // `self.<field> = <alloc>` whole-value replace the solver bounds.
@@ -1633,7 +1694,27 @@ impl<'a> Walker<'a> {
             // walk for the alloc summary.
             Stmt::Reperspective { .. } => {}
             Stmt::Fail { value, .. } => self.walk_diverging_payload(value),
-            Stmt::Send { subject, value, .. } => {
+            Stmt::Send { subject, value, span, .. } => {
+                // GH #265: a publish is an effect the language
+                // expresses syntactically — record it so publish-set
+                // assertions (and @no_publish) can see it. The
+                // subject is exact when it is a literal / declared
+                // topic name, which is the common case and what makes
+                // the closed-topic-set claim hold.
+                let subj = match subject {
+                    Expr::Literal(Literal::String(s), _) => {
+                        Some(s.clone())
+                    }
+                    // A declared topic name (`Sig <- v`) parses as a
+                    // bare identifier.
+                    Expr::Ident(id) => Some(id.name.clone()),
+                    _ => None,
+                };
+                self.push_effect_site(
+                    EffectSiteKind::Publish(subj),
+                    depth,
+                    *span,
+                );
                 self.walk_expr(subject, depth, Escape::Local);
                 self.walk_expr(value, depth, Escape::Sent);
             }
@@ -1736,6 +1817,17 @@ impl<'a> Walker<'a> {
                 // the site — that's the TP-3 anchor-clone class.
                 let inplace_no_heap = matches!(escape, Escape::StoredToSelf)
                     && inits.iter().all(|si| init_is_scalar_or_static(&si.value));
+                if self.locus_types.contains(&name) {
+                    // GH #265: locus instantiation — an effect in its
+                    // own right (arena create, possibly a thread or
+                    // pool post), recorded whether or not the alloc
+                    // site below is elided.
+                    self.push_effect_site(
+                        EffectSiteKind::Spawn(name.clone()),
+                        depth,
+                        *span,
+                    );
+                }
                 if !inplace_no_heap {
                     self.push_site(AllocKind::StructLit(name), escape, depth, *span);
                 }

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -99,6 +99,136 @@ fn chain(root: &FnKey, steps: &[callgraph::WitnessStep]) -> String {
 /// Returns hard-error diagnostics (opt-in: you asked for the
 /// contract, so a violation fails the build) — empty when every
 /// contract holds.
+/// GH #265: **placement-implied contracts** — the check that needs
+/// no annotation at all. A locus placed `cooperative(pool = X) where
+/// async_io` runs its methods on that pool's single worker; a
+/// BLOCKING operation reachable from one of its handlers holds that
+/// worker, so every other locus on the pool stalls behind it. The
+/// placement IS the assertion, so the compiler enforces it without
+/// the author writing `@no_block`.
+///
+/// Reported as a WARNING, not an error: the placement may be
+/// deliberate (a lone locus on a pool it owns), and the escape hatch
+/// is explicit — the diagnostic names both fixes. This is the
+/// Crumb batch-5 bug (a JS handler's `await sleep(400)` holding the
+/// engine pool) as a compile-time finding.
+fn placement_implied_diags(
+    programs: &[&Program],
+    summary: &AllocSummary,
+) -> Vec<Diag> {
+    use crate::stdlib_surface::EffectSet;
+    // main-locus params fields placed on an async_io pool → the locus
+    // TYPE names whose methods must not block.
+    let mut async_io_types: Vec<(String, String)> = Vec::new(); // (type, pool)
+    for p in programs {
+        for item in &p.items {
+            let TopDecl::Locus(l) = item else { continue };
+            if !l.is_main {
+                continue;
+            }
+            let mut field_ty: std::collections::BTreeMap<String, String> =
+                Default::default();
+            for m in &l.members {
+                if let LocusMember::Params(pb) = m {
+                    for prm in &pb.params {
+                        if let Some(TypeExpr::Named { path, .. }) = &prm.ty {
+                            if path.segments.len() == 1 {
+                                field_ty.insert(
+                                    prm.name.name.clone(),
+                                    path.segments[0].name.clone(),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            for m in &l.members {
+                if let LocusMember::Placement(pb) = m {
+                    for e in &pb.entries {
+                        let is_async = e.constraints.iter().any(|c| {
+                            matches!(c.kind, PlacementConstraint::AsyncIo)
+                        });
+                        if !is_async {
+                            continue;
+                        }
+                        let PlacementSpec::Cooperative { pool } = &e.spec
+                        else {
+                            continue;
+                        };
+                        if let Some(t) = field_ty.get(&e.field.name) {
+                            async_io_types.push((
+                                t.clone(),
+                                pool.as_ref()
+                                    .map(|i| i.name.clone())
+                                    .unwrap_or_else(|| "main".to_string()),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if async_io_types.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for p in programs {
+        for item in &p.items {
+            let TopDecl::Locus(l) = item else { continue };
+            let Some((_, pool)) = async_io_types
+                .iter()
+                .find(|(t, _)| *t == l.name.name)
+            else {
+                continue;
+            };
+            for m in &l.members {
+                let LocusMember::Fn(fd) = m else { continue };
+                // An explicit assertion means the author is already
+                // engaged with this — don't double-report.
+                if !fd.effects.is_empty() {
+                    continue;
+                }
+                let key =
+                    FnKey::method(l.name.name.clone(), fd.name.name.clone());
+                let mut pred = |probe: &Probe<'_>| match probe {
+                    Probe::Unresolved(name, _) => {
+                        let segs: Vec<&str> = name.split("::").collect();
+                        let eff = crate::stdlib_surface::effects_for(&segs)?;
+                        if eff.contains(EffectSet::BLOCK) {
+                            Some(name.to_string())
+                        } else {
+                            None
+                        }
+                    }
+                    Probe::Site(_) | Probe::Resolved(..) => None,
+                };
+                let Some(path) =
+                    callgraph::witness_path(summary, &key, &mut pred)
+                else {
+                    continue;
+                };
+                out.push(Diag::warn(
+                    fd.name.span,
+                    format!(
+                        "`{}` is placed on the async_io pool `{}`, whose \
+                         single worker it shares — but it reaches {}. A \
+                         blocking call here stalls every other locus on \
+                         `{}` until it returns. Either move the blocking \
+                         work to its own pool, or assert the intent with \
+                         `@no_block` (to have the compiler enforce it) — \
+                         the placement is the contract.",
+                        key.display(),
+                        pool,
+                        chain(&key, &path),
+                        pool
+                    ),
+                ));
+            }
+        }
+    }
+    out
+}
+
 pub fn effect_diags(programs: &[&Program]) -> Vec<Diag> {
     let mut roots: Vec<(FnKey, Vec<EffectAssert>, Span)> = Vec::new();
     for program in programs {
@@ -131,112 +261,27 @@ pub fn effect_diags(programs: &[&Program]) -> Vec<Diag> {
             }
         }
     }
-    if roots.is_empty() {
-        return Vec::new();
-    }
-
     let summary = alloc_summary::summarize_programs(programs);
+    // The placement-implied pass runs whether or not anything is
+    // annotated — that is its point.
+    let mut placement = placement_implied_diags(programs, &summary);
+    if roots.is_empty() {
+        return placement;
+    }
     let ffi = ffi_names(programs);
-    let mut diags = Vec::new();
+    let mut diags = std::mem::take(&mut placement);
     for (key, asserts, span) in &roots {
         for a in asserts {
             match a {
-                EffectAssert::NoBlock => {
-                    check_leaf(
-                        &summary, key, *span, "@no_block", &mut diags,
-                        &mut |probe| match probe {
-                            Probe::Unresolved(name, _) => {
-                                blocking_leaf(name).map(|why| {
-                                    format!("{} — {}", name, why)
-                                })
-                            }
-                            Probe::Site(_) | Probe::Resolved(..) => None,
-                        },
-                        "Move the blocking call off this path (a reader \
-                         locus on its own pool, or a bus message that \
-                         triggers the work), or drop `@no_block`.",
-                    );
-                }
-                EffectAssert::NoFfi => {
-                    check_leaf(
-                        &summary, key, *span, "@no_ffi", &mut diags,
-                        &mut |probe| match probe {
-                            // An `@ffi` fn resolves (empty body, real
-                            // summary entry), so it appears as a
-                            // RESOLVED callee — not on the unresolved
-                            // frontier. Match both: a bundle-local
-                            // extern, and (defensively) an unresolved
-                            // name that happens to be declared @ffi.
-                            Probe::Resolved(k, _) => {
-                                if k.locus.is_none()
-                                    && ffi.contains(&k.fn_name)
-                                {
-                                    Some(format!(
-                                        "{} is an `@ffi` fn",
-                                        k.fn_name
-                                    ))
-                                } else {
-                                    None
-                                }
-                            }
-                            Probe::Unresolved(name, _) => {
-                                let bare =
-                                    name.rsplit("::").next().unwrap_or(name);
-                                if ffi.contains(bare) || ffi.contains(*name) {
-                                    Some(format!("{} is an `@ffi` fn", name))
-                                } else {
-                                    None
-                                }
-                            }
-                            Probe::Site(_) => None,
-                        },
-                        "An `@ffi` call is a trust boundary the managed \
-                         contract excludes — route the foreign work through \
-                         a locus this fn doesn't reach, or drop `@no_ffi`.",
-                    );
-                }
-                EffectAssert::NoSyscall => {
-                    check_registry(
-                        &summary, key, *span, "@no_syscall",
-                        crate::stdlib_surface::EffectSet::SYSCALL,
-                        "a syscall-class operation (filesystem, socket, \
-                         process, terminal, stdio)",
-                        &mut diags,
-                        "Move the I/O behind a locus this fn doesn't reach \
-                         (the reader/writer-locus shape), or drop \
-                         `@no_syscall`.",
-                    );
-                }
-                EffectAssert::Deterministic => {
-                    check_registry(
-                        &summary, key, *span, "@deterministic",
-                        crate::stdlib_surface::EffectSet::TIME
-                            .union(crate::stdlib_surface::EffectSet::ENTROPY)
-                            .union(crate::stdlib_surface::EffectSet::ENV),
-                        "a nondeterministic read (clock, entropy, or \
-                         environment)",
-                        &mut diags,
-                        "Pass the value in as a parameter (a captured \
-                         timestamp, a seeded generator, resolved config) so \
-                         the fn is a function of its inputs, or drop \
-                         `@deterministic`.",
-                    );
-                }
-                EffectAssert::NoRecursion => {
-                    if let Some(cyc) = find_recursion(&summary, key) {
-                        diags.push(Diag::ty(
-                            *span,
-                            format!(
-                                "`@no_recursion` violated: `{}` reaches a \
-                                 recursive cycle. {}. A recursive path has \
-                                 no static stack bound — restructure to an \
-                                 explicit worklist/loop, or drop \
-                                 `@no_recursion`.",
-                                key.display(),
-                                cyc
-                            ),
-                        ));
+                EffectAssert::Forbid(classes) => {
+                    for c in classes {
+                        check_class(
+                            &summary, key, *span, *c, &ffi, &mut diags,
+                        );
                     }
+                }
+                EffectAssert::PublishSet(allowed) => {
+                    check_publish_set(&summary, key, *span, allowed, &mut diags);
                 }
             }
         }
@@ -244,32 +289,126 @@ pub fn effect_diags(programs: &[&Program]) -> Vec<Diag> {
     diags
 }
 
-/// #265 phase 2: assertions whose leaf set comes from the CLASSIFIED
-/// stdlib registry rather than a hand-list. `mask` is the effect
-/// classes the contract forbids; any reachable stdlib call whose
-/// registry row intersects it is a violation, reported with the
-/// witness chain. An UNCLASSIFIED row is treated conservatively as
-/// may-do-anything — it violates every assertion, which is the
-/// "frontier stays true forever" discipline: an unclassified entry
-/// can never silently pass.
-fn check_registry(
+/// GH #265 coherence: ONE dispatcher over the effect classes. Every
+/// `@no_*` flag desugars to `Forbid([class])` at parse time, so this
+/// is the single place a class's meaning is defined — no flag can
+/// drift from the general form.
+fn check_class(
     summary: &AllocSummary,
     key: &FnKey,
     span: Span,
-    label: &str,
-    mask: crate::stdlib_surface::EffectSet,
-    what: &str,
+    class: EffectClass,
+    ffi: &BTreeSet<String>,
     diags: &mut Vec<Diag>,
-    advice: &str,
 ) {
+    use crate::stdlib_surface::EffectSet;
+    // The three classes that are NOT stdlib-frontier queries.
+    match class {
+        EffectClass::Recursion => {
+            if let Some(cyc) = find_recursion(summary, key) {
+                diags.push(Diag::ty(
+                    span,
+                    format!(
+                        "effect assertion violated: `{}` reaches a recursive \
+                         cycle. {}. A recursive path has no static stack \
+                         bound — restructure to an explicit worklist/loop, \
+                         or drop the `recursion` assertion.",
+                        key.display(),
+                        cyc
+                    ),
+                ));
+            }
+            return;
+        }
+        EffectClass::Ffi => {
+            let mut pred = |probe: &Probe<'_>| match probe {
+                Probe::Resolved(k, _) => {
+                    if k.locus.is_none() && ffi.contains(&k.fn_name) {
+                        Some(format!("{} is an `@ffi` fn", k.fn_name))
+                    } else {
+                        None
+                    }
+                }
+                Probe::Unresolved(name, _) => {
+                    let bare = name.rsplit("::").next().unwrap_or(name);
+                    if ffi.contains(bare) || ffi.contains(*name) {
+                        Some(format!("{} is an `@ffi` fn", name))
+                    } else {
+                        None
+                    }
+                }
+                Probe::Site(_) => None,
+            };
+            report(
+                summary, key, span, "ffi", &mut pred, diags,
+                "An `@ffi` call is a trust boundary the managed contract \
+                 excludes — route the foreign work through a locus this fn \
+                 doesn't reach.",
+            );
+            return;
+        }
+        EffectClass::Publish | EffectClass::Spawn => {
+            // Syntactic effects: carried by `Topic <- v` / `Child { }`,
+            // not by any call. Walk the effect-site vectors.
+            if let Some((chain_s, site_span)) =
+                find_effect_site(summary, key, |k| match (class, k) {
+                    (
+                        EffectClass::Publish,
+                        alloc_summary::EffectSiteKind::Publish(subj),
+                    ) => Some(match subj {
+                        Some(s) => format!("publishes to `{}`", s),
+                        None => "publishes".to_string(),
+                    }),
+                    (
+                        EffectClass::Spawn,
+                        alloc_summary::EffectSiteKind::Spawn(name),
+                    ) => Some(format!("instantiates locus `{}`", name)),
+                    _ => None,
+                })
+            {
+                diags.push(Diag::ty(
+                    span,
+                    format!(
+                        "effect assertion violated: `{}` reaches {}. Move \
+                         the effect behind a locus this fn doesn't reach, or \
+                         drop the `{}` assertion.",
+                        key.display(),
+                        chain_s,
+                        class.as_str()
+                    ),
+                ));
+                diags.push(Diag::ty(
+                    site_span,
+                    format!("the `{}` effect happens here", class.as_str()),
+                ));
+            }
+            return;
+        }
+        _ => {}
+    }
+    // The frontier-query classes.
+    let (mask, what) = match class {
+        EffectClass::Syscall => (
+            EffectSet::SYSCALL,
+            "a syscall-class operation (filesystem, socket, process, \
+             terminal, stdio)",
+        ),
+        EffectClass::Block => (
+            EffectSet::BLOCK,
+            "a blocking operation — it waits, holding its thread (or, on \
+             an async_io pool, its worker's turn)",
+        ),
+        EffectClass::Time => (EffectSet::TIME, "a clock read"),
+        EffectClass::Entropy => (EffectSet::ENTROPY, "an entropy read"),
+        EffectClass::Env => (EffectSet::ENV, "an environment read"),
+        _ => unreachable!("handled above"),
+    };
     let mut pred = |probe: &Probe<'_>| match probe {
         Probe::Unresolved(name, _) => {
             let segs: Vec<&str> = name.split("::").collect();
             let eff = crate::stdlib_surface::effects_for(&segs)?;
             if eff.is_unclassified() {
-                return Some(format!(
-                    "{} is not yet effect-classified", name
-                ));
+                return Some(format!("{} is not yet effect-classified", name));
             }
             if (eff.0 & mask.0) != 0 {
                 Some(format!("{} — {}", name, what))
@@ -279,18 +418,124 @@ fn check_registry(
         }
         Probe::Site(_) | Probe::Resolved(..) => None,
     };
-    check_leaf(summary, key, span, label, diags, &mut pred, advice);
+    report(
+        summary, key, span, class.as_str(), &mut pred, diags,
+        "Move the effect behind a locus this fn doesn't reach (the \
+         reader/writer-locus shape), or pass the value in as a parameter.",
+    );
 }
 
-/// Shared shape for the reachability assertions: find the first
-/// witness chain to a matching leaf and report it.
-fn check_leaf(
+/// `@effects(publish: {A, B})` — the allowed publish set. A publish
+/// to a subject outside the set is a violation; the closed topic set
+/// makes this exact. A computed (non-literal) subject can't be
+/// proven in-set, so it is reported too.
+fn check_publish_set(
     summary: &AllocSummary,
     key: &FnKey,
     span: Span,
-    label: &str,
+    allowed: &[String],
     diags: &mut Vec<Diag>,
+) {
+    let found = find_effect_site(summary, key, |k| match k {
+        alloc_summary::EffectSiteKind::Publish(Some(subj)) => {
+            if allowed.iter().any(|a| a == subj) {
+                None
+            } else {
+                Some(format!("publishes to `{}`", subj))
+            }
+        }
+        alloc_summary::EffectSiteKind::Publish(None) => Some(
+            "publishes to a computed subject (not provably in the \
+             declared set)"
+                .to_string(),
+        ),
+        _ => None,
+    });
+    if let Some((chain_s, site_span)) = found {
+        diags.push(Diag::ty(
+            span,
+            format!(
+                "declared publish set violated: `{}` reaches {}. The \
+                 contract allows only {{{}}} — add the subject to the set, \
+                 or route the publish through a locus this fn doesn't reach.",
+                key.display(),
+                chain_s,
+                allowed.join(", ")
+            ),
+        ));
+        diags.push(Diag::ty(site_span, "the publish happens here".to_string()));
+    }
+}
+
+/// Walk the call graph looking for a matching SYNTACTIC effect site
+/// (publish / spawn) in any reachable fn body, returning the rendered
+/// witness chain and the site's span.
+fn find_effect_site(
+    summary: &AllocSummary,
+    root: &FnKey,
+    matches_kind: impl Fn(&alloc_summary::EffectSiteKind) -> Option<String> + Copy,
+) -> Option<(String, Span)> {
+    fn walk(
+        summary: &AllocSummary,
+        key: &FnKey,
+        path: &mut Vec<(FnKey, Span, String)>,
+        seen: &mut BTreeSet<FnKey>,
+        steps: &mut u32,
+        matches_kind: impl Fn(&alloc_summary::EffectSiteKind) -> Option<String> + Copy,
+    ) -> Option<(Vec<callgraph::WitnessStep>, Span)> {
+        let fs = summary.fns.get(key)?;
+        for site in &fs.effect_sites {
+            if let Some(label) = matches_kind(&site.kind) {
+                return Some((
+                    vec![callgraph::WitnessStep {
+                        in_fn: key.clone(),
+                        span: site.span,
+                        label,
+                    }],
+                    site.span,
+                ));
+            }
+        }
+        for edge in &fs.calls {
+            *steps += 1;
+            if *steps > callgraph::MAX_STEPS {
+                break;
+            }
+            if let alloc_summary::Callee::Resolved(callee) = &edge.callee {
+                if !seen.insert(callee.clone()) {
+                    continue;
+                }
+                if let Some((mut tail, sp)) =
+                    walk(summary, callee, path, seen, steps, matches_kind)
+                {
+                    let mut out = vec![callgraph::WitnessStep {
+                        in_fn: key.clone(),
+                        span: edge.span,
+                        label: callee.display(),
+                    }];
+                    out.append(&mut tail);
+                    return Some((out, sp));
+                }
+            }
+        }
+        None
+    }
+    let mut path = Vec::new();
+    let mut seen = BTreeSet::new();
+    let mut steps = 0u32;
+    let (steps_v, sp) =
+        walk(summary, root, &mut path, &mut seen, &mut steps, matches_kind)?;
+    Some((callgraph::render_witness(root, &steps_v), sp))
+}
+
+/// Emit the two-diagnostic report (root + leaf) for a witness chain.
+fn report(
+    summary: &AllocSummary,
+    key: &FnKey,
+    span: Span,
+    class_name: &str,
     pred: &mut dyn FnMut(&Probe<'_>) -> Option<String>,
+    diags: &mut Vec<Diag>,
     advice: &str,
 ) {
     let Some(path) = callgraph::witness_path(summary, key, pred) else {
@@ -300,16 +545,17 @@ fn check_leaf(
     diags.push(Diag::ty(
         span,
         format!(
-            "`{}` violated: `{}` reaches {}. {}",
-            label,
+            "effect assertion violated: `{}` must not reach `{}`, but \
+             reaches {}. {}",
             key.display(),
+            class_name,
             chain(key, &path),
             advice
         ),
     ));
     diags.push(Diag::ty(
         leaf_span,
-        format!("the {} violation is reached here", label),
+        format!("the `{}` effect is reached here", class_name),
     ));
 }
 

--- a/crates/hale-types/tests/effect_assertions.rs
+++ b/crates/hale-types/tests/effect_assertions.rs
@@ -29,8 +29,8 @@ fn no_block_reports_the_call_chain() {
     let ds = diags_for(src);
     let hit = ds
         .iter()
-        .find(|m| m.contains("@no_block` violated"))
-        .unwrap_or_else(|| panic!("expected a @no_block error; got {:?}", ds));
+        .find(|m| m.contains("must not reach `block`"))
+        .unwrap_or_else(|| panic!("expected a block-effect error; got {:?}", ds));
     // The witness chain, not just the fn name.
     assert!(
         hit.contains("on_tick -> helper -> nap"),
@@ -54,7 +54,7 @@ fn no_block_clean_program_passes() {
     "#;
     let ds = diags_for(src);
     assert!(
-        !ds.iter().any(|m| m.contains("@no_block")),
+        !ds.iter().any(|m| m.contains("must not reach `block`")),
         "clean fn must not trip @no_block: {:?}",
         ds
     );
@@ -78,8 +78,8 @@ fn no_recursion_names_the_cycle() {
     let ds = diags_for(src);
     let hit = ds
         .iter()
-        .find(|m| m.contains("@no_recursion` violated"))
-        .unwrap_or_else(|| panic!("expected a @no_recursion error; got {:?}", ds));
+        .find(|m| m.contains("reaches a recursive cycle"))
+        .unwrap_or_else(|| panic!("expected a recursion error; got {:?}", ds));
     assert!(
         hit.contains("cycle:") && hit.contains("ping") && hit.contains("pong"),
         "must name the cycle members: {}",
@@ -97,7 +97,7 @@ fn no_recursion_acyclic_passes() {
     "#;
     let ds = diags_for(src);
     assert!(
-        !ds.iter().any(|m| m.contains("@no_recursion")),
+        !ds.iter().any(|m| m.contains("recursive cycle")),
         "diamond (not a cycle) must pass: {:?}",
         ds
     );
@@ -118,8 +118,8 @@ fn no_ffi_reports_the_chain_to_the_extern() {
     let ds = diags_for(src);
     let hit = ds
         .iter()
-        .find(|m| m.contains("@no_ffi` violated"))
-        .unwrap_or_else(|| panic!("expected a @no_ffi error; got {:?}", ds));
+        .find(|m| m.contains("must not reach `ffi`"))
+        .unwrap_or_else(|| panic!("expected an ffi error; got {:?}", ds));
     assert!(
         hit.contains("managed -> wrapper") && hit.contains("c_helper"),
         "must carry the chain to the extern: {}",
@@ -159,7 +159,7 @@ fn assertion_on_a_locus_method_is_checked() {
     "#;
     let ds = diags_for(src);
     assert!(
-        ds.iter().any(|m| m.contains("@no_block` violated")
+        ds.iter().any(|m| m.contains("must not reach `block`")
             && m.contains("H::on_e")),
         "method assertions must be checked and named: {:?}",
         ds
@@ -185,8 +185,8 @@ fn no_syscall_reports_the_chain_to_the_io() {
     let ds = diags_for(src);
     let hit = ds
         .iter()
-        .find(|m| m.contains("@no_syscall` violated"))
-        .unwrap_or_else(|| panic!("expected @no_syscall error; got {:?}", ds));
+        .find(|m| m.contains("must not reach `syscall`"))
+        .unwrap_or_else(|| panic!("expected a syscall-effect error; got {:?}", ds));
     assert!(
         hit.contains("compute -> stage -> persist"),
         "witness chain missing: {}",
@@ -206,7 +206,7 @@ fn no_syscall_pure_computation_passes() {
     "#;
     let ds = diags_for(src);
     assert!(
-        !ds.iter().any(|m| m.contains("@no_syscall")),
+        !ds.iter().any(|m| m.contains("must not reach `syscall`")),
         "pure computation must pass: {:?}",
         ds
     );
@@ -231,7 +231,7 @@ fn deterministic_rejects_clock_entropy_and_env() {
         );
         let ds = diags_for(&src);
         assert!(
-            ds.iter().any(|m| m.contains("@deterministic` violated")
+            ds.iter().any(|m| m.contains("must not reach `time`") || m.contains("must not reach `entropy`") || m.contains("must not reach `env`")
                 && m.contains("decide -> peek")),
             "{} read must violate @deterministic with a chain: {:?}",
             what,
@@ -251,7 +251,7 @@ fn deterministic_pure_function_of_inputs_passes() {
     "#;
     let ds = diags_for(src);
     assert!(
-        !ds.iter().any(|m| m.contains("@deterministic")),
+        !ds.iter().any(|m| m.contains("must not reach `time`")),
         "a function of its inputs must pass: {:?}",
         ds
     );
@@ -270,7 +270,7 @@ fn deterministic_allows_formatting_a_supplied_instant() {
     "#;
     let ds = diags_for(src);
     assert!(
-        !ds.iter().any(|m| m.contains("@deterministic")),
+        !ds.iter().any(|m| m.contains("must not reach `time`")),
         "formatting a supplied instant is deterministic: {:?}",
         ds
     );
@@ -292,6 +292,199 @@ fn full_certificate_composes() {
     assert!(
         !ds.iter().any(|m| m.contains("violated") || m.contains("budget")),
         "the stacked certificate must pass on a clean fn: {:?}",
+        ds
+    );
+}
+
+// ---- the general @effects(...) form + the new classes ----
+
+/// The general form expresses contracts the sugar can't name: "no
+/// clock, but entropy is fine" (a jittered retry, a fuzzer).
+#[test]
+fn general_form_expresses_partial_determinism() {
+    let src = r#"
+        fn jitter() -> Int { return std::rand::next_int(10); }
+        fn stamp() -> Int { return std::time::monotonic_ns(); }
+        @effects(none: {time}) fn backoff() -> Int {
+            return jitter();
+        }
+        @effects(none: {time}) fn bad() -> Int {
+            return stamp();
+        }
+        fn main() { println(backoff() + bad()); }
+    "#;
+    let ds = diags_for(src);
+    // entropy is allowed under `none: {time}` …
+    assert!(
+        !ds.iter().any(|m| m.contains("`backoff`")),
+        "entropy must be allowed when only time is forbidden: {:?}",
+        ds
+    );
+    // … but the clock read is not.
+    assert!(
+        ds.iter().any(|m| m.contains("`bad`")
+            && m.contains("must not reach `time`")),
+        "clock read must violate none: {{time}}: {:?}",
+        ds
+    );
+}
+
+/// The sugar IS the general form — `@no_block` and
+/// `@effects(none: {block})` must produce the same diagnostic.
+#[test]
+fn sugar_and_general_form_agree() {
+    let mk = |ann: &str| {
+        format!(
+            r#"
+            fn nap() {{ std::time::sleep(5ms); }}
+            {} fn h() {{ nap(); }}
+            fn main() {{ h(); }}
+        "#,
+            ann
+        )
+    };
+    let a = diags_for(&mk("@no_block"));
+    let b = diags_for(&mk("@effects(none: {block})"));
+    assert_eq!(a, b, "sugar must desugar to the general form exactly");
+    assert!(a.iter().any(|m| m.contains("must not reach `block`")), "{:?}", a);
+}
+
+/// #265: publishes are syntactic (`Topic <- v`), so the effect
+/// engine records them as sites rather than call edges.
+#[test]
+fn no_publish_catches_a_syntactic_send() {
+    let src = r#"
+        type Ev { n: Int; }
+        topic T { payload: Ev; subject: "t"; }
+        locus P {
+            bus { publish T; }
+            fn emit(n: Int) {
+                T <- Ev { n: n };
+            }
+            @no_publish fn compute(n: Int) {
+                self.emit(n);
+            }
+        }
+        fn main() { P { }; }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        ds.iter().any(|m| m.contains("must not reach")
+            || m.contains("publishes to")),
+        "a transitive publish must violate @no_publish: {:?}",
+        ds
+    );
+}
+
+/// The issue's headline positive form: an allowed publish set.
+#[test]
+fn publish_set_allows_declared_and_rejects_others() {
+    let src = r#"
+        type Ev { n: Int; }
+        topic Ok { payload: Ev; subject: "ok"; }
+        topic Nope { payload: Ev; subject: "nope"; }
+        locus P {
+            bus { publish Ok; publish Nope; }
+            @effects(publish: {Ok}) fn good(n: Int) {
+                Ok <- Ev { n: n };
+            }
+            @effects(publish: {Ok}) fn bad(n: Int) {
+                Nope <- Ev { n: n };
+            }
+        }
+        fn main() { P { }; }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("`P::good`")),
+        "a publish inside the declared set must pass: {:?}",
+        ds
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("`P::bad`")
+            && m.contains("publish set violated")
+            && m.contains("Nope")),
+        "a publish outside the set must be reported: {:?}",
+        ds
+    );
+}
+
+/// Locus instantiation is an effect (arena create + possibly a
+/// thread/pool post) — the Hale-specific class.
+#[test]
+fn no_spawn_catches_locus_instantiation() {
+    let src = r#"
+        locus Child { params { n: Int = 0; } }
+        fn make(n: Int) { Child { n: n }; }
+        @no_spawn fn handler(n: Int) { make(n); }
+        fn main() { handler(1); }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        ds.iter().any(|m| m.contains("instantiates locus `Child`")),
+        "a transitive locus instantiation must violate @no_spawn: {:?}",
+        ds
+    );
+}
+
+/// #265: **placement-implied contracts** — the check that needs no
+/// annotation. A handler on a `where async_io` pool that reaches a
+/// blocking call stalls every other locus on that pool; the
+/// placement is the assertion, so the compiler says so unprompted.
+/// (This is Crumb batch-5's bug as a compile-time finding.)
+#[test]
+fn async_io_placement_warns_about_blocking_without_annotation() {
+    let src = r#"
+        type Ev { n: Int; }
+        locus Worker {
+            bus { subscribe "e" as on_e of type Ev; }
+            fn on_e(e: Ev) {
+                std::time::sleep(400ms);
+            }
+        }
+        main locus App {
+            params { w: Worker = Worker { }; }
+            placement { w: cooperative(pool = web) where async_io; }
+            run() { std::time::sleep(10ms); }
+        }
+        fn main() { App { }; }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        ds.iter().any(|m| m.contains("async_io pool `web`")
+            && m.contains("stalls every other locus")),
+        "an unannotated blocking handler on an async_io pool must be \
+         flagged by placement alone: {:?}",
+        ds
+    );
+}
+
+/// …and an explicit assertion means the author is engaged: the
+/// enforced error replaces the advisory warning (no double report).
+#[test]
+fn explicit_assertion_suppresses_the_placement_advisory() {
+    let src = r#"
+        type Ev { n: Int; }
+        locus Worker {
+            bus { subscribe "e" as on_e of type Ev; }
+            @no_block fn on_e(e: Ev) {
+                std::time::sleep(400ms);
+            }
+        }
+        main locus App {
+            params { w: Worker = Worker { }; }
+            placement { w: cooperative(pool = web) where async_io; }
+            run() { std::time::sleep(10ms); }
+        }
+        fn main() { App { }; }
+    "#;
+    let ds = diags_for(src);
+    let advisories =
+        ds.iter().filter(|m| m.contains("stalls every other locus")).count();
+    assert_eq!(advisories, 0, "annotated fn must not also warn: {:?}", ds);
+    assert!(
+        ds.iter().any(|m| m.contains("must not reach `block`")),
+        "the explicit assertion must still error: {:?}",
         ds
     );
 }

--- a/docs/src/systems/performance.md
+++ b/docs/src/systems/performance.md
@@ -165,94 +165,78 @@ build — because you asked for it). The two stack:
 
 ## Saying what a function may *do*
 
-Beyond counting allocations, a fn can assert what it's allowed to
-*reach*:
+A fn can declare what it's allowed to *reach*, and the compiler
+enforces it across everything reachable from it:
 
 ```hale,fragment
-@no_block fn on_tick(t: Tick) { ... }        // nothing blocking reachable
-@no_syscall fn compute(n: Int) -> Int { ... } // no file/socket/process I/O
-@deterministic fn decide(seed: Int) -> Int { ... } // no clock, entropy, or env
-@no_recursion fn step(n: Int) -> Int { ... } // no cycle under this root
-@no_ffi fn managed(x: Int) -> Int { ... }    // no @ffi call reachable
+@effects(none: {syscall, block}) fn decode(b: Bytes) -> Msg { ... }
+@effects(none: {time})           fn backoff(n: Int) -> Int { ... }
+@effects(publish: {OrderFill})   fn route(o: Order) { ... }
 ```
 
-`@deterministic` is the one worth knowing about for replay: a fn that
-reads no clock, no randomness and no environment is a function of its
-inputs, so replaying its inputs replays its behavior exactly. The
-compiler knows the difference between reading a source and using a
-supplied value — `std::time::time_from_unix(at)` formats an instant
-you passed in and is fine; `std::time::monotonic_ns()` is not.
+`none: {…}` forbids effect classes — `syscall`, `block`, `time`,
+`entropy`, `env`, `ffi`, `publish`, `spawn`, `recursion`.
+`publish: {…}` declares which topics a fn may publish to (exact,
+because Hale's topic set is closed).
 
-They stack with each other and with the contracts above —
-`@no_block @hot @budget(alloc_per_call = 0) fn handle(...)` is the
-full hot-path certificate.
+The common contracts have short names, which are exactly the same
+thing spelled shorter:
 
-`@no_block` is the one to reach for on an `async_io`-placed handler:
-a blocking call there holds the pool's single worker, which is
-invisible until something else wants it. If a violation exists the
-compiler shows you the path, not just the verdict:
+| shorthand | full form |
+|---|---|
+| `@no_syscall` | `@effects(none: {syscall})` |
+| `@no_block` | `@effects(none: {block})` |
+| `@no_ffi` | `@effects(none: {ffi})` |
+| `@no_publish` | `@effects(none: {publish})` |
+| `@no_spawn` | `@effects(none: {spawn})` |
+| `@no_recursion` | `@effects(none: {recursion})` |
+| `@deterministic` | `@effects(none: {time, entropy, env})` |
 
-```
-`@no_block` violated: `on_tick` reaches
-on_tick -> helper -> nap [std::time::sleep — blocks/parks for the
-full duration].
-```
+They stack with each other and with the contracts above, so the full
+hot-path certificate is one line:
 
-
-```hale
+```hale,fragment
+@no_block @no_syscall @deterministic @no_recursion @hot
 @budget(alloc_per_call = 0)
-fn decode(buf: Bytes) -> Tick {
-    // no arena allocation reachable from here — the compiler proves it.
-    // reads via reused fields / recv_into; parses in place.
-}
+fn on_tick(a: Int, b: Int) -> Int { ... }
 ```
 
-`N = 0` is the zero-alloc certificate — exactly what you want on a
-per-datagram handler or decode helper. The check counts the arena
-allocations it can see (literals, `@form` inserts) transitively through
-resolved callees, plus the known-allocating `recv` family; a loop-nested
-allocation or a call to an allocating fn in a loop is unbounded per call
-and busts any finite budget. On a violation it reports the count and
-points at every offending line. It's the dual of `@unbounded` — one
-acknowledges intentional allocation, the other forbids it — and the two
-are mutually exclusive on a fn.
+`@deterministic` is the one to know for replay: a fn that reads no
+clock, no randomness and no environment is a function of its inputs,
+so replaying its inputs replays its behavior exactly. The compiler
+knows the difference between reading a source and using a supplied
+value — `std::time::time_from_unix(at)` formats an instant you
+passed in and is fine; `std::time::monotonic_ns()` is not.
 
-The same idea extends to file descriptors and resource budgets. The
-full diagnostic surface — runtime residency dumps,
-`--dump-alloc-summary`, the fd-leak and resource-budget checks, and
-the `@unbounded` carve-out — is the operator's toolkit, documented in
-[Operations & debugging](./operations.md). This chapter is about
-writing code that doesn't accumulate in the first place; that one is
-about pinning it down when it does.
+Reach for the general form when the shorthand doesn't say what you
+mean. "No wall clock, but jitter is fine" is a real contract for a
+retry loop, and it's `@effects(none: {time})` — entropy stays
+allowed.
 
-For the resource *surface* — thread / pool / subject / fd counts,
-not a leak — there's a budget you can read or gate on:
+When an assertion fails you get the path, not just the verdict:
 
-```sh
-hale check app.hl --dump-resource-budget
-# OS threads (pinned loci):  1
-# cooperative pools:         1  [io]
-# bus subjects:              4
-# fd acquisition sites:      2
+```
+effect assertion violated: `on_tick` must not reach `block`, but reaches
+  on_tick -> helper -> nap [std::time::sleep — a blocking operation …].
 ```
 
-Drop a ceiling file in CI and the build fails when a count climbs
-past it — *"this PR added a pinned thread; bump the ceiling if you
-meant to."* Every key is optional:
+### The assertion you don't have to write
 
-```toml
-# budget.toml
-pinned_threads = 4
-bus_subjects   = 16
+Placement already declares intent, so some contracts need no
+annotation. A locus placed `cooperative(pool = web) where async_io`
+shares that pool's single worker — so a handler on it that blocks
+holds up every other locus on the pool:
+
+```
+`Worker::on_e` is placed on the async_io pool `web`, whose single worker
+it shares — but it reaches Worker::on_e -> nap [std::time::sleep …].
+A blocking call here stalls every other locus on `web` until it returns.
 ```
 
-```sh
-hale check app.hl --check-resource-budget budget.toml
-```
+That's a warning, not an error: a locus that owns its pool may block
+on purpose. Writing `@no_block` on the handler says "I mean it" and
+upgrades the check to an enforced error.
 
-None of these run by default — they're tools you reach for when a
-program's memory or fd surface is something you want to hold the
-line on.
 
 ## Knobs for when it's not your code
 

--- a/spec/styleguide.md
+++ b/spec/styleguide.md
@@ -380,6 +380,8 @@ a rolled one — log the friction, don't ship the invention.
 Each rule is tagged with its enforcement status:
 **[error]** the compiler rejects it, **[warn]** the compiler
 warns by default, **[@hot]** checked only inside `@hot` fns,
+**[@effects]** checked when the fn declares the matching effect
+assertion (`@effects(none: {…})` or its `@no_*` sugar),
 **[convention]** nothing checks it — the guide is the enforcement.
 
 ### C1. Value ownership on assignment — trust it, know the edges
@@ -712,9 +714,10 @@ is regression-tested. **[convention]**
 
 ## 5. The enforcement ladder
 
-The compiler backs this guide in four tiers. Everything default
-is advisory or genuinely-broken-only; strictness is opt-in where
-you certify a path.
+The compiler backs this guide in tiers. Everything default is
+advisory or genuinely-broken-only; strictness is opt-in where you
+certify a path — plus one tier you get for free because your
+*placement* already declared the intent.
 
 | Tier | Check | Status |
 |---|---|---|
@@ -722,6 +725,8 @@ you certify a path.
 | **warn** (default) | unbounded-alloc survey (self-escaping allocs in unbounded contexts; retirement-aware since v0.11.3); subscription nothing publishes to; locus/builder in a loop **or bus handler**; allocating recv in a loop; blocking call on a cooperative pool (interprocedural); accept-without-release on a daemon | advisory |
 | **@hot** (opt-in) | all of the above as errors within the fn; `snapshot()`/`finish()` in a loop; whole-struct self-field replace | errors in certified fns |
 | **@budget** (opt-in) | `alloc_per_call = N` counted transitively; `N=0` zero-alloc certificate | build fails on violation |
+| **@effects** (opt-in) | `@effects(none: {syscall, block, time, entropy, env, ffi, publish, spawn, recursion})` / `@effects(publish: {T})`, and the `@no_*` / `@deterministic` sugar — checked transitively; diagnostics carry the call chain to the offending leaf | build fails on violation |
+| **placement-implied** (automatic) | a handler on a `cooperative(pool = X) where async_io` locus that reaches a blocking call — the placement *is* the assertion, so no annotation is needed; writing `@no_block` upgrades it to an enforced error | advisory |
 | **fmt** (CI gate) | `hale fmt --check` — canonical mechanical form (§2, "Canonical form"); exit 1 lists offenders | gate in CI; `hale fmt` fixes |
 | escape hatches | `@unbounded` (fn or lifecycle hook) acknowledges intentional accumulation; `--allow-unowned-subscriber`; `--no-warn-unbounded-alloc` | |
 

--- a/spec/tokens.md
+++ b/spec/tokens.md
@@ -586,3 +586,28 @@ lexer errors if encountered outside a string or comment:
 
 (Backticks are reserved for time literals only; bare backslash
 outside a string literal is illegal.)
+
+
+## Annotation inventory
+
+Annotations are `@`-prefixed contextual idents (never reserved
+words), so a program may still use these names as identifiers.
+They attach to the declaration that follows.
+
+| annotation | attaches to | meaning |
+|---|---|---|
+| `@ffi("c")` | free fn | external C-ABI binding |
+| `@export` | fn / locus | WASM module export; persistent singleton |
+| `@form(kind)` | locus | storage form (vec / hashmap / ring_buffer / lru_cache) |
+| `@locality(tier)` | locus | placement locality tier |
+| `@bounded` | locus | opt into the memory-bound proof |
+| `@unbounded` | fn | acknowledge intentional unbounded allocation |
+| `@hot` | fn | certify a hot path (promotes advisories to errors) |
+| `@budget(alloc_per_call = N)` | fn | per-call allocation ceiling |
+| `@effects(none: {…})` | fn | forbid effect classes, checked transitively |
+| `@effects(publish: {…})` | fn | the allowed publish set |
+| `@no_syscall` `@no_block` `@no_ffi` `@no_publish` `@no_spawn` `@no_recursion` `@deterministic` | fn | sugar for the `@effects(none: …)` forms |
+
+Effect annotations stack with each other and with `@hot` /
+`@budget(...)`; see `spec/verification.md` for what each class
+means and where its truth comes from.

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -150,62 +150,92 @@ assume the others in a build:
   contract with `recv_into` + a reused `BytesBuilder`. fn-only; mutually
   exclusive with `@unbounded`. A violation reports the measured count and
   points at every offending allocation with the fast-path fix.
-- **Categoric effect assertions — `@no_recursion` / `@no_ffi` /
-  `@no_block`** (GH #265 phase 1, 2026-07-29). `@budget`'s discipline
-  generalized from *allocation count* to *effect classes*: an opt-in
-  contract at a root the author cares about, inferred everywhere else,
-  enforced as a hard error over the resolved call graph. All three are
-  bare `@`-flags before a `fn` (free or method), stackable with each
-  other and with `@hot` / `@budget(...)`.
-  - `@no_recursion` — no cycle reachable from this root (the
-    static-stack precondition). Diamonds are not cycles.
-  - `@no_ffi` — no `@ffi` fn transitively reachable ("pure managed
-    Hale", the `forbid(unsafe)` analog).
-  - `@no_block` — no blocking stdlib operation reachable (`sleep`, the
-    blocking `recv` family, `accept`, `connect`, subprocess waits,
-    `Reader.next`). This is the contract an `async_io`-placed handler
-    needs: a blocking call there stalls the pool's single worker.
+- **Effect assertions — `@effects(...)` and its `@no_*` sugar**
+  (GH #265, 2026-07-29). `@budget`'s discipline generalized from
+  allocation *count* to effect *classes*: an opt-in contract at a root
+  the author cares about, inferred everywhere else, enforced as a hard
+  error. **One surface, one engine, one classified frontier** — not a
+  family of independent flags.
 
-  Unlike `@budget`'s fixpoint (which reports a count and the offending
-  sites), an effect violation reports the **witness chain** — the call
-  path from the asserting root to the offending leaf,
-  `on_tick -> helper -> nap [std::time::sleep — …]` — plus a second
-  diagnostic at the leaf itself. Both run on the shared
-  witness-preserving engine (`hale-types::callgraph`), which is also
-  what `@budget` now walks.
+  The general form is `@effects(...)`:
 
-  Boundaries, unchanged from the issue: opaque callees other than the
-  classified leaf sets are outside what an assertion sees (the same
-  soundness boundary the escape analysis and `@budget` draw); `@ffi`
-  labels are trusted, not verified. `@no_panic` remains a later phase —
-  it is a different analysis (disposition coverage + index-op
-  selection), not leaf reachability.
-- **Registry-driven assertions — `@no_syscall` / `@deterministic`**
-  (GH #265 phase 2, 2026-07-29). The stdlib surface is now **fully
-  effect-classified**: every one of its entries carries an `EffectSet`
-  (`SYSCALL` / `BLOCK` / `PUBLISH` / `TIME` / `ENTROPY` / `ENV` /
-  `ALLOC` / `PURE`) in `hale-types::stdlib_surface`, and these two
-  assertions are predicates over it rather than hand-lists:
-  - `@no_syscall` — nothing syscall-class reachable (filesystem,
-    sockets, process, terminal, stdio). The compute-only contract.
-  - `@deterministic` — no clock read, no entropy, no environment: the
-    fn is a function of its inputs. The contract replicated /
-    replayable workloads need; with a message log it buys exact replay
-    debugging.
+  ```hale
+  @effects(none: {syscall, block})   fn decode(b: Bytes) -> Msg { ... }
+  @effects(none: {time})             fn backoff(n: Int) -> Int { ... }
+  @effects(publish: {OrderFill})     fn route(o: Order) { ... }
+  ```
 
-  The classification distinguishes *reading* an effect source from
-  *operating on a supplied value*: `std::time::time_from_unix(n)`
-  formats a caller-provided instant and is deterministic, while
-  `monotonic_ns()` is not; `std::http::parse_request` is pure while
-  `std::http::get` is blocking I/O. An **unclassified** registry entry
-  is treated as may-do-anything and therefore violates every
-  assertion — incompleteness can never silently pass, which is what
-  keeps the frontier true as the stdlib grows.
+  `none: {…}` forbids effect classes; `publish: {…}` declares the
+  allowed publish set (exact, because the topic set is closed). The
+  classes are `syscall`, `block`, `time`, `entropy`, `env`, `ffi`,
+  `publish`, `spawn`, `recursion`.
 
-  Composing the set gives the certificates the issue names:
+  The `@no_*` family is **documented sugar**, desugared at parse time
+  so the checker has exactly one shape to interpret (a flag can never
+  drift from the general form):
+
+  | sugar | means |
+  |---|---|
+  | `@no_syscall` | `@effects(none: {syscall})` |
+  | `@no_block` | `@effects(none: {block})` |
+  | `@no_ffi` | `@effects(none: {ffi})` |
+  | `@no_publish` | `@effects(none: {publish})` |
+  | `@no_spawn` | `@effects(none: {spawn})` |
+  | `@no_recursion` | `@effects(none: {recursion})` |
+  | `@deterministic` | `@effects(none: {time, entropy, env})` |
+
+  All stack with each other and with `@hot` / `@budget(...)`, so the
+  full hot-path certificate is one line:
   `@no_block @no_syscall @deterministic @no_recursion @hot
-  @budget(alloc_per_call = 0)` is the complete hot-path contract, and
-  it is checked in one whole-seed pass.
+  @budget(alloc_per_call = 0)`.
+
+  **Where each class's truth comes from.** `syscall` / `block` /
+  `time` / `entropy` / `env` are queries against the **fully
+  classified stdlib registry** — all 327 surface entries carry an
+  `EffectSet` in `hale-types::stdlib_surface`, with zero unclassified
+  residue (pinned by a test). The classification distinguishes
+  *reading* an effect source from operating on a *supplied value*:
+  `time_from_unix(n)` is deterministic while `monotonic_ns()` is not;
+  `http::parse_request` is pure while `http::get` is blocking I/O. An
+  unclassified entry is treated as may-do-anything and violates every
+  assertion, so incompleteness can never silently pass. `ffi` matches
+  bundle-local `@ffi` declarations. `publish` and `spawn` are
+  **syntactic** — `Topic <- v` and `Child { … }` are effects the
+  language expresses directly, recorded as effect *sites* on the
+  summary rather than as call edges. `recursion` is a graph property.
+
+  **Diagnostics carry the witness path** — the call chain from the
+  asserting root to the offending leaf, which `@budget`'s fixpoint
+  structurally could not produce:
+
+  ```
+  effect assertion violated: `on_tick` must not reach `block`, but reaches
+    on_tick -> helper -> nap [std::time::sleep — a blocking operation …].
+  ```
+
+  plus a second diagnostic at the leaf itself.
+
+  **Boundaries:** opaque callees outside the classified frontier are
+  not seen (the same soundness boundary the escape analysis and
+  `@budget` draw); `@ffi` labels are trusted, not verified; a computed
+  publish subject cannot be proven in-set and is reported. `@no_panic`
+  remains a separate track — disposition coverage + index-op
+  selection, not leaf reachability.
+- **Placement-implied contracts — the assertion you don't write**
+  (GH #265, 2026-07-29). A locus placed
+  `cooperative(pool = X) where async_io` shares that pool's single
+  worker; a blocking operation reachable from one of its handlers
+  holds the worker and stalls every other locus on the pool. Since
+  the placement already declares the intent, the compiler enforces it
+  **with no annotation at all**: an unannotated handler on an
+  async_io pool that reaches a blocking call gets a warning naming
+  the chain and both fixes (move the work to its own pool, or assert
+  `@no_block` to have it enforced as an error). Advisory rather than
+  hard, because a lone locus owning its pool may block deliberately;
+  writing an explicit assertion suppresses the advisory (the author
+  is engaged, and the enforced error replaces it). This is the class
+  of bug that shipped as a downstream latency mystery — a sleeping
+  handler holding an engine pool — now visible at compile time.
 - **Hot-path allocation lint — default-on advisory** (2026-07-16). Two
   loop-scoped anti-patterns get a **warning** (never a build failure), so
   the allocation-free shape is the path of least resistance rather than


### PR DESCRIPTION
Phases 1–2 shipped five ad-hoc `@no_*` flags bolted onto the engine — which is precisely what my own design comment on this issue said *not* to build ("don't build ten `@no_X` flags — build **one query engine over one classified frontier**"). This closes that gap and fills the two real holes it left.

## 1. The general form (the flags become sugar)
```hale
@effects(none: {syscall, block})   fn decode(b: Bytes) -> Msg { ... }
@effects(none: {time})             fn backoff(n: Int) -> Int { ... }
@effects(publish: {OrderFill})     fn route(o: Order) { ... }
```
Classes: `syscall`, `block`, `time`, `entropy`, `env`, `ffi`, `publish`, `spawn`, `recursion`.

Every `@no_*` / `@deterministic` flag is now **desugared at parse time**, so the checker interprets exactly one shape and a flag can't drift from the general form — pinned by a test asserting `@no_block` and `@effects(none: {block})` produce *identical* diagnostics. The general form also expresses what the sugar can't: `@effects(none: {time})` forbids the clock while allowing jitter, which `@deterministic` (a bundle of time+entropy+env) can't say.

## 2. Syntactic effects — `publish` and `spawn` are real now
`PUBLISH` was a class in the enum that **nothing populated**: publishes are `Topic <- v`, carried by syntax, not by any call edge — so a leaf predicate over calls could never see one. `alloc_summary` now records `EffectSite` (publish/spawn) alongside `AllocSite`, which makes the issue's headline example (`@effects(publish: {OrderFill})`) actually implementable. `@no_spawn` is new and Hale-specific: locus instantiation is an arena create plus, depending on placement, a thread spawn or pool post.

## 3. Placement-implied contracts — the assertion you don't write
A handler on a `cooperative(pool = X) where async_io` locus that reaches a blocking call stalls **every other locus on that pool**. The placement already declared the intent, so this is checked with *no annotation at all*:

```
`Worker::on_e` is placed on the async_io pool `web`, whose single worker it
shares — but it reaches Worker::on_e -> nap [std::time::sleep …]. A blocking
call here stalls every other locus on `web` until it returns.
```

Advisory (a locus owning its pool may block deliberately); writing `@no_block` upgrades it to an enforced error and suppresses the advisory. **This is Crumb batch-5's bug** — a sleeping handler holding an engine pool, discovered downstream as a latency mystery — now a compile-time finding.

## Docs (they were behind)
- `spec/verification.md` — rewritten as **one systematic entry**: the surface, the sugar table, where each class's truth comes from (registry query vs. syntactic site vs. graph property), and the boundaries.
- `spec/tokens.md` — gains the **annotation inventory** it never had (all 11 annotation forms in one table).
- `spec/styleguide.md` — the enforcement ladder gains the `@effects` and placement-implied tiers, plus an `[@effects]` status tag in the rule legend.
- `AGENTS.md` — the ladder line updated for agents writing `.hl`.
- `docs/src/systems/performance.md` — the surface, when to reach for the general form, and the assertion-you-don't-write.

20 effect tests (7 new), full workspace nextest: **1869/1869**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)