### PR TITLE
test: the compiler tests itself in Hale — and that found a real bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,35 @@ behavior.
   dispatch arms** (`["std", "io", "mirror", op]`), which the literal
   scraper counted as zero coverage.
 
+
+- **`err.kind` did not compile.** Reading a stdlib error payload in
+  an `or` block — `parse_int(s) or { println(err.kind); -1 }`, a
+  shape `docs/src/everyday/http.md` and `spec/decisions.md` both
+  show — failed with `no field 'kind' on 'ParseError'`. The stdlib
+  error types (IoError, ParseError, CryptoError, …) were injected
+  into scope only when a program used `@form` machinery, which has
+  nothing to do with reading an error field. Now injected
+  unconditionally; a user declaration still wins.
+- **The compiler now tests itself in its own language.** `hale test`
+  shipped in the same binary as `hale build`, and the repo contained
+  four `*_test.hl` files — all of them fixtures for testing the
+  runner. `tests/hale/` is the real suite, run by `hale test` and
+  wired into the workspace run. The first two files replace nine
+  Rust tests in `stdlib_str.rs`.
+- The move is not cosmetic. The expectation stops being transcribed
+  (and gets stricter: `assert_eq_int(n, 42)` rejects what
+  `stdout.contains("a=42")` accepts, since that also passes on
+  `a=421`), and the program gets **typechecked** —
+  `build_executable`, which every Rust codegen test calls, parses
+  and lowers but never runs the checker. Converting the first test
+  is what surfaced the `err.kind` bug above.
+- **Measured that gap:** 8.5% of the ~1,000 programs embedded in
+  codegen tests do not pass `hale check` while compiling and running
+  fine. Some is deliberate (a codegen test may lower a shape the
+  checker rejects), so this ships a guard on the part that should
+  hold unconditionally — the on-disk example corpus typechecks
+  clean — rather than a blanket assertion.
+
 ---
 
 ## v0.11.24 — stdlib registry/dispatch parity enforced; effect-classification hole closed (2026-07-29)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,19 @@ work, they are just slower and no longer buy anything:
 cargo test --release -p hale-codegen --test topic_phase2
 ```
 
+The repo also tests the language *in* the language:
+
+```sh
+hale test tests/hale        # or: cargo test -p hale-cli --test hale_native_suite
+```
+
+Prefer a `*_test.hl` there for "run a program, check what it
+computed" — the assertion sits next to the code instead of being
+transcribed into a Rust substring match, and it gets typechecked
+(`build_executable`, which the Rust codegen tests use, does not run
+the checker). Keep assertions about *compiler output* — diagnostics,
+IR shape, leak counts — in Rust.
+
 Codegen requires **LLVM 18** dev libs with `llvm-config-18` on
 PATH (or `LLVM_SYS_180_PREFIX` set); `inkwell` is pinned to
 `llvm18-0`. LLVM 17 / 19 / 20 will not link.

--- a/crates/hale-cli/tests/hale_native_suite.rs
+++ b/crates/hale-cli/tests/hale_native_suite.rs
@@ -1,0 +1,93 @@
+//! Runs the repo's own Hale-language test suite (`tests/hale/`)
+//! through `hale test`.
+//!
+//! ## Why the compiler should test itself in its own language
+//!
+//! `hale test` ships in the same binary as `hale build` and is
+//! documented in `spec/testing.md` — and until now the repo
+//! contained exactly four `*_test.hl` files, all of them fixtures
+//! for testing the runner. The compiler did not use its own test
+//! framework on itself.
+//!
+//! Two things change when a behaviour test moves from Rust into Hale:
+//!
+//!   * **The expectation stops being transcribed.** The Rust form is
+//!     "compile a program that prints, then substring-match the
+//!     output from another language". The Hale form is an assertion
+//!     next to the code. There is no second copy to drift, and
+//!     `assert_eq_int(n, 42)` is strictly stronger than
+//!     `stdout.contains("a=42")` — which also passes on `a=421`.
+//!     The suite leans heavily on substring matching: 2,553
+//!     `.contains(` against 256 `assert_eq!`.
+//!
+//!   * **The program gets typechecked.** `build_executable` — what
+//!     the codegen tests call — parses and lowers but never runs
+//!     `check_program`. So those programs are compiled and executed
+//!     without ever being checked. Measured across the corpus, 8.5%
+//!     of the programs embedded in codegen tests do not pass `hale
+//!     check`. The first conversion here hit that immediately: the
+//!     `err.kind` shape, which `docs/src/everyday/http.md` and
+//!     `spec/decisions.md` both show, failed to typecheck — a live
+//!     bug no Rust test could see.
+//!
+//! ## What does NOT belong here
+//!
+//! Tests that assert on *compiler output* rather than program
+//! behaviour — diagnostics, LLVM IR shape, leak counts, obs-segment
+//! records. Those stay in Rust, and `stdlib_str.rs` keeps exactly
+//! its two diagnostic tests for that reason.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.pop();
+    p
+}
+
+#[test]
+fn hale_native_suite_passes() {
+    let dir = repo_root().join("tests/hale");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("test")
+        .arg(&dir)
+        .output()
+        .expect("invoke hale test tests/hale");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "the Hale-language test suite failed.\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains(", 0 failed"),
+        "expected a passing summary, got:\n{}",
+        stdout
+    );
+}
+
+/// A suite that quietly emptied would pass the check above by
+/// running nothing.
+#[test]
+fn hale_native_suite_is_not_empty() {
+    let dir = repo_root().join("tests/hale");
+    let n = std::fs::read_dir(&dir)
+        .expect("tests/hale exists")
+        .flatten()
+        .filter(|e| {
+            e.path()
+                .file_name()
+                .map(|f| f.to_string_lossy().ends_with("_test.hl"))
+                .unwrap_or(false)
+        })
+        .count();
+    assert!(
+        n >= 2,
+        "expected the Hale-native suite to hold tests, found {}",
+        n
+    );
+}

