### PR TITLE
docs: scrub downstream project names from public-facing text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,9 @@ behavior.
   now reported where they are actionable — when that seed is the
   check target — and **errors are never filtered**, wherever they
   originate.
-- **Observation shm segments no longer leak on SIGKILL (fathom
-  FRICTION P3).** A clean exit unlinks the segment and its
+- **Observation shm segments no longer leak on SIGKILL (downstream handoff).** A clean exit unlinks the segment and its
   registration via `atexit`; a SIGKILLed process by definition runs no
-  handler. fathom measured **442 stale segments, 245 MB of host
+  handler. A downstream fleet measured **442 stale segments, 245 MB of host
   tmpfs** from one fleet run, because `docker stop` never reaches
   `dissolve` and their compose bind-mounts `/dev/shm`. A dead emitter
   cannot clean up after itself, so the next observed process to start
@@ -30,7 +29,7 @@ behavior.
   skips anything alive — blinding a running observer would be far
   worse than leaving a file behind. (Our own suite had accumulated 69
   of these on a dev box, so this was never only a downstream problem.)
-- **A cross-seed observation fixture is in-tree.** fathom reported
+- **A cross-seed observation fixture is in-tree.** A downstream handoff reported
   `CT_PUBLISHED` always 0 for a topic declared in an imported seed,
   and correctly identified why we could not see it: every in-tree obs
   test declares its topics inline. The bug did **not** reproduce at
@@ -39,16 +38,17 @@ behavior.
   standing guard with an inline control rather than a fix, and the
   open question goes back to them with what was ruled out.
 - **Effect assertions now resolve through an F.20 interface-typed
-  slot (fathom FRICTION P1).** `self.sink.emit()` where `sink`'s
+  slot (downstream handoff).** `self.sink.emit()` where `sink`'s
   declared type is an interface resolved to nothing — an interface
   has no body — so every effect behind the slot was invisible. The
   concrete locus in the slot's default is what actually runs, and the
   witness now reads `certified -> Manifest::reach ->
-  LoudEmitter::emit`. This is the venue-tier design: consumers see
+  LoudEmitter::emit`. This is the plug-in-implementation design:
+  consumers see
   only the abstract type, so a contract reaching a venue surface
   through a slot was vacuous.
-- **A publish set can name a qualified topic (fathom FRICTION).**
-  `@effects(publish: {t::ExecOrderRequest})` was a parse error, so the
+- **A publish set can name a qualified topic (downstream handoff).**
+  `@effects(publish: {t::SharedTopic})` was a parse error, so the
   contract could only name app-local topics — and the contract worth
   having most, "this binary is the only one permitted to publish X",
   was the one it could not state. Two halves had to agree: the parser
@@ -56,7 +56,7 @@ behavior.
   records a qualified subject instead of writing it off as a computed
   one (which had made every shared-topic publish unprovable).
 - **Effect assertions were silently vacuous across a seed boundary
-  (fathom FRICTION P0), and `hale check` rejected cross-seed types it
+  (downstream handoff), and `hale check` rejected cross-seed types it
   could not see (P2). Same root cause.** `hale check` collected only
   the target directory's own `.hl` files and never followed
   `import` — so an imported seed's bodies were absent from the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,22 @@ The in-tree `.hl` corpus lives at
 acceptance surface — `crates/hale-syntax/tests/examples.rs`
 parses all of them).
 
+## Downstream projects are never named
+
+`hale` is public. Downstream users' project names, app names, venue
+or counterparty names, and internal architecture are **not**.
+
+Attribute findings as **"downstream handoff"** (the established
+convention) in CHANGELOG entries, commit messages, code comments,
+test doc-comments, PR titles and PR bodies. Keep everything
+technical — the measurements, the shapes, the reproducers, the
+reasoning. Only the identity goes.
+
+This matters most exactly when a friction report is good: a detailed
+one carries the reporter's architecture, and a verbatim quote leaks
+it. Rename domain-specific identifiers too (a topic named after a
+real message type becomes `SharedTopic`).
+
 ## Repo conventions
 
 - **Hale** is the language. **lotus** is the runtime substrate.

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2512,7 +2512,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
     // visible, and that is the point — a soundness violation reached
     // through an import is still your violation. But the same change
     // drags every advisory lint in every imported seed into the
-    // target's output: checking one fathom app began reporting 47
+    // target's output: checking one downstream app began reporting 47
     // hot-path warnings from `lib/` and `pond/`, and since `hale
     // verify` gates on ANY finding, 10 of 12 apps that passed it
     // started failing. A gate that goes red for library internals
