### PR TITLE
feat: report a locus aliased into two differently-placed towers (#334/#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ behavior.
 
 ## Unreleased
 
+- **Aliasing one locus into two differently-placed towers is now
+  reported** (#334, #333). F.31 keeps a locus's methods on one pool's
+  thread, but reasons per *field declaration*: each holder correctly
+  concludes it owns its own field, and nothing related the two
+  declarations back to the single object they both name. Two pinned
+  workers each doing 100k increments on one shared locus produced
+  ~140k of 200k with `hale check` reporting `ok`.
+
+  A **warning, not an error**, deliberately. The sanctioned way to
+  share across pools is a `@form(..., sync = ...)` locus, and a plain
+  locus whose mutable state sits entirely behind such fields is a
+  legitimate design — two applications in a downstream fleet do
+  exactly that, with the reasoning written above their placement
+  block. Distinguishing those from a real race needs a declared
+  shared-locus surface; until that exists, reporting without failing
+  the build is the honest position.
+
+  Scoped to the static params-init tower of the main locus, which is
+  the domain placement already operates on. Instances created
+  dynamically inherit their creator's pool and are not this shape.
+
 - **One topic now has one identity across a seed boundary** (#334,
   closes #332). A qualified topic reference (`relay::Recalled`) kept
   its qualified form while the declaring seed's own `topic Recalled`

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -391,6 +391,9 @@ pub fn check_bundle(
     // not a direct method call. See spec/types.md
     // § "Single-threaded-method invariant (F.31)".
     check_placement_single_thread(bundle, top, &mut diags);
+    // #334 / #333: F.31 above reasons per field DECLARATION, so it
+    // cannot see one instance aliased into two towers.
+    check_instance_aliasing(bundle, &mut diags);
     // F.31-followup (2026-05-28): the nested-long-running-child
     // antipattern. A non-main locus whose `run()` body has work
     // to do, holding a params field of a locus type whose own
@@ -11710,5 +11713,154 @@ fn lit_ty(lit: &Literal) -> Ty {
         Literal::Duration(_) => Ty::Prim(PrimType::Duration),
         Literal::Time(_) => Ty::Prim(PrimType::Time),
         Literal::Bytes(_) => Ty::Prim(PrimType::Bytes),
+    }
+}
+
+/// #334 / #333: one locus instance may not be shared by two
+/// main-locus fields placed on different pools.
+///
+/// F.31 keeps a locus's methods on its own pool's thread, but it
+/// reasons per FIELD DECLARATION: for `self.s.bump()` inside
+/// `WorkerA`, `s` has no placement entry of its own so it inherits
+/// WorkerA's pool, and WorkerB reasons identically about its own `s`.
+/// Neither is wrong about its own field — they are wrong about each
+/// other, and nothing related the two declarations back to the single
+/// object they both name.
+///
+/// The result was a silent data race: two pinned workers mutating one
+/// locus lost ~30% of their writes with `hale check` reporting `ok`.
+///
+/// Scope, deliberately: the STATIC params-init tower of the main
+/// locus. Instances created dynamically (in a loop, via `accept()`)
+/// have no static identity to reason about, and they inherit their
+/// creator's pool, so they are not the shape this protects.
+fn check_instance_aliasing(
+    bundle: &Bundle,
+    diags: &mut Vec<Diag>,
+) {
+    let mut main: Option<&LocusDecl> = None;
+    for program in bundle.programs.values() {
+        for item in &program.items {
+            if let TopDecl::Locus(l) = item {
+                if l.is_main {
+                    main = Some(l);
+                }
+            }
+        }
+    }
+    let Some(main) = main else { return };
+
+    let placement: BTreeMap<String, PoolId> = main
+        .members
+        .iter()
+        .find_map(|m| match m {
+            LocusMember::Placement(pb) => Some(pb),
+            _ => None,
+        })
+        .map(|pb| {
+            pb.entries
+                .iter()
+                .map(|e| {
+                    (
+                        e.field.name.clone(),
+                        placement_spec_to_pool(&e.spec, &e.field.name),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let Some(params) = main.members.iter().find_map(|m| match m {
+        LocusMember::Params(pb) => Some(pb),
+        _ => None,
+    }) else {
+        return;
+    };
+
+    // shared field -> [(holder field, pool, span)]
+    let mut holders: BTreeMap<String, Vec<(String, PoolId, Span)>> =
+        BTreeMap::new();
+    for p in &params.params {
+        let ParamInit::Value(init) = &p.init else { continue };
+        let pool = placement
+            .get(&p.name.name)
+            .cloned()
+            .unwrap_or(PoolId::Cooperative("main".to_string()));
+        let mut refs = Vec::new();
+        collect_self_field_refs(init, &mut refs);
+        for r in refs {
+            holders.entry(r).or_default().push((
+                p.name.name.clone(),
+                pool.clone(),
+                p.span,
+            ));
+        }
+    }
+
+    for (shared, hs) in &holders {
+        if hs.len() < 2 {
+            continue;
+        }
+        let first_pool = &hs[0].1;
+        if let Some(other) =
+            hs.iter().find(|(_, pool, _)| pool != first_pool)
+        {
+            // A WARNING, not an error, and deliberately so. The
+            // sanctioned way to share state across pools is a
+            // `@form(..., sync = ...)` locus, and a plain locus whose
+            // mutable state sits entirely behind such fields is a
+            // legitimate design — two applications in a downstream
+            // fleet do exactly that, with the reasoning written in a
+            // comment above their placement block.
+            //
+            // Distinguishing "all mutable state is synchronized" from
+            // "this races" needs the declared shared-locus surface
+            // discussed on #333; until that exists, reporting the
+            // aliasing without failing the build is the honest
+            // position. The race it points at is real: two pinned
+            // workers mutating one plain locus lose ~30% of their
+            // writes.
+            diags.push(Diag::warn(
+                other.2,
+                format!(
+                    "locus `self.{}` is shared by `{}` and `{}`, which are \
+                     placed on different pools, so its methods can run on \
+                     both threads. F.31 keeps a locus's methods on ONE \
+                     pool, and that guarantee reasons per field \
+                     declaration — it does not survive aliasing one \
+                     instance into two towers. This is safe only if every \
+                     mutable field is behind a `sync = ...` form; \
+                     otherwise give each holder its own instance or \
+                     coordinate through the bus.",
+                    shared, hs[0].0, other.0
+                ),
+            ));
+        }
+    }
+}
+
+/// `self.<field>` references appearing as values inside a locus
+/// initializer, which is how one instance reaches two towers.
+fn collect_self_field_refs(e: &Expr, out: &mut Vec<String>) {
+    match e {
+        Expr::Field { receiver, name, .. }
+        | Expr::Path2 { receiver, name, .. } => {
+            if matches!(receiver.as_ref(), Expr::KwSelf(_)) {
+                out.push(name.name.clone());
+            } else {
+                collect_self_field_refs(receiver, out);
+            }
+        }
+        Expr::Struct { inits, .. } => {
+            for f in inits {
+                collect_self_field_refs(&f.value, out);
+            }
+        }
+        Expr::Call { args, .. } => {
+            for a in args {
+                collect_self_field_refs(a, out);
+            }
+        }
+        _ => {}
     }
 }

--- a/crates/hale-types/tests/instance_aliasing.rs
+++ b/crates/hale-types/tests/instance_aliasing.rs
@@ -1,0 +1,122 @@
+//! One locus instance shared by two differently-placed towers (#333,
+//! the `InstanceId` half of #334).
+//!
+//! F.31 keeps a locus's methods on its own pool's thread, but reasons
+//! per FIELD DECLARATION: for `self.s.bump()` inside `WorkerA`, `s`
+//! inherits WorkerA's pool, and WorkerB reasons identically about its
+//! own `s`. Neither is wrong about its own field — they are wrong
+//! about each other, and nothing related the two declarations back to
+//! the single object they both name.
+//!
+//! Measured consequence before this: two pinned workers each doing
+//! 100k increments on one shared locus produced ~140k of 200k, with
+//! `hale check` reporting `ok`.
+
+use hale_syntax::error::DiagKind;
+use hale_syntax::parse_source;
+
+fn diags(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+const SHARED: &str = "\
+locus Shared { params { n: Int = 0; } fn bump() { self.n = self.n + 1; } }
+locus A { params { s: Shared = Shared { }; } run() { self.s.bump(); } }
+locus B { params { s: Shared = Shared { }; } run() { self.s.bump(); } }
+";
+
+#[test]
+fn aliasing_into_two_pools_is_reported() {
+    let src = format!(
+        "{SHARED}
+main locus App {{
+    params {{ sh: Shared = Shared {{ }};
+             a: A = A {{ s: self.sh }};
+             b: B = B {{ s: self.sh }}; }}
+    placement {{ a: pinned(core = 0); b: pinned(core = 1); }}
+}}
+fn main() {{ App {{ }}; }}"
+    );
+    let ds = diags(&src);
+    let hit = ds
+        .iter()
+        .find(|m| m.contains("is shared by"))
+        .unwrap_or_else(|| panic!("cross-pool aliasing must be reported: {:?}", ds));
+    assert!(
+        hit.contains("self.sh") && hit.contains('a') && hit.contains('b'),
+        "the report must name the instance and both holders: {}",
+        hit
+    );
+}
+
+/// Sharing within ONE pool is ordinary composition — handler
+/// serialization already orders the accesses.
+#[test]
+fn aliasing_within_one_pool_is_fine() {
+    let src = format!(
+        "{SHARED}
+main locus App {{
+    params {{ sh: Shared = Shared {{ }};
+             a: A = A {{ s: self.sh }};
+             b: B = B {{ s: self.sh }}; }}
+}}
+fn main() {{ App {{ }}; }}"
+    );
+    assert!(
+        !diags(&src).iter().any(|m| m.contains("is shared by")),
+        "same-pool sharing must not be reported"
+    );
+}
+
+#[test]
+fn a_single_holder_is_fine_however_it_is_placed() {
+    let src = format!(
+        "{SHARED}
+main locus App {{
+    params {{ sh: Shared = Shared {{ }}; a: A = A {{ s: self.sh }}; }}
+    placement {{ a: pinned(core = 0); }}
+}}
+fn main() {{ App {{ }}; }}"
+    );
+    assert!(
+        !diags(&src).iter().any(|m| m.contains("is shared by")),
+        "one holder cannot race with itself"
+    );
+}
+
+/// A WARNING, not an error. The sanctioned way to share across pools
+/// is a `@form(..., sync = ...)` locus, and a plain locus whose
+/// mutable state sits entirely behind such fields is a legitimate
+/// design — two applications in a downstream fleet do exactly that.
+/// Distinguishing those needs the declared shared-locus surface
+/// discussed on #333; until then this reports without failing builds.
+#[test]
+fn the_report_does_not_fail_the_build() {
+    let src = format!(
+        "{SHARED}
+main locus App {{
+    params {{ sh: Shared = Shared {{ }};
+             a: A = A {{ s: self.sh }};
+             b: B = B {{ s: self.sh }}; }}
+    placement {{ a: pinned(core = 0); b: pinned(core = 1); }}
+}}
+fn main() {{ App {{ }}; }}"
+    );
+    let program = parse_source(&src).expect("parse");
+    let ds = hale_types::check_program(&program);
+    assert!(
+        ds.iter().any(|d| d.message.contains("is shared by")),
+        "the aliasing should still be surfaced"
+    );
+    assert!(
+        !ds.iter().any(|d| {
+            d.message.contains("is shared by")
+                && matches!(d.kind, DiagKind::Type)
+        }),
+        "but as a warning, not a type error"
+    );
+}


### PR DESCRIPTION
Second half of #334, addressing #333.

## The gap

F.31 keeps a locus's methods on its own pool's thread, but reasons per
**field declaration**. For `self.s.bump()` inside `WorkerA`, `s` has no
placement entry of its own so it inherits WorkerA's pool; `WorkerB`
reasons identically about its own `s`.

**Neither is wrong about its own field. They are wrong about each
other**, and nothing related the two declarations back to the single
object they both name.

Measured before this: two pinned workers each doing 100k increments on
one shared locus produced **~140k of 200k**, with `hale check`
reporting `ok`.

## A warning, not an error — and that is the substance

The sanctioned way to share across pools is a `@form(..., sync = ...)`
locus, and a plain locus whose mutable state sits entirely behind such
fields is a legitimate design.

Scanning a downstream fleet found exactly **two** programs doing this,
**both deliberate**. One has the reasoning in a comment directly above
its placement block:

> `http::Server` on `io` — cross-pool read into the registry's
> **sync=serialized** MetricMap

An error would have broken two working programs whose authors reasoned
about the hazard more carefully than this check can. Distinguishing
"all mutable state is synchronized" from "this races" needs the
declared shared-locus surface discussed on #333; until then, reporting
without failing the build is the honest position.

## Scope is deliberate

The static params-init tower of the main locus — exactly the domain
placement already operates on. Dynamically created instances (in a
loop, via `accept()`) have no static identity and inherit their
creator's pool, so they are not this shape.

The analysis **cannot** be total, and I would rather write the limit
down than have someone discover it.

## Verification

- the #333 reproducer is reported
- same-pool sharing and single-holder placement stay silent
- **534 files** across a downstream fleet, pond and the example corpus:
  2 flagged, both deliberate, both still building
- failure counts **unchanged at 57 before and after** (all pre-existing)
- **1980/1980**

## What this leaves

#333 stays open: this reports the hazard, it does not close it. The
closing move is the declared shared-locus surface, which also needs
this instance identity to be checkable — so the ordering was forced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)