### PR TITLE
fix: a repeated @budget dimension silently kept the last value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ behavior.
 
 ## Unreleased
 
+- **A repeated `@budget` dimension silently kept the last value.**
+  `@budget(alloc_per_call = 0, alloc_per_call = 5)` enforced **5** —
+  you wrote a zero-alloc certificate and got a ceiling of five, with
+  nothing said. Rejected now: whichever way precedence fell would be
+  a guess, and the annotation is simply ambiguous. Distinct
+  dimensions in one clause are untouched.
 - **A typo'd `@phase_effects` phase was silently ignored.**
   `@phase_effects(disolve: {})` typechecked clean and checked
   nothing — you declared a contract and got no contract and no

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -1554,6 +1554,26 @@ impl Parser {
                 }
             };
             self.bump();
+            // A repeated dimension used to overwrite silently, so
+            // `@budget(alloc_per_call = 0, alloc_per_call = 5)`
+            // enforced 5 — the author wrote a zero-alloc certificate
+            // and got a ceiling of five with no diagnostic. Whichever
+            // way precedence fell it would be a guess; the honest
+            // answer is that the annotation is ambiguous.
+            if key == "alloc_per_call" && alloc.is_some()
+                || QuantDim::from_ident(&key)
+                    .is_some_and(|d| dims.iter().any(|(e, _)| *e == d))
+            {
+                return Err(Diag::parse(
+                    key_tok.span,
+                    format!(
+                        "budget dimension `{}` is given twice — the \
+                         later value would silently replace the \
+                         earlier one. State it once.",
+                        key
+                    ),
+                ));
+            }
             if key == "alloc_per_call" {
                 alloc = Some(n as u32);
             } else if let Some(d) = QuantDim::from_ident(&key) {

--- a/crates/hale-types/tests/quantitative_budgets.rs
+++ b/crates/hale-types/tests/quantitative_budgets.rs
@@ -198,3 +198,42 @@ fn dimensions_compose_in_one_budget_clause() {
         ds
     );
 }
+
+/// A repeated dimension used to overwrite silently: writing
+/// `@budget(alloc_per_call = 0, alloc_per_call = 5)` enforced **5**.
+/// The author asked for a zero-alloc certificate and got a ceiling
+/// of five, with nothing said. Whichever way precedence fell would
+/// be a guess — the annotation is ambiguous, so it is rejected.
+#[test]
+fn a_repeated_budget_dimension_is_rejected() {
+    for src in [
+        "@budget(alloc_per_call = 0, alloc_per_call = 5)\nfn f() -> Int { return 1; }\nfn main() { println(f()); }",
+        "@budget(stack_bytes = 16, stack_bytes = 32)\nfn f() -> Int { return 1; }\nfn main() { println(f()); }",
+    ] {
+        let err = hale_syntax::parse_source(src)
+            .err()
+            .unwrap_or_else(|| panic!("expected a parse error for:\n{}", src));
+        let msg = err
+            .iter()
+            .map(|d| d.message.clone())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(
+            msg.contains("given twice"),
+            "expected a duplicate-dimension diagnostic, got: {}",
+            msg
+        );
+    }
+}
+
+/// …but distinct dimensions in one clause are the documented shape
+/// and must keep working.
+#[test]
+fn distinct_budget_dimensions_still_compose() {
+    let src = "@budget(alloc_per_call = 0, stack_bytes = 4096, block_points = 0)\n\
+               fn f() -> Int { return 1; }\nfn main() { println(f()); }";
+    assert!(
+        hale_syntax::parse_source(src).is_ok(),
+        "a multi-dimension budget is the canonical hot-path certificate"
+    );
+}


### PR DESCRIPTION
Result of the annotation-parameter sweep.

## The bug

```hale
@budget(alloc_per_call = 0, alloc_per_call = 5)
fn f() -> Int { let b = Buf { n: 1 }; return b.n; }
```

Parsed fine, enforced **5**. Confirmed in both orders, so it was
last-wins rather than strictest-wins: you write a zero-alloc
certificate and get a ceiling of five, silently.

Rejected at parse time now. Picking a winner would be a guess dressed
up as a rule — the annotation is ambiguous, and saying so is the
honest answer. Distinct dimensions in one clause are untouched and
pinned by a test.

## What the sweep checked and found solid

Everything below already behaves correctly — recorded so the next
person doesn't re-derive it:

| probe | result |
|---|---|
| unknown `@budget` dimension | rejected, lists the five valid ones |
| negative `@budget` value | rejected |
| unknown effect class | rejected, lists the valid classes |
| unknown `@effects` key | rejected, names `none:` / `publish:` / `causes:` |
| `@no_syscall` on a locus | rejected |
| `@phase_effects` on a fn | rejected |
| `@budget` on a locus | rejected |
| `@supervised` on a fn | rejected |
| duplicate `@effects` keys | **accumulate** (checked both orders) — correct |
| `@secret` reaching a sink | fires |
| `@supervised` uncovered subtree | fires |
| `@no_panic` on a trapping index | fires |
| `@hot` + `@budget` stacked | works |
| `@effects(publish: {})` on a publishing fn | fires |

## One thing deliberately not changed

`@effects(publish: {NoSuchTopic})` is accepted. It's untidy, but it
fails **closed** — a real publish isn't in the declared set, so it
violates and the diagnostic names the actual subject. I chose not to
add an unknown-topic check because topics arrive via imports and
cross-seed aliases, so the check would risk false positives on valid
programs to tidy a case that already errors. Flagging it here rather
than fixing it silently.

1926/1926.

🤖 Generated with [Claude Code](https://claude.com/claude-code)