### PR TITLE
fix: obs counters for variable-size payloads + build enforces cross-seed effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ behavior.
 
 ## Unreleased
 
+- **Observation counters were missing for any payload containing a
+  variable-size field.** `lotus_bus_dispatch_static` probed
+  `BUS_PUBLISH` and `BUS_DELIVER` inside its `if (flat)` branch, which
+  returns — so a payload carrying a `String` or `Bytes` counted
+  nothing and its topic never entered the observation manifest at all.
+  Deliveries were correct and cross-process NET edges paired with real
+  latencies; only the probes were absent, which is what made it look
+  like a counter bug rather than a missing call.
+  The class is variable-size storage, not one type (reproduces for
+  `String` and `Bytes` alike). Worth recording how it was found: it was
+  first reported — and first investigated here — as a *cross-seed*
+  bug, because in the reporting codebase every shared topic also
+  carried a String, so the two properties were perfectly correlated.
+  A cross-seed topic with a scalars-only payload counts correctly and
+  is what exonerated the seed boundary. The in-tree fixture now runs
+  that six-way differential.
+- **`hale build` enforces cross-seed effect assertions, like `hale
+  check` already did.** Only the check path carried the import rename
+  table, so a contract violated one seed away compiled, linked and
+  shipped. A downstream fleet gates on `build` across 109 binaries —
+  "it built" must not be weaker than "it checked" on a contract the
+  compiler already knows how to evaluate. All four analysis paths
+  (`build`, `run` file, `run` dir, test-compile) now pass the table.
 - **An app's effects manifest describes the app, not its imports.**
   Once `check` resolved imports, every imported fn emitted a row under
   its merged symbol — one downstream fleet's committed baseline went

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2762,7 +2762,14 @@ fn compile_test_binary(entry: &Path) -> Result<PathBuf, String> {
     };
     let mut bundle_programs: BTreeMap<String, &Program> = BTreeMap::new();
     bundle_programs.insert(entry.display().to_string(), &program);
-    let bundle = hale_types::Bundle::new(bundle_programs);
+    // The rename table must reach the analysis here too, not only in
+    // `check`. Without it a cross-seed call is an unresolved edge, so
+    // an effect assertion violated one seed away compiles, links and
+    // ships — a downstream fleet gates on `build` across 109 binaries,
+    // and "it built" must not be weaker than "it checked" on a
+    // contract the compiler already knows how to evaluate.
+    let mut bundle = hale_types::Bundle::new(bundle_programs);
+    bundle.import_renames = renames.clone();
     let diags = hale_types::check_bundle_opts(&bundle, false);
     if diags.iter().any(|d| d.is_error()) {
         let mut msg = String::new();
@@ -2999,7 +3006,14 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         };
         let mut bundle_programs: BTreeMap<String, &Program> = BTreeMap::new();
         bundle_programs.insert(target.display().to_string(), &program);
-        let bundle = hale_types::Bundle::new(bundle_programs);
+        // The rename table must reach the analysis here too, not only in
+        // `check`. Without it a cross-seed call is an unresolved edge, so
+        // an effect assertion violated one seed away compiles, links and
+        // ships — a downstream fleet gates on `build` across 109 binaries,
+        // and "it built" must not be weaker than "it checked" on a
+        // contract the compiler already knows how to evaluate.
+        let mut bundle = hale_types::Bundle::new(bundle_programs);
+        bundle.import_renames = renames.clone();
         let allow_unowned =
             std::env::args().any(|a| a == "--allow-unowned-subscriber");
         let diags = hale_types::check_bundle_opts(&bundle, allow_unowned);
@@ -3106,7 +3120,14 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
 
     let bundle_programs: BTreeMap<String, &Program> =
         std::iter::once((target.display().to_string(), &program)).collect();
