### PR TITLE
fix: manifest/diagnostic alias spelling + keyword struct-literal fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ behavior.
 
 ## Unreleased
 
+- **An app's effects manifest describes the app, not its imports.**
+  Once `check` resolved imports, every imported fn emitted a row under
+  its merged symbol — one downstream fleet's committed baseline went
+  from 1,319 rows to 8,021, and 131 of one app's 151 rows were mangled
+  names. That defeats the artifact: an effect regression is meant to
+  be a one-line diff in review. Merged symbols are excluded; a
+  library's rows come from checking the library, and what an import
+  contributes here is already folded into the caller's `does={…}`.
+- **Every diagnostic renders the alias spelling**, not only effect
+  witnesses. The no-locus-return rule was naming
+  `__lib_lib_a_b_OrderBook.query_bulk` — a symbol appearing nowhere in
+  the user's program.
+- **A framework keyword is legal as a struct-literal field name.**
+  `tier` was declarable, readable and assignable, but `Row { tier: 1 }`
+  failed with `expected ;, got LBrace` pointing at `Row {` and never
+  naming `tier`. `parse_struct_init` already accepted these keywords;
+  the struct-literal *lookahead* did not, so the literal fell through
+  to "expression followed by a block". The two now agree.
 - **Advisories from an imported seed are not reported on the
   importer.** Making `check` resolve imports is what exposes
   cross-seed errors — and it also drags every advisory lint in every

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2553,6 +2553,13 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
     // With `hale check` at ~10 ms on the largest apps, an
     // on-save/on-keystroke loop needs nothing more than this.
     let json_mode = std::env::args().any(|a| a == "--json");
+    // Every diagnostic renders in the spelling the author wrote.
+    // Effect witnesses were demangled at their source, but any other
+    // check that names a type or method — the no-locus-return rule,
+    // for one — still emitted `__lib_lib_a_b_OrderBook.query_bulk`,
+    // a symbol that appears nowhere in their program. Doing it once
+    // here covers every pass rather than each remembering.
+    hale_types::stdlib_bodies::demangle_imports(&mut diags, &import_renames);
     retain_owned_advisories(&mut diags, &own_files, &file_bases);
     if !diags.is_empty() {
         for d in &diags {

--- a/crates/hale-cli/tests/cross_seed_effects.rs
+++ b/crates/hale-cli/tests/cross_seed_effects.rs
@@ -236,3 +236,83 @@ fn the_targets_own_advisories_survive_the_filter() {
         text
     );
 }
+
+/// An app's effects manifest describes the APP, not the libraries it
+/// imports.
+///
+/// Once `check` resolved imports, every imported fn emitted its own
+/// row under its merged symbol: one downstream fleet's committed
+/// baseline went from 1,319 rows to 8,021, and 131 of one app's 151
+/// rows were mangled names. That defeats the artifact's purpose — an
+/// effect regression is meant to be a one-line diff in review, and a
+/// mangled name is unreadable and encodes an internal scheme that
+/// churns.
+///
+/// Nothing is lost: a library's rows come from checking the library,
+/// and what an imported fn contributes here is already folded into
+/// the caller's inferred `does={…}`.
+#[test]
+fn the_manifest_carries_no_merged_symbols() {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(fixture())
+        .arg("--dump-effects-manifest")
+        .output()
+        .expect("invoke hale check --dump-effects-manifest");
+    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(
+        !text.contains("__lib_"),
+        "no merged cross-seed symbol may appear in a manifest:\n{}",
+        text
+    );
+    // Non-vacuous: the app's OWN annotated fns must still be listed.
+    assert!(
+        text.contains("certified_no_syscall"),
+        "the app's own rows must survive the filter:\n{}",
+        text
+    );
+}
+
+/// Every diagnostic renders in the spelling the author wrote — not
+/// only effect witnesses. The no-locus-return rule was naming
+/// `__lib_lib_a_b_OrderBook.query_bulk`, a symbol appearing nowhere
+/// in the user's program and impossible to search for.
+#[test]
+fn non_effect_diagnostics_are_demangled_too() {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/xseed-cqrs");
+    std::fs::create_dir_all(dir.join("lib/mat")).ok();
+    std::fs::create_dir_all(dir.join("app")).ok();
+    std::fs::write(dir.join("hale.toml"), "name = \"xseed-cqrs\"\n").ok();
+    std::fs::write(
+        dir.join("lib/mat/m.hl"),
+        "locus Matrix { params { n: Int = 0; } }\n",
+    )
+    .ok();
+    std::fs::write(
+        dir.join("app/main.hl"),
+        "import \"lib/mat\" as mx;\n\
+         locus Book {\n\
+         \x20   params { n: Int = 0; }\n\
+         \x20   fn query_bulk() -> mx::Matrix { return mx::Matrix { n: 1 }; }\n\
+         }\n\
+         main locus App { params { b: Book = Book { }; } }\n\
+         fn main() { App { }; }\n",
+    )
+    .ok();
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(dir.join("app"))
+        .output()
+        .expect("invoke hale check");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        text.contains("mx::Matrix") && !text.contains("__lib_"),
+        "the no-locus-return diagnostic must name the alias spelling:\n{}",
+        text
+    );
+}

