### PR TITLE
test: one collision-proof build path, enforced

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,10 +7,17 @@ name: tests
 # at tag time.
 #
 # Uses cargo-nextest (drop-in replacement for `cargo test`) for
-# smarter scheduling: each test runs in its own process, so the
-# shared `/tmp/lotus_test_*` paths that historically required
-# `--test-threads=1` no longer collide. Workspace-wide test time
-# drops ~2-3x vs libtest.
+# smarter scheduling: each test runs in its own process.
+# Workspace-wide test time drops ~2-3x vs libtest.
+#
+# NB: an earlier version of this comment claimed process-per-test
+# was what made the shared `/tmp/lotus_test_*` paths safe. That was
+# wrong — process isolation is not filesystem isolation, and two
+# processes writing one path are MORE concurrent than two threads,
+# not less. The suite passed because the `name` arguments happened
+# not to overlap; nothing enforced it. Uniqueness now comes from
+# `harness::unique_bin` (pid + counter), enforced by
+# `harness_paths_are_unique.rs`.
 #
 # Build-and-run-per-partition shape: N parallel `test` jobs each
 # build the workspace from the shared cargo cache and run a

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ experiments/token-efficiency/.todo_storage*
 # (per CLAUDE.md: no planning/status/progress markdown in-tree).
 HANDOFF-*.md
 UPSTREAM*.md
+
+# Agent worktrees (transient; can hold root-owned build artifacts)
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,29 @@ behavior.
   the Hale-source stdlib actually declares, which the accidental
   version could not do.
 
+  hazard is gone rather than avoided.** ~131 codegen test files wrote
+  their compiled binary to a temp path with no uniquifier — most of
+  them `temp_dir()/lotus_test_{name}`, a template eleven files shared
+  verbatim (nine more shared `lotus_{name}`). Nothing made those
+  distinct; the suite passed only because the `name` arguments
+  happened not to overlap. One `build_and_run("basic", …)` in the
+  wrong file and two tests write and exec the same path.
+  `harness::unique_bin` (pid + process-local counter) now supplies
+  every build-artifact path, and `harness_paths_are_unique.rs` fails
+  the build if a test rolls its own. `harness::free_port()` replaces
+  the hand-maintained 57xxx/47xxx port registry spread across 159
+  files (`9876` was already used six times).
+- **Two docs disagreed about that hazard and neither was right.**
+  `CLAUDE.md` mandated the serial flag because of it; `tests.yml`
+  claimed nextest's process-per-test made the shared paths safe.
+  Process isolation is not filesystem isolation — two processes
+  writing one path are *more* concurrent than two threads, not less.
+  Both are corrected, and the guidance is now "run it in parallel"
+  because that is finally true.
+- ~115 copies of `build_and_run` (104 textually distinct) had drifted
+  almost entirely in where they put the binary; at least three had
+  independently rediscovered the pid+counter fix and left a comment
+  about it. That is a missing invariant, not a missing convention.
 ---
 
 ## v0.11.24 — stdlib registry/dispatch parity enforced; effect-classification hole closed (2026-07-29)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,16 +17,26 @@ apply:
 
 ```sh
 cargo build --release
-cargo test --release --workspace -- --test-threads=1
+cargo nextest run --release --workspace
 ```
 
-The serial flag avoids "text file busy" flakes from parallel
-test binaries racing each other on the same temp path. Keep it
-on single-crate runs too:
+**Run the suite in parallel.** It used to require
+`--test-threads=1` because ~131 test files wrote their compiled
+binary to a temp path with no uniquifier (mostly
+`temp_dir()/lotus_test_{name}`), so two tests could race on one
+path — "text file busy", or worse, a test silently executing
+another test's binary.
+
+That is fixed structurally: every test builds through
+`harness::unique_bin` (pid + process-local counter), and
+`harness_paths_are_unique.rs` fails the build if a new test
+rolls its own. Ports come from `harness::free_port()` rather
+than the hand-maintained 57xxx/47xxx registry. Serial runs still
+work, they are just slower and no longer buy anything:
 
 ```sh
 # one integration test in hale-codegen
-cargo test --release -p hale-codegen --test topic_phase2 -- --test-threads=1
+cargo test --release -p hale-codegen --test topic_phase2
 ```
 
 Codegen requires **LLVM 18** dev libs with `llvm-config-18` on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,12 @@ LLVM 17 / 19 / 20 will not link.
 
 ```sh
 cargo build --release
-cargo test --release --workspace -- --test-threads=1
+cargo nextest run --release --workspace
 ```
 
-The serial flag avoids "text file busy" flakes from parallel test
-binaries racing on the same temp path. To spot-check a change against a
+Run it in parallel — `harness::unique_bin` gives every compiled
+test binary a collision-proof path, so the `--test-threads=1`
+this used to need is no longer necessary. To spot-check a change against a
 real program without installing:
 
 ```sh

--- a/agents/compiler-dev.md
+++ b/agents/compiler-dev.md
@@ -185,11 +185,13 @@ After non-trivial changes:
 
 ```sh
 cargo build --release
