### PR TITLE
fix: attribute a direct call into a sync-bearing form (#341)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ behavior.
 
 ## Unreleased
 
+- **A direct call into a `sync`-bearing form is attributed too**
+  (#341). The attribution fired at a locus *holding* such a form but
+  not at a call straight into it — backwards, since the direct call is
+  the one plainly taking the lock. Synthesized form methods have no
+  summary entry, so they arrive unresolved with only a bare name; the
+  receiver's type now rides on the call edge, where it was already
+  computed and then discarded.
+
+  The reason `block` is attributed at all is worth stating, because
+  it is a semantic commitment: **placement is not static.** Once
+  placement can be swapped at runtime, whether a mutex ever contends
+  is undecidable at compile time, so a certificate reading "never
+  blocks, we are single-pool today" would be invalidated by a later
+  swap. Conservative is the only sound reading. A form with **no**
+  `sync` discipline takes no lock and stays certifiable — pinned by a
+  control test.
+
 - **`@shared` is now an effect surface** (#340). Shipping `@shared`
   (#333) sanctioned cross-pool sharing, which made three contracts
   false inside code the compiler had blessed — worse than before, when

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -310,6 +310,17 @@ pub enum Callee {
 #[derive(Debug, Clone)]
 pub struct CallEdge {
     pub callee: Callee,
+    /// #341: the receiver's declared type name for a method call.
+    ///
+    /// A SYNTHESIZED form method (`counts.set(x)`) has no summary
+    /// entry, so it resolves to `Unresolved("set")` — a bare name with
+    /// the receiver discarded. That lost the one fact an effect
+    /// predicate needs about it: whether the receiver's form carries a
+    /// `sync` discipline, and therefore a lock.
+    ///
+    /// The name was already computed one line earlier to attempt
+    /// resolution; this keeps it instead of throwing it away.
+    pub recv_ty: Option<String>,
     pub loop_depth: u32,
     /// True if the call is inside an unbounded loop — then the callee is
     /// invoked unboundedly many times regardless of its own multiplicity.
@@ -493,6 +504,10 @@ pub struct AllocSummary {
     /// the form's own declaration, not of anyone's intent or of how a
     /// consumer wires up placement.
     pub sync_holding_loci: BTreeSet<String>,
+    /// #341: form loci carrying a `sync` discipline — the forms
+    /// themselves, not the loci that hold them. A direct call into one
+    /// takes its lock.
+    pub sync_forms: BTreeSet<String>,
     /// Fns carrying `@unbounded` — an acknowledged-intentional
     /// accumulation. Their leak sites are dropped entirely (the
     /// greppable carve-out), even under the survey flag.
@@ -1339,6 +1354,7 @@ pub fn summarize_programs_with_renames(
         }
     }
     summary.sync_holding_loci = sync_holding_loci;
+    summary.sync_forms = sync_forms;
     summary.unbounded_fns = unbounded_fns;
     summary.locus_shapes = locus_shapes;
     summary
@@ -2118,6 +2134,7 @@ impl<'a> Walker<'a> {
     }
 
     fn record_call(&mut self, callee: &Expr, span: Span, depth: u32, escape: Escape) {
+        let mut recv_ty: Option<String> = None;
         let resolved = match callee {
             Expr::Ident(id) => {
                 let key = FnKey::free_fn(id.name.clone());
@@ -2165,6 +2182,7 @@ impl<'a> Walker<'a> {
                     // decorative outside free-fn code.
                     self.receiver_type_name(receiver).cloned()
                 };
+                recv_ty = owner.clone();
                 match owner {
                     Some(ty) => {
                         let key = FnKey::method(ty, name.name.clone());
@@ -2180,6 +2198,7 @@ impl<'a> Walker<'a> {
             _ => Callee::Unresolved("<expr>".to_string()),
         };
         self.calls.push(CallEdge {
+            recv_ty,
             callee: resolved,
             loop_depth: depth,
             in_unbounded_loop: self.loop_stack.iter().any(|bounded| !bounded),

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -676,6 +676,41 @@ fn check_class(
                 why
             ))
         }
+        // #341: a DIRECT call into a synthesized form method
+        // (`counts.set(x)`). These have no summary entry, so they
+        // arrive Unresolved with only a bare name — the receiver type
+        // rides on the edge instead.
+        //
+        // `block` is attributed because placement is not static:
+        // whether the lock ever contends is undecidable at compile
+        // time once placement can be swapped at runtime, so a
+        // certificate reading "never blocks, we are single-pool
+        // today" would be invalidated by a later swap. Conservative is
+        // the only sound reading.
+        Probe::Unresolved(_, edge)
+            if (mask.0
+                & (EffectSet::BLOCK.0
+                    | EffectSet::TIME.0
+                    | EffectSet::ENTROPY.0
+                    | EffectSet::ENV.0))
+                != 0
+                && edge
+                    .recv_ty
+                    .as_deref()
+                    .is_some_and(|t| summary.sync_forms.contains(t)) =>
+        {
+            let why = if mask.0 == EffectSet::BLOCK.0 {
+                "acquiring its lock can wait on another thread"
+            } else {
+                "reading it sees state another pool can change, so the \
+                 result is not a function of this call's inputs"
+            };
+            Some(format!(
+                "`{}` carries a `sync` discipline — {}",
+                edge.recv_ty.as_deref().unwrap_or(""),
+                why
+            ))
+        }
         Probe::Unresolved(name, _) => {
             let segs: Vec<&str> = name.split("::").collect();
             let Some(eff) = crate::stdlib_surface::effects_for(&segs) else {

--- a/crates/hale-types/tests/shared_effect_surface.rs
+++ b/crates/hale-types/tests/shared_effect_surface.rs
@@ -119,3 +119,48 @@ fn an_ordinary_locus_call_is_still_non_blocking() {
         ds
     );
 }
+
+/// #341: a DIRECT call into a synthesized form method. These have no
+/// summary entry, so they arrive `Unresolved` with only a bare name —
+/// the receiver type rides on the edge instead. Before this, a call
+/// THROUGH a holder was caught while the direct call was not, which is
+/// backwards: the direct call is the one plainly taking the lock.
+#[test]
+fn a_direct_call_into_a_sync_form_is_caught() {
+    let ds = diags(
+        "type E { k: Int; v: Int; }\n\
+         @form(hashmap, sync = serialized)\n\
+         locus Counts { capacity { pool entries of E indexed_by k; } }\n\
+         locus Direct { params { c: Counts = Counts { }; }\n\
+           @no_block fn hot(e: E) { self.c.set(e); } }\n\
+         main locus App { params { d: Direct = Direct { }; } }\n\
+         fn main() { App { }; }",
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("must not reach `block`")),
+        "a direct call into a sync form must be caught: {:?}",
+        ds
+    );
+}
+
+/// The control that keeps the attribution honest: a form with NO sync
+/// discipline takes no lock, so it must stay certifiable. Without
+/// this, keying on "is a form" rather than "carries a discipline"
+/// would pass its own tests while making every collection blocking.
+#[test]
+fn a_form_without_a_sync_discipline_stays_certifiable() {
+    let ds = diags(
+        "type E { k: Int; v: Int; }\n\
+         @form(hashmap)\n\
+         locus Plain { capacity { pool entries of E indexed_by k; } }\n\
+         locus W { params { c: Plain = Plain { }; }\n\
+           @no_block @deterministic fn hot(e: E) { self.c.set(e); } }\n\
+         main locus App { params { w: W = W { }; } }\n\
+         fn main() { App { }; }",
+    );
+    assert!(
+        !ds.iter().any(|m| m.contains("must not reach")),
+        "an unsynchronized form takes no lock: {:?}",
+        ds
+    );
+}


### PR DESCRIPTION
Closes #341.

The attribution fired at a locus **holding** a `sync` form but not at a
call **straight into one** — backwards, since the direct call is the
one plainly taking the lock.

```hale
locus ViaHolder { @no_block fn hot(e: E) { self.h.record(e); } }  // was caught
locus Direct    { @no_block fn hot(e: E) { self.c.set(e); } }     // was not
```

## Cause

Synthesized form methods have no summary entry, so `counts.set(x)`
resolves to `Unresolved("set")` — a bare name, with the receiver type
discarded **one line after** it was computed for the resolution
attempt. `CallEdge` now keeps it.

Both earlier attempts failed on the hook, not the idea:
`frontier::infer_effects` powers the `does={…}` manifest and assertions
never reach it, and a `Probe::Resolved` guard cannot see a callee that
never resolves. Instrumenting the predicate showed `Unresolved(set)`
with the edge in hand, which made the fix obvious.

## Why `block` at all — a semantic commitment, now justified

**Placement is not static.** Once placement can be swapped at runtime,
whether a mutex ever contends is undecidable at compile time: a
certificate reading *"never blocks, we are single-pool today"* is
invalidated by a later swap.

So conservative is the only sound reading — not a judgment call. And
it stays true when the dynamic runtime lands rather than needing
revisiting, which is a better footing than the one this had.

## Verification

- direct **and** through-a-holder both caught; the asymmetry is gone
- **CONTROL**: a form with **no** `sync` discipline takes no lock and
  stays certifiable — so this keys on the discipline, not on being a
  form. Without that test, keying on "is a form" would pass its own
  tests while making every collection blocking.
- downstream fleet + pond unchanged at 57 pre-existing failures
- **1986/1986**

🤖 Generated with [Claude Code](https://claude.com/claude-code)