### PR TITLE
feat(effects): closed contracts (only:) and composed classes

### DIFF
--- a/.effects-baseline/corpus.effects
+++ b/.effects-baseline/corpus.effects
@@ -326,7 +326,9 @@ main  does={alloc}
 App::birth  does={syscall,publish,alloc,money}
 charge  does={money}
 double  none={block,syscall}
+label  only={alloc}  does={alloc}
 main  does={alloc}
+no_io  none={io}
 quote  none={money,syscall}
 safe  none={panic}
 scale  none={entropy,env,time}  alloc_per_call=0

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -1722,6 +1722,12 @@ fn collect_target_files(t: &ImportTarget) -> Result<Vec<PathBuf>, String> {
 struct EffectTable {
     names: Vec<String>,
     declared: std::collections::BTreeSet<String>,
+    /// #354: composed definitions, index-parallel to `names`. Members
+    /// are remapped into THIS table on absorb — a definition holds
+    /// `EffectClass::User` indices, so carrying it across a seed
+    /// boundary without remapping aliases it exactly like any other
+    /// class reference.
+    defs: Vec<Option<Vec<hale_syntax::ast::EffectClass>>>,
 }
 
 impl EffectTable {
@@ -1739,7 +1745,8 @@ impl EffectTable {
                 self.declared.insert(n.clone());
             }
         }
-        p.effect_names
+        let map: Vec<u16> = p
+            .effect_names
             .iter()
             .map(|n| {
                 let at = self
@@ -1748,11 +1755,34 @@ impl EffectTable {
                     .position(|e| e == n)
                     .unwrap_or_else(|| {
                         self.names.push(n.clone());
+                        self.defs.push(None);
                         self.names.len() - 1
                     });
                 at as u16
             })
-            .collect()
+            .collect();
+        // Carry definitions across, remapping their MEMBERS. A member
+        // is a `User(i)` in the source seed's numbering; storing it
+        // unremapped would silently point the definition at whatever
+        // class holds that index in the merged table.
+        for (i, def) in p.effect_defs.iter().enumerate() {
+            let Some(members) = def else { continue };
+            let Some(&to) = map.get(i) else { continue };
+            let remapped: Vec<hale_syntax::ast::EffectClass> = members
+                .iter()
+                .map(|m| match m {
+                    hale_syntax::ast::EffectClass::User(j) => map
+                        .get(*j as usize)
+                        .map(|&k| hale_syntax::ast::EffectClass::User(k))
+                        .unwrap_or(*m),
+                    other => *other,
+                })
+                .collect();
+            if let Some(slot) = self.defs.get_mut(to as usize) {
+                *slot = Some(remapped);
+            }
+        }
+        map
     }
 
     fn declared_indices(&self) -> Vec<u16> {
@@ -2185,10 +2215,12 @@ fn parse_with_imports(
     // merging its items, so the merged program carries one table that
     // every `User(i)` in `merged_items` agrees on.
     let declared: Vec<u16> = effects.declared_indices();
+    let effect_defs = effects.defs;
     let effect_names = effects.names;
     let mut merged = Program {
         effect_names,
         declared_effects: declared,
+        effect_defs,
         imports: Vec::new(),
         items: merged_items,
         span: entry_program.span,
@@ -2381,6 +2413,7 @@ fn collect_checkable(
         // `merged.effect_names` is the pre-import table and every
         // imported seed's `User(i)` was remapped into this one.
         declared_effects: effects.declared_indices(),
+        effect_defs: effects.defs,
         effect_names: effects.names,
         imports: Vec::new(),
         items: merged_items,
@@ -3200,6 +3233,7 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
     }
     let mut program = Program {
         declared_effects: effects.declared_indices(),
+        effect_defs: effects.defs,
         effect_names: effects.names,
         imports: Vec::new(),
         items: merged_items,
@@ -3356,6 +3390,7 @@ fn run_build(target: &Path) -> ExitCode {
         }
         let mut with_imports = Program {
             declared_effects: effects.declared_indices(),
+            effect_defs: effects.defs,
             effect_names: effects.names,
             imports: Vec::new(),
             items: merged_items,
@@ -3862,6 +3897,7 @@ where
     }
     let merged = Program {
         declared_effects: effects.declared_indices(),
+        effect_defs: effects.defs,
         effect_names: effects.names,
         items,
         imports: Vec::new(),

--- a/crates/hale-codegen/tests/fixtures/examples/74-effect-contracts/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/74-effect-contracts/main.hl
@@ -14,6 +14,11 @@
 
 effect money;
 
+// #354: a class DEFINED as a union of others. `io` has no bit of its
+// own — its mask is its members', so forbidding `io` forbids both, and
+// anything reaching a syscall carries `io`.
+effect io = { syscall, block };
+
 type Payment {
     cents: Int;
 }
@@ -39,6 +44,20 @@ fn double(n: Int) -> Int {
 @effects(none: { syscall, money })
 fn quote(cents: Int) -> Int {
     return double(cents);
+}
+
+// #354: the CLOSED form. Anything outside the listed set is a
+// violation, including classes declared after this was written — the
+// complement is computed, not enumerated here.
+@effects(only: { alloc })
+fn label(n: Int) -> String {
+    return "a" + "b";
+}
+
+// Forbidding a composed class.
+@effects(none: { io })
+fn no_io(n: Int) -> Int {
+    return n * 3;
 }
 
 // Quantitative + certification decorators stack with the categoric
@@ -82,6 +101,8 @@ main locus App {
         println(quote(21));
         println(scale(1));
         println(safe(2));
+        println(label(3));
+        println(no_io(4));
         if charge(100) {
             Settled <- Payment { cents: 100 };
         }

--- a/crates/hale-codegen/tests/multi_file_build.rs
+++ b/crates/hale-codegen/tests/multi_file_build.rs
@@ -35,6 +35,7 @@ fn merge(programs: Vec<Program>) -> Program {
     let mut iter = programs.into_iter();
     let first = iter.next().expect("at least one program");
     let mut merged = Program {
+        effect_defs: Vec::new(),
         effect_names: Vec::new(),
         declared_effects: Vec::new(),
         items: first.items,

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -16,6 +16,16 @@ pub struct Program {
     /// silently-inert class.
     pub effect_names: Vec<String>,
     pub declared_effects: Vec<u16>,
+    /// #354: `effect io = { syscall, block };` — a class DEFINED as a
+    /// union of others. Indexed like `effect_names`; `None` = atomic
+    /// (owns a bit in the mask), `Some(members)` = composed (owns no
+    /// bit; its mask is the union of its members').
+    ///
+    /// Because a composed class has no bit of its own, both useful
+    /// directions fall out of the existing subset test with no new
+    /// analysis: forbidding `io` forbids every member, and a fn that
+    /// reaches a member satisfies "carries `io`".
+    pub effect_defs: Vec<Option<Vec<EffectClass>>>,
     pub imports: Vec<Import>,
     pub items: Vec<TopDecl>,
     pub span: Span,
@@ -1662,6 +1672,17 @@ pub enum EffectAssert {
     /// engine propagates what leaves carry, and this is how a leaf
     /// says what it carries.
     Carries(Vec<EffectClass>),
+    /// #354: `@effects(only: {alloc})` — the CLOSED form of `none:`.
+    /// The fn's inferred effect set must be a SUBSET of the listed
+    /// classes.
+    ///
+    /// `none:` is open-ended, so it rots: a contract meaning "only
+    /// allocates" has to enumerate every other class, and adding a
+    /// class to the language silently widens every such contract. The
+    /// complement is computed at check time from the live class
+    /// universe (built-ins + declared user classes) rather than
+    /// written down, so it cannot go stale.
+    Only(Vec<EffectClass>),
     /// `@no_panic` — no reachable path can trap. Deliberately NOT an
     /// `EffectClass`: this is a different analysis (disposition
     /// coverage + trap-op selection over the fn's own body and its
@@ -2419,7 +2440,8 @@ pub fn remap_user_effects(items: &mut [TopDecl], map: &[u16]) {
             match a {
                 EffectAssert::Forbid(cs)
                 | EffectAssert::Causes(cs)
-                | EffectAssert::Carries(cs) => classes(cs, map),
+                | EffectAssert::Carries(cs)
+                | EffectAssert::Only(cs) => classes(cs, map),
                 // Subjects, not classes.
                 EffectAssert::PublishSet(_) => {}
                 EffectAssert::NoPanic => {}

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -40,6 +40,9 @@ struct Parser {
     /// would turn a typo into a contract that passes.
     effect_names: Vec<String>,
     declared_effects: Vec<u16>,
+    /// #354: parallel to `effect_names`; `Some` for a class declared
+    /// as a union of others.
+    effect_defs: Vec<Option<Vec<EffectClass>>>,
     /// v1.x-FORM-1: tracks whether we're inside the body of a
     /// fallible fn. When true, leading-statement `fail` Ident is
     /// recognized as the fail-keyword. Outside that context,
@@ -56,6 +59,7 @@ impl Parser {
             diags: Vec::new(),
             effect_names: Vec::new(),
             declared_effects: Vec::new(),
+            effect_defs: Vec::new(),
             in_fallible_body: false,
         }
     }
@@ -279,6 +283,7 @@ impl Parser {
         Ok(Program {
             effect_names: std::mem::take(&mut self.effect_names),
             declared_effects: std::mem::take(&mut self.declared_effects),
+            effect_defs: std::mem::take(&mut self.effect_defs),
             imports,
             items,
             span: Span {
@@ -756,8 +761,39 @@ impl Parser {
             };
             let name = name.clone();
             self.bump();
+            // #354: optional definition — `effect io = { a, b };`.
+            let mut members: Option<Vec<EffectClass>> = None;
+            if matches!(self.peek(), TokenKind::Eq) {
+                self.bump();
+                self.expect(TokenKind::LBrace, "{")?;
+                let mut ms = Vec::new();
+                while !matches!(self.peek(), TokenKind::RBrace) {
+                    let t = self.peek_token().clone();
+                    let TokenKind::Ident(m) = &t.kind else {
+                        return Err(Diag::parse(
+                            t.span,
+                            "expected an effect class name".to_string(),
+                        ));
+                    };
+                    let m = m.clone();
+                    self.bump();
+                    ms.push(
+                        EffectClass::from_ident(&m).unwrap_or_else(|| {
+                            EffectClass::User(self.intern_effect(&m))
+                        }),
+                    );
+                    if matches!(self.peek(), TokenKind::Comma) {
+                        self.bump();
+                    }
+                }
+                self.expect(TokenKind::RBrace, "}")?;
+                members = Some(ms);
+            }
             self.expect(TokenKind::Semi, ";")?;
             let idx = self.intern_effect(&name);
+            if let Some(ms) = members {
+                self.effect_defs[idx as usize] = Some(ms);
+            }
             // Fail CLOSED on overflow. A class past the mask's
             // capacity has no bit, so it unions as PURE — and
             // `@effects(none: {it})` would then certify a fn that
@@ -1475,6 +1511,21 @@ impl Parser {
                     }
                     out.push(EffectAssert::Carries(classes));
                 }
+                // #354: the CLOSED dual of `none:`. Same class
+                // resolution — including the user-class interning
+                // fallback, which the `causes` arm originally omitted
+                // and which made user classes unusable there.
+                "only" => {
+                    let mut classes = Vec::new();
+                    for it in &items {
+                        classes.push(
+                            EffectClass::from_ident(it).unwrap_or_else(|| {
+                                EffectClass::User(self.intern_effect(it))
+                            }),
+                        );
+                    }
+                    out.push(EffectAssert::Only(classes));
+                }
                 "none" => {
                     let mut classes = Vec::new();
                     for it in &items {
@@ -1563,6 +1614,9 @@ impl Parser {
             return i as u16;
         }
         self.effect_names.push(name.to_string());
+        // Stays index-parallel with `effect_names`; a definition is
+        // filled in later if the class is declared with one.
+        self.effect_defs.push(None);
         (self.effect_names.len() - 1) as u16
     }
 

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -965,12 +965,13 @@ impl AllocSummary {
 /// #345: the classes an `@effects(is: {…})` clause declares.
 fn carried_by(
     effects: &[hale_syntax::ast::EffectAssert],
+    defs: &[Option<Vec<hale_syntax::ast::EffectClass>>],
 ) -> crate::stdlib_surface::EffectSet {
     let mut acc = crate::stdlib_surface::EffectSet::PURE;
     for a in effects {
         if let hale_syntax::ast::EffectAssert::Carries(cs) = a {
             for c in cs {
-                acc = acc.union(crate::frontier::class_mask_pub(*c));
+                acc = acc.union(crate::frontier::class_mask_with(*c, defs));
             }
         }
     }
@@ -1197,7 +1198,7 @@ pub fn summarize_programs_with_renames(
             match item {
                 TopDecl::Fn(decl) => {
                     {
-                        let c = carried_by(&decl.effects);
+                        let c = carried_by(&decl.effects, &program.effect_defs);
                         if c.0 != 0 {
                             carries.insert(
                                 FnKey::free_fn(decl.name.name.clone()),
@@ -1283,7 +1284,7 @@ pub fn summarize_programs_with_renames(
                             }
                             LocusMember::Fn(decl) => {
                                 let key = FnKey::method(locus.clone(), decl.name.name.clone());
-                                let c = carried_by(&decl.effects);
+                                let c = carried_by(&decl.effects, &program.effect_defs);
                                 if c.0 != 0 {
                                     carries.insert(key.clone(), c);
                                 }

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -128,6 +128,39 @@ fn close(a: &str, b: &str) -> bool {
     common * 2 >= x.len().min(y.len())
 }
 
+/// Every effect class that EXISTS for this program: the built-ins
+/// plus each declared user class. `only:` is checked against this
+/// rather than against a written-down list, so a class added later is
+/// automatically outside any existing `only:` set instead of silently
+/// slipping inside it.
+fn class_universe(declared: &std::collections::BTreeSet<u16>) -> Vec<EffectClass> {
+    let mut out = vec![
+        EffectClass::Syscall,
+        EffectClass::Block,
+        EffectClass::Time,
+        EffectClass::Entropy,
+        EffectClass::Env,
+        EffectClass::Ffi,
+        EffectClass::Publish,
+        EffectClass::Spawn,
+        EffectClass::Recursion,
+        EffectClass::Alloc,
+    ];
+    out.extend(declared.iter().map(|i| EffectClass::User(*i)));
+    out
+}
+
+/// #354: the seed's composed-class definitions, index-parallel to
+/// `effect_names`.
+fn defs_of(programs: &[&Program]) -> Vec<Option<Vec<EffectClass>>> {
+    programs
+        .iter()
+        .map(|p| &p.effect_defs)
+        .find(|d| !d.is_empty())
+        .cloned()
+        .unwrap_or_default()
+}
+
 fn declared_of(programs: &[&Program]) -> std::collections::BTreeSet<u16> {
     programs
         .iter()
@@ -143,6 +176,7 @@ fn phase_effects_diags(
 ) -> Vec<Diag> {
     let mut out = Vec::new();
     let names = &effect_names_of(programs);
+    let defs = &defs_of(programs);
     for p in programs {
         for item in &p.items {
             let TopDecl::Locus(l) = item else { continue };
@@ -248,7 +282,7 @@ fn phase_effects_diags(
                         continue;
                     }
                     let before = out.len();
-                    check_class(summary, &key, span, class, ffi, names, &mut out);
+                    check_class(summary, &key, span, class, ffi, names, defs, &mut out);
                     // Re-label the generic message with the phase.
                     for d in out.iter_mut().skip(before) {
                         d.message = format!(
@@ -500,6 +534,55 @@ fn effect_diags_inner(
     // success. A certificate that is quietly true of nothing is the
     // same failure as one that is quietly false.
     let declared = declared_of(programs);
+    let defs_v = defs_of(programs);
+    // No per-declaration span survives to here (`effect NAME;` produces
+    // no AST item), so a cycle is reported against the program.
+    let program_span = programs
+        .first()
+        .map(|p| p.span)
+        .expect("at least one program");
+    // #354: `effect a = { b }; effect b = { a };` resolves to PURE in
+    // the mask walk, which would make both classes silently inert —
+    // a contract naming either would hold vacuously. Reject it.
+    for (i, def) in defs_v.iter().enumerate() {
+        if def.is_none() {
+            continue;
+        }
+        let mut seen = vec![i as u16];
+        let mut frontier_q: Vec<u16> = Vec::new();
+        if let Some(Some(ms)) = defs_v.get(i) {
+            for m in ms {
+                if let EffectClass::User(j) = m {
+                    frontier_q.push(*j);
+                }
+            }
+        }
+        while let Some(j) = frontier_q.pop() {
+            if j == i as u16 {
+                placement.push(Diag::ty(
+                    program_span,
+                    format!(
+                        "effect class `{}` is defined in terms of itself. \
+                         A cyclic definition resolves to no effect at all, \
+                         so every contract naming it would hold vacuously.",
+                        names.get(i).cloned().unwrap_or_default()
+                    ),
+                ));
+                break;
+            }
+            if seen.contains(&j) {
+                continue;
+            }
+            seen.push(j);
+            if let Some(Some(ms)) = defs_v.get(j as usize) {
+                for m in ms {
+                    if let EffectClass::User(k) = m {
+                        frontier_q.push(*k);
+                    }
+                }
+            }
+        }
+    }
     let mut diags = std::mem::take(&mut placement);
     for (key, asserts, span) in &roots {
         let mut seen: Vec<u16> = Vec::new();
@@ -556,8 +639,51 @@ fn effect_diags_inner(
                 EffectAssert::Forbid(classes) => {
                     for c in classes {
                         check_class(
-                            &summary, key, *span, *c, &ffi, &names, &mut diags,
+                            &summary, key, *span, *c, &ffi, &names, &defs_v,
+                            &mut diags,
                         );
+                    }
+                }
+                // #354: the closed dual. Checked as `none:` over the
+                // COMPLEMENT, and the complement is computed from the
+                // live class universe rather than written down — which
+                // is the whole point. A hand-enumerated `none:` list
+                // silently widens the moment a class is added; this
+                // cannot, because nothing is recorded that could go
+                // stale.
+                EffectAssert::Only(allowed) => {
+                    let set: Vec<String> =
+                        allowed.iter().map(|c| cls_name(*c, &names)).collect();
+                    for c in class_universe(&declared) {
+                        if allowed.contains(&c) {
+                            continue;
+                        }
+                        let before = diags.len();
+                        check_class(
+                            &summary, key, *span, c, &ffi, &names, &defs_v,
+                            &mut diags,
+                        );
+                        // Re-label with the contract that was actually
+                        // violated. `check_class` phrases everything as
+                        // `none:`, so without this a reader goes looking
+                        // for a `none: {money}` that was never written —
+                        // the class is forbidden by omission, and the
+                        // message has to say so. Same re-labelling the
+                        // `@phase_effects` path does.
+                        for d in diags.iter_mut().skip(before) {
+                            let body = d
+                                .message
+                                .strip_prefix("effect assertion violated: ")
+                                .unwrap_or(&d.message)
+                                .to_string();
+                            d.message = format!(
+                                "closed effect contract violated: \
+                                 `{}` declares `only: {{ {} }}`, so {}",
+                                key.display(),
+                                set.join(", "),
+                                body
+                            );
+                        }
                     }
                 }
                 EffectAssert::PublishSet(allowed) => {
@@ -604,6 +730,7 @@ fn check_class(
     class: EffectClass,
     ffi: &BTreeSet<String>,
     names: &[String],
+    defs: &[Option<Vec<EffectClass>>],
     diags: &mut Vec<Diag>,
 ) {
     use crate::stdlib_surface::EffectSet;
@@ -738,8 +865,8 @@ fn check_class(
         // #345: a user class queries the frontier exactly like a
         // built-in — the bit differs, the machinery does not.
         EffectClass::User(_) => (
-            crate::frontier::class_mask_pub(class),
-            "an operation declared to carry this effect class",
+            crate::frontier::class_mask_with(class, defs),
+            "an operation in this effect class",
         ),
         _ => unreachable!("handled above"),
     };
@@ -1149,6 +1276,10 @@ fn find_recursion(summary: &AllocSummary, root: &FnKey) -> Option<String> {
 pub struct EffectManifestRow {
     pub func: String,
     pub forbids: Vec<String>,
+    /// #354: the CLOSED contract, rendered distinctly from `forbids`.
+    /// A reader of the baseline must be able to tell an open contract
+    /// from a closed one — they weaken differently over time.
+    pub only: Option<Vec<String>>,
     pub publish_set: Option<Vec<String>>,
     pub quantities: Vec<(String, u64)>,
     /// GH #265: the INFERRED effect set — what the fn actually does,
@@ -1171,10 +1302,19 @@ pub fn effect_manifest(programs: &[&Program]) -> Vec<EffectManifestRow> {
     let names = effect_names_of(programs);
     let mut push = |name: String, fd: &FnDecl| {
         let mut forbids = Vec::new();
+        let mut onlys: Option<Vec<String>> = None;
         let mut publish_set = None;
         for a in &fd.effects {
             match a {
                 EffectAssert::Carries(_) => {}
+                EffectAssert::Only(cs) => {
+                    // Rendered distinctly from `none:` — a reader of the
+                    // baseline must be able to tell a closed contract
+                    // from an open one.
+                    onlys = Some(
+                        cs.iter().map(|c| cls_name(*c, &names)).collect(),
+                    );
+                }
                 EffectAssert::Forbid(cs) => {
                     for c in cs {
                         forbids.push(cls_name(*c, &names));
@@ -1205,7 +1345,10 @@ pub fn effect_manifest(programs: &[&Program]) -> Vec<EffectManifestRow> {
         // caller fills in an inferred set (see
         // `effect_manifest_with_inference`); the declaration-only
         // builder skips them.
-        if forbids.is_empty() && publish_set.is_none() && quantities.is_empty()
+        if forbids.is_empty()
+            && onlys.is_none()
+            && publish_set.is_none()
+            && quantities.is_empty()
         {
             return;
         }
@@ -1214,6 +1357,7 @@ pub fn effect_manifest(programs: &[&Program]) -> Vec<EffectManifestRow> {
         rows.push(EffectManifestRow {
             func: name,
             forbids,
+            only: onlys,
             publish_set,
             quantities,
             inferred: Vec::new(),
@@ -1265,6 +1409,7 @@ pub fn effect_manifest_with_inference(
             EffectManifestRow {
                 func: name.clone(),
                 forbids: Vec::new(),
+                only: None,
                 publish_set: None,
                 quantities: Vec::new(),
                 inferred: Vec::new(),
@@ -1340,6 +1485,12 @@ pub fn render_effect_manifest(rows: &[EffectManifestRow]) -> String {
         out.push_str(&r.func);
         if !r.forbids.is_empty() {
             out.push_str(&format!("  none={{{}}}", r.forbids.join(",")));
+        }
+        // #354: rendered separately from `none=` — a reader of the
+        // baseline must be able to tell a CLOSED contract from an open
+        // one, because they weaken differently as classes are added.
+        if let Some(o) = &r.only {
+            out.push_str(&format!("  only={{{}}}", o.join(",")));
         }
         if let Some(ps) = &r.publish_set {
             out.push_str(&format!("  publish={{{}}}", ps.join(",")));

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -272,12 +272,18 @@ pub fn causes_diags(
             _ => None,
         })
         .collect();
+    let defs: Vec<Option<Vec<EffectClass>>> = programs
+        .iter()
+        .map(|p| &p.effect_defs)
+        .find(|d| !d.is_empty())
+        .cloned()
+        .unwrap_or_default();
     let mut diags = Vec::new();
     for (key, declared, span) in &roots {
         let (actual, via) = causal_effects(&summary, graph, key, &ffi);
         let mut allowed = EffectSet::PURE;
         for c in declared {
-            allowed = allowed.union(class_mask(*c));
+            allowed = allowed.union(class_mask_with(*c, &defs));
         }
         // Only report classes reached THROUGH the bus (the causal
         // surface); direct effects are the `none:` form's job.
@@ -307,9 +313,6 @@ pub fn causes_diags(
     diags
 }
 
-pub(crate) fn class_mask_pub(c: EffectClass) -> EffectSet {
-    class_mask(c)
-}
 
 fn class_mask(c: EffectClass) -> EffectSet {
     match c {
@@ -338,6 +341,46 @@ fn class_mask(c: EffectClass) -> EffectSet {
             }
         }
     }
+}
+
+/// #354: a class's mask, following `effect io = { a, b };` definitions.
+///
+/// A COMPOSED class has no bit of its own — its mask is the union of
+/// its members'. That single fact gives both useful directions with no
+/// new analysis: forbidding `io` tests against `syscall|block` and so
+/// catches either, and a fn that reaches a syscall has that bit set and
+/// therefore satisfies "carries `io`".
+///
+/// `defs` is index-parallel to the program's `effect_names`. Recursion
+/// is depth-bounded by `seen`, which also rejects a definition cycle by
+/// resolving it to PURE rather than looping — the cycle itself is
+/// diagnosed separately, at declaration.
+pub fn class_mask_with(
+    c: EffectClass,
+    defs: &[Option<Vec<EffectClass>>],
+) -> EffectSet {
+    fn go(
+        c: EffectClass,
+        defs: &[Option<Vec<EffectClass>>],
+        seen: &mut Vec<u16>,
+    ) -> EffectSet {
+        if let EffectClass::User(i) = c {
+            if let Some(Some(members)) = defs.get(i as usize) {
+                if seen.contains(&i) {
+                    return EffectSet::PURE; // cycle; diagnosed at decl
+                }
+                seen.push(i);
+                let mut acc = EffectSet::PURE;
+                for m in members {
+                    acc = acc.union(go(*m, defs, seen));
+                }
+                seen.pop();
+                return acc;
+            }
+        }
+        class_mask(c)
+    }
+    go(c, defs, &mut Vec::new())
 }
 
 // ===================== @supervised ==============================

--- a/crates/hale-types/tests/only_clause.rs
+++ b/crates/hale-types/tests/only_clause.rs
@@ -1,0 +1,205 @@
+//! `@effects(only: {…})` — the closed dual of `none:` (#354).
+//!
+//! `none:` is open-ended, so it rots. Expressing "this handler only
+//! allocates" means enumerating every other class, and adding a class
+//! to the language silently widens every such contract: the annotation
+//! still reads "only alloc" and no longer means it. Nothing fails; the
+//! certificate just quietly weakens.
+//!
+//! `only:` is checked as `none:` over the COMPLEMENT, computed at
+//! check time from the live class universe — the built-ins plus every
+//! declared user class. Nothing is written down that could go stale,
+//! which is the entire difference.
+//!
+//! The load-bearing test here is the last one: a class the contract
+//! never mentions, declared after the contract was written, is caught
+//! anyway. That is the property a hand-enumerated `none:` list cannot
+//! have.
+
+use hale_syntax::parse_source;
+
+fn errs(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+#[test]
+fn a_fn_within_its_declared_set_passes() {
+    let ds = errs(
+        "@effects(only: { alloc })\n\
+         fn ok(n: Int) -> String { return \"a\" + \"b\"; }\n\
+         fn main() { println(ok(1)); }",
+    );
+    assert!(
+        !ds.iter().any(|m| m.contains("closed effect contract")),
+        "allocating under `only: {{ alloc }}` must be allowed: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn a_class_outside_the_declared_set_violates() {
+    let ds = errs(
+        "@effects(only: { alloc })\n\
+         fn bad(n: Int) -> String { println(\"x\"); return \"a\" + \"b\"; }\n\
+         fn main() { println(bad(1)); }",
+    );
+    let d = ds
+        .iter()
+        .find(|m| m.contains("closed effect contract"))
+        .unwrap_or_else(|| panic!("syscall is outside `only: {{alloc}}`: {:?}", ds));
+    assert!(
+        d.contains("syscall"),
+        "the diagnostic must name the class reached: {}",
+        d
+    );
+    assert!(
+        d.contains("only: { alloc }"),
+        "and the contract that forbids it by OMISSION — otherwise a \
+         reader hunts for a `none:` that was never written: {}",
+        d
+    );
+}
+
+/// The point of the feature. `money` is declared, carried by a leaf,
+/// and never named in the contract — and is caught regardless, because
+/// the complement is computed rather than enumerated.
+#[test]
+fn a_class_the_contract_never_mentions_is_still_caught() {
+    let ds = errs(
+        "effect money;\n\
+         @effects(is: { money })\n\
+         fn charge(n: Int) -> Int { return n; }\n\
+         @effects(only: { alloc })\n\
+         fn quote(n: Int) -> Int { return charge(n); }\n\
+         fn main() { println(quote(1)); }",
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("closed effect contract") && m.contains("money")),
+        "a user class outside the declared set must be caught without \
+         the contract naming it — this is what `none:` cannot do: {:?}",
+        ds
+    );
+}
+
+/// A user class INSIDE the set is permitted — the complement must be
+/// a real complement, not "everything user-declared".
+#[test]
+fn a_user_class_inside_the_declared_set_passes() {
+    let ds = errs(
+        "effect money;\n\
+         @effects(is: { money })\n\
+         fn charge(n: Int) -> Int { return n; }\n\
+         @effects(only: { money })\n\
+         fn quote(n: Int) -> Int { return charge(n); }\n\
+         fn main() { println(quote(1)); }",
+    );
+    assert!(
+        !ds.iter().any(|m| m.contains("closed effect contract")),
+        "`money` is declared allowed and must not be reported: {:?}",
+        ds
+    );
+}
+
+// ---- composed classes (#354 part 2) --------------------------------
+//
+// `effect io = { syscall, block };` gives `io` no bit of its own — its
+// mask is the union of its members'. That one fact yields both useful
+// directions with no new analysis, which is what these pin.
+
+/// Downward: forbidding the composed name forbids every member.
+#[test]
+fn forbidding_a_composed_class_catches_a_member() {
+    let ds = errs(
+        "effect io = { syscall, block };\n\
+         @effects(none: { io })\n\
+         fn f(n: Int) -> Int { println(\"x\"); return n; }\n\
+         fn main() { println(f(1)); }",
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("effect assertion violated") && m.contains("io")),
+        "a syscall is a member of `io`, so `none: {{io}}` must catch it: {:?}",
+        ds
+    );
+}
+
+/// A composed class must not forbid classes it does NOT list.
+#[test]
+fn a_composed_class_does_not_over_forbid() {
+    let ds = errs(
+        "effect io = { syscall };\n\
+         @effects(none: { io })\n\
+         fn f(n: Int) -> String { return \"a\" + \"b\"; }\n\
+         fn main() { println(f(1)); }",
+    );
+    assert!(
+        !ds.iter().any(|m| m.contains("effect assertion violated")),
+        "`io` is only syscall here; allocating must stay legal: {:?}",
+        ds
+    );
+}
+
+/// The payoff. `@deterministic` is a hardcoded blacklist of
+/// {time, entropy, env} and cannot see a user class — the fail-open
+/// this issue was filed for. Composition fixes it with no new
+/// mechanism: defining the class in terms of `time` puts the time bit
+/// in its mask, so the existing contract catches it.
+#[test]
+fn a_composed_class_is_visible_to_deterministic() {
+    let ds = errs(
+        "effect wallclock = { time };\n\
+         @effects(is: { wallclock })\n\
+         fn read_clock(n: Int) -> Int { return n; }\n\
+         @deterministic\n\
+         fn pure_ish(n: Int) -> Int { return read_clock(n); }\n\
+         fn main() { println(pure_ish(1)); }",
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("effect assertion violated")),
+        "a user class defined as `{{ time }}` must be caught by \
+         @deterministic without touching the parser's hardcoded list: {:?}",
+        ds
+    );
+}
+
+/// An ATOMIC user class is still invisible to `@deterministic` — that
+/// is correct, not a bug. `money` is not a clock read. The fix is
+/// opt-in by definition, which is the principled form.
+#[test]
+fn an_atomic_user_class_is_not_swept_into_deterministic() {
+    let ds = errs(
+        "effect money;\n\
+         @effects(is: { money })\n\
+         fn charge(n: Int) -> Int { return n; }\n\
+         @deterministic\n\
+         fn quote(n: Int) -> Int { return charge(n); }\n\
+         fn main() { println(quote(1)); }",
+    );
+    assert!(
+        !ds.iter().any(|m| m.contains("effect assertion violated")),
+        "`money` is unrelated to determinism and must not be swept in: {:?}",
+        ds
+    );
+}
+
+/// A cyclic definition resolves to no effect at all, so every contract
+/// naming it would hold vacuously — a silently-inert class is the same
+/// failure mode as the mask overflow in #348.
+#[test]
+fn a_cyclic_definition_is_rejected() {
+    let ds = errs(
+        "effect a = { b };\n\
+         effect b = { a };\n\
+         @effects(none: { a })\n\
+         fn f(n: Int) -> Int { return n; }\n\
+         fn main() { println(f(1)); }",
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("defined in terms of itself")),
+        "a definition cycle must be rejected, not silently inert: {:?}",
+        ds
+    );
+}

--- a/docs/src/effects.md
+++ b/docs/src/effects.md
@@ -455,3 +455,89 @@ nothing", so `@effects(none: {it})` would silently certify a function
 that calls a declared source. Everything else here fails closed, and
 a certificate that is quietly false is worse than none, because it is
 believed.
+
+## Saying what a function may do, not what it may not
+
+Everything so far forbids. `@effects(none: { syscall })` names what is
+out of bounds and permits the rest — which is the right shape when you
+care about one or two things.
+
+It is the wrong shape when you care about *everything else*. To say
+"this handler allocates and does nothing more" you would have to write
+out every other class:
+
+```hale,fragment
+@effects(none: { syscall, block, publish, time, entropy, env, ffi, spawn, recursion })
+```
+
+And that list is a snapshot. Add a class to the language — or declare
+one of your own — and every contract like it silently permits the new
+class. The annotation still reads "only alloc"; it no longer means it.
+Nothing fails. The certificate just quietly weakens, which is the one
+failure mode this system exists to rule out.
+
+So there is a closed form:
+
+```hale
+@effects(only: { alloc })
+fn label(n: Int) -> String {
+    return "a" + "b";
+}
+```
+
+The inferred effect set must be a **subset** of what you listed. The
+complement is computed when the program is checked, from the classes
+that actually exist — the ten built-ins plus every class the program
+declares. Nothing is written down, so nothing can go stale:
+
+```hale
+effect money;
+
+@effects(is: { money })
+fn charge(cents: Int) -> Int { return cents; }
+
+@effects(only: { alloc })
+fn quote(n: Int) -> Int { return charge(n); }   // violation
+
+fn main() { println(quote(1)); }
+```
+
+`quote` never mentions `money`. It is caught anyway, because `money`
+is not in the permitted set — and it would still be caught if `money`
+were declared a year after `quote` was written. That is the whole
+difference between the two forms.
+
+## Classes built from other classes
+
+A class can be defined as the union of others:
+
+```hale,fragment
+effect io = { syscall, block };
+```
+
+`io` has no bit of its own — its mask *is* `syscall | block`. One fact,
+two useful consequences, no extra machinery: forbidding `io` catches
+either member, and a function that reaches a syscall carries `io`.
+
+This is also how a user class joins a built-in contract. `@deterministic`
+means "must not read anything that varies", and it is defined over
+`time`, `entropy` and `env` — so a class of your own is invisible to it:
+
+```hale,fragment
+effect wallclock;              // atomic: @deterministic cannot see it
+effect wallclock = { time };   // composed: it can
+```
+
+The second form says *your class is a kind of clock read*, which puts
+the `time` bit in its mask, which is exactly what `@deterministic`
+already tests. Nothing about the contract changes.
+
+It stays opt-in, and that is deliberate. An atomic class like `money`
+is **not** swept into `@deterministic` — moving money is not a source
+of nondeterminism, and the compiler has no business guessing that it
+is. You say so by defining the class in terms of what it actually is.
+
+A definition may name other declared classes as well as built-ins. A
+cycle — `effect a = { b }; effect b = { a };` — resolves to no effect
+at all, so every contract naming either would hold vacuously. Cycles
+are rejected rather than left inert.

--- a/spec/tokens.md
+++ b/spec/tokens.md
@@ -612,8 +612,15 @@ They attach to the declaration that follows.
 | `@effects(publish: {…})` | fn | the allowed publish set |
 | `@effects(depends: {…})` | locus | complete set of subjects that may transitively reach any handler |
 | `@effects(is: {…})` | fn | classify this fn as a source of the named effect classes |
+| `@effects(only: {…})` | fn | CLOSED contract — the inferred set must be a subset of these |
 | `@no_syscall` `@no_block` `@no_ffi` `@no_publish` `@no_spawn` `@no_recursion` `@deterministic` | fn | sugar for the `@effects(none: …)` forms |
 | `@no_panic` | fn | no reachable trap (disposition coverage — a different analysis) |
+
+`effect NAME = { A, B };` optionally DEFINES a class as the union of
+others. A composed class owns no bit of its own, so forbidding it
+forbids every member, and a fn reaching a member carries it. Members
+may be built-ins or other declared classes; a definition cycle is
+rejected.
 
 `effect NAME;` is a top-level **declaration**, not an annotation:
 it introduces a user effect class that `is:` / `none:` / `causes:`

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -399,6 +399,34 @@ assume the others in a build:
   zero, so the merge unions the tables and rewrites each seed's
   indices before concatenating items — without that, two seeds' class
   0 share a bit and a `none:` on one is checked against the other.
+- **Closed effect contracts — `@effects(only: {…})`** (#354,
+  2026-08-03). The dual of `none:`. `none:` forbids a listed set and
+  permits everything else, which makes it **rot**: expressing "this
+  handler only allocates" requires enumerating every other class, and
+  adding a class to the language silently widens every such contract —
+  the annotation still reads "only alloc" and no longer means it.
+  Nothing fails; the certificate quietly weakens. `only:` states the
+  permitted set and is checked against the **complement computed at
+  check time** from the live class universe (the ten built-ins plus
+  every declared user class). Nothing is written down that can go
+  stale, so a class declared after the contract was written is outside
+  it automatically. Rendered separately from `none=` in the manifest —
+  a reader must be able to tell a closed contract from an open one,
+  because they age differently.
+- **Composed effect classes — `effect NAME = { A, B };`** (#354,
+  2026-08-03). A class may be DEFINED as the union of others. A
+  composed class owns **no bit**; its mask is its members', which
+  yields both useful directions with no additional analysis:
+  forbidding `io` tests against `syscall|block` and catches either,
+  and a fn that reaches a syscall carries `io`. This also repairs a
+  fail-open in `@deterministic`, which desugars to a hardcoded
+  `none: {time, entropy, env}` and therefore could not see a
+  user-declared class: `effect wallclock = { time };` puts the time
+  bit in the class's mask, so the existing contract catches it with no
+  new mechanism — and it stays opt-in, since an atomic class like
+  `money` is correctly *not* swept into determinism. A definition
+  cycle resolves to no effect at all, so every contract naming it
+  would hold vacuously; cycles are rejected.
 - **Synchronized access is blocking and non-deterministic** (#340/#341,
   2026-08-01). A `sync`-bearing form takes a lock, so a call reaching
   one contributes `block`, and a read through one defeats


### PR DESCRIPTION
Closes #354. Both halves of the same gap: user effect classes were a flat namespace of atomic labels, and the only categorical contract was open-ended.

## `only:` — the closed dual of `none:`

`none:` forbids a listed set and permits the rest, which makes it **rot**. Saying "this handler only allocates" means enumerating every other class, and adding a class to the language silently widens every such contract — the annotation still reads "only alloc" and no longer means it. Nothing fails; the certificate quietly weakens.

```hale
@effects(only: { alloc })
fn label(n: Int) -> String { return "a" + "b"; }
```

Checked as `none:` over the **complement, computed at check time** from the live class universe — the ten built-ins plus every declared user class. Nothing is written down that can go stale:

```hale
effect money;

@effects(is: { money })
fn charge(cents: Int) -> Int { return cents; }

@effects(only: { alloc })
fn quote(n: Int) -> Int { return charge(n); }   // violation
```

`quote` never mentions `money` and is caught anyway — and would still be caught if `money` were declared a year later. That is the entire difference between the two forms, and it is what the load-bearing test pins.

Implemented by feeding the complement to the existing `check_class`, so the witness path, class naming and message quality are identical to `none:`. The diagnostic is then re-labelled with the contract that was actually violated — the same re-labelling `@phase_effects` does — because otherwise a reader hunts for a `none: { money }` nobody wrote. The class is forbidden by *omission*, and the message has to say so:

```
closed effect contract violated: `quote` declares `only: { alloc }`,
so `quote` must not reach `money`, but reaches quote
[`charge` declares it carries this effect class]
```

Rendered as `only={…}` in the manifest, distinct from `none={…}` — a reader of the baseline must be able to tell a closed contract from an open one, because they age differently.

## `effect NAME = { A, B };` — composed classes

A composed class owns **no bit**; its mask is the union of its members'. One fact, both useful directions, no new analysis: forbidding `io` tests against `syscall|block` and catches either, and a fn reaching a syscall carries `io`.

**This repairs the `@deterministic` fail-open** described in the issue. `@deterministic` desugars to a hardcoded `none: {time, entropy, env}` and therefore could not see a user-declared class. Now:

```hale
effect wallclock = { time };
```

puts the time bit in the class's mask, so the *existing* contract catches it. No new mechanism, and it stays opt-in — an atomic `money` is correctly **not** swept into determinism, since moving money is not a source of nondeterminism and the compiler has no business guessing that it is. You say what your class is by defining it.

Definition cycles resolve to no effect at all, so every contract naming either class would hold vacuously — the same silently-inert failure as the mask overflow in #348. Rejected.

## Two things worth flagging from the build

- The `only:` parse arm uses the **user-class interning fallback**. The `causes` arm originally omitted exactly this and it was a live bug until #350; the delivery plan called it out and it would otherwise have been repeated verbatim.
- The manifest's skip-empty guard didn't know about `only`, so a function whose *only* contract was `only:` was dropped from the baseline entirely. Caught because the regenerated baseline diff looked wrong, not by a test — which is the argument for the baseline being a review artifact.

Also: `class_mask_pub` is gone, superseded by `class_mask_with`. Cross-seed, `EffectTable` now carries definitions and remaps their **members** — a definition holds `User(i)` indices, so carrying one across a seed boundary unremapped would alias it exactly like any other class reference.

## Scope notes

Composed classes still consume an intern index, so the 54-class ceiling counts composed and atomic together. Simpler than an atomic-rank mapping and not a correctness issue; worth revisiting only if someone hits it.

## Tests

2024/2024 workspace, zero build warnings, `hale fmt --check .` clean. Nine new tests in `only_clause.rs` covering both halves, including the two that matter: a class the contract never mentions is still caught, and an atomic user class is *not* swept into `@deterministic`.

Corpus fixture `74-effect-contracts` extended with both, so the surface is enforced rather than remembered. Grammar side is hale-lang/tree-sitter-hale#3 — the `only:` half needed no grammar change at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
