### PR TITLE
fix: don't report an imported seed's advisories on the importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ behavior.
 
 ## Unreleased
 
+- **Advisories from an imported seed are not reported on the
+  importer.** Making `check` resolve imports is what exposes
+  cross-seed errors — and it also drags every advisory lint in every
+  imported seed into the target's output. Checking one downstream app
+  began reporting 47 hot-path warnings from library code, and since
+  `hale verify` gates on ANY finding, 10 of 12 apps that passed it
+  started failing. A gate that goes red for library internals you
+  cannot edit from there is a gate people switch off. Advisories are
+  now reported where they are actionable — when that seed is the
+  check target — and **errors are never filtered**, wherever they
+  originate.
 - **Observation shm segments no longer leak on SIGKILL (fathom
   FRICTION P3).** A clean exit unlinks the segment and its
   registration via `atexit`; a SIGKILLed process by definition runs no

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2209,6 +2209,7 @@ fn collect_checkable(
         BTreeMap<PathBuf, String>,
         Vec<(u32, PathBuf, u32)>,
         ImportRenames,
+        std::collections::BTreeSet<PathBuf>,
     ),
     ExitCode,
 > {
@@ -2221,10 +2222,15 @@ fn collect_checkable(
     };
     let (programs, sources, file_bases) = parse_files(&files)?;
 
+    // The files the target itself owns — everything else reached
+    // from here arrived through an `import`.
+    let own: std::collections::BTreeSet<PathBuf> =
+        files.iter().filter_map(|f| f.canonicalize().ok()).collect();
+
     // Nothing imported: the old behaviour, exactly.
     let has_imports = programs.values().any(|p| !p.imports.is_empty());
     if !has_imports {
-        return Ok((programs, sources, file_bases, Vec::new()));
+        return Ok((programs, sources, file_bases, Vec::new(), own));
     }
 
     let union_imports: Vec<hale_syntax::ast::Import> = programs
@@ -2289,8 +2295,48 @@ fn collect_checkable(
 
     let mut out: BTreeMap<PathBuf, Program> = BTreeMap::new();
     out.insert(target.to_path_buf(), program);
-    Ok((out, path_sources, file_bases, renames))
+    Ok((out, path_sources, file_bases, renames, own))
 }
+
+/// Drop WARNING-level diagnostics whose span resolves to a file the
+/// check target does not own. Errors always survive.
+fn retain_owned_advisories(
+    diags: &mut Vec<hale_syntax::Diag>,
+    own_files: &std::collections::BTreeSet<PathBuf>,
+    file_bases: &[(u32, PathBuf, u32)],
+) {
+    if own_files.is_empty() || file_bases.len() <= 1 {
+        return;
+    }
+    diags.retain(|d| {
+        if d.is_error() {
+            return true;
+        }
+        match file_of_span(d.span.start.0, file_bases) {
+            Some(p) => own_files.contains(&p),
+            // Unattributable span: keep it rather than silently drop.
+            None => true,
+        }
+    });
+}
+
+/// Which file a merged span belongs to, via the per-file virtual
+/// base offsets `resolve_imports` records.
+fn file_of_span(
+    pos: u32,
+    file_bases: &[(u32, PathBuf, u32)],
+) -> Option<PathBuf> {
+    let mut best: Option<(u32, &PathBuf)> = None;
+    for (base, path, len) in file_bases {
+        if pos >= *base && pos < base.saturating_add(*len + 1) {
+            if best.map(|(b, _)| *base >= b).unwrap_or(true) {
+                best = Some((*base, path));
+            }
+        }
+    }
+    best.map(|(_, p)| p.clone())
+}
+
 
 fn run_check(target: &Path) -> ExitCode {
     run_check_impl(target, false)
@@ -2309,7 +2355,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
     // and a cross-seed payload type rendered as `?`. Codegen resolved
     // these names all along; only the analysis phases could not see
     // them.
-    let (mut programs, sources, file_bases, import_renames) =
+    let (mut programs, sources, file_bases, import_renames, own_files) =
         match collect_checkable(target) {
             Ok(x) => x,
             Err(code) => return code,
@@ -2450,6 +2496,23 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
     let allow_unowned =
         std::env::args().any(|a| a == "--allow-unowned-subscriber");
     let mut diags = hale_types::check_bundle_opts(&bundle, allow_unowned);
+    // Advisories about code the target does not own are dropped.
+    //
+    // `check` resolving imports is what makes cross-seed ERRORS
+    // visible, and that is the point — a soundness violation reached
+    // through an import is still your violation. But the same change
+    // drags every advisory lint in every imported seed into the
+    // target's output: checking one fathom app began reporting 47
+    // hot-path warnings from `lib/` and `pond/`, and since `hale
+    // verify` gates on ANY finding, 10 of 12 apps that passed it
+    // started failing. A gate that goes red for library internals
+    // you cannot edit from here is a gate people switch off.
+    //
+    // Nothing is lost: an advisory about a seed is reported when that
+    // seed is checked, which is how a multi-seed project is checked
+    // anyway (fathom walks all 58 `lib/` seeds plus 107 apps).
+    // Errors are NEVER filtered, wherever they originate.
+
     // GH #18 item 1 → M3 stage 5 (2026-07-02): unbounded-allocation
     // warnings are DEFAULT-ON (Riley's flip call after the 402-warning
     // audit: every audited true positive preserved, every residual FP
@@ -2480,6 +2543,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
     // With `hale check` at ~10 ms on the largest apps, an
     // on-save/on-keystroke loop needs nothing more than this.
     let json_mode = std::env::args().any(|a| a == "--json");
+    retain_owned_advisories(&mut diags, &own_files, &file_bases);
     if !diags.is_empty() {
         for d in &diags {
             if json_mode {

--- a/crates/hale-cli/tests/cross_seed_effects.rs
+++ b/crates/hale-cli/tests/cross_seed_effects.rs
@@ -112,3 +112,56 @@ fn a_clean_in_seed_fn_is_not_flagged() {
         out
     );
 }
+
+/// Resolving imports is what makes cross-seed ERRORS visible — and it
+/// also drags every advisory lint in every imported seed into the
+/// target's output. Checking one fathom app began reporting 47
+/// hot-path warnings from `lib/` and `pond/`, and because
+/// `hale verify` gates on ANY finding, 10 of 12 apps that passed it
+/// started failing.
+///
+/// A gate that goes red for library internals you cannot edit from
+/// here is a gate people switch off. Advisories are therefore
+/// reported where they are actionable — when that seed is checked —
+/// while errors are never filtered, wherever they originate.
+#[test]
+fn advisories_from_an_imported_seed_are_not_reported_on_the_app() {
+    let out = check();
+    assert!(
+        !out.contains("warning:"),
+        "checking the app must not report advisories about the seed it \
+         imports:\n{}",
+        out
+    );
+    // …and the errors that motivated resolving imports still fire.
+    assert!(
+        out.contains("must not reach `syscall`"),
+        "cross-seed errors must survive the advisory filter:\n{}",
+        out
+    );
+}
+
+/// The other half, and what makes the filter honest rather than a
+/// blanket suppression: checking the SEED reports its own advisories.
+/// Nothing is lost, it just lands where someone can act on it.
+#[test]
+fn the_seed_still_reports_its_own_advisories_when_checked_directly() {
+    let seed = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/xseed-effects/lib/probe");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(&seed)
+        .output()
+        .expect("invoke hale check on the seed");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        text.contains("warning:"),
+        "the seed's own advisories must appear when IT is the target — \
+         otherwise the filter is hiding them, not relocating them:\n{}",
+        text
+    );
+}

--- a/crates/hale-cli/tests/fixtures/xseed-effects/lib/probe/p.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-effects/lib/probe/p.hl
@@ -15,3 +15,20 @@ fn far_syscall() -> Int {
 fn far_time() -> Int {
     return std::time::monotonic_ns();
 }
+
+// Warn-worthy on purpose: an unbounded accumulation the app cannot
+// fix from its side. Checking the APP must not report it; checking
+// this seed must.
+type Slot { key: String; n: Int; }
+@form(hashmap)
+locus Acc { capacity { pool slots of Slot indexed_by key; } }
+locus Grow {
+    params { acc: Acc = Acc { }; }
+    run() {
+        let mut i = 0;
+        while true {
+            self.acc.set(Slot { key: "k" + to_string(i), n: i });
+            i = i + 1;
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #312, caught by running that change against the
downstream fleet instead of only the unit tests.

## The regression I introduced

Making `hale check` resolve imports is what exposes cross-seed
errors — the point of #312. It also drags every advisory lint in
every imported seed into the target's output. Checking one a downstream project app
went from clean to **47 hot-path warnings** originating in `lib/` and
`pond/`.

`hale verify` gates on ANY finding, so **10 of 12 sampled apps that
passed it started failing**. That is a worse regression than the bug
#312 fixed: a gate that goes red for library internals you cannot
edit from there is a gate people switch off.

## The fix

Advisories whose span resolves outside the target's own files are
dropped. **Errors are never filtered**, wherever they originate.

Nothing is hidden, only relocated to where it is actionable: an
advisory about a seed is reported when that seed is the check target,
which is how a multi-seed project gets checked anyway (a downstream project walks
every seed as well as every app). Both halves are pinned by tests —
the app must not report the seed's warnings, and the seed must still
report them itself.

## Verification

Fleet `verify`: **2/12 → 10/12 passing**. Both remaining failures are
correct:

- `the effects probe` — the downstream project's deliberate regression target,
  which is *supposed* to start failing once the cross-seed gap
  closes;
- another app — a pre-existing advisory in its own `main.hl`.

Cross-seed errors still fire (6 on the fixture).

One ordering bug of mine on the way, worth noting because it was
silent: the filter first ran *before* `unbounded_alloc_warnings` was
appended, so exactly the warnings it existed to catch bypassed it.

1941/1941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
