### PR TITLE
release: v0.11.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.11.23 — effect assertions (GH #265, complete) + the #265/#262 refactor substrate (2026-07-29)
 
 - **GH #265: effect assertions — one surface, one engine, one
   classified frontier.** `@budget`'s discipline generalized from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,6 @@ behavior.
     and placement-implied tiers, `AGENTS.md` updated, and
     `docs/src/systems/performance.md` documents the surface.
 
-## Unreleased
-
 - **GH #265 COMPLETE — the effect-assertion system, all seven build
   steps.** The remaining phases land together on the substrate the
   earlier ones established:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.22"
+version = "0.11.23"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.22"
+version = "0.11.23"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.22"
+version = "0.11.23"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.22"
+version = "0.11.23"
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.22"
+version = "0.11.23"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.22"
+version = "0.11.23"
 dependencies = [
  "hale-syntax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.22"
+version = "0.11.23"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for **v0.11.23** — the effect-assertion system (GH #265, complete) plus the refactor substrate it was built on.

Rolled from six Unreleased entries:
- **Refactor batch** (#291) — callgraph witness engine, stdlib registry, `DeploymentPlan`, fanout core, obs test reader.
- **Effect assertions** (#294, #295) — `@effects(none:/publish:/causes:)` with the `@no_*` family as parse-time sugar; the fully classified 327-entry frontier; placement-implied contracts.
- **Quantitative + phase + conformance** (#298) — `@budget(stack_bytes/block_points/publish/fanout)`, `@phase_effects`, `@no_panic`, the runtime-oracle conformance loop.
- **Frontier items** (#299) — cross-actor causality, `@supervised`, `@secret` taint, effect inference, symbolic cost.
- **Manifest end-to-end** (#300) — `.hale.effects` with inferred sets, the `--check-effects-manifest` CI gate, corpus-wide conformance.

Also carries the properly-fixed transport test flake (#297).

🤖 Generated with [Claude Code](https://claude.com/claude-code)