### PR TITLE
release: v0.11.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.11.24 — stdlib registry/dispatch parity enforced; effect-classification hole closed (2026-07-29)
 
 - **Registry/dispatch parity is enforced (R2 completion), and it
   found real drift.** The R2 refactor made `stdlib_surface` the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.23"
+version = "0.11.24"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.23"
+version = "0.11.24"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.23"
+version = "0.11.24"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.23"
+version = "0.11.24"
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.23"
+version = "0.11.24"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.23"
+version = "0.11.24"
 dependencies = [
  "hale-syntax",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.23"
+version = "0.11.24"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Releases the registry/dispatch parity work merged in #302.

The headline is a soundness fix: `std::ts` and `std::shm` were absent
from the stdlib registry entirely, so they typed as `Ty::Unknown` and
**escaped effect classification** — a `@no_syscall` fn could call into
them unchallenged. The effect system shipped in v0.11.23; this closes
the hole in it, which is not something to leave unreleased while
downstream pins versions.

Also in: two surface-without-lowering entries removed
(`io::fs::list_dir`, `str::can_parse_decimal`) and
`io::udp::Reader` added to `LOCUS_PATHS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)