### PR TITLE
docs: publish the effect catalogue, generated from the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ behavior.
 
 ## Unreleased
 
+- **The effect catalogue is published, and generated.**
+  `hale doc --stdlib` now prints each function's effect classes beside
+  its signature (283 of them; the 57 without are locus/type paths that
+  legitimately have no row), and `--json` carries an `effects` field.
+  The registry has held an `EffectSet` per fn since #265 and the doc
+  generator was already walking those entries to print signatures
+  while ignoring the column next to them — so the classification the
+  checker enforces was invisible to anyone reading the docs. Derived,
+  not transcribed: a hand-written table of 300+ rows would drift, and
+  this repo has been bitten by exactly that three times now.
+- The book gains a **per-class reference** — what each of the ten
+  classes covers, why `println` is a `syscall`, and the distinction
+  that makes `@deterministic` useful rather than merely restrictive
+  (`time_from_unix(n)` is pure, `monotonic_ns()` is not). Every
+  example in it was verified against the compiler.
 - **The book documents the effect system.**
   `docs/src/verification.md` — the chapter named Verification — had
   zero mentions of effects; the whole surface lived in

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -772,6 +772,9 @@ fn run_doc_stdlib(json: bool, out_path: Option<PathBuf>) -> ExitCode {
                 "\n### {}\n\n```hale\n{}\n```\n",
                 e.name, e.signature
             ));
+            if let Some(cls) = effect_line(&e.name) {
+                md.push_str(&format!("\n{}\n", cls));
+            }
             if !e.doc.is_empty() {
                 md.push_str(&format!("\n{}\n", e.doc));
             }
