### PR TITLE
feat(stdlib): std::str contains / starts_with / ends_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ behavior.
   codegen, so a typo'd or imagined stdlib call was invisible to
   `check`, to the CI gate and to the LSP — the editor would confirm
   made-up code as valid. Offers the nearest real namespace.
+- **`std::str::contains` / `starts_with` / `ends_with`** (#353).
+  `lotus_str_contains` and `lotus_str_starts_with` had been in the
+  runtime for a long time — carrying `memory(read)` so LICM can hoist
+  them — but neither was reachable from Hale. `ends_with` is new. The
+  trio was previously unusable as a set: two of the three questions
+  were askable and the third had to be hand-rolled.
 
 - **An undeclared effect class is now an error** (#345). Interning
   happened on an `effect NAME;` declaration and on a bare reference in

--- a/crates/hale-cli/tests/str_predicates.rs
+++ b/crates/hale-cli/tests/str_predicates.rs
@@ -1,0 +1,77 @@
+//! `std::str::contains` / `starts_with` / `ends_with` (#353 item 2).
+//!
+//! `lotus_str_contains` and `lotus_str_starts_with` have been in the
+//! runtime for a long time — they even carry `memory(read)` attributes
+//! from the pure-read work, so LICM can hoist them — but neither was
+//! reachable from Hale. Exposing them was plumbing, not
+//! implementation. `ends_with` is genuinely new, and its absence is
+//! why the trio was unusable as a set: you could ask two of the three
+//! questions and had to hand-roll the third.
+
+use std::process::Command;
+
+fn run(src: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir()
+        .join(format!("hale-pred-{}-{}", std::process::id(), tag));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let f = dir.join("main.hl");
+    std::fs::write(&f, src).expect("write");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("run")
+        .arg(&f)
+        .output()
+        .expect("run");
+    let _ = std::fs::remove_dir_all(&dir);
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+#[test]
+fn the_predicates_answer_correctly() {
+    let out = run(
+        "fn main() {\n\
+             println(std::str::contains(\"hello world\", \"o w\"));\n\
+             println(std::str::contains(\"hello\", \"zz\"));\n\
+             println(std::str::starts_with(\"hello\", \"he\"));\n\
+             println(std::str::starts_with(\"hello\", \"lo\"));\n\
+             println(std::str::ends_with(\"hello\", \"lo\"));\n\
+             println(std::str::ends_with(\"hello\", \"he\"));\n\
+         }",
+        "answers",
+    );
+    let got: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        got,
+        vec!["true", "false", "true", "false", "true", "false"],
+        "predicate answers wrong: {:?}",
+        got
+    );
+}
+
+/// Empty needle is vacuously true, and a suffix longer than the string
+/// is false rather than an out-of-bounds read — the two edges a
+/// hand-rolled `ends_with` gets wrong.
+#[test]
+fn the_edges_are_right() {
+    let out = run(
+        "fn main() {\n\
+             println(std::str::ends_with(\"hi\", \"\"));\n\
+             println(std::str::ends_with(\"hi\", \"longer\"));\n\
+             println(std::str::contains(\"hi\", \"\"));\n\
+         }",
+        "edges",
+    );
+    let got: Vec<&str> = out.lines().collect();
+    assert_eq!(got, vec!["true", "false", "true"], "edges wrong: {:?}", got);
+}
+
+/// They are pure, so a `@no_syscall` fn may use them freely.
+#[test]
+fn the_predicates_are_pure() {
+    let out = run(
+        "@no_syscall @deterministic\n\
+         fn has(s: String) -> Bool { return std::str::contains(s, \"a\"); }\n\
+         fn main() { println(has(\"abc\")); }",
+        "pure",
+    );
+    assert_eq!(out.trim(), "true", "must certify as pure: {}", out);
+}

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -9475,6 +9475,18 @@ int lotus_str_starts_with(const char *s, const char *prefix) {
     return strncmp(s, prefix, lp) == 0 ? 1 : 0;
 }
 
+/* #353: the third predicate. `starts_with` and `contains` shipped;
+ * `ends_with` did not, so the everyday trio was two-thirds present and
+ * unusable as a set. Same pure-read shape as its siblings. */
+int lotus_str_ends_with(const char *s, const char *suffix) {
+    if (!s || !suffix) return 0;
+    size_t ls = strlen(s);
+    size_t lx = strlen(suffix);
+    if (lx == 0) return 1;
+    if (lx > ls) return 0;
+    return memcmp(s + (ls - lx), suffix, lx) == 0 ? 1 : 0;
+}
+
 int lotus_str_contains(const char *s, const char *sub) {
     if (!s || !sub) return 0;
     if (*sub == '\0') return 1;

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -22915,6 +22915,24 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ["std", "str", "index_of"] => {
                 self.lower_std_str_index_of(args, scope)
             }
+            ["std", "str", "contains"] => self.lower_std_str_predicate(
+                "lotus_str_contains",
+                "contains",
+                args,
+                scope,
+            ),
+            ["std", "str", "starts_with"] => self.lower_std_str_predicate(
+                "lotus_str_starts_with",
+                "starts_with",
+                args,
+                scope,
+            ),
+            ["std", "str", "ends_with"] => self.lower_std_str_predicate(
+                "lotus_str_ends_with",
+                "ends_with",
+                args,
+                scope,
+            ),
             ["std", "str", "range_eq"] => {
                 self.lower_std_str_range_eq(args, scope)
             }

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -733,6 +733,12 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             .module
             .add_function("lotus_str_contains", str_predicate_ty, None);
         self.mark_pure_read(str_contains_fn);
+        // #353: `ends_with` completes the trio. Pure read over
+        // immutable data, like its siblings.
+        let str_ends_with_fn = self
+            .module
+            .add_function("lotus_str_ends_with", str_predicate_ty, None);
+        self.mark_pure_read(str_ends_with_fn);
 
         // m84: byte index of substring (or -1 if not found).
         // declare i64 @lotus_str_index_of(ptr s, ptr sub)

--- a/crates/hale-codegen/src/stdlib/str.rs
+++ b/crates/hale-codegen/src/stdlib/str.rs
@@ -49,6 +49,18 @@ pub(crate) trait StrStdlib<'ctx> {
         args: &[Expr],
         scope: &Scope<'ctx>,
     ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
+    /// #353: `contains` / `starts_with` / `ends_with`. The runtime
+    /// carried `lotus_str_contains` and `lotus_str_starts_with` for a
+    /// long time — with `memory(read)` attributes — but neither was
+    /// reachable from Hale. Exposing them is plumbing.
+    fn lower_std_str_predicate(
+        &mut self,
+        sym: &str,
+        hale_name: &str,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
+
     fn lower_std_str_index_of(
         &mut self,
         args: &[Expr],
@@ -827,6 +839,68 @@ impl<'ctx, 'p> StrStdlib<'ctx> for Cx<'ctx, 'p> {
     /// the substring-search primitive HTTP request parsing leans
     /// on (find ` ` between method and path, `\r\n` to bound the
     /// request line).
+    /// #353: `contains` / `starts_with` / `ends_with`.
+    ///
+    /// The runtime carried `lotus_str_contains` and
+    /// `lotus_str_starts_with` for a long time — with `memory(read)`
+    /// attributes from the pure-read work — but neither was reachable
+    /// from Hale. Exposing them is plumbing, not implementation.
+    fn lower_std_str_predicate(
+        &mut self,
+        sym: &str,
+        hale_name: &str,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        if args.len() != 2 {
+            return Err(CodegenError::Unsupported(format!(
+                "std::str::{} takes 2 args (s, sub), got {}",
+                hale_name,
+                args.len()
+            )));
+        }
+        let mut vals = Vec::new();
+        for (i, a) in args.iter().enumerate() {
+            let (v, ty) = self.lower_expr(a, scope)?;
+            if !matches!(ty, CodegenTy::String | CodegenTy::StringView) {
+                return Err(CodegenError::Unsupported(format!(
+                    "std::str::{}: arg {} must be String, got {:?}",
+                    hale_name, i, ty
+                )));
+            }
+            vals.push(self.unpack_view_if_needed(v, &ty)?);
+        }
+        let f = self
+            .module
+            .get_function(sym)
+            .unwrap_or_else(|| panic!("{} declared", sym));
+        let call = self
+            .builder
+            .build_call(
+                f,
+                &[vals[0].into(), vals[1].into()],
+                &format!("str.{}.ret", hale_name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let v = call
+            .try_as_basic_value()
+            .left()
+            .ok_or_else(|| {
+                CodegenError::LlvmEmit(format!("{} returned void", sym))
+            })?;
+        // The runtime returns i32 0/1; Hale's Bool is i1.
+        let b = self
+            .builder
+            .build_int_compare(
+                inkwell::IntPredicate::NE,
+                v.into_int_value(),
+                self.context.i32_type().const_zero(),
+                &format!("str.{}.bool", hale_name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        Ok((b.into(), CodegenTy::Bool))
+    }
+
     fn lower_std_str_index_of(
         &mut self,
         args: &[Expr],

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -607,7 +607,7 @@ pub const SURFACES: &[NsSurface] = &[
         fns: &[
             e("builder_append", EffectSet::PURE), e("builder_finish", EffectSet::PURE), e("builder_len", EffectSet::PURE),
             e("builder_new", EffectSet::PURE), e("byte_at_unchecked", EffectSet::PURE),             e("can_parse_float", EffectSet::PURE), e("can_parse_int", EffectSet::PURE), e("clone", EffectSet::PURE), e("from_bytes", EffectSet::PURE),
-            e("index_of", EffectSet::PURE), e("lower", EffectSet::PURE), e("pad_left", EffectSet::PURE), e("pad_right", EffectSet::PURE), e("parse_decimal", EffectSet::PURE),
+            e("index_of", EffectSet::PURE), e("contains", EffectSet::PURE), e("starts_with", EffectSet::PURE), e("ends_with", EffectSet::PURE), e("lower", EffectSet::PURE), e("pad_left", EffectSet::PURE), e("pad_right", EffectSet::PURE), e("parse_decimal", EffectSet::PURE),
             e("parse_float", EffectSet::PURE), e("parse_int", EffectSet::PURE), e("range_eq", EffectSet::PURE), e("range_parse_decimal", EffectSet::PURE),
             e("range_parse_int", EffectSet::PURE), e("repeat", EffectSet::PURE), e("replace", EffectSet::PURE), e("substring", EffectSet::PURE), e("trim", EffectSet::PURE),
             e("upper", EffectSet::PURE),
@@ -911,6 +911,12 @@ pub const SIGS: &[FnSig] = &[
     sig!(NS_STR, "range_eq", [Str, Int, Int, Str], Bool),
     sig!(NS_STR, "byte_at_unchecked", [Str, Int], Int),
     sig!(NS_STR, "index_of", [Str, Str], Int),
+    // #353: the everyday predicates. The runtime carried
+    // `lotus_str_contains` / `_starts_with` all along; `ends_with` is
+    // new. Pure reads over immutable data — no effects.
+    sig!(NS_STR, "contains", [Str, Str], Bool),
+    sig!(NS_STR, "starts_with", [Str, Str], Bool),
+    sig!(NS_STR, "ends_with", [Str, Str], Bool),
     sig!(NS_STR, "lower", [Str], Str),
     sig!(NS_STR, "upper", [Str], Str),
     sig!(NS_STR, "trim", [Str], Str),


### PR DESCRIPTION
#353 item 2, first slice.

`lotus_str_contains` and `lotus_str_starts_with` have been in the runtime for a long time — they even carry `memory(read)` from the pure-read work, so LICM can hoist them out of a loop — but **neither was reachable from Hale**. Exposing them is plumbing, not implementation.

`ends_with` is genuinely new, and its absence is why the trio was unusable as a set: you could ask two of the three questions and had to hand-roll the third. That is exactly where the off-by-one and the suffix-longer-than-string out-of-bounds read live, so both edges are tested along with the empty-needle case.

One generic `lower_std_str_predicate` rather than three near-identical lowerings, since they differ only in the runtime symbol. Registry rows classify all three PURE, so a `@no_syscall @deterministic` fn can use them freely — tested.

Still open in item 2: `split` and `join`. Those are not plumbing — they have to return a sequence, which runs straight into the sequence-value question (cluster B in the #353 design comment). Deliberately not guessed at here.

2034/2034 tests, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)