### PR TITLE
fix(effects): an effect-class overflow must fail closed, not open

### DIFF
--- a/.effects-baseline/corpus.effects
+++ b/.effects-baseline/corpus.effects
@@ -322,6 +322,13 @@ Full::dissolve  does={syscall}
 Pusher::run  does={syscall,block,publish,time,alloc}
 Sampler::dissolve  does={syscall}
 main  does={alloc}
+### 74-effect-contracts
+App::birth  does={syscall,publish,alloc}
+double  none={block,syscall}
+main  does={alloc}
+quote  none={money,syscall}
+safe  none={panic}
+scale  none={entropy,env,time}  alloc_per_call=0
 ### 85-bindings-unix
 App::run  does={syscall,block,time}
 Counter::on_beat  does={syscall}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ behavior.
 
 ## Unreleased
 
+- **An effect-class overflow no longer fails open** (#345). `class_mask`
+  saturated to `PURE` past the mask ceiling, and `PURE` means "reaches
+  nothing" — so `@effects(none: {overflowed})` silently CERTIFIED a fn
+  that called a declared source of that class. The analysis failed open
+  in the one direction it must not; every other incompleteness here
+  fails closed. `EffectSet` widens u32 → u64 (54 user classes, was 22)
+  and declaring past the ceiling is now an error at the `effect NAME;`
+  line, where there is a span to point at.
+- **The effects manifest names user classes** (#345). The committed
+  baseline rendered every user class as `<user effect>`, so two
+  distinct classes produced the same line and a real change could diff
+  to nothing — in the artifact whose diff *is* the review.
+- **A corpus fixture covers the effect-annotation surface** (#345).
+  `74-effect-contracts` exercises `@effects`, the `@no_*` sugar,
+  `@deterministic`, `@budget`, `@no_panic`, `@phase_effects` and
+  `effect NAME;`. The tree-sitter grammar could not parse any of them
+  for weeks after they shipped and nothing caught it: the corpus gate
+  scans the fixture directory, and no fixture used an effect
+  annotation.
+
 - **A user effect-class violation names the class you declared**
   (#345). `EffectClass::as_str` returns a `&'static str`, so a
   `User(i)` — an index into the seed's intern table — had no static

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ behavior.
 
 ## Unreleased
 
+- **User effect classes resolve across a seed boundary** (#345). Was
+  single-seed at v1: `EffectClass::User(i)` indexes the *declaring*
+  seed's intern table, and every seed interns from zero, so two seeds
+  each declaring one class both used `User(0)` for different names —
+  concatenating their items aliased them onto one bit. Rejecting
+  cross-seed names avoided that but made a class unusable across the
+  boundary it most wants to cross: `money` holds everywhere the money
+  goes, and the money goes through `lib/`. The merge now unions the
+  name tables and remaps each seed's indices before merging its items.
+- **`hale check` on a directory no longer aliases effect classes**
+  (#345). `merge_programs` concatenated items while discarding every
+  input's `effect_names`, so a `@effects(none: {money})` in one file
+  was checked against another file's class 0. It reported `quote`
+  reaching `pii` for an assertion that named `money`.
+
 - **An effect-class overflow no longer fails open** (#345). `class_mask`
   saturated to `PURE` past the mask ceiling, and `PURE` means "reaches
   nothing" — so `@effects(none: {overflowed})` silently CERTIFIED a fn

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -1731,6 +1731,12 @@ fn resolve_imports(
     // ("qualified type `g::Rect` not in stdlib path-renames
     // table" / "unknown type name in signature").
     seed_cache: &mut BTreeMap<PathBuf, std::collections::HashMap<String, String>>,
+    // #345: the MERGED user effect-class table. Each seed interns its
+    // own `effect NAME;` declarations from zero, so the same index
+    // means different classes in different seeds. Names are unioned
+    // here and each seed's items are remapped into this table before
+    // they are merged.
+    effect_names: &mut Vec<String>,
 ) -> Result<(), ()> {
     // Defensive guards + env-gated tracing. The guards bound the
     // resolver's accumulators so a future bug (or pathological
@@ -1996,10 +2002,35 @@ fn resolve_imports(
                 merged_items,
                 renames,
                 seed_cache,
+                effect_names,
             )?;
         }
         // Move mangled items into the merged program; stash sources.
-        for pf in parsed_files {
+        for mut pf in parsed_files {
+            // Remap BEFORE merging: `User(i)` indices are seed-local,
+            // so concatenating two seeds' items without this aliases
+            // seed A's class 0 onto seed B's class 0.
+            if !pf.program.effect_names.is_empty() {
+                let map: Vec<u16> = pf
+                    .program
+                    .effect_names
+                    .iter()
+                    .map(|n| {
+                        let at = effect_names
+                            .iter()
+                            .position(|e| e == n)
+                            .unwrap_or_else(|| {
+                                effect_names.push(n.clone());
+                                effect_names.len() - 1
+                            });
+                        at as u16
+                    })
+                    .collect();
+                hale_syntax::ast::remap_user_effects(
+                    &mut pf.program.items,
+                    &map,
+                );
+            }
             merged_items.extend(pf.program.items);
             sources.insert(pf.canon, pf.source);
             let _ = pf.path; // path was only needed for diagnostics above
@@ -2077,6 +2108,10 @@ fn parse_with_imports(
 
     let entry_imports = entry_program.imports.clone();
     let mut merged_items = entry_program.items;
+    // Seed the merged table with the ENTRY's classes so the entry's
+    // own `User(i)` indices stay identity — its items are already in
+    // `merged_items` and are never walked.
+    let mut effect_names: Vec<String> = entry_program.effect_names.clone();
     let mut renames: ImportRenames = Vec::new();
     let mut seed_cache: BTreeMap<PathBuf, std::collections::HashMap<String, String>> = BTreeMap::new();
 
@@ -2091,6 +2126,7 @@ fn parse_with_imports(
         &mut merged_items,
         &mut renames,
         &mut seed_cache,
+        &mut effect_names,
     )
     .is_err()
     {
@@ -2100,13 +2136,16 @@ fn parse_with_imports(
     if !errors.is_empty() {
         return Err(errors);
     }
-    // #345: user effect-class tables are per-seed. Merging them needs
-    // index remapping across the merged AST, so user effects are
-    // single-seed at v1 — a cross-seed name resolves to nothing and is
-    // rejected as undeclared rather than silently aliasing.
+    // #345: user effect-class tables are per-seed — each seed interns
+    // its own `effect NAME;` from zero, so the same index means a
+    // DIFFERENT class in a different seed. `resolve_imports` unions the
+    // names and rewrites each seed's indices into this table before
+    // merging its items, so the merged program carries one table that
+    // every `User(i)` in `merged_items` agrees on.
+    let declared: Vec<u16> = (0..effect_names.len() as u16).collect();
     let mut merged = Program {
-        effect_names: Vec::new(),
-        declared_effects: Vec::new(),
+        effect_names,
+        declared_effects: declared,
         imports: Vec::new(),
         items: merged_items,
         span: entry_program.span,
@@ -2252,6 +2291,10 @@ fn collect_checkable(
     };
     let workspace_root = find_workspace_root(target);
     let mut merged_items = merged.items;
+    // Same identity-seeding rule as the entry path: `merged`'s own
+    // items are already in `merged_items` and are never walked, so its
+    // table must come first.
+    let mut effect_names: Vec<String> = merged.effect_names.clone();
     let mut renames: ImportRenames = Vec::new();
     let mut seed_cache: BTreeMap<
         PathBuf,
@@ -2279,6 +2322,7 @@ fn collect_checkable(
         &mut merged_items,
         &mut renames,
         &mut seed_cache,
+        &mut effect_names,
     )
     .is_err()
     {
@@ -2290,10 +2334,11 @@ fn collect_checkable(
     }
 
     let mut program = Program {
-        // Carried through from the merge above; see the note there on
-        // user effect classes being single-seed at v1.
-        effect_names: merged.effect_names.clone(),
-        declared_effects: merged.declared_effects.clone(),
+        // The UNIONED table from the merge above, not `merged`'s own —
+        // `merged.effect_names` is the pre-import table and every
+        // imported seed's `User(i)` was remapped into this one.
+        declared_effects: (0..effect_names.len() as u16).collect(),
+        effect_names,
         imports: Vec::new(),
         items: merged_items,
         span: merged.span,
@@ -3076,6 +3121,10 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
     };
     let workspace_root = find_workspace_root(target);
     let mut merged_items = merged.items;
+    // Same identity-seeding rule as the entry path: `merged`'s own
+    // items are already in `merged_items` and are never walked, so its
+    // table must come first.
+    let mut effect_names: Vec<String> = merged.effect_names.clone();
     let mut renames: ImportRenames = Vec::new();
     let mut seed_cache: BTreeMap<PathBuf, std::collections::HashMap<String, String>> = BTreeMap::new();
     let mut path_sources: BTreeMap<PathBuf, String> = sources.into_iter().collect();
@@ -3099,6 +3148,7 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         &mut merged_items,
         &mut renames,
         &mut seed_cache,
+        &mut effect_names,
     )
     .is_err()
         || !import_errors.is_empty()
@@ -3110,8 +3160,8 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         return ExitCode::from(1);
     }
     let mut program = Program {
-        effect_names: Vec::new(),
-        declared_effects: Vec::new(),
+        declared_effects: (0..effect_names.len() as u16).collect(),
+        effect_names,
         imports: Vec::new(),
         items: merged_items,
         span: merged.span,
@@ -3221,6 +3271,8 @@ fn run_build(target: &Path) -> ExitCode {
         // own dir as the importer dir + the workspace fallback.
         let workspace_root = find_workspace_root(target);
         let mut merged_items = merged.items;
+        // Identity-seeded: `merged`'s items are already merged.
+        let mut effect_names: Vec<String> = merged.effect_names.clone();
         let mut renames: ImportRenames = Vec::new();
     let mut seed_cache: BTreeMap<PathBuf, std::collections::HashMap<String, String>> = BTreeMap::new();
         let mut path_sources: BTreeMap<PathBuf, String> =
@@ -3246,6 +3298,7 @@ fn run_build(target: &Path) -> ExitCode {
             &mut merged_items,
             &mut renames,
             &mut seed_cache,
+            &mut effect_names,
         )
         .is_err()
         {
@@ -3263,8 +3316,8 @@ fn run_build(target: &Path) -> ExitCode {
             return ExitCode::from(1);
         }
         let mut with_imports = Program {
-            effect_names: Vec::new(),
-            declared_effects: Vec::new(),
+            declared_effects: (0..effect_names.len() as u16).collect(),
+            effect_names,
             imports: Vec::new(),
             items: merged_items,
             span: merged.span,
@@ -3749,16 +3802,45 @@ where
 {
     let mut iter = programs.into_iter();
     let first = iter.next()?;
-    let mut merged = Program {
-        effect_names: Vec::new(),
-        declared_effects: Vec::new(),
-        items: first.items.clone(),
+    // #345: same per-seed index hazard as the import path. Each file
+    // interns its own `effect NAME;` from zero, so concatenating items
+    // without remapping makes file A's class 0 and file B's class 0
+    // the same bit — `@effects(none: {money})` in one file would then
+    // be checked against `pii` in another. (Observed: the diagnostic
+    // reported reaching `pii` for a `none: {money}` assertion.)
+    let mut effect_names: Vec<String> = Vec::new();
+    let mut take = |p: &Program| -> Vec<hale_syntax::ast::TopDecl> {
+        let mut items = p.items.clone();
+        if !p.effect_names.is_empty() {
+            let map: Vec<u16> = p
+                .effect_names
+                .iter()
+                .map(|n| {
+                    let at = effect_names
+                        .iter()
+                        .position(|e| e == n)
+                        .unwrap_or_else(|| {
+                            effect_names.push(n.clone());
+                            effect_names.len() - 1
+                        });
+                    at as u16
+                })
+                .collect();
+            hale_syntax::ast::remap_user_effects(&mut items, &map);
+        }
+        items
+    };
+    let mut items = take(first);
+    for p in iter {
+        items.extend(take(p));
+    }
+    let merged = Program {
+        declared_effects: (0..effect_names.len() as u16).collect(),
+        effect_names,
+        items,
         imports: Vec::new(),
         span: first.span,
     };
-    for p in iter {
-        merged.items.extend(p.items.clone());
-    }
     Some(merged)
 }
 

--- a/crates/hale-cli/tests/fixtures/xseed-user-effects/app/main.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-user-effects/app/main.hl
@@ -1,0 +1,22 @@
+import "lib/pay" as pay;
+import "lib/pii" as pii;
+
+effect money;
+
+// MUST fire: `pay::charge` carries `money`, one seed away.
+@effects(none: {money})
+fn quote(n: Int) -> Int {
+    return pay::charge(n);
+}
+
+// MUST NOT fire: `pii::read_name` carries `pii`, not `money` — even
+// though both are class 0 in their declaring seed.
+@effects(none: {money})
+fn label(n: Int) -> Int {
+    return pii::read_name(n);
+}
+
+fn main() {
+    println(quote(5));
+    println(label(5));
+}

--- a/crates/hale-cli/tests/fixtures/xseed-user-effects/hale.toml
+++ b/crates/hale-cli/tests/fixtures/xseed-user-effects/hale.toml
@@ -1,0 +1,1 @@
+name = "xseed-user-effects"

--- a/crates/hale-cli/tests/fixtures/xseed-user-effects/lib/pay/p.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-user-effects/lib/pay/p.hl
@@ -1,0 +1,7 @@
+// A library that classifies its own money-moving leaf.
+effect money;
+
+@effects(is: {money})
+fn charge(cents: Int) -> Int {
+    return cents;
+}

--- a/crates/hale-cli/tests/fixtures/xseed-user-effects/lib/pii/p.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-user-effects/lib/pii/p.hl
@@ -1,0 +1,9 @@
+// A DIFFERENT class, and — critically — it is index 0 in this seed
+// just as `money` is index 0 in its own. Nothing but the remap keeps
+// them apart.
+effect pii;
+
+@effects(is: {pii})
+fn read_name(n: Int) -> Int {
+    return n;
+}

--- a/crates/hale-cli/tests/xseed_user_effects.rs
+++ b/crates/hale-cli/tests/xseed_user_effects.rs
@@ -1,0 +1,80 @@
+//! User-declared effect classes across a seed boundary (#345).
+//!
+//! `EffectClass::User(i)` is an index into the DECLARING seed's intern
+//! table. Every seed interns from zero, so two seeds that each declare
+//! one class both use `User(0)` for different names. Import merging
+//! concatenates items, which meant those two classes shared a bit:
+//! seed A's `money` and seed B's `pii` became indistinguishable, and a
+//! `none: {money}` was checked against whichever one won.
+//!
+//! v1 avoided that by rejecting cross-seed names outright — sound, but
+//! it made a class unusable across the boundary it most wants to
+//! cross. The point of `money` is that it holds everywhere the money
+//! goes, and in a real codebase the money goes through `lib/`.
+//!
+//! So the merge remaps instead. This fixture pins BOTH directions,
+//! because each alone is passable by a broken implementation:
+//!
+//!   - the same class one seed away must still fire (a remap that
+//!     dropped everything would look "safe" and prove nothing), and
+//!   - two DIFFERENT classes that are both index 0 in their own seed
+//!     must not alias (the bug the restriction existed to prevent).
+//!
+//! The second half is the one that caught a real defect: `hale check`
+//! on a directory goes through `merge_programs`, which concatenated
+//! items while discarding every input's `effect_names`. It reported
+//! `quote` reaching `pii` for an assertion that named `money`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn check() -> String {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/xseed-user-effects/app");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(&fixture)
+        .output()
+        .expect("run hale check");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+#[test]
+fn a_user_class_fires_across_a_seed_boundary() {
+    let out = check();
+    assert!(
+        out.contains("effect assertion violated") && out.contains("`quote`"),
+        "`quote` reaches `pay::charge`, which declares it carries \
+         `money` — the assertion must fire one seed away:\n{}",
+        out
+    );
+    assert!(
+        out.contains("money"),
+        "the violation must name the class the author declared:\n{}",
+        out
+    );
+}
+
+/// The aliasing case. `money` (app seed) and `pii` (lib seed) are both
+/// class 0 where they are declared; only the remap keeps them apart.
+#[test]
+fn distinct_classes_sharing_a_local_index_do_not_alias() {
+    let out = check();
+    assert!(
+        !out.contains("`label`"),
+        "`label` reaches `pii::read_name`, which carries `pii` — NOT \
+         the `money` it forbids. Firing here means the two seeds' \
+         class 0 aliased onto one bit:\n{}",
+        out
+    );
+    assert!(
+        !out.contains("reach `pii`"),
+        "no assertion in this fixture names `pii`; reporting it means \
+         an index was read against the wrong seed's table:\n{}",
+        out
+    );
+}

--- a/crates/hale-codegen/tests/fixtures/examples/74-effect-contracts/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/74-effect-contracts/main.hl
@@ -1,0 +1,93 @@
+// The effect-annotation surface, as a corpus fixture.
+//
+// This exists because the surface was UNENFORCED everywhere except the
+// compiler's own tests. The tree-sitter grammar could not parse a
+// single `@no_syscall` / `@effects(...)` / `@deterministic` for weeks
+// after they shipped, and nothing caught it: the corpus gate scans
+// this directory, and not one fixture here used an effect annotation.
+// A grammar blind spot is only invisible while no corpus file steps
+// into it.
+//
+// So the value of this file is coverage, not cleverness. It should
+// name every annotation shape the language accepts, and keep doing so
+// as the surface grows.
+
+effect money;
+
+type Payment {
+    cents: Int;
+}
+
+topic Settled {
+    payload: Payment;
+    subject: "settled";
+}
+
+// A declared source of a user effect class (#345).
+@effects(is: {money})
+fn charge(cents: Int) -> Bool {
+    return cents > 0;
+}
+
+// Sugar for the `@effects(none: ...)` forms.
+@no_syscall @no_block
+fn double(n: Int) -> Int {
+    return n * 2;
+}
+
+// The explicit form, plus a class the program declared itself.
+@effects(none: {syscall, money})
+fn quote(cents: Int) -> Int {
+    return double(cents);
+}
+
+// Quantitative + certification decorators stack with the categoric
+// ones; the compiler owns which combinations are legal.
+@deterministic @hot
+@budget(alloc_per_call = 0)
+fn scale(n: Int) -> Int {
+    return n + 1;
+}
+
+@no_panic
+fn safe(n: Int) -> Int {
+    return n;
+}
+
+@phase_effects(birth: {alloc})
+locus Ledger {
+    params {
+        total: Int = 0;
+    }
+
+    bus {
+        subscribe Settled as on_settled;
+    }
+
+    fn on_settled(p: Payment) {
+        self.total = self.total + p.cents;
+    }
+}
+
+main locus App {
+    params {
+        ledger: Ledger = Ledger { };
+    }
+
+    bus {
+        publish Settled;
+    }
+
+    birth() {
+        println(quote(21));
+        println(scale(1));
+        println(safe(2));
+        if charge(100) {
+            Settled <- Payment { cents: 100 };
+        }
+    }
+}
+
+fn main() {
+    App { };
+}

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -2374,3 +2374,83 @@ pub struct Ident {
     pub name: String,
     pub span: Span,
 }
+
+/// #345: rewrite this seed's user effect-class indices into a merged
+/// program's table.
+///
+/// `EffectClass::User(i)` is an index into the *declaring seed's*
+/// intern table, so two seeds that each declare one class both use
+/// `User(0)` for different names. Concatenating their items — which is
+/// what import merging does — silently aliases those classes: seed A's
+/// `money` and seed B's `pii` become the same bit, and a `none:` on
+/// one is checked against the other.
+///
+/// Rejecting cross-seed names avoided the aliasing but made a class
+/// unusable across the import boundary it most wants to cross: the
+/// point of `money` is that it holds everywhere the money goes,
+/// including through a library. So instead, remap: `map[i]` is the
+/// merged index for this seed's class `i`, and every carrier of an
+/// `EffectClass` in the seed's items is rewritten before the items
+/// are merged.
+///
+/// Deliberately exhaustive over the AST rather than a visitor over
+/// "the interesting nodes" — a missed carrier here does not fail
+/// loudly, it silently keeps a stale index that now means a DIFFERENT
+/// class in the merged table. That is the aliasing bug this exists to
+/// prevent, reintroduced quietly.
+pub fn remap_user_effects(items: &mut [TopDecl], map: &[u16]) {
+    fn class(c: &mut EffectClass, map: &[u16]) {
+        if let EffectClass::User(i) = c {
+            // Out of range means the seed declared fewer classes than
+            // it referenced, which the parser already rejected; leave
+            // it alone rather than inventing an index.
+            if let Some(&to) = map.get(*i as usize) {
+                *i = to;
+            }
+        }
+    }
+    fn classes(cs: &mut [EffectClass], map: &[u16]) {
+        for c in cs {
+            class(c, map);
+        }
+    }
+    fn fn_decl(fd: &mut FnDecl, map: &[u16]) {
+        for a in &mut fd.effects {
+            match a {
+                EffectAssert::Forbid(cs)
+                | EffectAssert::Causes(cs)
+                | EffectAssert::Carries(cs) => classes(cs, map),
+                // Subjects, not classes.
+                EffectAssert::PublishSet(_) => {}
+                EffectAssert::NoPanic => {}
+            }
+        }
+    }
+    for item in items {
+        match item {
+            TopDecl::Fn(fd) => fn_decl(fd, map),
+            TopDecl::Locus(l) => {
+                if let Some(pe) = &mut l.phase_effects {
+                    for (_, cs) in &mut pe.phases {
+                        classes(cs, map);
+                    }
+                }
+                for m in &mut l.members {
+                    if let LocusMember::Fn(fd) = m {
+                        fn_decl(fd, map);
+                    }
+                }
+            }
+            TopDecl::Perspective(p) => {
+                for m in &mut p.members {
+                    if let PerspectiveMember::Fn(fd) = m {
+                        fn_decl(fd, map);
+                    }
+                }
+            }
+            // Modules nest arbitrarily deep.
+            TopDecl::Module(m) => remap_user_effects(&mut m.items, map),
+            _ => {}
+        }
+    }
+}

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -1582,6 +1582,17 @@ pub enum EffectClass {
 }
 
 impl EffectClass {
+    /// Bits `EffectSet` reserves for the built-in classes; user
+    /// classes start above them.
+    pub const BUILTIN_BITS: u32 = 10;
+
+    /// How many user-declared classes fit in the mask. `EffectSet` is
+    /// a u64, so 54. Enforced at the `effect NAME;` declaration —
+    /// a class with no bit unions as PURE, which would certify
+    /// `@effects(none: {it})` on a fn that reaches a declared source.
+    /// The overflow must fail closed, so it is rejected up front.
+    pub const USER_CAPACITY: u32 = 64 - Self::BUILTIN_BITS;
+
     pub fn from_ident(s: &str) -> Option<EffectClass> {
         Some(match s {
             "syscall" => EffectClass::Syscall,

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -758,6 +758,26 @@ impl Parser {
             self.bump();
             self.expect(TokenKind::Semi, ";")?;
             let idx = self.intern_effect(&name);
+            // Fail CLOSED on overflow. A class past the mask's
+            // capacity has no bit, so it unions as PURE — and
+            // `@effects(none: {it})` would then certify a fn that
+            // reaches a declared source of it. A silently false
+            // certificate is the one outcome this system must never
+            // produce, so the declaration is an error instead.
+            if u32::from(idx) >= EffectClass::USER_CAPACITY {
+                return Err(Diag::parse(
+                    name_tok.span,
+                    format!(
+                        "too many declared effect classes: `{}` is #{}, \
+                         but the effect mask holds {}. Effect classes are \
+                         a domain vocabulary, not a per-module taxonomy — \
+                         merge the ones that travel together.",
+                        name,
+                        u32::from(idx) + 1,
+                        EffectClass::USER_CAPACITY
+                    ),
+                ));
+            }
             if !self.declared_effects.contains(&idx) {
                 self.declared_effects.push(idx);
             }

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -1075,6 +1075,12 @@ pub struct EffectManifestRow {
 /// Build the whole-program effect manifest, sorted for stable diffs.
 pub fn effect_manifest(programs: &[&Program]) -> Vec<EffectManifestRow> {
     let mut rows: Vec<EffectManifestRow> = Vec::new();
+    // #345: the manifest is a REVIEW artifact — a committed baseline
+    // whose diff is the thing a human reads. `<user effect>` there is
+    // worse than in a diagnostic: every user class renders identically,
+    // so two different classes produce the same line and a real change
+    // can diff to nothing.
+    let names = effect_names_of(programs);
     let mut push = |name: String, fd: &FnDecl| {
         let mut forbids = Vec::new();
         let mut publish_set = None;
@@ -1083,7 +1089,7 @@ pub fn effect_manifest(programs: &[&Program]) -> Vec<EffectManifestRow> {
                 EffectAssert::Carries(_) => {}
                 EffectAssert::Forbid(cs) => {
                     for c in cs {
-                        forbids.push(c.as_str().to_string());
+                        forbids.push(cls_name(*c, &names));
                     }
                 }
                 EffectAssert::PublishSet(items) => {
@@ -1094,7 +1100,7 @@ pub fn effect_manifest(programs: &[&Program]) -> Vec<EffectManifestRow> {
                 }
                 EffectAssert::Causes(cs) => {
                     for c in cs {
-                        forbids.push(format!("causes:{}", c.as_str()));
+                        forbids.push(format!("causes:{}", cls_name(*c, &names)));
                     }
                 }
             }

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -284,13 +284,16 @@ fn class_mask(c: EffectClass) -> EffectSet {
         EffectClass::Ffi => EffectSet::SYSCALL,
         EffectClass::Spawn | EffectClass::Recursion => EffectSet::PURE,
         // #345: user classes occupy the bits above the built-ins.
-        // `EffectSet` is a u32 with 10 built-in bits used, so 22 are
-        // available; beyond that the set silently could not represent
-        // the class, so it saturates to PURE rather than aliasing an
-        // existing bit — and the checker rejects the overflow up front.
+        // Saturating past the ceiling would be UNSOUND in the open
+        // direction: a class with no bit unions as PURE, so
+        // `@effects(none: {overflowed})` certifies a fn that calls a
+        // declared source of it. The declaration is rejected up front
+        // (`check_effect_capacity`) so this arm is unreachable for a
+        // program that typechecks; it stays saturating rather than
+        // panicking for callers that analyse un-checked ASTs.
         EffectClass::User(i) => {
-            if (i as u32) < 22 {
-                EffectSet(1 << (10 + i as u32))
+            if (i as u32) < EffectClass::USER_CAPACITY {
+                EffectSet(1 << (EffectClass::BUILTIN_BITS as u64 + i as u64))
             } else {
                 EffectSet::PURE
             }

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -170,7 +170,7 @@ impl FnSig {
 /// lattice of the effect-assertion engine (`crate::callgraph`).
 /// Const-constructible so the registry stays a static table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct EffectSet(pub u32);
+pub struct EffectSet(pub u64);
 
 impl EffectSet {
     pub const PURE: EffectSet = EffectSet(0);
@@ -183,7 +183,7 @@ impl EffectSet {
     pub const ALLOC: EffectSet = EffectSet(1 << 6);
     /// Not yet classified (#265 step 4 turns the surface; until
     /// then queries must treat this as "may do anything").
-    pub const UNCLASSIFIED: EffectSet = EffectSet(u32::MAX);
+    pub const UNCLASSIFIED: EffectSet = EffectSet(u64::MAX);
 
     pub const fn union(self, o: EffectSet) -> EffectSet {
         EffectSet(self.0 | o.0)
@@ -192,7 +192,7 @@ impl EffectSet {
         (self.0 & o.0) == o.0
     }
     pub fn is_unclassified(self) -> bool {
-        self.0 == u32::MAX
+        self.0 == u64::MAX
     }
 }
 

--- a/crates/hale-types/tests/user_effects.rs
+++ b/crates/hale-types/tests/user_effects.rs
@@ -138,3 +138,85 @@ fn declaring_a_user_class_leaves_builtin_names_intact() {
         ds
     );
 }
+
+/// Declaring more classes than the mask holds must be an ERROR, not a
+/// saturating no-op.
+///
+/// `class_mask` used to answer `PURE` for any class past the ceiling.
+/// PURE means "reaches nothing", so `@effects(none: {overflowed})`
+/// SILENTLY CERTIFIED a fn that called a declared source of it — the
+/// analysis failed open. Everything else in this system fails closed
+/// (an unclassified stdlib leaf is treated as doing anything), and an
+/// effect certificate that is quietly false is worse than no
+/// certificate: it is believed. The ceiling is now rejected at the
+/// declaration, where there is a span to point at.
+#[test]
+fn overflowing_the_class_ceiling_is_rejected() {
+    let cap = hale_syntax::ast::EffectClass::USER_CAPACITY;
+    let decls: String =
+        (0..=cap).map(|i| format!("effect e{};\n", i)).collect();
+    let src = format!("{decls}fn main() {{ println(1); }}");
+    let err = hale_syntax::parse_source(&src)
+        .err()
+        .expect("declaring past the ceiling must not parse");
+    let rendered = format!("{:?}", err);
+    assert!(
+        rendered.contains("too many declared effect classes"),
+        "the overflow must be diagnosed at the declaration: {}",
+        rendered
+    );
+}
+
+/// The last class that FITS must still work — an off-by-one here would
+/// silently cost a usable class, or worse, hand out a bit that aliases.
+#[test]
+fn the_last_class_within_the_ceiling_still_propagates() {
+    let cap = hale_syntax::ast::EffectClass::USER_CAPACITY;
+    let last = cap - 1;
+    let decls: String =
+        (0..cap).map(|i| format!("effect e{};\n", i)).collect();
+    let src = format!(
+        "{decls}@effects(is: {{e{last}}})\n\
+         fn leaf(n: Int) -> Int {{ return n; }}\n\
+         @effects(none: {{e{last}}})\n\
+         fn caller(n: Int) -> Int {{ return leaf(n); }}\n\
+         fn main() {{ println(caller(1)); }}"
+    );
+    let program = hale_syntax::parse_source(&src).expect("parse");
+    let ds: Vec<String> = hale_types::check_program(&program)
+        .into_iter()
+        .map(|d| d.message)
+        .collect();
+    assert!(
+        ds.iter().any(|m| m.contains("effect assertion violated")
+            && m.contains(&format!("e{last}"))),
+        "the highest in-range class must still propagate and be named: {:?}",
+        ds
+    );
+}
+
+/// The manifest is a committed baseline whose DIFF is the review
+/// artifact. A placeholder name there is worse than in a diagnostic:
+/// every user class renders identically, so two distinct classes
+/// produce the same line and a real change can diff to nothing.
+#[test]
+fn the_manifest_names_user_classes() {
+    let src = format!(
+        "{MONEY}@effects(none: {{money}})\n\
+         fn price(n: Int) -> Int {{ return n; }}\n\
+         fn main() {{ println(price(5)); }}"
+    );
+    let program = hale_syntax::parse_source(&src).expect("parse");
+    let rows = hale_types::effects::effect_manifest(&[&program]);
+    let rendered = format!("{:?}", rows);
+    assert!(
+        rendered.contains("money"),
+        "the manifest must name the declared class: {}",
+        rendered
+    );
+    assert!(
+        !rendered.contains("<user effect>"),
+        "the manifest must not leak the placeholder: {}",
+        rendered
+    );
+}

--- a/docs/src/effects.md
+++ b/docs/src/effects.md
@@ -442,10 +442,14 @@ is tedious and error-prone to maintain by review, and exactly the one
 that stops holding the moment a call graph is more than a few edges
 deep.
 
-Two limits at v1:
+One limit at v1: **classes are single-seed**. A class declared in one
+compilation seed does not resolve from another, because merging
+per-seed intern tables needs index remapping across the merged AST.
 
-- **Single seed.** A class declared in one compilation seed does not
-  resolve from another; merging per-seed intern tables needs index
-  remapping across the merged AST.
-- **22 classes.** They occupy the free bits above the built-ins in
-  the effect bitmask.
+There are 54 classes available — the bits above the built-ins in the
+effect mask. Declaring past that is an error at the `effect NAME;`
+line, not a saturating no-op: a class with no bit unions as "reaches
+nothing", so `@effects(none: {it})` would silently certify a function
+that calls a declared source. Everything else here fails closed, and
+a certificate that is quietly false is worse than none, because it is
+believed.

--- a/docs/src/effects.md
+++ b/docs/src/effects.md
@@ -442,9 +442,11 @@ is tedious and error-prone to maintain by review, and exactly the one
 that stops holding the moment a call graph is more than a few edges
 deep.
 
-One limit at v1: **classes are single-seed**. A class declared in one
-compilation seed does not resolve from another, because merging
-per-seed intern tables needs index remapping across the merged AST.
+Classes cross seed boundaries — a class declared in a library resolves
+from the app that imports it, which is the whole point: `money` should
+hold everywhere the money goes, and in a real codebase the money goes
+through `lib/`. Each seed interns its own names from zero, so the merge
+unions the tables and remaps each seed's indices before combining them.
 
 There are 54 classes available — the bits above the built-ins in the
 effect mask. Declaring past that is an error at the `effect NAME;`

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -395,9 +395,10 @@ assume the others in a build:
   no-op: a class with no bit unions as PURE, so `none: {…}` on it
   would certify a fn that reaches a declared source. The analysis
   fails closed everywhere else and must here too.
-  **Single-seed at v1**: merging per-seed intern tables needs index
-  remapping across the merged AST, so a cross-seed class name does
-  not resolve.
+  Classes cross seed boundaries. Each seed interns its own names from
+  zero, so the merge unions the tables and rewrites each seed's
+  indices before concatenating items — without that, two seeds' class
+  0 share a bit and a `none:` on one is checked against the other.
 - **Synchronized access is blocking and non-deterministic** (#340/#341,
   2026-08-01). A `sync`-bearing form takes a lock, so a call reaching
   one contributes `block`, and a read through one defeats

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -390,9 +390,14 @@ assume the others in a build:
   same split the stdlib registry has, with a different owner.
 
   Classes are interned as indices and occupy the free bits above the
-  ten built-ins (22 available). **Single-seed at v1**: merging
-  per-seed intern tables needs index remapping across the merged AST,
-  so a cross-seed class name does not resolve.
+  ten built-ins — `EffectSet` is a u64, so 54 are available.
+  Overflow is an **error at the declaration**, not a saturating
+  no-op: a class with no bit unions as PURE, so `none: {…}` on it
+  would certify a fn that reaches a declared source. The analysis
+  fails closed everywhere else and must here too.
+  **Single-seed at v1**: merging per-seed intern tables needs index
+  remapping across the merged AST, so a cross-seed class name does
+  not resolve.
 - **Synchronized access is blocking and non-deterministic** (#340/#341,
   2026-08-01). A `sync`-bearing form takes a lock, so a call reaching
   one contributes `block`, and a read through one defeats


### PR DESCRIPTION
Found while writing the docs chapter for #345 — the article claimed 22 classes as a limit, and checking that number turned up a soundness hole behind it.

## The bug

`class_mask` saturated to `PURE` for any user class past the mask ceiling. `PURE` means "reaches nothing", so a 25-class program where `caller` directly calls a fn declaring `is: {e24}`, while itself declaring `none: {e24}`, reported `ok: 1 file(s) typechecked`. The identical program with 22 classes correctly errors.

This is the one direction the analysis must never fail. Every other incompleteness here fails **closed** — an unclassified stdlib leaf is treated as doing anything. A certificate that is quietly false is worse than no certificate, because it gets believed. The code even claimed the guard existed (*"and the checker rejects the overflow up front"*). Nothing did.

## The fix

`EffectSet` widens u32 → u64, giving **54** user classes instead of 22. Declaring past the ceiling is now an error at the `effect NAME;` line, where there's a span to point at. The saturating arm stays for callers analysing un-checked ASTs, but is unreachable for a program that typechecks. `BUILTIN_BITS` / `USER_CAPACITY` live on `EffectClass` so the parser and the mask cannot disagree about the number.

## Cross-seed classes now resolve

`EffectClass::User(i)` indexes the *declaring seed's* intern table, and every seed interns from zero — so two seeds that each declare one class both use `User(0)` for different names. v1 rejected cross-seed names to avoid the aliasing, which made a class unusable across the boundary it most wants to cross: the point of `money` is that it holds everywhere the money goes, and the money goes through `lib/`.

The merge now unions the name tables and remaps each seed's indices before concatenating items. `remap_user_effects` is deliberately exhaustive over the AST rather than a visitor over "the interesting nodes" — a missed carrier doesn't fail loudly, it silently keeps a stale index that now means a *different* class, which is the aliasing bug reintroduced quietly.

This turned up a second live defect: `hale check` on a directory goes through `merge_programs`, which concatenated items while discarding every input's `effect_names`. It reported `quote` reaching `pii` for an assertion that named `money`.

## Same name-loss bug, second site

The manifest rendered every user class as `<user effect>` — so two distinct classes produce the same line and a real change can diff to nothing, in the artifact whose diff **is** the review. `quote none={<user effect>,syscall}` becomes `quote none={money,syscall}`.

## Why nothing caught any of this

New fixture `74-effect-contracts` covers the annotation surface. The tree-sitter grammar could not parse a single `@no_syscall` / `@effects(…)` / `@deterministic` for weeks after they shipped, and nothing caught it: the corpus gate scans this directory, and **not one fixture used an effect annotation**. A grammar blind spot is invisible only while no corpus file steps into it. The fixture bites — 8 parse errors against the old grammar, 0 against the new. Grammar side is hale-lang/tree-sitter-hale#2.

## Tests

2005/2005 workspace, plus: overflow rejected, last in-range class still propagates (off-by-one), manifest names user classes, built-in names undisturbed, and a two-seed fixture pinning both directions — the same class must fire one seed away, and two different classes that are both index 0 in their own seed must not alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