--- a/crates/hale-codegen/tests/stdlib_str.rs
+++ b/crates/hale-codegen/tests/stdlib_str.rs
@@ -1,4 +1,22 @@
 //! m78: std::str — minimal string parsing primitives.
+//!
+//! The parse_int / parse_decimal behaviour tests moved to
+//! `tests/hale/str_parse_*_test.hl`, written in Hale and run by
+//! `hale test`. Two reasons, both concrete rather than stylistic:
+//!
+//!  * the expectation stops being transcribed. It was
+//!    `stdout.contains("a=42")` here; it is
+//!    `assert_eq_int(parse_int("42"), 42)` there — which is also
+//!    STRICTER, since `contains("a=42")` passes on `a=421`.
+//!  * `build_executable` (what these tests call) does NOT run the
+//!    typechecker, so the programs here were compiled and run but
+//!    never checked. `hale test` checks them. That gap is not
+//!    hypothetical: the `err.kind` shape these tests exercise did
+//!    not typecheck at all, and moving them found it.
+//!
+//! What stays here is what genuinely needs the Rust side: the two
+//! DIAGNOSTIC tests, which assert on compiler output rather than
+//! program behaviour.
 
 use std::process::Command;
 
@@ -14,212 +32,6 @@ fn build_and_run(name: &str, source: &str) -> (String, std::process::ExitStatus)
     let output = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
     (String::from_utf8_lossy(&output.stdout).to_string(), output.status)
