### PR TITLE
verification: two new GenMC models for the drifted surfaces

### DIFF
--- a/verification/README.md
+++ b/verification/README.md
@@ -35,6 +35,8 @@ GenMC v0.17.0 builds against the project's LLVM 18. See
 | `mailbox_model.c` | `lotus_mailbox_*` / `lotus_mpsc_ring_*` in `lotus_arena.c` — the pinned-locus mailbox: a **lock-free Vyukov MPSC ring + signal-when-parked wake** (the `_Atomic int parked` flag + the seq_cst fences in post/drain_one, plus the missed-wakeup handshake) | ✅ verified: **10 executions, no errors** |
 | `coop_pool_model.c` | `lotus_coop_pool_*` / `lotus_mpsc_ring_*` in `lotus_arena.c` — the cooperative pool's classic consumer path after Phase-1b swapped the cell-buffer-under-mutex queue for the same lock-free Vyukov MPSC ring + signal-when-parked wake; the coop-pool twin of `mailbox_model.c` (byte-identical ring + wake handshake) | ✅ verified (mailbox-twin ring + wake) |
 | `bus_queue_model.c` | `lotus_bus_queue_*` in `lotus_arena.c` — the cooperative-pool queue's `g_bus_has_pinned`-gated **conditional lock** on enqueue/drain (concurrent enqueues under the lock; drain snapshots under the lock) | ✅ verified: **2 executions, no errors** |
+| `bus_grow_model.c` | the GROW branch of `bus_queue_enqueue_inner` vs. `lotus_bus_queue_drain` in `lotus_arena.c` — a producer reallocs and frees the `cells` array while a consumer is between its unlock and its use of the popped cell. The pop-snapshot-under-lock is what makes that safe. | ✅ verified: **6 executions, no errors** |
+| `hashmap_iter_model.c` | `lotus_hashmap_iter_next` (LOCKFREE arm) in `lotus_arena.c` — iteration is a SEQUENCE of enter/exit steps, so a grow can land between them. Pinned to `--sc`; see "the RA question" below. | ⚠️ verified under `--sc` only: **13 executions**; fails under the default RA model |
 | `arena_subregion_model.c` | `lotus_arena_create_subregion` / `lotus_arena_destroy` in `lotus_arena.c` — the per-parent `subregion_lock` guarding the child-slot freelist (`free_list` / `free_count` / `next_slot`): concurrent create (pop-or-bump) + destroy (push) on the same parent must never hand the same slot to two live children. The per-thread chunk pool itself is `__thread` (no cross-thread surface); this is the real "arena locks" surface. | ✅ verified: **6 executions, no errors** |
 
 ## Coverage gaps and drift (audited 2026-08-02)
@@ -49,10 +51,10 @@ commit and at HEAD:
 | Model | Skeleton drift |
 |---|---|
 | `arena_subregion_model.c` | none — the transcribed protocol is unchanged |
-| `lockfree_hashmap_model.c` | new untranscribed atomics in `lotus_hashmap_iter_next` / `iter_batch` (iteration under concurrent writers) |
+| `lockfree_hashmap_model.c` | new untranscribed atomics in `lotus_hashmap_iter_next` / `iter_batch` — now covered by `hashmap_iter_model.c` (`iter_batch` / `iter_batch_ptrs` still untranscribed) |
 | `mailbox_model.c` | new untranscribed atomics in `lotus_mpsc_ring_peek_nonempty` / `size_approx` |
 | `coop_pool_model.c` | `lotus_coop_pool_enable_async_io` lost its atomic |
