### PR TITLE
fix(effects): three more ways a user effect class failed open

### DIFF
--- a/.effects-baseline/corpus.effects
+++ b/.effects-baseline/corpus.effects
@@ -323,7 +323,8 @@ Pusher::run  does={syscall,block,publish,time,alloc}
 Sampler::dissolve  does={syscall}
 main  does={alloc}
 ### 74-effect-contracts
-App::birth  does={syscall,publish,alloc}
+App::birth  does={syscall,publish,alloc,money}
+charge  does={money}
 double  none={block,syscall}
 main  does={alloc}
 quote  none={money,syscall}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ behavior.
 
 ## Unreleased
 
+- **An undeclared effect class is now an error** (#345). Interning
+  happened on an `effect NAME;` declaration and on a bare reference in
+  `@effects(...)` alike, so a misspelling minted a brand-new class that
+  nothing carries — `@effects(none: { monye })` typechecked clean on a
+  fn that called a declared `money` source. Same failure as the mask
+  overflow from the other side: there the class had no bit, here it has
+  no carriers, and both yield a certificate quietly true of nothing.
+  The diagnostic offers the nearest declared name.
+- **User effect classes travel over the bus** (#345). `causes:` infers
+  each subscriber's effects from `frontier::infer_effects`, which
+  unioned a leaf's `carries` only when something CALLED it — a fn's own
+  `is: {…}` was invisible to its own set, so a subscriber declaring
+  `is: {money}` contributed nothing to the publisher's causal set. The
+  identical shape with a built-in class reported the violation
+  correctly, which is why spot-checks missed it. `@effects(causes: {…})`
+  also never learned to intern user classes, so the diagnostic's own
+  advice led to a parse error — the feature was unreachable from both
+  ends. The docs, spec and published article all claimed this worked.
+- **The causal diagnostic and the manifest name user classes** (#345).
+  `render_effects` knows only built-ins, so a user class rendered as
+  nothing: `can transitively cause  through the bus`.
+
 - **User effect classes resolve across a seed boundary** (#345). Was
   single-seed at v1: `EffectClass::User(i)` indexes the *declaring*
   seed's intern table, and every seed interns from zero, so two seeds

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -1709,6 +1709,62 @@ fn collect_target_files(t: &ImportTarget) -> Result<Vec<PathBuf>, String> {
 /// names, so a transitive util lib reached through two different
 /// libs lives twice in the binary — no re-export, no dedup, just
 /// per-importer scoped resolution.
+/// #345: the merged user effect-class table.
+///
+/// Carries declared-ness, not just names. A name reaches the table two
+/// ways — an `effect NAME;` DECLARATION, or a mere REFERENCE in an
+/// `@effects(...)` clause — and only the first makes the class real.
+/// Without the distinction a typo interns a fresh class that nothing
+/// carries, so `@effects(none: { monye })` is vacuously satisfied and
+/// reports success: the exact silently-false certificate this analysis
+/// exists to rule out.
+#[derive(Default)]
+struct EffectTable {
+    names: Vec<String>,
+    declared: std::collections::BTreeSet<String>,
+}
+
+impl EffectTable {
+    fn from_seed(p: &Program) -> Self {
+        let mut t = EffectTable::default();
+        t.absorb(p);
+        t
+    }
+
+    /// Union `p`'s table into this one and return the index map that
+    /// rewrites `p`'s `User(i)` into this table.
+    fn absorb(&mut self, p: &Program) -> Vec<u16> {
+        for &i in &p.declared_effects {
+            if let Some(n) = p.effect_names.get(i as usize) {
+                self.declared.insert(n.clone());
+            }
+        }
+        p.effect_names
+            .iter()
+            .map(|n| {
+                let at = self
+                    .names
+                    .iter()
+                    .position(|e| e == n)
+                    .unwrap_or_else(|| {
+                        self.names.push(n.clone());
+                        self.names.len() - 1
+                    });
+                at as u16
+            })
+            .collect()
+    }
+
+    fn declared_indices(&self) -> Vec<u16> {
+        self.names
+            .iter()
+            .enumerate()
+            .filter(|(_, n)| self.declared.contains(*n))
+            .map(|(i, _)| i as u16)
+            .collect()
+    }
+}
+
 fn resolve_imports(
     imports: &[hale_syntax::ast::Import],
     importer_dir: &Path,
@@ -1736,7 +1792,7 @@ fn resolve_imports(
     // means different classes in different seeds. Names are unioned
     // here and each seed's items are remapped into this table before
     // they are merged.
-    effect_names: &mut Vec<String>,
+    effects: &mut EffectTable,
 ) -> Result<(), ()> {
     // Defensive guards + env-gated tracing. The guards bound the
     // resolver's accumulators so a future bug (or pathological
@@ -2002,7 +2058,7 @@ fn resolve_imports(
                 merged_items,
                 renames,
                 seed_cache,
-                effect_names,
+                effects,
             )?;
         }
         // Move mangled items into the merged program; stash sources.
@@ -2011,21 +2067,7 @@ fn resolve_imports(
             // so concatenating two seeds' items without this aliases
             // seed A's class 0 onto seed B's class 0.
             if !pf.program.effect_names.is_empty() {
-                let map: Vec<u16> = pf
-                    .program
-                    .effect_names
-                    .iter()
-                    .map(|n| {
-                        let at = effect_names
-                            .iter()
-                            .position(|e| e == n)
-                            .unwrap_or_else(|| {
-                                effect_names.push(n.clone());
-                                effect_names.len() - 1
-                            });
-                        at as u16
-                    })
-                    .collect();
+                let map = effects.absorb(&pf.program);
                 hale_syntax::ast::remap_user_effects(
                     &mut pf.program.items,
                     &map,
@@ -2107,11 +2149,11 @@ fn parse_with_imports(
     sources.insert(entry_canon, entry_source);
 
     let entry_imports = entry_program.imports.clone();
+    let mut effects = EffectTable::from_seed(&entry_program);
     let mut merged_items = entry_program.items;
     // Seed the merged table with the ENTRY's classes so the entry's
     // own `User(i)` indices stay identity — its items are already in
     // `merged_items` and are never walked.
-    let mut effect_names: Vec<String> = entry_program.effect_names.clone();
     let mut renames: ImportRenames = Vec::new();
     let mut seed_cache: BTreeMap<PathBuf, std::collections::HashMap<String, String>> = BTreeMap::new();
 
@@ -2126,7 +2168,7 @@ fn parse_with_imports(
         &mut merged_items,
         &mut renames,
         &mut seed_cache,
-        &mut effect_names,
+        &mut effects,
     )
     .is_err()
     {
@@ -2142,7 +2184,8 @@ fn parse_with_imports(
     // names and rewrites each seed's indices into this table before
     // merging its items, so the merged program carries one table that
     // every `User(i)` in `merged_items` agrees on.
-    let declared: Vec<u16> = (0..effect_names.len() as u16).collect();
+    let declared: Vec<u16> = effects.declared_indices();
+    let effect_names = effects.names;
     let mut merged = Program {
         effect_names,
         declared_effects: declared,
@@ -2290,11 +2333,11 @@ fn collect_checkable(
         }
     };
     let workspace_root = find_workspace_root(target);
+    let mut effects = EffectTable::from_seed(&merged);
     let mut merged_items = merged.items;
     // Same identity-seeding rule as the entry path: `merged`'s own
     // items are already in `merged_items` and are never walked, so its
     // table must come first.
-    let mut effect_names: Vec<String> = merged.effect_names.clone();
     let mut renames: ImportRenames = Vec::new();
     let mut seed_cache: BTreeMap<
         PathBuf,
@@ -2322,7 +2365,7 @@ fn collect_checkable(
         &mut merged_items,
         &mut renames,
         &mut seed_cache,
-        &mut effect_names,
+        &mut effects,
     )
     .is_err()
     {
@@ -2337,8 +2380,8 @@ fn collect_checkable(
         // The UNIONED table from the merge above, not `merged`'s own —
         // `merged.effect_names` is the pre-import table and every
         // imported seed's `User(i)` was remapped into this one.
-        declared_effects: (0..effect_names.len() as u16).collect(),
-        effect_names,
+        declared_effects: effects.declared_indices(),
+        effect_names: effects.names,
         imports: Vec::new(),
         items: merged_items,
         span: merged.span,
@@ -3120,11 +3163,11 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         }
     };
     let workspace_root = find_workspace_root(target);
+    let mut effects = EffectTable::from_seed(&merged);
     let mut merged_items = merged.items;
     // Same identity-seeding rule as the entry path: `merged`'s own
     // items are already in `merged_items` and are never walked, so its
     // table must come first.
-    let mut effect_names: Vec<String> = merged.effect_names.clone();
     let mut renames: ImportRenames = Vec::new();
     let mut seed_cache: BTreeMap<PathBuf, std::collections::HashMap<String, String>> = BTreeMap::new();
     let mut path_sources: BTreeMap<PathBuf, String> = sources.into_iter().collect();
@@ -3148,7 +3191,7 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         &mut merged_items,
         &mut renames,
         &mut seed_cache,
-        &mut effect_names,
+        &mut effects,
     )
     .is_err()
         || !import_errors.is_empty()
@@ -3160,8 +3203,8 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         return ExitCode::from(1);
     }
     let mut program = Program {
-        declared_effects: (0..effect_names.len() as u16).collect(),
-        effect_names,
+        declared_effects: effects.declared_indices(),
+        effect_names: effects.names,
         imports: Vec::new(),
         items: merged_items,
         span: merged.span,
@@ -3270,9 +3313,9 @@ fn run_build(target: &Path) -> ExitCode {
         // Resolve the union of imports against the directory's
         // own dir as the importer dir + the workspace fallback.
         let workspace_root = find_workspace_root(target);
-        let mut merged_items = merged.items;
+        let mut effects = EffectTable::from_seed(&merged);
+    let mut merged_items = merged.items;
         // Identity-seeded: `merged`'s items are already merged.
-        let mut effect_names: Vec<String> = merged.effect_names.clone();
         let mut renames: ImportRenames = Vec::new();
     let mut seed_cache: BTreeMap<PathBuf, std::collections::HashMap<String, String>> = BTreeMap::new();
         let mut path_sources: BTreeMap<PathBuf, String> =
@@ -3298,7 +3341,7 @@ fn run_build(target: &Path) -> ExitCode {
             &mut merged_items,
             &mut renames,
             &mut seed_cache,
-            &mut effect_names,
+            &mut effects,
         )
         .is_err()
         {
@@ -3316,8 +3359,8 @@ fn run_build(target: &Path) -> ExitCode {
             return ExitCode::from(1);
         }
         let mut with_imports = Program {
-            declared_effects: (0..effect_names.len() as u16).collect(),
-            effect_names,
+            declared_effects: effects.declared_indices(),
+            effect_names: effects.names,
             imports: Vec::new(),
             items: merged_items,
             span: merged.span,
@@ -3808,24 +3851,11 @@ where
     // the same bit — `@effects(none: {money})` in one file would then
     // be checked against `pii` in another. (Observed: the diagnostic
     // reported reaching `pii` for a `none: {money}` assertion.)
-    let mut effect_names: Vec<String> = Vec::new();
+    let mut effects = EffectTable::default();
     let mut take = |p: &Program| -> Vec<hale_syntax::ast::TopDecl> {
         let mut items = p.items.clone();
         if !p.effect_names.is_empty() {
-            let map: Vec<u16> = p
-                .effect_names
-                .iter()
-                .map(|n| {
-                    let at = effect_names
-                        .iter()
-                        .position(|e| e == n)
-                        .unwrap_or_else(|| {
-                            effect_names.push(n.clone());
-                            effect_names.len() - 1
-                        });
-                    at as u16
-                })
-                .collect();
+            let map = effects.absorb(p);
             hale_syntax::ast::remap_user_effects(&mut items, &map);
         }
         items
@@ -3835,8 +3865,8 @@ where
         items.extend(take(p));
     }
     let merged = Program {
-        declared_effects: (0..effect_names.len() as u16).collect(),
-        effect_names,
+        declared_effects: effects.declared_indices(),
+        effect_names: effects.names,
         items,
         imports: Vec::new(),
         span: first.span,

--- a/crates/hale-cli/tests/user_effects_cross_bus.rs
+++ b/crates/hale-cli/tests/user_effects_cross_bus.rs
@@ -1,0 +1,103 @@
+//! A user effect class must travel over the BUS, not just the call
+//! graph (#345).
+//!
+//! The docs, the spec and the published article all stated that a user
+//! class "travels over the bus under `causes:`" like a built-in. It
+//! did not. `causes_diags` infers each subscriber's effect set from
+//! `frontier::infer_effects`, which unioned a leaf's `carries` only
+//! when something CALLED it — a fn's own `is: {…}` was invisible to
+//! its own set. A subscriber declaring `is: {money}` therefore
+//! contributed nothing, and the publisher's `causes:` contract was
+//! satisfied without naming it.
+//!
+//! Two things made this hard to notice. The identical shape with a
+//! built-in class (`println` in the handler) reports the violation
+//! correctly, so any spot-check with a built-in passes. And
+//! `@effects(causes: { money })` did not PARSE — the `causes` arm
+//! never learned to intern user classes — so the diagnostic's own
+//! advice ("add the class to the declaration") led to a parse error.
+//! The feature was unreachable from both ends.
+
+use std::process::Command;
+
+fn check_src(name: &str, src: &str) -> String {
+    let dir = std::env::temp_dir().join(format!(
+        "hale-ue-bus-{}-{}",
+        std::process::id(),
+        name
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let f = dir.join("main.hl");
+    std::fs::write(&f, src).expect("write");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(&f)
+        .output()
+        .expect("run hale check");
+    let _ = std::fs::remove_dir_all(&dir);
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+/// `is: {…}` on the handler, `causes:` on the publisher omitting it.
+fn program(causes: &str) -> String {
+    format!(
+        "effect money;\n\
+         \n\
+         type Payment {{ cents: Int; }}\n\
+         topic Settled {{ payload: Payment; subject: \"settled\"; }}\n\
+         \n\
+         locus Ledger {{\n\
+             params {{ total: Int = 0; }}\n\
+             bus {{ subscribe Settled as on_settled; }}\n\
+         \n\
+             @effects(is: {{ money }})\n\
+             fn on_settled(p: Payment) {{ self.total = self.total + p.cents; }}\n\
+         }}\n\
+         \n\
+         main locus App {{\n\
+             params {{ l: Ledger = Ledger {{ }}; }}\n\
+             bus {{ publish Settled; }}\n\
+         \n\
+             @effects(causes: {{ {causes} }})\n\
+             fn fire() {{ Settled <- Payment {{ cents: 1 }}; }}\n\
+         \n\
+             birth() {{ self.fire(); }}\n\
+         }}\n\
+         \n\
+         fn main() {{ App {{ }}; }}\n"
+    )
+}
+
+#[test]
+fn a_user_class_reached_through_the_bus_violates_causes() {
+    let out = check_src("omitted", &program("publish"));
+    assert!(
+        out.contains("declared causal set violated"),
+        "publishing reaches a subscriber carrying `money`, which the \
+         `causes:` set omits — this must be a violation:\n{}",
+        out
+    );
+    assert!(
+        out.contains("money"),
+        "the causal diagnostic must NAME the class; `render_effects` \
+         knows only built-ins, so a user class rendered as nothing and \
+         the message read `can transitively cause  through the bus`:\n{}",
+        out
+    );
+}
+
+/// The other half: the advice the diagnostic gives must actually work.
+#[test]
+fn declaring_the_user_class_in_causes_satisfies_it() {
+    let out = check_src("declared", &program("publish, money"));
+    assert!(
+        out.contains("typechecked") && !out.contains("error"),
+        "`@effects(causes: {{ publish, money }})` must parse AND \
+         satisfy the contract:\n{}",
+        out
+    );
+}

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -1517,15 +1517,18 @@ impl Parser {
                 "causes" => {
                     let mut classes = Vec::new();
                     for it in &items {
-                        match EffectClass::from_ident(it) {
-                            Some(c) => classes.push(c),
-                            None => {
-                                return Err(Diag::parse(
-                                    key_tok.span,
-                                    format!("unknown effect class `{}`", it),
-                                ))
-                            }
-                        }
+                        // #345: user classes travel over the bus like
+                        // built-ins, so `causes:` must accept them.
+                        // Interning here was missed when user classes
+                        // landed, which made the causal diagnostic
+                        // unfollowable: it said "add the class to the
+                        // declaration" and the declaration then failed
+                        // to parse.
+                        classes.push(
+                            EffectClass::from_ident(it).unwrap_or_else(
+                                || EffectClass::User(self.intern_effect(it)),
+                            ),
+                        );
                     }
                     out.push(EffectAssert::Causes(classes));
                 }

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -101,6 +101,41 @@ fn effect_names_of(programs: &[&Program]) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Indices in the seed's table that came from an `effect NAME;`
+/// DECLARATION, as opposed to a bare reference in an `@effects(...)`
+/// clause. Interning happens for both, so without this a misspelt
+/// class is indistinguishable from a real one.
+/// Cheap near-miss test for the did-you-mean hint: one edit apart, or
+/// a shared prefix long enough that a transposition is the likely
+/// cause. Not a general spell-checker — it only has to catch typing.
+fn close(a: &str, b: &str) -> bool {
+    if a == b {
+        return false;
+    }
+    let (x, y): (Vec<char>, Vec<char>) = (a.chars().collect(), b.chars().collect());
+    if x.len().abs_diff(y.len()) > 1 {
+        return false;
+    }
+    let mut sorted_x = x.clone();
+    let mut sorted_y = y.clone();
+    sorted_x.sort_unstable();
+    sorted_y.sort_unstable();
+    // an anagram of the same letters is almost always a transposition
+    if sorted_x == sorted_y {
+        return true;
+    }
+    let common = x.iter().zip(y.iter()).take_while(|(p, q)| p == q).count();
+    common * 2 >= x.len().min(y.len())
+}
+
+fn declared_of(programs: &[&Program]) -> std::collections::BTreeSet<u16> {
+    programs
+        .iter()
+        .find(|p| !p.effect_names.is_empty())
+        .map(|p| p.declared_effects.iter().copied().collect())
+        .unwrap_or_default()
+}
+
 fn phase_effects_diags(
     programs: &[&Program],
     summary: &AllocSummary,
@@ -458,7 +493,60 @@ fn effect_diags_inner(
     }
     let ffi = ffi_names(programs);
     let names = effect_names_of(programs);
+    // #345: a user class must be DECLARED before it can be asserted
+    // about. Both a declaration and a bare reference intern a name, so
+    // a typo silently became a brand-new class that nothing carries —
+    // and `@effects(none: { monye })` then held vacuously and reported
+    // success. A certificate that is quietly true of nothing is the
+    // same failure as one that is quietly false.
+    let declared = declared_of(programs);
     let mut diags = std::mem::take(&mut placement);
+    for (key, asserts, span) in &roots {
+        let mut seen: Vec<u16> = Vec::new();
+        for a in *&asserts {
+            let cs: &[EffectClass] = match a {
+                EffectAssert::Forbid(cs)
+                | EffectAssert::Causes(cs)
+                | EffectAssert::Carries(cs) => cs,
+                _ => &[],
+            };
+            for c in cs {
+                if let EffectClass::User(i) = c {
+                    if !declared.contains(i) && !seen.contains(i) {
+                        seen.push(*i);
+                        let bad = names
+                            .get(*i as usize)
+                            .cloned()
+                            .unwrap_or_default();
+                        let mut near: Vec<&String> = names
+                            .iter()
+                            .enumerate()
+                            .filter(|(j, _)| declared.contains(&(*j as u16)))
+                            .map(|(_, n)| n)
+                            .filter(|n| close(n, &bad))
+                            .collect();
+                        near.sort();
+                        let hint = match near.first() {
+                            Some(n) => format!(" Did you mean `{}`?", n),
+                            None => String::new(),
+                        };
+                        diags.push(Diag::ty(
+                            *span,
+                            format!(
+                                "`{}` asserts about effect class `{}`, \
+                                 which is never declared. Add `effect {};` \
+                                 at the top level.{}",
+                                key.display(),
+                                bad,
+                                bad,
+                                hint
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+    }
     for (key, asserts, span) in &roots {
         for a in asserts {
             match a {
@@ -1162,14 +1250,16 @@ pub fn effect_manifest_with_inference(
 ) -> Vec<EffectManifestRow> {
     let summary = crate::stdlib_bodies::summarize_with_stdlib(programs);
     let ffi = ffi_names(programs);
+    let names = effect_names_of(programs);
     let declared: BTreeMap<String, EffectManifestRow> = effect_manifest(programs)
         .into_iter()
         .map(|r| (r.func.clone(), r))
         .collect();
     let mut rows: Vec<EffectManifestRow> = Vec::new();
     let mut add = |name: String, key: FnKey| {
-        let inferred = crate::frontier::render_effects(
+        let inferred = crate::frontier::render_effects_named(
             crate::frontier::infer_effects(&summary, &key, &ffi),
+            &names,
         );
         let mut row = declared.get(&name).cloned().unwrap_or(
             EffectManifestRow {

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -61,6 +61,16 @@ pub fn infer_effects(
             return EffectSet::PURE;
         };
         let mut acc = EffectSet::PURE;
+        // #345: what THIS fn declares it carries. The callee arm below
+        // unions a leaf's `carries` when something calls it, but a fn's
+        // own classification was invisible to its own inferred set — so
+        // a bus subscriber declaring `is: {money}` contributed nothing
+        // to `causes_diags`, which infers each subscriber's effects
+        // from here. A user class silently did not travel over the bus,
+        // while every built-in did.
+        if let Some(c) = summary.carries.get(key) {
+            acc = acc.union(*c);
+        }
         if !fs.sites.is_empty() {
             acc = acc.union(EffectSet::ALLOC);
         }
@@ -103,7 +113,18 @@ pub fn infer_effects(
 
 /// Render an effect set as sorted class names — the manifest's
 /// stable form.
+///
+/// Built-ins only; a user class has no static name. Prefer
+/// [`render_effects_named`] anywhere the seed's intern table is in
+/// reach, or a set containing a user class renders as if it were
+/// empty — which reads as "causes nothing".
 pub fn render_effects(e: EffectSet) -> Vec<String> {
+    render_effects_named(e, &[])
+}
+
+/// [`render_effects`] with the seed's user effect-class table, so
+/// `User(i)` bits render as the name the author declared.
+pub fn render_effects_named(e: EffectSet, names: &[String]) -> Vec<String> {
     if e.is_unclassified() {
         return vec!["unclassified".to_string()];
     }
@@ -119,6 +140,16 @@ pub fn render_effects(e: EffectSet) -> Vec<String> {
     ] {
         if e.contains(mask) {
             out.push(name.to_string());
+        }
+    }
+    for (i, n) in names.iter().enumerate() {
+        if (i as u32) < EffectClass::USER_CAPACITY {
+            let bit = EffectSet(
+                1 << (EffectClass::BUILTIN_BITS as u64 + i as u64),
+            );
+            if e.contains(bit) {
+                out.push(n.clone());
+            }
         }
     }
     out
@@ -190,6 +221,14 @@ pub fn causes_diags(
     programs: &[&Program],
     graph: &BusGraph,
 ) -> Vec<Diag> {
+    // The seed's user effect-class table, so an excess class renders
+    // as `money` rather than as nothing at all.
+    let names: Vec<String> = programs
+        .iter()
+        .map(|p| &p.effect_names)
+        .find(|n| !n.is_empty())
+        .cloned()
+        .unwrap_or_default();
     let mut roots: Vec<(FnKey, Vec<EffectClass>, Span)> = Vec::new();
     for p in programs {
         for item in &p.items {
@@ -255,7 +294,7 @@ pub fn causes_diags(
                      class to the declaration, or route the publish to a \
                      subject whose subscribers don't perform it.",
                     key.display(),
-                    render_effects(excess).join(", "),
+                    render_effects_named(excess, &names).join(", "),
                     if via.is_empty() {
                         String::new()
                     } else {

--- a/crates/hale-types/tests/user_effects.rs
+++ b/crates/hale-types/tests/user_effects.rs
@@ -220,3 +220,79 @@ fn the_manifest_names_user_classes() {
         rendered
     );
 }
+
+/// An undeclared class must be an ERROR, not a fresh class.
+///
+/// Interning happens on DECLARATION (`effect money;`) and on bare
+/// REFERENCE (`@effects(none: { money })`) alike, so a misspelling
+/// minted a brand-new class that nothing carries — and the assertion
+/// then held vacuously and reported success. `@effects(none: { monye })`
+/// typechecked clean on a fn that called a declared `money` source.
+///
+/// This is the same failure as the mask overflow, arrived at from the
+/// other side: there the class had no bit, here it has no carriers.
+/// Both produce a certificate that is quietly true of nothing, which
+/// is indistinguishable to the reader from one that is true of
+/// something — and a typo is a far likelier way to reach it than
+/// declaring 55 classes.
+#[test]
+fn an_undeclared_class_is_rejected() {
+    let ds = errs(&format!(
+        "{MONEY}@effects(none: {{monye}})\n\
+         fn price(n: Int) -> Int {{ return charge(n); }}\n\
+         fn main() {{ println(price(5)); }}"
+    ));
+    let d = ds
+        .iter()
+        .find(|m| m.contains("never declared"))
+        .unwrap_or_else(|| panic!("undeclared class must be rejected: {:?}", ds));
+    assert!(
+        d.contains("monye"),
+        "the diagnostic must name the undeclared class: {}",
+        d
+    );
+    assert!(
+        d.contains("Did you mean `money`?"),
+        "a one-transposition miss should offer the declared neighbour: {}",
+        d
+    );
+}
+
+/// The guard must not fire on a legitimately declared class, or every
+/// real user of the feature eats a false error.
+#[test]
+fn a_declared_class_is_not_flagged_undeclared() {
+    let ds = errs(&format!(
+        "{MONEY}@effects(none: {{money}})\n\
+         fn price(n: Int) -> Int {{ return n; }}\n\
+         fn main() {{ println(price(5)); }}"
+    ));
+    assert!(
+        !ds.iter().any(|m| m.contains("never declared")),
+        "a declared class must not be reported undeclared: {:?}",
+        ds
+    );
+}
+
+/// A fn's OWN `is: {…}` must be part of its inferred effect set.
+///
+/// `infer_effects` unioned `carries` for a CALLEE but never for the
+/// function itself, so a fn's classification was invisible to its own
+/// set. That is what made a user class silently not travel over the
+/// bus: `causes_diags` infers each subscriber's effects from here, and
+/// a subscriber declaring `is: {money}` contributed nothing.
+#[test]
+fn a_fns_own_carries_is_in_its_inferred_set() {
+    let program = hale_syntax::parse_source(MONEY).expect("parse");
+    let rows = hale_types::effects::effect_manifest_with_inference(&[&program]);
+    let charge = rows
+        .iter()
+        .find(|r| r.func == "charge")
+        .expect("charge is in the manifest");
+    let rendered = format!("{:?}", charge);
+    assert!(
+        rendered.contains("money"),
+        "a fn declaring `is: {{money}}` must infer `money` for itself: {}",
+        rendered
+    );
+}

--- a/verification/README.md
+++ b/verification/README.md
@@ -37,6 +37,41 @@ GenMC v0.17.0 builds against the project's LLVM 18. See
 | `bus_queue_model.c` | `lotus_bus_queue_*` in `lotus_arena.c` — the cooperative-pool queue's `g_bus_has_pinned`-gated **conditional lock** on enqueue/drain (concurrent enqueues under the lock; drain snapshots under the lock) | ✅ verified: **2 executions, no errors** |
 | `arena_subregion_model.c` | `lotus_arena_create_subregion` / `lotus_arena_destroy` in `lotus_arena.c` — the per-parent `subregion_lock` guarding the child-slot freelist (`free_list` / `free_count` / `next_slot`): concurrent create (pop-or-bump) + destroy (push) on the same parent must never hand the same slot to two live children. The per-thread chunk pool itself is `__thread` (no cross-thread surface); this is the real "arena locks" surface. | ✅ verified: **6 executions, no errors** |
 
+## Coverage gaps and drift (audited 2026-08-02)
+
+The models are **transcriptions**, not the shipping code, and nothing
+detects when the two diverge. A model that still passes proves a
+property of whatever `lotus_arena.c` looked like when the model was
+written. Audited by extracting each mirrored function's
+synchronization skeleton (atomics, fences, mutexes) at the model's
+commit and at HEAD:
+
+| Model | Skeleton drift |
+|---|---|
+| `arena_subregion_model.c` | none — the transcribed protocol is unchanged |
+| `lockfree_hashmap_model.c` | new untranscribed atomics in `lotus_hashmap_iter_next` / `iter_batch` (iteration under concurrent writers) |
+| `mailbox_model.c` | new untranscribed atomics in `lotus_mpsc_ring_peek_nonempty` / `size_approx` |
+| `coop_pool_model.c` | `lotus_coop_pool_enable_async_io` lost its atomic |
+| `bus_queue_model.c` | enqueue body moved into `bus_queue_enqueue_inner`; protocol shape preserved, but it gained a **third** conditional-unlock path for the bounded-capacity branch (#255) that the model predates |
+
+Also untranscribed: `lotus_bus_queue_enqueue_st`, the **zero-
+synchronization** enqueue used when codegen proves no thread crosses
+the bus. Its safety is a *compiler* property (`no_pinned ==
+!program_has_offthread`), not a runtime protocol, so GenMC cannot
+speak to it. `crates/hale-codegen/tests/bus_devirt_no_pinned.rs` pins
+it by example — two specific programs — rather than structurally. The
+residual risk is `program_has_offthread` becoming incomplete: the
+runtime has a **second** writer of `g_bus_has_pinned`
+(`lotus_coop_pool_start_all`, gated on `g_coop_pool_count > 0`) whose
+correspondence to the compile-time predicate nothing asserts.
+
+`spsc_ring_model.c` runs (the runner globs `*_model.c`) but has no row
+in the table above.
+
+None of this means a model is wrong. It means "verified" in the table
+below is a claim about a past revision, and re-transcription is owed
+before it can be read as a claim about HEAD.
+
 ## How to run
 
 ```sh


### PR DESCRIPTION
Asking what *enforces* the claims the effects docs make, rather than whether the docs read well. Three more ways a user effect class failed open, all the same shape as the mask overflow in #348: a certificate that is quietly true of nothing.

## 1. An undeclared class was silently a new class

Interning happens on an `effect NAME;` declaration and on a bare reference in `@effects(...)` alike. So a typo minted a brand-new class that nothing carries:

```hale
effect money;

@effects(is: { money })
fn charge(cents: Int) -> Int { return cents; }

@effects(none: { monye })          // typo — typechecked CLEAN
fn quote(n: Int) -> Int { return charge(n); }
```

`ok: 1 file(s) typechecked`. You believe you have forbidden money; you have forbidden nothing. This is the mask overflow arrived at from the other side — there the class had no bit, here it has no carriers — and a typo is a far likelier route than declaring 55 classes.

Declared-ness now survives the merge. `EffectTable` carries it explicitly; previously the merge marked every interned name as declared, which erased the distinction the parser had already tracked. A reference to an undeclared class is an error, with the nearest declared name offered.

## 2. A user class did not travel over the bus

`causes_diags` infers each subscriber's effect set from `frontier::infer_effects`, which unioned a leaf's `carries` only when something **called** it. A function's own `is: {…}` was invisible to its own inferred set — so a subscriber declaring `is: {money}` contributed nothing to the publisher's causal set, and `@effects(causes: { publish })` was satisfied while publishing into a money-moving handler.

Two things kept this hidden. The identical program with a built-in class (a `println` in the handler) reports the violation correctly, so any spot-check with a built-in passes. And `@effects(causes: { money })` did not **parse** — the `causes` arm never learned to intern user classes — so the diagnostic's own advice, *"add the class to the declaration"*, led to a parse error. The feature was unreachable from both ends.

`docs/src/effects.md`, `spec/verification.md` and the published article all stated this worked. It now does.

## 3. The diagnostic could not name the class

`render_effects` knows only the built-in bits, so a user class rendered as the empty string: `can transitively cause  through the bus`. Fixed there and in the manifest's `does=` column. Third site in the same name-loss family as #348.

## The baseline diff is the review artifact

```
-App::birth  does={syscall,publish,alloc}
+App::birth  does={syscall,publish,alloc,money}
+charge  does={money}
```

`charge` now reports its own classification, and `App::birth` picks it up transitively through the call graph. Exactly the intended change, nothing else.

## GenMC transcription drift (documented, not fixed)

`verification/README.md` now records an audit. The models are transcriptions of `lotus_arena.c`, and **nothing detects divergence** — a passing model proves a property of whatever the runtime looked like when the model was written. Comparing each mirrored function's synchronization skeleton at the model's commit versus HEAD:

- `arena_subregion_model.c` — clean, protocol unchanged.
- `bus_queue_model.c` — enqueue moved into a static helper; shape preserved, but it gained a **third** conditional-unlock path for the bounded-capacity branch (#255) that the model predates.
- `lockfree_hashmap_model.c`, `mailbox_model.c` — new untranscribed atomics (`hashmap_iter_next`/`iter_batch`, `mpsc_ring_peek_nonempty`/`size_approx`).
- `coop_pool_model.c` — `enable_async_io` lost its atomic.

Also untranscribed: `lotus_bus_queue_enqueue_st`, the zero-synchronization enqueue. Its safety is a *compiler* property (`no_pinned == !program_has_offthread`), so GenMC cannot speak to it, and `bus_devirt_no_pinned.rs` pins it by example rather than structurally. The residual risk is `program_has_offthread` becoming incomplete — the runtime has a second writer of `g_bus_has_pinned` (`lotus_coop_pool_start_all`, gated on `g_coop_pool_count > 0`) whose correspondence to the compile-time predicate nothing asserts.

I did not re-transcribe the models; that wants runtime review rather than a docs pass. `spsc_ring_model.c` also runs but had no row in the table — now noted.

## Tests

2015/2015 workspace. Five new: undeclared class rejected with a did-you-mean, a declared class not falsely flagged, a fn's own `carries` in its inferred set, a user class through the bus violating `causes:`, and the declared form both parsing and satisfying the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