@@ -2520,7 +2520,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
     //
     // Nothing is lost: an advisory about a seed is reported when that
     // seed is checked, which is how a multi-seed project is checked
-    // anyway (fathom walks all 58 `lib/` seeds plus 107 apps).
+    // anyway — a real multi-seed project checks every seed directly).
     // Errors are NEVER filtered, wherever they originate.
 
     // GH #18 item 1 → M3 stage 5 (2026-07-02): unbounded-allocation

--- a/crates/hale-cli/tests/cross_seed_effects.rs
+++ b/crates/hale-cli/tests/cross_seed_effects.rs
@@ -1,17 +1,17 @@
 //! Effect assertions must survive a seed boundary.
 //!
-//! Reported by fathom (FRICTION.md P0), and the highest-cost item on
+//! Reported in a downstream handoff, and the highest-cost item on
 //! their list: `@no_syscall` / `@budget` / `@deterministic` enforced
 //! only within the asserting fn's own seed, and were **silently
 //! vacuous** through a cross-seed call. Their probe showed all three
 //! contracts violated one seed away with `hale check` reporting
 //! nothing, then the binary printing proof every effect had run.
 //!
-//! That is worse than no annotation: it reads as verified. Fathom's
+//! That is worse than no annotation: it reads as verified. The
 //! hot paths are almost entirely cross-seed — every venue parse, every
 //! domain helper, every topic lives in `lib/` and is imported under an
 //! alias — so their certificates certified only the thin app-seed
-//! portion, and their venue-tier rollout was blocked on it.
+//! portion, and the rollout of real certificates was blocked on it.
 //!
 //! ## Why the compiler's own corpus could not see this
 //!