--- a/crates/hale-cli/tests/fixtures/xseed-cqrs/app/main.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-cqrs/app/main.hl
@@ -1,0 +1,7 @@
+import "lib/mat" as mx;
+locus Book {
+    params { n: Int = 0; }
+    fn query_bulk() -> mx::Matrix { return mx::Matrix { n: 1 }; }
+}
+main locus App { params { b: Book = Book { }; } }
+fn main() { App { }; }

--- a/crates/hale-cli/tests/fixtures/xseed-cqrs/hale.toml
+++ b/crates/hale-cli/tests/fixtures/xseed-cqrs/hale.toml
@@ -1,0 +1,1 @@
+name = "xseed-cqrs"

--- a/crates/hale-cli/tests/fixtures/xseed-cqrs/lib/mat/m.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-cqrs/lib/mat/m.hl
@@ -1,0 +1,1 @@
+locus Matrix { params { n: Int = 0; } }

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -5588,11 +5588,21 @@ impl Parser {
         if !matches!(self.peek(), TokenKind::LBrace) {
             return false;
         }
-        // Peek inside the brace.
+        // Peek inside the brace. The field-name position accepts the
+        // same framework keywords `parse_struct_init` does — the two
+        // disagreed, so `Row { tier: 1 }` failed the lookahead, fell
+        // through to "expression followed by a block", and reported
+        // `expected ;, got LBrace` pointing at `Row {` without ever
+        // mentioning `tier`. The field was declarable, readable and
+        // assignable; only naming it in a literal was blocked, which
+        // is the strangest possible surface for the restriction.
         match self.peek_at(1) {
             TokenKind::RBrace => true,
             TokenKind::Ident(_) => matches!(self.peek_at(2), TokenKind::Colon),
-            _ => false,
+            other => {
+                try_member_keyword_as_name(other).is_some()
+                    && matches!(self.peek_at(2), TokenKind::Colon)
+            }
         }
     }
 

--- a/crates/hale-syntax/tests/field_tags.rs
+++ b/crates/hale-syntax/tests/field_tags.rs
@@ -58,3 +58,41 @@ fn tag_coexists_with_a_default() {
     );
     assert_eq!(got, vec![("count".to_string(), Some("json:\"n\"".to_string()))]);
 }