-    let bundle = hale_types::Bundle::new(bundle_programs);
+    // The rename table must reach the analysis here too, not only in
+    // `check`. Without it a cross-seed call is an unresolved edge, so
+    // an effect assertion violated one seed away compiles, links and
+    // ships — a downstream fleet gates on `build` across 109 binaries,
+    // and "it built" must not be weaker than "it checked" on a
+    // contract the compiler already knows how to evaluate.
+    let mut bundle = hale_types::Bundle::new(bundle_programs);
+    bundle.import_renames = renames.clone();
     let allow_unowned =
         std::env::args().any(|a| a == "--allow-unowned-subscriber");
     let diags = hale_types::check_bundle_opts(&bundle, allow_unowned);
@@ -3315,7 +3336,14 @@ fn run_build(target: &Path) -> ExitCode {
     // string; this is good enough for v0.
     let mut bundle_programs: BTreeMap<String, &Program> = BTreeMap::new();
     bundle_programs.insert(target.display().to_string(), &program);
-    let bundle = hale_types::Bundle::new(bundle_programs);
+    // The rename table must reach the analysis here too, not only in
+    // `check`. Without it a cross-seed call is an unresolved edge, so
+    // an effect assertion violated one seed away compiles, links and
+    // ships — a downstream fleet gates on `build` across 109 binaries,
+    // and "it built" must not be weaker than "it checked" on a
+    // contract the compiler already knows how to evaluate.
+    let mut bundle = hale_types::Bundle::new(bundle_programs);
+    bundle.import_renames = renames.clone();
     let allow_unowned =
         std::env::args().any(|a| a == "--allow-unowned-subscriber");
     let diags = hale_types::check_bundle_opts(&bundle, allow_unowned);

--- a/crates/hale-cli/tests/fixtures/xseed-obs/app/main.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-obs/app/main.hl
@@ -1,26 +1,40 @@
 import "lib/topics" as t;
+import "lib/payload" as pay;
 
 // An inline topic published the same number of times, as the
 // in-file control: if the cross-seed counter is broken, this one
 // still counts and the asymmetry is the finding.
 type Local { n: Int = 0; }
+type LocalStr { n: Int = 0; s: String = ""; }
 topic Inline { payload: Local; subject: "xseed.inline"; }
+topic InlineStr { payload: LocalStr; subject: "xseed.inline.str"; }
+topic XScalar { payload: pay::XFlat; subject: "xseed.xscalar"; }
+topic XPayload { payload: pay::XStr; subject: "xseed.xpayload"; }
 
 locus Sink {
     params { seen: Int = 0; }
-    bus { subscribe t::Shared as on_s; subscribe Inline as on_i; }
+    bus { subscribe t::Shared as on_s; subscribe Inline as on_i;
+          subscribe InlineStr as on_is; subscribe XScalar as on_xs;
+          subscribe XPayload as on_xp; }
     fn on_s(v: t::Tick) { self.seen = self.seen + 1; }
     fn on_i(v: Local) { self.seen = self.seen + 1; }
+    fn on_is(v: LocalStr) { self.seen = self.seen + 1; }
+    fn on_xs(v: pay::XFlat) { self.seen = self.seen + 1; }
+    fn on_xp(v: pay::XStr) { self.seen = self.seen + 1; }
 }
 
 locus Pub {
-    bus { publish t::Shared; publish Inline; }
+    bus { publish t::Shared; publish Inline; publish InlineStr;
+          publish XScalar; publish XPayload; }
     run() {
         std::time::sleep(300ms);
         let mut i = 0;
         while i < 10 {
             t::Shared <- t::Tick { n: i };
             Inline <- Local { n: i };
+            InlineStr <- LocalStr { n: i, s: "v" };
+            XScalar <- pay::XFlat { n: i };
+            XPayload <- pay::XStr { n: i, s: "v" };
             i = i + 1;
         }
         std::time::sleep(300ms);

--- a/crates/hale-cli/tests/fixtures/xseed-obs/app/main.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-obs/app/main.hl
@@ -14,8 +14,8 @@ topic XPayload { payload: pay::XStr; subject: "xseed.xpayload"; }
 locus Sink {
     params { seen: Int = 0; }
     bus { subscribe t::Shared as on_s; subscribe Inline as on_i;
-          subscribe InlineStr as on_is; subscribe XScalar as on_xs;
-          subscribe XPayload as on_xp; }
+        subscribe InlineStr as on_is; subscribe XScalar as on_xs;
+        subscribe XPayload as on_xp; }
     fn on_s(v: t::Tick) { self.seen = self.seen + 1; }
     fn on_i(v: Local) { self.seen = self.seen + 1; }
     fn on_is(v: LocalStr) { self.seen = self.seen + 1; }
@@ -25,7 +25,7 @@ locus Sink {
 
 locus Pub {
     bus { publish t::Shared; publish Inline; publish InlineStr;
-          publish XScalar; publish XPayload; }
+        publish XScalar; publish XPayload; }
     run() {
         std::time::sleep(300ms);
         let mut i = 0;

--- a/crates/hale-cli/tests/fixtures/xseed-obs/lib/payload/pay.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-obs/lib/payload/pay.hl
@@ -1,0 +1,5 @@
+// A cross-seed payload with a variable-size field — the shape that
+// correlates with cross-seed decls in real codebases and so hid the
+// real cause for a full round of investigation.
+type XStr { n: Int = 0; s: String = ""; }
+type XFlat { n: Int = 0; }

--- a/crates/hale-cli/tests/xseed_obs_counters.rs
+++ b/crates/hale-cli/tests/xseed_obs_counters.rs
@@ -129,6 +129,34 @@ fn imported_topic_publishes_are_counted() {
         Err(e) => panic!("no obs segment at {}: {}", seg_path, e),
     };
 
+    // The differential that isolates payload SHAPE from decl SITE.
+    // These two properties were perfectly correlated in the codebase
+    // that first reported this, so a cross-seed cause was assumed for
+    // a whole round. `xseed.xscalar` — cross-seed decl AND cross-seed
+    // payload, scalars only — is what exonerates the seed boundary.
+    for (subject, what) in [
+        ("xseed.inline.str", "in-seed decl, payload contains a String"),
+        ("xseed.xscalar", "cross-seed decl AND payload, scalars only"),
+        ("xseed.xpayload", "in-seed decl, cross-seed payload with a String"),
+    ] {
+        let c = counters(&seg, subject)
+            .unwrap_or_else(|| panic!("{} missing from the manifest", subject));
+        assert_eq!(
+            c.0, 10,
+            "{} ({}): publishes must be counted whatever the payload \
+             shape — the probe used to sit only on the flat branch, so \
+             a String or Bytes field meant pub=0 and the topic never \
+             entered the manifest at all. Got {:?}",
+            subject, what, c
+        );
+        assert_eq!(
+            c.1, 10,
+            "{} ({}): and deliveries too — the same omission cost both \
+             counters. Got {:?}",
+            subject, what, c
+        );
+    }
+
     let inline = counters(&seg, "xseed.inline")
         .unwrap_or_else(|| panic!("inline topic missing from the manifest"));
     let shared = counters(&seg, "xseed.shared")

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -14736,6 +14736,28 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
         return;
     }
 
+    /* BUS_PUBLISH for the non-flat payload. The probe above sits
+     * inside the `if (flat)` branch, which returns — so a payload
+     * carrying a String or Bytes reached this point having counted
+     * NOTHING, and its topic never even entered the observation
+     * manifest. Downstream saw `pub=0` on every real plane while
+     * deliveries and cross-process NET edges were perfect, because
+     * only the publish-side probe was missing.
+     *
+     * The class is variable-size storage, not one type: it reproduces
+     * for String and Bytes alike, and a scalars-only payload declared
+     * in the same imported seed counts correctly. (That is also why
+     * it was first reported, and first investigated, as a cross-seed
+     * bug — every shared topic in that codebase happened to carry a
+     * String, so the two properties were perfectly correlated.)
+     *
+     * Counted before the serialize so a serialize FAILURE still
+     * records the publish that was attempted; the drop is visible
+     * separately via LOTUS_BUS_LOG_DROP. */
+    if (lotus_obs_bus_publish) {
+        lotus_obs_bus_publish(subject, NULL, (uint64_t)struct_size);
+    }
+
     /* Non-flat: serialize once, then deserialize into each subscriber's
      * own arena before enqueue (mirror lotus_bus_dispatch ->
      * lotus_bus_dispatch_wire). serialize_fn is required here; when
@@ -14796,6 +14818,15 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
             if (!e->subject) continue;             /* quarantined */
             if (e->key_filter_kind != 0) continue;
             if (!e->deserialize) continue;
+            /* BUS_DELIVER for the non-flat path. The flat branch
+             * above probes per matched subscriber; this one did not,
+             * so a String/Bytes payload delivered correctly — the
+             * handler ran — while `dlv` stayed 0 alongside the `pub`
+             * gap. Both halves of the same omission. */
+            if (lotus_obs_bus_deliver) {
+                lotus_obs_bus_deliver(subject, e->self_ptr,
+                                      (uint64_t)struct_size);
+            }
             /* Bug 3: cross-thread target — post WIRE bytes +
              * deserialize fn; the owner materializes at drain. */
             if (!lotus_bus_target_owner_is_current(e,


### PR DESCRIPTION
Two live items from a re-tested downstream friction log — the file was
cleaned up and both of these are fresh signal.

## Observation counters missed any payload with a variable-size field

`lotus_bus_dispatch_static` probed `BUS_PUBLISH` **and** `BUS_DELIVER`
inside its `if (flat)` branch — which `return`s. A payload carrying a
`String` or `Bytes` counted nothing, and its topic never entered the
observation manifest at all, so it read as *absent* rather than zero.

Delivery itself was always fine: the handler runs, `dlv` on the flat
control increments, cross-process NET edges pair with real latencies.
Only the probes were missing, which is precisely why it presented as a
counter bug rather than a missing call.

**Both halves were missing.** With `pub` fixed, `dlv` still read 0
while the handler demonstrably ran 10 times.

| topic | decl | payload | before | after |
|---|---|---|---|---|
| `xseed.inline` | in-seed | scalars | 10 | 10 |
| `xseed.xscalar` | **cross-seed** | **cross-seed**, scalars | 10 | 10 |
| `xseed.inline.str` | in-seed | contains String | **0** | 10 |
| `xseed.xpayload` | in-seed | cross-seed, String | **0** | 10 |

### How it was found, because I got it wrong too

This was first reported — and first investigated here — as a
**cross-seed** bug. In the reporting codebase every shared topic also
carried a String, so decl-site and payload-shape were perfectly
correlated, and my scalars-only fixture "did not reproduce" it. I
reported it as not-reproducible and shipped a guard.

They caught the confound themselves and re-tested with a six-way
differential that varies the two properties independently. That table
is now the in-tree fixture, so the next person cannot repeat either of
our mistakes.

## `hale build` did not enforce cross-seed effect assertions

Only the `check` path carried the import rename table, so a contract
violated one seed away compiled, linked and shipped:

```
$ hale build <app>     # exit 0, zero diagnostics, binary produced
$ hale check <app>     # exit 1, 6 effect assertion violations
```

That gap was mine — introduced with the cross-seed link. A downstream
fleet gates on `build` across 109 binaries; "it built" must not be
weaker than "it checked" on a contract the compiler already knows how
to evaluate.

All four analysis paths (`build`, `run` file, `run` dir, test-compile)
now pass the table. `build` and `run` refuse and emit no binary.

1946/1946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)