### PR TITLE
feat(#265): wire the effect manifest end-to-end + corpus conformance sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,19 @@ behavior.
     `cost_expression` renders a structural `O(n^k)` estimate —
     explicitly not WCET.
 
+- **GH #265: the effect manifest is wired end-to-end.**
+  `hale check --dump-effects-manifest` emits the behavioural
+  fingerprint — declared contracts **plus inferred effect sets**
+  (`does={syscall,publish}`) for every fn, stable-sorted;
+  `--check-effects-manifest <baseline>` diffs against a committed
+  copy and fails the build on change, naming the fn and the gained
+  effect. That catches what annotations can't: a handler that
+  quietly starts doing filesystem I/O is a one-line review diff even
+  though nothing was annotated. Plus a **corpus-wide conformance
+  sweep** asserting, across every in-tree `.hl` program, that no
+  reachable stdlib call is unclassified, that inference is
+  deterministic, and that declared contracts hold.
+
 ## v0.11.22 — iris handoff-8: adapter ingest lit + the refactor batch (2026-07-29)
 
 - **The adapter ingest path carries the full observation trio**

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2206,6 +2206,48 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
     }
     // GH #18 item 5: dump the per-program resource budget (pinned threads,
     // cooperative pools, bus subjects) and exit.
+    // GH #265 step 7: the `.hale.effects` manifest — declared
+    // contracts + inferred effect sets, stable-sorted. Emit it for
+    // review, or DIFF it against a committed copy so an effect
+    // regression (a handler that quietly gained a syscall) fails CI
+    // the way an API break does.
+    if std::env::args().any(|a| a == "--dump-effects-manifest") {
+        print!("{}", hale_types::dump_effects_manifest(&bundle));
+    }
+    if let Some(path) = std::env::args()
+        .position(|a| a == "--check-effects-manifest")
+        .and_then(|i| std::env::args().nth(i + 1))
+    {
+        let current = hale_types::dump_effects_manifest(&bundle);
+        match std::fs::read_to_string(&path) {
+            Ok(expected) => {
+                if expected != current {
+                    eprintln!(
+                        "effect manifest changed — {} no longer matches the \
+                         program's effects.",
+                        path
+                    );
+                    for line in diff_lines(&expected, &current) {
+                        eprintln!("{}", line);
+                    }
+                    eprintln!(
+                        "\nIf the change is intended, regenerate:\n  \
+                         hale check <target> --dump-effects-manifest > {}",
+                        path
+                    );
+                    return ExitCode::from(1);
+                }
+            }
+            Err(_) => {
+                eprintln!(
+                    "effect manifest baseline not found: {}\nCreate it:\n  \
+                     hale check <target> --dump-effects-manifest > {}",
+                    path, path
+                );
+                return ExitCode::from(1);
+            }
+        }
+    }
     if std::env::args().any(|a| a == "--dump-resource-budget") {
         print!("{}", hale_types::dump_resource_budget(&bundle));
         return ExitCode::SUCCESS;
@@ -3535,4 +3577,23 @@ fn compute_codegen_src_hash(codegen_dir: &Path) -> String {
         }
     }
     format!("{:016x}", hasher.finish())
+}
+
+
+/// GH #265: minimal line diff for the effect-manifest gate — enough
+/// to show WHICH fn's effects changed without pulling in a diff
+/// crate. Lines are stable-sorted by fn name, so a set difference is
+/// an accurate rendering.
+fn diff_lines(expected: &str, current: &str) -> Vec<String> {
+    use std::collections::BTreeSet;
+    let a: BTreeSet<&str> = expected.lines().collect();
+    let b: BTreeSet<&str> = current.lines().collect();
+    let mut out = Vec::new();
+    for gone in a.difference(&b) {
+        out.push(format!("  - {}", gone));
+    }
+    for added in b.difference(&a) {
+        out.push(format!("  + {}", added));
+    }
+    out
 }