+
+/// A framework keyword is legal as a struct-literal FIELD NAME, the
+/// same way it is legal in the field declaration.
+///
+/// Reported downstream: `tier` was declarable, readable and
+/// assignable (`self.r.tier = 9` typechecks) — only naming it in a
+/// literal was blocked, which is the strangest possible surface for
+/// the restriction. `parse_struct_init` already accepted these
+/// keywords; the struct-literal LOOKAHEAD did not, so `Row { tier: 1 }`
+/// fell through to "expression followed by a block" and reported
+/// `expected ;, got LBrace` at `Row {` without ever naming `tier`.
+#[test]
+fn a_framework_keyword_parses_as_a_struct_literal_field() {
+    for kw in ["tier", "run", "bus", "type", "capacity", "params"] {
+        let src = format!(
+            "type Row {{ {kw}: Int = 0; }}\n\
+             fn main() {{ let r = Row {{ {kw}: 1 }}; println(r.{kw}); }}\n",
+            kw = kw
+        );
+        assert!(
+            hale_syntax::parse_source(&src).is_ok(),
+            "`{}` must parse as a struct-literal field name — it is \
+             already legal in the declaration",
+            kw
+        );
+    }
+}
+
+/// The lookahead must still tell a struct literal from a block, or
+/// the fix above would have made every `Foo { … }` a struct literal.
+#[test]
+fn a_block_is_still_not_a_struct_literal() {
+    let src = "fn main() { let x = 1; if x > 0 { println(\"hi\"); } }";
+    assert!(
+        hale_syntax::parse_source(src).is_ok(),
+        "an `if` block must not be parsed as a struct literal"
+    );
+}

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -3140,6 +3140,28 @@ mod unowned_subscriber_tests {
 pub fn dump_effects_manifest(bundle: &Bundle<'_>) -> String {
     let programs: Vec<&hale_syntax::ast::Program> =
         bundle.programs.values().copied().collect();
-    let rows = crate::effects::effect_manifest_with_inference(&programs);
+    let mut rows = crate::effects::effect_manifest_with_inference(&programs);
+    // An app's manifest describes the APP, not the libraries it
+    // imports.
+    //
+    // Once `check` began resolving imports, every imported fn started
+    // emitting its own row: one downstream fleet's committed baseline
+    // went from 1,319 rows to 8,021, with 131 of one app's 151 rows
+    // being merged symbols. That defeats the artifact's whole purpose
+    // — an effect regression is supposed to be a one-line diff in
+    // review, and a mangled name is both unreadable and encodes an
+    // internal scheme that churns.
+    //
+    // Dropping them loses nothing. A library's own rows come from
+    // checking that library (how a multi-seed project is baselined
+    // anyway), and what an imported fn contributes to THIS app is
+    // already visible in the caller's inferred `does={…}`.
+    rows.retain(|r| !is_merged_symbol(&r.func));
     crate::effects::render_effect_manifest(&rows)
+}
+
+/// Merged cross-seed symbols carry the `__lib_` prefix the import
+/// resolver mangles them with — on the fn itself or on its locus.
+fn is_merged_symbol(name: &str) -> bool {
+    name.split("::").any(|seg| seg.starts_with("__lib_"))
 }


### PR DESCRIPTION
Three more from a downstream friction log. The first two are fallout
from resolving imports in `check` — my own regressions.

## The manifest was reporting the libraries, not the app

Every imported fn began emitting a row under its merged symbol. A
downstream fleet's committed baseline went **1,319 → 8,021 rows**,
with **131 of one app's 151 rows** being mangled names.

That defeats the artifact's purpose: an effect regression is supposed
to be a one-line diff in review, and a mangled name is unreadable and
encodes an internal scheme a diff will churn on.

An app's manifest now describes the app. Nothing is lost — a
library's rows come from checking the library (how a multi-seed
project is baselined anyway), and what an import contributes here is
already folded into the caller's inferred `does={…}`. **151 → 21
rows, zero merged symbols.**

Their second ask was the sharper one, and it's the one implemented.

## Other diagnostics still mangled

Effect witnesses were demangled at their source; nothing else was. The
no-locus-return rule emitted:

```
type error: method `__lib_lib_a_b_OrderBook.query_bulk` declares return
type `__lib_matrix_matrix_Matrix` — methods on loci may not return locus
values.
```

Demangling once at the render boundary covers every pass rather than
each one remembering. Now reads `Book.query_bulk` / `mx::Matrix`.

## `tier` in a struct literal

Declarable, readable, assignable — only naming it in a literal was
blocked, which is the strangest possible surface for the restriction:

```
type Row { tier: Int = 0; }     # fine
let r = Row { tier: 1 };        # parse error: expected ;, got LBrace
```

…and the error pointed at `Row {` without ever mentioning `tier`.

`parse_struct_init` already accepted framework keywords; the
struct-literal **lookahead** did not, so the literal fell through to
"expression followed by a block". The two now agree, with a control
asserting an `if` block is still not parsed as a struct literal.

1946/1946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)