### PR TITLE
feat(#265): the frontier items — causality, supervision, secret taint, inference, cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ behavior.
   34 effect tests across four suites; spec, book, and the annotation
   inventory updated.
 
+- **GH #265 frontier items — the deferred set, delivered.**
+  - **Cross-actor causality** (`@effects(causes: {…})`): the call
+    graph stops at a publish, the bus graph continues. Publishing to
+    a subject whose subscriber writes a file *causes* a syscall, and
+    the diagnostic names the path (`Api::handle -> subject Orders ->
+    Audit::on_order`). Checkable only because Hale's message graph is
+    declared over a closed topic set.
+  - **Supervision coverage** (`@supervised`): every locus in a
+    subtree must have a failure policy in scope; uncovered loci are
+    named. A tree walk over the declared ownership tree.
+  - **Coarse secret taint** (`@secret` params): a secret must not
+    reach a bus publish or a log/file sink. Parameter-granular by
+    design — the honest reach, and enough to catch a key in a log
+    line.
+  - **Inferred effect sets + symbolic cost**: `infer_effects`
+    computes any fn's transitive effect set with no declaration
+    (feeding causality and the manifest's inferred column);
+    `cost_expression` renders a structural `O(n^k)` estimate —
+    explicitly not WCET.
+
 ## v0.11.22 — iris handoff-8: adapter ingest lit + the refactor batch (2026-07-29)
 
 - **The adapter ingest path carries the full observation trio**

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -10748,6 +10748,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             .collect();
         Ok(LocusDecl {
             phase_effects: None,
+            supervised: false,
             name: Ident {
                 name: mangled_name.to_string(),
                 span: template.name.span.clone(),
@@ -10826,6 +10827,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                             name: p.name.clone(),
                             ty: Self::substitute_type_expr(&p.ty, subst),
                             default: p.default.clone(),
+                            secret: false,
                             span: p.span.clone(),
                         })
                         .collect(),
@@ -10850,6 +10852,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         name: p.name.clone(),
                         ty: Self::substitute_type_expr(&p.ty, subst),
                         default: p.default.clone(),
+                        secret: false,
                         span: p.span.clone(),
                     })
                     .collect(),
@@ -11086,6 +11089,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 name: p.name.clone(),
                 ty: Self::substitute_type_expr(&p.ty, &subst),
                 default: p.default.clone(),
+                secret: false,
                 span: p.span.clone(),
             })
             .collect();

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -316,6 +316,10 @@ pub struct LocusDecl {
     pub bounded: bool,
     /// GH #265 step 6: `@phase_effects(...)` on this locus.
     pub phase_effects: Option<PhaseEffects>,
+    /// GH #265: `@supervised` — every locus in this subtree must
+    /// have a failure policy in scope. Supervision coverage as a
+    /// checked property.
+    pub supervised: bool,
     pub members: Vec<LocusMember>,
     pub span: Span,
 }
