### PR TITLE
docs(agents): catch AGENTS.md up with what has actually shipped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,6 +260,36 @@ surprises:
 - "Error not addressed" on a `fallible` call → add `or raise` /
   `or default` / `or handler(err)`.
 
+## The loop: the compiler is the oracle
+
+Write, then ask the compiler. Don't reason your way to certainty about
+a rule — `hale check` will tell you in under a second, and its
+diagnostics name the rule and usually the fix.
+
+```sh
+hale check <file-or-dir>     # the oracle: accepts, or says exactly why
+hale build <dir>             # compile to a binary
+hale run <file-or-dir>       # compile + exec
+hale test <dir>              # run *_test.hl files
+hale fmt <path>              # canonical form; zero config
+hale verify <dir>            # like check, but ANY finding fails (CI gate)
+hale doc --stdlib            # every stdlib fn, signature + effect classes
+```
+
+Iterate against `hale check` until it prints `ok: N file(s)
+typechecked`. A rejected program is not a setback; it is the fastest
+feedback in the toolchain.
+
+**Keep a `FRICTION.md`** in the project. When you hit a wall, append
+what you learned — the cause and the working shape — and read it
+before the next task. Large Hale systems stay buildable by agents
+because that file exists, not because anyone remembers.
+
+When something genuinely doesn't fit the patterns above, log it as
+friction rather than coding around it. Foreign shapes (TOML-in-a-locus,
+fluent builders, singletons, decorators) are the usual sign you're
+fighting the language instead of using it.
+
 ## First step
 
 1. Skim `spec/styleguide.md` if you haven't (the seven patterns
@@ -346,6 +376,41 @@ down" is a closure declaration + a member fn + one `violate`
 statement. Don't reach for a `should_exit: Bool` flag plus a
 `while !should_exit { yield; }` loop — the primitives above
 are the supported form.
+
+## Other contracts worth knowing
+
+Beyond the effect assertions above, all opt-in:
+
+- `@phase_effects(birth: {alloc}, run: {})` on a **locus** — what each
+  lifecycle phase may do. `{}` forbids everything; a phase you don't
+  mention is unconstrained. That one line is "no dynamic memory after
+  initialization".
+- `@secret name: T` on a **parameter** — the value must not reach a
+  publish or a log/file sink.
+- `@supervised` on a **locus** — every locus in its subtree must have a
+  failure policy in scope.
+- `@unbounded` on a fn or hook — acknowledges an intentional
+  accumulation and silences the unbounded-allocation advisory.
+- `@form(lru_cache)` joins `vec` / `hashmap` / `ring_buffer` as a
+  cap-bounded collection shape.
+
+## Matching
+
+`match` is an expression as well as a statement, so it can produce a
+value directly rather than through a mutable temporary:
+
+```hale
+let label = match code {
+    200 -> "ok",
+    404 -> "missing",
+    _   -> "other",
+};
+```
+
+Arms use `->`, not `=>`.
+
+Arms may be blocks. `_` is the catch-all and is required when the
+arms don't cover the domain.
 
 ## Hard gotchas (codegen-v0 limits — don't fight these)
 


### PR DESCRIPTION
Audited the canonical agent prompt against the shipped surface, after
the question "is this actually up to date beyond effects?" It wasn't,
and one gap was serious.

## `hale check` appeared zero times

The single most load-bearing instruction for an agent — write, then
ask the compiler, iterate until `ok: N file(s) typechecked` — was not
in the file at all. Nor were `hale test`, `hale verify`, or
`hale doc`.

It *was* in the site's `agent-assets/essentials.md`, which I retired
an hour ago in #319. So retiring that file would have **dropped the
check loop and the FRICTION.md discipline out of every context pack**.
Caught it by auditing rather than by noticing, which is luck I'd
rather not repeat — both now live here, where they belong.

## `match` was entirely absent

A control-flow construct an agent would never learn exists. Added with
the expression form.

Worth noting how the example got written: I wrote the arms with `=>`,
the compiler rejected it, and the corrected `->` version is verified
by running it (`ok missing other`). Same rule I've been applying to
diagnostics all week — the examples in a prompt agents follow
literally have to actually compile.

## Also added

All verified to typecheck: `@phase_effects`, `@secret`, `@supervised`,
`@unbounded`, and `@form(lru_cache)` alongside the three form shapes
already listed.

## Deliberately not added

`ring_layout` / `shm_ring` / `MirrorRing` (foreign-ring interop is
specialist and well covered in the spec), `@export` / wasm targets,
and `takeover`. My read is those belong in the spec an agent reaches
for, not the prompt it always carries — but if that's the wrong call
they're one section each.

## Follow-up

The site's context packs are generated from this file and are checked
in, so `scripts/build-agent-assets.sh` needs a re-run in hale-lang.org
once this merges. I'll do that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)