### PR TITLE
test(transport): fix the two-process flake properly — deterministic readiness handshake

### DIFF
--- a/crates/hale-codegen/tests/binding_stream_framing.rs
+++ b/crates/hale-codegen/tests/binding_stream_framing.rs
@@ -16,6 +16,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/transport.rs"]
+mod transport_support;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
     let mut bin = std::env::temp_dir();
@@ -98,6 +101,18 @@ fn framed_stream_delivers_and_rearms_without_seq_gaps() {
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn subscriber");
+    // Deterministic readiness handshake — see support/transport.rs.
+    // Without this the publisher races the listener's bind and
+    // depends on the runtime's ~1s connect-retry budget, which a
+    // loaded CI runner can exceed.
+    assert!(
+        transport_support::wait_for_listener(
+            &sock,
+            std::time::Duration::from_secs(30)
+        ),
+        "subscriber never bound its listen socket at {}",
+        sock
+    );
     for i in 0..2 {
         let p = Command::new(&pub_bin)
             .env("LOTUS_UNIX_STREAM", "1")

--- a/crates/hale-codegen/tests/support/transport.rs
+++ b/crates/hale-codegen/tests/support/transport.rs
@@ -1,0 +1,63 @@
+//! Shared readiness handshake for two-process unix-transport tests.
+//!
+//! Both `transport_counters` and `binding_stream_framing` spawn a
+//! LISTEN-role subscriber and then immediately run a CONNECT-role
+//! publisher. The runtime retries a refused connect for ~1s
+//! (200 × 5ms, `lotus_tcp_create`), which is ample on a quiet
+//! machine — and NOT ample on a CI runner executing 16 test
+//! binaries in parallel, where a freshly-spawned process can take
+//! longer than that just to reach its `bind()`. When the budget
+//! expires the publish is lost, the subscriber never sees its 2
+//! deliveries, its wait loop hits the cap and `exit(3)`s — which
+//! skips the counters dump, so the failure surfaced as the
+//! misleading "no counters dump line from subscriber" rather than
+//! "the exchange never happened".
+//!
+//! The fix is a deterministic handshake instead of a race against a
+//! timeout: wait for the listener's socket FILE to exist before
+//! launching the publisher. `bind()` is what creates it, and the
+//! runtime's listener setup binds + listens back-to-back in one
+//! function (#227 hoisted it out of the reader thread), so the file
+//! appearing means the listener is up.
+//!
+//! Deliberately NOT a probe connect: these tests assert on `rearms`,
+//! and every accepted-then-closed peer increments it — a probe
+//! connection would corrupt the very counter under test.
+#![allow(dead_code)]
+
+use std::time::{Duration, Instant};
+
+/// Block until `path` exists (the listener bound), or `timeout`
+/// elapses. Returns whether it appeared — callers assert on it so a
+/// genuinely dead subscriber fails loudly rather than as a downstream
+/// symptom.
+pub fn wait_for_listener(path: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if std::path::Path::new(path).exists() {
+            // The file appears at bind(); listen() follows
+            // immediately in the same C function. One short settle
+            // covers that instruction-level window without racing.
+            std::thread::sleep(Duration::from_millis(20));
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    false
+}
+
+/// Turn the subscriber's exit status into a diagnosis. Exit code 3 is
+/// the in-Hale wait-loop cap ("never saw the expected deliveries"),
+/// which is a different failure from "ran but printed nothing".
+pub fn describe_sub_exit(status: &std::process::ExitStatus) -> Option<String> {
+    match status.code() {
+        Some(3) => Some(
+            "the subscriber timed out waiting for its deliveries \
+             (exit 3) — the publisher's connect never landed, so no \
+             counters were dumped. This is the transport handshake \
+             failing, not a counters bug."
+                .to_string(),
+        ),
+        _ => None,
+    }
+}

--- a/crates/hale-codegen/tests/transport_counters.rs
+++ b/crates/hale-codegen/tests/transport_counters.rs
@@ -14,6 +14,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/transport.rs"]
+mod transport_support;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
     let mut bin = std::env::temp_dir();
@@ -91,6 +94,18 @@ fn counters_dump_reflects_rearm_scenario() {
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn subscriber");
+    // Deterministic readiness handshake — see support/transport.rs.
+    // Without this the publisher races the listener's bind and
+    // depends on the runtime's ~1s connect-retry budget, which a
+    // loaded CI runner can exceed.
+    assert!(
+        transport_support::wait_for_listener(
+            &sock,
+            std::time::Duration::from_secs(30)
+        ),
+        "subscriber never bound its listen socket at {}",
+        sock
+    );
     let p1 = Command::new(&pub_bin)
         .env("LOTUS_BUS_COUNTERS_DUMP", "1")
         .output()
@@ -107,6 +122,12 @@ fn counters_dump_reflects_rearm_scenario() {
     let _ = std::fs::remove_file(&pub_bin);
     let _ = std::fs::remove_file(&sock);
 
+    // Distinguish "the exchange never completed" (in-Hale wait cap →
+    // exit 3) from "ran but dumped nothing" — the former used to
+    // surface as the latter's misleading message.
+    if let Some(why) = transport_support::describe_sub_exit(&sub_out.status) {
+        panic!("{}", why);
+    }
     let sub_err = String::from_utf8_lossy(&sub_out.stderr);
     let pub_err = String::from_utf8_lossy(&p1.stderr);
     let sub_line = sub_err


### PR DESCRIPTION
`counters_dump_reflects_rearm_scenario` and `framed_stream_delivers_and_rearms_without_seq_gaps` flaked on **three PRs today** (#278, #288, #295) — always passing on rerun, always in CI's parallel `nextest`, never in serial local runs. Reruns were treating the symptom.

## Root cause
Both tests spawn a LISTEN-role subscriber and then *immediately* run a CONNECT-role publisher, relying entirely on the runtime's connect-retry budget to cover the gap. That budget is **~1s** (200 × 5ms in `lotus_tcp_create`) — ample on a quiet machine, not ample on a CI runner executing 16 test binaries in parallel, where a freshly-spawned process can exceed it just reaching `bind()`.

When it expires: the publish is lost → the subscriber never sees its 2 deliveries → its in-Hale wait loop hits the cap and `exit(3)`s → **which skips the counters dump**. So the failure surfaced as *"no counters dump line from subscriber"*, pointing the investigation at the counters code when the transport handshake was what actually failed.

## Fix
`tests/support/transport.rs`, shared by both tests:
- **`wait_for_listener`** — block until the listener's socket *file* exists before launching the publisher. `bind()` creates it, and the runtime binds+listens back-to-back in one function (#227 hoisted listener setup out of the reader thread), so its appearance means the listener is up. Deterministic; no dependence on the retry budget.
- **Deliberately not a probe connect** — both tests assert on `rearms`, and every accepted-then-closed peer increments it, so a probe connection would corrupt the counter under test.
- **`describe_sub_exit`** — exit code 3 now reports "the exchange never completed" instead of masquerading as a missing dump line.

**Runtime unchanged**: the ~1s retry is a legitimate grace for real deployments; the test shouldn't have been racing it.

## Verification
6/6 passes under simulated CI load (all cores saturated) — the condition the pre-fix shape was tripping on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)