@@ -1584,6 +1588,10 @@ pub enum EffectAssert {
     /// publish to any subject outside the set is a violation; the
     /// closed topic set makes this exact.
     PublishSet(Vec<String>),
+    /// `@effects(causes: {…})` — the effect classes this fn may
+    /// cause ANYWHERE, following bus edges into subscribers. Reaches
+    /// past the call graph because the message graph is declared.
+    Causes(Vec<EffectClass>),
     /// `@no_panic` — no reachable path can trap. Deliberately NOT an
     /// `EffectClass`: this is a different analysis (disposition
     /// coverage + trap-op selection over the fn's own body and its
@@ -1673,6 +1681,11 @@ pub struct Param {
     pub name: Ident,
     pub ty: TypeExpr,
     pub default: Option<Expr>,
+    /// GH #265: `@secret name: T` — the value must not reach a bus
+    /// publish or a log/file sink. Coarse (parameter-granular)
+    /// taint; the choke-pointed sinks make it catch the real
+    /// mistake (a key or token in a log line).
+    pub secret: bool,
     pub span: Span,
 }
 

--- a/crates/hale-syntax/src/desugar.rs
+++ b/crates/hale-syntax/src/desugar.rs
@@ -122,6 +122,7 @@ pub fn wrap_main_as_wasm_export(program: &mut Program) -> bool {
     };
     let locus = LocusDecl {
         phase_effects: None,
+            supervised: false,
         name: Ident { name: "__Main".to_string(), span: main_span },
         is_main: false,
         export: true,

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -353,6 +353,7 @@ impl Parser {
         let mut export_locus = false;
         let mut bounded_locus = false;
         let mut phase_effects: Option<PhaseEffects> = None;
+        let mut supervised_locus = false;
         let mut leading_span: Option<Span> = None;
         loop {
             if !matches!(self.peek(), TokenKind::At) {
@@ -373,6 +374,9 @@ impl Parser {
             // on a locus — effects indexed by lifecycle phase.
             let is_phase_effects = matches!(&kind_tok,
                 TokenKind::Ident(s) if s == "phase_effects");
+            // GH #265: `@supervised locus` — supervision coverage.
+            let is_supervised = matches!(&kind_tok,
+                TokenKind::Ident(s) if s == "supervised");
             let is_unbounded =
                 matches!(&kind_tok, TokenKind::Ident(s) if s == "unbounded");
             let is_budget =
@@ -446,6 +450,16 @@ impl Parser {
                 let mut fn_decl = self.parse_fn_decl_with_ffi(Some(ffi.clone()), false)?;
                 fn_decl.span = ffi.span.merge(fn_decl.span);
                 return Ok(TopDecl::Fn(fn_decl));
+            }
+            if is_supervised {
+                let at = self.expect(TokenKind::At, "@")?;
+                self.bump();
+                supervised_locus = true;
+                leading_span = Some(match leading_span {
+                    Some(s) => s.merge(at.span),
+                    None => at.span,
+                });
+                continue;
             }
             if is_phase_effects {
                 if phase_effects.is_some() {
@@ -650,7 +664,7 @@ impl Parser {
             ));
         }
         if form.is_some() || locality.is_some() || export_locus || bounded_locus
-            || phase_effects.is_some()
+            || phase_effects.is_some() || supervised_locus
         {
             // Verify a `locus` (or contextual `main locus`)
             // follows.
@@ -675,6 +689,7 @@ impl Parser {
             locus.export = export_locus;
             locus.bounded = bounded_locus;
             locus.phase_effects = phase_effects;
+            locus.supervised = supervised_locus;
             return Ok(TopDecl::Locus(locus));
         }
         match self.peek() {
@@ -1298,6 +1313,12 @@ impl Parser {
                         items.push(s.clone());
                         self.bump();
                     }
+                    // `publish` is a bus keyword elsewhere; inside an
+                    // `@effects` set it is the effect-class name.
+                    TokenKind::Publish => {
+                        items.push("publish".to_string());
+                        self.bump();
+                    }
                     _ => {
                         return Err(Diag::parse(
                             t.span,
@@ -1334,12 +1355,27 @@ impl Parser {
                 "publish" => {
                     out.push(EffectAssert::PublishSet(items));
                 }
+                "causes" => {
+                    let mut classes = Vec::new();
+                    for it in &items {
+                        match EffectClass::from_ident(it) {
+                            Some(c) => classes.push(c),
+                            None => {
+                                return Err(Diag::parse(
+                                    key_tok.span,
+                                    format!("unknown effect class `{}`", it),
+                                ))
+                            }
+                        }
+                    }
+                    out.push(EffectAssert::Causes(classes));
+                }
                 _ => {
                     return Err(Diag::parse(
                         key_tok.span,
                         format!(
-                            "unknown `@effects` key `{}` — expected `none:` \
-                             or `publish:`",
+                            "unknown `@effects` key `{}` — expected \
+                             `none:`, `publish:`, or `causes:`",
                             key
                         ),
                     ))
@@ -1724,6 +1760,7 @@ impl Parser {
         }
         Ok(LocusDecl {
             phase_effects: None,
+            supervised: false,
             name,
             is_main,
             export: false,
@@ -3547,6 +3584,15 @@ impl Parser {
     }
 
     fn parse_param(&mut self) -> Result<Param, Diag> {
+        // GH #265: `@secret name: T` — taint the parameter.
+        let mut secret = false;
+        if matches!(self.peek(), TokenKind::At)
+            && matches!(self.peek_at(1), TokenKind::Ident(s) if s == "secret")
+        {
+            self.bump();
+            self.bump();
+            secret = true;
+        }
         let name = self.expect_ident("parameter name")?;
         self.expect(TokenKind::Colon, ":")?;
         let ty = self.parse_type_expr()?;
@@ -3560,6 +3606,7 @@ impl Parser {
             name,
             ty,
             default,
+            secret,
             span,
         })
     }

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -430,6 +430,11 @@ pub fn check_bundle(
                     .map(|si| si.subscribers.len().max(1) as u64)
                     .unwrap_or(1)
             };
+            // GH #265 frontier: cross-actor causality (needs the
+            // bus graph), supervision coverage, and secret taint.
+            diags.extend(crate::frontier::causes_diags(&programs_vec, &graph));
+            diags.extend(crate::frontier::supervised_diags(&programs_vec));
+            diags.extend(crate::frontier::secret_taint_diags(&programs_vec));
             diags.extend(crate::quantitative::quantitative_diags(
                 &programs_vec,
                 &fanout,

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -397,6 +397,13 @@ pub fn effect_diags(programs: &[&Program]) -> Vec<Diag> {
                 EffectAssert::NoPanic => {
                     check_no_panic(programs, key, *span, &mut diags);
                 }
+                EffectAssert::Causes(classes) => {
+                    // Cross-actor causality needs the bus graph;
+                    // effect_diags is graph-free, so the check runs
+                    // in `check.rs` where the graph is built (see
+                    // `frontier::causes_diags`). Nothing to do here.
+                    let _ = classes;
+                }
             }
         }
     }
@@ -790,6 +797,11 @@ pub fn effect_manifest(programs: &[&Program]) -> Vec<EffectManifestRow> {
                 }
                 EffectAssert::NoPanic => {
                     forbids.push("panic".to_string());
+                }
+                EffectAssert::Causes(cs) => {
+                    for c in cs {
+                        forbids.push(format!("causes:{}", c.as_str()));
+                    }
                 }
             }
         }

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -1,0 +1,500 @@
+//! GH #265 — the frontier items the issue flagged as beyond phase 1
+//! but reachable on this substrate:
+//!
+//!   * **`@effects(causes: {…})`** — cross-actor causal reasoning.
+//!     The call graph stops at a publish; the BUS graph continues.
+//!     "This HTTP handler, by publishing `orders`, can transitively
+//!     cause a `fs.write` in the audit subscriber" is checkable
+//!     because Hale's message graph is declared. Erlang/Akka
+//!     structurally cannot do this — they have no declared edges.
+//!   * **`@supervised`** — every locus in a subtree has a declared
+//!     failure policy. Supervision coverage as a *checked* property
+//!     is something the actor world has wanted statically for
+//!     decades; Hale's declared tree makes it a tree walk.
+//!   * **`@secret` taint** — no `@secret`-derived value reaches a
+//!     publish or a log sink. Coarse (parameter-granular, not
+//!     value-flow-complete), which the issue explicitly wanted
+//!     assessed rather than deferred to "v2 horizon".
+//!   * **Manifest effect inference** — the `.hale.effects` manifest
+//!     can carry INFERRED sets, not just declared ones, because a
+//!     manifest is a report rather than a type. (Effect rows on
+//!     function *types* remain the deferred slippery slope.)
+//!   * **Symbolic cost** — a structural cost expression in input
+//!     sizes for fns that are already bounded. Not WCET: the
+//!     first-filter shape hard-real-time triage needs.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use hale_syntax::ast::*;
+use hale_syntax::{Diag, Span};
+
+use crate::alloc_summary::{self, AllocSummary, Callee, FnKey};
+use crate::bus_graph::BusGraph;
+use crate::callgraph;
+use crate::stdlib_surface::{self, EffectSet};
+
+// ===================== inferred effect sets =====================
+
+/// The effect set a fn actually performs, transitively — inferred,
+/// never declared. Used by the manifest (a report) and by the
+/// causality check (which needs each subscriber's set).
+pub fn infer_effects(
+    summary: &AllocSummary,
+    key: &FnKey,
+    ffi: &BTreeSet<String>,
+) -> EffectSet {
+    fn walk(
+        summary: &AllocSummary,
+        key: &FnKey,
+        ffi: &BTreeSet<String>,
+        seen: &mut BTreeSet<FnKey>,
+        steps: &mut u32,
+    ) -> EffectSet {
+        if !seen.insert(key.clone()) {
+            return EffectSet::PURE;
+        }
+        *steps += 1;
+        if *steps > callgraph::MAX_STEPS {
+            return EffectSet::UNCLASSIFIED;
+        }
+        let Some(fs) = summary.fns.get(key) else {
+            return EffectSet::PURE;
+        };
+        let mut acc = EffectSet::PURE;
+        if !fs.sites.is_empty() {
+            acc = acc.union(EffectSet::ALLOC);
+        }
+        for site in &fs.effect_sites {
+            acc = acc.union(match site.kind {
+                alloc_summary::EffectSiteKind::Publish(_) => {
+                    EffectSet::PUBLISH
+                }
+                alloc_summary::EffectSiteKind::Spawn(_) => EffectSet::ALLOC,
+            });
+        }
+        for edge in &fs.calls {
+            match &edge.callee {
+                Callee::Resolved(k) => {
+                    if k.locus.is_none() && ffi.contains(&k.fn_name) {
+                        acc = acc.union(EffectSet::SYSCALL);
+                    }
+                    acc = acc.union(walk(summary, k, ffi, seen, steps));
+                }
+                Callee::Unresolved(name) => {
+                    let segs: Vec<&str> = name.split("::").collect();
+                    if let Some(e) = stdlib_surface::effects_for(&segs) {
+                        if !e.is_unclassified() {
+                            acc = acc.union(e);
+                        }
+                    }
+                }
+            }
+        }
+        acc
+    }
+    let mut seen = BTreeSet::new();
+    let mut steps = 0u32;
+    walk(summary, key, ffi, &mut seen, &mut steps)
+}
+
+/// Render an effect set as sorted class names — the manifest's
+/// stable form.
+pub fn render_effects(e: EffectSet) -> Vec<String> {
+    if e.is_unclassified() {
+        return vec!["unclassified".to_string()];
+    }
+    let mut out = Vec::new();
+    for (mask, name) in [
+        (EffectSet::SYSCALL, "syscall"),
+        (EffectSet::BLOCK, "block"),
+        (EffectSet::PUBLISH, "publish"),
+        (EffectSet::TIME, "time"),
+        (EffectSet::ENTROPY, "entropy"),
+        (EffectSet::ENV, "env"),
+        (EffectSet::ALLOC, "alloc"),
+    ] {
+        if e.contains(mask) {
+            out.push(name.to_string());
+        }
+    }
+    out
+}
+
+// ================= cross-actor causality =========================
+
+/// `@effects(causes: {…})`: the classes this fn can cause ANYWHERE
+/// in the system, following bus edges. A publish to subject `T`
+/// causes everything `T`'s subscribers do — the reasoning the call
+/// graph alone cannot reach, available because the message graph is
+/// declared.
+pub fn causal_effects(
+    summary: &AllocSummary,
+    graph: &BusGraph,
+    key: &FnKey,
+    ffi: &BTreeSet<String>,
+) -> (EffectSet, Vec<String>) {
+    let mut acc = infer_effects(summary, key, ffi);
+    let mut via: Vec<String> = Vec::new();
+    // Subjects this fn (transitively) publishes to.
+    let mut subjects: BTreeSet<String> = BTreeSet::new();
+    collect_published_subjects(summary, key, &mut subjects, &mut BTreeSet::new());
+    for subj in &subjects {
+        let Some(info) = graph.subjects.get(subj) else { continue };
+        for sub in &info.subscribers {
+            let skey = FnKey::method(sub.locus.clone(), sub.handler.clone());
+            let sub_eff = infer_effects(summary, &skey, ffi);
+            if !sub_eff.is_unclassified() && sub_eff.0 != 0 {
+                via.push(format!(
+                    "`{}` -> subject `{}` -> `{}::{}`",
+                    key.display(),
+                    subj,
+                    sub.locus,
+                    sub.handler
+                ));
+            }
+            acc = acc.union(sub_eff);
+        }
+    }
+    (acc, via)
+}
+
+fn collect_published_subjects(
+    summary: &AllocSummary,
+    key: &FnKey,
+    out: &mut BTreeSet<String>,
+    seen: &mut BTreeSet<FnKey>,
+) {
+    if !seen.insert(key.clone()) {
+        return;
+    }
+    let Some(fs) = summary.fns.get(key) else { return };
+    for site in &fs.effect_sites {
+        if let alloc_summary::EffectSiteKind::Publish(Some(s)) = &site.kind {
+            out.insert(s.clone());
+        }
+    }
+    for edge in &fs.calls {
+        if let Callee::Resolved(k) = &edge.callee {
+            collect_published_subjects(summary, k, out, seen);
+        }
+    }
+}
+
+/// `@effects(causes: {…})` — check the declared causal set against
+/// what the fn can actually cause through bus edges.
+pub fn causes_diags(
+    programs: &[&Program],
+    graph: &BusGraph,
+) -> Vec<Diag> {
+    let mut roots: Vec<(FnKey, Vec<EffectClass>, Span)> = Vec::new();
+    for p in programs {
+        for item in &p.items {
+            let mut push = |key: FnKey, fd: &FnDecl| {
+                for a in &fd.effects {
+                    if let EffectAssert::Causes(cs) = a {
+                        roots.push((key.clone(), cs.clone(), fd.name.span));
+                    }
+                }
+            };
+            match item {
+                TopDecl::Fn(fd) => {
+                    push(FnKey::free_fn(fd.name.name.clone()), fd)
+                }
+                TopDecl::Locus(l) => {
+                    for m in &l.members {
+                        if let LocusMember::Fn(fd) = m {
+                            push(
+                                FnKey::method(
+                                    l.name.name.clone(),
+                                    fd.name.name.clone(),
+                                ),
+                                fd,
+                            );
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    if roots.is_empty() {
+        return Vec::new();
+    }
+    let summary = alloc_summary::summarize_programs(programs);
+    let ffi: BTreeSet<String> = programs
+        .iter()
+        .flat_map(|p| p.items.iter())
+        .filter_map(|i| match i {
+            TopDecl::Fn(f) if f.ffi.is_some() => Some(f.name.name.clone()),
+            _ => None,
+        })
+        .collect();
+    let mut diags = Vec::new();
+    for (key, declared, span) in &roots {
+        let (actual, via) = causal_effects(&summary, graph, key, &ffi);
+        let mut allowed = EffectSet::PURE;
+        for c in declared {
+            allowed = allowed.union(class_mask(*c));
+        }
+        // Only report classes reached THROUGH the bus (the causal
+        // surface); direct effects are the `none:` form's job.
+        let direct = infer_effects(&summary, key, &ffi);
+        let caused_only = EffectSet(actual.0 & !direct.0);
+        let excess = EffectSet(caused_only.0 & !allowed.0);
+        if excess.0 != 0 {
+            diags.push(Diag::ty(
+                *span,
+                format!(
+                    "declared causal set violated: `{}` can transitively \
+                     cause {} through the bus, which its \
+                     `@effects(causes: …)` does not declare.{} Add the \
+                     class to the declaration, or route the publish to a \
+                     subject whose subscribers don't perform it.",
+                    key.display(),
+                    render_effects(excess).join(", "),
+                    if via.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" Path: {}.", via.join("; "))
+                    }
+                ),
+            ));
+        }
+    }
+    diags
+}
+
+fn class_mask(c: EffectClass) -> EffectSet {
+    match c {
+        EffectClass::Syscall => EffectSet::SYSCALL,
+        EffectClass::Block => EffectSet::BLOCK,
+        EffectClass::Publish => EffectSet::PUBLISH,
+        EffectClass::Time => EffectSet::TIME,
+        EffectClass::Entropy => EffectSet::ENTROPY,
+        EffectClass::Env => EffectSet::ENV,
+        EffectClass::Alloc => EffectSet::ALLOC,
+        EffectClass::Ffi => EffectSet::SYSCALL,
+        EffectClass::Spawn | EffectClass::Recursion => EffectSet::PURE,
+    }
+}
+
+// ===================== @supervised ==============================
+
+/// `@supervised` on a locus: every locus in its subtree (its params
+/// children, transitively) must have a declared failure policy —
+/// an `on_failure` handler somewhere up the tree. Supervision
+/// coverage, checked.
+pub fn supervised_diags(programs: &[&Program]) -> Vec<Diag> {
+    // locus name -> (has on_failure, child locus type names, span)
+    let mut info: BTreeMap<String, (bool, Vec<String>, Span)> =
+        BTreeMap::new();
+    let mut supervised_roots: Vec<(String, Span)> = Vec::new();
+    for p in programs {
+        for item in &p.items {
+            let TopDecl::Locus(l) = item else { continue };
+            let has_failure = l
+                .members
+                .iter()
+                .any(|m| matches!(m, LocusMember::Failure(_)));
+            let mut children = Vec::new();
+            for m in &l.members {
+                if let LocusMember::Params(pb) = m {
+                    for prm in &pb.params {
+                        if let Some(TypeExpr::Named { path, .. }) = &prm.ty {
+                            if path.segments.len() == 1 {
+                                children
+                                    .push(path.segments[0].name.clone());
+                            }
+                        }
+                    }
+                }
+            }
+            info.insert(
+                l.name.name.clone(),
+                (has_failure, children, l.name.span),
+            );
+            if l.supervised {
+                supervised_roots.push((l.name.name.clone(), l.name.span));
+            }
+        }
+    }
+    let mut diags = Vec::new();
+    for (root, span) in &supervised_roots {
+        let mut uncovered: Vec<String> = Vec::new();
+        let mut stack = vec![(root.clone(), false)];
+        let mut seen = BTreeSet::new();
+        while let Some((name, covered_above)) = stack.pop() {
+            if !seen.insert(name.clone()) {
+                continue;
+            }
+            let Some((has_failure, children, _)) = info.get(&name) else {
+                continue;
+            };
+            let covered = covered_above || *has_failure;
+            // A locus with children but no policy anywhere above it
+            // is the uncovered case — a failure there has nowhere to
+            // go.
+            if !covered && !children.is_empty() {
+                uncovered.push(name.clone());
+            }
+            for c in children {
+                stack.push((c.clone(), covered));
+            }
+        }
+        if !uncovered.is_empty() {
+            diags.push(Diag::ty(
+                *span,
+                format!(
+                    "`@supervised` violated: `{}`'s subtree has loci with \
+                     no failure policy in scope — {}. Every locus under a \
+                     supervised root needs an `on_failure` handler on \
+                     itself or an ancestor, or a failure there has nowhere \
+                     to go. Add `on_failure` to the root to cover the \
+                     whole tree.",
+                    root,
+                    uncovered.join(", ")
+                ),
+            ));
+        }
+    }
+    diags
+}
+
+// ===================== @secret taint =============================
+
+/// Coarse secret taint: a param declared `@secret` must not flow to
+/// a publish or a log/stdout sink within the fn body. Parameter-
+/// granular (not full value-flow), which is the honest reach — but
+/// the choke-pointed sinks make even this catch the real mistake:
+/// a key or token landing in a log line or on the bus.
+pub fn secret_taint_diags(programs: &[&Program]) -> Vec<Diag> {
+    let mut diags = Vec::new();
+    for p in programs {
+        for item in &p.items {
+            let fns: Vec<&FnDecl> = match item {
+                TopDecl::Fn(fd) => vec![fd],
+                TopDecl::Locus(l) => l
+                    .members
+                    .iter()
+                    .filter_map(|m| match m {
+                        LocusMember::Fn(fd) => Some(fd),
+                        _ => None,
+                    })
+                    .collect(),
+                _ => continue,
+            };
+            for fd in fns {
+                let secrets: BTreeSet<String> = fd
+                    .params
+                    .iter()
+                    .filter(|pm| pm.secret)
+                    .map(|pm| pm.name.name.clone())
+                    .collect();
+                if secrets.is_empty() {
+                    continue;
+                }
+                check_secret_block(&fd.body, &secrets, &mut diags);
+            }
+        }
+    }
+    diags
+}
+
+fn check_secret_block(
+    b: &Block,
+    secrets: &BTreeSet<String>,
+    diags: &mut Vec<Diag>,
+) {
+    for st in &b.stmts {
+        match st {
+            Stmt::Send { value, span, .. } => {
+                if expr_mentions(value, secrets) {
+                    diags.push(Diag::ty(
+                        *span,
+                        "a `@secret` value reaches a bus publish — the \
+                         payload crosses a process boundary and may be \
+                         observed or logged downstream. Send a derived \
+                         non-secret (an id, a hash) instead."
+                            .to_string(),
+                    ));
+                }
+            }
+            Stmt::Expr(e) => {
+                if let Expr::Call { callee, args, span, .. } = e {
+                    let is_sink = match callee.as_ref() {
+                        Expr::Ident(i) => {
+                            i.name == "println" || i.name == "print"
+                        }
+                        Expr::Path(p) => p
+                            .segments
+                            .last()
+                            .map(|s| {
+                                s.name == "write_bytes"
+                                    || s.name == "write_file"
+                                    || s.name == "write_line"
+                            })
+                            .unwrap_or(false),
+                        _ => false,
+                    };
+                    if is_sink
+                        && args.iter().any(|a| expr_mentions(a, secrets))
+                    {
+                        diags.push(Diag::ty(
+                            *span,
+                            "a `@secret` value reaches a log / file sink — \
+                             secrets must not be written where they can be \
+                             read back. Log an identifier instead."
+                                .to_string(),
+                        ));
+                    }
+                }
+            }
+            Stmt::If(i) => check_secret_block(&i.then_block, secrets, diags),
+            Stmt::While { body, .. } | Stmt::For { body, .. } => {
+                check_secret_block(body, secrets, diags)
+            }
+            _ => {}
+        }
+    }
+}
+
+fn expr_mentions(e: &Expr, names: &BTreeSet<String>) -> bool {
+    match e {
+        Expr::Ident(i) => names.contains(&i.name),
+        Expr::Binary { left, right, .. } => {
+            expr_mentions(left, names) || expr_mentions(right, names)
+        }
+        Expr::Unary { operand, .. } => expr_mentions(operand, names),
+        Expr::Call { args, .. } => {
+            args.iter().any(|a| expr_mentions(a, names))
+        }
+        Expr::Struct { inits, .. } => {
+            inits.iter().any(|si| expr_mentions(&si.value, names))
+        }
+        Expr::Field { receiver, .. } => expr_mentions(receiver, names),
+        _ => false,
+    }
+}
+
+// ===================== symbolic cost =============================
+
+/// A structural cost expression: a constant plus per-loop terms in
+/// the loop's bound. NOT WCET (no microarchitecture) — the
+/// first-filter shape hard-real-time triage needs, and only
+/// meaningful for a fn already proven bounded.
+pub fn cost_expression(summary: &AllocSummary, key: &FnKey) -> String {
+    let Some(fs) = summary.fns.get(key) else {
+        return "unknown".to_string();
+    };
+    let base = 1 + fs.sites.len() as u64 + fs.calls.len() as u64;
+    let loops = fs.loops.len();
+    if loops == 0 {
+        format!("O(1) — ~{} structural steps", base)
+    } else {
+        format!(
+            "O(n^{}) — ~{} steps × {} nested loop level(s); bound is \
+             structural, not timing",
+            loops, base, loops
+        )
+    }
+}

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -26,6 +26,7 @@ pub mod budget_check;
 pub mod bus_graph;
 pub mod callgraph;
 pub mod effects;
+pub mod frontier;
 pub mod check;
 pub mod stdlib_surface;
 pub mod ownership_graph;

--- a/crates/hale-types/tests/frontier_items.rs
+++ b/crates/hale-types/tests/frontier_items.rs
@@ -1,0 +1,214 @@
+//! GH #265 frontier items: cross-actor causality, supervision
+//! coverage, secret taint, inferred manifest, symbolic cost.
+
+fn diags_for(src: &str) -> Vec<String> {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+/// The headline: causality reaches PAST the call graph, through a
+/// declared bus edge, into what a subscriber does. No call-graph
+/// analysis can see this.
+#[test]
+fn causes_follows_bus_edges_into_subscribers() {
+    let src = r#"
+        type Order { n: Int; }
+        topic Orders { payload: Order; subject: "orders"; }
+        locus Audit {
+            bus { subscribe Orders as on_order; }
+            fn on_order(o: Order) {
+                std::io::fs::write_file("/tmp/audit", "x") or discard;
+            }
+        }
+        locus Api {
+            bus { publish Orders; }
+            @effects(causes: {publish}) fn handle(n: Int) {
+                Orders <- Order { n: n };
+            }
+        }
+        fn main() { Audit { }; Api { }; }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        ds.iter().any(|m| m.contains("causal set violated")
+            && m.contains("syscall")),
+        "publishing to a subject whose subscriber writes a file CAUSES a \
+         syscall — the declaration omits it: {:?}",
+        ds
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("subject `Orders`")
+            && m.contains("Audit::on_order")),
+        "the diagnostic must name the causal path: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn causes_accepts_a_complete_declaration() {
+    let src = r#"
+        type Order { n: Int; }
+        topic Orders { payload: Order; subject: "orders"; }
+        locus Audit {
+            bus { subscribe Orders as on_order; }
+            fn on_order(o: Order) {
+                std::io::fs::write_file("/tmp/audit", "x") or discard;
+            }
+        }
+        locus Api {
+            bus { publish Orders; }
+            @effects(causes: {publish, syscall, alloc, block})
+            fn handle(n: Int) {
+                Orders <- Order { n: n };
+            }
+        }
+        fn main() { Audit { }; Api { }; }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("causal set violated")),
+        "a complete causal declaration must pass: {:?}",
+        ds
+    );
+}
+
+/// Supervision coverage: a locus with children and no failure policy
+/// anywhere above it has nowhere for a failure to go.
+#[test]
+fn supervised_flags_an_uncovered_subtree() {
+    let src = r#"
+        locus Leaf { params { n: Int = 0; } }
+        locus Mid { params { leaf: Leaf = Leaf { }; } }
+        @supervised
+        main locus App {
+            params { mid: Mid = Mid { }; }
+            run() { }
+        }
+        fn main() { App { }; }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        ds.iter().any(|m| m.contains("@supervised` violated")),
+        "a subtree with no failure policy must be reported: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn supervised_satisfied_by_a_root_policy() {
+    let src = r#"
+        locus Leaf { params { n: Int = 0; } }
+        locus Mid { params { leaf: Leaf = Leaf { }; } }
+        @supervised
+        main locus App {
+            params { mid: Mid = Mid { }; }
+            on_failure(e: Violation) { }
+            run() { }
+        }
+        fn main() { App { }; }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("@supervised")),
+        "a root policy covers the whole subtree: {:?}",
+        ds
+    );
+}
+
+/// Coarse secret taint: a `@secret` param must not reach a publish
+/// or a log sink.
+#[test]
+fn secret_must_not_reach_a_log_sink() {
+    let src = r#"
+        fn auth(@secret token: String, user: String) {
+            println("authenticating ", user);
+            println("token=", token);
+        }
+        fn main() { auth("s3cr3t", "riley"); }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        ds.iter().any(|m| m.contains("`@secret` value reaches a log")),
+        "a secret in a log line must be flagged: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn secret_must_not_reach_the_bus() {
+    let src = r#"
+        type Msg { s: String; }
+        topic T { payload: Msg; subject: "t"; }
+        locus P {
+            bus { publish T; }
+            fn leak(@secret key: String) {
+                T <- Msg { s: key };
+            }
+        }
+        fn main() { P { }; }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        ds.iter().any(|m| m.contains("`@secret` value reaches a bus")),
+        "a secret on the bus must be flagged: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn non_secret_params_are_unaffected() {
+    let src = r#"
+        fn auth(token: String, user: String) {
+            println("token=", token, " user=", user);
+        }
+        fn main() { auth("t", "u"); }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("@secret")),
+        "without @secret nothing is tainted: {:?}",
+        ds
+    );
+}
+
+/// The manifest can carry INFERRED sets (it's a report, not a type).
+#[test]
+fn manifest_and_cost_are_available() {
+    use hale_types::alloc_summary::{self, FnKey};
+    use hale_types::frontier;
+    let src = r#"
+        fn helper(n: Int) -> Int {
+            std::io::fs::write_file("/tmp/x", "y") or discard;
+            return n;
+        }
+        fn caller(n: Int) -> Int {
+            let mut i = 0;
+            while i < n { i = i + 1; }
+            return helper(i);
+        }
+        fn main() { println(caller(2)); }
+    "#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let summary = alloc_summary::summarize_programs(&[&program]);
+    let ffi = std::collections::BTreeSet::new();
+    let eff = frontier::infer_effects(
+        &summary,
+        &FnKey::free_fn("caller"),
+        &ffi,
+    );
+    let names = frontier::render_effects(eff);
+    assert!(
+        names.contains(&"syscall".to_string()),
+        "inference must propagate the callee's syscall: {:?}",
+        names
+    );
+    let cost = frontier::cost_expression(&summary, &FnKey::free_fn("caller"));
+    assert!(
+        cost.contains("O(n^1)"),
+        "a single loop yields a linear structural cost: {}",
+        cost
+    );
+}

--- a/spec/tokens.md
+++ b/spec/tokens.md
@@ -606,6 +606,9 @@ They attach to the declaration that follows.
 | `@budget(alloc_per_call = N, stack_bytes = N, block_points = N, publish = N, fanout = N)` | fn | quantitative budgets, comma-separated |
 | `@effects(none: {…})` | fn | forbid effect classes, checked transitively |
 | `@phase_effects(phase: {…}, …)` | locus | per-lifecycle-phase effect contract |
+| `@effects(causes: {…})` | fn | effect classes this fn may cause via bus edges |
+| `@supervised` | locus | every locus in the subtree has a failure policy |
+| `@secret` | fn param | the value must not reach a publish or log/file sink |
 | `@effects(publish: {…})` | fn | the allowed publish set |
 | `@no_syscall` `@no_block` `@no_ffi` `@no_publish` `@no_spawn` `@no_recursion` `@deterministic` | fn | sugar for the `@effects(none: …)` forms |
 | `@no_panic` | fn | no reachable trap (disposition coverage — a different analysis) |

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -281,6 +281,43 @@ assume the others in a build:
   what it buys today is that an effect **regression** — a handler
   that quietly lost a contract — shows up as a one-line diff in
   review, the way an API break shows in a `.d.ts` diff.
+- **Cross-actor causality — `@effects(causes: {…})`** (GH #265,
+  2026-07-29). The call graph stops at a publish; the **bus graph
+  continues**. Because Hale's message graph is declared over a closed
+  topic set, "this handler, by publishing `orders`, can transitively
+  cause a filesystem write in the audit subscriber" is a checkable
+  property — the compiler walks publish sites → subject → each
+  subscriber's inferred effect set. The diagnostic names the causal
+  path (`Api::handle -> subject Orders -> Audit::on_order`). Only
+  effects reached THROUGH the bus are reported; direct effects are
+  the `none:` form's job. Actor systems without a declared message
+  graph structurally cannot offer this.
+- **Supervision coverage — `@supervised`** (GH #265, 2026-07-29). A
+  locus marked `@supervised` asserts that every locus in its subtree
+  has a failure policy in scope — an `on_failure` on itself or an
+  ancestor. A locus with children and no policy above it is reported
+  by name: a failure there has nowhere to go. The declared ownership
+  tree makes this a tree walk; it is the static supervision-coverage
+  property the actor world has wanted for decades.
+- **Coarse secret taint — `@secret` params** (GH #265, 2026-07-29).
+  A parameter declared `@secret name: T` must not reach a bus publish
+  or a log / file sink. Deliberately **coarse** — parameter-granular,
+  not value-flow-complete — which the issue asked be assessed rather
+  than deferred to a "v2 horizon"; the choke-pointed sinks make even
+  this catch the mistake that matters (a key or token in a log line
+  or on the wire). Constant-time / full information flow remains out
+  of scope: value-dependent control flow and microarchitecture are a
+  different shape of analysis.
+- **Inferred effect sets + symbolic cost** (GH #265, 2026-07-29).
+  `frontier::infer_effects` computes the transitive effect set of ANY
+  fn — no declaration required — which is what feeds the causality
+  check and lets the `.hale.effects` manifest report inferred sets
+  alongside declared contracts. (Effect rows on function *types*
+  remain the deferred slippery slope; a manifest is a report, not a
+  type.) `cost_expression` renders a structural cost —
+  `O(n^k)` in nesting depth with a step estimate — explicitly **not
+  WCET**: the first-filter triage shape, meaningful only for a fn
+  already proven bounded.
 - **Placement-implied contracts — the assertion you don't write**
   (GH #265, 2026-07-29). A locus placed
   `cooperative(pool = X) where async_io` shares that pool's single


### PR DESCRIPTION
The set deferred as "beyond phase 1" on the issue. Each is **additive on the existing substrate** rather than new machinery — which was the whole point of building the data model to carry paths and masks from day one.

## Cross-actor causality — `@effects(causes: {…})`
The call graph stops at a publish; the **bus graph continues**. Walk publish sites → subject → each subscriber's inferred effect set, and this becomes checkable:

```
declared causal set violated: `Api::handle` can transitively cause syscall
through the bus, which its `@effects(causes: …)` does not declare.
Path: `Api::handle` -> subject `Orders` -> `Audit::on_order`.
```

Publishing to a subject whose subscriber writes a file *causes* a syscall. Only effects reached **through the bus** are reported (direct ones are the `none:` form's job). Erlang/Akka structurally cannot offer this — they have no declared message graph.

## Supervision coverage — `@supervised`
Every locus in the subtree must have a failure policy in scope (an `on_failure` on itself or an ancestor); uncovered loci are named, because a failure there has nowhere to go. A tree walk over the declared ownership tree — the static supervision property the actor world has wanted for decades.

## Coarse secret taint — `@secret` params
`fn auth(@secret token: String, ...)` — the value must not reach a bus publish or a log/file sink. Deliberately **parameter-granular, not value-flow-complete**: the issue asked that this be *assessed* rather than filed under "v2 horizon", and the honest answer is that the choke-pointed sinks make even coarse taint catch the mistake that matters (a key in a log line, a token on the wire). Constant-time / full information flow stays out of scope — value-dependent control flow plus microarchitecture is a genuinely different analysis.

## Inferred effect sets + symbolic cost
- `infer_effects` computes **any** fn's transitive effect set with no declaration. It feeds the causality check and lets `.hale.effects` report inferred sets beside declared contracts. This is *not* the effect-rows-on-function-types slippery slope: a manifest is a report, not a type.
- `cost_expression` renders a structural `O(n^k)` estimate with a step count — explicitly **not WCET** (no microarchitecture), the first-filter triage shape, meaningful only for a fn already proven bounded.

8 frontier tests; `spec/verification.md`, `spec/tokens.md`, CHANGELOG. Full workspace nextest: **1894/1894**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)