### PR TITLE
fix: a typo'd @phase_effects phase silently checked nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ behavior.
 
 ## Unreleased
 
+- **A typo'd `@phase_effects` phase was silently ignored.**
+  `@phase_effects(disolve: {})` typechecked clean and checked
+  nothing — you declared a contract and got no contract and no
+  diagnostic. It is now an error naming the bad phase and listing
+  what the locus actually has. The six lifecycle names stay legal
+  whether the hook is written out or not, so the canonical
+  `@phase_effects(birth: {alloc}, run: {})` line still works on a
+  locus with only `params`.
+- **Documented the annotation parameters that were only implied.**
+  The book stated that an omitted phase is unconstrained but left
+  `run: {}` — the opposite meaning, and the load-bearing one — to be
+  inferred from an example. Both are now spelled out in a table,
+  along with what a phase name may be, and the gotcha that a
+  publishing handler needs `{publish, alloc}` because building the
+  payload allocates.
 - **The effect catalogue is published, and generated.**
   `hale doc --stdlib` now prints each function's effect classes beside
   its signature (283 of them; the 57 without are locus/type paths that

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -122,7 +122,68 @@ fn phase_effects_diags(
                         }
                         _ => None,
                     });
-                let Some(span) = span else { continue };
+                let Some(span) = span else {
+                    // A phase naming nothing on this locus used to be
+                    // skipped in silence — so `@phase_effects(disolve:
+                    // {})` declared a contract that was never checked,
+                    // and the author had no way to tell. Every other
+                    // form of incompleteness in this system fails
+                    // closed; a typo'd phase must too.
+                    //
+                    // But the six LIFECYCLE names are always
+                    // meaningful, declared or not: a locus with only
+                    // `params` still has a birth, and
+                    // `@phase_effects(birth: {alloc}, run: {})` — the
+                    // canonical no-alloc-after-init line — must not
+                    // error just because the hook is implicit.
+                    const LIFECYCLE: &[&str] = &[
+                        "birth", "accept", "release", "run", "drain",
+                        "dissolve",
+                    ];
+                    if LIFECYCLE.contains(&phase.as_str()) {
+                        continue;
+                    }
+                    let mut candidates: Vec<String> = Vec::new();
+                    for m in &l.members {
+                        match m {
+                            LocusMember::Fn(fd) => {
+                                candidates.push(fd.name.name.clone())
+                            }
+                            LocusMember::Lifecycle(lc) => candidates
+                                .push(lifecycle_name(lc.kind).to_string()),
+                            _ => {}
+                        }
+                    }
+                    let hint = crate::stdlib_surface::nearest_name(
+                        phase,
+                        candidates.iter().map(|s| s.as_str()),
+                    )
+                    .map(|s| format!(" — did you mean `{}`?", s))
+                    .unwrap_or_else(|| {
+                        if candidates.is_empty() {
+                            String::new()
+                        } else {
+                            format!(
+                                " — this locus has {}",
+                                candidates
+                                    .iter()
+                                    .map(|c| format!("`{}`", c))
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            )
+                        }
+                    });
+                    out.push(Diag::ty(
+                        l.name.span,
+                        format!(
+                            "`@phase_effects` names phase `{}`, which \
+                             locus `{}` does not declare{}. The contract \
+                             would never be checked.",
+                            phase, l.name.name, hint
+                        ),
+                    ));
+                    continue;
+                };
                 let key = FnKey::method(l.name.name.clone(), phase.clone());
                 // The frontier/graph classes: anything NOT allowed.
                 for class in [

--- a/crates/hale-types/tests/phase_effects.rs
+++ b/crates/hale-types/tests/phase_effects.rs
@@ -112,3 +112,98 @@ fn phase_allows_named_classes_only() {
         ds
     );
 }
+
+/// An empty set FORBIDS everything; an omitted phase is
+/// unconstrained. These are opposite meanings and the difference is
+/// the whole feature — `run: {}` is what "no dynamic memory after
+/// initialization" actually says.
+#[test]
+fn empty_set_forbids_where_omission_permits() {
+    let body = r#"
+        type Buf { n: Int; }
+        @phase_effects(PHASES)
+        locus A {
+            params { seen: Int = 0; }
+            run() { let b = Buf { n: 1 }; self.seen = b.n; }
+        }
+        fn main() { A { }; }
+    "#;
+    let empty = diags_for(&body.replace("PHASES", "run: {}"));
+    assert!(
+        empty.iter().any(|m| m.contains("phase `run`") && m.contains("alloc")),
+        "`run: {{}}` must forbid every class: {:?}",
+        empty
+    );
+    let omitted = diags_for(&body.replace("PHASES", "birth: {alloc}"));
+    assert!(
+        !omitted.iter().any(|m| m.contains("phase `run`")),
+        "a phase not mentioned is unconstrained: {:?}",
+        omitted
+    );
+}
+
+/// A phase naming nothing on the locus was silently skipped, so a
+/// typo produced a contract that was never checked and never
+/// reported. Fails closed now, like every other incompleteness in
+/// this system.
+#[test]
+fn unknown_phase_name_is_rejected() {
+    let src = r#"
+        @phase_effects(not_a_phase: {})
+        locus A { params { n: Int = 0; } run() { self.n = 1; } }
+        fn main() { A { }; }
+    "#;
+    let ds = diags_for(src);
+    let hit = ds
+        .iter()
+        .find(|m| m.contains("does not declare"))
+        .unwrap_or_else(|| panic!("expected an unknown-phase error: {:?}", ds));
+    assert!(
+        hit.contains("not_a_phase") && hit.contains("`run`"),
+        "the diagnostic must name the bad phase and what IS available: {}",
+        hit
+    );
+}
+
+/// The six lifecycle names stay legal even when the hook is
+/// implicit: a locus with only `params` still has a birth, and the
+/// canonical `@phase_effects(birth: {alloc}, run: {})` line must not
+/// error just because no `birth()` block is written out.
+#[test]
+fn implicit_lifecycle_phases_are_not_flagged_as_unknown() {
+    let src = r#"
+        @phase_effects(birth: {alloc}, dissolve: {})
+        locus A { params { n: Int = 0; } run() { self.n = 1; } }
+        fn main() { A { }; }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("does not declare")),
+        "implicit lifecycle hooks are real phases: {:?}",
+        ds
+    );
+}
+
+/// A handler is addressable by name — that is how a per-message
+/// contract is written.
+#[test]
+fn handler_name_works_as_a_phase() {
+    let src = r#"
+        type Ev { n: Int; }
+        topic T { payload: Ev; subject: "t"; }
+        @phase_effects(on_ev: {})
+        locus A {
+            bus { subscribe T as on_ev; }
+            fn on_ev(e: Ev) { let n = std::io::fs::file_size("/x") or 0; }
+        }
+        locus P { bus { publish T; } fn go() { T <- Ev { n: 1 }; } }
+        main locus App { params { a: A = A { }; p: P = P { }; } }
+        fn main() { App { }; }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        ds.iter().any(|m| m.contains("phase `on_ev`") && m.contains("syscall")),
+        "a handler named as a phase must be checked: {:?}",
+        ds
+    );
+}

