### PR TITLE
fix: canonicalize the new effect fixtures (fmt gate)

### DIFF
--- a/crates/hale-cli/tests/fixtures/xseed-user-effects/app/main.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-user-effects/app/main.hl
@@ -4,14 +4,14 @@ import "lib/pii" as pii;
 effect money;
 
 // MUST fire: `pay::charge` carries `money`, one seed away.
-@effects(none: {money})
+@effects(none: { money })
 fn quote(n: Int) -> Int {
     return pay::charge(n);
 }
 
 // MUST NOT fire: `pii::read_name` carries `pii`, not `money` — even
 // though both are class 0 in their declaring seed.
-@effects(none: {money})
+@effects(none: { money })
 fn label(n: Int) -> Int {
     return pii::read_name(n);
 }

--- a/crates/hale-cli/tests/fixtures/xseed-user-effects/lib/pay/p.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-user-effects/lib/pay/p.hl
@@ -1,7 +1,7 @@
 // A library that classifies its own money-moving leaf.
 effect money;
 
-@effects(is: {money})
+@effects(is: { money })
 fn charge(cents: Int) -> Int {
     return cents;
 }

--- a/crates/hale-cli/tests/fixtures/xseed-user-effects/lib/pii/p.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-user-effects/lib/pii/p.hl
@@ -3,7 +3,7 @@
 // them apart.
 effect pii;
 
-@effects(is: {pii})
+@effects(is: { pii })
 fn read_name(n: Int) -> Int {
     return n;
 }

--- a/crates/hale-codegen/tests/fixtures/examples/74-effect-contracts/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/74-effect-contracts/main.hl
@@ -24,7 +24,7 @@ topic Settled {
 }
 
 // A declared source of a user effect class (#345).
-@effects(is: {money})
+@effects(is: { money })
 fn charge(cents: Int) -> Bool {
     return cents > 0;
 }
@@ -36,7 +36,7 @@ fn double(n: Int) -> Int {
 }
 
 // The explicit form, plus a class the program declared itself.
-@effects(none: {syscall, money})
+@effects(none: { syscall, money })
 fn quote(cents: Int) -> Int {
     return double(cents);
 }
@@ -54,7 +54,7 @@ fn safe(n: Int) -> Int {
     return n;
 }
 
-@phase_effects(birth: {alloc})
+@phase_effects(birth: { alloc })
 locus Ledger {
     params {
         total: Int = 0;


### PR DESCRIPTION
The fixtures added in #348 were not in canonical form, so the whole-repo `hale fmt --check` gate went red on main. Canonical form puts spaces inside an effect set — `{ money }`, not `{money}`.

#348 was merged with `--admin`, which bypassed the gate that would otherwise have caught this before merge.

Verified with the exact CI invocation (`crates/hale-codegen/tests/fixtures/examples`, `crates/hale-stdlib/hl`, `crates/hale-cli/tests/fixtures`, `assets/readme play`): clean. Fixtures still typecheck and `xseed_user_effects` still passes.

Noted separately, not fixed here: `docs/src` and `spec/` use the tight form in 30 places and the spaced form in 0, so the teaching material disagrees with what `hale fmt` produces. That is pre-existing and repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