-cargo test --release --workspace -- --test-threads=1
+cargo nextest run --release --workspace
 ```
 
-The serial flag avoids "text file busy" flakes from parallel
-builds racing each other on the same temp binary path. Phase-2
+Parallel is correct here: every test's compiled binary goes to a
+collision-proof path via `harness::unique_bin`, enforced by
+`harness_paths_are_unique.rs`. The `--test-threads=1` this used
+to require was working around hand-rolled temp paths. Phase-2
 topic tests (`crates/hale-codegen/tests/topic_phase2.rs`) and
 the examples-parse acceptance test
 (`crates/hale-syntax/tests/examples.rs`) are the broadest

--- a/crates/hale-codegen/tests/alloc_model_rss.rs
+++ b/crates/hale-codegen/tests/alloc_model_rss.rs
@@ -22,6 +22,9 @@ use std::process::Command;
 use hale_codegen::build_executable;
 use hale_types::alloc_summary::{summarize_programs, SiteVerdict};
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn model_has_unbounded_site(src: &str) -> bool {
     let program = hale_syntax::parse_source(src).expect("parse");
     let summary = summarize_programs(&[&program]);
@@ -34,8 +37,7 @@ fn model_has_unbounded_site(src: &str) -> bool {
 
 fn build_and_rss(name: &str, src: &str) -> i64 {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_alloc_rss_{}", name));
+    let bin = harness::unique_bin(&format!("hale_alloc_rss_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/array_repeat.rs
+++ b/crates/hale-codegen/tests/array_repeat.rs
@@ -9,10 +9,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_arep_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_arep_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/async_io_park_resume.rs
+++ b/crates/hale-codegen/tests/async_io_park_resume.rs
@@ -25,6 +25,9 @@ use std::time::Duration;
 use hale_codegen::build_executable;
 
 /// Find two free TCP ports for the listeners.
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_two_free_ports() -> (u16, u16) {
     use std::net::TcpListener;
     let a = TcpListener::bind("127.0.0.1:0").expect("bind a");
@@ -102,8 +105,7 @@ fn async_io_pool_multiplexes_two_listeners() {
         port_a = port_a, port_b = port_b
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_async_io_park_resume");
+    let bin = harness::unique_bin("hale_test_async_io_park_resume");
     build_executable(&program, &bin).expect("build");
     // Spawn the binary in the background.
     let mut child = Command::new(&bin)

--- a/crates/hale-codegen/tests/async_io_recv_into_park.rs
+++ b/crates/hale-codegen/tests/async_io_recv_into_park.rs
@@ -17,6 +17,9 @@ use std::time::{Duration, Instant};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_free_port() -> u16 {
     let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     l.local_addr().expect("local_addr").port()
@@ -24,8 +27,7 @@ fn pick_free_port() -> u16 {
 
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_async_recv_into_park_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/async_io_shutdown_parked.rs
+++ b/crates/hale-codegen/tests/async_io_shutdown_parked.rs
@@ -19,6 +19,9 @@ use std::time::{Duration, Instant};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn program_with_coro_parked_at_shutdown_exits_cleanly() {
     // A lone async_io listener that no client ever connects to, so
@@ -44,8 +47,7 @@ fn program_with_coro_parked_at_shutdown_exits_cleanly() {
         fn main() { App { }; }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_async_io_shutdown_parked");
+    let bin = harness::unique_bin("hale_test_async_io_shutdown_parked");
     build_executable(&program, &bin).expect("build");
 
     let mut child = Command::new(&bin).spawn().expect("spawn");

--- a/crates/hale-codegen/tests/async_io_udp_multi_reader.rs
+++ b/crates/hale-codegen/tests/async_io_udp_multi_reader.rs
@@ -25,13 +25,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!("lt-async-udp-multi-{}-{}-{}.bin", tag, std::process::id(), nanos));
+    let p = harness::unique_bin(&format!("lt-async-udp-multi-{}-{}-{}.bin", tag, std::process::id(), nanos));
     p
 }
 

--- a/crates/hale-codegen/tests/async_io_udp_recv_in_handler.rs
+++ b/crates/hale-codegen/tests/async_io_udp_recv_in_handler.rs
@@ -16,10 +16,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale-async-udp-handler-{}-{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale-async-udp-handler-{}-{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/asyncio_sleep_park.rs
+++ b/crates/hale-codegen/tests/asyncio_sleep_park.rs
@@ -15,6 +15,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 const SRC: &str = r#"
     type Go { n: Int; }
 
@@ -63,8 +66,7 @@ const SRC: &str = r#"
 #[test]
 fn asyncio_sleeps_park_and_overlap() {
     let program = hale_syntax::parse_source(SRC).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_sleep_park_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_sleep_park_{}", std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/base64url.rs
+++ b/crates/hale-codegen/tests/base64url.rs
@@ -9,10 +9,12 @@ use std::process::Command;
 use hale_codegen::build_executable;
 
 /// Compile `source` to a temp binary, run it, return stdout.
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> String {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_b64url_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_b64url_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/binding_birth_fail.rs
+++ b/crates/hale-codegen/tests/binding_birth_fail.rs
@@ -22,10 +22,12 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_binding_birth_fail_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_binding_birth_fail_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/binding_listen_rearm.rs
+++ b/crates/hale-codegen/tests/binding_listen_rearm.rs
@@ -17,10 +17,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_listen_rearm_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_listen_rearm_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/binding_loss_supervision.rs
+++ b/crates/hale-codegen/tests/binding_loss_supervision.rs
@@ -12,10 +12,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_loss_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_loss_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
@@ -25,8 +27,7 @@ fn build(name: &str, src: &str) -> PathBuf {
 /// EPIPE on the publisher's next send.
 fn build_peer_driver(tag: &str) -> PathBuf {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_loss_peer_{}", tag));
+    let bin = harness::unique_bin(&format!("hale_loss_peer_{}", tag));
     let status = Command::new("clang")
         .arg(manifest.join("tests").join("transport_driver.c"))
         .arg(manifest.join("runtime").join("lotus_arena.c"))
@@ -150,7 +151,7 @@ fn on_failure_restart_reconnects_and_resumes() {
         .stderr(Stdio::null())
         .spawn()
         .expect("spawn peer 1");
-    let mut publisher = Command::new(&bin)
+    let publisher = Command::new(&bin)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()

--- a/crates/hale-codegen/tests/binding_stream_framing.rs
+++ b/crates/hale-codegen/tests/binding_stream_framing.rs
@@ -16,13 +16,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[path = "support/transport.rs"]
 mod transport_support;
 
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stream_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stream_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/bounded_collections.rs
+++ b/crates/hale-codegen/tests/bounded_collections.rs
@@ -7,18 +7,12 @@ use std::process::Command;
 use hale_codegen::build_executable;
 use hale_syntax::parse_source;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> String {
     let program = parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    static NEXT: std::sync::atomic::AtomicU64 =
-        std::sync::atomic::AtomicU64::new(0);
-    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    bin.push(format!(
-        "hale_bounded_{}_{}_{}",
-        name,
-        std::process::id(),
-        n
-    ));
+    let bin = harness::unique_bin(name);
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/build_hello.rs
+++ b/crates/hale-codegen/tests/build_hello.rs
@@ -9,6 +9,9 @@ use std::time::Instant;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn examples_dir() -> PathBuf {
     // CARGO_MANIFEST_DIR is `crates/hale-codegen`; the example
     // fixtures live under `tests/fixtures/examples/` inside that
@@ -25,8 +28,7 @@ fn examples_dir() -> PathBuf {
 /// (stdout, status). Caller asserts on the output.
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -382,8 +384,7 @@ fn build_time_sleep_blocks_for_at_least_requested_duration() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("lotus_test_time_sleep");
+    let bin = harness::unique_bin("lotus_test_time_sleep");
     build_executable(&program, &bin).expect("build");
 
     let start = Instant::now();
@@ -427,8 +428,7 @@ fn build_time_sleep_in_loop_accumulates() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("lotus_test_time_sleep_loop");
+    let bin = harness::unique_bin("lotus_test_time_sleep_loop");
     build_executable(&program, &bin).expect("build");
 
     let start = Instant::now();

--- a/crates/hale-codegen/tests/bus_adapter_inbound.rs
+++ b/crates/hale-codegen/tests/bus_adapter_inbound.rs
@@ -13,10 +13,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_adapter_inbound_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/bus_array_payload.rs
+++ b/crates/hale-codegen/tests/bus_array_payload.rs
@@ -15,10 +15,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_bus_array_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_bus_array_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bus_async_wire_payload_reclaim.rs
+++ b/crates/hale-codegen/tests/bus_async_wire_payload_reclaim.rs
@@ -33,6 +33,9 @@ use hale_codegen::build_executable;
 /// exits. The publisher is `pinned`, so every publish crosses a thread
 /// boundary and posts a wire cell that the subscriber's pool worker
 /// materializes — the exact path that leaked.
+#[path = "support/harness.rs"]
+mod harness;
+
 fn flood_src(body_expr: &str, n: u32) -> String {
     format!(
         r#"
@@ -85,8 +88,7 @@ fn flood_src(body_expr: &str, n: u32) -> String {
 
 fn build_and_rss(name: &str, src: &str) -> i64 {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_bus_async_reclaim_{}", name));
+    let bin = harness::unique_bin(&format!("hale_bus_async_reclaim_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bus_backpressure.rs
+++ b/crates/hale-codegen/tests/bus_backpressure.rs
@@ -16,10 +16,12 @@ use hale_codegen::build_executable;
 /// Build, run, and read `final_rss_mb=` from stdout (MB). Panics if the
 /// program crashes or never prints the line — which also asserts the flood
 /// ran to completion (the line is only printed once the count reaches N).
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_rss(name: &str, src: &str) -> i64 {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_bus_bp_{}", name));
+    let bin = harness::unique_bin(&format!("hale_bus_bp_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bus_bounded_topics.rs
+++ b/crates/hale-codegen/tests/bus_bounded_topics.rs
@@ -16,10 +16,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_busbound_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_busbound_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/bus_bytes_payload.rs
+++ b/crates/hale-codegen/tests/bus_bytes_payload.rs
@@ -10,10 +10,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_bus_bytes_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_bus_bytes_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bus_config.rs
+++ b/crates/hale-codegen/tests/bus_config.rs
@@ -21,6 +21,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -42,8 +45,7 @@ fn driver_c_path() -> PathBuf {
 /// Compile transport_driver.c + lotus_arena.c into a one-off
 /// listener binary in $TMPDIR. Same recipe as tests/transport.rs.
 fn build_listener_driver(tag: &str) -> PathBuf {
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_m58_listener_{}", tag));
+    let bin = harness::unique_bin(&format!("lotus_m58_listener_{}", tag));
     let status = Command::new("clang")
         .arg(driver_c_path())
         .arg(runtime_c_path())
@@ -62,8 +64,7 @@ fn unique_path(tag: &str, ext: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-m58-{}-{}-{}.{}",
         tag,
         std::process::id(),
@@ -138,15 +139,7 @@ fn deployment_config_routes_publisher_to_remote_listener() {
         .expect("spawn listener");
 
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
-        "lotus_m58_publisher_{}_{}",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0),
-    ));
+    let bin = harness::unique_bin("m58_publisher");
     build_executable(&program, &bin).expect("build publisher");
 
     let pub_out = Command::new(&bin)
@@ -241,15 +234,7 @@ fn no_config_set_behaves_as_pre_m58() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
-        "lotus_m58_no_config_{}_{}",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0),
-    ));
+    let bin = harness::unique_bin("m58_publisher");
     build_executable(&program, &bin).expect("build");
 
     let out = Command::new(&bin).output().expect("run");

--- a/crates/hale-codegen/tests/bus_cross_thread_drain.rs
+++ b/crates/hale-codegen/tests/bus_cross_thread_drain.rs
@@ -25,13 +25,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "hale-xthread-drain-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/bus_decimal_store.rs
+++ b/crates/hale-codegen/tests/bus_decimal_store.rs
@@ -29,10 +29,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_bus_decimal_store_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_test_bus_decimal_store_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bus_devirt_differential.rs
+++ b/crates/hale-codegen/tests/bus_devirt_differential.rs
@@ -27,6 +27,9 @@ use std::time::{Duration, Instant};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 const DEADLINE: Duration = Duration::from_secs(20);
 
 /// Servers never self-terminate — out of scope (matches corpus_oracle).
@@ -139,8 +142,7 @@ fn run(bin: &Path, cwd: &Path) -> Option<RunOutcome> {
 /// failure, since both arms must compile identically).
 fn build(src: &str, tag: &str, devirt: bool) -> Option<PathBuf> {
     let program = hale_syntax::parse_source(src).ok()?;
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "lotus_devirt_{}_{}_{}",
         tag.replace(['/', '-', '.'], "_"),
         if devirt { "stat" } else { "dyn" },

--- a/crates/hale-codegen/tests/bus_devirt_direct.rs
+++ b/crates/hale-codegen/tests/bus_devirt_direct.rs
@@ -19,13 +19,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str, ext: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!("lt-direct-{}-{}-{}.{}", tag, std::process::id(), nanos, ext));
+    let p = harness::unique_bin(&format!("lt-direct-{}-{}-{}.{}", tag, std::process::id(), nanos, ext));
     p
 }
 

--- a/crates/hale-codegen/tests/bus_devirt_no_pinned.rs
+++ b/crates/hale-codegen/tests/bus_devirt_no_pinned.rs
@@ -27,13 +27,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str, ext: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!("lt-nopin-{}-{}-{}.{}", tag, std::process::id(), nanos, ext));
+    let p = harness::unique_bin(&format!("lt-nopin-{}-{}-{}.{}", tag, std::process::id(), nanos, ext));
     p
 }
 

--- a/crates/hale-codegen/tests/bus_handler_freefn.rs
+++ b/crates/hale-codegen/tests/bus_handler_freefn.rs
@@ -14,17 +14,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn run_lines(src: &str) -> Vec<String> {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    // pid alone is NOT unique here: both #[test] fns run inside one
-    // test-binary process, so parallel execution raced on the same
-    // artifact path (each test intermittently ran the OTHER test's
-    // binary). A per-call counter disambiguates.
-    static NEXT: std::sync::atomic::AtomicU64 =
-        std::sync::atomic::AtomicU64::new(0);
-    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    bin.push(format!("hale_bus_freefn_{}_{}", std::process::id(), n));
+    let bin = harness::unique_bin("bus_handler_freefn");
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bus_large_payload.rs
+++ b/crates/hale-codegen/tests/bus_large_payload.rs
@@ -13,10 +13,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_bus_large_payload_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_bus_large_payload_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bus_payload_arena_cap.rs
+++ b/crates/hale-codegen/tests/bus_payload_arena_cap.rs
@@ -15,10 +15,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_bus_arena_cap_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_bus_arena_cap_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/bus_publish_stack_alloca.rs
+++ b/crates/hale-codegen/tests/bus_publish_stack_alloca.rs
@@ -18,13 +18,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str, ext: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-bus-publish-stack-{}-{}-{}.{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/bus_routing_keys.rs
+++ b/crates/hale-codegen/tests/bus_routing_keys.rs
@@ -8,10 +8,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_bus_routing_keys_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_bus_routing_keys_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/bus_subscriber.rs
+++ b/crates/hale-codegen/tests/bus_subscriber.rs
@@ -30,13 +30,15 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str, ext: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-m59-{}-{}-{}.{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/bus_udp_transport.rs
+++ b/crates/hale-codegen/tests/bus_udp_transport.rs
@@ -18,13 +18,15 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str, ext: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-bus-udp-{}-{}-{}.{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/bus_wildcards.rs
+++ b/crates/hale-codegen/tests/bus_wildcards.rs
@@ -11,10 +11,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_buswild_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_buswild_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/bytes_builder.rs
+++ b/crates/hale-codegen/tests/bytes_builder.rs
@@ -26,10 +26,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_bytes_builder_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_bytes_builder_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/bytes_builder_inplace.rs
+++ b/crates/hale-codegen/tests/bytes_builder_inplace.rs
@@ -10,10 +10,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -164,8 +166,7 @@ fn builder_append_slice_out_of_range_violates() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("lotus_test_bb_append_slice_oob");
+    let bin = harness::unique_bin("lotus_test_bb_append_slice_oob");
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -211,8 +212,7 @@ fn builder_append_slice_oob_distinguishable_from_alloc_failed() {
         fn main() { Catcher { }; }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("lotus_test_bb_append_slice_oob_distinguishable");
+    let bin = harness::unique_bin("lotus_test_bb_append_slice_oob_distinguishable");
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bytes_builder_view.rs
+++ b/crates/hale-codegen/tests/bytes_builder_view.rs
@@ -18,10 +18,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_bb_view_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_bb_view_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bytes_builder_violate.rs
+++ b/crates/hale-codegen/tests/bytes_builder_violate.rs
@@ -21,10 +21,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_bb_violate_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_bb_violate_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -129,8 +131,7 @@ fn unhandled_snapshot_failure_exits_nonzero() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_bb_violate_unhandled");
+    let bin = harness::unique_bin("hale_test_bb_violate_unhandled");
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bytes_construction.rs
+++ b/crates/hale-codegen/tests/bytes_construction.rs
@@ -9,10 +9,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_bytes_construct_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_bytes_construct_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/bytes_pack_read.rs
+++ b/crates/hale-codegen/tests/bytes_pack_read.rs
@@ -12,23 +12,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> String {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    // Salt the temp path with a process-wide counter in addition to
-    // name + pid: pid disambiguates across test *binaries*, but nextest
-    // runs tests within one binary in parallel threads, so two tests
-    // sharing a `name` would otherwise compile/exec the same path and
-    // clobber each other (a nondeterministic flake — same class as the
-    // #64 runtime-object race). The counter makes every call unique.
-    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    bin.push(format!(
-        "hale_bytes_pack_{}_{}_{}",
-        name,
-        std::process::id(),
-        seq
-    ));
+    let bin = harness::unique_bin(name);
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bytes_pack_write.rs
+++ b/crates/hale-codegen/tests/bytes_pack_write.rs
@@ -8,10 +8,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> String {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_bytes_pack_w_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_bytes_pack_w_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bytes_view_stale.rs
+++ b/crates/hale-codegen/tests/bytes_view_stale.rs
@@ -20,10 +20,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> std::process::Output {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_view_stale_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_view_stale_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/bytes_view_type.rs
+++ b/crates/hale-codegen/tests/bytes_view_type.rs
@@ -9,10 +9,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_bytesview_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_bytesview_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -96,8 +98,7 @@ fn view_into_bytes_let_rejected() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("lotus_test_bytesview_reject");
+    let bin = harness::unique_bin("lotus_test_bytesview_reject");
     let result = build_executable(&program, &bin);
     let _ = std::fs::remove_file(&bin);
     assert!(

--- a/crates/hale-codegen/tests/bytes_xor_find.rs
+++ b/crates/hale-codegen/tests/bytes_xor_find.rs
@@ -7,10 +7,12 @@
 use hale_codegen::build_executable;
 use std::process::Command;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_bytes_xf_{}", name));
+    let bin = harness::unique_bin(&format!("hale_bytes_xf_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/case_fold_and_nested_fstring.rs
+++ b/crates/hale-codegen/tests/case_fold_and_nested_fstring.rs
@@ -17,10 +17,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_case_fstring_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_case_fstring_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/children_count_sugar.rs
+++ b/crates/hale-codegen/tests/children_count_sugar.rs
@@ -7,6 +7,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn children_count_and_is_empty() {
     let src = r#"
@@ -40,8 +43,7 @@ fn children_count_and_is_empty() {
         fn main() { App { }; }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_children_count_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_children_count_{}", std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/children_growable.rs
+++ b/crates/hale-codegen/tests/children_growable.rs
@@ -15,10 +15,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_children_growable_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_children_growable_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/closed_world_nested_struct.rs
+++ b/crates/hale-codegen/tests/closed_world_nested_struct.rs
@@ -20,10 +20,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/closure_resets_per_epoch.rs
+++ b/crates/hale-codegen/tests/closure_resets_per_epoch.rs
@@ -9,13 +9,15 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(
     name: &str,
     source: &str,
 ) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/codec_dispatch_roundtrip.rs
+++ b/crates/hale-codegen/tests/codec_dispatch_roundtrip.rs
@@ -26,10 +26,12 @@ use hale_codegen::build_executable;
 /// binding below needs a real listener peer — the pre-#227
 /// version of this test silently relied on the broker tolerating
 /// a dead transport.
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_peer_driver(tag: &str) -> PathBuf {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_codec_e2e_peer_{}", tag));
+    let bin = harness::unique_bin(&format!("hale_codec_e2e_peer_{}", tag));
     let status = Command::new("clang")
         .arg(manifest.join("tests").join("transport_driver.c"))
         .arg(manifest.join("runtime").join("lotus_arena.c"))
@@ -98,8 +100,7 @@ fn xor_codec_round_trip_through_in_process_wire_path() {
         sock
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_codec_dispatch_roundtrip");
+    let bin = harness::unique_bin("hale_test_codec_dispatch_roundtrip");
     build_executable(&program, &bin).expect("build");
     // Listener peer first so the app's connect-with-retry lands.
     // The peer just absorbs the (scrambled) wire bytes; the

--- a/crates/hale-codegen/tests/codec_instantiation.rs
+++ b/crates/hale-codegen/tests/codec_instantiation.rs
@@ -26,10 +26,12 @@ use hale_codegen::build_executable;
 /// binding below needs a real listener peer — the pre-#227
 /// version of this test silently relied on the broker tolerating
 /// a dead transport.
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_peer_driver(tag: &str) -> PathBuf {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_codec_inst_peer_{}", tag));
+    let bin = harness::unique_bin(&format!("hale_codec_inst_peer_{}", tag));
     let status = Command::new("clang")
         .arg(manifest.join("tests").join("transport_driver.c"))
         .arg(manifest.join("runtime").join("lotus_arena.c"))
@@ -90,8 +92,7 @@ fn codec_locus_is_instantiated_at_main_prelude() {
         sock
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_codec_instantiation");
+    let bin = harness::unique_bin("hale_test_codec_instantiation");
     build_executable(&program, &bin).expect("build");
     // Listener peer first so the app's connect-with-retry lands.
     let driver = build_peer_driver("smoke");

--- a/crates/hale-codegen/tests/compress_tar.rs
+++ b/crates/hale-codegen/tests/compress_tar.rs
@@ -17,10 +17,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_compress_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_compress_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/coop_pool_basic.rs
+++ b/crates/hale-codegen/tests/coop_pool_basic.rs
@@ -15,13 +15,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-coop-pool-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/coop_pool_multi_locus.rs
+++ b/crates/hale-codegen/tests/coop_pool_multi_locus.rs
@@ -26,13 +26,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-coop-pool-multi-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/coop_pool_run_dispatch.rs
+++ b/crates/hale-codegen/tests/coop_pool_run_dispatch.rs
@@ -21,13 +21,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-coop-run-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/coop_to_pinned_mid_program.rs
+++ b/crates/hale-codegen/tests/coop_to_pinned_mid_program.rs
@@ -18,13 +18,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-coop-to-pinned-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/corpus_oracle.rs
+++ b/crates/hale-codegen/tests/corpus_oracle.rs
@@ -40,6 +40,9 @@ use std::time::{Duration, Instant};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn examples_dir() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tests");
@@ -290,8 +293,7 @@ fn check_fixture(name: &str, main_hl: &Path, deadline: Duration) -> Outcome {
         Ok(p) => p,
         Err(d) => return Outcome::Fail(format!("parse: {d:?}")),
     };
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_corpus_{}_{}", name.replace(['/', '-'], "_"), std::process::id()));
+    let bin = harness::unique_bin(&format!("lotus_corpus_{}_{}", name.replace(['/', '-'], "_"), std::process::id()));
     if let Err(e) = build_executable(&program, &bin) {
         let msg = format!("{e:?}");
         // A codegen feature gap is ACKNOWLEDGED only when the fixture

--- a/crates/hale-codegen/tests/cross_locus_from_method.rs
+++ b/crates/hale-codegen/tests/cross_locus_from_method.rs
@@ -18,10 +18,12 @@
 use std::process::Command;
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_cross_locus_method_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/cross_locus_return_chain.rs
+++ b/crates/hale-codegen/tests/cross_locus_return_chain.rs
@@ -12,10 +12,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_cross_locus_return_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_cross_locus_return_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/cross_seed_imports.rs
+++ b/crates/hale-codegen/tests/cross_seed_imports.rs
@@ -28,6 +28,9 @@ use hale_codegen::mangle;
 use hale_syntax::ast::{Program, TopDecl};
 use hale_syntax::parse_source;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn fixtures_dir() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tests");
@@ -108,8 +111,7 @@ fn or_on_path_callee_for_imported_fallible_fn() {
     let (lib_items, renames) = resolve_and_mangle_lib(&lib_dir, "lp");
     consumer_prog.items.extend(lib_items);
 
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_or_on_path_callee_{}",
         std::process::id()
     ));
@@ -150,8 +152,7 @@ fn cross_seed_form_vec_split_across_two_files() {
     let (lib_items, renames) = resolve_and_mangle_lib(&lib_dir, "lib");
     consumer_prog.items.extend(lib_items);
 
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_cross_seed_form_vec_multi_{}",
         std::process::id()
     ));
@@ -188,8 +189,7 @@ fn cross_seed_topic_subscribe_and_publish() {
     let (lib_items, renames) = resolve_and_mangle_lib(&lib_dir, "source");
     consumer_prog.items.extend(lib_items);
 
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_cross_seed_topic_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_cross_seed_topic_{}", std::process::id()));
     build_executable_with_imports(&consumer_prog, &bin, &renames)
         .expect("build consumer + lib");
 
@@ -248,8 +248,7 @@ fn three_file_lib_exposes_decls_from_every_file() {
         rename_strings
     );
 
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_three_file_lib_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_three_file_lib_{}", std::process::id()));
     build_executable_with_imports(&consumer_prog, &bin, &renames)
         .expect("build consumer + lib");
 
@@ -292,8 +291,7 @@ fn cross_seed_non_fallible_free_fn_call_in_expr_and_stmt_positions() {
     let (lib_items, renames) = resolve_and_mangle_lib(&lib_dir, "h");
     consumer_prog.items.extend(lib_items);
 
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_cross_seed_nonfallible_{}",
         std::process::id()
     ));
@@ -357,8 +355,7 @@ fn consumer_uses_greeter_and_formatted_from_lib_toy() {
 
     consumer_prog.items.extend(lib_items);
 
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_cross_seed_imports_{}",
         std::process::id()
     ));
@@ -425,8 +422,7 @@ fn method_name_shadowed_by_top_level_fn_resolves() {
     consumer.imports.clear();
     consumer.items.extend(lib_prog.items);
 
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_p1_method_shadow_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_p1_method_shadow_{}", std::process::id()));
     build_executable_with_imports(&consumer, &bin, &renames).expect("build consumer + lib");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/cross_seed_locus_arg.rs
+++ b/crates/hale-codegen/tests/cross_seed_locus_arg.rs
@@ -23,10 +23,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_cross_seed_locus_arg_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/crypto_crc32.rs
+++ b/crates/hale-codegen/tests/crypto_crc32.rs
@@ -13,10 +13,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_crypto_crc32_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_crypto_crc32_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/crypto_sha256_hmac.rs
+++ b/crates/hale-codegen/tests/crypto_sha256_hmac.rs
@@ -16,10 +16,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_crypto_sha256_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_crypto_sha256_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/crypto_sha512_hmac.rs
+++ b/crates/hale-codegen/tests/crypto_sha512_hmac.rs
@@ -12,10 +12,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_crypto_sha512_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_crypto_sha512_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/decimal_alignment.rs
+++ b/crates/hale-codegen/tests/decimal_alignment.rs
@@ -19,10 +19,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> std::process::Output {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_dec_align_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_dec_align_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/decimal_format.rs
+++ b/crates/hale-codegen/tests/decimal_format.rs
@@ -8,6 +8,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn format_renders_fixed_places_with_half_up_rounding() {
     let src = r#"
@@ -21,8 +24,7 @@ fn format_renders_fixed_places_with_half_up_rounding() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_decimal_format");
+    let bin = harness::unique_bin("hale_test_decimal_format");
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/docs_server.rs
+++ b/crates/hale-codegen/tests/docs_server.rs
@@ -18,6 +18,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn examples_dir() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tests");
@@ -35,15 +38,7 @@ fn build_docs_server() -> PathBuf {
     let src_path = examples_dir().join("docs-server").join("main.hl");
     let src = std::fs::read_to_string(&src_path).expect("read example");
     let program = hale_syntax::parse_source(&src).expect("parse example");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
-        "hale_docs_server_{}_{}",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ));
+    let bin = harness::unique_bin("docs_server");
     build_executable(&program, &bin).expect("build example");
     bin
 }
@@ -53,8 +48,7 @@ fn unique_dir(tag: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "hale_docs_fixture_{}_{}_{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/dump_pool_residency.rs
+++ b/crates/hale-codegen/tests/dump_pool_residency.rs
@@ -9,6 +9,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn dump_pool_residency_lists_each_pool_with_mode() {
     let src = r#"
@@ -30,8 +33,7 @@ fn dump_pool_residency_lists_each_pool_with_mode() {
         fn main() { App { }; }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_dump_pool_residency");
+    let bin = harness::unique_bin("hale_test_dump_pool_residency");
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -67,8 +69,7 @@ fn dump_pool_residency_with_no_pools_emits_count_zero() {
         fn main() { App { }; }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_dump_pool_residency_empty");
+    let bin = harness::unique_bin("hale_test_dump_pool_residency_empty");
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/duration_scalar_arith.rs
+++ b/crates/hale-codegen/tests/duration_scalar_arith.rs
@@ -13,6 +13,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn int_times_duration_scales_the_interval() {
     let src = r#"
@@ -39,8 +42,7 @@ fn int_times_duration_scales_the_interval() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_dur_scalar_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_dur_scalar_{}", std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/ecdsa_p256.rs
+++ b/crates/hale-codegen/tests/ecdsa_p256.rs
@@ -21,6 +21,9 @@ use std::process::Command;
 use hale_codegen::build_executable;
 
 // Fixed P-256 test keypair (NOT a secret — generated for this test).
+#[path = "support/harness.rs"]
+mod harness;
+
 const PRIV_SEC1_PEM: &str = r#"-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIJrK0USBk0pXfFnQtXL9xFkQSdZ9C1OUbBcO5dnIWy8/oAoGCCqGSM49
 AwEHoUQDQgAEiGxPneeFcgjIV3jH5esGYi0uNMCRw16VEVuDZZbkiQ05htqoeEZY
@@ -43,8 +46,7 @@ const EXTERNAL_SIG_STD_B64: &str =
 
 fn build_and_run(name: &str, source: &str) -> String {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_ecdsa_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_ecdsa_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/effects_conformance.rs
+++ b/crates/hale-codegen/tests/effects_conformance.rs
@@ -26,6 +26,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(tag: &str, src: &str) -> (String, bool) {
     let program = hale_syntax::parse_source(src).expect("parse");
     // The program must also pass the static effect checks — if it
@@ -41,8 +44,7 @@ fn build_and_run(tag: &str, src: &str) -> (String, bool) {
         "program must satisfy its own assertions statically first: {:?}",
         hard
     );
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_conform_{}_{}", tag, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_conform_{}_{}", tag, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/f22_as_parent_for_surface.rs
+++ b/crates/hale-codegen/tests/f22_as_parent_for_surface.rs
@@ -10,10 +10,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_f22_apf_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_f22_apf_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
@@ -139,8 +141,7 @@ fn as_parent_for_codegen_rejects_kind_mismatch() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_f22_apf_kind_mismatch");
+    let bin = harness::unique_bin("hale_test_f22_apf_kind_mismatch");
     let err = build_executable(&program, &bin)
         .expect_err("should reject pool/heap kind mismatch");
     let msg = format!("{}", err);

--- a/crates/hale-codegen/tests/f22_capacity_acceptance.rs
+++ b/crates/hale-codegen/tests/f22_capacity_acceptance.rs
@@ -12,10 +12,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_f22_acc_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_f22_acc_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
@@ -201,8 +203,7 @@ fn cell_value_cannot_print_or_arithmetic() {
         fn main() { }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_f22_acc_no_print");
+    let bin = harness::unique_bin("hale_test_f22_acc_no_print");
     let err = build_executable(&program, &bin)
         .expect_err("expected cell-not-printable diagnostic");
     let msg = format!("{}", err);

--- a/crates/hale-codegen/tests/f22_capacity_dispatch.rs
+++ b/crates/hale-codegen/tests/f22_capacity_dispatch.rs
@@ -6,10 +6,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_f22_dispatch_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_f22_dispatch_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
@@ -128,8 +130,7 @@ fn pool_rejects_heap_methods() {
         fn main() { }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_f22_dispatch_pool_rejects_heap_methods");
+    let bin = harness::unique_bin("hale_test_f22_dispatch_pool_rejects_heap_methods");
     let err = build_executable(&program, &bin)
         .expect_err("expected pool-rejects-alloc diagnostic");
     let msg = format!("{}", err);
@@ -155,8 +156,7 @@ fn heap_rejects_pool_methods() {
         fn main() { }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_f22_dispatch_heap_rejects_pool_methods");
+    let bin = harness::unique_bin("hale_test_f22_dispatch_heap_rejects_pool_methods");
     let err = build_executable(&program, &bin)
         .expect_err("expected heap-rejects-acquire diagnostic");
     let msg = format!("{}", err);
@@ -187,8 +187,7 @@ fn cross_slot_cell_release_rejected() {
         fn main() { }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_f22_dispatch_cross_slot");
+    let bin = harness::unique_bin("hale_test_f22_dispatch_cross_slot");
     let err = build_executable(&program, &bin)
         .expect_err("v1.x-5 should reject cross-slot release");
     let msg = format!("{}", err);

--- a/crates/hale-codegen/tests/f22_capacity_smoke.rs
+++ b/crates/hale-codegen/tests/f22_capacity_smoke.rs
@@ -9,10 +9,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_f22_smoke_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_f22_smoke_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
@@ -112,8 +114,7 @@ fn locus_typed_slot_rejected_by_typecheck() {
         fn main() { }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_f22_smoke_locus_cell");
+    let bin = harness::unique_bin("hale_test_f22_smoke_locus_cell");
     let err = build_executable(&program, &bin).expect_err(
         "build should fail with F.22 restriction-1 diagnostic",
     );
@@ -139,8 +140,7 @@ fn duplicate_slot_name_rejected() {
         fn main() { }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_f22_smoke_dup");
+    let bin = harness::unique_bin("hale_test_f22_smoke_dup");
     let err = build_executable(&program, &bin).expect_err(
         "build should fail with duplicate-slot-name diagnostic",
     );

--- a/crates/hale-codegen/tests/f22_cell_field_io.rs
+++ b/crates/hale-codegen/tests/f22_cell_field_io.rs
@@ -7,10 +7,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_f22_cell_io_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_f22_cell_io_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
@@ -87,8 +89,7 @@ fn primitive_cell_field_access_rejected() {
         fn main() { }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_f22_cell_io_primitive_rejected");
+    let bin = harness::unique_bin("hale_test_f22_cell_io_primitive_rejected");
     let err = build_executable(&program, &bin)
         .expect_err("primitive cell field access should reject");
     let msg = format!("{}", err);

--- a/crates/hale-codegen/tests/ffi_basic.rs
+++ b/crates/hale-codegen/tests/ffi_basic.rs
@@ -17,14 +17,16 @@ use std::process::Command;
 
 use hale_codegen::{build_executable_with_options, BuildOptions};
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_with_csrc(
     name: &str,
     hale_src: &str,
     csrc_body: &str,
 ) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(hale_src).expect("parse");
-    let mut tmpdir = std::env::temp_dir();
-    tmpdir.push(format!("hale_test_ffi_basic_{}", name));
+    let tmpdir = harness::unique_bin(&format!("hale_test_ffi_basic_{}", name));
     let _ = std::fs::create_dir_all(&tmpdir);
 
     let csrc_path = tmpdir.join("glue.c");

--- a/crates/hale-codegen/tests/ffi_string_return.rs
+++ b/crates/hale-codegen/tests/ffi_string_return.rs
@@ -17,10 +17,12 @@ use std::process::Command;
 
 use hale_codegen::{build_executable_with_options, BuildOptions};
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_with_csrc(name: &str, hale_src: &str, csrc_body: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(hale_src).expect("parse");
-    let mut tmpdir = std::env::temp_dir();
-    tmpdir.push(format!("hale_test_ffi_strret_{}", name));
+    let tmpdir = harness::unique_bin(&format!("hale_test_ffi_strret_{}", name));
     let _ = std::fs::create_dir_all(&tmpdir);
     let csrc_path = tmpdir.join("glue.c");
     std::fs::write(&csrc_path, csrc_body).expect("write csrc");

--- a/crates/hale-codegen/tests/file_locus.rs
+++ b/crates/hale-codegen/tests/file_locus.rs
@@ -12,13 +12,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> std::path::PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "hale_file_locus_{}_{}_{}",
         tag,
         std::process::id(),
@@ -29,16 +31,7 @@ fn unique_path(tag: &str) -> std::path::PathBuf {
 
 fn build_and_run(name: &str, source: &str) -> (String, String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
-        "hale_file_locus_bin_{}_{}_{}",
-        name,
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0),
-    ));
+    let bin = harness::unique_bin(name);
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/float_to_int_cast.rs
+++ b/crates/hale-codegen/tests/float_to_int_cast.rs
@@ -8,10 +8,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_fp_to_int_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_fp_to_int_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/fn_nonalloc_add.rs
+++ b/crates/hale-codegen/tests/fn_nonalloc_add.rs
@@ -18,10 +18,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> String {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_nonalloc_add_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_nonalloc_add_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/fn_ptr.rs
+++ b/crates/hale-codegen/tests/fn_ptr.rs
@@ -19,10 +19,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_fn_ptr_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_fn_ptr_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/form_hashmap_codegen.rs
+++ b/crates/hale-codegen/tests/form_hashmap_codegen.rs
@@ -12,10 +12,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_form_hashmap_codegen_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_form_hashmap_codegen_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/form_hashmap_lockfree.rs
+++ b/crates/hale-codegen/tests/form_hashmap_lockfree.rs
@@ -43,13 +43,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-form-hashmap-lockfree-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/form_hashmap_lockfree_tsan.rs
+++ b/crates/hale-codegen/tests/form_hashmap_lockfree_tsan.rs
@@ -31,13 +31,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-lockfree-tsan-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/form_hashmap_serialized.rs
+++ b/crates/hale-codegen/tests/form_hashmap_serialized.rs
@@ -29,13 +29,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-form-hashmap-serialized-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/form_iteration.rs
+++ b/crates/hale-codegen/tests/form_iteration.rs
@@ -10,18 +10,12 @@ use std::process::Command;
 use hale_codegen::build_executable;
 use hale_syntax::parse_source;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> String {
     let program = parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    static NEXT: std::sync::atomic::AtomicU64 =
-        std::sync::atomic::AtomicU64::new(0);
-    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    bin.push(format!(
-        "hale_form_iter_{}_{}_{}",
-        name,
-        std::process::id(),
-        n
-    ));
+    let bin = harness::unique_bin(name);
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/form_lru_cache_codegen.rs
+++ b/crates/hale-codegen/tests/form_lru_cache_codegen.rs
@@ -19,10 +19,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_form_lru_codegen_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_form_lru_codegen_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
@@ -188,8 +190,7 @@ fn form_lru_cache_fixture_runs() {
         .join("tests/fixtures/examples/60-lru-cache/main.hl");
     let src = std::fs::read_to_string(&path).expect("read fixture");
     let program = hale_syntax::parse_source(&src).expect("parse fixture");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_form_lru_fixture");
+    let bin = harness::unique_bin("hale_test_form_lru_fixture");
     build_executable(&program, &bin).expect("build fixture");
     let (stdout, ok) = run(&bin);
     assert!(ok, "fixture exited non-zero: {:?}", stdout);

--- a/crates/hale-codegen/tests/form_ring_buffer_codegen.rs
+++ b/crates/hale-codegen/tests/form_ring_buffer_codegen.rs
@@ -11,10 +11,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_form_rb_codegen_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_form_rb_codegen_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/form_vec_bce.rs
+++ b/crates/hale-codegen/tests/form_vec_bce.rs
@@ -24,10 +24,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_form_vec_bce_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_form_vec_bce_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
@@ -49,8 +51,7 @@ fn run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
 /// it (and vectorizes the loop) — so we assert on the emit-time facts.
 fn build_dump_ir(name: &str, src: &str) -> String {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_form_vec_bce_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_form_vec_bce_{}", name));
     std::env::set_var("LOTUS_DUMP_IR", "1");
     build_executable(&program, &bin).expect("build");
     std::env::remove_var("LOTUS_DUMP_IR");

--- a/crates/hale-codegen/tests/form_vec_codegen.rs
+++ b/crates/hale-codegen/tests/form_vec_codegen.rs
@@ -14,10 +14,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_form_vec_codegen_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_form_vec_codegen_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/form_vec_inline.rs
+++ b/crates/hale-codegen/tests/form_vec_inline.rs
@@ -14,10 +14,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_form_vec_inline_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_form_vec_inline_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/form_vec_set_retire.rs
+++ b/crates/hale-codegen/tests/form_vec_set_retire.rs
@@ -23,10 +23,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_vecretire_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_vecretire_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/framework_elision.rs
+++ b/crates/hale-codegen/tests/framework_elision.rs
@@ -23,13 +23,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str, ext: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-framework-elision-{}-{}-{}.{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/fs.rs
+++ b/crates/hale-codegen/tests/fs.rs
@@ -13,6 +13,9 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -32,8 +35,7 @@ fn driver_c_path() -> PathBuf {
 }
 
 fn build_driver(name: &str) -> PathBuf {
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_fs_driver_{}", name));
+    let bin = harness::unique_bin(&format!("hale_fs_driver_{}", name));
     let status = Command::new("clang")
         .arg(driver_c_path())
         .arg(runtime_c_path())
@@ -55,8 +57,7 @@ fn unique_tempfile(tag: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "hale_fs_test_{}_{}_{}.tmp",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/fs_index_and_status.rs
+++ b/crates/hale-codegen/tests/fs_index_and_status.rs
@@ -12,10 +12,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_fsindex_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_fsindex_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -27,8 +29,7 @@ fn unique_dir(tag: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "hale_fsindex_{}_{}_{}.d",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/fs_rename_unlink_mktemp.rs
+++ b/crates/hale-codegen/tests/fs_rename_unlink_mktemp.rs
@@ -17,10 +17,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_test_fs_c9_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/fstring_interpolation.rs
+++ b/crates/hale-codegen/tests/fstring_interpolation.rs
@@ -11,20 +11,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    // Salt with pid + a process-wide counter so two tests can never
-    // share a temp-build path under nextest's parallel execution
-    // (the bytes_pack_read flake class).
-    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    bin.push(format!(
-        "hale_test_fstring_{}_{}_{}",
-        name,
-        std::process::id(),
-        seq
-    ));
+    let bin = harness::unique_bin(name);
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/gate_counters.rs
+++ b/crates/hale-codegen/tests/gate_counters.rs
@@ -8,6 +8,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_free_port() -> u16 {
     let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     l.local_addr().expect("local_addr").port()
@@ -15,8 +18,7 @@ fn pick_free_port() -> u16 {
 
 fn build_and_run_argv(name: &str, src: &str, argv: &[&str]) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_gate_{}", name));
+    let bin = harness::unique_bin(&format!("hale_gate_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).args(argv).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/generics.rs
+++ b/crates/hale-codegen/tests/generics.rs
@@ -23,13 +23,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_bin(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-m61-{}-{}-{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/hale_self_test.rs
+++ b/crates/hale-codegen/tests/hale_self_test.rs
@@ -16,10 +16,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn run_self_test(name: &str, source: &str) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_self_test_{}", name));
+    let bin = harness::unique_bin(&format!("hale_self_test_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/harness_paths_are_unique.rs
+++ b/crates/hale-codegen/tests/harness_paths_are_unique.rs
@@ -1,0 +1,152 @@
+//! Every test that builds an executable must get its path from
+//! `harness::unique_bin`.
+//!
+//! The lesson from the stdlib-registry refactor applies verbatim: a
+//! shared helper is not a guarantee until something enforces that it
+//! is *the* one used. `support/harness.rs` existing does not stop the
+//! next test from writing `temp_dir().push("lotus_test_basic")`, and
+//! the failure mode is nasty — not a clean error but an intermittent
+//! `ETXTBSY`, or (worse, and observed in this suite before) a test
+//! silently executing a *different* test's binary.
+//!
+//! At least three files independently rediscovered the fix and left a
+//! comment about it. That is the signature of a missing invariant,
+//! not a missing convention.
+//!
+//! Scope note: this checks *executable* paths. Shared temp files are
+//! sometimes deliberate — `hale_bubble_suite.lock` is a cross-test
+//! mutex whose whole purpose is to be the same path in every
+//! process — so a blanket ban on `temp_dir()` would be wrong.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+/// Files that call `build_executable` but legitimately don't need
+/// `unique_bin`, each with the reason.
+fn exemptions() -> BTreeSet<&'static str> {
+    // Populated only with a stated reason. An empty set is the goal
+    // state and the current one.
+    BTreeSet::new()
+}
+
+fn tests_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests")
+}
+
+fn test_sources() -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(tests_dir()) else {
+        return out;
+    };
+    for e in entries.flatten() {
+        let p = e.path();
+        if p.extension().map(|x| x != "rs").unwrap_or(true) {
+            continue;
+        }
+        let name = p.file_name().unwrap().to_string_lossy().to_string();
+        if let Ok(t) = std::fs::read_to_string(&p) {
+            out.push((name, t));
+        }
+    }
+    out.sort();
+    out
+}
+
+#[test]
+fn every_builder_uses_unique_bin() {
+    let exempt = exemptions();
+    let offenders: Vec<String> = test_sources()
+        .into_iter()
+        .filter(|(name, text)| {
+            text.contains("build_executable")
+                && !text.contains("unique_bin")
+                && !exempt.contains(name.as_str())
+        })
+        .map(|(name, _)| name)
+        .collect();
+    assert!(
+        offenders.is_empty(),
+        "these tests build an executable without `harness::unique_bin`, \
+         so two of them can race on one path under any parallel runner \
+         ({} found):\n{:#?}\n\n\
+         Use `harness::unique_bin(name)` (add \
+         `#[path = \"support/harness.rs\"] mod harness;`), or add the \
+         file to `exemptions()` with the reason.",
+        offenders.len(),
+        offenders
+    );
+}
+
+/// The hazard in its original form: two files whose binary-path
+/// template is textually identical are one duplicated `name`
+/// argument away from colliding. `unique_bin` makes the template
+/// irrelevant, so what this really guards is that nobody
+/// reintroduces a hand-rolled one.
+#[test]
+fn no_hand_rolled_binary_temp_paths() {
+    let offenders: Vec<String> = test_sources()
+        .into_iter()
+        .filter(|(_, text)| text.contains("build_executable"))
+        .filter(|(_, text)| {
+            // Trace it properly: a variable bound from a raw
+            // `temp_dir()` that is later handed to
+            // `build_executable`. Matching on artifact-*shaped names*
+            // instead flags config files and scratch dirs that are
+            // legitimately temp-rooted — the suite has 14 of those.
+            let temp_vars: BTreeSet<&str> = text
+                .match_indices("= std::env::temp_dir()")
+                .filter_map(|(i, _)| {
+                    let head = &text[..i];
+                    let decl = head.rsplit_once("let ")?.1;
+                    Some(decl.trim().trim_start_matches("mut ").trim())
+                })
+                .filter(|v| !v.is_empty() && v.chars().all(|c| c.is_alphanumeric() || c == '_'))
+                .collect();
+            temp_vars.iter().any(|v| {
+                text.contains(&format!("build_executable(&program, &{})", v))
+                    || text.contains(&format!("build_executable(&prog, &{})", v))
+            })
+        })
+        .map(|(name, _)| name)
+        .collect();
+    assert!(
+        offenders.is_empty(),
+        "these tests derive a build-artifact path from a raw \
+         `std::env::temp_dir()` ({} found):\n{:#?}\n\n\
+         Route it through `harness::unique_bin`. (Deliberately shared \
+         temp paths — a cross-test lock file, say — are fine; this only \
+         fires on files that also call `build_executable` and use an \
+         artifact-shaped name.)",
+        offenders.len(),
+        offenders
+    );
+}
+
+/// A scraper that matched nothing would make both checks above pass
+/// vacuously, which is exactly how the first registry-parity test
+/// shipped with a hole.
+#[test]
+fn scan_is_not_vacuous() {
+    let srcs = test_sources();
+    assert!(
+        srcs.len() > 200,
+        "expected to scan the whole codegen test suite, saw {} files",
+        srcs.len()
+    );
+    let builders = srcs
+        .iter()
+        .filter(|(_, t)| t.contains("build_executable"))
+        .count();
+    assert!(
+        builders > 150,
+        "only {} files call build_executable — the scan is not seeing \
+         the suite it thinks it is",
+        builders
+    );
+    let using = srcs.iter().filter(|(_, t)| t.contains("unique_bin")).count();
+    assert!(
+        using > 150,
+        "only {} files reference unique_bin — the sweep did not land",
+        using
+    );
+}