@@ -115,7 +115,7 @@ fn a_clean_in_seed_fn_is_not_flagged() {
 
 /// Resolving imports is what makes cross-seed ERRORS visible — and it
 /// also drags every advisory lint in every imported seed into the
-/// target's output. Checking one fathom app began reporting 47
+/// target's output. Checking one downstream app began reporting 47
 /// hot-path warnings from `lib/` and `pond/`, and because
 /// `hale verify` gates on ANY finding, 10 of 12 apps that passed it
 /// started failing.

--- a/crates/hale-cli/tests/xseed_obs_counters.rs
+++ b/crates/hale-cli/tests/xseed_obs_counters.rs
@@ -1,6 +1,6 @@
 //! Observation counters for a topic declared in an IMPORTED seed.
 //!
-//! fathom (FRICTION P1) reported `CT_PUBLISHED` always 0 for a
+//! A downstream handoff reported `CT_PUBLISHED` always 0 for a
 //! cross-seed topic declaration, with deliveries and NET edges
 //! unaffected — and correctly identified why the substrate could not
 //! see it: **every in-tree obs test declares its topics inline in the
@@ -9,7 +9,7 @@
 //! was untested.
 //!
 //! That corpus gap is what this file closes. The bug itself did NOT
-//! reproduce at the tree fathom measured (`8e1af0f`) in either shape
+//! reproduce at the tree the report measured (`8e1af0f`) in either shape
 //! tried here — in-process with a local subscriber, and
 //! transport-bound with no local subscriber. Both count correctly.
 //! So this is a standing guard rather than a fix: if the counter
@@ -157,7 +157,7 @@ fn imported_topic_publishes_are_counted() {
 }
 
 /// A SIGKILLed emitter leaks its shm segment: by definition it runs
-/// no atexit handler. fathom measured **442 stale segments, 245 MB
+/// no atexit handler. A downstream fleet measured **442 stale segments, 245 MB
 /// of host tmpfs** from a single fleet run, because `docker stop`
 /// never reaches `dissolve` and their compose bind-mounts /dev/shm.
 ///

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -13015,7 +13015,7 @@ typedef struct lotus_bus_remote_entry {
  * shape, a subsequent register_remote call that grew the array
  * could realloc-move the storage and dangle every previously-
  * spawned reader thread's `entry` pointer. A downstream app hit this when
- * priceview's LOTUS_BUS_CONFIG mixed 4 listens + 2 connects:
+ * a downstream app's LOTUS_BUS_CONFIG mixed 4 listens + 2 connects:
  * the 5th entry's realloc invalidated the first 4 reader
  * threads' entry pointers, segfaulting silently on the first
  * inbound datagram. Single-role configs (listen-only or

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -292,7 +292,8 @@ static void *obs_heartbeat_main(void *arg) {
  * A SIGKILLed process cannot: by definition it runs no handler. The
  * segments are ~570 KB each, so a fleet stopped with `docker stop`
  * (which never reaches dissolve) accumulates them on the host —
- * fathom measured 442 stale segments, 245 MB of tmpfs, from one run.
+ * A downstream fleet measured 442 stale segments, 245 MB of tmpfs,
+ * from one run.
  *
  * PROTOCOL §1 already says consumers may GC a stale REGISTRATION by
  * pid liveness; that covers the small JSON file, not the segment.

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -6266,7 +6266,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 // hands the SLOT pointer; load the aggregate before
                 // the call. Passing the ptr raw was unverified-IR
                 // UB (garbage len half) until the DWARF verify gate
-                // exposed it (magus-md, 2026-07-03).
+                // exposed it (downstream handoff, 2026-07-03).
                 // Gate on the DECLARED payload type, not ABI shape:
                 // non-view by-value struct params (cross-pool bubble
                 // cells) are already passed correctly by the queue,

--- a/crates/hale-codegen/src/stdlib/bytes.rs
+++ b/crates/hale-codegen/src/stdlib/bytes.rs
@@ -487,7 +487,7 @@ impl<'ctx, 'p> BytesStdlib<'ctx> for Cx<'ctx, 'p> {
         // Per-repr len (2026-07-03): a BytesView is a { ptr, i64 }
         // aggregate and a BytesMut has its own base/len shape —
         // passing either raw to ptr-typed lotus_bytes_len was the
-        // magus-md DI-verifier failure.
+        // downstream DI-verifier failure.
         let len_ssa = match &b_ty {
             CodegenTy::BytesMut => self
                 .bytesmut_base_len(b_val)?

--- a/crates/hale-codegen/tests/bus_udp_transport.rs
+++ b/crates/hale-codegen/tests/bus_udp_transport.rs
@@ -234,7 +234,7 @@ fn book_snapshot_subscriber_src() -> &'static str {
     // BookSignalSnapshot-shaped: two Strings (variable-length
     // length-prefixed on the wire) ahead of a long tail of
     // fixed-size Decimals and Decimal arrays. The a downstream app
-    // priceview crash report (2026-05-27) said inbound udp
+    // a downstream crash report (2026-05-27) said inbound udp
     // datagrams trigger `g_bus_payload_arena` cap-hit on the
     // first message, with the diagnostic numbers matching a
     // single ~64 MB alloc from inside the deserializer.
@@ -329,7 +329,7 @@ fn book_snapshot_publisher_src() -> &'static str {
 
 #[test]
 fn udp_unicast_delivers_multi_string_payload() {
-    // Reproduces the a downstream app priceview crash shape: a payload
+    // Reproduces the downstream crash shape: a payload
     // with two variable-length Strings followed by a tail of
     // fixed-size fields. Without the deserializer length
     // bound-check, the first udp datagram would trigger the
@@ -387,7 +387,7 @@ fn udp_unicast_delivers_payload_over_inline_threshold() {
 }
 
 fn multi_listener_subscriber_src() -> &'static str {
-    // 2026-05-27 — mirrors the a downstream app priceview shape: a
+    // 2026-05-27 — mirrors the downstream shape: a
     // single subscriber binary with FOUR multicast listeners
     // on the same port, different groups, different payload
     // types. The reader threads each call into a different
@@ -464,7 +464,7 @@ fn multi_listener_publisher_src() -> &'static str {
 #[test]
 fn udp_multi_listener_same_port_different_groups() {
     // Stress the SO_REUSEPORT + multicast-group-membership
-    // case that priceview uses in production. Four reader
+    // case a downstream app uses in production. Four reader
     // threads, each bound to the same port and joined to a
     // distinct multicast group. A single publisher fires one
     // payload at the venue_a-book group; the subscriber should
@@ -534,7 +534,7 @@ fn udp_multi_listener_same_port_different_groups() {
 
 #[test]
 fn udp_mixed_listen_connect_survives_realloc() {
-    // 2026-05-27 — a downstream app priceview hit a silent SIGSEGV when
+    // 2026-05-27 — a downstream app hit a silent SIGSEGV when
     // LOTUS_BUS_CONFIG mixed udp:// listen and udp:// connect
     // roles. Root cause: `g_bus_remote_entries` was an
     // array-of-structs with initial cap = 4. The udp listen
@@ -551,7 +551,7 @@ fn udp_mixed_listen_connect_survives_realloc() {
     // The array can realloc freely; per-entry addresses stay
     // stable.
     //
-    // This test reproduces the priceview shape: more than 4
+    // This test reproduces the downstream shape: more than 4
     // total entries with at least one listen and at least one
     // connect. Without the fix, the subscriber binary
     // segfaults on the first inbound datagram. With the fix,
@@ -637,11 +637,11 @@ fn udp_mixed_listen_connect_survives_realloc() {
 #[test]
 fn udp_corrupt_length_prefix_rejected_cleanly() {
     // 2026-05-27 — proves the deserialize bound-check (added
-    // alongside the a downstream app priceview crash report) actually
+    // alongside the downstream crash report) actually
     // engages. We bypass the publisher binary entirely and
     // send a malformed datagram straight from the test
     // harness: 8 bytes encoding length-prefix = 0x04000000
-    // (= 64 MB, exactly the value that triggered priceview's
+    // (= 64 MB, exactly the value that triggered the downstream
     // `g_bus_payload_arena` cap-hit symptom).
     //
     // Without the bound-check, the subscriber's deserialize
@@ -695,7 +695,7 @@ fn udp_corrupt_length_prefix_rejected_cleanly() {
     std::thread::sleep(Duration::from_millis(200));
 
     // Send the malformed datagram. The 8 bytes are the LE
-    // encoding of i64=67108864 — what priceview observed in
+    // encoding of i64=67108864 — what the downstream app observed in
     // the wild.
     let sock = UdpSocket::bind("127.0.0.1:0").expect("test sock");
     let bad = [0x00u8, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00];

--- a/crates/hale-codegen/tests/coop_child_handler_cadence.rs
+++ b/crates/hale-codegen/tests/coop_child_handler_cadence.rs
@@ -1,7 +1,7 @@
 //! When does a cooperative CHILD's bus handler run relative to its
 //! own `run()` loop?
 //!
-//! fathom (FRICTION) reported this as "a bus handler's write to a
+//! A downstream handoff reported this as "a bus handler's write to a
 //! `self` param isn't observed by `run()`" and read it as a memory
 //! visibility problem between the handler context and the loop.
 //!

--- a/crates/hale-codegen/tests/ws1_ffi_handle_reassign.rs
+++ b/crates/hale-codegen/tests/ws1_ffi_handle_reassign.rs
@@ -1,7 +1,7 @@
 //! WS1#4 — whole-value reassignment of a nested locus param that
 //! holds an `@ffi`-acquired resource handle.
 //!
-//! a downstream app (refgw-evm `set_rpc_ws`) reported that `self.conn =
+//! a downstream app reported that `self.conn =
 //! ws::WsClient { url: …, … }` to swap an endpoint left the new
 //! client half-initialized — `conn.url` logged `(null)` and the
 //! first `read_msg()` cored — while in-place mutation

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -1308,7 +1308,7 @@ impl Parser {
                     TokenKind::Ident(s) => {
                         // A topic shared between binaries lives in a
                         // central catalog and is imported under an
-                        // alias (`t::ExecOrderRequest`). Accepting
+                        // alias (`t::SharedTopic`). Accepting
                         // only a bare ident meant the declared
                         // publish set could name app-local topics
                         // only — so the contract worth having most

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -1795,7 +1795,7 @@ impl<'a> Walker<'a> {
                     // bare identifier.
                     Expr::Ident(id) => Some(id.name.clone()),
                     // A topic imported from a shared catalog
-                    // (`t::ExecOrderRequest <- v`) is a qualified
+                    // (`t::SharedTopic <- v`) is a qualified
                     // path. Treating it as "computed" made every
                     // publish of a SHARED topic unprovable — which is
                     // every topic that crosses a binary, and so the

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -2117,7 +2117,7 @@ fn check_cooperative_pool_blocking(
                     // blocking call monopolizes it, so these handlers
                     // never fire. (Corrected 2026-06-03 from the
                     // placement-only rule, which over-fired on
-                    // event-driven subscribers — `PriceView`/`WsDispatcher`
+                    // event-driven subscribers — `Reader`/`Dispatcher`
                     // received fine for 16h+ in production.)
                     diags.push(Diag::ty(
                         span,

--- a/crates/hale-types/tests/effect_assertions.rs
+++ b/crates/hale-types/tests/effect_assertions.rs
@@ -542,7 +542,7 @@ fn no_panic_accepts_handled_dispositions() {
     );
 }
 
-/// A publish set must be able to name a QUALIFIED topic (fathom
+/// A publish set must be able to name a QUALIFIED topic (downstream
 /// FRICTION). Topics shared between binaries live in a central
 /// catalog and are imported under an alias, so accepting only bare
 /// idents meant the contract worth having most — "this binary is the
@@ -554,13 +554,13 @@ fn no_panic_accepts_handled_dispositions() {
 fn publish_set_accepts_and_enforces_a_qualified_topic() {
     let src = r#"
         type Order { n: Int; }
-        topic ExecOrderRequest { payload: Order; subject: "exec.order.request"; }
+        topic SharedTopic { payload: Order; subject: "shared.topic"; }
         locus Api {
-            bus { publish ExecOrderRequest; }
+            bus { publish SharedTopic; }
             @effects(publish: {})
-            fn go() { ExecOrderRequest <- Order { n: 1 }; }
+            fn go() { SharedTopic <- Order { n: 1 }; }
         }
-        locus S { bus { subscribe ExecOrderRequest as on_o; } fn on_o(o: Order) { } }
+        locus S { bus { subscribe SharedTopic as on_o; } fn on_o(o: Order) { } }
         main locus App { params { a: Api = Api { }; s: S = S { }; } }
         fn main() { App { }; }
     "#;
@@ -576,7 +576,7 @@ fn publish_set_accepts_and_enforces_a_qualified_topic() {
 /// set must parse. It used to die on the `::`.
 #[test]
 fn qualified_names_parse_inside_an_effects_set() {
-    let src = "@effects(publish: {t::ExecOrderRequest, LocalTopic})\n\
+    let src = "@effects(publish: {t::SharedTopic, LocalTopic})\n\
                fn go() -> Int { return 1; }\nfn main() { println(go()); }";
     assert!(
         hale_syntax::parse_source(src).is_ok(),

--- a/crates/hale-types/tests/effects_through_handles.rs
+++ b/crates/hale-types/tests/effects_through_handles.rs
@@ -195,13 +195,14 @@ fn eprintln_is_a_syscall_too() {
     assert!(violation(src, "syscall").contains("eprintln"));
 }
 
-/// F.20 interface-typed slot (fathom FRICTION P1). The declared type
+/// F.20 interface-typed slot (downstream handoff). The declared type
 /// of `self.sink` is an INTERFACE, which has no body — so
 /// `self.sink.emit()` resolved to nothing and every effect behind the
 /// slot was invisible. The concrete locus in the slot's default is
 /// what actually runs.
 ///
-/// This is the venue tier's entire design: consumers see only the
+/// This is the whole point of a plug-in-implementation tier:
+/// consumers see only the
 /// abstract type, so a contract on a consumer that reaches a venue
 /// surface through a slot was vacuous.
 #[test]

--- a/crates/hale-types/tests/placement.rs
+++ b/crates/hale-types/tests/placement.rs
@@ -533,7 +533,7 @@ fn main() { App { }; }
 // Corrected 2026-06-03 (a downstream app over-fire handoff): a non-main
 // cooperative subscriber is a dead receiver only when its run() ALSO
 // makes a blocking call that starves the pool thread. Placement alone
-// over-fired on event-driven subscribers (PriceView/WsDispatcher),
+// over-fired on event-driven subscribers (reader/dispatcher shapes),
 // which receive fine. The error message no longer claims "will never
 // fire" flatly.
 const DEAD_RX: &str = "monopolizes the pool's thread";
@@ -586,7 +586,7 @@ fn cooperative_nonmain_subscriber_blocking_rejected() {
 
 #[test]
 fn cooperative_nonmain_subscriber_event_driven_compiles() {
-    // The PriceView shape: non-main cooperative subscriber that does
+    // The downstream reader shape: non-main cooperative subscriber that does
     // NOT block (handlers + a sleep loop) — receives fine, must NOT be
     // rejected. This is the over-fire the correction fixes.
     let msgs = check(&dead_receiver_src(


### PR DESCRIPTION
The repo already had a convention for this — **"downstream handoff"**,
established when the earlier handoff work was scrubbed — and I didn't
follow it while working the friction log.

## What had leaked

Project names, a private stack's tier architecture, and a domain
topic name copied verbatim, across:

- `CHANGELOG.md` (7 references)
- source comments in `hale-cli`, `hale-codegen`, `lotus_obs.c`
- test doc-comments in 5 files
- **three public PR descriptions** (already corrected in place)

Two of the references predate this session (`magus-md` in
`codegen.rs` and `stdlib/bytes.rs`) and are scrubbed on the same pass.

## What is kept

Everything technical. The measurements (442 stale segments / 245 MB
of tmpfs; 47 advisories; 8.5% of embedded programs failing check),
the shapes, the reasoning, and the reproducers all stay — they are
what makes the comments worth reading. Only the identity is removed,
and a domain topic name in a fixture is renamed to `SharedTopic`.

## Still outstanding

**Commit messages on `main` carry the names.** Rewriting merged
history is destructive — it breaks every existing clone and any
in-flight branch — so that is a call for you to make, not one for me
to take unilaterally. Say the word and I'll do it; otherwise the
public-facing surface (CHANGELOG, code, PRs) is now clean and the
names survive only in `git log`.

1942/1942.

🤖 Generated with [Claude Code](https://claude.com/claude-code)