### PR TITLE
fix: the advisory filter was dropping the target's own findings too

### DIFF
--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2313,7 +2313,17 @@ fn retain_owned_advisories(
             return true;
         }
         match file_of_span(d.span.start.0, file_bases) {
-            Some(p) => own_files.contains(&p),
+            Some(p) => {
+                // Compare canonically. `file_bases` carries paths as
+                // they were passed in (often relative) while
+                // `own_files` is canonicalized, so a plain set lookup
+                // silently reported EVERY file as foreign — including
+                // the target's own, whose advisories then vanished.
+                // Suppressing the user's own findings is far worse
+                // than the noise this filter exists to remove.
+                let canon = p.canonicalize().unwrap_or(p);
+                own_files.contains(&canon)
+            }
             // Unattributable span: keep it rather than silently drop.
             None => true,
         }

--- a/crates/hale-cli/tests/cross_seed_effects.rs
+++ b/crates/hale-cli/tests/cross_seed_effects.rs
@@ -165,3 +165,74 @@ fn the_seed_still_reports_its_own_advisories_when_checked_directly() {
         text
     );
 }
+
+/// The filter must not swallow the TARGET's own advisories.
+///
+/// Its first cut did exactly that: `file_bases` carries paths as they
+/// were passed in (usually relative) while the owned-file set is
+/// canonicalized, so a plain set lookup reported every file as
+/// foreign and the app's own warnings vanished along with the
+/// imported ones. Suppressing findings the author can act on is a
+/// worse failure than the noise the filter exists to remove, and it
+/// is silent — the output just looks clean.
+#[test]
+fn the_targets_own_advisories_survive_the_filter() {
+    // The app fixture's own file carries an unbounded accumulation.
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/xseed-own-warning");
+    std::fs::create_dir_all(&dir).ok();
+    std::fs::write(
+        dir.join("hale.toml"),
+        "name = \"xseed-own-warning\"\n",
+    )
+    .ok();
+    std::fs::create_dir_all(dir.join("lib/quiet")).ok();
+    std::fs::write(
+        dir.join("lib/quiet/q.hl"),
+        "fn helper(n: Int) -> Int { return n + 1; }\n",
+    )
+    .ok();
+    std::fs::create_dir_all(dir.join("app")).ok();
+    std::fs::write(
+        dir.join("app/main.hl"),
+        "import \"lib/quiet\" as q;\n\
+         type Slot { key: String; n: Int; }\n\
+         @form(hashmap)\n\
+         locus Acc { capacity { pool slots of Slot indexed_by key; } }\n\
+         locus Grow {\n\
+         \x20   params { acc: Acc = Acc { }; }\n\
+         \x20   run() {\n\
+         \x20       let mut i = 0;\n\
+         \x20       while true {\n\
+         \x20           self.acc.set(Slot { key: \"k\" + to_string(i), n: q::helper(i) });\n\
+         \x20           i = i + 1;\n\
+         \x20       }\n\
+         \x20   }\n\
+         }\n\
+         main locus App { params { g: Grow = Grow { }; } }\n\
+         fn main() { App { }; }\n",
+    )
+    .ok();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(dir.join("app"))
+        .output()
+        .expect("invoke hale check");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        text.contains("warning:"),
+        "the target's OWN advisory must survive — the filter drops \
+         foreign findings, not local ones:\n{}",
+        text
+    );
+    assert!(
+        text.contains("app/main.hl"),
+        "and it must be attributed to the app's own file:\n{}",
+        text
+    );
+}

--- a/crates/hale-cli/tests/fixtures/xseed-own-warning/app/main.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-own-warning/app/main.hl
@@ -1,0 +1,16 @@
+import "lib/quiet" as q;
+type Slot { key: String; n: Int; }
+@form(hashmap)
+locus Acc { capacity { pool slots of Slot indexed_by key; } }
+locus Grow {
+    params { acc: Acc = Acc { }; }
+    run() {
+        let mut i = 0;
+        while true {
+            self.acc.set(Slot { key: "k" + to_string(i), n: q::helper(i) });
+            i = i + 1;
+        }
+    }
+}
+main locus App { params { g: Grow = Grow { }; } }
+fn main() { App { }; }

--- a/crates/hale-cli/tests/fixtures/xseed-own-warning/hale.toml
+++ b/crates/hale-cli/tests/fixtures/xseed-own-warning/hale.toml
@@ -1,0 +1,1 @@
+name = "xseed-own-warning"

--- a/crates/hale-cli/tests/fixtures/xseed-own-warning/lib/quiet/q.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-own-warning/lib/quiet/q.hl
@@ -1,0 +1,1 @@
+fn helper(n: Int) -> Int { return n + 1; }


### PR DESCRIPTION
Bug in my own #313, caught by re-measuring the fleet *after* merging
rather than trusting the unit tests.

## The bug

#313 compared a path from `file_bases` — carried as passed in,
usually **relative** — against a **canonicalized** owned-file set.
Every file therefore looked foreign, so the target's own advisories
vanished along with the imported ones.

An app whose own `main.hl` carried 22 findings suddenly reported zero
and "passed" `verify`. That is the worse failure mode: silently
suppressing findings the author can act on, where clean output is
indistinguishable from correct output.

## The fix

Compare canonically.

- own advisories return (22 on that app, attributed to `app/main.hl`);
- imported ones stay suppressed — **0** foreign-file diagnostics
  across 30 apps, the sole exception being `the effects probe`,
  whose cross-seed *errors* are correctly never filtered.

## The number I should have had before claiming #313 worked

I built `hale` at the pre-#312 commit and measured the a downstream project fleet
rather than assuming:

| | verify pass | verify fail |
|---|---|---|
| before any of this work (`bb1e008`) | 42 | 47 |
| after #312 + #313 + this | 41 | 48 |

The one-app difference is `the effects probe` — the downstream project's deliberate
regression target, which is *supposed* to start failing once the
cross-seed gap closes. So the gate is not regressed, and those 47
failures are pre-existing own-file advisories that have nothing to do
with these changes.

Pinned by a test that builds a fixture whose app file carries a
warning and whose imported seed does not.

1942/1942.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