-}
-
-#[test]
-fn parse_int_handles_basic_digit_strings() {
-    // 2026-05-17 — parse_int returns `Int fallible(ParseError)`.
-    // For known-valid inputs the test uses `or raise` to surface
-    // an interpreter panic if the parser ever rejects something
-    // it should have accepted.
-    let src = r#"
-        fn main() {
-            let a = std::str::parse_int("42") or raise;
-            let b = std::str::parse_int("0") or raise;
-            let c = std::str::parse_int("-7") or raise;
-            let d = std::str::parse_int("9999999999") or raise;
-            println("a=", a);
-            println("b=", b);
-            println("c=", c);
-            println("d=", d);
-        }
-    "#;
-    let (stdout, status) = build_and_run("basic", src);
-    assert!(status.success());
-    assert!(stdout.contains("a=42"), "got: {:?}", stdout);
-    assert!(stdout.contains("b=0"), "got: {:?}", stdout);
-    assert!(stdout.contains("c=-7"), "got: {:?}", stdout);
-    assert!(stdout.contains("d=9999999999"), "got: {:?}", stdout);
-}
-
-#[test]
-fn parse_int_err_arm_substitutes_zero_on_garbage_input() {
-    // The fallible flip means "garbage in" routes through `or`
-    // rather than silently returning 0. Test uses `or 0` as the
-    // substitute so the expected sentinel still appears.
-    let src = r#"
-        fn main() {
-            let bad1 = std::str::parse_int("abc") or 0;
-            let bad2 = std::str::parse_int("12abc") or 0;
-            let bad3 = std::str::parse_int("") or 0;
-            let bad4 = std::str::parse_int("  42  ") or 0;
-            println("bad1=", bad1);
-            println("bad2=", bad2);
-            println("bad3=", bad3);
-            println("bad4=", bad4);
-        }
-    "#;
-    let (stdout, status) = build_and_run("garbage", src);
-    assert!(status.success());
-    // strtoll-ish: trailing non-NUL chars reject. "  42  "
-    // rejects because the trailing spaces aren't consumed.
-    assert!(stdout.contains("bad1=0"), "got: {:?}", stdout);
-    assert!(stdout.contains("bad2=0"), "got: {:?}", stdout);
-    assert!(stdout.contains("bad3=0"), "got: {:?}", stdout);
-    assert!(stdout.contains("bad4=0"), "got: {:?}", stdout);
-}
-
-#[test]
-fn parse_int_err_payload_carries_kind_and_input() {
-    // The substitute RHS sees `err: ParseError { kind, input }`
-    // — both fields readable in scope for diagnostics / logging.
-    let src = r#"
-        fn main() {
-            let s = "totally bogus";
-            let n = std::str::parse_int(s) or {
-                println("kind=", err.kind, " input=", err.input);
-                -1
-            };
-            println("n=", n);
-        }
-    "#;
-    let (stdout, status) = build_and_run("err_payload", src);
-    assert!(status.success(), "non-zero: {:?}", status);
-    assert!(stdout.contains("kind=parse_int"), "got: {:?}", stdout);
-    assert!(stdout.contains("input=totally bogus"), "got: {:?}", stdout);
-    assert!(stdout.contains("n=-1"), "got: {:?}", stdout);
-}
-
-#[test]
-fn can_parse_int_distinguishes_valid_from_invalid() {
-    let src = r#"
-        fn main() {
-            let v1 = std::str::can_parse_int("42");
-            let v2 = std::str::can_parse_int("-7");
-            let v3 = std::str::can_parse_int("abc");
-            let v4 = std::str::can_parse_int("");
-            let v5 = std::str::can_parse_int("0");
-            println("v1=", v1);
-            println("v2=", v2);
-            println("v3=", v3);
-            println("v4=", v4);
-            println("v5=", v5);
-        }
-    "#;
-    let (stdout, status) = build_and_run("can_parse", src);
-    assert!(status.success());
-    assert!(stdout.contains("v1=true"), "got: {:?}", stdout);
-    assert!(stdout.contains("v2=true"), "got: {:?}", stdout);
-    assert!(stdout.contains("v3=false"), "got: {:?}", stdout);
-    assert!(stdout.contains("v4=false"), "got: {:?}", stdout);
-    assert!(stdout.contains("v5=true"), "got: {:?}", stdout);
-}
-
-#[test]
-fn parse_int_round_trips_with_arithmetic() {
-    // Confirms the parsed Int actually behaves as Int — can be
-    // compared, arithmetic'd, etc. — not some opaque thing.
-    let src = r#"
-        fn main() {
-            let n = std::str::parse_int("100") or raise;
-            let doubled = n * 2;
-            if n > 50 {
-                println("doubled=", doubled);
-            }
-        }
-    "#;
-    let (stdout, status) = build_and_run("arithmetic", src);
-    assert!(status.success());
-    assert!(stdout.contains("doubled=200"), "got: {:?}", stdout);
-}
-
-#[test]
-fn parse_decimal_handles_basic_inputs() {
-    // 2026-05-20 — parse_decimal returns `Decimal fallible(ParseError)`.
-    // Mantissa is i128 with implicit scale 9 (matches Decimal literal
-    // codegen). Trailing-zero precision survives — the IEEE 754
-    // rounding that bit parse_float on high-precision decimals doesn't apply.
-    let src = r#"
-        fn main() {
-            let a = std::str::parse_decimal("100.5") or raise;
-            let b = std::str::parse_decimal("0") or raise;
-            let c = std::str::parse_decimal("-7.25") or raise;
-            let d = std::str::parse_decimal("0.00005100") or raise;
-            let e = std::str::parse_decimal("12345.678901234") or raise;
-            println("a=", a);
-            println("b=", b);
-            println("c=", c);
-            println("d=", d);
-            println("e=", e);
-        }
-    "#;
-    let (stdout, status) = build_and_run("parse_decimal_basic", src);
-    assert!(status.success());
-    assert!(stdout.contains("a=100.5"), "got: {:?}", stdout);
-    assert!(stdout.contains("b=0"), "got: {:?}", stdout);
-    assert!(stdout.contains("c=-7.25"), "got: {:?}", stdout);
-    // Trailing zeros past 9 fractional digits get truncated, but
-    // 8 digits round-trip — high-precision decimal use case.
-    assert!(stdout.contains("d=0.000051"), "got: {:?}", stdout);
-    assert!(stdout.contains("e=12345.678901234"), "got: {:?}", stdout);
-}
-
-#[test]
-fn parse_decimal_err_arm_substitutes_zero_on_garbage_input() {
-    let src = r#"
-        fn main() {
-            let bad1 = std::str::parse_decimal("abc") or 0.0d;
-            let bad2 = std::str::parse_decimal("12.3abc") or 0.0d;
-            let bad3 = std::str::parse_decimal("") or 0.0d;
-            let bad4 = std::str::parse_decimal(".") or 0.0d;
-            println("bad1=", bad1);
-            println("bad2=", bad2);
-            println("bad3=", bad3);
-            println("bad4=", bad4);
-        }
-    "#;
-    let (stdout, status) = build_and_run("parse_decimal_garbage", src);
-    assert!(status.success());
-    assert!(stdout.contains("bad1=0"), "got: {:?}", stdout);
-    assert!(stdout.contains("bad2=0"), "got: {:?}", stdout);
-    assert!(stdout.contains("bad3=0"), "got: {:?}", stdout);
-    assert!(stdout.contains("bad4=0"), "got: {:?}", stdout);
-}
-
-#[test]
-fn parse_decimal_err_payload_carries_kind_and_input() {
-    let src = r#"
-        fn main() {
-            let s = "not a number";
-            let v = std::str::parse_decimal(s) or {
-                println("kind=", err.kind, " input=", err.input);
-                -1.0d
-            };
-            println("v=", v);
-        }
-    "#;
-    let (stdout, status) = build_and_run("parse_decimal_err_payload", src);
-    assert!(status.success(), "non-zero: {:?}", status);
-    assert!(stdout.contains("kind=parse_decimal"), "got: {:?}", stdout);
-    assert!(stdout.contains("input=not a number"), "got: {:?}", stdout);
-    assert!(stdout.contains("v=-1"), "got: {:?}", stdout);
-}
-
-#[test]
-fn parse_decimal_round_trips_through_arithmetic() {
-    // Confirms the parsed Decimal behaves as Decimal — i128
-    // mantissa arithmetic survives the fallible flip.
-    let src = r#"
-        fn main() {
-            let p = std::str::parse_decimal("100.40") or raise;
-            let q = std::str::parse_decimal("0.005") or raise;
-            let total = p + q;
-            println("total=", total);
-        }
-    "#;
-    let (stdout, status) = build_and_run("parse_decimal_arith", src);
-    assert!(status.success());
-    assert!(stdout.contains("total=100.405"), "got: {:?}", stdout);
 }
 
 #[test]

