### PR TITLE
feat: @shared locus — a declared coordination primitive (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ behavior.
 
 ## Unreleased
 
+- **`@shared locus` — a declared coordination primitive** (#333).
+  F.31 reasons per field declaration, so it cannot tell a deliberate
+  cross-pool registry from an accidental alias; both look like one
+  instance reachable from two towers. `@shared` is how the author says
+  which one it is, and two checked restraints make that a claim rather
+  than a label: no `bus {}` block (pub/sub names what a system
+  *means*, this role is mechanical), and no direct assignment to its
+  own fields (mutable state belongs to a field whose own form carries
+  a sync discipline).
+
+  A locus so declared may be reached from several pools without the
+  aliasing report; an undeclared one in the identical shape is still
+  reported, or the annotation would be decoration.
+
+  **What it does not do** is prove every field is synchronized.
+  `@form(vec)` has no sync discipline in v1 — a real registry in a
+  downstream fleet holds one `sync = serialized` map beside an
+  unsynchronized vec — so that proof is not yet expressible. The
+  annotation pins the shape and keeps the gap reviewable; the stricter
+  form becomes available once vec has a discipline to name.
+
 - **Aliasing one locus into two differently-placed towers is now
   reported** (#334, #333). F.31 keeps a locus's methods on one pool's
   thread, but reasons per *field declaration*: each holder correctly

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -10497,6 +10497,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             phase_effects: None,
             depends: None,
             supervised: false,
+            shared: false,
             name: Ident {
                 name: mangled_name.to_string(),
                 span: template.name.span.clone(),

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -342,6 +342,22 @@ pub struct LocusDecl {
     /// have a failure policy in scope. Supervision coverage as a
     /// checked property.
     pub supervised: bool,
+    /// #333: `@shared` — a COORDINATION PRIMITIVE, not a domain
+    /// participant. Declares that this locus is reachable from more
+    /// than one pool BY DESIGN, which F.31's per-field-declaration
+    /// reasoning cannot otherwise distinguish from an accidental
+    /// alias.
+    ///
+    /// The restraints are what make it meaningful, and both are
+    /// checked: no `bus {}` block (pub/sub is domain-oriented, this
+    /// role is mechanical), and no direct assignment to its own
+    /// fields (mutable state belongs to the fields' own
+    /// disciplines, e.g. `@form(hashmap, sync = serialized)`).
+    ///
+    /// It declares intent and pins the shape. It does NOT prove the
+    /// fields are individually synchronized — `@form(vec)` has no
+    /// sync discipline in v1, so that proof is not yet expressible.
+    pub shared: bool,
     pub members: Vec<LocusMember>,
     pub span: Span,
 }

--- a/crates/hale-syntax/src/desugar.rs
+++ b/crates/hale-syntax/src/desugar.rs
@@ -124,6 +124,7 @@ pub fn wrap_main_as_wasm_export(program: &mut Program) -> bool {
         phase_effects: None,
         depends: None,
             supervised: false,
+            shared: false,
         name: Ident { name: "__Main".to_string(), span: main_span },
         is_main: false,
         export: true,

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -356,6 +356,8 @@ impl Parser {
         // RFC #330
         let mut depends: Option<DependsSet> = None;
         let mut supervised_locus = false;
+        // #333
+        let mut shared_locus = false;
         let mut leading_span: Option<Span> = None;
         loop {
             if !matches!(self.peek(), TokenKind::At) {
@@ -379,6 +381,10 @@ impl Parser {
             // GH #265: `@supervised locus` — supervision coverage.
             let is_supervised = matches!(&kind_tok,
                 TokenKind::Ident(s) if s == "supervised");
+            // #333: `@shared locus` — a coordination primitive,
+            // reachable from more than one pool by design.
+            let is_shared = matches!(&kind_tok,
+                TokenKind::Ident(s) if s == "shared");
             let is_unbounded =
                 matches!(&kind_tok, TokenKind::Ident(s) if s == "unbounded");
             let is_budget =
@@ -452,6 +458,16 @@ impl Parser {
                 let mut fn_decl = self.parse_fn_decl_with_ffi(Some(ffi.clone()), false)?;
                 fn_decl.span = ffi.span.merge(fn_decl.span);
                 return Ok(TopDecl::Fn(fn_decl));
+            }
+            if is_shared {
+                let at = self.expect(TokenKind::At, "@")?;
+                self.bump();
+                shared_locus = true;
+                leading_span = Some(match leading_span {
+                    Some(s) => s.merge(at.span),
+                    None => at.span,
+                });
+                continue;
             }
             if is_supervised {
                 let at = self.expect(TokenKind::At, "@")?;
@@ -704,6 +720,7 @@ impl Parser {
         }
         if form.is_some() || locality.is_some() || export_locus || bounded_locus
             || phase_effects.is_some() || supervised_locus || depends.is_some()
+            || shared_locus
         {
             // Verify a `locus` (or contextual `main locus`)
             // follows.
@@ -730,6 +747,7 @@ impl Parser {
             locus.phase_effects = phase_effects;
             locus.depends = depends;
             locus.supervised = supervised_locus;
+            locus.shared = shared_locus;
             return Ok(TopDecl::Locus(locus));
         }
         match self.peek() {
@@ -1892,6 +1910,7 @@ impl Parser {
             phase_effects: None,
             depends: None,
             supervised: false,
+            shared: false,
             name,
             is_main,
             export: false,

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -394,6 +394,8 @@ pub fn check_bundle(
     // #334 / #333: F.31 above reasons per field DECLARATION, so it
     // cannot see one instance aliased into two towers.
     check_instance_aliasing(bundle, &mut diags);
+    // #333: the restraints that make `@shared` a claim.
+    check_shared_locus(bundle, &mut diags);
     // F.31-followup (2026-05-28): the nested-long-running-child
     // antipattern. A non-main locus whose `run()` body has work
     // to do, holding a params field of a locus type whose own
@@ -11777,6 +11779,32 @@ fn check_instance_aliasing(
         return;
     };
 
+    // #333: a locus DECLARED `@shared` is a coordination primitive —
+    // being reached from several pools is its purpose, and the
+    // restraints checked in `check_shared_locus` are what make that
+    // claim mean something. Only accidental aliasing is reported.
+    let shared_types: BTreeSet<String> = bundle
+        .programs
+        .values()
+        .flat_map(|p| p.items.iter())
+        .filter_map(|i| match i {
+            TopDecl::Locus(l) if l.shared => Some(l.name.name.clone()),
+            _ => None,
+        })
+        .collect();
+    let declared_shared: BTreeSet<String> = params
+        .params
+        .iter()
+        .filter(|p| {
+            p.ty.as_ref().is_some_and(|te| {
+                matches!(te, TypeExpr::Named { path, .. }
+                    if path.segments.last().is_some_and(|s|
+                        shared_types.contains(&s.name)))
+            })
+        })
+        .map(|p| p.name.name.clone())
+        .collect();
+
     // shared field -> [(holder field, pool, span)]
     let mut holders: BTreeMap<String, Vec<(String, PoolId, Span)>> =
         BTreeMap::new();
@@ -11798,7 +11826,7 @@ fn check_instance_aliasing(
     }
 
     for (shared, hs) in &holders {
-        if hs.len() < 2 {
+        if hs.len() < 2 || declared_shared.contains(shared) {
             continue;
         }
         let first_pool = &hs[0].1;
@@ -11861,6 +11889,117 @@ fn collect_self_field_refs(e: &Expr, out: &mut Vec<String>) {
                 collect_self_field_refs(a, out);
             }
         }
+        _ => {}
+    }
+}
+
+/// #333: the restraints that make `@shared` a claim rather than a
+/// label.
+///
+/// A shared locus is a COORDINATION PRIMITIVE — its whole role is
+/// mediated access to state reachable from more than one pool. Two
+/// rules follow from that role and both are checked:
+///
+///   1. No `bus {}` block. Pub/sub is domain-oriented and names what
+///      a system MEANS; this role is mechanical and names what it
+///      DOES. A locus is one or the other, never both. Enforcing the
+///      split also keeps the bus graph free of nodes that exist for
+///      plumbing reasons.
+///   2. No direct assignment to its own fields. Mutable state belongs
+///      to the fields' own disciplines — `@form(hashmap, sync =
+///      serialized)` and friends — not to a bare `self.n = ...` that
+///      two threads can execute at once.
+///
+/// What this does NOT do is prove every field is individually
+/// synchronized. `@form(vec)` has no sync discipline in v1, so that
+/// proof is not yet expressible; a real registry in a downstream
+/// fleet holds one synchronized map and one unsynchronized vec. The
+/// annotation declares the intent and pins the shape so the gap is
+/// reviewable, and the stricter form becomes available once vec has a
+/// discipline to name.
+fn check_shared_locus(bundle: &Bundle, diags: &mut Vec<Diag>) {
+    for program in bundle.programs.values() {
+        for item in &program.items {
+            let TopDecl::Locus(l) = item else { continue };
+            if !l.shared {
+                continue;
+            }
+            for m in &l.members {
+                match m {
+                    LocusMember::Bus(bb) => {
+                        diags.push(Diag::ty(
+                            bb.span,
+                            format!(
+                                "`@shared locus {}` may not declare a `bus \
+                                 {{}}` block. A shared locus is a \
+                                 coordination primitive — its role is \
+                                 mechanical, and pub/sub is where a system \
+                                 says what it MEANS. Split the two: keep \
+                                 the shared state here and put the \
+                                 subscriptions on a domain locus that \
+                                 holds it.",
+                                l.name.name
+                            ),
+                        ));
+                    }
+                    LocusMember::Fn(fd) => {
+                        collect_self_assign_spans(&fd.body, &mut |span| {
+                            diags.push(Diag::ty(
+                                span,
+                                format!(
+                                    "`@shared locus {}` may not assign to \
+                                     its own fields. It is reachable from \
+                                     more than one pool, so a bare \
+                                     assignment is a race; hold mutable \
+                                     state in a field whose own form \
+                                     carries a sync discipline (e.g. \
+                                     `@form(hashmap, sync = serialized)`) \
+                                     and mutate it through that.",
+                                    l.name.name
+                                ),
+                            ));
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn collect_self_assign_spans(b: &Block, f: &mut impl FnMut(Span)) {
+    for s in &b.stmts {
+        collect_self_assign_in_stmt(s, f);
+    }
+}
+
+fn collect_self_assign_in_stmt(s: &Stmt, f: &mut impl FnMut(Span)) {
+    match s {
+        Stmt::Assign { target, span, .. } => {
+            // `self.n = ...` is head `self` with a field tail. A bare
+            // `n = ...` (head only) is a local, not shared state.
+            if target.head.name == "self" && !target.tail.is_empty() {
+                f(*span);
+            }
+        }
+        Stmt::If(i) => {
+            collect_self_assign_spans(&i.then_block, f);
+            if let Some(e) = &i.else_block {
+                match e.as_ref() {
+                    ElseBranch::Else(b) => collect_self_assign_spans(b, f),
+                    ElseBranch::ElseIf(inner) => {
+                        collect_self_assign_in_stmt(
+                            &Stmt::If(inner.clone()),
+                            f,
+                        );
+                    }
+                }
+            }
+        }
+        Stmt::While { body, .. } | Stmt::For { body, .. } => {
+            collect_self_assign_spans(body, f)
+        }
+        Stmt::Block(b) => collect_self_assign_spans(b, f),
         _ => {}
     }
 }

--- a/crates/hale-types/tests/shared_locus.rs
+++ b/crates/hale-types/tests/shared_locus.rs
@@ -1,0 +1,137 @@
+//! `@shared locus` — a declared coordination primitive (#333).
+//!
+//! F.31 reasons per field declaration, so it cannot tell a deliberate
+//! cross-pool registry from an accidental alias. Both look like one
+//! instance reachable from two towers. `@shared` is how the author
+//! says which one it is, and the restraints are what make that a
+//! claim rather than a label.
+//!
+//! What it does NOT do is prove every field is synchronized.
+//! `@form(vec)` has no sync discipline in v1 — a real registry in a
+//! downstream fleet holds one `sync = serialized` map beside an
+//! unsynchronized vec — so that proof is not yet expressible. The
+//! annotation pins the shape and keeps the gap reviewable.
+
+use hale_syntax::parse_source;
+
+fn diags(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+/// Pub/sub is domain-oriented and names what a system MEANS; a
+/// coordination primitive is mechanical and names what it DOES. A
+/// locus is one or the other.
+#[test]
+fn a_shared_locus_may_not_be_a_bus_participant() {
+    let ds = diags(
+        "type P { n: Int; }\n\
+         topic T { payload: P; }\n\
+         @shared\n\
+         locus R { params { n: Int = 0; } bus { subscribe T as on_t; }\n\
+           fn on_t(p: P) { } }\n\
+         locus Q { bus { publish T; } fn go() { T <- P { n: 1 }; } }\n\
+         main locus App { params { r: R = R { }; q: Q = Q { }; } }\n\
+         fn main() { App { }; }",
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("may not declare a `bus")),
+        "a shared locus must not carry a bus block: {:?}",
+        ds
+    );
+}
+
+/// A bare `self.n = v` is exactly the race the annotation is supposed
+/// to be ruling out; mutable state belongs to a field whose own form
+/// carries a discipline.
+#[test]
+fn a_shared_locus_may_not_assign_its_own_fields() {
+    let ds = diags(
+        "@shared\n\
+         locus R { params { n: Int = 0; } fn set(v: Int) { self.n = v; } }\n\
+         main locus App { params { r: R = R { }; } }\n\
+         fn main() { App { }; }",
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("may not assign to its own fields")),
+        "a bare self-field assignment must be rejected: {:?}",
+        ds
+    );
+}
+
+const REGISTRY: &str = "\
+type E { k: Int; v: Int; }
+@form(hashmap, sync = serialized)
+locus Counts { capacity { pool entries of E indexed_by k; } }
+@shared
+locus Registry {
+    params { store: Counts = Counts { }; }
+    fn record(e: E) { self.store.set(e); }
+}
+locus A { params { r: Registry = Registry { }; } run() { self.r.record(E { k: 1, v: 1 }); } }
+locus B { params { r: Registry = Registry { }; } run() { self.r.record(E { k: 2, v: 2 }); } }
+";
+
+/// The point of the annotation: a declared coordination primitive
+/// reached from two pools is its purpose, not an accident.
+#[test]
+fn a_declared_shared_locus_may_be_reached_from_two_pools() {
+    let src = format!(
+        "{REGISTRY}
+main locus App {{
+    params {{ reg: Registry = Registry {{ }};
+             a: A = A {{ r: self.reg }};
+             b: B = B {{ r: self.reg }}; }}
+    placement {{ a: pinned(core = 0); b: pinned(core = 1); }}
+}}
+fn main() {{ App {{ }}; }}"
+    );
+    assert!(
+        !diags(&src).iter().any(|m| m.contains("is shared by")),
+        "declared sharing must not be reported as accidental"
+    );
+}
+
+/// And the distinction has to cut both ways, or the annotation is
+/// decoration: an UNdeclared locus in the identical shape is still
+/// reported.
+#[test]
+fn an_undeclared_locus_in_the_same_shape_is_still_reported() {
+    let src = format!(
+        "{}
+main locus App {{
+    params {{ reg: Registry = Registry {{ }};
+             a: A = A {{ r: self.reg }};
+             b: B = B {{ r: self.reg }}; }}
+    placement {{ a: pinned(core = 0); b: pinned(core = 1); }}
+}}
+fn main() {{ App {{ }}; }}",
+        REGISTRY.replace("@shared\n", "")
+    );
+    assert!(
+        diags(&src).iter().any(|m| m.contains("is shared by")),
+        "without the annotation the aliasing must still be reported"
+    );
+}
+
+/// The restraints apply to the annotation, not to every locus.
+#[test]
+fn an_ordinary_locus_keeps_its_bus_block_and_its_fields() {
+    let ds = diags(
+        "type P { n: Int; }\n\
+         topic T { payload: P; }\n\
+         locus R { params { n: Int = 0; } bus { subscribe T as on_t; }\n\
+           fn on_t(p: P) { self.n = p.n; } }\n\
+         locus Q { bus { publish T; } fn go() { T <- P { n: 1 }; } }\n\
+         main locus App { params { r: R = R { }; q: Q = Q { }; } }\n\
+         fn main() { App { }; }",
+    );
+    assert!(
+        !ds.iter().any(|m| m.contains("may not")),
+        "the restraints must not leak onto ordinary loci: {:?}",
+        ds
+    );
+}


### PR DESCRIPTION
Closes #333.

F.31 reasons per **field declaration**, so it cannot distinguish a
deliberate cross-pool registry from an accidental alias — both look
like one instance reachable from two towers. #338 reported the shape;
this is how an author says which one it is.

## Two restraints make it a claim, not a label

- **No `bus {}` block.** Pub/sub is domain-oriented and names what a
  system *means*; this role is mechanical and names what it *does*. A
  locus is one or the other.
- **No direct assignment to its own fields.** Mutable state belongs to
  the fields' own disciplines — `@form(hashmap, sync = serialized)` —
  not a bare `self.n = ...` two threads can run at once.

A declared locus may be reached from several pools without the
aliasing report. An **undeclared** one in the identical shape is still
reported — pinned by a test that strips only the `@shared` line, since
otherwise the annotation would be decoration.

## Where I stopped, and why

The natural stricter rule is "prove every field is synchronized." It is
**not yet expressible**: `@form(vec)` takes no sync kwarg in v1 —
*"vec has no tuning knobs"*.

Scanning a downstream fleet found a real registry holding a
`sync = serialized` map **beside a plain `@form(vec)`**. So the strict
rule would reject a working program whose author has no in-language
remedy, and would be a check saying "do it right" while the language
offers no right way.

This pins the shape and keeps the gap reviewable. Widening `sync` to
vec is what unblocks the rest, and it is a runtime change rather than
a checker one.

## Verification

- declared sharing silent, undeclared reported — both pinned
- restraints do not leak onto ordinary loci
- downstream fleet + pond unchanged at 57 pre-existing failures
- **1985/1985**

🤖 Generated with [Claude Code](https://claude.com/claude-code)