### PR TITLE
fix: one topic, one identity across a seed boundary (#334, closes #332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ behavior.
 
 ## Unreleased
 
+- **One topic now has one identity across a seed boundary** (#334,
+  closes #332). A qualified topic reference (`relay::Recalled`) kept
+  its qualified form while the declaring seed's own `topic Recalled`
+  was mangled to `__lib_lib_relay_main_Recalled`, and desugaring
+  resolved the two through different paths — the qualified one via
+  `BusSubject::canonical()`, which is *syntactic* and returns the last
+  path segment. One topic became two subjects in the bus graph.
+
+  Everything downstream of that split is fixed together: a library
+  locus subscribing to its own topic now receives an importing
+  application's publish (its handler previously never fired); the
+  library's subscription is no longer reported dead; and `depends:`
+  follows a republisher across a seed, which was explicitly a lower
+  bound when that feature shipped.
+
+  The fix canonicalizes qualified topic references in the same pass
+  and against the same rename table that already canonicalized
+  qualified *type* paths — the bus arm there destructured `{ ty, .. }`
+  and never visited the subject.
+
+  **Behaviour change worth noting:** qualified topics now participate
+  in orphan detection, which they never did. An unqualified topic in
+  the same shape has always warned; five smoke-test binaries in a
+  downstream fleet gain "published but has no subscriber" warnings
+  that are true of those programs. Warnings only — exit codes are
+  unchanged.
+
 - **`hale check` now compares types at call boundaries** (#335). It
   compared types at assignment sites and never at calls, so a
   wrong-typed argument or return reached codegen and surfaced as

--- a/crates/hale-cli/tests/fixtures/xseed-launderer/app/main.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-launderer/app/main.hl
@@ -49,8 +49,14 @@ main locus App {
         c: Compute = Compute { };
         s: StatedCarry = StatedCarry { };
         k: Sink = Sink { };
+        // the launderer itself, one seed away
+        r: relay::Launderer = relay::Launderer { };
     }
     birth() { self.c.emit(42.0); }
+    // Observable end-to-end: the magnitude only reaches `recalled` by
+    // travelling app -> lib (SumLookup) -> lib republish (Recalled)
+    // -> app. Read at dissolve so the bus has dispatched.
+    dissolve() { println("final carry = ", self.s.recalled); }
 }
 
 fn main() { App { }; }

--- a/crates/hale-cli/tests/xseed_topic_identity.rs
+++ b/crates/hale-cli/tests/xseed_topic_identity.rs
@@ -1,0 +1,124 @@
+//! One topic must have one identity across a seed boundary (#334/#332).
+//!
+//! A qualified topic reference (`relay::Recalled`) kept its qualified
+//! form while the declaring seed's own `topic Recalled` was mangled to
+//! `__lib_lib_relay_main_Recalled`. Desugaring resolved the two
+//! through different paths — the qualified one via
+//! `BusSubject::canonical()`, which is SYNTACTIC and returns the last
+//! path segment — so one topic became two subjects in the bus graph.
+//!
+//! Consequences, all from that single split:
+//!   - a library locus subscribing to its own topic never received an
+//!     importing application's publish (the handler simply never fired)
+//!   - the bus graph reported the library's subscription as dead
+//!   - qualified topics were invisible to orphan detection, while
+//!     unqualified ones in the same shape were reported
+//!   - `depends:` could not follow a republisher across a seed
+//!
+//! The fix canonicalizes qualified topic references in the same pass
+//! and against the same rename table that already canonicalized
+//! qualified TYPE paths — the bus arm there destructured `{ ty, .. }`
+//! and never visited the subject.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn fixture(sub: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/xseed-launderer")
+        .join(sub)
+}
+
+fn run(cmd: &str, dir: PathBuf) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg(cmd)
+        .arg(dir)
+        .output()
+        .expect("invoke hale");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+/// The whole chain: the app publishes to a topic the LIBRARY declares,
+/// the library's own subscriber fires, and its republish reaches back
+/// into an app-side subscriber.
+#[test]
+fn a_library_subscriber_receives_an_applications_publish() {
+    let out = run("run", fixture("app"));
+    assert!(
+        out.contains("final carry = 42"),
+        "the laundered value must cross both seed boundaries: {}",
+        out
+    );
+}
+
+/// The graph-level symptom: before the fix the library's subscription
+/// was reported dead, because the app's publish landed on a different
+/// subject node.
+#[test]
+fn the_librarys_subscription_is_not_reported_dead() {
+    let out = run("check", fixture("app"));
+    assert!(
+        !out.contains("subscribed but never published"),
+        "one topic must be one node in the bus graph: {}",
+        out
+    );
+    assert!(out.contains("typechecked"), "fixture should check: {}", out);
+}
+
+/// The `depends:` closure could not cross a seed. It was explicitly a
+/// LOWER BOUND when that feature shipped; topic identity closes it,
+/// and the diagnostic still names the path through the republisher.
+#[test]
+fn depends_follows_a_republisher_across_a_seed() {
+    // Copy the fixture rather than patching it in place: nextest runs
+    // these in parallel, and mutating a shared fixture made the other
+    // two tests in this file observe the patched copy.
+    let src = fixture("");
+    let tmp = std::env::temp_dir().join(format!(
+        "hale_xseed_depends_{}_{}",
+        std::process::id(),
+        line!()
+    ));
+    let _ = std::fs::remove_dir_all(&tmp);
+    copy_tree(&src, &tmp);
+
+    let app = tmp.join("app/main.hl");
+    let original = std::fs::read_to_string(&app).expect("read fixture copy");
+    let patched = original.replace(
+        "locus StatedCarry {",
+        "@effects(depends: {relay::Recalled})\nlocus StatedCarry {",
+    );
+    assert_ne!(patched, original, "anchor for the depends clause moved");
+    std::fs::write(&app, &patched).expect("write fixture copy");
+
+    let out = run("check", tmp.join("app"));
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    assert!(
+        out.contains("declared dependency set violated"),
+        "a dependence laundered through another seed must be caught: {}",
+        out
+    );
+    assert!(
+        out.contains("SumLookup") && out.contains("Launderer"),
+        "and the path must name the cross-seed republisher: {}",
+        out
+    );
+}
+
+fn copy_tree(from: &std::path::Path, to: &std::path::Path) {
+    std::fs::create_dir_all(to).expect("mkdir");
+    for e in std::fs::read_dir(from).expect("read_dir") {
+        let e = e.expect("entry");
+        let dst = to.join(e.file_name());
+        if e.file_type().expect("ft").is_dir() {
+            copy_tree(&e.path(), &dst);
+        } else {
+            std::fs::copy(e.path(), dst).expect("copy");
+        }
+    }
+}

--- a/crates/hale-codegen/src/mangle.rs
+++ b/crates/hale-codegen/src/mangle.rs
@@ -173,6 +173,101 @@ struct QualifiedRenameApplier<'a> {
 }
 
 impl<'a> QualifiedRenameApplier<'a> {
+    /// #334 / #332: canonicalize a QUALIFIED topic reference the same
+    /// way a qualified type path is canonicalized.
+    ///
+    /// Without this, `subscribe relay::Recalled` kept its qualified
+    /// form while the declaring seed's own `topic Recalled` was
+    /// mangled to `__lib_lib_relay_main_Recalled`. Desugaring then
+    /// resolved the two through different paths — the qualified one
+    /// via `BusSubject::canonical()`, which is syntactic and returns
+    /// the last segment — so ONE topic became TWO subjects in the bus
+    /// graph, and a publisher on one side never reached a subscriber
+    /// on the other.
+    ///
+    /// The bus arm here already rewrote the payload TYPE and
+    /// destructured `{ ty, .. }`, so the subject was simply never
+    /// visited.
+    fn rewrite_bus_subject(&self, subject: &mut BusSubject) {
+        let BusSubject::QualifiedTopic(qn) = subject else { return };
+        if qn.segments.len() < 2 {
+            return;
+        }
+        let segs: Vec<String> =
+            qn.segments.iter().map(|s| s.name.clone()).collect();
+        for (key, mangled) in self.renames {
+            if key.len() == segs.len()
+                && key.iter().zip(segs.iter()).all(|(k, p)| k == p)
+            {
+                let span = qn.segments[0].span;
+                *subject = BusSubject::Topic(Ident {
+                    name: mangled.clone(),
+                    span,
+                });
+                return;
+            }
+        }
+    }
+
+    /// #334: canonicalize a qualified SEND subject.
+    ///
+    /// `relay::SumLookup <- v` parses as
+    /// `Path2 { receiver: Ident("relay"), name: Ident("SumLookup") }`,
+    /// and desugar only rewrites the `Expr::Ident` form, so a
+    /// qualified send never became the topic's wire subject while the
+    /// declaring seed's own reference did. Rewriting it here — the
+    /// same pass and table that canonicalizes the `bus {}` block —
+    /// keeps the two ends of one topic on one identity.
+    fn rewrite_sends_in_block(&self, b: &mut Block) {
+        for s in &mut b.stmts {
+            self.rewrite_sends_in_stmt(s);
+        }
+    }
+
+    fn rewrite_sends_in_if(&self, i: &mut IfStmt) {
+        self.rewrite_sends_in_block(&mut i.then_block);
+        if let Some(e) = &mut i.else_block {
+            match e.as_mut() {
+                ElseBranch::Else(b) => self.rewrite_sends_in_block(b),
+                // Recurse on the branch IN PLACE. Cloning into a
+                // temporary `Stmt::If` compiles and silently discards
+                // every rewrite in the else-if chain.
+                ElseBranch::ElseIf(inner) => self.rewrite_sends_in_if(inner),
+            }
+        }
+    }
+
+    fn rewrite_sends_in_stmt(&self, s: &mut Stmt) {
+        match s {
+            Stmt::Send { subject, .. } => {
+                let Expr::Path(qn) = subject else { return };
+                if qn.segments.len() < 2 {
+                    return;
+                }
+                let segs: Vec<String> =
+                    qn.segments.iter().map(|s| s.name.clone()).collect();
+                for (key, mangled) in self.renames {
+                    if key.len() == segs.len()
+                        && key.iter().zip(segs.iter()).all(|(k, p)| k == p)
+                    {
+                        let span = qn.segments[0].span;
+                        *subject = Expr::Ident(Ident {
+                            name: mangled.clone(),
+                            span,
+                        });
+                        return;
+                    }
+                }
+            }
+            Stmt::If(i) => self.rewrite_sends_in_if(i),
+            Stmt::While { body, .. } | Stmt::For { body, .. } => {
+                self.rewrite_sends_in_block(body)
+            }
+            Stmt::Block(b) => self.rewrite_sends_in_block(b),
+            _ => {}
+        }
+    }
+
     fn rewrite_type_expr(&self, t: &mut TypeExpr) {
         match t {
             TypeExpr::Primitive(_, _) => {}
@@ -345,15 +440,17 @@ impl<'a> QualifiedRenameApplier<'a> {
             LocusMember::Bus(bb) => {
                 for m in &mut bb.members {
                     match m {
-                        BusMember::Subscribe { ty, .. } => {
+                        BusMember::Subscribe { ty, subject, .. } => {
                             if let Some(t) = ty {
                                 self.rewrite_type_expr(t);
                             }
+                            self.rewrite_bus_subject(subject);
                         }
-                        BusMember::Publish { ty, .. } => {
+                        BusMember::Publish { ty, subject, .. } => {
                             if let Some(t) = ty {
                                 self.rewrite_type_expr(t);
                             }
+                            self.rewrite_bus_subject(subject);
                         }
                     }
                 }
@@ -362,6 +459,7 @@ impl<'a> QualifiedRenameApplier<'a> {
                 for p in &mut lc.params {
                     self.rewrite_type_expr(&mut p.ty);
                 }
+                self.rewrite_sends_in_block(&mut lc.body);
             }
             LocusMember::Mode(md) => {
                 if let Some(r) = &mut md.ret {
@@ -374,6 +472,7 @@ impl<'a> QualifiedRenameApplier<'a> {
                 }
             }
             LocusMember::Fn(fd) => {
+                self.rewrite_sends_in_block(&mut fd.body);
                 for p in &mut fd.params {
                     self.rewrite_type_expr(&mut p.ty);
                 }


### PR DESCRIPTION
First half of #334, and it closes #332.

## The split

```
app:  subscribe relay::Recalled   ->  canonical() = "Recalled"
lib:  topic Recalled              ->  __lib_lib_relay_main_Recalled
```

`BusSubject::canonical()` is **syntactic** — it returns the last path
segment — so it stood where a semantic resolution belonged. One topic
became two subjects in the bus graph.

## Four symptoms, one cause

- a library locus subscribing to its own topic **never received** an
  importing application's publish; the handler simply never fired
- the bus graph reported that subscription as **dead**
- qualified topics were **invisible to orphan detection** while
  unqualified ones in the same shape were reported
- **`depends:` could not follow a republisher across a seed** — called
  out as a lower bound when that feature shipped yesterday

All fixed together, which is the argument #334 makes: these were never
four bugs.

## The fix

Canonicalize qualified topic references in the same pass and against
the same rename table that already canonicalized qualified *type*
paths. The bus arm there destructured `{ ty, .. }` — it rewrote the
payload type and never visited the subject.

Send statements needed the same treatment: `relay::T <- v` parses as
`Expr::Path`, and desugar only rewrote the `Expr::Ident` form. That
meant teaching the walker to descend into fn and lifecycle bodies.

## Behaviour change: qualified topics now get orphan warnings

Five smoke-test binaries in a downstream fleet gain "published but has
no subscriber" warnings. They are **true** of those programs — they
publish to another binary.

I checked whether this invents a rule or applies an existing one: an
**unqualified** topic in the identical shape already warned, both
before and after this change. So qualified topics were the exception,
and this makes them consistent. Warnings only; exit codes unchanged.

## Verification

- **End-to-end**: app publishes to a library topic → library handler
  fires → its republish reaches an app subscriber (`final carry = 42`)
- **`depends:` across a seed**: catches the launderer, names the path
  `SumLookup -> Launderer -> Recalled -> StatedCarry`
- **442 files** across a downstream fleet and pond: no new errors
- **1976/1976**, fmt gate clean

The new tests copy the fixture rather than patching it in place —
nextest runs them in parallel, and a first cut had one test mutating
the shared fixture out from under the other two.

## Not in this PR

`InstanceId` — the other half of #334 (#333, and the shared-state
`depends:` edge). That one needs new machinery rather than finishing
something half-applied, and it has a scope limit worth designing
deliberately: only the static params-init tower has static identity,
which is exactly the domain placement already operates on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)