--- a/crates/hale-codegen/tests/hashmap.rs
+++ b/crates/hale-codegen/tests/hashmap.rs
@@ -12,6 +12,9 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -36,8 +39,7 @@ fn build_driver(tag: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_hashmap_driver_{}_{}_{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/hashmap_cell_alias.rs
+++ b/crates/hale-codegen/tests/hashmap_cell_alias.rs
@@ -11,10 +11,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_cell_alias_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_cell_alias_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/http_client.rs
+++ b/crates/hale-codegen/tests/http_client.rs
@@ -19,10 +19,12 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_http_client_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_http_client_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/http_hello.rs
+++ b/crates/hale-codegen/tests/http_hello.rs
@@ -16,6 +16,9 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn examples_dir() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tests");
@@ -33,8 +36,7 @@ fn build_http_hello() -> PathBuf {
     let src_path = examples_dir().join("http-hello").join("main.hl");
     let src = std::fs::read_to_string(&src_path).expect("read example");
     let program = hale_syntax::parse_source(&src).expect("parse example");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_http_hello_{}",
         std::process::id()
     ));

--- a/crates/hale-codegen/tests/http_request_headers.rs
+++ b/crates/hale-codegen/tests/http_request_headers.rs
@@ -8,10 +8,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_http_headers_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_http_headers_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/http_response_headers.rs
+++ b/crates/hale-codegen/tests/http_response_headers.rs
@@ -26,10 +26,12 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_http_resp_headers_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_http_resp_headers_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/http_router.rs
+++ b/crates/hale-codegen/tests/http_router.rs
@@ -16,6 +16,9 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_free_port() -> u16 {
     let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     probe.local_addr().expect("local_addr").port()
@@ -23,8 +26,7 @@ fn pick_free_port() -> u16 {
 
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_http_router_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_http_router_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -129,8 +131,7 @@ fn router_serves_through_server_over_tcp() {
     "#
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_http_router_wire_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_http_router_wire_{}", std::process::id()));
     build_executable(&program, &bin).expect("build");
     let mut child = Command::new(&bin)
         .stdout(std::process::Stdio::piped())

--- a/crates/hale-codegen/tests/http_server_bind_failure.rs
+++ b/crates/hale-codegen/tests/http_server_bind_failure.rs
@@ -16,6 +16,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn http_server_violates_on_bind_failure() {
     // Take a port. The Rust listener doesn't set SO_REUSEPORT,
@@ -45,8 +48,7 @@ fn http_server_violates_on_bind_failure() {
     );
 
     let prog = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_test_http_bind_fail_{}_{}",
         std::process::id(),
         port,

--- a/crates/hale-codegen/tests/http_server_bus_logging.rs
+++ b/crates/hale-codegen/tests/http_server_bus_logging.rs
@@ -15,10 +15,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_http_server_bus_logging_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_http_server_bus_logging_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/http_server_classic_pool_shutdown.rs
+++ b/crates/hale-codegen/tests/http_server_classic_pool_shutdown.rs
@@ -21,6 +21,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn http_server_on_classic_pool_shuts_down_cleanly() {
     let src = r#"
@@ -44,8 +47,7 @@ fn http_server_on_classic_pool_shuts_down_cleanly() {
         fn main() { App { }; }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_http_classic_shutdown_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_http_classic_shutdown_{}", std::process::id()));
     build_executable(&program, &bin).expect("build");
 
     for run in 0..4 {

--- a/crates/hale-codegen/tests/http_split_write.rs
+++ b/crates/hale-codegen/tests/http_split_write.rs
@@ -17,6 +17,9 @@ use hale_codegen::build_executable;
 
 // Echo server: responds 200 with the request body it parsed, so the
 // client can observe exactly what the server-side reassembly saw.
+#[path = "support/harness.rs"]
+mod harness;
+
 const ECHO_SERVER: &str = r#"
     locus Echo {
         fn handle(req: std::http::Request) -> std::http::Response {
@@ -42,8 +45,7 @@ fn pick_free_port() -> u16 {
 
 fn build_echo(name: &str) -> PathBuf {
     let program = hale_syntax::parse_source(ECHO_SERVER).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_http_split_write_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_http_split_write_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/http_upgrade.rs
+++ b/crates/hale-codegen/tests/http_upgrade.rs
@@ -15,6 +15,9 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_free_port() -> u16 {
     let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     probe.local_addr().expect("local_addr").port()
@@ -54,8 +57,7 @@ fn takeover_answers_101_and_keeps_the_connection_live() {
     "#
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_http_upgrade_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_http_upgrade_{}", std::process::id()));
     build_executable(&program, &bin).expect("build");
     let mut child = Command::new(&bin)
         .stdout(std::process::Stdio::piped())
@@ -150,8 +152,7 @@ fn takeover_raw_writes_nothing_and_defers_the_response() {
     "#
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_http_takeover_raw_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_http_takeover_raw_{}", std::process::id()));
     build_executable(&program, &bin).expect("build");
     let mut child = Command::new(&bin)
         .stdout(std::process::Stdio::piped())

--- a/crates/hale-codegen/tests/if_expression.rs
+++ b/crates/hale-codegen/tests/if_expression.rs
@@ -14,10 +14,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_ifexpr_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_ifexpr_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/int_bitwise_ops.rs
+++ b/crates/hale-codegen/tests/int_bitwise_ops.rs
@@ -7,10 +7,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_int_bitwise_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_int_bitwise_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/interface_dispatch.rs
+++ b/crates/hale-codegen/tests/interface_dispatch.rs
@@ -19,10 +19,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_iface_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_iface_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/interface_in_composites.rs
+++ b/crates/hale-codegen/tests/interface_in_composites.rs
@@ -23,10 +23,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_g20_composite_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/interface_in_form_vec.rs
+++ b/crates/hale-codegen/tests/interface_in_form_vec.rs
@@ -23,10 +23,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_iface_in_form_vec_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/interface_return.rs
+++ b/crates/hale-codegen/tests/interface_return.rs
@@ -23,10 +23,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_iface_return_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/io_demo.rs
+++ b/crates/hale-codegen/tests/io_demo.rs
@@ -15,6 +15,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn examples_dir() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tests");
@@ -35,8 +38,7 @@ fn unique_path(tag: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "hale_io_demo_{}_{}_{}.tmp",
         tag,
         std::process::id(),
@@ -70,8 +72,7 @@ impl Demo {
         src_path.push("main.hl");
         let source = std::fs::read_to_string(&src_path).expect("read source");
         let program = hale_syntax::parse_source(&source).expect("parse");
-        let mut bin = std::env::temp_dir();
-        bin.push(format!("hale_io_demo_bin_{}_{}", std::process::id(), tag));
+        let bin = harness::unique_bin(&format!("hale_io_demo_bin_{}_{}", std::process::id(), tag));
         build_executable(&program, &bin).expect("build");
         Self {
             port: pick_free_port(),
@@ -194,8 +195,7 @@ fn io_demo_falls_back_to_default_port_on_garbage_argv() {
     src_path.push("main.hl");
     let source = std::fs::read_to_string(&src_path).expect("read source");
     let program = hale_syntax::parse_source(&source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_io_demo_bin_garbage_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_io_demo_bin_garbage_{}", std::process::id()));
     build_executable(&program, &bin).expect("build");
 
     let log_path = unique_path("garbage_log");

--- a/crates/hale-codegen/tests/io_error_fallible.rs
+++ b/crates/hale-codegen/tests/io_error_fallible.rs
@@ -11,10 +11,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_io_err_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_test_io_err_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -27,8 +29,7 @@ fn build_and_run(name: &str, src: &str) -> (String, String, std::process::ExitSt
 
 #[test]
 fn read_file_ok_path_returns_contents() {
-    let mut tmp = std::env::temp_dir();
-    tmp.push(format!("ioerr_ok_{}.txt", std::process::id()));
+    let tmp = harness::unique_bin(&format!("ioerr_ok_{}.txt", std::process::id()));
     std::fs::write(&tmp, "hello world").unwrap();
     let path_str = tmp.to_string_lossy().to_string();
     let src = format!(
@@ -112,8 +113,7 @@ fn ioerror_carries_errno_and_path_fields() {
 
 #[test]
 fn write_file_then_read_roundtrip_via_fallible() {
-    let mut tmp = std::env::temp_dir();
-    tmp.push(format!("ioerr_wf_{}.txt", std::process::id()));
+    let tmp = harness::unique_bin(&format!("ioerr_wf_{}.txt", std::process::id()));
     let path_str = tmp.to_string_lossy().to_string();
     let src = format!(
         r#"
@@ -135,8 +135,7 @@ fn write_file_then_read_roundtrip_via_fallible() {
 fn mkdir_fallible_emits_already_exists_kind_on_existing_dir() {
     // mkdir's success is Unit, so the `or` substitute RHS has to
     // be Unit-typed too — a void helper that prints the IoError.
-    let mut tmp = std::env::temp_dir();
-    tmp.push(format!("ioerr_md_{}", std::process::id()));
+    let tmp = harness::unique_bin(&format!("ioerr_md_{}", std::process::id()));
     std::fs::create_dir_all(&tmp).unwrap();
     let path_str = tmp.to_string_lossy().to_string();
     let src = format!(
@@ -162,8 +161,7 @@ fn mkdir_fallible_emits_already_exists_kind_on_existing_dir() {
 
 #[test]
 fn file_size_ok_path_returns_size() {
-    let mut tmp = std::env::temp_dir();
-    tmp.push(format!("ioerr_fs_{}.txt", std::process::id()));
+    let tmp = harness::unique_bin(&format!("ioerr_fs_{}.txt", std::process::id()));
     std::fs::write(&tmp, "12345").unwrap();
     let path_str = tmp.to_string_lossy().to_string();
     let src = format!(
@@ -211,8 +209,7 @@ fn or_over_non_fallible_path_call_has_clear_diagnostic() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_or_diag_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_test_or_diag_{}", std::process::id()));
     let err = hale_codegen::build_executable(&program, &bin).expect_err("should reject");
     let _ = std::fs::remove_file(&bin);
     let msg = format!("{:?}", err);
@@ -229,8 +226,7 @@ fn str_bytes_mismatch_diagnostic_suggests_converter() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_str_diag_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_test_str_diag_{}", std::process::id()));
     let err = hale_codegen::build_executable(&program, &bin).expect_err("should reject");
     let _ = std::fs::remove_file(&bin);
     let msg = format!("{:?}", err);
@@ -246,8 +242,7 @@ fn bytes_str_mismatch_diagnostic_suggests_converter() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_bytes_diag_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_test_bytes_diag_{}", std::process::id()));
     let err = hale_codegen::build_executable(&program, &bin).expect_err("should reject");
     let _ = std::fs::remove_file(&bin);
     let msg = format!("{:?}", err);
@@ -265,8 +260,7 @@ fn missing_std_prefix_diagnostic_suggests_correction() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_typo_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_test_typo_{}", std::process::id()));
     let err = hale_codegen::build_executable(&program, &bin).expect_err("should reject");
     let _ = std::fs::remove_file(&bin);
     let msg = format!("{:?}", err);

--- a/crates/hale-codegen/tests/io_tcp_bus_logging.rs
+++ b/crates/hale-codegen/tests/io_tcp_bus_logging.rs
@@ -20,10 +20,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_io_tcp_bus_logging_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_io_tcp_bus_logging_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/io_tcp_recv_timeout.rs
+++ b/crates/hale-codegen/tests/io_tcp_recv_timeout.rs
@@ -15,10 +15,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_io_tcp_recv_timeout_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_io_tcp_recv_timeout_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/io_tls.rs
+++ b/crates/hale-codegen/tests/io_tls.rs
@@ -22,10 +22,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_io_tls_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_io_tls_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/json_from_json.rs
+++ b/crates/hale-codegen/tests/json_from_json.rs
@@ -9,10 +9,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let n = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lt-fromjson-{}-{}-{}.bin", name, std::process::id(), n));
+    let bin = harness::unique_bin(&format!("lt-fromjson-{}-{}-{}.bin", name, std::process::id(), n));
     let program = hale_syntax::parse_source(src).expect("parse");
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");

--- a/crates/hale-codegen/tests/json_object_cursor.rs
+++ b/crates/hale-codegen/tests/json_object_cursor.rs
@@ -12,10 +12,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let nanos = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lt-json-obj-{}-{}-{}.bin", name, std::process::id(), nanos));
+    let bin = harness::unique_bin(&format!("lt-json-obj-{}-{}-{}.bin", name, std::process::id(), nanos));
     let program = hale_syntax::parse_source(src).expect("parse");
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");

--- a/crates/hale-codegen/tests/json_range_helpers.rs
+++ b/crates/hale-codegen/tests/json_range_helpers.rs
@@ -26,13 +26,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-json-range-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/json_span_iter.rs
+++ b/crates/hale-codegen/tests/json_span_iter.rs
@@ -12,13 +12,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-json-span-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/k_max_builtin.rs
+++ b/crates/hale-codegen/tests/k_max_builtin.rs
@@ -11,10 +11,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_k_max_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_k_max_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/library_shape_2026_05_16.rs
+++ b/crates/hale-codegen/tests/library_shape_2026_05_16.rs
@@ -17,10 +17,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str, argv: &[&str]) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_libshape_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_libshape_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).args(argv).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -73,8 +75,7 @@ fn hashmap_bump_rejects_three_field_cells() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_libshape_bump_bad_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_libshape_bump_bad_{}", std::process::id()));
     let err = hale_codegen::build_executable(&program, &bin).expect_err("should reject");
     let _ = std::fs::remove_file(&bin);
     let msg = format!("{:?}", err);
@@ -208,8 +209,7 @@ fn or_discard_rejects_value_bearing_call() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_discard_bad_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_test_discard_bad_{}", std::process::id()));
     let err = hale_codegen::build_executable(&program, &bin).expect_err("should reject");
     let _ = std::fs::remove_file(&bin);
     let msg = format!("{:?}", err);

--- a/crates/hale-codegen/tests/library_shape_http_json.rs
+++ b/crates/hale-codegen/tests/library_shape_http_json.rs
@@ -10,10 +10,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_libshape_http_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_libshape_http_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     bin
 }
@@ -204,8 +206,7 @@ fn http_server_without_handler_is_compile_error() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_libshape_http_required_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_libshape_http_required_{}", std::process::id()));
     let err = build_executable(&program, &bin).expect_err("expected compile error");
     let msg = format!("{:?}", err);
     assert!(

--- a/crates/hale-codegen/tests/locus_fallible_return_multichild.rs
+++ b/crates/hale-codegen/tests/locus_fallible_return_multichild.rs
@@ -31,13 +31,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-mapper-fallible-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/locus_field_cascade.rs
+++ b/crates/hale-codegen/tests/locus_field_cascade.rs
@@ -24,10 +24,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_locus_field_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_locus_field_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/locus_field_reorder.rs
+++ b/crates/hale-codegen/tests/locus_field_reorder.rs
@@ -28,13 +28,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-locus-field-reorder-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/locus_let_lifecycle.rs
+++ b/crates/hale-codegen/tests/locus_let_lifecycle.rs
@@ -15,10 +15,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_let_lifecycle_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_let_lifecycle_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/locus_member_fallible.rs
+++ b/crates/hale-codegen/tests/locus_member_fallible.rs
@@ -17,13 +17,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-locus-member-fallible-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/locus_member_fallible_rejects.rs
+++ b/crates/hale-codegen/tests/locus_member_fallible_rejects.rs
@@ -16,13 +16,15 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-locus-fallible-heap-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/log_routing.rs
+++ b/crates/hale-codegen/tests/log_routing.rs
@@ -6,13 +6,15 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run_split_streams(
     name: &str,
     source: &str,
 ) -> (String, String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/main_return_call_teardown.rs
+++ b/crates/hale-codegen/tests/main_return_call_teardown.rs
@@ -22,13 +22,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-main-ret-call-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/match_expression.rs
+++ b/crates/hale-codegen/tests/match_expression.rs
@@ -15,10 +15,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_matchexpr_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_matchexpr_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/math_and_int_float.rs
+++ b/crates/hale-codegen/tests/math_and_int_float.rs
@@ -13,10 +13,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_math_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_math_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/math_nan_inf.rs
+++ b/crates/hale-codegen/tests/math_nan_inf.rs
@@ -15,20 +15,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> std::process::Output {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    // Salt with pid + a process-wide counter so two tests can never
-    // share a temp-build path under nextest's parallel execution
-    // (the bytes_pack_read flake class).
-    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    bin.push(format!(
-        "lotus_test_math_nan_inf_{}_{}_{}",
-        name,
-        std::process::id(),
-        seq
-    ));
+    let bin = harness::unique_bin(name);
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/method_call_from_free_fn.rs
+++ b/crates/hale-codegen/tests/method_call_from_free_fn.rs
@@ -14,10 +14,12 @@
 use hale_codegen::build_executable;
 use std::process::Command;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_method_from_freefn_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_method_from_freefn_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/method_scratch_elision.rs
+++ b/crates/hale-codegen/tests/method_scratch_elision.rs
@@ -25,10 +25,12 @@ use hale_codegen::build_executable;
 
 /// Build with `LOTUS_DUMP_IR=1` and return the emitted LLVM IR text. Lets a
 /// test assert directly whether a method body opened a scratch subregion.
+#[path = "support/harness.rs"]
+mod harness;
+
 fn dump_ir(name: &str, src: &str) -> String {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_ms_ir_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_ms_ir_{}_{}", name, std::process::id()));
     let ir = bin.with_extension("ll");
     std::env::set_var("LOTUS_DUMP_IR", "1");
     let result = build_executable(&program, &bin);
@@ -54,8 +56,7 @@ fn carve_fn_body<'a>(ir: &'a str, name: &str) -> &'a str {
 
 fn build_and_run(name: &str, src: &str) -> String {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_method_scratch_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_method_scratch_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/method_scratch_reclaim.rs
+++ b/crates/hale-codegen/tests/method_scratch_reclaim.rs
@@ -31,13 +31,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str, ext: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-method-scratch-{}-{}-{}.{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/mirror_ring.rs
+++ b/crates/hale-codegen/tests/mirror_ring.rs
@@ -8,14 +8,16 @@
 use hale_codegen::build_executable;
 use std::process::Command;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     build_and_run_argv(name, src, &[])
 }
 
 fn build_and_run_argv(name: &str, src: &str, argv: &[&str]) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_mirror_{}", name));
+    let bin = harness::unique_bin(&format!("hale_mirror_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).args(argv).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/multi_file_build.rs
+++ b/crates/hale-codegen/tests/multi_file_build.rs
@@ -10,13 +10,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use hale_codegen::build_executable;
 use hale_syntax::ast::Program;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_dir(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "hale_multi_file_{}_{}_{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/nested_long_lived_child.rs
+++ b/crates/hale-codegen/tests/nested_long_lived_child.rs
@@ -18,10 +18,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_nested_long_lived_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_nested_long_lived_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/nested_struct_bus_payload.rs
+++ b/crates/hale-codegen/tests/nested_struct_bus_payload.rs
@@ -11,10 +11,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_nested_bus_payload_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_nested_bus_payload_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/noalias_self.rs
+++ b/crates/hale-codegen/tests/noalias_self.rs
@@ -7,13 +7,12 @@
 use hale_codegen::build_executable;
 use hale_syntax::parse_source;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn ir_for(src: &str) -> String {
     let program = parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    static NEXT: std::sync::atomic::AtomicU64 =
-        std::sync::atomic::AtomicU64::new(0);
-    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    bin.push(format!("hale_noalias_{}_{}", std::process::id(), n));
+    let bin = harness::unique_bin("noalias_self");
     std::env::set_var("LOTUS_DUMP_IR", "1");
     build_executable(&program, &bin).expect("build");
     std::env::remove_var("LOTUS_DUMP_IR");

--- a/crates/hale-codegen/tests/obs_emission.rs
+++ b/crates/hale-codegen/tests/obs_emission.rs
@@ -17,14 +17,16 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[path = "support/obs.rs"]
 mod obs;
 use obs::{obs_bus_locus, read_u32, read_u64};
 
 fn build(name: &str, src: &str) -> PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_obs_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_obs_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/obs_fleet_contract.rs
+++ b/crates/hale-codegen/tests/obs_fleet_contract.rs
@@ -31,6 +31,9 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[path = "support/obs.rs"]
 mod obs;
 use obs::{
@@ -40,8 +43,7 @@ use obs::{
 
 fn compile(tag: &str, src: &str) -> PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_obsfleet_{}_{}", tag, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_obsfleet_{}_{}", tag, std::process::id()));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/obs_net_seq.rs
+++ b/crates/hale-codegen/tests/obs_net_seq.rs
@@ -23,14 +23,16 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[path = "support/obs.rs"]
 mod obs;
 use obs::{attach_observer, net_origin_seq, records, snapshot_shm};
 
 fn compile(tag: &str, src: &str) -> PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_obsnet_{}_{}", tag, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_obsnet_{}_{}", tag, std::process::id()));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/or_block_disposer.rs
+++ b/crates/hale-codegen/tests/or_block_disposer.rs
@@ -19,10 +19,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_or_block_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_or_block_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/or_fallible_handler.rs
+++ b/crates/hale-codegen/tests/or_fallible_handler.rs
@@ -12,18 +12,12 @@ use hale_codegen::build_executable;
 use hale_syntax::parse_source;
 use hale_types::check_program;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    static NEXT: std::sync::atomic::AtomicU64 =
-        std::sync::atomic::AtomicU64::new(0);
-    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    bin.push(format!(
-        "hale_or_fallible_{}_{}_{}",
-        name,
-        std::process::id(),
-        n
-    ));
+    let bin = harness::unique_bin(name);
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/or_wait_loss_window.rs
+++ b/crates/hale-codegen/tests/or_wait_loss_window.rs
@@ -21,18 +21,19 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_orwait_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_orwait_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
 
 fn build_peer_driver(tag: &str) -> PathBuf {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_orwait_peer_{}", tag));
+    let bin = harness::unique_bin(&format!("hale_orwait_peer_{}", tag));
     let status = Command::new("clang")
         .arg(manifest.join("tests").join("transport_driver.c"))
         .arg(manifest.join("runtime").join("lotus_arena.c"))
@@ -102,7 +103,7 @@ fn or_wait_parks_through_loss_window_no_drops() {
         .stderr(Stdio::null())
         .spawn()
         .expect("spawn peer 1");
-    let mut publisher = Command::new(&bin)
+    let publisher = Command::new(&bin)
         .env("LOTUS_BUS_COUNTERS_DUMP", "1")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/hale-codegen/tests/os_getrandom.rs
+++ b/crates/hale-codegen/tests/os_getrandom.rs
@@ -22,13 +22,15 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(
     name: &str,
     src: &str,
 ) -> (String, String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_test_os_getrandom_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/ownership_bubble.rs
+++ b/crates/hale-codegen/tests/ownership_bubble.rs
@@ -30,10 +30,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_named(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_ownership_bubble_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_ownership_bubble_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/ownership_bubble_crosspool.rs
+++ b/crates/hale-codegen/tests/ownership_bubble_crosspool.rs
@@ -25,10 +25,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_named(name: &str, src: &str) -> Result<std::path::PathBuf, String> {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_test_xpool_bubble_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/ownership_bubble_multi.rs
+++ b/crates/hale-codegen/tests/ownership_bubble_multi.rs
@@ -28,10 +28,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_named(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_ownership_bubble_multi_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_ownership_bubble_multi_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/panic_atexit.rs
+++ b/crates/hale-codegen/tests/panic_atexit.rs
@@ -11,10 +11,12 @@ use std::process::Command;
 
 use hale_codegen::{build_executable_with_options, BuildOptions};
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_with_csrc(name: &str, hale_src: &str, csrc_body: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(hale_src).expect("parse");
-    let mut tmpdir = std::env::temp_dir();
-    tmpdir.push(format!("hale_test_panic_atexit_{}", name));
+    let tmpdir = harness::unique_bin(&format!("hale_test_panic_atexit_{}", name));
     let _ = std::fs::create_dir_all(&tmpdir);
     let csrc_path = tmpdir.join("glue.c");
     std::fs::write(&csrc_path, csrc_body).expect("write csrc");

--- a/crates/hale-codegen/tests/params_default_scalar_self_ref.rs
+++ b/crates/hale-codegen/tests/params_default_scalar_self_ref.rs
@@ -18,13 +18,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-pdssr-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/parse_float_and_base64_decode.rs
+++ b/crates/hale-codegen/tests/parse_float_and_base64_decode.rs
@@ -11,10 +11,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_parse_b64_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_parse_b64_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/phase_b_fixes.rs
+++ b/crates/hale-codegen/tests/phase_b_fixes.rs
@@ -6,10 +6,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_phase_b_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_phase_b_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/placement_where_async_io.rs
+++ b/crates/hale-codegen/tests/placement_where_async_io.rs
@@ -15,6 +15,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn typecheck_diags(source: &str) -> Vec<String> {
     let program = hale_syntax::parse_source(source).expect("parse");
     let mut programs = std::collections::BTreeMap::new();
@@ -196,8 +199,7 @@ fn placement_where_async_io_builds_and_runs() {
     // here. The "with async_io" path needs an actual long-running
     // sibling shape — covered by the standalone smoke below.
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_placement_where_no_async");
+    let bin = harness::unique_bin("hale_test_placement_where_no_async");
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -243,8 +245,7 @@ fn placement_where_async_io_emits_enable_call() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_placement_where_async_io_e2e");
+    let bin = harness::unique_bin("hale_test_placement_where_async_io_e2e");
     build_executable(&program, &bin).expect("build");
     let output = Command::new("timeout")
         .arg("3")

--- a/crates/hale-codegen/tests/process_child.rs
+++ b/crates/hale-codegen/tests/process_child.rs
@@ -26,13 +26,15 @@ use std::time::Instant;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(
     name: &str,
     src: &str,
 ) -> (String, String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_test_process_child_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/process_run.rs
+++ b/crates/hale-codegen/tests/process_run.rs
@@ -18,13 +18,15 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(
     name: &str,
     src: &str,
 ) -> (String, String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_test_process_run_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/process_try_wait.rs
+++ b/crates/hale-codegen/tests/process_try_wait.rs
@@ -14,10 +14,12 @@ use std::time::Instant;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_try_wait_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_try_wait_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/qualified_locus_type_coop_pool.rs
+++ b/crates/hale-codegen/tests/qualified_locus_type_coop_pool.rs
@@ -22,6 +22,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn qualified_stdlib_locus_on_non_main_pool_does_not_starve_main_run() {
     // Same shape as the a downstream app: main locus with a
@@ -65,8 +68,7 @@ fn qualified_stdlib_locus_on_non_main_pool_does_not_starve_main_run() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_qualified_locus_coop_pool");
+    let bin = harness::unique_bin("hale_test_qualified_locus_coop_pool");
     build_executable(&program, &bin).expect("build");
     // Run with a short timeout via `timeout` — the listener's
     // forever-accept loop on the io pool keeps the program alive

--- a/crates/hale-codegen/tests/rand_primitives.rs
+++ b/crates/hale-codegen/tests/rand_primitives.rs
@@ -6,10 +6,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_rand_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_rand_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/read_file_proc.rs
+++ b/crates/hale-codegen/tests/read_file_proc.rs
@@ -15,10 +15,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_read_file_proc_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/reclamation_spine.rs
+++ b/crates/hale-codegen/tests/reclamation_spine.rs
@@ -15,10 +15,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_run(tag: &str, src: &str) -> (bool, String) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_reclaim_spine_{}", tag));
+    let bin = harness::unique_bin(&format!("hale_test_reclaim_spine_{}", tag));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/recpool.rs
+++ b/crates/hale-codegen/tests/recpool.rs
@@ -11,6 +11,9 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -35,8 +38,7 @@ fn build_driver(tag: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_recpool_driver_{}_{}_{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/recpool_codegen.rs
+++ b/crates/hale-codegen/tests/recpool_codegen.rs
@@ -9,6 +9,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     use std::time::{SystemTime, UNIX_EPOCH};
     let program = hale_syntax::parse_source(src).expect("parse");
@@ -16,8 +19,7 @@ fn build(name: &str, src: &str) -> std::path::PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_test_recpool_{}_{}_{}",
         name,
         std::process::id(),

--- a/crates/hale-codegen/tests/recv_into.rs
+++ b/crates/hale-codegen/tests/recv_into.rs
@@ -9,6 +9,9 @@ use std::process::{Command, Stdio};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_free_port() -> u16 {
     let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     let port = probe.local_addr().expect("local_addr").port();
@@ -18,8 +21,7 @@ fn pick_free_port() -> u16 {
 
 fn build_hale_binary(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_recv_into_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_recv_into_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/recv_stamped.rs
+++ b/crates/hale-codegen/tests/recv_stamped.rs
@@ -19,6 +19,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_free_port() -> u16 {
     let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     l.local_addr().expect("local_addr").port()
@@ -26,8 +29,7 @@ fn pick_free_port() -> u16 {
 
 fn build_and_run_argv(name: &str, src: &str, argv: &[&str]) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_recv_stamped_{}", name));
+    let bin = harness::unique_bin(&format!("hale_recv_stamped_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).args(argv).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/recv_timeout_sentinel.rs
+++ b/crates/hale-codegen/tests/recv_timeout_sentinel.rs
@@ -14,6 +14,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_free_port() -> u16 {
     let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     l.local_addr().expect("local_addr").port()
@@ -21,8 +24,7 @@ fn pick_free_port() -> u16 {
 
 fn build_and_run_argv(name: &str, src: &str, argv: &[&str]) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_recv_timeout_{}", name));
+    let bin = harness::unique_bin(&format!("hale_recv_timeout_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).args(argv).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/recv_zero_alloc.rs
+++ b/crates/hale-codegen/tests/recv_zero_alloc.rs
@@ -28,10 +28,12 @@
 use hale_codegen::build_executable;
 use std::process::Command;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run_argv(name: &str, src: &str, argv: &[&str]) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_recv0_{}", name));
+    let bin = harness::unique_bin(&format!("hale_recv0_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).args(argv).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/release_reclaims_flow.rs
+++ b/crates/hale-codegen/tests/release_reclaims_flow.rs
@@ -17,6 +17,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn release_fires_and_reclaims_each_flow_child_on_run_completion() {
     const N: usize = 20;
@@ -60,8 +63,7 @@ fn release_fires_and_reclaims_each_flow_child_on_run_completion() {
     "#
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_release_reclaims_flow");
+    let bin = harness::unique_bin("hale_test_release_reclaims_flow");
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/repr_field_accessors.rs
+++ b/crates/hale-codegen/tests/repr_field_accessors.rs
@@ -12,6 +12,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn tag(label: &str) -> String {
     let n = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
     format!("rfa-{}-{}-{}", label, std::process::id(), n)
@@ -87,8 +90,7 @@ fn repr_accessors_round_trip_through_a_foreign_ring() {
         shm = shm,
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_{}.bin", tag("bin")));
+    let bin = harness::unique_bin(&format!("lotus_{}.bin", tag("bin")));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/self_field_alias.rs
+++ b/crates/hale-codegen/tests/self_field_alias.rs
@@ -19,10 +19,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> String {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_self_field_alias_{}", name));
+    let bin = harness::unique_bin(&format!("hale_self_field_alias_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/self_field_index_assign.rs
+++ b/crates/hale-codegen/tests/self_field_index_assign.rs
@@ -8,10 +8,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_self_field_idx_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_self_field_idx_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/serializer_shape.rs
+++ b/crates/hale-codegen/tests/serializer_shape.rs
@@ -17,13 +17,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str, ext: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-m60-{}-{}-{}.{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/sha1_base64.rs
+++ b/crates/hale-codegen/tests/sha1_base64.rs
@@ -9,10 +9,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_sha1_base64_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_sha1_base64_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/shm_drain_batch.rs
+++ b/crates/hale-codegen/tests/shm_drain_batch.rs
@@ -26,6 +26,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_tag(label: &str) -> String {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -36,8 +39,7 @@ fn unique_tag(label: &str) -> String {
 
 fn build_binary(src: &str, label: &str) -> PathBuf {
     let prog = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_shm_drain_{}.bin", unique_tag(label)));
+    let bin = harness::unique_bin(&format!("lotus_shm_drain_{}.bin", unique_tag(label)));
     build_executable(&prog, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/shm_ring.rs
+++ b/crates/hale-codegen/tests/shm_ring.rs
@@ -22,6 +22,9 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -41,8 +44,7 @@ fn ring_c_path() -> PathBuf {
 }
 
 fn build_driver(tag: &str) -> PathBuf {
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_shm_ring_driver_{}", tag));
+    let bin = harness::unique_bin(&format!("lotus_shm_ring_driver_{}", tag));
     let status = Command::new("clang")
         .arg(driver_c_path())
         .arg(ring_c_path())

--- a/crates/hale-codegen/tests/shm_ring_hale_subscriber.rs
+++ b/crates/hale-codegen/tests/shm_ring_hale_subscriber.rs
@@ -24,6 +24,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_tag(label: &str) -> String {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -34,8 +37,7 @@ fn unique_tag(label: &str) -> String {
 
 fn build_binary(src: &str, label: &str) -> PathBuf {
     let prog = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_shm_k6b_{}.bin", unique_tag(label)));
+    let bin = harness::unique_bin(&format!("lotus_shm_k6b_{}.bin", unique_tag(label)));
     build_executable(&prog, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/shm_ring_layout_bytesview.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_bytesview.rs
@@ -18,6 +18,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -37,8 +40,7 @@ fn build_producer() -> PathBuf {
     let mut ring_c = manifest_dir();
     ring_c.push("runtime");
     ring_c.push("lotus_shm_ring.c");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_{}", unique_tag("producer")));
+    let bin = harness::unique_bin(&format!("lotus_{}", unique_tag("producer")));
     let status = Command::new("clang")
         .arg(&driver_c)
         .arg(&ring_c)
@@ -103,8 +105,7 @@ fn hale_bytesview_subscriber_decodes_heterogeneous_ring() {
     );
 
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut consumer_bin = std::env::temp_dir();
-    consumer_bin.push(format!("lotus_{}.bin", unique_tag("consumer")));
+    let consumer_bin = harness::unique_bin(&format!("lotus_{}.bin", unique_tag("consumer")));
     build_executable(&program, &consumer_bin).expect("build consumer");
 
     let producer_bin = build_producer();

--- a/crates/hale-codegen/tests/shm_ring_layout_bytesview_producer.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_bytesview_producer.rs
@@ -15,6 +15,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_tag(label: &str) -> String {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -95,8 +98,7 @@ fn hale_bytesview_producer_frames_variable_length_records() {
     );
 
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_{}.bin", unique_tag("bin")));
+    let bin = harness::unique_bin(&format!("lotus_{}.bin", unique_tag("bin")));
     build_executable(&program, &bin).expect("build");
 
     let out = Command::new(&bin).output().expect("run");

--- a/crates/hale-codegen/tests/shm_ring_layout_codegen.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_codegen.rs
@@ -18,13 +18,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str, ext: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-pr0b-{}-{}-{}.{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/shm_ring_layout_lotus_dogfood.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_lotus_dogfood.rs
@@ -19,6 +19,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -38,8 +41,7 @@ fn build_native_producer() -> PathBuf {
     let mut ring_c = manifest_dir();
     ring_c.push("runtime");
     ring_c.push("lotus_shm_ring.c");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_{}", unique_tag("producer")));
+    let bin = harness::unique_bin(&format!("lotus_{}", unique_tag("producer")));
     let status = Command::new("clang")
         .arg(&driver_c)
         .arg(&ring_c)
@@ -101,8 +103,7 @@ fn hale_layout_lotus_ring_reads_native_producer() {
     );
 
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut consumer_bin = std::env::temp_dir();
-    consumer_bin.push(format!("lotus_{}.bin", unique_tag("consumer")));
+    let consumer_bin = harness::unique_bin(&format!("lotus_{}.bin", unique_tag("consumer")));
     build_executable(&program, &consumer_bin).expect("build consumer");
 
     let producer_bin = build_native_producer();

--- a/crates/hale-codegen/tests/shm_ring_layout_producer.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_producer.rs
@@ -24,6 +24,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_tag(label: &str) -> String {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -97,8 +100,7 @@ fn hale_producer_roundtrips_through_foreign_layout() {
     );
 
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_{}.bin", unique_tag("bin")));
+    let bin = harness::unique_bin(&format!("lotus_{}.bin", unique_tag("bin")));
     build_executable(&program, &bin).expect("build");
 
     let out = Command::new(&bin).output().expect("run");

--- a/crates/hale-codegen/tests/shm_ring_layout_record_header.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_record_header.rs
@@ -19,6 +19,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -38,8 +41,7 @@ fn build_producer() -> PathBuf {
     let mut ring_c = manifest_dir();
     ring_c.push("runtime");
     ring_c.push("lotus_shm_ring.c");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_{}", unique_tag("producer")));
+    let bin = harness::unique_bin(&format!("lotus_{}", unique_tag("producer")));
     let status = Command::new("clang")
         .arg(&driver_c)
         .arg(&ring_c)
@@ -104,8 +106,7 @@ fn hale_subscriber_reads_record_header_ring_with_post_copy() {
     );
 
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut consumer_bin = std::env::temp_dir();
-    consumer_bin.push(format!("lotus_{}.bin", unique_tag("consumer")));
+    let consumer_bin = harness::unique_bin(&format!("lotus_{}.bin", unique_tag("consumer")));
     build_executable(&program, &consumer_bin).expect("build consumer");
 
     let producer_bin = build_producer();

--- a/crates/hale-codegen/tests/shm_ring_layout_zerocopy_write.rs
+++ b/crates/hale-codegen/tests/shm_ring_layout_zerocopy_write.rs
@@ -11,6 +11,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_tag(label: &str) -> String {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -80,8 +83,7 @@ fn hale_zero_copy_write_in_place_round_trips() {
         shm_name = shm_name,
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_{}.bin", unique_tag("bin")));
+    let bin = harness::unique_bin(&format!("lotus_{}.bin", unique_tag("bin")));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/shm_ring_nested_param_subscriber.rs
+++ b/crates/hale-codegen/tests/shm_ring_nested_param_subscriber.rs
@@ -24,6 +24,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_tag(label: &str) -> String {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -34,8 +37,7 @@ fn unique_tag(label: &str) -> String {
 
 fn build_binary(src: &str, label: &str) -> PathBuf {
     let prog = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_shm_ws35_{}.bin", unique_tag(label)));
+    let bin = harness::unique_bin(&format!("lotus_shm_ws35_{}.bin", unique_tag(label)));
     build_executable(&prog, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/shm_ring_overflow.rs
+++ b/crates/hale-codegen/tests/shm_ring_overflow.rs
@@ -19,6 +19,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_tag(label: &str) -> String {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -29,8 +32,7 @@ fn unique_tag(label: &str) -> String {
 
 fn build_binary(src: &str, label: &str) -> PathBuf {
     let prog = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_shm_k7_{}.bin", unique_tag(label)));
+    let bin = harness::unique_bin(&format!("lotus_shm_k7_{}.bin", unique_tag(label)));
     build_executable(&prog, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/shm_ring_publish.rs
+++ b/crates/hale-codegen/tests/shm_ring_publish.rs
@@ -20,6 +20,9 @@ use hale_codegen::build_executable;
 /// `/dev/shm/<name>` (with the leading slash from the name
 /// stripped). Used to confirm the K-cleanup atexit hook
 /// actually shm_unlink'd creator-owned rings.
+#[path = "support/harness.rs"]
+mod harness;
+
 fn shm_object_exists(shm_name: &str) -> bool {
     let stripped = shm_name.trim_start_matches('/');
     PathBuf::from(format!("/dev/shm/{}", stripped)).exists()
@@ -46,8 +49,7 @@ fn build_reader(tag: &str) -> PathBuf {
     ring_c.push("runtime");
     ring_c.push("lotus_shm_ring.c");
 
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_shm_ring_reader_{}", tag));
+    let bin = harness::unique_bin(&format!("lotus_shm_ring_reader_{}", tag));
     let status = Command::new("clang")
         .arg(&driver)
         .arg(&ring_c)
@@ -112,8 +114,7 @@ fn hale_publisher_routes_through_shm_ring() {
     );
 
     let program = hale_syntax::parse_source(&hale_src).expect("parse");
-    let mut publisher_bin = std::env::temp_dir();
-    publisher_bin.push(format!("lotus_shm_pub_{}.bin", tag));
+    let publisher_bin = harness::unique_bin(&format!("lotus_shm_pub_{}.bin", tag));
     build_executable(&program, &publisher_bin).expect("build publisher");
 
     let reader_bin = build_reader(&tag);
@@ -194,8 +195,7 @@ fn shm_object_unlinked_on_clean_exit() {
         slot_count = slot_count,
     );
     let program = hale_syntax::parse_source(&hale_src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_shm_unlink_{}.bin", tag));
+    let bin = harness::unique_bin(&format!("lotus_shm_unlink_{}.bin", tag));
     build_executable(&program, &bin).expect("build");
 
     // Pre-condition: name doesn't exist yet (unique per test).

--- a/crates/hale-codegen/tests/shm_ring_record_header_fields.rs
+++ b/crates/hale-codegen/tests/shm_ring_record_header_fields.rs
@@ -19,6 +19,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -38,8 +41,7 @@ fn build_producer() -> PathBuf {
     let mut ring_c = manifest_dir();
     ring_c.push("runtime");
     ring_c.push("lotus_shm_ring.c");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_{}", unique_tag("producer")));
+    let bin = harness::unique_bin(&format!("lotus_{}", unique_tag("producer")));
     let status = Command::new("clang")
         .arg(&driver_c)
         .arg(&ring_c)
@@ -108,8 +110,7 @@ fn hale_subscriber_reads_in_band_header_fields() {
     );
 
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut consumer_bin = std::env::temp_dir();
-    consumer_bin.push(format!("lotus_{}.bin", unique_tag("consumer")));
+    let consumer_bin = harness::unique_bin(&format!("lotus_{}.bin", unique_tag("consumer")));
     build_executable(&program, &consumer_bin).expect("build consumer");
 
     let producer_bin = build_producer();

--- a/crates/hale-codegen/tests/shm_ring_torn_read_stress.rs
+++ b/crates/hale-codegen/tests/shm_ring_torn_read_stress.rs
@@ -25,6 +25,9 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -44,8 +47,7 @@ fn build_driver() -> PathBuf {
     let mut ring_c = manifest_dir();
     ring_c.push("runtime");
     ring_c.push("lotus_shm_ring.c");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_{}", unique_tag()));
+    let bin = harness::unique_bin(&format!("lotus_{}", unique_tag()));
     let status = Command::new("clang")
         .arg(&driver_c)
         .arg(&ring_c)

--- a/crates/hale-codegen/tests/sibling_field_forward_ref.rs
+++ b/crates/hale-codegen/tests/sibling_field_forward_ref.rs
@@ -21,13 +21,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-sibling-fwd-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/sink_polymorphism.rs
+++ b/crates/hale-codegen/tests/sink_polymorphism.rs
@@ -12,10 +12,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_sink_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_sink_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/sleep_drains_bus.rs
+++ b/crates/hale-codegen/tests/sleep_drains_bus.rs
@@ -25,13 +25,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-sleep-drain-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/spsc_ring.rs
+++ b/crates/hale-codegen/tests/spsc_ring.rs
@@ -10,11 +10,13 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn spsc_driver_concurrent_contract_holds() {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let mut bin = std::env::temp_dir();
-    bin.push("lotus_spsc_driver_test");
+    let bin = harness::unique_bin("lotus_spsc_driver_test");
     let status = Command::new("clang")
         .arg(manifest.join("tests").join("spsc_driver.c"))
         .arg(manifest.join("runtime").join("lotus_arena.c"))
@@ -58,8 +60,7 @@ fn hale_surface_lowers_and_links() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_spsc_surface");
+    let bin = harness::unique_bin("hale_test_spsc_surface");
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/std_process_exit.rs
+++ b/crates/hale-codegen/tests/std_process_exit.rs
@@ -6,10 +6,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> std::process::ExitStatus {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_{}", name));
     build_executable(&program, &bin).expect("build");
     let status = Command::new(&bin).status().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/std_process_rss.rs
+++ b/crates/hale-codegen/tests/std_process_rss.rs
@@ -9,10 +9,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_std_process_rss_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/stdlib_bytes.rs
+++ b/crates/hale-codegen/tests/stdlib_bytes.rs
@@ -24,10 +24,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_bytes_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_bytes_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
@@ -37,8 +39,7 @@ fn unique_path(tag: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "hale_bytes_{}_{}_{}.tmp",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/stdlib_cli.rs
+++ b/crates/hale-codegen/tests/stdlib_cli.rs
@@ -10,10 +10,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stdlib_cli_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stdlib_cli_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/stdlib_env.rs
+++ b/crates/hale-codegen/tests/stdlib_env.rs
@@ -15,10 +15,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stdlib_env_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stdlib_env_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/stdlib_fs.rs
+++ b/crates/hale-codegen/tests/stdlib_fs.rs
@@ -18,10 +18,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stdlib_fs_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stdlib_fs_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -33,8 +35,7 @@ fn unique_tempfile(tag: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "hale_fs_test_{}_{}_{}.tmp",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/stdlib_http_request.rs
+++ b/crates/hale-codegen/tests/stdlib_http_request.rs
@@ -16,10 +16,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_http_req_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_http_req_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/stdlib_http_response.rs
+++ b/crates/hale-codegen/tests/stdlib_http_response.rs
@@ -15,10 +15,12 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_http_resp_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_http_resp_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/stdlib_iter.rs
+++ b/crates/hale-codegen/tests/stdlib_iter.rs
@@ -9,10 +9,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stdlib_iter_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stdlib_iter_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/stdlib_json.rs
+++ b/crates/hale-codegen/tests/stdlib_json.rs
@@ -4,10 +4,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stdlib_json_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stdlib_json_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/stdlib_list_dir.rs
+++ b/crates/hale-codegen/tests/stdlib_list_dir.rs
@@ -12,10 +12,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_list_dir_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_list_dir_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
@@ -25,8 +27,7 @@ fn unique_dir(tag: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "hale_list_dir_{}_{}_{}",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/stdlib_listener_multi.rs
+++ b/crates/hale-codegen/tests/stdlib_listener_multi.rs
@@ -24,10 +24,12 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_listener_multi_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_listener_multi_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/stdlib_locus.rs
+++ b/crates/hale-codegen/tests/stdlib_locus.rs
@@ -21,6 +21,9 @@ use std::process::{Command, Stdio};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_free_port() -> u16 {
     let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     let port = probe.local_addr().expect("local_addr").port();
@@ -30,8 +33,7 @@ fn pick_free_port() -> u16 {
 
 fn build_hale_binary(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stdlib_locus_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stdlib_locus_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
@@ -166,8 +168,7 @@ fn unknown_stdlib_path_struct_literal_errors_clearly() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_stdlib_locus_unknown");
+    let bin = harness::unique_bin("hale_test_stdlib_locus_unknown");
     let result = build_executable(&program, &bin);
     let _ = std::fs::remove_file(&bin);
     assert!(result.is_err(), "expected build error for unknown stdlib path");
@@ -192,8 +193,7 @@ fn user_program_with_no_stdlib_use_still_compiles() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_stdlib_locus_no_use");
+    let bin = harness::unique_bin("hale_test_stdlib_locus_no_use");
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/stdlib_log.rs
+++ b/crates/hale-codegen/tests/stdlib_log.rs
@@ -14,10 +14,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_log_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_log_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/stdlib_log_sinks.rs
+++ b/crates/hale-codegen/tests/stdlib_log_sinks.rs
@@ -8,6 +8,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn file_sink_rotates_and_console_sink_renders() {
     let dir = std::env::temp_dir().join(format!(
@@ -38,8 +41,7 @@ fn file_sink_rotates_and_console_sink_renders() {
         log = log_path.display()
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_log_sinks_bin_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_log_sinks_bin_{}", std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin)
         .env("NO_COLOR", "1")

--- a/crates/hale-codegen/tests/stdlib_m79.rs
+++ b/crates/hale-codegen/tests/stdlib_m79.rs
@@ -5,10 +5,12 @@ use std::time::Instant;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_m79_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_m79_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/stdlib_markdown.rs
+++ b/crates/hale-codegen/tests/stdlib_markdown.rs
@@ -9,6 +9,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn render(source_md: &str) -> String {
     // Each test compiles a tiny Hale program that calls
     // std::text::md_to_html on the supplied markdown and
@@ -29,15 +32,7 @@ fn render(source_md: &str) -> String {
         escaped
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
-        "hale_md_test_{}_{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ));
+    let bin = harness::unique_bin("stdlib_markdown");
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/stdlib_metrics.rs
+++ b/crates/hale-codegen/tests/stdlib_metrics.rs
@@ -16,6 +16,9 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_free_port() -> u16 {
     let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     probe.local_addr().expect("local_addr").port()
@@ -52,8 +55,7 @@ fn registry_renders_counter_gauge_histogram() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_metrics_direct_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_metrics_direct_{}", std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -98,8 +100,7 @@ fn endpoint_scrapes_through_server_over_tcp() {
     "#
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_metrics_wire_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_metrics_wire_{}", std::process::id()));
     build_executable(&program, &bin).expect("build");
     let mut child = Command::new(&bin)
         .stdout(std::process::Stdio::piped())

--- a/crates/hale-codegen/tests/stdlib_name.rs
+++ b/crates/hale-codegen/tests/stdlib_name.rs
@@ -4,10 +4,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stdlib_name_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stdlib_name_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/stdlib_path.rs
+++ b/crates/hale-codegen/tests/stdlib_path.rs
@@ -13,10 +13,12 @@ use std::process::Command;
 use hale_codegen::build_executable;
 
 /// Compile `source`, run the binary, return (stdout, status).
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stdlib_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stdlib_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -66,8 +68,7 @@ fn std_process_pid_matches_runtime_pid() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_stdlib_process_pid_match");
+    let bin = harness::unique_bin("hale_test_stdlib_process_pid_match");
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -106,8 +107,7 @@ fn unknown_std_path_errors_with_useful_message() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_stdlib_unknown_path");
+    let bin = harness::unique_bin("hale_test_stdlib_unknown_path");
     let result = build_executable(&program, &bin);
     let _ = std::fs::remove_file(&bin);
     assert!(result.is_err(), "expected build error for unknown std path");

--- a/crates/hale-codegen/tests/stdlib_source.rs
+++ b/crates/hale-codegen/tests/stdlib_source.rs
@@ -9,17 +9,18 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stdlib_source_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stdlib_source_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }
 
 fn make_fixture(test_name: &str, files: &[(&str, &str)]) -> std::path::PathBuf {
-    let mut dir = std::env::temp_dir();
-    dir.push(format!("hale_test_source_walk_{}", test_name));
+    let dir = harness::unique_bin(&format!("hale_test_source_walk_{}", test_name));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).expect("create fixture dir");
     for (name, body) in files {

--- a/crates/hale-codegen/tests/stdlib_stdin.rs
+++ b/crates/hale-codegen/tests/stdlib_stdin.rs
@@ -6,10 +6,12 @@ use std::process::{Command, Stdio};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_for_stdin(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/stdlib_str.rs
+++ b/crates/hale-codegen/tests/stdlib_str.rs
@@ -4,10 +4,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stdlib_str_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stdlib_str_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -263,8 +265,7 @@ fn std_str_parse_user_parse_error_collision_diagnoses_cleanly() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_stdlib_str_collision");
+    let bin = harness::unique_bin("hale_test_stdlib_str_collision");
     let result = build_executable(&program, &bin);
     let _ = std::fs::remove_file(&bin);
     let err = match result {

--- a/crates/hale-codegen/tests/stdlib_stream.rs
+++ b/crates/hale-codegen/tests/stdlib_stream.rs
@@ -27,10 +27,12 @@ use std::thread;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stream_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stream_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/stdlib_tagged.rs
+++ b/crates/hale-codegen/tests/stdlib_tagged.rs
@@ -9,20 +9,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    // Salt with pid + a process-wide counter so two tests can never
-    // share a temp-build path under nextest's parallel execution
-    // (the bytes_pack_read flake class).
-    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    bin.push(format!(
-        "hale_test_stdlib_tagged_{}_{}_{}",
-        name,
-        std::process::id(),
-        seq
-    ));
+    let bin = harness::unique_bin(name);
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/stdlib_test_assert.rs
+++ b/crates/hale-codegen/tests/stdlib_test_assert.rs
@@ -15,10 +15,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> std::process::Output {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_assert_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_assert_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/stdlib_ts.rs
+++ b/crates/hale-codegen/tests/stdlib_ts.rs
@@ -17,23 +17,16 @@
 //! ensures cargo materializes it before these tests run.
 
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
+
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    bin.push(format!(
-        "hale_test_stdlib_ts_{}_{}_{}",
-        name,
-        std::process::id(),
-        nanos
-    ));
+    let bin = harness::unique_bin(name);
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/stdlib_yaml.rs
+++ b/crates/hale-codegen/tests/stdlib_yaml.rs
@@ -4,10 +4,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_stdlib_yaml_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_stdlib_yaml_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/str_repeat_and_pad.rs
+++ b/crates/hale-codegen/tests/str_repeat_and_pad.rs
@@ -7,10 +7,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_str_repeat_pad_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_str_repeat_pad_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/str_trim_and_replace.rs
+++ b/crates/hale-codegen/tests/str_trim_and_replace.rs
@@ -10,10 +10,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_str_trim_replace_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_str_trim_replace_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/stream_fallible_io.rs
+++ b/crates/hale-codegen/tests/stream_fallible_io.rs
@@ -13,6 +13,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_free_port() -> u16 {
     let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     l.local_addr().expect("local_addr").port()
@@ -23,8 +26,7 @@ fn unique_path(tag: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "hale-stream-fallible-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/stream_fallible_unaddressed_rejects.rs
+++ b/crates/hale-codegen/tests/stream_fallible_unaddressed_rejects.rs
@@ -15,10 +15,12 @@
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_err(src: &str) -> Option<String> {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale-stream-unaddr-{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale-stream-unaddr-{}", std::process::id()));
     match build_executable(&program, &bin) {
         Ok(()) => {
             let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/string_builder.rs
+++ b/crates/hale-codegen/tests/string_builder.rs
@@ -9,10 +9,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_strbuilder_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_strbuilder_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/string_escapes.rs
+++ b/crates/hale-codegen/tests/string_escapes.rs
@@ -11,10 +11,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_test_str_esc_{}_{}",
         name,
         std::process::id()
@@ -119,8 +121,7 @@ fn unresolved_callee_ident_suggests_close_match() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_test_typo_diag_{}",
         std::process::id()
     ));

--- a/crates/hale-codegen/tests/struct_layout_with_i128.rs
+++ b/crates/hale-codegen/tests/struct_layout_with_i128.rs
@@ -12,10 +12,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/support/harness.rs
+++ b/crates/hale-codegen/tests/support/harness.rs
@@ -1,0 +1,84 @@
+//! Shared test-harness primitives: collision-proof temp paths and
+//! ports.
+//!
+//! ## Why this exists
+//!
+//! Nearly every codegen test compiles a `.hl` program to a native
+//! binary and runs it, and each test file grew its own copy of that
+//! helper — 115 declarations, 104 of them textually distinct. The
+//! variation was almost entirely in *where the binary is written*,
+//! and 131 files picked a path with no uniquifier at all, most of
+//! them `temp_dir()/lotus_test_{name}`. Eleven files shared that
+//! exact template; nine shared `lotus_{name}`.
+//!
+//! Nothing made those distinct. It worked only because the `name`
+//! arguments happened not to overlap — one `build_and_run("basic", …)`
+//! in the wrong file and two tests write and exec the same path,
+//! which is `ETXTBSY` ("text file busy") under any parallel runner.
+//!
+//! That latent hazard is why `CLAUDE.md` mandated `--test-threads=1`.
+//! The CI workflow, meanwhile, claimed nextest's process-per-test
+//! made the shared paths safe — which is not true: process isolation
+//! is not filesystem isolation, and two processes writing one path
+//! are *more* concurrent than two threads, not less. Two documents
+//! disagreed and neither described the real situation.
+//!
+//! [`unique_bin`] removes the hazard structurally rather than by
+//! convention, and `harness_paths_are_unique.rs` fails the build if a
+//! test reintroduces a hand-rolled temp path.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// A binary path no other test can collide with, in this process or
+/// any other.
+///
+/// Three components, each covering a case the others don't:
+///   * the caller's `name` — keeps the path readable when a test
+///     leaves one behind;
+///   * the **pid** — separates concurrent test *processes*, which is
+///     what nextest actually gives us;
+///   * a process-local **counter** — separates tests within one
+///     process, which the pid alone does not (libtest threads).
+pub fn unique_bin(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "hale_t_{}_{}_{}",
+        name,
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    p
+}
+
+/// A TCP port nothing else holds, obtained by binding `:0` and
+/// letting the kernel choose.
+///
+/// The alternative in the suite today is a hand-maintained registry
+/// of high port numbers (the 57xxx / 47xxx blocks) spread across 159
+/// files — a uniqueness invariant kept in a person's head, and
+/// already violated: `9876` appears six times.
+///
+/// Note the inherent race: the listener is closed before the port is
+/// handed back, so it is *free*, not *reserved*. That is still
+/// strictly better than a fixed number, because the kernel does not
+/// hand out a port already bound by a concurrent test.
+pub fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind an ephemeral port")
+        .local_addr()
+        .expect("read back the bound addr")
+        .port()
+}
+
+/// Same, for UDP — the kernel's UDP and TCP port spaces are
+/// separate, so a datagram test must ask on the right one.
+pub fn free_udp_port() -> u16 {
+    std::net::UdpSocket::bind("127.0.0.1:0")
+        .expect("bind an ephemeral udp port")
+        .local_addr()
+        .expect("read back the bound addr")
+        .port()
+}

--- a/crates/hale-codegen/tests/tcp_dns_connect.rs
+++ b/crates/hale-codegen/tests/tcp_dns_connect.rs
@@ -21,10 +21,12 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_test_tcp_dns_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/tcp_listener_exclusive_bind.rs
+++ b/crates/hale-codegen/tests/tcp_listener_exclusive_bind.rs
@@ -20,6 +20,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn free_tcp_port() -> u16 {
     let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     l.local_addr().expect("local_addr").port()
@@ -42,8 +45,7 @@ fn second_bind_of_same_port_fails() {
         "#,
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale-listener-exclusive-{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale-listener-exclusive-{}", std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/tcp_raw_fd_freefns.rs
+++ b/crates/hale-codegen/tests/tcp_raw_fd_freefns.rs
@@ -24,6 +24,9 @@ use std::time::Duration;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_free_port() -> u16 {
     let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     l.local_addr().expect("local_addr").port()
@@ -31,8 +34,7 @@ fn pick_free_port() -> u16 {
 
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_tcp_raw_fd_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/tcp_recv_bytes.rs
+++ b/crates/hale-codegen/tests/tcp_recv_bytes.rs
@@ -23,10 +23,12 @@ use std::thread;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_recvbytes_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_recvbytes_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/tcp_set_nodelay.rs
+++ b/crates/hale-codegen/tests/tcp_set_nodelay.rs
@@ -12,6 +12,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn pick_free_port() -> u16 {
     let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
     l.local_addr().expect("local_addr").port()
@@ -19,8 +22,7 @@ fn pick_free_port() -> u16 {
 
 fn build_and_run_argv(name: &str, src: &str, argv: &[&str]) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_tcp_nodelay_{}", name));
+    let bin = harness::unique_bin(&format!("hale_tcp_nodelay_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).args(argv).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/teardown_pinned_join_order.rs
+++ b/crates/hale-codegen/tests/teardown_pinned_join_order.rs
@@ -21,10 +21,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_count(tag: &str, src: &str) -> usize {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_teardown_join_{}_{}", tag, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_teardown_join_{}_{}", tag, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/term_primitives.rs
+++ b/crates/hale-codegen/tests/term_primitives.rs
@@ -4,10 +4,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_term_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_term_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -104,8 +106,7 @@ fn size_returns_zero_when_stdout_not_a_tty() {
 fn run_with_stdin(name: &str, source: &str, stdin: std::process::Stdio) -> String {
     use std::io::Read;
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_term_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_term_{}", name));
     build_executable(&program, &bin).expect("build");
     let mut child = Command::new(&bin)
         .stdin(stdin)

--- a/crates/hale-codegen/tests/terminate_reclaims_child.rs
+++ b/crates/hale-codegen/tests/terminate_reclaims_child.rs
@@ -20,6 +20,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn terminate_reclaims_each_accepted_child() {
     // Manager (async_io pool) accepts a Worker per trigger; each
@@ -66,8 +69,7 @@ fn terminate_reclaims_each_accepted_child() {
     "#
     );
     let program = hale_syntax::parse_source(&src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_terminate_reclaims_child");
+    let bin = harness::unique_bin("hale_test_terminate_reclaims_child");
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/test_assert_granularity.rs
+++ b/crates/hale-codegen/tests/test_assert_granularity.rs
@@ -7,6 +7,9 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[test]
 fn failure_reports_earlier_passing_assertions() {
     let src = r#"
@@ -18,8 +21,7 @@ fn failure_reports_earlier_passing_assertions() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_assert_granularity");
+    let bin = harness::unique_bin("hale_test_assert_granularity");
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -42,8 +44,7 @@ fn passing_file_stays_silent() {
         }
     "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("hale_test_assert_silent");
+    let bin = harness::unique_bin("hale_test_assert_silent");
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/time_now.rs
+++ b/crates/hale-codegen/tests/time_now.rs
@@ -9,10 +9,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> std::process::Output {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/tls_fast_io.rs
+++ b/crates/hale-codegen/tests/tls_fast_io.rs
@@ -18,10 +18,12 @@
 use hale_codegen::build_executable;
 use std::process::Command;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run_argv(name: &str, src: &str, argv: &[&str]) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_tlsfast_{}", name));
+    let bin = harness::unique_bin(&format!("hale_tlsfast_{}", name));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).args(argv).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/top_level_const.rs
+++ b/crates/hale-codegen/tests/top_level_const.rs
@@ -24,10 +24,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_top_level_const_{}_{}",
         name,
         std::process::id()

--- a/crates/hale-codegen/tests/topic_declarations.rs
+++ b/crates/hale-codegen/tests/topic_declarations.rs
@@ -25,6 +25,9 @@ use hale_codegen::build_executable;
 use hale_syntax::{parse_source, ast::*};
 use hale_syntax::desugar::desugar_topics;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn parse(src: &str) -> Program {
     parse_source(src).expect("parse")
 }
@@ -154,8 +157,7 @@ fn desugar_rewrites_topic_refs_to_literals() {
 
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = parse(src);
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_topic_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_topic_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/topic_phase2.rs
+++ b/crates/hale-codegen/tests/topic_phase2.rs
@@ -22,6 +22,9 @@ use hale_codegen::build_executable;
 use hale_syntax::{ast::*, parse_source};
 use hale_syntax::desugar::{desugar_intra_locus_topics, desugar_topics};
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn parse(src: &str) -> Program {
     parse_source(src).expect("parse")
 }
@@ -42,8 +45,7 @@ fn typecheck_diags(src: &str) -> Vec<String> {
 
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = parse(src);
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_phase2_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_phase2_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/topic_phase2_adapter_binding.rs
+++ b/crates/hale-codegen/tests/topic_phase2_adapter_binding.rs
@@ -16,10 +16,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_adapter_binding_{}_{}",
         name,
         std::process::id()
@@ -244,8 +246,7 @@ fn build_rejects_locus_missing_send_method() {
         fn main() { App { }; }
     "#)
     .expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
+    let bin = harness::unique_bin(&format!(
         "hale_adapter_missing_send_{}",
         std::process::id()
     ));

--- a/crates/hale-codegen/tests/transport.rs
+++ b/crates/hale-codegen/tests/transport.rs
@@ -22,6 +22,9 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -44,8 +47,7 @@ fn driver_c_path() -> PathBuf {
 /// in $TMPDIR. Returns the path; caller is responsible for the
 /// best-effort cleanup at the end of the test.
 fn build_driver(name: &str) -> PathBuf {
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_transport_driver_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_transport_driver_{}", name));
     let status = Command::new("clang")
         .arg(driver_c_path())
         .arg(runtime_c_path())
@@ -67,8 +69,7 @@ fn unique_socket_path(tag: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!("lt-m57-{}-{}-{}.sock", tag, std::process::id(), nanos));
+    let p = harness::unique_bin(&format!("lt-m57-{}-{}-{}.sock", tag, std::process::id(), nanos));
     p
 }
 

--- a/crates/hale-codegen/tests/transport_counters.rs
+++ b/crates/hale-codegen/tests/transport_counters.rs
@@ -14,13 +14,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 #[path = "support/transport.rs"]
 mod transport_support;
 
 fn build(name: &str, src: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_counters_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_counters_{}", name));
     build_executable(&program, &bin).expect("build");
     bin
 }

--- a/crates/hale-codegen/tests/transport_tcp.rs
+++ b/crates/hale-codegen/tests/transport_tcp.rs
@@ -25,6 +25,9 @@
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -44,8 +47,7 @@ fn driver_c_path() -> PathBuf {
 }
 
 fn build_driver(name: &str) -> PathBuf {
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_tcp_driver_{}", name));
+    let bin = harness::unique_bin(&format!("hale_tcp_driver_{}", name));
     let status = Command::new("clang")
         .arg(driver_c_path())
         .arg(runtime_c_path())

--- a/crates/hale-codegen/tests/type_record_fn_pointer_field.rs
+++ b/crates/hale-codegen/tests/type_record_fn_pointer_field.rs
@@ -20,10 +20,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_type_fnptr_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_type_fnptr_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/udp_multicast.rs
+++ b/crates/hale-codegen/tests/udp_multicast.rs
@@ -11,13 +11,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-udp-multicast-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/udp_p4_source_and_timeout.rs
+++ b/crates/hale-codegen/tests/udp_p4_source_and_timeout.rs
@@ -13,13 +13,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!(
+    let p = harness::unique_bin(&format!(
         "lt-udp-p4-{}-{}-{}.bin",
         tag,
         std::process::id(),

--- a/crates/hale-codegen/tests/udp_primitives.rs
+++ b/crates/hale-codegen/tests/udp_primitives.rs
@@ -8,9 +8,12 @@
 //! two sockets in the same process).
 
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
+
 
 use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
 
 fn pick_free_port() -> u16 {
     // We can't bind a UDP socket here easily without pulling in
@@ -26,16 +29,7 @@ fn pick_free_port() -> u16 {
 
 fn build_and_run(name: &str, source: &str) -> (String, String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!(
-        "hale_udp_test_{}_{}_{}",
-        name,
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0),
-    ));
+    let bin = harness::unique_bin(name);
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/udp_reader.rs
+++ b/crates/hale-codegen/tests/udp_reader.rs
@@ -19,13 +19,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn unique_path(tag: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let mut p = std::env::temp_dir();
-    p.push(format!("lt-udp-reader-{}-{}-{}.bin", tag, std::process::id(), nanos));
+    let p = harness::unique_bin(&format!("lt-udp-reader-{}-{}-{}.bin", tag, std::process::id(), nanos));
     p
 }
 

--- a/crates/hale-codegen/tests/unit_fallible.rs
+++ b/crates/hale-codegen/tests/unit_fallible.rs
@@ -18,10 +18,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_unit_fallible_{}_{}", name, std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_unit_fallible_{}_{}", name, std::process::id()));
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/view_coerce_e1.rs
+++ b/crates/hale-codegen/tests/view_coerce_e1.rs
@@ -11,10 +11,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_view_e1_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_view_e1_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/view_storage_e2.rs
+++ b/crates/hale-codegen/tests/view_storage_e2.rs
@@ -18,10 +18,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_test_view_e2_{}", name));
+    let bin = harness::unique_bin(&format!("hale_test_view_e2_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/violate_build.rs
+++ b/crates/hale-codegen/tests/violate_build.rs
@@ -6,10 +6,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
@@ -270,8 +272,7 @@ fn main() {
 }
 "#;
     let program = hale_syntax::parse_source(src).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push("lotus_test_birth_check_panic");
+    let bin = harness::unique_bin("lotus_test_birth_check_panic");
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/violate_child_state_read.rs
+++ b/crates/hale-codegen/tests/violate_child_state_read.rs
@@ -8,10 +8,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("lotus_test_{}", name));
+    let bin = harness::unique_bin(&format!("lotus_test_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/wasm_target.rs
+++ b/crates/hale-codegen/tests/wasm_target.rs
@@ -20,13 +20,15 @@ use hale_codegen::{build_executable_with_options, BuildOptions, CompileTarget};
 use std::path::PathBuf;
 use std::process::Command;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn wasm_opts() -> BuildOptions {
     BuildOptions { target: CompileTarget::Wasm32, ..Default::default() }
 }
 
 fn tmp(name: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!("hale_wasm_target_{}", name));
+    let p = harness::unique_bin(&format!("hale_wasm_target_{}", name));
     p
 }
 

--- a/crates/hale-codegen/tests/ws1_cross_seed_bus_decimal.rs
+++ b/crates/hale-codegen/tests/ws1_cross_seed_bus_decimal.rs
@@ -28,6 +28,9 @@ use hale_codegen::mangle;
 use hale_syntax::ast::{Program, TopDecl};
 use hale_syntax::parse_source;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn fixtures_dir() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tests");
@@ -97,8 +100,7 @@ fn cross_seed_struct_literal_from_bus_deserialized_decimal() {
     let mut renames = intent_renames;
     renames.extend(grease_renames);
 
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_ws1_xseed_bus_decimal_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_ws1_xseed_bus_decimal_{}", std::process::id()));
     build_executable_with_imports(&consumer_prog, &bin, &renames)
         .expect("build consumer + two libs");
 

--- a/crates/hale-codegen/tests/ws1_cross_seed_locus_reassign.rs
+++ b/crates/hale-codegen/tests/ws1_cross_seed_locus_reassign.rs
@@ -25,6 +25,9 @@ use hale_codegen::mangle;
 use hale_syntax::ast::{Program, TopDecl};
 use hale_syntax::parse_source;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn fixtures_dir() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tests");
@@ -84,8 +87,7 @@ fn cross_seed_nested_locus_param_whole_reassignment_is_fully_initialized() {
     let (conn_items, renames) = resolve_and_mangle_lib(&conn_dir, "wsx");
     consumer_prog.items.extend(conn_items);
 
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_ws1_xseed_reassign_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_ws1_xseed_reassign_{}", std::process::id()));
     build_executable_with_imports(&consumer_prog, &bin, &renames)
         .expect("build consumer + lib");
 

--- a/crates/hale-codegen/tests/ws1_ffi_handle_reassign.rs
+++ b/crates/hale-codegen/tests/ws1_ffi_handle_reassign.rs
@@ -30,10 +30,12 @@ use std::process::Command;
 
 use hale_codegen::{build_executable_with_options, BuildOptions};
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_with_csrc(name: &str, hale_src: &str, csrc_body: &str) -> std::path::PathBuf {
     let program = hale_syntax::parse_source(hale_src).expect("parse");
-    let mut tmpdir = std::env::temp_dir();
-    tmpdir.push(format!("hale_test_ws1_ffi_reassign_{}", name));
+    let tmpdir = harness::unique_bin(&format!("hale_test_ws1_ffi_reassign_{}", name));
     let _ = std::fs::create_dir_all(&tmpdir);
     let csrc_path = tmpdir.join("glue.c");
     std::fs::write(&csrc_path, csrc_body).expect("write csrc");

--- a/crates/hale-codegen/tests/ws3_int_float_conversion.rs
+++ b/crates/hale-codegen/tests/ws3_int_float_conversion.rs
@@ -14,10 +14,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_ws3_int_float_{}", name));
+    let bin = harness::unique_bin(&format!("hale_ws3_int_float_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/ws3_nested_if_tail.rs
+++ b/crates/hale-codegen/tests/ws3_nested_if_tail.rs
@@ -22,10 +22,12 @@ use std::process::Command;
 
 use hale_codegen::build_executable;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus) {
     let program = hale_syntax::parse_source(source).expect("parse");
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_ws3_nested_if_{}", name));
+    let bin = harness::unique_bin(&format!("hale_ws3_nested_if_{}", name));
     build_executable(&program, &bin).expect("build");
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/ws3_topic_cross_file.rs
+++ b/crates/hale-codegen/tests/ws3_topic_cross_file.rs
@@ -19,6 +19,9 @@ use hale_codegen::mangle;
 use hale_syntax::ast::{Program, TopDecl};
 use hale_syntax::parse_source;
 
+#[path = "support/harness.rs"]
+mod harness;
+
 fn fixtures_dir() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tests");
@@ -78,8 +81,7 @@ fn topic_decl_and_publisher_in_separate_lib_files() {
     let (lib_items, renames) = resolve_and_mangle_lib(&lib_dir, "hb");
     consumer_prog.items.extend(lib_items);
 
-    let mut bin = std::env::temp_dir();
-    bin.push(format!("hale_ws33_topic_split_{}", std::process::id()));
+    let bin = harness::unique_bin(&format!("hale_ws33_topic_split_{}", std::process::id()));
     build_executable_with_imports(&consumer_prog, &bin, &renames)
         .expect("build consumer + split-topic lib");
 

--- a/docs/src/getting-started/install.md
+++ b/docs/src/getting-started/install.md
@@ -129,7 +129,7 @@ file busy" flakes from parallel test binaries racing on the same
 temp path):
 
 ```sh
-cargo test --release --workspace -- --test-threads=1
+cargo nextest run --release --workspace
 ```
 
 ## The two ways to run a program


### PR DESCRIPTION
Tier 1 of the test-suite work. Stacked conceptually on #304 but
independent — no code overlap.

## The hazard

~131 codegen test files wrote their compiled binary to a temp path
with **no uniquifier**. Eleven shared the template
`temp_dir()/lotus_test_{name}` verbatim; nine more shared
`lotus_{name}`. Nothing made those distinct — the suite passed only
because the `name` arguments happened not to overlap, which nothing
checked. One `build_and_run("basic", …)` in the wrong file and two
tests write and exec the same path.

## The docs were worse than the code

Two files described this hazard and contradicted each other:

- `CLAUDE.md` mandated `--test-threads=1` because of it.
- `tests.yml` claimed nextest's process-per-test made the shared
  paths safe.

The second is false. Process isolation is not filesystem isolation;
two processes writing one path are *more* concurrent than two
threads, not less. Neither document described the real situation.

## Changes

- **`support/harness.rs`** — `unique_bin` (name + pid + process-local
  counter; the pid separates nextest processes, the counter separates
  tests inside one) and `free_port` / `free_udp_port`, which ask the
  kernel rather than consulting the hand-maintained 57xxx/47xxx
  registry spread over 159 files (`9876` was already used six times).

- **344 sites across 255 files** swept onto it. Twelve had already
  hand-rolled pid+counter, three with a comment describing this exact
  flake — the same fix rediscovered independently, which is what a
  missing invariant looks like.

- **`harness_paths_are_unique.rs`** makes it stick. Every
  `build_executable` caller must use `unique_bin`; no build-artifact
  path may come from a raw `temp_dir()`; plus a non-vacuity guard.
  It traces the variable into the `build_executable` call rather than
  guessing from names — the first cut guessed and flagged 14 config
  files and scratch dirs, and would have missed the real ones.

- Deliberately shared temp paths still pass: `hale_bubble_suite.lock`
  is a cross-test mutex whose whole purpose is to be the same path
  everywhere.

## Result

`--test-threads=1` is gone from CLAUDE.md, CONTRIBUTING.md,
agents/compiler-dev.md and the install docs — not because we stopped
caring, but because the hazard is structurally absent and enforced.

1904/1904 in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)