### PR TITLE
release: v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,54 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.12.0 — the effect system becomes trustworthy (2026-07-30)
+
+Minor bump. `@effects` shipped in v0.11.23, but it could be walked
+around in four different ways — and this release is mostly the work of
+finding that out and closing them. A contract that reads as verified
+and isn't is worse than no contract, so the headline is not a new
+feature: it is that the existing one now means what it says.
+
+**The four holes, all found downstream and all closed:**
+
+1. **Calls through a handle were invisible.** `reader.slurp()` was an
+   unresolved edge, so `@no_syscall` passed over real I/O. Since
+   locus-with-methods is how Hale does I/O, the contracts were largely
+   decorative outside free-fn code — and the shape they missed is the
+   one the violation diagnostic recommends as the fix.
+2. **Seed boundaries stopped the analysis.** `hale check` never
+   followed `import`, so a contract violated one seed away was silent.
+   Then `hale build` still didn't enforce it after `check` did.
+3. **Interface-typed slots resolved to nothing**, an interface having
+   no body — so any contract reaching a plug-in implementation through
+   a slot was vacuous.
+4. **Absent frontier rows failed open.** An unclassified registry entry
+   violated every assertion, but a `std::` path with *no row at all*
+   contributed nothing, so an unregistered namespace read as pure.
+
+**Also in the effect system:** `println` is syscall-class (writing to
+a stream is a `write(2)`); a typo'd `@phase_effects` phase and a
+repeated `@budget` dimension are errors instead of silent no-ops; a
+publish set can name a qualified topic, so the "only this binary may
+publish X" contract is finally expressible; and `hale doc --stdlib`
+publishes every function's effect classes, generated from the same
+registry the checker queries so the catalogue cannot drift from the
+enforcement.
+
+**Why none of this was caught here:** every in-tree effect test
+declared its types, topics and loci inline in one seed. The shapes the
+corpus never exercised were the only shapes a real multi-seed codebase
+has. That is now fixed structurally — cross-seed fixtures are in-tree,
+and `crates/hale-corpus` exposes the ~1.2k Hale programs embedded in
+test string literals (3× more Hale than the on-disk corpus) to every
+corpus-wide property.
+
+**Test-suite and tooling work** landed alongside: a collision-proof
+build-path harness (the suite no longer needs `--test-threads=1`,
+because the hazard is gone rather than avoided), a committed effect
+baseline the CI gate actually checks, the compiler testing itself in
+its own language via `hale test`, and observation counters fixed for
+payloads carrying a `String` or `Bytes`.
 
 - **Observation counters were missing for any payload containing a
   variable-size field.** `lotus_bus_dispatch_static` probed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.11.24"
+version = "0.12.0"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.11.24"
+version = "0.12.0"
 dependencies = [
  "hale-corpus",
  "hale-stdlib",
@@ -71,11 +71,11 @@ dependencies = [
 
 [[package]]
 name = "hale-corpus"
-version = "0.11.24"
+version = "0.12.0"
 
 [[package]]
 name = "hale-lsp"
-version = "0.11.24"
+version = "0.12.0"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -84,18 +84,18 @@ dependencies = [
 
 [[package]]
 name = "hale-stdlib"
-version = "0.11.24"
+version = "0.12.0"
 
 [[package]]
 name = "hale-syntax"
-version = "0.11.24"
+version = "0.12.0"
 dependencies = [
  "hale-corpus",
 ]
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.11.24"
+version = "0.12.0"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.11.24"
+version = "0.12.0"
 dependencies = [
  "hale-corpus",
  "hale-stdlib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.24"
+version = "0.12.0"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Minor bump. `@effects` shipped in v0.11.23 — but it could be walked
around in **four different ways**, and this release is mostly the work
of finding that out and closing them.

A contract that reads as verified and isn't is worse than no contract,
so the headline is not a new feature: it's that the existing one now
means what it says.

## The four holes

1. **Calls through a handle were invisible.** `reader.slurp()` was an
   unresolved edge, so `@no_syscall` passed over real I/O — and since
   locus-with-methods is how Hale does I/O, the contracts were largely
   decorative outside free-fn code. The shape they missed is the one
   the violation diagnostic recommends as the fix.
2. **Seed boundaries stopped the analysis.** `hale check` never
   followed `import`; then `build` still didn't enforce it after
   `check` did.
3. **Interface-typed slots resolved to nothing** — an interface has no
   body, so any contract reaching a plug-in implementation through a
   slot was vacuous.
4. **Absent frontier rows failed open.** An unclassified registry entry
   violated every assertion, but a `std::` path with *no row at all*
   contributed nothing, so an unregistered namespace read as pure.

## Why minor, not patch

Programs that passed `hale check` will now fail it. That is the
intended effect — the assertions finally bite — but it is a behaviour
change for anyone with a cross-seed or through-a-slot certificate.

## Also

`println` is syscall-class; typo'd `@phase_effects` phases and
repeated `@budget` dimensions are errors instead of silent no-ops;
publish sets can name qualified topics; `hale doc --stdlib` publishes
every function's effect classes, generated from the same registry the
checker queries.

Plus the test-suite work that made it findable: a collision-proof
build-path harness (no more `--test-threads=1`), `crates/hale-corpus`
exposing the ~1.2k programs embedded in test literals, a committed
effect baseline the CI gate actually checks, and the compiler testing
itself in its own language.

1946/1946 on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)