--- a/docs/src/systems/performance.md
+++ b/docs/src/systems/performance.md
@@ -267,9 +267,39 @@ locus Engine { ... }
 
 That single line is the "no dynamic memory after initialization"
 discipline: allocate while starting up, never in the steady state.
-Phases are the lifecycle hooks (`birth`, `run`, `drain`,
-`dissolve`, `accept`, `release`) or any handler by name; a phase you
-don't mention is unconstrained.
+
+**A phase name** is one of the six lifecycle hooks — `birth`,
+`accept`, `release`, `run`, `drain`, `dissolve` — or **any handler or
+method by name**, which is how you write a per-message contract:
+
+```hale,fragment
+@phase_effects(on_order: {publish, alloc})
+locus Router { ... }
+```
+
+Note the `alloc` there. The set is **exact**, and building the payload
+you publish is an allocation — so a handler that constructs `Ack { … }`
+and sends it needs both classes. `{publish}` alone is a stricter claim
+than most publishing handlers can honour, and the compiler will say so.
+
+The lifecycle names are always legal, written out or not: a locus with
+only `params` still has a birth. A phase that names *nothing* on the
+locus — a typo, or a handler you renamed — is an error, because a
+contract nobody checks is worse than no contract.
+
+**Empty braces and omission are opposites**, and this is the part to
+get right:
+
+| form | means |
+|---|---|
+| `run: {}` | `run` may perform **no** effect at all |
+| `run: {alloc}` | `run` may allocate, and do nothing else |
+| *(`run` not mentioned)* | `run` is **unconstrained** |
+
+So `@phase_effects(birth: {alloc})` alone constrains only birth —
+`run` stays free. It takes the explicit `run: {}` to say "and nothing
+in the steady state." Violations are errors, and the diagnostic is
+prefixed with the phase: ``phase `run`: effect assertion violated…``
 
 ### Never trapping
 


### PR DESCRIPTION
Prompted by "where are the details for `phase_effects`?" — auditing
the parameters turned up a bug.

## The bug

```hale
@phase_effects(disolve: {})
locus A { params { n: Int = 0; } run() { self.n = 1; } }
```

`ok: 1 file(s) typechecked`

The phase matched no member, the pass hit
`let Some(span) = span else { continue }`, and the contract was
dropped silently. You declared something, got no enforcement, and got
no diagnostic. Same fail-open shape as the other holes closed today.

Now:

```
type error: `@phase_effects` names phase `not_a_phase`, which locus `A`
does not declare — this locus has `run`. The contract would never be
checked.
```

Narrowly scoped, and the first cut was wrong: it flagged
`@phase_effects(birth: {alloc}, run: {})` on a locus with only
`params` — which is the book's own canonical example. The six
lifecycle names stay legal whether or not the hook is written out,
because a locus with only `params` still has a birth.

## The docs gap behind it

The book said an **omitted** phase is unconstrained, and left
`run: {}` — the opposite meaning, and the one the feature turns on —
to be inferred from an example. A reader could reasonably read `{}`
as "unconstrained" and get the DO-178 discipline exactly backwards.

| form | means |
|---|---|
| `run: {}` | `run` may perform **no** effect |
| `run: {alloc}` | `run` may allocate, nothing else |
| *(not mentioned)* | `run` is **unconstrained** |

Plus what a phase name may be (six lifecycle hooks, or any
handler/method by name), and a gotcha found while checking my own
example compiles: a publishing handler needs `{publish, alloc}`,
because constructing the payload allocates and the set is exact.
`{publish}` alone is a stricter claim than most publishing handlers
can honour.

## Verification

Four new tests: empty-vs-omitted, unknown-phase rejection, implicit
lifecycle phases accepted, handler-as-phase.

1924/1924. One transport test flaked on the first full run under load
(`listen_binding_serves_sequential_peers`); it passes in isolation on
this branch and on `main`, and the rerun was clean — contention, not a
regression from a docs-and-diagnostic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)