@@ -791,6 +794,7 @@ fn run_doc_stdlib(json: bool, out_path: Option<PathBuf>) -> ExitCode {
                     "kind": e.kind,
                     "name": e.name,
                     "signature": e.signature,
+                    "effects": effect_classes(&e.name),
                     "doc": e.doc,
                     "members": e.members.iter().map(|m| serde_json::json!({
                         "signature": m.signature, "doc": m.doc
@@ -830,6 +834,44 @@ struct DocEntry {
     signature: String,
     doc: String,
     members: Vec<DocMember>,
+}
+
+/// The effect classes for a `std::` path, for `--json` consumers.
+/// Empty vec = pure; `None` = no registry row (a locus or type).
+fn effect_classes(path: &str) -> Option<Vec<String>> {
+    let segs: Vec<&str> = path.split("::").collect();
+    let set = hale_types::stdlib_surface::effects_for(&segs)?;
+    Some(hale_types::frontier::render_effects(set))
+}
+
+/// The effect classification for a `std::` path, as a doc line.
+///
+/// Read straight out of the registry rather than written down here:
+/// every surface entry already carries an `EffectSet`, and the
+/// generator was walking those entries to print signatures while
+/// ignoring the column sitting next to them. Deriving it means the
+/// published catalogue cannot drift from what the checker enforces —
+/// a hand-maintained table of 327 rows certainly would.
+///
+/// `None` for anything with no registry row (locus and type paths,
+/// which are tracked separately) so those entries render unchanged.
+fn effect_line(path: &str) -> Option<String> {
+    let segs: Vec<&str> = path.split("::").collect();
+    let set = hale_types::stdlib_surface::effects_for(&segs)?;
+    let classes = hale_types::frontier::render_effects(set);
+    if classes.is_empty() {
+        // PURE is a real answer, and a useful one: it is what makes a
+        // fn callable from a `@no_syscall` / `@deterministic` context.
+        return Some("**Effects:** none — callable under any assertion.".into());
+    }
+    Some(format!(
+        "**Effects:** {}",
+        classes
+            .iter()
+            .map(|c| format!("`{}`", c))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
 }
 
 /// The `///` block directly above the line holding `anchor`

--- a/crates/hale-cli/tests/doc_effects_catalogue.rs
+++ b/crates/hale-cli/tests/doc_effects_catalogue.rs
@@ -1,0 +1,116 @@
+//! `hale doc --stdlib` publishes each function's effect class.
+//!
+//! The registry has carried an `EffectSet` per stdlib fn since #265,
+//! and the doc generator walked those very entries to print
+//! signatures while ignoring the column beside them. So the
+//! classification the checker enforces was invisible to anyone
+//! reading the docs — you could not find out whether
+//! `std::time::monotonic_ns` is callable from a `@deterministic` fn
+//! without reading `stdlib_surface.rs`.
+//!
+//! Deriving the catalogue from the registry rather than writing it
+//! down is the whole point: a hand-maintained table of 300+ rows
+//! would drift from the checker, and this repo has now been bitten
+//! by exactly that failure mode three times.
+
+use std::process::Command;
+
+fn stdlib_doc() -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(["doc", "--stdlib"])
+        .output()
+        .expect("invoke hale doc --stdlib");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// Split the markdown into `### <path>` sections.
+fn sections(md: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for chunk in md.split("\n### ").skip(1) {
+        let name = chunk.lines().next().unwrap_or("").trim().to_string();
+        out.push((name, chunk.to_string()));
+    }
+    out
+}
+
+/// Every documented FUNCTION carries its effect classification.
+/// Locus and type paths legitimately have no row, and are excluded
+/// by case — the surface capitalizes them.
+#[test]
+fn every_documented_fn_publishes_its_effects() {
+    let secs = sections(&stdlib_doc());
+    assert!(
+        secs.len() > 300,
+        "expected the full stdlib surface, saw {} entries",
+        secs.len()
+    );
+    let missing: Vec<String> = secs
+        .iter()
+        .filter(|(name, _)| {
+            !name
+                .rsplit("::")
+                .next()
+                .and_then(|leaf| leaf.chars().next())
+                .map(|c| c.is_uppercase())
+                .unwrap_or(false)
+        })
+        .filter(|(_, body)| !body.contains("**Effects:**"))
+        .map(|(name, _)| name.clone())
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "these documented functions do not publish an effect class \
+         ({} of {}) — they are missing a registry row, which also \
+         means an effect assertion over them cannot be certified:\n{:#?}",
+        missing.len(),
+        secs.len(),
+        &missing[..missing.len().min(20)]
+    );
+}
+
+/// The catalogue must reflect the registry, not a copy of it. Spot
+/// checks in both directions: an effectful fn and a pure one, chosen
+/// because their classification is load-bearing for the `@no_syscall`
+/// and `@deterministic` contracts respectively.
+#[test]
+fn published_classes_match_the_registry() {
+    let md = stdlib_doc();
+    let secs = sections(&md);
+    let find = |p: &str| -> String {
+        secs.iter()
+            .find(|(n, _)| n == p)
+            .unwrap_or_else(|| panic!("{} missing from the stdlib docs", p))
+            .1
+            .clone()
+    };
+    assert!(
+        find("std::io::fs::read_file").contains("**Effects:** `syscall`"),
+        "reading a file is a syscall"
+    );
+    assert!(
+        find("std::str::parse_int").contains("**Effects:** none"),
+        "parsing a supplied string is pure — this is what makes it \
+         callable inside a @no_syscall fn"
+    );
+    // The distinction the classification exists to draw: operating on
+    // a SUPPLIED value is deterministic; READING the clock is not.
+    assert!(
+        find("std::time::monotonic_ns").contains("`time`"),
+        "reading the clock is a time effect"
+    );
+}
+
+/// A generator that silently stopped emitting the line would make
+/// the coverage test above pass vacuously if the case filter ever
+/// over-matched.
+#[test]
+fn catalogue_is_not_vacuous() {
+    let md = stdlib_doc();
+    let n = md.matches("**Effects:**").count();
+    assert!(
+        n > 250,
+        "only {} effect lines in the stdlib docs — the catalogue is \
+         not being generated",
+        n
+    );
+}

--- a/docs/src/verification.md
+++ b/docs/src/verification.md
@@ -137,12 +137,60 @@ never do, and the compiler proves it over the call graph.
 fn price(book: OrderBook, qty: Int) -> Decimal { ... }
 ```
 
-The classes are `syscall`, `block`, `time`, `entropy`, `env`, `ffi`,
-`publish`, `spawn`, `recursion` and `alloc`. The full surface — the
-general `@effects(none: {…})` form, the `@no_*` shorthands, quantitative
-`@budget(...)`, and per-lifecycle-phase contracts — is taught in
+The full surface — the general `@effects(none: {…})` form, the `@no_*`
+shorthands, quantitative `@budget(...)`, and per-lifecycle-phase
+contracts — is taught in
 [Performance](./systems/performance.md#saying-what-a-function-may-do),
 where the hot-path certificate is the motivating use.
+
+### The classes
+
+| class | covers | example |
+|---|---|---|
+| `syscall` | the kernel: filesystem, sockets, processes, terminal, stdio — including `println` | `std::io::fs::read_file` |
+| `block` | waits, holding its thread (or, on an `async_io` pool, its worker's turn) | `std::http::get` |
+| `time` | *reading* a clock | `std::time::monotonic_ns` |
+| `entropy` | *reading* randomness | `std::rand::next_int` |
+| `env` | *reading* the environment or argv | `std::env::var` |
+| `ffi` | reaching an `@ffi` declaration — leaving managed Hale | any `@ffi` fn |
+| `publish` | sending on the bus | `Orders <- o` |
+| `spawn` | instantiating a locus | `Worker { }` |
+| `recursion` | a cycle in the call graph | a fn that reaches itself |
+| `alloc` | arena allocation — a phase-only class, see `@phase_effects` | `Buf { n: 1 }` |
+
+Two of those are worth dwelling on, because they are the ones people
+guess wrong.
+
+**`println` is a `syscall`.** Writing to a stream is a `write(2)`; it
+can block, and a certificate that permitted it would not be certifying
+what it claims. Debug printing inside a `@no_syscall` function is a
+contract violation — which is the point of having asked.
+
+**Reading an effect source differs from operating on a supplied
+value.** This is the distinction that makes `@deterministic` useful
+rather than merely restrictive:
+
+| pure | effectful |
+|---|---|
+| `std::time::time_from_unix(n)` | `std::time::monotonic_ns()` — `time` |
+| `std::str::parse_int(s)` | `std::env::var(k)` — `env` |
+| `std::http::parse_request(b)` | `std::http::get(u)` — `syscall`, `block` |
+
+A function handed a timestamp is a function of its inputs. A function
+that *fetches* one is not, and cannot be replayed.
+
+You never have to work this out from memory. `hale doc --stdlib`
+publishes every function's classes alongside its signature, generated
+from the same registry the checker queries — so the catalogue and the
+enforcement cannot disagree:
+
+```
+### std::io::fs::read_file
+
+    fn read_file(String) -> String fallible(IoError)
+
+**Effects:** `syscall`
+```
 
 Two properties matter for *verification* specifically, and neither is a
 performance concern.


### PR DESCRIPTION
There was no effects catalogue. The book named the ten classes once,
in a sentence, and the only way to learn *which functions are in which
class* was to read `stdlib_surface.rs`.

The sharper part: **the data was already there and already being
walked.** `hale doc --stdlib` iterates `SURFACES` entry by entry to
print signatures — and ignored the `EffectSet` sitting on the same
struct. Grepping the entire generated stdlib doc for "effect" or
"syscall" returned 2 hits.

## Two halves

**1. Generated catalogue.** Each entry now renders its classes, and
`--json` carries an `effects` array:

```
### std::io::fs::read_file

    fn read_file(String) -> String fallible(IoError)

**Effects:** `syscall`
```

283 functions classified. The 57 without a line are locus/type paths,
which have no registry row by design — verified that the split is
exactly that, not an accident of formatting.

Derived at render time from `effects_for`, so the published catalogue
cannot drift from the enforced one. A hand-maintained table of 300+
rows would, and this repo has been bitten by precisely that three
times now.

**2. Per-class reference** in the Verification chapter: what each class
covers, why `println` is a `syscall`, and the distinction the
classification exists to draw —

| pure | effectful |
|---|---|
| `time_from_unix(n)` | `monotonic_ns()` — `time` |
| `parse_int(s)` | `env::var(k)` — `env` |
| `http::parse_request(b)` | `http::get(u)` — `syscall`, `block` |

A function handed a timestamp is a function of its inputs; one that
fetches a timestamp is not. That is what makes `@deterministic` useful
rather than merely restrictive.

## Accuracy

Every example was checked against the compiler rather than recalled.
Two things were wrong on the first pass: `std::rand::next_int` is a
free function, not an `Rng` method; and I had written that
`spec/stdlib.md` publishes the classes, which it does not — the
generated `hale doc` output does.

`doc_effects_catalogue.rs` enforces coverage, spot-checks published
classes against the registry in both directions, and guards against a
vacuous pass.

1920/1920. Book builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)