### PR TITLE
perf(codegen): string/byte scanners are pure reads (#322 follow-on)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ behavior.
 
 ## Unreleased
 
+- **String/byte scanners and predicates are now pure reads for LLVM**
+  (#322, follow-on). Seven more runtime symbols join the audited
+  `memory(read) nounwind willreturn` list: `lotus_str_eq`,
+  `lotus_str_starts_with`, `lotus_str_contains`, `lotus_str_index_of`,
+  `lotus_bytes_find_byte`, `lotus_bytes_find_byte_raw`,
+  `lotus_bytes_at_raw` — all `strcmp` / `strncmp` / `strstr` / `memchr`
+  / const-index over `const` pointers, which is the shape the HTTP and
+  JSON byte scanners are built from. Two that look identical by name
+  are excluded: `lotus_bytes_read_uint` and `_raw` take an
+  `int64_t *oob` and write `*oob = 1` on an out-of-bounds read.
+
 - **Indexed byte accessors are now pure reads for LLVM** (#322).
   `lotus_str_len` / `lotus_bytes_len` / `lotus_bytes_data` have carried
   `memory(read) nounwind willreturn` since 2026-07-01 so LICM can hoist

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -684,7 +684,9 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         let i32_t_local = self.context.i32_type();
         let str_eq_ty =
             i32_t_local.fn_type(&[ptr_t.into(), ptr_t.into()], false);
-        self.module.add_function("lotus_str_eq", str_eq_ty, None);
+        let str_eq_fn =
+            self.module.add_function("lotus_str_eq", str_eq_ty, None);
+        self.mark_pure_read(str_eq_fn);
         let str_len_ty = i64_t.fn_type(&[ptr_t.into()], false);
         let str_len_fn = self
             .module
@@ -721,20 +723,25 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // declare i32 @lotus_str_contains(ptr s, ptr sub)
         let str_predicate_ty =
             i32_t_local.fn_type(&[ptr_t.into(), ptr_t.into()], false);
-        self.module.add_function(
+        let str_starts_with_fn = self.module.add_function(
             "lotus_str_starts_with",
             str_predicate_ty,
             None,
         );
-        self.module
+        self.mark_pure_read(str_starts_with_fn);
+        let str_contains_fn = self
+            .module
             .add_function("lotus_str_contains", str_predicate_ty, None);
+        self.mark_pure_read(str_contains_fn);
 
         // m84: byte index of substring (or -1 if not found).
         // declare i64 @lotus_str_index_of(ptr s, ptr sub)
         let str_index_of_ty =
             i64_t.fn_type(&[ptr_t.into(), ptr_t.into()], false);
-        self.module
+        let str_index_of_fn = self
+            .module
             .add_function("lotus_str_index_of", str_index_of_ty, None);
+        self.mark_pure_read(str_index_of_fn);
 
         // m89: Bytes value primitives.
         // declare ptr @lotus_bytes_create(ptr arena, i64 len)
@@ -2842,11 +2849,12 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         self.mark_pure_read(bytes_at_fn);
         // 2026-06-13 — std::bytes word-scan + masked-XOR primitives (#4).
         // declare i64 @lotus_bytes_find_byte(ptr b, i64 off, i64 needle)
-        self.module.add_function(
+        let bytes_find_byte_fn = self.module.add_function(
             "lotus_bytes_find_byte",
             i64_t.fn_type(&[ptr_t.into(), i64_t.into(), i64_t.into()], false),
             None,
         );
+        self.mark_pure_read(bytes_find_byte_fn);
         // declare i32 @lotus_bytes_builder_xor_mask_into(ptr handle, ptr src, i64 key)
         self.module.add_function(
             "lotus_bytes_builder_xor_mask_into",
@@ -2888,13 +2896,14 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             None,
         );
         // declare i64 @lotus_bytes_at_raw(ptr base, i64 len, i64 i)
-        self.module.add_function(
+        let bytes_at_raw_fn = self.module.add_function(
             "lotus_bytes_at_raw",
             i64_t.fn_type(&[ptr_t.into(), i64_t.into(), i64_t.into()], false),
             None,
         );
+        self.mark_pure_read(bytes_at_raw_fn);
         // declare i64 @lotus_bytes_find_byte_raw(ptr base, i64 len, i64 off, i64 needle)
-        self.module.add_function(
+        let bytes_find_byte_raw_fn = self.module.add_function(
             "lotus_bytes_find_byte_raw",
             i64_t.fn_type(
                 &[ptr_t.into(), i64_t.into(), i64_t.into(), i64_t.into()],
@@ -2902,6 +2911,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ),
             None,
         );
+        self.mark_pure_read(bytes_find_byte_raw_fn);
         // MirrorRing runtime: new/free/readable/writable/commit/consume/
         // len/capacity + recv-into-mirror. readable/writable return the
         // {ptr,len} view struct (a BytesMut).

--- a/crates/hale-codegen/tests/pure_read_accessors.rs
+++ b/crates/hale-codegen/tests/pure_read_accessors.rs
@@ -56,7 +56,19 @@ fn attrs_of(ir: &str, sym: &str) -> Option<String> {
 #[test]
 fn indexed_immutable_accessors_are_pure_reads() {
     let ir = builtin_ir("pure_read_idx");
-    for sym in ["lotus_bytes_at", "lotus_str_byte_at"] {
+    for sym in [
+        "lotus_bytes_at",
+        "lotus_str_byte_at",
+        // scanners + predicates over immutable data (strcmp / strncmp /
+        // strstr / memchr / const index) — the HTTP and JSON hot paths
+        "lotus_str_eq",
+        "lotus_str_starts_with",
+        "lotus_str_contains",
+        "lotus_str_index_of",
+        "lotus_bytes_find_byte",
+        "lotus_bytes_find_byte_raw",
+        "lotus_bytes_at_raw",
+    ] {
         let body = attrs_of(&ir, sym)
             .unwrap_or_else(|| panic!("{} should carry an attribute group", sym));
         assert!(
@@ -120,7 +132,17 @@ fn mutable_container_lengths_are_not_pure_reads() {
 #[test]
 fn out_param_and_recency_writing_accessors_are_not_pure_reads() {
     let ir = builtin_ir("pure_read_excl_out");
-    for sym in ["lotus_vec_get", "lotus_hashmap_get", "lotus_lru_get"] {
+    for sym in [
+        "lotus_vec_get",
+        "lotus_hashmap_get",
+        "lotus_lru_get",
+        // `lotus_bytes_read_uint{,_raw}` take an `int64_t *oob` and
+        // write `*oob = 1` on an out-of-bounds read — same rule as
+        // vec_get, and easy to miss because the rest of the body is a
+        // pure load.
+        "lotus_bytes_read_uint",
+        "lotus_bytes_read_uint_raw",
+    ] {
         if let Some(body) = attrs_of(&ir, sym) {
             assert!(
                 !body.contains("memory(read)") && !body.contains("memory(none)"),


### PR DESCRIPTION
Follow-on to #323. Extends the audited pure-read list from the indexed
accessors to the **scanners and predicates**, which is where the HTTP
and JSON hot paths actually live.

| symbol | body |
|---|---|
| `lotus_str_eq` | `strcmp` |
| `lotus_str_starts_with` | `strlen` + `strncmp` |
| `lotus_str_contains` | `strstr` |
| `lotus_str_index_of` | `strstr` |
| `lotus_bytes_find_byte` | `memchr` over a const body |
| `lotus_bytes_find_byte_raw` | `memchr` over a const base |
| `lotus_bytes_at_raw` | const index |

All take `const` pointers, return a scalar, take no lock, and write
nothing — audited against the runtime C rather than inferred from the
name.

## The two that look identical and aren't

`lotus_bytes_read_uint` and `lotus_bytes_read_uint_raw` take an
`int64_t *oob` and write `*oob = 1` on an out-of-bounds read. The rest
of both bodies is a pure load, so the out-parameter is easy to miss —
which is the argument for doing this per-symbol against the C source
instead of deriving it from anything the compiler already computes.
They're now pinned by the exclusion test.

## Evidence

- **Differential run of all 86 example fixtures: identical.** The one
  apparent diff (`20-pinned-core`) is nondeterministic *against
  itself* — the before binary produced two different hashes across
  three runs, and the after binary matches its stable value.
- **1952/1952**, fmt gate clean.
- The negative control from #323 still holds; exclusion coverage now
  includes the `read_uint` pair.

## Not benchmarked

No claim is made about real-world gain here. The *mechanism* was
measured in #323 — a loop-invariant `bytes::at` went **0.78s → 0.00s**
at 1e9 iterations. These symbols are the same class and the same
attribute, but their call sites sit inside stdlib scanners with
varying indices, where the win is CSE and scheduling rather than
hoisting. I did not measure that, and I'd rather say so than imply a
number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)