### PR TITLE
docs(effects): specify depends: and user-declared effect classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ behavior.
 
 ## Unreleased
 
+- **A user effect-class violation names the class you declared**
+  (#345). `EffectClass::as_str` returns a `&'static str`, so a
+  `User(i)` — an index into the seed's intern table — had no static
+  name to answer with and returned `<user effect>`. Every diagnostic
+  that reached for it printed that placeholder, discarding the one
+  thing the feature exists to carry: the report now says ``must not
+  reach `money` `` where it said ``must not reach `<user effect>` ``.
+- **Spec and docs catch up with the effect surface**. `depends:`
+  (#330) and user-declared classes (#345) shipped without reaching
+  `spec/verification.md`, `spec/tokens.md`, or the `docs/src/effects.md`
+  chapter, contrary to the same-commit rule in `CLAUDE.md`. Both are
+  now specified, including the boundaries: `depends:` closes over the
+  bus graph only, and user classes are single-seed with 22 available.
 - **User-declared effect classes** (#345). A program can name its own
   effect classes and have the compiler propagate them:
 

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -90,12 +90,24 @@ fn demangle_stdlib(rendered: &str) -> String {
 /// frontier call); the rest reuse the same leaf lattice as
 /// `@effects(...)`. A phase omitted from the annotation is
 /// unconstrained; a phase present with `{}` forbids everything.
+/// The seed's user effect-class intern table. Single-seed at v1, so the
+/// first non-empty table is the one every `User(i)` indexes into.
+fn effect_names_of(programs: &[&Program]) -> Vec<String> {
+    programs
+        .iter()
+        .map(|p| &p.effect_names)
+        .find(|n| !n.is_empty())
+        .cloned()
+        .unwrap_or_default()
+}
+
 fn phase_effects_diags(
     programs: &[&Program],
     summary: &AllocSummary,
     ffi: &BTreeSet<String>,
 ) -> Vec<Diag> {
     let mut out = Vec::new();
+    let names = &effect_names_of(programs);
     for p in programs {
         for item in &p.items {
             let TopDecl::Locus(l) = item else { continue };
@@ -201,7 +213,7 @@ fn phase_effects_diags(
                         continue;
                     }
                     let before = out.len();
-                    check_class(summary, &key, span, class, ffi, &mut out);
+                    check_class(summary, &key, span, class, ffi, names, &mut out);
                     // Re-label the generic message with the phase.
                     for d in out.iter_mut().skip(before) {
                         d.message = format!(
@@ -445,6 +457,7 @@ fn effect_diags_inner(
         return placement;
     }
     let ffi = ffi_names(programs);
+    let names = effect_names_of(programs);
     let mut diags = std::mem::take(&mut placement);
     for (key, asserts, span) in &roots {
         for a in asserts {
@@ -455,7 +468,7 @@ fn effect_diags_inner(
                 EffectAssert::Forbid(classes) => {
                     for c in classes {
                         check_class(
-                            &summary, key, *span, *c, &ffi, &mut diags,
+                            &summary, key, *span, *c, &ffi, &names, &mut diags,
                         );
                     }
                 }
@@ -482,12 +495,27 @@ fn effect_diags_inner(
 /// `@no_*` flag desugars to `Forbid([class])` at parse time, so this
 /// is the single place a class's meaning is defined — no flag can
 /// drift from the general form.
+/// #345: resolve an effect class to the name the USER wrote. Built-ins
+/// are static; a `User(i)` is an index into the seed's intern table, so
+/// a diagnostic that reaches for `as_str()` prints `<user effect>` and
+/// loses the one thing the author named it for.
+fn cls_name(class: EffectClass, names: &[String]) -> String {
+    match class {
+        EffectClass::User(i) => names
+            .get(i as usize)
+            .cloned()
+            .unwrap_or_else(|| "<user effect>".to_string()),
+        _ => class.as_str().to_string(),
+    }
+}
+
 fn check_class(
     summary: &AllocSummary,
     key: &FnKey,
     span: Span,
     class: EffectClass,
     ffi: &BTreeSet<String>,
+    names: &[String],
     diags: &mut Vec<Diag>,
 ) {
     use crate::stdlib_surface::EffectSet;
@@ -592,12 +620,12 @@ fn check_class(
                          drop the `{}` assertion.",
                         key.display(),
                         chain_s,
-                        class.as_str()
+                        cls_name(class, names)
                     ),
                 ));
                 diags.push(Diag::ty(
                     site_span,
-                    format!("the `{}` effect happens here", class.as_str()),
+                    format!("the `{}` effect happens here", cls_name(class, names)),
                 ));
             }
             return;
@@ -768,7 +796,7 @@ fn check_class(
         Probe::Site(_) | Probe::Resolved(..) => None,
     };
     report(
-        summary, key, span, class.as_str(), &mut pred, diags,
+        summary, key, span, &cls_name(class, names), &mut pred, diags,
         "Move the effect behind a locus this fn doesn't reach (the \
          reader/writer-locus shape), or pass the value in as a parameter.",
     );

--- a/crates/hale-types/tests/user_effects.rs
+++ b/crates/hale-types/tests/user_effects.rs
@@ -89,3 +89,52 @@ fn builtin_classes_still_work_alongside() {
         ds
     );
 }
+
+/// The diagnostic must name the class the AUTHOR declared.
+///
+/// `EffectClass::as_str` returns `&'static str`, so a `User(i)` — an
+/// index into the seed's intern table — has no static name to give and
+/// answered `<user effect>`. Every diagnostic that reached for it
+/// printed that placeholder, which discards the single thing a user
+/// effect exists to carry: `money` is the reason anyone declared it,
+/// and a violation report that won't say `money` is barely a report.
+#[test]
+fn a_violation_names_the_declared_class() {
+    let ds = errs(&format!(
+        "{MONEY}@effects(none: {{money}})\n\
+         fn price(n: Int) -> Int {{ return charge(n); }}\n\
+         fn main() {{ println(price(5)); }}"
+    ));
+    let violation = ds
+        .iter()
+        .find(|m| m.contains("effect assertion violated"))
+        .expect("the assertion is violated");
+    assert!(
+        violation.contains("money"),
+        "the diagnostic must name the declared class, not a placeholder: {}",
+        violation
+    );
+    assert!(
+        !ds.iter().any(|m| m.contains("<user effect>")),
+        "no diagnostic may leak the placeholder name: {:?}",
+        ds
+    );
+}
+
+/// Declaring a user class must not rename the built-ins — `User(i)`
+/// resolves through a table the built-ins never index into.
+#[test]
+fn declaring_a_user_class_leaves_builtin_names_intact() {
+    let ds = errs(
+        "effect money;\n\
+         fn leaf(n: Int) -> Int { println(\"x\"); return n; }\n\
+         @no_syscall\n\
+         fn price(n: Int) -> Int { return leaf(n); }\n\
+         fn main() { println(price(5)); }",
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("`syscall`")),
+        "a built-in class must still print its own name: {:?}",
+        ds
+    );
+}

--- a/docs/src/effects.md
+++ b/docs/src/effects.md
@@ -348,3 +348,104 @@ Only effects reached *through* the bus count here; direct ones are
 `none:`'s job. "Publishing is cheap" is often false because of what
 runs downstream, and this is the only place the compiler can see it —
 a system built on opaque message sends cannot ask the question.
+
+## …and effects that travel *toward* you
+
+`causes:` walks the bus graph forward. `depends:` walks it backward —
+the complete set of subjects that can transitively reach any of a
+locus's handlers:
+
+```hale,fragment
+@effects(depends: {Recalled})
+locus StatedCarry {
+  bus { subscribe SumLookup as on_sum; }
+}
+```
+
+Without it, an independence claim is unenforceable. A locus that
+subscribes only to `SumLookup` looks isolated from `Recalled` in
+every declaration it carries — but if some third locus subscribes to
+`Recalled` and republishes onto `SumLookup`, the influence arrives
+anyway, and nothing in the depending locus's source mentions it. The
+diagnostic names the laundering path:
+
+```
+type error: declared dependence set violated: `StatedCarry` can be
+transitively influenced by subject `Recalled`, which its
+`@effects(depends: …)` does not declare. Path: subject `Recalled` ->
+`Launderer` -> subject `SumLookup` -> `StatedCarry`.
+```
+
+It sits on the **locus**, not a fn: dependence enters through
+subscriptions, and those are declared per-locus. A fn-level
+`depends:` is a parse error rather than a silent no-op.
+
+It is opt-in, on measured grounds. Over a real application — 428
+topics, 114 loci — transitivity added nothing beyond what `bus {}`
+already said for 87% of loci. A mandatory form would be redundant far
+more often than it was informative. Reach for it where independence
+is load-bearing: a locus that must not see PII, a control plane that
+must not be influenced by user traffic.
+
+One boundary worth stating plainly: the closure is over the **bus
+graph**. Influence that travels outside it — through a shared form,
+through a file — is not part of it.
+
+## Effects you declare yourself
+
+The ten classes above are the compiler's. A program can name its own:
+
+```hale
+effect money;
+
+@effects(is: {money})
+fn charge(cents: Int) -> Bool { return cents > 0; }
+
+@effects(none: {money})
+fn quote(cents: Int) -> Int { return cents * 2; }
+
+fn main() { println(quote(100)); }
+```
+
+`effect money;` declares the class. `is:` classifies a function as a
+source of it. From there it is an ordinary effect: it propagates
+through the call graph, it travels over the bus under `causes:`, it
+can be forbidden with `none:`, and a violation reports the same
+witness path a built-in would.
+
+```
+type error: effect assertion violated: `quote` must not reach `money`,
+but reaches quote [`charge` declares it carries this effect class].
+Move the effect behind a locus this fn doesn't reach (the
+reader/writer-locus shape), or pass the value in as a parameter.
+```
+
+The usual objection is that a user effect has no frontier — that
+`none: {money}` can only ever mean "no function anybody remembered to
+annotate", which is a linting convention wearing a type system's
+clothes. It's a fair objection to answer rather than wave at.
+
+The answer is that the effects worth checking are about interaction
+with the outside, and that *is* the frontier. Money moves when the
+payment processor is called, when the ledger row is written, when the
+settlement is published — all of which are already frontier calls the
+compiler classifies. `is:` doesn't introduce a second kind of
+grounding; it adds rows to the classification that already exists.
+The compiler owns propagation; the program owns classification — the
+same split the stdlib registry has, with a different owner.
+
+That split is also the honest statement of what you get. If you
+annotate `charge` and forget its sibling, `none: {money}` will not
+catch the sibling. What it does guarantee is that *given* your
+classification, no path escapes — which is exactly the property that
+is tedious and error-prone to maintain by review, and exactly the one
+that stops holding the moment a call graph is more than a few edges
+deep.
+
+Two limits at v1:
+
+- **Single seed.** A class declared in one compilation seed does not
+  resolve from another; merging per-seed intern tables needs index
+  remapping across the merged AST.
+- **22 classes.** They occupy the free bits above the built-ins in
+  the effect bitmask.

--- a/spec/tokens.md
+++ b/spec/tokens.md
@@ -610,8 +610,17 @@ They attach to the declaration that follows.
 | `@supervised` | locus | every locus in the subtree has a failure policy |
 | `@secret` | fn param | the value must not reach a publish or log/file sink |
 | `@effects(publish: {…})` | fn | the allowed publish set |
+| `@effects(depends: {…})` | locus | complete set of subjects that may transitively reach any handler |
+| `@effects(is: {…})` | fn | classify this fn as a source of the named effect classes |
 | `@no_syscall` `@no_block` `@no_ffi` `@no_publish` `@no_spawn` `@no_recursion` `@deterministic` | fn | sugar for the `@effects(none: …)` forms |
 | `@no_panic` | fn | no reachable trap (disposition coverage — a different analysis) |
+
+`effect NAME;` is a top-level **declaration**, not an annotation:
+it introduces a user effect class that `is:` / `none:` / `causes:`
+then name like a built-in. `effect` is a **contextual keyword** —
+recognized only at the start of a top-level item followed by an
+identifier and `;`, so an existing `effect` binding is unaffected.
+Declared classes are single-seed (see `spec/verification.md`).
 
 Effect annotations stack with each other and with `@hot` /
 `@budget(...)`; see `spec/verification.md` for what each class

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -346,6 +346,63 @@ assume the others in a build:
   effects reached THROUGH the bus are reported; direct effects are
   the `none:` form's job. Actor systems without a declared message
   graph structurally cannot offer this.
+- **Backward causality — `@effects(depends: {…})`** (#330,
+  2026-07-31). The dual of `causes:`. `causes:` walks the bus graph
+  forward; nothing walked it backward, so an independence claim
+  between two parts of a bus graph was unenforceable — a dependence
+  routed through one republishing intermediary is invisible in every
+  declaration on the depending locus, whose `bus {}` block names only
+  the innocent subject it directly subscribes to. `depends:` is a
+  COMPLETE declaration of the subjects that may transitively reach any
+  of the locus's handlers, and the diagnostic names the path
+  (`subject SumLookup -> Launderer -> subject Recalled ->
+  StatedCarry`). **Locus-level**: dependence enters through
+  subscriptions, which are declared per-locus, so a fn-level
+  `depends:` is a parse error rather than a silent no-op. Opt-in on
+  measured grounds — over a real application (428 topics, 114 loci)
+  transitivity adds nothing beyond the `bus {}` block for 87% of loci,
+  so a mandatory form would be redundant far more often than
+  informative. The closure is over the **bus graph**: influence
+  travelling outside it (see shared state below) is not part of it.
+- **User-declared effect classes — `effect NAME;` and
+  `@effects(is: {…})`** (#345, 2026-08-01). A program may name its own
+  effect classes and have them propagated by the same engine, with the
+  same witness paths:
+
+  ```
+  effect money;
+
+  @effects(is: {money})
+  fn charge(cents: Int) -> Int { … }
+
+  @effects(none: {money})
+  fn price(n: Int) -> Decimal { … }   // violates if it reaches charge
+  ```
+
+  Grounded exactly like a built-in. The objection to user effects is
+  that they have no frontier — that `@no_money` could only mean "no fn
+  somebody remembered to annotate". But effects worth checking are
+  about interaction with the outside, and that IS the frontier: money
+  moves when the processor is called, the ledger row is written, the
+  settlement is published. So `is:` adds rows to the classification
+  that already exists rather than introducing a second kind. **The
+  compiler owns propagation; the program owns classification** — the
+  same split the stdlib registry has, with a different owner.
+
+  Classes are interned as indices and occupy the free bits above the
+  ten built-ins (22 available). **Single-seed at v1**: merging
+  per-seed intern tables needs index remapping across the merged AST,
+  so a cross-seed class name does not resolve.
+- **Synchronized access is blocking and non-deterministic** (#340/#341,
+  2026-08-01). A `sync`-bearing form takes a lock, so a call reaching
+  one contributes `block`, and a read through one defeats
+  `@deterministic` — another pool can change the value between two
+  calls with identical arguments. Attributed because **placement is
+  not static**: once placement can be swapped at runtime, whether a
+  mutex ever contends is undecidable at compile time, so a certificate
+  reading "never blocks, we are single-pool today" would be
+  invalidated by a later swap. A form with no `sync` discipline takes
+  no lock and stays certifiable.
 - **Supervision coverage — `@supervised`** (GH #265, 2026-07-29). A
   locus marked `@supervised` asserts that every locus in its subtree
   has a failure policy in scope — an `on_failure` on itself or an


### PR DESCRIPTION
`depends:` (#330) and user-declared effect classes (#345) both shipped
without reaching `spec/` or `docs/`, contrary to the same-commit rule in
`CLAUDE.md`. This closes that gap and fixes a defect found while writing it.

## Spec + docs

- `spec/verification.md` — `depends:`, user-declared classes, and the
  sync-form `block`/`@deterministic` attribution from #340/#341.
- `spec/tokens.md` — `is:` and `depends:` attribute rows; `effect NAME;`
  documented as a **contextual** keyword, so an existing `effect` binding
  is unaffected.
- `docs/src/effects.md` — two teaching sections. Snippets verified against
  the compiler, not just against the parser.

Boundaries are stated rather than implied: `depends:` closes over the **bus
graph only** (influence through a shared form or a file is not in it), and
user classes are single-seed with 22 available.

## The defect

The doc snippet I drafted showed the diagnostic naming `money`. The
compiler printed `` `<user effect>` ``.

`EffectClass::as_str` returns `&'static str`, so a `User(i)` — an index
into the seed's intern table — has no static name to answer with. Every
diagnostic that reached for it printed that placeholder, discarding the
one thing a user effect exists to carry. `money` is the reason anyone
declared the class, and a violation report that won't say `money` is
barely a report.

`cls_name()` resolves through the table; `effect_names_of()` supplies it
(single-seed at v1). Two regression tests — one asserts no diagnostic
leaks the placeholder, the other that declaring a user class leaves
built-in class names intact.

## Not fixed

The witness path still reads ``reaches quote [`charge` declares it carries
this effect class]`` rather than the built-in style ``quote -> charge
[...]``. That is redundancy, not information loss — `charge` is named in
the label — and fixing it means touching witness-path internals shared by
every effect diagnostic. Left alone deliberately.

## Tests

583 hale-types, 157 hale-syntax, and the effect/token-filtered set across
the workspace pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)