--- a/crates/hale-cli/tests/effects_manifest.rs
+++ b/crates/hale-cli/tests/effects_manifest.rs
@@ -1,0 +1,142 @@
+//! GH #265 step 7 — the `.hale.effects` manifest and its CI gate.
+//!
+//! The manifest is a **behavioural fingerprint**: declared contracts
+//! plus INFERRED effect sets, stable-sorted. Its value is the diff —
+//! a handler that quietly gains a syscall shows up in review the way
+//! an API break shows in a `.d.ts` diff, even though no annotation
+//! changed.
+
+use std::process::Command;
+
+fn hale() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_hale"))
+}
+
+const CLEAN: &str = r#"
+type Ev { n: Int; }
+topic T { payload: Ev; subject: "t"; }
+locus Sink {
+    bus { subscribe T as on_t; }
+    fn on_t(e: Ev) {
+        std::io::fs::write_file("/tmp/hale-manifest-test", "x") or discard;
+    }
+}
+locus Api {
+    bus { publish T; }
+    @no_block fn emit(n: Int) {
+        T <- Ev { n: n };
+    }
+}
+fn main() { Sink { }; Api { }; }
+"#;
+
+/// The regressed variant: `Api::emit` silently gains a filesystem
+/// write. No annotation changes — only the inferred set does.
+const REGRESSED: &str = r#"
+type Ev { n: Int; }
+topic T { payload: Ev; subject: "t"; }
+locus Sink {
+    bus { subscribe T as on_t; }
+    fn on_t(e: Ev) {
+        std::io::fs::write_file("/tmp/hale-manifest-test", "x") or discard;
+    }
+}
+locus Api {
+    bus { publish T; }
+    @no_block fn emit(n: Int) {
+        T <- Ev { n: n };
+        std::io::fs::write_file("/tmp/hale-sneaky", "x") or discard;
+    }
+}
+fn main() { Sink { }; Api { }; }
+"#;
+
+fn workdir(tag: &str) -> std::path::PathBuf {
+    let d = std::env::temp_dir()
+        .join(format!("hale-manifest-{}-{}", tag, std::process::id()));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+#[test]
+fn manifest_reports_inferred_effects_without_annotations() {
+    let d = workdir("dump");
+    let app = d.join("app.hl");
+    std::fs::write(&app, CLEAN).unwrap();
+    let out = hale()
+        .arg("check")
+        .arg(&app)
+        .arg("--dump-effects-manifest")
+        .output()
+        .expect("run");
+    let text = String::from_utf8_lossy(&out.stdout);
+    let _ = std::fs::remove_dir_all(&d);
+    // Declared contract shows up …
+    assert!(
+        text.contains("Api::emit") && text.contains("none={block}"),
+        "declared contract missing: {}",
+        text
+    );
+    // … and so does the INFERRED set of a fn with no annotation at
+    // all. That is what makes this a fingerprint rather than an
+    // annotation dump.
+    assert!(
+        text.contains("Sink::on_t") && text.contains("does={syscall}"),
+        "inferred effect of an unannotated handler missing: {}",
+        text
+    );
+}
+
+#[test]
+fn manifest_gate_passes_unchanged_and_catches_a_silent_regression() {
+    let d = workdir("gate");
+    let app = d.join("app.hl");
+    let baseline = d.join("baseline.effects");
+    std::fs::write(&app, CLEAN).unwrap();
+
+    // Record the baseline.
+    let dump = hale()
+        .arg("check")
+        .arg(&app)
+        .arg("--dump-effects-manifest")
+        .output()
+        .expect("dump");
+    std::fs::write(&baseline, &dump.stdout).unwrap();
+
+    // Unchanged program → gate passes.
+    let ok = hale()
+        .arg("check")
+        .arg(&app)
+        .arg("--check-effects-manifest")
+        .arg(&baseline)
+        .output()
+        .expect("gate");
+    assert!(
+        ok.status.success(),
+        "unchanged program must pass the gate. stderr: {}",
+        String::from_utf8_lossy(&ok.stderr)
+    );
+
+    // A handler silently gains a syscall → gate fails, naming it.
+    std::fs::write(&app, REGRESSED).unwrap();
+    let bad = hale()
+        .arg("check")
+        .arg(&app)
+        .arg("--check-effects-manifest")
+        .arg(&baseline)
+        .output()
+        .expect("gate");
+    let err = String::from_utf8_lossy(&bad.stderr).to_string();
+    let _ = std::fs::remove_dir_all(&d);
+    assert!(
+        !bad.status.success(),
+        "a silent effect regression must fail the gate"
+    );
+    assert!(
+        err.contains("effect manifest changed")
+            && err.contains("Api::emit")
+            && err.contains("syscall"),
+        "the diff must name the fn and the gained effect: {}",
+        err
+    );
+}

--- a/crates/hale-codegen/tests/effects_corpus_conformance.rs
+++ b/crates/hale-codegen/tests/effects_corpus_conformance.rs
@@ -1,0 +1,171 @@
+//! GH #265 step 7 — the CORPUS-WIDE conformance sweep.
+//!
+//! `effects_conformance.rs` checks hand-written programs against the
+//! runtime oracle. This is the scaled version the issue describes:
+//! walk the whole in-tree `.hl` corpus, compute each program's
+//! INFERRED effect sets, and assert the analysis is internally
+//! coherent everywhere real code lives — not just on fixtures
+//! written to exercise it.
+//!
+//! What it checks per program:
+//!   1. **Total classification** — no reachable stdlib call lands on
+//!      an UNCLASSIFIED registry row. An unclassified leaf silently
+//!      weakens every assertion, so the frontier staying complete as
+//!      the corpus grows is the property that must not rot.
+//!   2. **Inference terminates and is deterministic** — the same
+//!      program inferred twice yields identical sets (no
+//!      iteration-order or memo-poisoning nondeterminism, the class
+//!      of bug that makes a manifest diff-noisy).
+//!   3. **Declared contracts hold** — any corpus program that
+//!      carries an assertion must satisfy it. A corpus fixture that
+//!      violates its own contract is either a compiler bug or a bad
+//!      fixture; both want to fail loudly here.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use hale_types::alloc_summary::{self, FnKey};
+use hale_types::frontier;
+
+fn corpus_files() -> Vec<PathBuf> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/examples");
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return out;
+    };
+    for e in entries.flatten() {
+        let main = e.path().join("main.hl");
+        if main.is_file() {
+            out.push(main);
+        }
+    }
+    out.sort();
+    out
+}
+
+fn fn_keys(program: &hale_syntax::ast::Program) -> Vec<FnKey> {
+    use hale_syntax::ast::*;
+    let mut keys = Vec::new();
+    for item in &program.items {
+        match item {
+            TopDecl::Fn(fd) => keys.push(FnKey::free_fn(fd.name.name.clone())),
+            TopDecl::Locus(l) => {
+                for m in &l.members {
+                    if let LocusMember::Fn(fd) = m {
+                        keys.push(FnKey::method(
+                            l.name.name.clone(),
+                            fd.name.name.clone(),
+                        ));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    keys
+}
+
+#[test]
+fn corpus_effect_inference_is_total_and_deterministic() {
+    let files = corpus_files();
+    assert!(
+        files.len() > 10,
+        "corpus should be substantial; found {}",
+        files.len()
+    );
+    let mut unclassified_hits: Vec<String> = Vec::new();
+    let mut nondeterministic: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+
+    for f in &files {
+        let Ok(src) = std::fs::read_to_string(f) else { continue };
+        let Ok(program) = hale_syntax::parse_source(&src) else {
+            // Parse failures are other suites' business.
+            continue;
+        };
+        let summary = alloc_summary::summarize_programs(&[&program]);
+        let ffi: BTreeSet<String> = BTreeSet::new();
+        for key in fn_keys(&program) {
+            let a = frontier::infer_effects(&summary, &key, &ffi);
+            let b = frontier::infer_effects(&summary, &key, &ffi);
+            checked += 1;
+            if a != b {
+                nondeterministic.push(format!(
+                    "{}::{}",
+                    f.file_name().unwrap().to_string_lossy(),
+                    key.display()
+                ));
+            }
+            if a.is_unclassified() {
+                unclassified_hits.push(format!(
+                    "{} :: {}",
+                    f.parent()
+                        .and_then(|p| p.file_name())
+                        .map(|s| s.to_string_lossy().to_string())
+                        .unwrap_or_default(),
+                    key.display()
+                ));
+            }
+        }
+    }
+
+    assert!(checked > 50, "expected to check many fns, got {}", checked);
+    assert!(
+        nondeterministic.is_empty(),
+        "effect inference is nondeterministic for: {:?} — a manifest built \
+         from this would diff spuriously",
+        nondeterministic
+    );
+    assert!(
+        unclassified_hits.is_empty(),
+        "these corpus fns reach an UNCLASSIFIED stdlib row, which silently \
+         weakens every assertion over them: {:?}",
+        unclassified_hits
+    );
+}
+
+/// Every corpus program that carries an effect assertion must
+/// satisfy it. A fixture violating its own contract is either a
+/// compiler bug or a bad fixture — both should fail here rather than
+/// rot silently.
+#[test]
+fn corpus_declared_contracts_hold() {
+    let mut violations: Vec<String> = Vec::new();
+    for f in corpus_files() {
+        let Ok(src) = std::fs::read_to_string(&f) else { continue };
+        if !(src.contains("@no_")
+            || src.contains("@effects(")
+            || src.contains("@deterministic")
+            || src.contains("@phase_effects")
+            || src.contains("@supervised"))
+        {
+            continue;
+        }
+        let Ok(program) = hale_syntax::parse_source(&src) else { continue };
+        for d in hale_types::check_program(&program) {
+            let m = &d.message;
+            if m.contains("effect assertion violated")
+                || m.contains("phase contract violated")
+                || m.contains("causal set violated")
+                || m.contains("publish set violated")
+                || m.contains("@supervised` violated")
+                || m.contains("@no_panic` violated")
+            {
+                violations.push(format!(
+                    "{}: {}",
+                    f.parent()
+                        .and_then(|p| p.file_name())
+                        .map(|s| s.to_string_lossy().to_string())
+                        .unwrap_or_default(),
+                    m
+                ));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "corpus programs violate their own declared effect contracts: {:#?}",
+        violations
+    );
+}

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -777,6 +777,13 @@ pub struct EffectManifestRow {
     pub forbids: Vec<String>,
     pub publish_set: Option<Vec<String>>,
     pub quantities: Vec<(String, u64)>,
+    /// GH #265: the INFERRED effect set — what the fn actually does,
+    /// transitively, whether or not it declares anything. This is
+    /// what makes the manifest a behavioural fingerprint rather than
+    /// a restatement of the annotations: a handler that silently
+    /// gains a syscall shows up here as a one-line diff even though
+    /// no annotation changed.
+    pub inferred: Vec<String>,
 }
 
 /// Build the whole-program effect manifest, sorted for stable diffs.
@@ -813,6 +820,10 @@ pub fn effect_manifest(programs: &[&Program]) -> Vec<EffectManifestRow> {
         if let Some(b) = fd.budget {
             quantities.push(("alloc_per_call".to_string(), b as u64));
         }
+        // Rows with no declaration are still emitted when the
+        // caller fills in an inferred set (see
+        // `effect_manifest_with_inference`); the declaration-only
+        // builder skips them.
         if forbids.is_empty() && publish_set.is_none() && quantities.is_empty()
         {
             return;
@@ -824,6 +835,7 @@ pub fn effect_manifest(programs: &[&Program]) -> Vec<EffectManifestRow> {
             forbids,
             publish_set,
             quantities,
+            inferred: Vec::new(),
         });
     };
     for p in programs {
@@ -836,6 +848,73 @@ pub fn effect_manifest(programs: &[&Program]) -> Vec<EffectManifestRow> {
                             push(
                                 format!("{}::{}", l.name.name, fd.name.name),
                                 fd,
+                            );
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    rows.sort_by(|a, b| a.func.cmp(&b.func));
+    rows
+}
+
+/// GH #265: the manifest with INFERRED sets filled in for every fn
+/// in the bundle — declared contracts plus what the compiler can see
+/// each fn actually does. This is the diffable behavioural
+/// fingerprint; `effect_manifest` alone reports declarations only.
+pub fn effect_manifest_with_inference(
+    programs: &[&Program],
+) -> Vec<EffectManifestRow> {
+    let summary = alloc_summary::summarize_programs(programs);
+    let ffi = ffi_names(programs);
+    let declared: BTreeMap<String, EffectManifestRow> = effect_manifest(programs)
+        .into_iter()
+        .map(|r| (r.func.clone(), r))
+        .collect();
+    let mut rows: Vec<EffectManifestRow> = Vec::new();
+    let mut add = |name: String, key: FnKey| {
+        let inferred = crate::frontier::render_effects(
+            crate::frontier::infer_effects(&summary, &key, &ffi),
+        );
+        let mut row = declared.get(&name).cloned().unwrap_or(
+            EffectManifestRow {
+                func: name.clone(),
+                forbids: Vec::new(),
+                publish_set: None,
+                quantities: Vec::new(),
+                inferred: Vec::new(),
+            },
+        );
+        row.inferred = inferred;
+        // A fn with neither a declaration nor an observable effect
+        // adds nothing to the fingerprint.
+        if row.forbids.is_empty()
+            && row.publish_set.is_none()
+            && row.quantities.is_empty()
+            && row.inferred.is_empty()
+        {
+            return;
+        }
+        rows.push(row);
+    };
+    for p in programs {
+        for item in &p.items {
+            match item {
+                TopDecl::Fn(fd) => {
+                    let n = fd.name.name.clone();
+                    add(n.clone(), FnKey::free_fn(n));
+                }
+                TopDecl::Locus(l) => {
+                    for m in &l.members {
+                        if let LocusMember::Fn(fd) = m {
+                            add(
+                                format!("{}::{}", l.name.name, fd.name.name),
+                                FnKey::method(
+                                    l.name.name.clone(),
+                                    fd.name.name.clone(),
+                                ),
                             );
                         }
                     }
@@ -863,6 +942,9 @@ pub fn render_effect_manifest(rows: &[EffectManifestRow]) -> String {
         }
         for (d, n) in &r.quantities {
             out.push_str(&format!("  {}={}", d, n));
+        }
+        if !r.inferred.is_empty() {
+            out.push_str(&format!("  does={{{}}}", r.inferred.join(",")));
         }
         out.push('\n');
     }

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -3130,3 +3130,15 @@ mod unowned_subscriber_tests {
         assert!(!flagged(src, false));
     }
 }
+
+
+/// GH #265: render the whole-bundle `.hale.effects` manifest —
+/// declared contracts plus inferred effect sets, sorted for stable
+/// diffs. The CLI writes this next to `.hale.topo`; a diff in review
+/// is an effect regression.
+pub fn dump_effects_manifest(bundle: &Bundle<'_>) -> String {
+    let programs: Vec<&hale_syntax::ast::Program> =
+        bundle.programs.values().copied().collect();
+    let rows = crate::effects::effect_manifest_with_inference(&programs);
+    crate::effects::render_effect_manifest(&rows)
+}

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -273,6 +273,26 @@ assume the others in a build:
   A negative control asserts the oracle detects the effect when it
   genuinely happens, so the conformance checks can never pass
   vacuously. Same philosophy as GenMC-in-CI, applied to effects.
+- **The `.hale.effects` manifest + CI gate** (GH #265 step 7). The
+  manifest is a **behavioural fingerprint**: every fn's declared
+  contracts *and* its INFERRED effect set (`does={…}`), stable-sorted
+  for diffs. `hale check <target> --dump-effects-manifest` writes it;
+  `--check-effects-manifest <path>` diffs against a committed
+  baseline and **fails the build** when the program's effects change,
+  printing which fn gained or lost what. That catches the case
+  annotations cannot: a handler that quietly starts doing filesystem
+  I/O shows up as `+ Api::emit … does={syscall,publish,alloc}` in
+  review even though no annotation changed. Regenerate deliberately
+  with the dump flag when the change is intended.
+- **Corpus-wide conformance** (GH #265 step 7). Beyond the per-test
+  runtime oracle, a sweep over the whole in-tree `.hl` corpus asserts
+  three properties everywhere real code lives: no reachable stdlib
+  call lands on an **unclassified** registry row (an unclassified
+  leaf silently weakens every assertion over it, so frontier
+  completeness must not rot as the corpus grows); inference is
+  **deterministic** (the same program inferred twice yields identical
+  sets — otherwise manifests diff spuriously); and every corpus
+  program carrying an assertion **satisfies** it.
 - **The `.hale.effects` manifest** (GH #265 step 7). `effect_manifest`
   / `render_effect_manifest` emit the whole program's declared
   contracts in a stable, sorted line format alongside `.hale.topo`.


### PR DESCRIPTION
The three items I enumerated as *remaining* when reporting #265 complete. They were real gaps, not bookkeeping.

## The manifest carries inferred effects
`effect_manifest_with_inference` fills a `does={…}` column for **every** fn — what the compiler can see it actually does, transitively, with no annotation required:

```
# .hale.effects v1 — declared effect contracts
Api::emit   none={block}  does={publish,alloc}
Sink::on_t                does={syscall}
```

`Sink::on_t` carries no annotation at all; its inferred set is still recorded. That's what makes this a **behavioural fingerprint** rather than a restatement of the annotations.

## CLI + CI gate
- `hale check <target> --dump-effects-manifest` — emit it.
- `hale check <target> --check-effects-manifest <baseline>` — diff against a committed copy, **fail the build** on change:

```
effect manifest changed — baseline.effects no longer matches the program's effects.
  - Api::emit  none={block}  does={publish,alloc}
  + Api::emit  none={block}  does={syscall,publish,alloc}
```

This catches what annotations structurally cannot: a handler that quietly starts doing filesystem I/O is a one-line review diff **even though nothing was annotated**.

## Corpus-wide conformance
Beyond the per-test runtime oracle, a sweep over every in-tree `.hl` program asserts three properties where real code lives:
1. **No reachable stdlib call is UNCLASSIFIED** — an unclassified leaf silently weakens every assertion over it, so frontier completeness must not rot as the corpus grows.
2. **Inference is deterministic** — the same program inferred twice yields identical sets, or manifests diff spuriously.
3. **Declared contracts hold** — a corpus fixture violating its own contract is either a compiler bug or a bad fixture; both should fail loudly.

Guarded against vacuity (`files > 10`, `fns checked > 50`).

## One thing worth reporting
While testing the gate, my own fixture declared `@budget(alloc_per_call = 0)` on a fn that allocates its payload. The compiler rejected it — **the fixture was wrong, not the checker**. That's the gate doing its job on its author.

4 new tests; `spec/verification.md`, CHANGELOG. Full workspace nextest: **1898/1898**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)