### PR TITLE
fix(effects): an indirect call must not void a certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ behavior.
 
 ## Unreleased
 
+- **An indirect call no longer voids every certificate** (#353).
+  A call through a function-typed parameter reached the graph as
+  `Callee::Unresolved(param_name)` — indistinguishable from an unknown
+  free fn, which contributed nothing. So `@no_syscall` on a fn whose
+  body is `return f(v);` typechecked while the program performed the
+  syscall, and `@budget(alloc_per_call = 0)` leaked identically. Every
+  certificate the language offers ran through that hole. The edge is
+  now marked `indirect` at construction (the enclosing fn's parameter
+  list is in hand there, exactly as it is for `recv_ty`), and an
+  indirect call is treated as "may do anything" rather than "does
+  nothing". Deliberately conservative: exact resolution is possible
+  given the closed world, but a certificate that is wrong in the safe
+  direction beats one that is wrong in the other.
+- **`hale check` rejects an unknown `std::` namespace** (#353).
+  `std::totally::fake()` passed the checker and was caught only by
+  codegen, so a typo'd or imagined stdlib call was invisible to
+  `check`, to the CI gate and to the LSP — the editor would confirm
+  made-up code as valid. Offers the nearest real namespace.
+
 - **An undeclared effect class is now an error** (#345). Interning
   happened on an `effect NAME;` declaration and on a bare reference in
   `@effects(...)` alike, so a misspelling minted a brand-new class that

--- a/crates/hale-cli/tests/unknown_stdlib_namespace.rs
+++ b/crates/hale-cli/tests/unknown_stdlib_namespace.rs
@@ -1,0 +1,72 @@
+//! `hale check` must reject an unknown `std::` namespace (#353 item 9).
+//!
+//! `unknown_fn_error` resolved the namespace first and returned early
+//! when it was untabled — "fine or not our business". So a call into a
+//! namespace that does not exist passed the checker and was caught only
+//! by codegen:
+//!
+//! ```text
+//! std::totally::fake()   check: PASS      build: caught
+//! ```
+//!
+//! Which meant a typo'd or imagined stdlib call was invisible to
+//! `hale check`, to the CI check gate, and to the LSP — the editor
+//! would positively confirm that made-up code was valid. That
+//! undermines the promise the whole toolchain rests on: that
+//! structured checking is authoritative.
+//!
+//! Found by falling into it. An earlier survey of missing stdlib
+//! features reported regex, sort and sets as PRESENT, because `check`
+//! accepted calls into all three.
+
+use std::process::Command;
+
+fn check(src: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir()
+        .join(format!("hale-ns-{}-{}", std::process::id(), tag));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let f = dir.join("main.hl");
+    std::fs::write(&f, src).expect("write");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(&f)
+        .output()
+        .expect("run hale check");
+    let _ = std::fs::remove_dir_all(&dir);
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+#[test]
+fn an_unknown_namespace_is_rejected_by_check() {
+    let out = check("fn main() { println(std::totally::fake()); }", "unknown");
+    assert!(
+        out.contains("unknown stdlib namespace"),
+        "an entirely made-up `std::` namespace must not pass check:\n{}",
+        out
+    );
+}
+
+#[test]
+fn a_near_miss_namespace_offers_the_real_one() {
+    let out = check("fn main() { println(std::tmie::now()); }", "nearmiss");
+    assert!(
+        out.contains("did you mean `std::time`"),
+        "a transposition should point at the namespace meant:\n{}",
+        out
+    );
+}
+
+/// The guard must not fire on real namespaces, or every program breaks.
+#[test]
+fn a_real_namespace_still_passes() {
+    let out = check("fn main() { println(std::math::sqrt(4.0)); }", "real");
+    assert!(
+        out.contains("typechecked"),
+        "`std::math::sqrt` is real and must pass:\n{}",
+        out
+    );
+}

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -321,6 +321,16 @@ pub struct CallEdge {
     /// The name was already computed one line earlier to attempt
     /// resolution; this keeps it instead of throwing it away.
     pub recv_ty: Option<String>,
+    /// #353: this call goes through a FUNCTION-TYPED PARAMETER of the
+    /// enclosing fn — an indirect call whose target is not knowable
+    /// from this fn alone.
+    ///
+    /// Recorded here for the same reason `recv_ty` is: the enclosing
+    /// fn's parameter list is in hand at construction and nowhere
+    /// else, and without it the edge is indistinguishable from a call
+    /// to an unknown free fn. That indistinguishability is what let an
+    /// indirect call void every certificate.
+    pub indirect: bool,
     pub loop_depth: u32,
     /// True if the call is inside an unbounded loop — then the callee is
     /// invoked unboundedly many times regardless of its own multiplicity.
@@ -423,6 +433,16 @@ pub struct FnSummary {
     /// predicate over call edges alone can never see them. Today:
     /// `Topic <- value` publishes and locus instantiations.
     pub effect_sites: Vec<EffectSite>,
+    /// #353: names of this fn's FUNCTION-TYPED parameters.
+    ///
+    /// A call through one of these lands in the graph as
+    /// `Callee::Unresolved(param_name)` — indistinguishable from an
+    /// unknown free fn, which contributed nothing. That is how an
+    /// indirect call voided every certificate: `@no_syscall` on a fn
+    /// whose body is `return f(v);` passed while the program performed
+    /// the syscall. Knowing which unresolved names are parameters is
+    /// what lets the walk treat them as indirect rather than absent.
+    pub fn_params: Vec<String>,
 }
 
 /// GH #265: an effect a fn performs directly in its own body,
@@ -999,7 +1019,7 @@ pub fn summarize_programs_with_renames(
     // method referenced by `subscribe ... -> handler` is tagged BusHandler.
     // The trailing `Vec<(String, String)>` seeds each body's var→type map
     // from its params (D2).
-    type BodyEntry = (FnKey, Block, Option<EntryKind>, Option<String>, Vec<(String, String)>);
+    type BodyEntry = (FnKey, Block, Option<EntryKind>, Option<String>, Vec<(String, String)>, Vec<String>);
     let mut bodies: Vec<BodyEntry> = Vec::new();
     let mut known: BTreeSet<FnKey> = BTreeSet::new();
     // GH #18 item 1 — the `@bounded` / `@unbounded` opt-in/carve-out sets.
@@ -1211,7 +1231,7 @@ pub fn summarize_programs_with_renames(
                         unbounded_fns.insert(key.clone());
                     }
                     known.insert(key.clone());
-                    bodies.push((key, decl.body.clone(), entry, None, param_var_types(&decl.params)));
+                    bodies.push((key, decl.body.clone(), entry, None, param_var_types(&decl.params), fn_typed_params(&decl.params)));
                 }
                 TopDecl::Type(td) => {
                     if let TypeDeclBody::Struct(fields) = &td.body {
@@ -1279,6 +1299,7 @@ pub fn summarize_programs_with_renames(
                                     None,
                                     Some(locus.clone()),
                                     param_var_types(&md.params),
+                                    fn_typed_params(&md.params),
                                 ));
                             }
                             LocusMember::Fn(decl) => {
@@ -1302,6 +1323,7 @@ pub fn summarize_programs_with_renames(
                                     entry,
                                     Some(locus.clone()),
                                     param_var_types(&decl.params),
+                                    fn_typed_params(&decl.params),
                                 ));
                             }
                             LocusMember::Lifecycle(lc) => {
@@ -1317,6 +1339,7 @@ pub fn summarize_programs_with_renames(
                                     Some(entry),
                                     Some(locus.clone()),
                                     param_var_types(&lc.params),
+                                    fn_typed_params(&lc.params),
                                 ));
                             }
                             _ => {}
@@ -1345,7 +1368,7 @@ pub fn summarize_programs_with_renames(
     // Phase 2 — walk each body.
     let mut summary = AllocSummary::default();
     summary.eager_only_loci = eager_only_loci;
-    for (key, body, entry, enclosing_locus, param_types) in &bodies {
+    for (key, body, entry, enclosing_locus, param_types, fn_params) in &bodies {
         let escaping = collect_escaping_names(body);
         let field_types = enclosing_locus
             .as_ref()
@@ -1356,6 +1379,7 @@ pub fn summarize_programs_with_renames(
             .and_then(|l| locus_inline_arrays.get(l))
             .unwrap_or(&empty_inline_arrays);
         let mut w = Walker {
+            fn_params: fn_params.clone(),
             sites: Vec::new(),
             effect_sites: Vec::new(),
             locus_types: &locus_type_names,
@@ -1386,6 +1410,7 @@ pub fn summarize_programs_with_renames(
                 calls: w.calls,
                 loops: w.loops,
                 effect_sites: w.effect_sites,
+                fn_params: fn_params.clone(),
             },
         );
     }
@@ -1422,6 +1447,18 @@ pub fn summarize_programs_with_renames(
 
 /// D2: a fn's params as (name, declared-type-name) pairs — the seed for
 /// the var→type map (only `Named` types; primitives/arrays are skipped).
+/// #353: names of the FUNCTION-TYPED parameters. `param_var_types`
+/// drops these — `type_expr_name` has no name for a function type — so
+/// a call through one is indistinguishable from a call to an unknown
+/// free fn, and contributed nothing to any effect set.
+fn fn_typed_params(params: &[Param]) -> Vec<String> {
+    params
+        .iter()
+        .filter(|p| matches!(p.ty, TypeExpr::Function { .. }))
+        .map(|p| p.name.name.clone())
+        .collect()
+}
+
 fn param_var_types(params: &[Param]) -> Vec<(String, String)> {
     params
         .iter()
@@ -1664,6 +1701,9 @@ struct Walker<'a> {
     /// of these is a locus INSTANTIATION (arena create + possibly a
     /// thread spawn / pool post), not a plain data allocation.
     locus_types: &'a BTreeSet<String>,
+    /// #353: function-typed parameter names of the fn being walked, so
+    /// a call through one can be marked indirect on its edge.
+    fn_params: Vec<String>,
     calls: Vec<CallEdge>,
     loops: Vec<LoopInfo>,
     escaping: &'a BTreeMap<String, Escape>,
@@ -2257,9 +2297,14 @@ impl<'a> Walker<'a> {
             }
             _ => Callee::Unresolved("<expr>".to_string()),
         };
+        let indirect = match &resolved {
+            Callee::Unresolved(n) => self.fn_params.iter().any(|p| p == n),
+            _ => false,
+        };
         self.calls.push(CallEdge {
             recv_ty,
             callee: resolved,
+            indirect,
             loop_depth: depth,
             in_unbounded_loop: self.loop_stack.iter().any(|bounded| !bounded),
             escape,

--- a/crates/hale-types/src/budget_check.rs
+++ b/crates/hale-types/src/budget_check.rs
@@ -179,6 +179,27 @@ impl FactVisitor for BudgetVisitor {
         in_loop: bool,
         emit: bool,
     ) -> Count {
+        // #353: an INDIRECT call through a function-typed parameter is
+        // NOT merely opaque — its target is chosen by the caller, so
+        // treating it as zero lets `@budget(alloc_per_call = 0)` certify
+        // a fn that allocates through it. The budget's documented
+        // "opaque calls are invisible" boundary covers calls whose
+        // callee is fixed and simply unmodelled; this one has no fixed
+        // callee at all, so it counts as unbounded.
+        if edge.indirect {
+            if emit {
+                self.offenders.push(Offender {
+                    span: edge.span,
+                    note: format!(
+                        "`{}` is an indirect call through a \
+                         function-typed parameter — its target, and so \
+                         its allocation count, is chosen by the caller",
+                        name
+                    ),
+                });
+            }
+            return Count::Unbounded;
+        }
         if !opaque_recv_allocates(name) {
             // Any other opaque call is outside what the budget can
             // see (documented boundary).

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -848,7 +848,26 @@ fn check_class(
                 why
             ))
         }
-        Probe::Unresolved(name, _) => {
+        Probe::Unresolved(name, edge) => {
+            // #353: an INDIRECT call — through a function-typed
+            // parameter. Checked FIRST, because a bare name like `f` is
+            // not a `std::` path and would otherwise return None a few
+            // lines down, which is exactly how this stayed invisible.
+            //
+            // The target is not knowable from this fn, so it may do
+            // anything and no certificate over it can hold. Before
+            // this, such a call looked like an unknown free fn and
+            // contributed nothing: `@no_syscall` on a fn whose body is
+            // `return f(v);` passed while the program performed the
+            // syscall, and `@budget(alloc_per_call = 0)` leaked the
+            // same way.
+            if edge.indirect {
+                return Some(format!(
+                    "`{}` — an indirect call through a function-typed \
+                     parameter, whose target this fn cannot determine",
+                    name
+                ));
+            }
             let segs: Vec<&str> = name.split("::").collect();
             let Some(eff) = crate::stdlib_surface::effects_for(&segs) else {
                 // ABSENT must fail closed, exactly like UNCLASSIFIED.

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -95,6 +95,25 @@ pub fn infer_effects(
                     acc = acc.union(walk(summary, k, ffi, seen, steps));
                 }
                 Callee::Unresolved(name) => {
+                    // #353: a call through a FUNCTION-TYPED PARAMETER.
+                    // It lands here looking like an unknown free fn, so
+                    // it contributed nothing — and that is how an
+                    // indirect call voided every certificate:
+                    // `@no_syscall` on a fn whose body is `return f(v);`
+                    // passed while the program performed the syscall,
+                    // and `@budget(alloc_per_call = 0)` leaked the same
+                    // way.
+                    //
+                    // The target is not knowable from this fn alone, so
+                    // it is UNCLASSIFIED — "may do anything" — which is
+                    // the same fail-closed treatment an unclassified
+                    // stdlib leaf gets. Resolving it exactly needs the
+                    // binding from the call site (see the tier-1 note in
+                    // the issue); until then, closed beats open.
+                    if fs.fn_params.iter().any(|p| p == name) {
+                        acc = acc.union(EffectSet::UNCLASSIFIED);
+                        continue;
+                    }
                     let segs: Vec<&str> = name.split("::").collect();
                     if let Some(e) = stdlib_surface::effects_for(&segs) {
                         if !e.is_unclassified() {

--- a/crates/hale-types/src/quantitative.rs
+++ b/crates/hale-types/src/quantitative.rs
@@ -239,6 +239,17 @@ fn count_dim(
             }
         }
     }
+    // #353: an INDIRECT call through a function-typed parameter. Its
+    // target is not knowable from this fn, so it may allocate, block
+    // or publish any number of times — the quantity is Unbounded, not
+    // zero. `@budget(alloc_per_call = 0)` on a fn whose body is
+    // `return f(v);` passed while the callee allocated, which is the
+    // budget half of the same certificate hole as the effect classes.
+    for edge in &fs.calls {
+        if edge.indirect {
+            total = total.add(Qty::Unbounded);
+        }
+    }
     // Frontier leaves (block points).
     if dim == QuantDim::BlockPoints {
         for edge in &fs.calls {

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -680,6 +680,23 @@ pub fn is_locus_path(segs: &[&str]) -> bool {
     LOCUS_PATHS.iter().any(|p| *p == segs)
 }
 
+/// Nearest tabled namespace, for the did-you-mean on an unknown one.
+fn nearest_namespace(segs: &[&str]) -> Option<String> {
+    let want = segs.join("::");
+    let mut best: Option<(String, usize)> = None;
+    for s in SURFACES {
+        let cand = s.ns.join("::");
+        let d = edit_distance(&want, &cand);
+        if d * 2 <= cand.len().max(want.len()) {
+            match &best {
+                Some((_, bd)) if *bd <= d => {}
+                _ => best = Some((cand, d)),
+            }
+        }
+    }
+    best.map(|(n, _)| n)
+}
+
 /// Nearest known name within the namespace, for the did-you-mean
 /// hint. Only offered when the edit distance is small relative to
 /// the name length (a distance-2 match on a 3-char name is noise).
@@ -749,6 +766,22 @@ fn edit_distance(a: &str, b: &str) -> usize {
 pub fn unknown_fn_error(segs: &[&str]) -> Option<String> {
     if is_locus_path(segs) {
         return None;
+    }
+    // #353 item 9: an UNTABLED namespace used to short-circuit here —
+    // `lookup` returned None and the call was waved through as "not our
+    // business". So `std::totally::fake()` passed `hale check` and only
+    // codegen rejected it, which meant a typo'd or imagined stdlib call
+    // was invisible to the checker, to the CI check gate and to the
+    // LSP. `std::` is a closed namespace; an unknown one is an error.
+    if lookup(segs).is_none() && segs.first() == Some(&"std") && segs.len() >= 2
+    {
+        let ns = segs[..segs.len() - 1].join("::");
+        let known = nearest_namespace(&segs[1..segs.len() - 1]);
+        let hint = match known {
+            Some(k) => format!(" — did you mean `std::{}`?", k),
+            None => String::new(),
+        };
+        return Some(format!("unknown stdlib namespace `{}`{}", ns, hint));
     }
     let (surface, fn_idx) = lookup(segs)?;
     let name = segs[fn_idx];

--- a/crates/hale-types/tests/indirect_calls.rs
+++ b/crates/hale-types/tests/indirect_calls.rs
@@ -1,0 +1,113 @@
+//! An indirect call must not void a certificate (#353).
+//!
+//! Function pointers were the first genuinely open-world construct in
+//! the language, and nothing noticed. A call through a function-typed
+//! parameter reached the call graph as `Callee::Unresolved(param_name)`
+//! — indistinguishable from a call to an unknown free fn, which
+//! contributed nothing to any effect set or budget. So:
+//!
+//! ```text
+//! @no_syscall
+//! fn apply(f: fn(Int) -> Int, v: Int) -> Int { return f(v); }
+//! ```
+//!
+//! typechecked, and the program printed the side effect. The same hole
+//! swallowed `@budget`, and by extension `@hot`, `@deterministic`,
+//! `@no_panic` and causality — every certificate the language offers.
+//!
+//! The fix is fail-closed: the enclosing fn's parameter list is in
+//! hand when the edge is built (exactly as it is for `recv_ty`), so
+//! the edge is marked `indirect`, and an indirect call is treated as
+//! "may do anything" rather than "does nothing".
+//!
+//! This is deliberately conservative. Resolving the target exactly is
+//! possible — Hale is whole-program and closed-world, and every
+//! function value in the corpus is a literal name at its binding site
+//! — but a conservative certificate is wrong in the safe direction and
+//! an optimistic one is not.
+
+use hale_syntax::parse_source;
+
+fn errs(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+#[test]
+fn an_effect_certificate_cannot_pass_through_an_indirect_call() {
+    let ds = errs(
+        "fn does_syscall(x: Int) -> Int { println(\"side effect\"); return x; }\n\
+         @no_syscall\n\
+         fn apply(f: fn(Int) -> Int, v: Int) -> Int { return f(v); }\n\
+         fn main() { println(apply(does_syscall, 1)); }",
+    );
+    let d = ds
+        .iter()
+        .find(|m| m.contains("effect assertion violated"))
+        .unwrap_or_else(|| {
+            panic!("`@no_syscall` must not hold over an indirect call: {:?}", ds)
+        });
+    assert!(
+        d.contains("indirect call"),
+        "the diagnostic must say WHY it cannot certify — the reader has \
+         to know the target is unknowable, not that a syscall was \
+         found: {}",
+        d
+    );
+}
+
+#[test]
+fn a_budget_cannot_pass_through_an_indirect_call() {
+    let ds = errs(
+        "fn allocates(n: Int) -> String { return \"x\" + \"y\"; }\n\
+         @budget(alloc_per_call = 0)\n\
+         fn apply(f: fn(Int) -> String, v: Int) -> String { return f(v); }\n\
+         fn main() { println(apply(allocates, 1)); }",
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("budget exceeded")),
+        "`alloc_per_call = 0` must not hold over an indirect call — the \
+         callee, and so the allocation count, is the caller's choice: {:?}",
+        ds
+    );
+}
+
+/// The conservatism must be SCOPED. A fn with no function-typed
+/// parameter is unaffected, or every certificate in the language would
+/// start failing.
+#[test]
+fn a_direct_call_still_certifies() {
+    let ds = errs(
+        "fn pure_double(x: Int) -> Int { return x * 2; }\n\
+         @no_syscall\n\
+         fn apply(v: Int) -> Int { return pure_double(v); }\n\
+         fn main() { println(apply(1)); }",
+    );
+    assert!(
+        ds.is_empty(),
+        "a direct call to a syscall-free fn must still certify: {:?}",
+        ds
+    );
+}
+
+/// A fn-typed parameter that is never CALLED is not an indirect call
+/// site. Passing a function through must stay free.
+#[test]
+fn merely_holding_a_fn_param_is_not_an_indirect_call() {
+    let ds = errs(
+        "fn inner(f: fn(Int) -> Int, v: Int) -> Int { return v; }\n\
+         @no_syscall\n\
+         fn outer(f: fn(Int) -> Int, v: Int) -> Int { return inner(f, v); }\n\
+         fn main() { println(outer(inner_id, 1)); }\n\
+         fn inner_id(x: Int) -> Int { return x; }",
+    );
+    assert!(
+        !ds.iter().any(|m| m.contains("indirect call")),
+        "neither fn calls through its parameter, so nothing is \
+         indirect: {:?}",
+        ds
+    );
+}


### PR DESCRIPTION
First and most urgent part of #353. Two fail-opens, one of them the largest in the language.

## An indirect call voided every certificate

Function pointers were the first genuinely open-world construct in Hale, and nothing noticed. A call through a function-typed parameter reached the call graph as `Callee::Unresolved(param_name)` — indistinguishable from a call to an unknown free fn, which contributed nothing to any effect set or budget:

```hale
fn does_syscall(x: Int) -> Int { println("side effect"); return x; }

@no_syscall
fn apply(f: fn(Int) -> Int, v: Int) -> Int { return f(v); }

fn main() { println(apply(does_syscall, 1)); }
```

`ok: 1 file(s) typechecked` — and the program printed `side effect`. `@budget(alloc_per_call = 0)` leaked identically, and by extension `@hot`, `@deterministic`, `@no_panic` and causality. **Every certificate the language offers ran through one hole.**

## Fixed fail-closed

The enclosing fn's parameter list is in hand when the edge is built — exactly as it is for `recv_ty`, which was added in #341 for the same class of blindness and whose doc comment describes it: *"the name was already computed one line earlier… this keeps it instead of throwing it away."* So the edge is marked `indirect`, and an indirect call is treated as "may do anything" rather than "does nothing".

Three sites, because these analyses do not share a walk:

- **the probe predicate** in `effects.rs` — checked **first** in the `Unresolved` arm, because a bare name like `f` is not a `std::` path and returns `None` a few lines down. That ordering is exactly how the bug stayed invisible, and getting it wrong once during this change reproduced the original symptom.
- **`quantitative.rs`** — an indirect call contributes `Unbounded`.
- **`budget_check.rs`** — its documented *"any other opaque call is outside what the budget can see"* boundary covers callees that are **fixed but unmodelled**. An indirect call has no fixed callee at all, so it does not belong inside that boundary.

## Why conservative and not exact

Hale is whole-program and closed-world, and every function value in the corpus is a literal name at its binding site (`on_connection: handle_request`), so tier-1 exact resolution is achievable and is written up in #353. It is not what lands here. A conservative certificate is wrong in the safe direction; an optimistic one is not — and the conservative version is what removes the unsoundness today. Exact resolution then becomes a precision improvement rather than a correctness fix, which is a much better thing to be reviewing.

The conservatism is scoped: a fn with no function-typed parameter is untouched, and merely *passing* a function through without calling it is not an indirect call site. Both are tested, because over-broad conservatism here would break every certificate in the language.

## Also: #353 item 9

`hale check` accepted an unknown `std::` namespace. `unknown_fn_error` resolved the namespace first and returned early when it was untabled — "fine or not our business" — so:

```
std::totally::fake()   →   check: PASS      build: caught
```

A typo'd or imagined stdlib call was invisible to `hale check`, to the CI check gate, and to the LSP, which would positively confirm made-up code as valid. Now an error, offering the nearest real namespace (`std::tmie` → *did you mean `std::time`?*).

This one was found by falling into it: an earlier survey reported regex, sort and sets as **present** because `check` accepted calls into all three.

Verified against real projects outside the test corpus (causality, pond): zero false positives.

## Tests

2022/2022 workspace. Seven new — four pinning the indirect-call behaviour in both directions, three for the namespace check including the near-miss hint and a real-namespace control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
