### PR TITLE
chore: zero build warnings, and stop the fmt gate going stale

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,11 +117,11 @@ jobs:
         # whole-repo and takes <1s; running it 4× adds nothing.
         if: matrix.partition == 1
         run: |
-          ./target/release/hale fmt --check \
-            crates/hale-codegen/tests/fixtures/examples \
-            crates/hale-stdlib/hl \
-            crates/hale-cli/tests/fixtures \
-            assets/readme play
+          # Whole repo, not an enumerated list. The list form silently
+          # excluded tests/hale (the in-language suite), which drifted
+          # out of canonical form unnoticed — an enumerated scope is a
+          # scope that goes stale every time a directory is added.
+          ./target/release/hale fmt --check .
 
       - name: cargo nextest run (partition ${{ matrix.partition }}/4)
         # Build-and-run in one job (no separate archive job + upload/

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2446,10 +2446,6 @@ fn file_of_span(
 }
 
 
-fn run_check(target: &Path) -> ExitCode {
-    run_check_impl(target, false)
-}
-
 /// Shared core of `hale check` (advisories print, only errors
 /// fail) and `hale verify` (every finding fails — the CI
 /// discipline gate; same ~10 ms analysis, no execution).

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -877,7 +877,7 @@ pub fn build_executable_with_options(
     let time_phases = std::env::var("HALE_TIME").is_ok();
     let t_start = std::time::Instant::now();
     let mut t_last = t_start;
-    let mut phase = |name: &str, t_last: &mut std::time::Instant| {
+    let phase = |name: &str, t_last: &mut std::time::Instant| {
         if time_phases {
             let now = std::time::Instant::now();
             eprintln!(

--- a/crates/hale-lsp/src/lib.rs
+++ b/crates/hale-lsp/src/lib.rs
@@ -1792,12 +1792,9 @@ fn placement_spec_str(e: &hale_syntax::ast::PlacementEntry) -> String {
             None => "cooperative(pool = main)".to_string(),
         },
         PlacementSpec::Pinned { affinity, replicas } => {
-            let mut s = format!("pinned{:?}", affinity)
-                .replace("Any", "")
-                .replace("pinned", "pinned");
             // Debug-format affinity compactly; `PinAffinity::Any`
             // renders as bare `pinned`.
-            s = if format!("{:?}", affinity).contains("Any") {
+            let mut s = if format!("{:?}", affinity).contains("Any") {
                 "pinned".to_string()
             } else {
                 format!("pinned({:?})", affinity)

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -2637,7 +2637,6 @@ fn check_placement_single_thread(
                         let mut cx = PoolCheckCx {
                             enclosing_locus: l,
                             caller_pool,
-                            pool_of_locus_type: &pool_of_locus_type,
                             cross_pool_safe_loci: &cross_pool_safe_loci,
                             form_bearing_loci: &form_bearing_loci,
                             inferred_sync: &inferred_sync,
@@ -2773,7 +2772,6 @@ fn form_has_explicit_sync_discipline(form: &FormAnnotation) -> bool {
 struct PoolCheckCx<'a> {
     enclosing_locus: &'a LocusDecl,
     caller_pool: Option<&'a PoolId>,
-    pool_of_locus_type: &'a BTreeMap<String, PoolId>,
     /// F.32-0 (2026-05-24): locus type names that opt in to
     /// cross-pool access by declaring `@form(<name>, sync = X)`
     /// where X is a recognized discipline (`serialized` /

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -203,11 +203,12 @@ pub struct FnEntry {
     pub effects: EffectSet,
 }
 
-/// Row constructor for the (current) unclassified default — keeps
-/// the table visually close to the old bare-name lists.
-const fn f(name: &'static str) -> FnEntry {
-    FnEntry { name, effects: EffectSet::UNCLASSIFIED }
-}
+// The unclassified-default row constructor `f(name)` used to live
+// here. It is gone because nothing calls it: every registry row below
+// is classified (#265 phase 2 finished the sweep). Its absence is a
+// small enforcement — adding an unclassified row now means
+// deliberately reintroducing a constructor for one, rather than
+// reaching for the one already sitting in the file.
 
 /// #265 phase 2: a CLASSIFIED registry row. Every effectful and
 /// pure stdlib fn carries its leaf effect set; `f(..)` remains for

--- a/tests/hale/str_parse_decimal_test.hl
+++ b/tests/hale/str_parse_decimal_test.hl
@@ -37,7 +37,7 @@ fn main() {
     let v = std::str::parse_decimal("not a number") or {
         std::test::assert_eq_str(err.kind, "parse_decimal", "err.kind");
         std::test::assert_eq_str(err.input, "not a number", "err.input");
-        -1.0d
+            -1.0d
     };
     std::test::assert_eq_str("" + v, "-1", "substitute value");
 }

--- a/tests/hale/str_parse_int_test.hl
+++ b/tests/hale/str_parse_int_test.hl
@@ -31,7 +31,7 @@ fn main() {
     let n = std::str::parse_int("totally bogus") or {
         std::test::assert_eq_str(err.kind, "parse_int", "err.kind");
         std::test::assert_eq_str(err.input, "totally bogus", "err.input");
-        -1
+            -1
     };
     std::test::assert_eq_int(n, -1, "substitute value");
 


### PR DESCRIPTION
Housekeeping, prompted by asking what else was left. Two unrelated things, both small.

## Zero build warnings

Five long-standing warnings, none load-bearing:

- `PoolCheckCx::pool_of_locus_type` — dead field, unread since the F.31 per-instance rework stopped needing a type-global map.
- `stdlib_surface::f` — the `UNCLASSIFIED`-default row constructor. Its disuse is the interesting part: every registry row is classified (#265 phase 2 finished the sweep), so nothing calls it. Removing it is a small enforcement — adding an unclassified row now means deliberately writing a constructor for one, rather than reaching for the one already sitting in the file.
- `run_check` — a wrapper nothing called; every caller uses `run_check_impl`.
- hale-lsp placement rendering — a dead initializer whose `.replace("pinned", "pinned")` no-op marks it as the leftover of an abandoned edit. `s` is now bound directly to the conditional it was immediately overwritten with.
- codegen's `phase` closure captures nothing mutably.

## The fmt gate had a stale scope

It enumerated four directories, which silently excluded `tests/hale` — the in-language test suite — and that had drifted out of canonical form unnoticed. An enumerated scope goes stale every time a directory is added.

The gate now checks the whole repo, which is what its own comment already claimed: *"the check is whole-repo and takes <1s"*. Both files reformatted; the in-language suite still passes.

This is the same shape as the `tree-sitter-hale` corpus workflow pointing at a moved stdlib path, and as the effect-annotation surface having no corpus fixture: an enforcement mechanism that quietly stopped covering the thing it was written for.

## Not done here

Zero warnings means `RUSTFLAGS: -D warnings` would now pass, and that would keep it at zero. I have not added it — it is a policy call with a real cost (a new lint in a future rustc breaks CI on unrelated PRs), and the ask was cleanup, not a new gate. Happy to add it if wanted.

## Status

2015/2015 workspace tests, zero build warnings, `hale fmt --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