--- a/crates/hale-types/src/resolve.rs
+++ b/crates/hale-types/src/resolve.rs
@@ -98,9 +98,23 @@ pub fn build_top_scope(bundle: &Bundle<'_>) -> (TopScope, Vec<Diag>) {
     // structs (IndexError fields) into the scope so call sites
     // that use them resolve. Idempotent — user-declared
     // IndexError wins.
-    if bundle_uses_form_machinery(bundle) {
-        inject_form_stdlib_types(&mut scope);
-    }
+    // 2026-07-29: this used to be gated on
+    // `bundle_uses_form_machinery(bundle)`, but the function injects
+    // the stdlib ERROR types (IoError, ParseError, CryptoError, …)
+    // as well as the form ones — and reading `err.kind` in an `or`
+    // block has nothing to do with `@form`. A program that only
+    // called `std::str::parse_int(s) or { println(err.kind); … }`
+    // never triggered the gate, so `ParseError` resolved with no
+    // fields and the documented pattern failed to compile:
+    //
+    //     type error: no field `kind` on `ParseError`
+    //
+    // That shape is in `docs/src/everyday/http.md` and
+    // `spec/decisions.md`, and the codegen tests exercise it — but
+    // `build_executable` does not typecheck, so nothing caught it.
+    // Injection is idempotent and a user declaration still wins, so
+    // running it unconditionally only ever adds the stdlib names.
+    inject_form_stdlib_types(&mut scope);
     // Phase 3 routing-keys v0.2 (2026-05-26): inject
     // BusUnmatchedKey for `on_unmatched: fail` topics whose
     // publishes use `or handler(err)` / `or fail <payload>`

--- a/crates/hale-types/tests/codegen_fixtures_typecheck.rs
+++ b/crates/hale-types/tests/codegen_fixtures_typecheck.rs
@@ -1,0 +1,65 @@
+//! On-disk fixtures must pass the typechecker, not merely compile.
+//!
+//! `build_executable` — the entry every codegen test uses — parses
+//! and lowers but never runs `check_program`. So programs compiled
+//! and executed by the suite were never typechecked. Measured across
+//! the corpus, **8.5% of the programs embedded in codegen tests do
+//! not pass `hale check`** while compiling and running fine.
+//!
+//! Some of that is legitimate: a codegen test may deliberately lower
+//! a shape the checker rejects. But it also hid a real bug — the
+//! `err.kind` pattern, which the docs and spec both show, failed to
+//! typecheck because the stdlib error types were injected only for
+//! programs using `@form` machinery. Nothing caught it, because the
+//! tests exercising that shape never typechecked and the typecheck
+//! tests never used it.
+//!
+//! Closing the embedded-program gap wholesale is a bigger job than
+//! it looks (many of those 85 are intentional). What this pins is
+//! the part that should hold unconditionally: the **on-disk example
+//! corpus** — the programs presented as exemplary Hale — typechecks
+//! clean.
+
+/// Multi-file projects: a single `main.hl` legitimately can't see
+/// types its siblings declare, so checking it in isolation reports
+/// "unknown type" for reasons that are not defects.
+const MULTI_FILE_PROJECTS: &[&str] = &["25-imports", "fitter-applier-pair"];
+
+#[test]
+fn on_disk_example_corpus_typechecks_clean() {
+    let mut failures: Vec<(String, String)> = Vec::new();
+    let mut checked = 0;
+    for p in hale_corpus::fixtures() {
+        if !p.origin.contains("tests/fixtures/examples") {
+            continue;
+        }
+        if MULTI_FILE_PROJECTS.iter().any(|m| p.origin.contains(m)) {
+            continue;
+        }
+        let Ok(program) = hale_syntax::parse_source(&p.source) else {
+            continue;
+        };
+        checked += 1;
+        let errs: Vec<String> = hale_types::check_program(&program)
+            .into_iter()
+            .filter(|d| d.is_error())
+            .map(|d| d.message)
+            .collect();
+        if !errs.is_empty() {
+            failures.push((p.origin.clone(), errs[0].clone()));
+        }
+    }
+    assert!(
+        checked > 80,
+        "only {} example programs checked — the sweep is not seeing \
+         the corpus",
+        checked
+    );
+    assert!(
+        failures.is_empty(),
+        "{} example programs fail `hale check` while still compiling \
+         (codegen does not typecheck, so this can rot silently):\n{:#?}",
+        failures.len(),
+        failures
+    );
+}

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -308,10 +308,33 @@ The test-runner contract is exit-code based:
   stdout. The first failure short-circuits — `std::process::exit`
   terminates immediately.
 
-A `.hl` test program is just an ordinary Hale binary. The
-current test runner is the Rust integration harness in
-`crates/hale-codegen/tests/`; future `hale test` CLI runs
-the same `.hl` programs unchanged.
+A `.hl` test program is just an ordinary Hale binary.
+
+### The compiler's own Hale-language suite
+
+`tests/hale/` holds `*_test.hl` programs that test the language in
+the language, run by `hale test` and wired into the workspace suite
+(`crates/hale-cli/tests/hale_native_suite.rs`). Run them directly
+with `hale test tests/hale`.
+
+A behaviour test belongs there rather than in a Rust integration
+test when it is "run a program, check what it computed". Two things
+change in the move:
+
+- **The expectation stops being transcribed.** The Rust form
+  compiles a program that *prints*, then substring-matches the
+  output from another language. The Hale form asserts next to the
+  code — no second copy to drift. It is also stricter:
+  `assert_eq_int(n, 42)` rejects what `stdout.contains("a=42")`
+  accepts, because the latter also passes on `a=421`.
+- **The program gets typechecked.** `build_executable`, which the
+  Rust codegen tests call, parses and lowers but never runs the
+  checker, so those programs are compiled and executed without ever
+  being checked.
+
+What stays in Rust is anything asserting on *compiler output* rather
+than program behaviour: diagnostics, IR shape, leak counts,
+observation records.
 
 ### What landed vs what's still aspirational
 

--- a/tests/hale/str_parse_decimal_test.hl
+++ b/tests/hale/str_parse_decimal_test.hl
@@ -1,0 +1,43 @@
+// std::str decimal parsing. Mantissa is i128 at implicit scale 9,
+// so trailing precision survives where parse_float's IEEE-754
+// rounding would not.
+
+fn main() {
+    std::test::assert_eq_str(
+        "" + (std::str::parse_decimal("100.5") or raise), "100.5", "100.5");
+    std::test::assert_eq_str(
+        "" + (std::str::parse_decimal("0") or raise), "0", "zero");
+    std::test::assert_eq_str(
+        "" + (std::str::parse_decimal("-7.25") or raise), "-7.25", "negative");
+    // Past 9 fractional digits truncates; 8 round-trip.
+    std::test::assert_eq_str(
+        "" + (std::str::parse_decimal("0.00005100") or raise),
+        "0.000051", "trailing zeros truncate at scale 9");
+    std::test::assert_eq_str(
+        "" + (std::str::parse_decimal("12345.678901234") or raise),
+        "12345.678901234", "full scale-9 precision");
+
+    // Garbage substitutes rather than silently yielding a value.
+    std::test::assert_eq_str(
+        "" + (std::str::parse_decimal("abc") or 0.0d), "0", "letters");
+    std::test::assert_eq_str(
+        "" + (std::str::parse_decimal("12.3abc") or 0.0d), "0", "trailing junk");
+    std::test::assert_eq_str(
+        "" + (std::str::parse_decimal("") or 0.0d), "0", "empty");
+    std::test::assert_eq_str(
+        "" + (std::str::parse_decimal(".") or 0.0d), "0", "bare dot");
+
+    // A parsed Decimal behaves as a Decimal — i128 mantissa
+    // arithmetic survives the fallible flip.
+    let p = std::str::parse_decimal("100.40") or raise;
+    let q = std::str::parse_decimal("0.005") or raise;
+    std::test::assert_eq_str("" + (p + q), "100.405", "decimal addition");
+
+    // The payload names which parser rejected, and what it saw.
+    let v = std::str::parse_decimal("not a number") or {
+        std::test::assert_eq_str(err.kind, "parse_decimal", "err.kind");
+        std::test::assert_eq_str(err.input, "not a number", "err.input");
+        -1.0d
+    };
+    std::test::assert_eq_str("" + v, "-1", "substitute value");
+}

--- a/tests/hale/str_parse_int_test.hl
+++ b/tests/hale/str_parse_int_test.hl
@@ -1,0 +1,49 @@
+// std::str integer parsing — the Hale-native form of what
+// `crates/hale-codegen/tests/stdlib_str.rs` checked by printing and
+// substring-matching from Rust.
+//
+// Two things get better in the translation. The expectation lives
+// next to the code, in the same language, so there is no transcription
+// to drift. And `assert_eq_int(n, 42)` is strictly stronger than
+// `stdout.contains("a=42")`, which also passes on `a=421`.
+
+fn main() {
+    // Known-good inputs: `or raise` turns a parser regression into a
+    // failure here rather than a silently-substituted value.
+    std::test::assert_eq_int(std::str::parse_int("42") or raise, 42, "42");
+    std::test::assert_eq_int(std::str::parse_int("0") or raise, 0, "zero");
+    std::test::assert_eq_int(std::str::parse_int("-7") or raise, -7, "negative");
+    std::test::assert_eq_int(
+        std::str::parse_int("9999999999") or raise,
+        9999999999,
+        "beyond 32 bits"
+    );
+
+    // Garbage routes through `or` rather than silently returning 0.
+    // strtoll-ish: unconsumed trailing characters reject, which is
+    // why the padded "  42  " is a rejection and not 42.
+    std::test::assert_eq_int(std::str::parse_int("abc") or 0, 0, "letters");
+    std::test::assert_eq_int(std::str::parse_int("12abc") or 0, 0, "trailing junk");
+    std::test::assert_eq_int(std::str::parse_int("") or 0, 0, "empty");
+    std::test::assert_eq_int(std::str::parse_int("  42  ") or 0, 0, "padded");
+
+    // The error payload is readable in the substitute's scope.
+    let n = std::str::parse_int("totally bogus") or {
+        std::test::assert_eq_str(err.kind, "parse_int", "err.kind");
+        std::test::assert_eq_str(err.input, "totally bogus", "err.input");
+        -1
+    };
+    std::test::assert_eq_int(n, -1, "substitute value");
+
+    // can_parse_int agrees with parse_int on the same inputs.
+    std::test::assert(std::str::can_parse_int("42"), "can_parse 42");
+    std::test::assert(std::str::can_parse_int("-7"), "can_parse -7");
+    std::test::assert(!std::str::can_parse_int("abc"), "can_parse abc");
+    std::test::assert(!std::str::can_parse_int(""), "can_parse empty");
+    std::test::assert(std::str::can_parse_int("0"), "can_parse 0");
+
+    // A parsed Int is a real Int, not an opaque handle.
+    let parsed = std::str::parse_int("100") or raise;
+    std::test::assert_eq_int(parsed * 2, 200, "arithmetic on a parsed Int");
+    std::test::assert(parsed > 50, "comparison on a parsed Int");
+}


### PR DESCRIPTION
Tier 3. Stacked on #306 (needs the corpus provider); base will
retarget to `main` once #306 merges.

## `err.kind` does not compile

```hale
fn main() {
    let n = std::str::parse_int("x") or { println(err.kind); -1 };
}
```

```
type error: no field `kind` on `ParseError`
```

That shape is in `docs/src/everyday/http.md:208` and
`spec/decisions.md:1252`. `hale run` rejects it.

Cause: the stdlib error types (IoError, ParseError, CryptoError, …)
were injected into scope only when the program used `@form`
machinery — which has nothing to do with reading an error field. Any
program that just parsed a string and inspected the failure got a
fieldless `ParseError`.

## Why 1,547 tests missed it

`build_executable` — the entry **every** Rust codegen test calls —
parses and lowers but never runs `check_program`. The tests that
exercise `err.kind` compile and run the program without ever
typechecking it. The typecheck tests never used the shape.

I found it by converting the first test to Hale, where `hale test`
does typecheck.

Measured the gap: **8.5% of the ~1,000 programs embedded in codegen
tests fail `hale check`** while compiling and running fine.

## The dogfooding

`hale test` ships in the same binary as `hale build` and is
specified in `spec/testing.md`. The repo had four `*_test.hl` files
— all fixtures for testing the runner. The compiler did not use its
own test framework.

`tests/hale/` is the real suite now, wired into the workspace run.
The first two files replace nine Rust tests in `stdlib_str.rs`.

Not cosmetic:

- **The expectation stops being transcribed**, and gets stricter:
  `assert_eq_int(n, 42)` rejects what `stdout.contains("a=42")`
  accepts — the latter passes on `a=421`. The suite leans hard on
  the weak form: 2,553 `.contains(` vs 256 `assert_eq!`.
- **The program gets typechecked.**

Diagnostics, IR shape, leak counts and obs records stay in Rust —
`stdlib_str.rs` keeps exactly its two diagnostic tests.

## Scope honesty

I did **not** convert the other ~85 failing embedded programs. Many
are deliberate (a codegen test may lower a shape the checker
rejects), so asserting "all embedded programs typecheck" would be
false. What ships is a guard on what should hold unconditionally:
the on-disk example corpus typechecks clean.

1905/1905.

🤖 Generated with [Claude Code](https://claude.com/claude-code)