### PR TITLE
perf(codegen): indexed byte accessors are pure reads (#322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,30 @@ behavior.
 
 ---
 
+## Unreleased
+
+- **Indexed byte accessors are now pure reads for LLVM** (#322).
+  `lotus_str_len` / `lotus_bytes_len` / `lotus_bytes_data` have carried
+  `memory(read) nounwind willreturn` since 2026-07-01 so LICM can hoist
+  a length read out of a loop; their indexed siblings
+  `lotus_bytes_at` / `lotus_str_byte_at` were missed. A loop-invariant
+  `std::bytes::at(b, i)` therefore stayed *inside* the loop body while
+  the identically-shaped `len` call in the same program was hoisted to
+  `entry:` and its loop folded away — the only difference was the
+  attribute. Synthetic upper bound: 1e9 loop-invariant reads, 0.78s →
+  0.00s, identical output.
+
+  The exclusions are the substance of the change and are pinned by
+  tests. Container accessors do **not** qualify: `lotus_vec_len` /
+  `lotus_hashmap_len` / `lotus_ring_buffer_len` read
+  concurrently-mutable state, and hoisting a poll loop's length read
+  out of the loop is a hang rather than a slowdown;
+  `lotus_vec_get` / `lotus_hashmap_get` write through an
+  out-parameter; `lotus_lru_get` writes a recency tick on read. Only
+  accessors over immutable values (Bytes, String) are eligible.
+
+---
+
 ## v0.12.0 — the effect system becomes trustworthy (2026-07-30)
 
 Minor bump. `@effects` shipped in v0.11.23, but it could be walked

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -11,6 +11,40 @@ use inkwell::AddressSpace;
 use crate::codegen::{Cx, SOCKOPT_NAMES};
 
 impl<'ctx, 'p> Cx<'ctx, 'p> {
+    /// Mark a runtime declaration as a **pure read**: `memory(read)`
+    /// (mask 21 = ArgMem|InaccessibleMem|Other = Ref, per
+    /// `llvm/Support/ModRef.h`) + `nounwind` + `willreturn`. Lets LICM
+    /// hoist the call out of a loop when its arguments are
+    /// loop-invariant, and lets CSE collapse repeated calls.
+    ///
+    /// **Only for accessors over IMMUTABLE data, audited against the
+    /// runtime C.** The bar is: no stores, no out-parameter, no lock,
+    /// and no concurrently-mutable source. A function that reads
+    /// `__atomic_load_n` on a live container fails the last clause —
+    /// hoisting a poll loop's read out of the loop turns a spin into a
+    /// hang. See the stage-1 block in `declare_builtins` for the full
+    /// exclusion list and why each one is excluded.
+    fn mark_pure_read(&self, f: inkwell::values::FunctionValue<'ctx>) {
+        use inkwell::attributes::{Attribute, AttributeLoc};
+        let mem_kind = Attribute::get_named_enum_kind_id("memory");
+        let nounwind_kind = Attribute::get_named_enum_kind_id("nounwind");
+        let willreturn_kind = Attribute::get_named_enum_kind_id("willreturn");
+        f.add_attribute(
+            AttributeLoc::Function,
+            self.context.create_enum_attribute(mem_kind, 21),
+        );
+        f.add_attribute(
+            AttributeLoc::Function,
+            self.context.create_enum_attribute(nounwind_kind, 0),
+        );
+        f.add_attribute(
+            AttributeLoc::Function,
+            self.context.create_enum_attribute(willreturn_kind, 0),
+        );
+    }
+}
+
+impl<'ctx, 'p> Cx<'ctx, 'p> {
     pub(crate) fn declare_builtins(&self) {
         // declare i32 @printf(ptr, ...)
         let i32_t = self.context.i32_type();
@@ -2151,6 +2185,28 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // encoding as the v0.9.0 static-dispatch block) + nounwind +
         // willreturn lets LICM hoist length reads out of loops and
         // CSE repeated calls.
+        //
+        // 2026-07-31 (#322): the INDEXED siblings join the list.
+        // `lotus_bytes_at` = one bounds check + one byte load,
+        // `lotus_str_byte_at` = strlen + one byte load. Both audited
+        // against the runtime C: no stores, no out-parameters, no
+        // locks. Measured: before this, a loop-invariant
+        // `std::bytes::at(b, 0)` stayed INSIDE the loop body across
+        // 1000 iterations while the annotated `lotus_str_len` in the
+        // same shape was hoisted to `entry:` and the loop folded away
+        // — the only difference was the attribute.
+        //
+        // The immutability argument is what limits the list, and it
+        // is why the container accessors are NOT here. `lotus_vec_len`
+        // / `lotus_hashmap_len` / `lotus_ring_buffer_len` read
+        // concurrently-mutable state (`__atomic_load_n` under
+        // striped/lockfree modes); memory(read) would let LICM hoist a
+        // poll loop's read out and never observe another worker's
+        // update — a hang, not a slowdown. `lotus_vec_get` /
+        // `lotus_hashmap_get` write through an out-parameter, and
+        // `lotus_lru_get` writes a recency tick ON READ. Bytes and
+        // String are immutable values in Hale (BytesBuilder is the
+        // mutable one), so only their accessors qualify.
         {
             use inkwell::attributes::{Attribute, AttributeLoc};
             let noalias_kind = Attribute::get_named_enum_kind_id("noalias");
@@ -2780,8 +2836,10 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // declare i64 @lotus_bytes_at(ptr bytes, i64 i)
         let bytes_at_ty =
             i64_t.fn_type(&[ptr_t.into(), i64_t.into()], false);
-        self.module
+        let bytes_at_fn = self
+            .module
             .add_function("lotus_bytes_at", bytes_at_ty, None);
+        self.mark_pure_read(bytes_at_fn);
         // 2026-06-13 — std::bytes word-scan + masked-XOR primitives (#4).
         // declare i64 @lotus_bytes_find_byte(ptr b, i64 off, i64 needle)
         self.module.add_function(
@@ -3295,11 +3353,12 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             &[ptr_t.into(), i64_t.into()],
             false,
         );
-        self.module.add_function(
+        let str_byte_at_fn = self.module.add_function(
             "lotus_str_byte_at",
             str_byte_at_ty,
             None,
         );
+        self.mark_pure_read(str_byte_at_fn);
         self.module.add_function(
             "lotus_str_byte_at_unchecked",
             str_byte_at_ty,

--- a/crates/hale-codegen/tests/pure_read_accessors.rs
+++ b/crates/hale-codegen/tests/pure_read_accessors.rs
@@ -1,0 +1,134 @@
+//! Aliasing stage 1, indexed accessors (#322, 2026-07-31).
+//!
+//! `lotus_str_len` / `lotus_bytes_len` / `lotus_bytes_data` have
+//! carried `memory(read) nounwind willreturn` since 2026-07-01 so LICM
+//! can hoist a length read out of a loop. Their INDEXED siblings —
+//! `lotus_bytes_at`, `lotus_str_byte_at` — were missed, so a
+//! loop-invariant `std::bytes::at(b, 0)` stayed inside the loop body
+//! across every iteration while the identically-shaped `len` call in
+//! the same program was hoisted to `entry:` and its loop folded away.
+//! The only difference was the attribute.
+//!
+//! The exclusion tests below are the important half. The bar is an
+//! accessor over IMMUTABLE data with no store, no out-parameter, and
+//! no lock — audited against the runtime C. Marking a container
+//! accessor would be a miscompilation, not a slow path: hoisting a
+//! poll loop's `len` read out of the loop turns a spin into a hang.
+
+use hale_codegen::build_executable;
+use hale_syntax::parse_source;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+/// Builtins are declared unconditionally and `LOTUS_DUMP_IR` dumps
+/// PRE-optimization, so a trivial program's IR carries every runtime
+/// declaration — no fixture needs to call them.
+fn builtin_ir(name: &str) -> String {
+    let program = parse_source("fn main() { println(\"hi\"); }").expect("parse");
+    let bin = harness::unique_bin(name);
+    std::env::set_var("LOTUS_DUMP_IR", "1");
+    build_executable(&program, &bin).expect("build");
+    std::env::remove_var("LOTUS_DUMP_IR");
+    let ll = bin.with_extension("ll");
+    let ir = std::fs::read_to_string(&ll).expect("IR dumped");
+    let _ = std::fs::remove_file(&bin);
+    let _ = std::fs::remove_file(&ll);
+    ir
+}
+
+/// The attribute-group body a declaration resolves to, e.g.
+/// `{ nounwind willreturn memory(read) }`. `None` when the symbol is
+/// declared with no group at all.
+fn attrs_of(ir: &str, sym: &str) -> Option<String> {
+    let decl = ir
+        .lines()
+        .find(|l| l.starts_with("declare") && l.contains(&format!("@{}(", sym)))?;
+    let group = decl
+        .split_whitespace()
+        .last()
+        .filter(|t| t.starts_with('#'))?;
+    ir.lines()
+        .find(|l| l.starts_with(&format!("attributes {} =", group)))
+        .map(|l| l.to_string())
+}
+
+#[test]
+fn indexed_immutable_accessors_are_pure_reads() {
+    let ir = builtin_ir("pure_read_idx");
+    for sym in ["lotus_bytes_at", "lotus_str_byte_at"] {
+        let body = attrs_of(&ir, sym)
+            .unwrap_or_else(|| panic!("{} should carry an attribute group", sym));
+        assert!(
+            body.contains("memory(read)"),
+            "{} must be memory(read) so LICM can hoist it: {}",
+            sym,
+            body
+        );
+        assert!(
+            body.contains("willreturn") && body.contains("nounwind"),
+            "{} must also carry willreturn + nounwind: {}",
+            sym,
+            body
+        );
+    }
+}
+
+/// The new symbols must land in the SAME group as the 2026-07-01
+/// precedent — one shared "pure read" classification, not a parallel
+/// one that could drift.
+#[test]
+fn indexed_accessors_match_the_length_accessor_precedent() {
+    let ir = builtin_ir("pure_read_precedent");
+    let precedent = attrs_of(&ir, "lotus_str_len").expect("str_len annotated");
+    for sym in ["lotus_bytes_at", "lotus_str_byte_at", "lotus_bytes_len"] {
+        assert_eq!(
+            attrs_of(&ir, sym).as_deref(),
+            Some(precedent.as_str()),
+            "{} should share the pure-read attribute group with lotus_str_len",
+            sym
+        );
+    }
+}
+
+/// Concurrently-mutable container lengths must NOT be pure reads.
+///
+/// These read `__atomic_load_n` on a live container under
+/// striped/lockfree modes. `memory(read)` would license LICM to hoist a
+/// poll loop's read out of the loop, so a worker waiting on another
+/// worker's push would never observe it — a hang, not a slowdown.
+#[test]
+fn mutable_container_lengths_are_not_pure_reads() {
+    let ir = builtin_ir("pure_read_excl_len");
+    for sym in ["lotus_vec_len", "lotus_hashmap_len", "lotus_ring_buffer_len"] {
+        if let Some(body) = attrs_of(&ir, sym) {
+            assert!(
+                !body.contains("memory(read)") && !body.contains("memory(none)"),
+                "{} reads concurrently-mutable state and must NOT be a pure \
+                 read — hoisting a poll loop's length read is a hang: {}",
+                sym,
+                body
+            );
+        }
+    }
+}
+
+/// Out-parameter writers and read-mutating accessors are excluded too:
+/// `lotus_vec_get` / `lotus_hashmap_get` `memcpy` into an out pointer
+/// (and hashmap_get takes a lock), and `lotus_lru_get` writes a
+/// recency tick ON READ.
+#[test]
+fn out_param_and_recency_writing_accessors_are_not_pure_reads() {
+    let ir = builtin_ir("pure_read_excl_out");
+    for sym in ["lotus_vec_get", "lotus_hashmap_get", "lotus_lru_get"] {
+        if let Some(body) = attrs_of(&ir, sym) {
+            assert!(
+                !body.contains("memory(read)") && !body.contains("memory(none)"),
+                "{} writes memory (out-param or recency tick) and must NOT \
+                 be a pure read: {}",
+                sym,
+                body
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes the first slice of #322, and answers its Open Question 1 —
which was flagged as a measurement that might close the issue outright.
It largely did, but not where expected.

## The measurement first

**For Hale-defined functions, LLVM already infers everything.** A
`fn square(x: Int) -> Int { return x * x; }` gets `memory(none)` from
LLVM's own `FunctionAttrs` pass despite the arena-pointer parameter —
SROA eliminates the pointer store, and the loop calling it constant-
folds to a single basic block. So the narrow class the issue proposed
starting with has **zero** available win. That part of #322 should not
be built.

**For runtime externs, attributes are everything** — and they are
hand-audited one at a time. `lotus_str_len` / `lotus_bytes_len` /
`lotus_bytes_data` got `memory(read) nounwind willreturn` in the
2026-07-01 aliasing work. Their indexed siblings were missed.

Same program, same shape, opposite outcome:

| call | attribute | result |
|---|---|---|
| `lotus_str_len(s)` | `memory(read)` | hoisted to `entry:`, loop folded |
| `lotus_bytes_at(b, 0)` | none | stayed in `while.body`, every iteration |

Synthetic upper bound at 1e9 loop-invariant reads: **0.78s → 0.00s**,
byte-identical output.

## The exclusions are the actual content

Each audited against the runtime C, not assumed:

- **`lotus_vec_len` / `lotus_hashmap_len` / `lotus_ring_buffer_len`** —
  read `__atomic_load_n` on a live container under striped/lockfree
  modes. `memory(read)` would let LICM hoist a poll loop's read out of
  the loop, so a worker waiting on another worker's push never
  observes it. **A hang, not a slowdown.**
- **`lotus_vec_get` / `lotus_hashmap_get`** — `memcpy` into an
  out-parameter; hashmap_get also takes a lock.
- **`lotus_lru_get`** — writes a recency tick *on read* (`++c->tick`).

The bar is therefore: an accessor over **immutable** data, no store, no
out-parameter, no lock. Bytes and String qualify; BytesBuilder is the
mutable one and does not.

## Evidence

This class of change miscompiles rather than misdiagnoses, so:

- **Differential run of all 86 example fixtures**, before vs after —
  byte-identical. (One apparent diff was a long-running server hitting
  the timeout at a different point; before-vs-*before* produced the
  same hash.)
- **Negative control** — injecting `mark_pure_read(lotus_vec_len)`
  makes the exclusion test fail, so the guard is load-bearing rather
  than decorative.
- **1952/1952**, fmt gate clean.

## Not measured

The varying-index case (`at(b, i)` inside a scan), where the win is CSE
and scheduling rather than hoisting. The stdlib's JSON and HTTP byte
scanners are the realistic consumers; no claim is made about them here.

## What this means for #322

The original framing — derive attributes for Hale-defined functions
from the effect summary — is **not worth building**; LLVM already does
it. The value is entirely in the runtime frontier, where the audit is
per-symbol and the effect registry is suggestive but not sufficient
(effect classes are not memory-access classes). I'd rescope the issue
to that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)