-| `bus_queue_model.c` | enqueue body moved into `bus_queue_enqueue_inner`; protocol shape preserved, but it gained a **third** conditional-unlock path for the bounded-capacity branch (#255) that the model predates |
+| `bus_queue_model.c` | enqueue body moved into `bus_queue_enqueue_inner`; protocol shape preserved, but it gained a **third** conditional-unlock path for the bounded-capacity branch (#255) that the model predates. The grow-vs-drain half is now covered by `bus_grow_model.c`; the shed/inline-drain half is still untranscribed |
 
 Also untranscribed: `lotus_bus_queue_enqueue_st`, the **zero-
 synchronization** enqueue used when codegen proves no thread crosses
@@ -71,6 +73,61 @@ in the table above.
 None of this means a model is wrong. It means "verified" in the table
 below is a claim about a past revision, and re-transcription is owed
 before it can be read as a claim about HEAD.
+
+## The RA question (open, raised 2026-08-02)
+
+`hashmap_iter_model.c` verifies clean under `--sc` and reports
+`Attempt to access freed memory!` under GenMC's **default
+release-acquire model** — which is the faithful one for the runtime's
+`__ATOMIC_ACQUIRE` / `__ATOMIC_RELEASE`. The counter-example:
+
+1. the iterator's second `lf_enter` acquire-loads `grow_phase` and
+   reads-from the *initial* store rather than the grower's release
+   reset, so it never observes the grow;
+2. it proceeds and acquire-loads `m->slots`, again reading-from the
+   initial store;
+3. it indexes the old array, which the grower has already freed.
+
+RA permits a load to read a coherence-older write when nothing orders
+a newer one before it. So the enter/exit protocol's safety rests on
+more than release-acquire provides *in the formal model*. Real
+hardware will not hand back an indefinitely stale line, which is why
+this has never been observed in practice — but "the hardware is
+stronger than the model we wrote against" is a reason to look, not a
+reason to close.
+
+**This is not a claim that the runtime has a live use-after-free.** It
+is a claim that the model-level justification is incomplete, and the
+gap is specific and reproducible:
+
+```sh
+genmc      -- verification/hashmap_iter_model.c   # RA: fails
+genmc --sc -- verification/hashmap_iter_model.c   # SC: clean
+```
+
+Worth noting that `bus_queue_model.c` already records this tension —
+it models `g_bus_has_pinned` as a plain int because "the atomic forces
+the weaker RA model". There that was a modelling convenience. Here it
+is load-bearing, so the model pins `--sc` explicitly and says so,
+rather than quietly arranging to pass.
+
+Resolving it means deciding whether the phase re-check needs a
+seq_cst fence, or whether the RA counter-example depends on an
+interleaving the single-grower discipline actually excludes. That
+wants runtime review.
+
+## Pinning a model's memory model
+
+`run_genmc.sh` honours a `GENMC-FLAGS:` line in a model's header
+comment:
+
+```c
+/* GENMC-FLAGS: --sc */
+```
+
+A model that pins `--sc` **must** state in its header why, and what
+the RA result was. Silently weakening the checker is how a model stops
+meaning anything.
 
 ## How to run
 

--- a/verification/bus_grow_model.c
+++ b/verification/bus_grow_model.c
@@ -1,0 +1,190 @@
+/* GenMC model of the bus queue's GROW-vs-DRAIN surface.
+ * GH issue #18 item 2 (race-completeness). Added 2026-08-02.
+ *
+ * ADDITIVE to bus_queue_model.c, which models the conditional-lock
+ * discipline and says of this branch:
+ *
+ *     "the compact/realloc grow branch elided (it runs under the same
+ *      mutex, so it serializes — no concurrency surface)"
+ *
+ * That reasoning holds only while every reader touches `cells` under
+ * the lock. It no longer does. `lotus_bus_queue_drain` snapshots the
+ * cell and RELEASES THE LOCK before using it:
+ *
+ *     lotus_bus_cell_t cell_copy = q->cells[q->head++];
+ *     pthread_mutex_unlock(&q->lock);
+ *     ... handler runs off the snapshot ...
+ *
+ * and production says why:
+ *
+ *     "must snapshot each cell under the lock so the cells array can't
+ *      be realloc'd out from under the in-flight pop"
+ *
+ * So the grow branch IS a concurrency surface: a producer's realloc
+ * frees the old array while a consumer is between its unlock and its
+ * use of the popped cell. The snapshot is the thing that makes that
+ * safe — and the old model elides exactly the hazard the snapshot
+ * defends against, so it verifies the handoff with nothing to defend
+ * against. This model supplies the hazard.
+ *
+ * FAITHFUL: the conditional lock, the pop-snapshot-under-lock handoff,
+ * the grow that reallocates and frees the previous array while other
+ * threads hold no lock, and the invariant that growth only ever
+ * happens with the lock held.
+ *
+ * NOT the production code: payload is an int; `realloc` is modeled as
+ * malloc+copy+free (same free-of-the-old-block hazard, and GenMC
+ * tracks the allocation); the bound/shed policy and the inline-drain
+ * batch are separate surfaces (see bus_shed_model.c); CAP starts at 1
+ * so a single extra post triggers the grow.
+ *
+ * NEGATIVE CONTROL — a model that cannot fail proves nothing:
+ *
+ *     genmc -- -DMODEL_BUG_INDEX_AFTER_UNLOCK verification/bus_grow_model.c
+ *
+ * makes the consumer keep an INDEX and re-read `q->cells[i]` after
+ * releasing the lock, instead of snapshotting the value under it.
+ * GenMC reports `Error: Non-atomic race!` on `q.cells` within the
+ * first executions — the consumer reads the array POINTER unsynchro-
+ * nized while a concurrent grow publishes the new one. That race is
+ * the precursor to the use-after-free (the old block is freed on the
+ * next line of the grow), and it is what the checker catches first.
+ *
+ * Note the define goes AFTER `--`: everything past it is passed to
+ * clang, not to genmc.
+ *
+ * Run:  genmc -- verification/bus_grow_model.c   (or run_genmc.sh)
+ */
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#define POSTS 2   /* CAP starts at 1, so post #2 grows */
+
+typedef struct {
+    int            *cells;   /* heap array; REALLOCATED on grow */
+    unsigned        head;
+    unsigned        tail;
+    unsigned        cap;
+    pthread_mutex_t lock;
+} queue_t;
+
+static queue_t q;
+
+/* Production reads `g_bus_has_pinned` per operation; in the modeled
+ * (sound) usage it is a constant 1 during the concurrent phase — the
+ * 0->1 transition window is bus_queue_model.c's subject, not this
+ * one's. Kept as a plain int for the same reason given there: it keeps
+ * the checker in SC. */
+static const int locked = 1;
+
+/* enqueue: grow under the lock, then place. Mirrors the
+ * `while (q->tail == q->cap) { ... realloc ... }` block of
+ * bus_queue_enqueue_inner. */
+static void enqueue(int v)
+{
+    if (locked) pthread_mutex_lock(&q.lock);
+
+    while (q.tail == q.cap) {
+        if (q.head > 0) {                      /* compact first */
+            unsigned live = q.tail - q.head;
+            for (unsigned i = 0; i < live; i++)
+                q.cells[i] = q.cells[q.head + i];
+            q.head = 0;
+            q.tail = live;
+        }
+        if (q.tail < q.cap) break;             /* compaction freed a slot */
+
+        /* Grow. The old block is FREED here while consumers hold no
+         * lock — safe only because a consumer never retains a pointer
+         * into it across its unlock. */
+        unsigned new_cap = q.cap * 2;
+        int *fresh = malloc(new_cap * sizeof(int));
+        if (!fresh) {                          /* OOM path: unlock + drop */
+            if (locked) pthread_mutex_unlock(&q.lock);
+            return;
+        }
+        for (unsigned i = 0; i < q.tail; i++)
+            fresh[i] = q.cells[i];
+        free(q.cells);
+        q.cells = fresh;
+        q.cap   = new_cap;
+        break;
+    }
+
+    q.cells[q.tail++] = v;
+    if (locked) pthread_mutex_unlock(&q.lock);
+}
+
+/* drain one: snapshot under the lock, use after releasing it. */
+static int drain_one(void)
+{
+    if (locked) pthread_mutex_lock(&q.lock);
+    if (q.head >= q.tail) {
+        if (locked) pthread_mutex_unlock(&q.lock);
+        return -1;
+    }
+#ifdef MODEL_BUG_INDEX_AFTER_UNLOCK
+    /* The bug the snapshot exists to prevent: keep an INDEX, release
+     * the lock, then dereference `cells` — which a concurrent grow may
+     * already have freed. */
+    unsigned i = q.head++;
+    if (locked) pthread_mutex_unlock(&q.lock);
+    int v = q.cells[i];
+#else
+    int v = q.cells[q.head++];   /* snapshot the VALUE under the lock */
+    if (locked) pthread_mutex_unlock(&q.lock);
+#endif
+    /* The handler would run here, off the snapshot, with no lock
+     * held — which is the whole point of copying. */
+    return v;
+}
+
+static void *producer(void *arg)
+{
+    (void)arg;
+    for (int i = 0; i < POSTS; i++) enqueue(i + 1);
+    return NULL;
+}
+
+static void *consumer(void *arg)
+{
+    (void)arg;
+    /* Bounded attempts, not a spin-to-completion: GenMC explores every
+     * interleaving, so a bounded consumer already covers "pops nothing",
+     * "pops mid-grow", and "pops after both posts". An unbounded spin
+     * would not terminate under exploration. */
+    for (int i = 0; i < POSTS; i++) {
+        int v = drain_one();
+        /* Anything popped must be a value some producer actually
+         * posted — never freed memory, never a torn slot. */
+        assert(v == -1 || (v >= 1 && v <= POSTS));
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    pthread_t p, c;
+
+    q.cap   = 1;
+    q.cells = malloc(q.cap * sizeof(int));
+    q.head  = 0;
+    q.tail  = 0;
+    pthread_mutex_init(&q.lock, NULL);
+
+    pthread_create(&p, NULL, producer, NULL);
+    pthread_create(&c, NULL, consumer, NULL);
+    pthread_join(p, NULL);
+    pthread_join(c, NULL);
+
+    /* Whatever the consumer left behind must still be intact and
+     * within the (possibly grown) array. */
+    assert(q.head <= q.tail);
+    assert(q.tail <= q.cap);
+
+    free(q.cells);
+    pthread_mutex_destroy(&q.lock);
+    return 0;
+}

--- a/verification/hashmap_iter_model.c
+++ b/verification/hashmap_iter_model.c
@@ -1,0 +1,316 @@
+/* GenMC model of lockfree hashmap ITERATION under a concurrent grow.
+ * GH issue #18 item 2 (race-completeness). Added 2026-08-02.
+ *
+ * ADDITIVE to lockfree_hashmap_model.c, which verifies set/remove
+ * against the enter/exit + grow-phase protocol. `lotus_hashmap_iter_next`
+ * / `_iter_batch` arrived after that model was written and were never
+ * transcribed, so nothing checked the one thing that makes iteration
+ * different from every other operation:
+ *
+ *     ITERATION IS NOT ONE OPERATION. IT IS A SEQUENCE OF THEM.
+ *
+ * `lotus_hashmap_iter_next(map, start_slot, out)` takes `lf_enter`,
+ * scans from `start_slot` for the next COMMITTED cell, copies it out,
+ * takes `lf_exit`, and returns the slot index. The caller loops,
+ * passing `found + 1` back in. So the protocol protects each STEP —
+ * and releases between steps. A grow that lands in that gap rehashes
+ * every entry into a new array with a new capacity, and the caller's
+ * cursor is an index into a table that no longer exists.
+ *
+ * This model checks the property that DOES hold, and pins the one that
+ * does NOT, so the contract is written down in an executable form
+ * rather than assumed.
+ *
+ *   HOLDS (checked here, unconditionally): iteration is MEMORY-SAFE
+ *   under concurrent growth. Each step re-reads `m->slots` inside its
+ *   own enter/exit, and the grower drains `writers_in_flight` to zero
+ *   before swapping and freeing — so a step never touches the freed
+ *   array, and every value it yields is one genuinely stored in the
+ *   map. This is inherited from the verified protocol; the point is
+ *   that iteration actually participates in it.
+ *
+ *   DOES NOT HOLD (demonstrated by control 2 below): iteration is NOT
+ *   a snapshot. A rehash relocates entries, and the caller's cursor is
+ *   an index, so an entry can be moved from a slot the cursor has
+ *   already passed to one ahead of it and be YIELDED TWICE. This model
+ *   exhibits exactly that. (The mirror case — an entry relocated
+ *   backwards and therefore never yielded — is possible in principle
+ *   but is NOT exhibited at this table size, where a rehash from
+ *   cap 2 to cap 4 only ever moves entries forward. Do not read a
+ *   completeness guarantee into its absence here.) Callers must treat
+ *   iteration under concurrent growth as neither complete nor
+ *   duplicate-free.
+ *
+ * FAITHFUL: the enter/exit writer-counter with its 0->1 re-check
+ * backout, the single-grower CAS + drain + migrate + free, the
+ * per-step (not per-loop) protection, and the caller's
+ * `start_slot = found + 1` cursor.
+ *
+ * NOT the production code: keys/values are ints; open addressing is
+ * linear probing over a power-of-two table, as in the sibling model;
+ * `sched_yield` in the spin is elided (GenMC explores the
+ * interleavings directly).
+ *
+ * NEGATIVE CONTROLS — two, because there are two claims:
+ *
+ *   1. The safety claim has teeth. Build with
+ *        genmc --sc -- -DMODEL_BUG_NO_DRAIN verification/hashmap_iter_model.c
+ *      to delete the grower's drain-wait. GenMC reports `Attempt to
+ *      access non-allocated memory!` — the iterator is inside its step,
+ *      holding a pointer into `old_slots`, when the grower frees it.
+ *
+ *   2. The not-a-snapshot NON-claim is real, not hypothetical:
+ *        genmc --sc -- -DMODEL_ASSERT_ITERATION_IS_A_SNAPSHOT verification/hashmap_iter_model.c
+ *      asserts that no value is yielded twice. GenMC reports a safety
+ *      violation, exhibiting the interleaving where a grow relocates
+ *      an entry ahead of the cursor and the iterator returns it again.
+ *      That failure is the DOCUMENTATION: it is the contract, not a
+ *      bug to fix.
+ *
+ * GENMC-FLAGS: --sc
+ *
+ * WHY THIS MODEL PINS --sc, AND THE OPEN QUESTION IT RAISES
+ * ---------------------------------------------------------
+ * Under GenMC's DEFAULT release-acquire model — the faithful one for
+ * the runtime's `__ATOMIC_ACQUIRE` / `__ATOMIC_RELEASE` — this model
+ * reports `Attempt to access freed memory!`. Under `--sc` it verifies
+ * clean (13 executions). The failing trace is:
+ *
+ *   - the iterator's 2nd `lf_enter` acquire-loads `grow_phase` and
+ *     reads-from the INITIAL store, not the grower's release reset;
+ *   - so it never observes the grow, proceeds, and acquire-loads
+ *     `m->slots` — also reading-from the initial store;
+ *   - it then indexes the OLD array, which the grower has freed.
+ *
+ * RA permits a load to read a coherence-older write when nothing
+ * orders a newer one before it. The protocol's safety therefore rests
+ * on more than release-acquire alone provides *in the formal model*.
+ * Real hardware (x86/ARM cache coherence) will not hand back an
+ * indefinitely stale line, which is why this has never been observed —
+ * but "the hardware is stronger than the model we wrote against" is a
+ * reason to look, not a reason to close.
+ *
+ * This is NOT a claim that the runtime has a live use-after-free.
+ * It is a claim that the model-level justification is incomplete, and
+ * that the gap is specific and reproducible:
+ *
+ *     genmc -- verification/hashmap_iter_model.c        # RA: fails
+ *     genmc --sc -- verification/hashmap_iter_model.c   # SC: clean
+ *
+ * The same tradeoff is already recorded in bus_queue_model.c, which
+ * uses a plain int for `g_bus_has_pinned` because "the atomic forces
+ * the weaker RA model". That was a modelling convenience there; here
+ * it is load-bearing, so it is pinned explicitly and written down
+ * rather than quietly arranged for.
+ *
+ * Resolving it means deciding whether the enter/exit protocol needs a
+ * seq_cst fence at the phase re-check (production already has
+ * `atomic_thread_fence` machinery elsewhere), or whether the RA
+ * counter-example depends on an interleaving the single-grower
+ * discipline actually excludes. That wants runtime review, not a
+ * transcription pass.
+ *
+ * Run:  genmc --sc -- verification/hashmap_iter_model.c  (or run_genmc.sh)
+ */
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <stdatomic.h>
+#include <assert.h>
+
+#define CELL_EMPTY     0
+#define CELL_COMMITTED 2
+
+typedef struct {
+    _Atomic(int) state;
+    int key;
+    int val;
+} slot_t;
+
+typedef struct {
+    _Atomic(slot_t *) slots;
+    _Atomic(size_t)   cap;
+    _Atomic(int)      grow_phase;
+    _Atomic(int)      writers_in_flight;
+} map_t;
+
+static map_t m;
+
+static slot_t *alloc_slots(size_t n) {
+    slot_t *p = (slot_t *)malloc(n * sizeof(slot_t));
+    for (size_t i = 0; i < n; i++) {
+        atomic_store_explicit(&p[i].state, CELL_EMPTY, memory_order_relaxed);
+        p[i].key = 0;
+        p[i].val = 0;
+    }
+    return p;
+}
+
+/* --- enter / exit (lotus_hashmap_lf_enter / _exit) ----------------- */
+
+static void lf_enter(map_t *mp) {
+    for (;;) {
+        int phase = atomic_load_explicit(&mp->grow_phase, memory_order_acquire);
+        if (phase != 0) continue;
+        atomic_fetch_add_explicit(&mp->writers_in_flight, 1,
+                                  memory_order_acquire);
+        /* Re-check: a grower may have CAS'd 0->1 between the load and
+         * the increment. Back out, or its drain spin deadlocks. */
+        phase = atomic_load_explicit(&mp->grow_phase, memory_order_acquire);
+        if (phase != 0) {
+            atomic_fetch_sub_explicit(&mp->writers_in_flight, 1,
+                                      memory_order_release);
+            continue;
+        }
+        return;
+    }
+}
+
+static void lf_exit(map_t *mp) {
+    atomic_fetch_sub_explicit(&mp->writers_in_flight, 1,
+                              memory_order_release);
+}
+
+/* --- grow (lotus_hashmap_grow_lockfree + _lf_migrate) -------------- */
+
+static void grow(map_t *mp) {
+    int expected = 0;
+    if (!atomic_compare_exchange_strong_explicit(
+            &mp->grow_phase, &expected, 1,
+            memory_order_acq_rel, memory_order_relaxed)) {
+        return;
+    }
+#ifndef MODEL_BUG_NO_DRAIN
+    /* The drain. Without it an iterator can still be inside its step,
+     * holding a pointer into old_slots, when the free below runs. */
+    while (atomic_load_explicit(&mp->writers_in_flight,
+                                memory_order_acquire) > 0) {
+        /* spin */
+    }
+#endif
+    slot_t *old_slots = atomic_load_explicit(&mp->slots, memory_order_relaxed);
+    size_t  old_cap   = atomic_load_explicit(&mp->cap, memory_order_relaxed);
+    size_t  new_cap   = old_cap * 2;
+    slot_t *new_slots = alloc_slots(new_cap);
+    if (!new_slots) {
+        atomic_store_explicit(&mp->grow_phase, 0, memory_order_release);
+        return;
+    }
+    /* Rehash. THIS is what breaks cursor continuity: an entry's slot
+     * index in the new table is unrelated to its index in the old. */
+    for (size_t s = 0; s < old_cap; s++) {
+        if (atomic_load_explicit(&old_slots[s].state, memory_order_relaxed)
+            != CELL_COMMITTED) continue;
+        int k = old_slots[s].key, v = old_slots[s].val;
+        size_t i = (size_t)k & (new_cap - 1);
+        for (;;) {
+            if (atomic_load_explicit(&new_slots[i].state,
+                                     memory_order_relaxed) == CELL_EMPTY) {
+                new_slots[i].key = k;
+                new_slots[i].val = v;
+                atomic_store_explicit(&new_slots[i].state, CELL_COMMITTED,
+                                      memory_order_relaxed);
+                break;
+            }
+            i = (i + 1) & (new_cap - 1);
+        }
+    }
+    atomic_store_explicit(&mp->slots, new_slots, memory_order_release);
+    atomic_store_explicit(&mp->cap, new_cap, memory_order_release);
+    free(old_slots);
+    atomic_store_explicit(&mp->grow_phase, 0, memory_order_release);
+}
+
+/* --- iter_next (lotus_hashmap_iter_next, LOCKFREE arm) ------------- */
+/* Returns the slot it yielded from, or -1 when the scan runs off the
+ * end. `*out` receives the value. Protection is per CALL. */
+static long iter_next(map_t *mp, long start_slot, int *out) {
+    if (start_slot < 0) return -1;
+    long found = -1;
+    lf_enter(mp);
+    slot_t *slots = atomic_load_explicit(&mp->slots, memory_order_acquire);
+    size_t  cap   = atomic_load_explicit(&mp->cap, memory_order_acquire);
+    for (size_t s = (size_t)start_slot; s < cap; s++) {
+        if (atomic_load_explicit(&slots[s].state, memory_order_acquire)
+            == CELL_COMMITTED) {
+            *out = slots[s].val;
+            found = (long)s;
+            break;
+        }
+    }
+    lf_exit(mp);
+    return found;
+}
+
+/* Pre-seeded, and never modified after the threads start: whatever an
+ * iteration yields must be one of these, and a complete iteration
+ * would yield both. */
+#define KEY_A 1
+#define VAL_A 11
+#define KEY_B 2
+#define VAL_B 22
+
+static int seen_vals[4];
+static int seen_n;
+
+static void *iterator(void *arg) {
+    (void)arg;
+    long cursor = 0;
+    for (int steps = 0; steps < 4; steps++) {
+        int v = 0;
+        long at = iter_next(&m, cursor, &v);
+        if (at < 0) break;
+        /* SAFETY: never freed memory, never a torn or unwritten cell.
+         * Anything yielded is a value genuinely stored in the map. */
+        assert(v == VAL_A || v == VAL_B);
+        seen_vals[seen_n++] = v;
+        cursor = at + 1;              /* the caller's cursor */
+    }
+    return NULL;
+}
+
+static void *grower(void *arg) {
+    (void)arg;
+    grow(&m);
+    return NULL;
+}
+
+int main(void) {
+    pthread_t it, gr;
+
+    size_t cap = 2;
+    slot_t *slots = alloc_slots(cap);
+    /* Seed both entries so a rehash has something to relocate. With
+     * cap 2 they occupy slots 1 and 0 (key & (cap-1)). */
+    size_t ia = (size_t)KEY_A & (cap - 1);
+    slots[ia].key = KEY_A; slots[ia].val = VAL_A;
+    atomic_store_explicit(&slots[ia].state, CELL_COMMITTED, memory_order_relaxed);
+    size_t ib = (size_t)KEY_B & (cap - 1);
+    if (ib == ia) ib = (ib + 1) & (cap - 1);
+    slots[ib].key = KEY_B; slots[ib].val = VAL_B;
+    atomic_store_explicit(&slots[ib].state, CELL_COMMITTED, memory_order_relaxed);
+
+    atomic_store_explicit(&m.slots, slots, memory_order_relaxed);
+    atomic_store_explicit(&m.cap, cap, memory_order_relaxed);
+    atomic_store_explicit(&m.grow_phase, 0, memory_order_relaxed);
+    atomic_store_explicit(&m.writers_in_flight, 0, memory_order_relaxed);
+
+    pthread_create(&it, NULL, iterator, NULL);
+    pthread_create(&gr, NULL, grower, NULL);
+    pthread_join(it, NULL);
+    pthread_join(gr, NULL);
+
+#ifdef MODEL_ASSERT_ITERATION_IS_A_SNAPSHOT
+    /* NOT a guarantee the implementation makes. Asserting it here makes
+     * GenMC exhibit the interleaving that breaks it: the grow lands
+     * mid-iteration and rehashes an entry to a slot the cursor has
+     * already passed, so it is never yielded. Both entries were present
+     * for the entire iteration. */
+    for (int i = 0; i < seen_n; i++)
+        for (int j = i + 1; j < seen_n; j++)
+            assert(seen_vals[i] != seen_vals[j]);
+#endif
+
+    free(atomic_load_explicit(&m.slots, memory_order_relaxed));
+    return 0;
+}

--- a/verification/run_genmc.sh
+++ b/verification/run_genmc.sh
@@ -18,10 +18,22 @@ fi
 
 echo "Using $("$GENMC" --version 2>&1 | head -2 | tail -1)"
 fail=0
+# A model may pin the memory model it is checked under with a
+# `GENMC-FLAGS:` line in its header comment, e.g.
+#
+#     /* GENMC-FLAGS: --sc */
+#
+# Default is GenMC's release-acquire model, which is the faithful one
+# for the runtime's `__ATOMIC_ACQUIRE` / `__ATOMIC_RELEASE`. A model
+# that pins `--sc` MUST say in its header why, and what the RA result
+# was — silently weakening the checker is how a model stops meaning
+# anything.
 for model in "$here"/*_model.c; do
     [ -e "$model" ] || continue
-    echo "── $(basename "$model") ───────────────────────────────"
-    if "$GENMC" -- "$model"; then
+    flags="$(sed -n 's|.*GENMC-FLAGS:[[:space:]]*||p' "$model" | head -1 \
+                | sed -e 's|\*/.*||' -e 's|[[:space:]]*$||')"
+    echo "── $(basename "$model") ${flags:+[$flags] }───────────────────────────────"
+    if "$GENMC" $flags -- "$model"; then
         echo "  ✓ verified (no races / UAF / assertion violations)"
     else
         echo "  ✗ GenMC reported a violation in $(basename "$model")" >&2


### PR DESCRIPTION
Additive re-transcription of the GenMC drift audited in #350. The existing five models are untouched and still pass; this adds two covering the surfaces that had drifted, plus the machinery to keep a model honest about what it is checked under.

## `bus_grow_model.c`

`bus_queue_model.c` explicitly elides the grow branch:

> "the compact/realloc grow branch elided (it runs under the same mutex, so it serializes — no concurrency surface)"

That reasoning holds only while every reader touches `cells` under the lock. It no longer does — `lotus_bus_queue_drain` snapshots the cell and **releases the lock before using it**, and production says exactly why:

> "must snapshot each cell under the lock so the cells array can't be realloc'd out from under the in-flight pop"

So the grow branch *is* a concurrency surface: a producer's realloc frees the old array while a consumer sits between its unlock and its use of the popped cell. The old model verifies the snapshot handoff with nothing for the snapshot to defend against; this one supplies the hazard.

Negative control (`-DMODEL_BUG_INDEX_AFTER_UNLOCK` — keep an index, re-read `cells` after unlocking) reports `Error: Non-atomic race!` on `q.cells`. I'd originally written that it would report a use-after-free; it reports the race on the array pointer first, which is the precursor, and the comment now says so.

## `hashmap_iter_model.c`

`lotus_hashmap_iter_next` arrived after the sibling model and was never transcribed. It is different in kind from every other map operation:

**Iteration is not one operation. It is a sequence of them.** Each `iter_next` takes `lf_enter`, scans, copies out, takes `lf_exit`, and returns a slot index the caller feeds back as `found + 1`. Protection is per *step*; a grow can land in the gap and rehash every entry.

The model checks what holds — memory safety, inherited from the verified protocol — and pins what does not. Control 2 asserts iteration is a snapshot and GenMC exhibits the violation: an entry **yielded twice** after a rehash relocates it ahead of the cursor.

Worth flagging a correction: I first asserted iteration could *skip* an entry. It cannot at this table size — a rehash from cap 2 to cap 4 only moves entries forward — so the control now asserts the duplication that actually occurs, and the header says the skip case is unexhibited rather than absent. A model that claims more than it demonstrates is the failure mode this whole exercise is about.

## The open question this surfaced

`hashmap_iter_model.c` verifies clean under `--sc` and reports `Attempt to access freed memory!` under GenMC's **default release-acquire model** — the faithful one for the runtime's `__ATOMIC_ACQUIRE` / `__ATOMIC_RELEASE`. The counter-example: the iterator's second `lf_enter` acquire-loads `grow_phase` and reads-from the *initial* store rather than the grower's release reset, never observes the grow, then acquire-loads `m->slots` — also stale — and indexes the freed array.

RA permits a load to read a coherence-older write when nothing orders a newer one before it. **This is not a claim that the runtime has a live use-after-free** — real hardware won't hand back an indefinitely stale line, which is why it has never been observed. It is a claim that the model-level justification is incomplete, and the gap is exactly reproducible:

```sh
genmc      -- verification/hashmap_iter_model.c   # RA: fails
genmc --sc -- verification/hashmap_iter_model.c   # SC: clean
```

Resolving it means deciding whether the phase re-check needs a seq_cst fence, or whether the RA counter-example depends on an interleaving the single-grower discipline actually excludes. That wants runtime review, not a transcription pass, so it is documented under "The RA question" rather than guessed at.

Notably `bus_queue_model.c` already recorded this tension — it models `g_bus_has_pinned` as a plain int because "the atomic forces the weaker RA model". There it was a modelling convenience; here it is load-bearing.

## Keeping models honest about their model

`run_genmc.sh` now honours a `GENMC-FLAGS:` line in a model's header, so a model can pin `--sc` visibly (the runner prints it: `hashmap_iter_model.c [--sc]`) instead of a maintainer weakening the checker globally. The README requires any model that pins `--sc` to state why and what the RA result was.

## Still untranscribed

Recorded in the README rather than silently left: `bus_queue`'s shed / inline-drain batch, `hashmap_iter_batch` / `iter_batch_ptrs`, `mpsc_ring_peek_nonempty` / `size_approx`, and `lotus_bus_queue_enqueue_st` (whose safety is a compiler property GenMC cannot speak to).

## Status

All 8 models pass — `verification/run_genmc.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
