### PR TITLE
feat(stdlib): std::time::parse_iso8601

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ behavior.
 
 ## Unreleased
 
+- **`std::time::parse_iso8601`** (#353). `std::time` was
+  monotonic/now/sleep/time_from_unix and nothing else, so a service
+  could emit a timestamp and had no way to read one back. Formatting
+  turned out not to be missing — `time_from_unix` already returns
+  ISO-8601 text, which is why `println` on a `Time` renders a date —
+  so only the inverse was added, as `fallible(ParseError)` with a
+  `can_parse_iso8601` probe, matching `str::parse_int`. UTC only: a
+  timezone database is megabytes against the wasm target, and local
+  time reads `TZ` and would therefore be `env`-effectful rather than
+  pure. A trailing offset is rejected rather than ignored, so a
+  local-time string is never silently read as UTC.
+
 - **An indirect call no longer voids every certificate** (#353).
   A call through a function-typed parameter reached the graph as
   `Callee::Unresolved(param_name)` — indistinguishable from an unknown

--- a/crates/hale-cli/tests/time_iso8601.rs
+++ b/crates/hale-cli/tests/time_iso8601.rs
@@ -1,0 +1,118 @@
+//! `std::time::parse_iso8601` (#353 item 3).
+//!
+//! The survey called this "time formatting", which turned out to be
+//! wrong in a useful way: `lotus_time_from_unix` ALREADY returns
+//! ISO-8601 text — Hale's `Time` is the formatted string, which is why
+//! `println(t)` on a Time renders a date. Formatting was never
+//! missing.
+//!
+//! PARSING had no counterpart at all. A service could emit a timestamp
+//! into a log or a config and had no way to read one back, so every
+//! application grew its own parser and they disagreed.
+//!
+//! UTC only, deliberately. A timezone database is megabytes and the
+//! wasm target carries whatever ships; local time additionally reads
+//! `TZ`, which makes it an `env` effect rather than a pure
+//! computation. A trailing offset is REJECTED rather than ignored, so
+//! a local-time string is never silently read as UTC.
+
+use std::process::Command;
+
+fn run(src: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir()
+        .join(format!("hale-iso-{}-{}", std::process::id(), tag));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let f = dir.join("main.hl");
+    std::fs::write(&f, src).expect("write");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("run")
+        .arg(&f)
+        .output()
+        .expect("run");
+    let _ = std::fs::remove_dir_all(&dir);
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+#[test]
+fn a_timestamp_round_trips() {
+    let out = run(
+        "fn main() {\n\
+             let s = std::time::parse_iso8601(\"2023-11-14T22:13:20Z\") or { -1 };\n\
+             println(s);\n\
+             println(std::time::time_from_unix(s));\n\
+         }",
+        "round",
+    );
+    let got: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        got,
+        vec!["1700000000", "2023-11-14T22:13:20Z"],
+        "parse must be the exact inverse of time_from_unix: {:?}",
+        got
+    );
+}
+
+#[test]
+fn the_epoch_is_exact() {
+    let out = run(
+        "fn main() {\n\
+             println(std::time::parse_iso8601(\"1970-01-01T00:00:00Z\") or { -1 });\n\
+         }",
+        "epoch",
+    );
+    assert_eq!(out.trim(), "0", "epoch must be 0: {}", out);
+}
+
+/// Malformed input is a `fallible`, not a sentinel the caller has to
+/// know to test for — the same shape as `str::parse_int`.
+#[test]
+fn malformed_input_takes_the_or_branch() {
+    let out = run(
+        "fn main() {\n\
+             println(std::time::parse_iso8601(\"not a date\") or { -1 });\n\
+             println(std::time::parse_iso8601(\"2023-13-99T00:00:00Z\") or { -1 });\n\
+             println(std::time::parse_iso8601(\"2023-11-14\") or { -1 });\n\
+         }",
+        "bad",
+    );
+    let got: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        got,
+        vec!["-1", "-1", "-1"],
+        "garbage, an impossible date, and a truncated one must all \
+         fail: {:?}",
+        got
+    );
+}
+
+/// A trailing offset must be REJECTED, not ignored. Silently reading
+/// `+01:00` as UTC would be an hour-wrong timestamp that never
+/// announces itself.
+#[test]
+fn a_non_utc_offset_is_rejected() {
+    let out = run(
+        "fn main() {\n\
+             println(std::time::parse_iso8601(\"2023-11-14T22:13:20+01:00\") or { -1 });\n\
+         }",
+        "offset",
+    );
+    assert_eq!(
+        out.trim(),
+        "-1",
+        "an offset must not be silently treated as UTC: {}",
+        out
+    );
+}
+
+/// Pure — no clock read, no TZ read — so it is usable from a
+/// `@deterministic` fn.
+#[test]
+fn parsing_is_pure() {
+    let out = run(
+        "@deterministic @no_syscall\n\
+         fn at(s: String) -> Int { return std::time::parse_iso8601(s) or { -1 }; }\n\
+         fn main() { println(at(\"1970-01-01T00:00:01Z\")); }",
+        "pure",
+    );
+    assert_eq!(out.trim(), "1", "must certify as pure: {}", out);
+}

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -9453,6 +9453,83 @@ char *lotus_str_from_float(lotus_arena_t *a, double f) {
     return out;
 }
 
+/*
+ * #353: ISO-8601 formatting and parsing, UTC only.
+ *
+ * A long-running service needs to emit a log timestamp, an HTTP date,
+ * or a config value, and had no way to do it — std::time was
+ * monotonic/now/sleep/time_from_unix and nothing else, so every
+ * application invented its own and they disagreed.
+ *
+ * UTC ONLY, deliberately. A timezone database is megabytes and the
+ * wasm target has to carry whatever ships; local time also needs to
+ * read TZ, which makes it an `env` effect rather than a pure
+ * computation. Formatting an instant you already hold is pure, and
+ * that is the operation worth having first. Local time can be added
+ * later as a distinct, effectful call rather than smuggled in here.
+ *
+ * `timegm` is avoided (not portable); the inverse is computed with
+ * the standard civil-from-days algorithm so parse is exact and
+ * dependency-free.
+ */
+static int64_t lotus_time_parse_iso8601_raw(const char *s);
+
+/* Days from civil date (Howard Hinnant's algorithm) — the exact
+ * inverse of the calendar split gmtime_r performs. */
+static int64_t lotus_days_from_civil(int64_t y, unsigned m, unsigned d) {
+    y -= m <= 2;
+    const int64_t era = (y >= 0 ? y : y - 399) / 400;
+    const unsigned yoe = (unsigned)(y - era * 400);
+    const unsigned doy = (153u * (m + (m > 2 ? -3 : 9)) + 2u) / 5u + d - 1u;
+    const unsigned doe = yoe * 365u + yoe / 4u - yoe / 100u + doy;
+    return era * 146097 + (int64_t)doe - 719468;
+}
+
+/* Returns unix seconds, or INT64_MIN when the input is not a
+ * well-formed `YYYY-MM-DDTHH:MM:SSZ`. The sentinel is out of any
+ * plausible range, and the Hale wrapper turns it into a fallible. */
+int lotus_time_can_parse_iso8601(const char *s) {
+    return lotus_time_parse_iso8601_raw(s) == INT64_MIN ? 0 : 1;
+}
+
+int64_t lotus_time_parse_iso8601(const char *s) {
+    int64_t v = lotus_time_parse_iso8601_raw(s);
+    return v == INT64_MIN ? 0 : v;
+}
+
+static int64_t lotus_time_parse_iso8601_raw(const char *s) {
+    /* Fixed shape: YYYY-MM-DDTHH:MM:SS with an optional trailing 'Z'.
+     * Parsed by hand rather than with sscanf — the wasm target does
+     * not declare it, and a fixed-width format needs no scanner. A
+     * trailing offset like `+01:00` is REJECTED rather than ignored,
+     * so a local-time string is never silently read as UTC. */
+    if (!s) return INT64_MIN;
+    for (int i = 0; i < 19; i++) {
+        if (s[i] == '\0') return INT64_MIN;
+    }
+    static const char shape[] = "____-__-__T__:__:__";
+    for (int i = 0; i < 19; i++) {
+        if (shape[i] == '_') {
+            if (s[i] < '0' || s[i] > '9') return INT64_MIN;
+        } else if (s[i] != shape[i]) {
+            return INT64_MIN;
+        }
+    }
+    if (s[19] != '\0' && !(s[19] == 'Z' && s[20] == '\0')) {
+        return INT64_MIN;
+    }
+    int y  = (s[0]-'0')*1000 + (s[1]-'0')*100 + (s[2]-'0')*10 + (s[3]-'0');
+    int mo = (s[5]-'0')*10 + (s[6]-'0');
+    int d  = (s[8]-'0')*10 + (s[9]-'0');
+    int h  = (s[11]-'0')*10 + (s[12]-'0');
+    int mi = (s[14]-'0')*10 + (s[15]-'0');
+    int se = (s[17]-'0')*10 + (s[18]-'0');
+    if (mo < 1 || mo > 12 || d < 1 || d > 31) return INT64_MIN;
+    if (h > 23 || mi > 59 || se > 60) return INT64_MIN;
+    int64_t days = lotus_days_from_civil(y, (unsigned)mo, (unsigned)d);
+    return days * 86400 + (int64_t)h * 3600 + (int64_t)mi * 60 + se;
+}
+
 char *lotus_str_from_duration(lotus_arena_t *a, int64_t ns) {
     char *out = (char *)lotus_arena_alloc(a, 32, 1);
     if (!out) return NULL;

--- a/crates/hale-codegen/src/channels/mod.rs
+++ b/crates/hale-codegen/src/channels/mod.rs
@@ -21,6 +21,7 @@ use crate::codegen::{
     Cx, FallibleCallResult, FallibleCtx, FnSig, LocusInfo, Scope, SelfCx,
 };
 use crate::stdlib::bytes::BytesStdlib;
+use crate::stdlib::time::TimeStdlib;
 use crate::stdlib::compress::CompressStdlib;
 use crate::stdlib::compress::{TarArg, TarRet, TarStdlib};
 use crate::stdlib::crypto::CryptoStdlib;
@@ -1201,6 +1202,21 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             // fallible(IndexError)`.
             ["std", "bytes", n] if n.starts_with("write_") => Ok(Some(
                 self.lower_std_bytes_write(n, args, scope)?,
+            )),
+            // #353: the INVERSE of `time_from_unix`.
+            //
+            // Formatting was never missing — `lotus_time_from_unix`
+            // already returns ISO-8601 text, which is why `println(t)`
+            // on a Time renders a date. Parsing had no counterpart, so
+            // a timestamp could be produced and never read back.
+            //
+            // UTC only. A timezone database is megabytes and the wasm
+            // target carries whatever ships; local time additionally
+            // reads TZ, an `env` effect rather than a pure
+            // computation. Local parsing can arrive later as a
+            // distinct, effectful call rather than be smuggled in.
+            ["std", "time", "parse_iso8601"] => Ok(Some(
+                self.lower_std_time_parse_iso8601_fallible(args, scope)?,
             )),
             ["std", "str", "parse_int"] => Ok(Some(
                 self.lower_std_str_parse_int_fallible(args, scope)?,

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -23429,6 +23429,39 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ["std", "time", "time_from_unix"] => {
                 self.lower_std_time_from_unix(args, scope)
             }
+            // #353: the `can_` probe beside the fallible parse, the
+            // same pairing `str::parse_int` / `can_parse_int` has.
+            ["std", "time", "can_parse_iso8601"] => {
+                if args.len() != 1 {
+                    return Err(CodegenError::Unsupported(format!(
+                        "std::time::can_parse_iso8601 takes 1 arg, got {}",
+                        args.len()
+                    )));
+                }
+                let (v, ty) = self.lower_expr(&args[0], scope)?;
+                let s_val = self.unpack_view_if_needed(v, &ty)?;
+                let f = self
+                    .module
+                    .get_function("lotus_time_can_parse_iso8601")
+                    .expect("lotus_time_can_parse_iso8601 declared");
+                let r = self
+                    .builder
+                    .build_call(f, &[s_val.into()], "iso.can.ret")
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                    .try_as_basic_value()
+                    .left()
+                    .expect("returns i32");
+                let b = self
+                    .builder
+                    .build_int_compare(
+                        inkwell::IntPredicate::NE,
+                        r.into_int_value(),
+                        self.context.i32_type().const_zero(),
+                        "iso.can.bool",
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                Ok((b.into(), CodegenTy::Bool))
+            }
             // std::math::* libm Float primitives. Resolves
             // notes/hale-friction.md 2026-05-10 float-surface-gaps
             // (the `std::math` sub-bullet). v0 cut: unary

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -718,6 +718,23 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         self.module
             .add_function("lotus_str_from_duration", str_from_dur_ty, None);
 
+        // #353: ISO-8601, UTC only.
+        // declare ptr @lotus_time_format_iso8601(ptr arena, i64 secs)
+        // declare i64 @lotus_time_parse_iso8601(ptr s)
+        let can_parse_iso_ty = i32_t_local.fn_type(&[ptr_t.into()], false);
+        let can_parse_iso_fn = self.module.add_function(
+            "lotus_time_can_parse_iso8601",
+            can_parse_iso_ty,
+            None,
+        );
+        self.mark_pure_read(can_parse_iso_fn);
+        let parse_iso_ty = i64_t.fn_type(&[ptr_t.into()], false);
+        let parse_iso_fn = self
+            .module
+            .add_function("lotus_time_parse_iso8601", parse_iso_ty, None);
+        // Pure over immutable input — no clock read, no TZ read.
+        self.mark_pure_read(parse_iso_fn);
+
         // m38: starts_with / contains string predicates.
         // declare i32 @lotus_str_starts_with(ptr s, ptr prefix)
         // declare i32 @lotus_str_contains(ptr s, ptr sub)

--- a/crates/hale-codegen/src/stdlib/time.rs
+++ b/crates/hale-codegen/src/stdlib/time.rs
@@ -5,7 +5,9 @@ use hale_syntax::ast::Expr;
 use inkwell::values::BasicValueEnum;
 
 use crate::bus::runtime::BusRuntime;
-use crate::codegen::{CodegenError, CodegenTy, Cx, Scope};
+use crate::codegen::{
+    CodegenError, CodegenTy, Cx, FallibleCallResult, Scope,
+};
 
 pub(crate) trait TimeStdlib<'ctx> {
     fn lower_time_monotonic_ns(
@@ -22,6 +24,14 @@ pub(crate) trait TimeStdlib<'ctx> {
         &mut self,
         args: &[Expr],
     ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError>;
+
+    /// #353: `std::time::parse_iso8601(s) -> Int fallible(ParseError)`
+    /// — the inverse of `time_from_unix`. UTC only.
+    fn lower_std_time_parse_iso8601_fallible(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<FallibleCallResult<'ctx>, CodegenError>;
 
     fn lower_std_time_from_unix(
         &mut self,
@@ -153,6 +163,62 @@ impl<'ctx, 'p> TimeStdlib<'ctx> for Cx<'ctx, 'p> {
     /// `lotus_time_from_unix`, which gmtime_r + strftime's the
     /// epoch into a 24-byte ISO 8601 UTC buffer in the caller arena.
     /// Mirrors the runtime shape of compile-time Time literals.
+    fn lower_std_time_parse_iso8601_fallible(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<FallibleCallResult<'ctx>, CodegenError> {
+        if args.len() != 1 {
+            return Err(CodegenError::Unsupported(format!(
+                "std::time::parse_iso8601 takes 1 arg (s), got {}",
+                args.len()
+            )));
+        }
+        let (v, ty) = self.lower_expr(&args[0], scope)?;
+        let s_val = self.unpack_view_if_needed(v, &ty)?;
+        // Same shape as `str::parse_int`: a `can_` probe decides the
+        // error branch, so a malformed timestamp is a fallible rather
+        // than a sentinel the caller has to know to test for.
+        let can_fn = self
+            .module
+            .get_function("lotus_time_can_parse_iso8601")
+            .expect("lotus_time_can_parse_iso8601 declared");
+        let can = self
+            .builder
+            .build_call(can_fn, &[s_val.into()], "iso.can")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .expect("returns i32");
+        let is_err = self
+            .builder
+            .build_int_compare(
+                inkwell::IntPredicate::EQ,
+                can.into_int_value(),
+                self.context.i32_type().const_zero(),
+                "iso.is_err",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let parse_fn = self
+            .module
+            .get_function("lotus_time_parse_iso8601")
+            .expect("lotus_time_parse_iso8601 declared");
+        let secs = self
+            .builder
+            .build_call(parse_fn, &[s_val.into()], "iso.value")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .expect("returns i64");
+        self.complete_parse_fallible_call(
+            is_err,
+            s_val,
+            "parse_iso8601",
+            Some((secs, CodegenTy::Int)),
+            "time.parse_iso8601",
+        )
+    }
+
     fn lower_std_time_from_unix(
         &mut self,
         args: &[Expr],

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -647,6 +647,7 @@ pub const SURFACES: &[NsSurface] = &[
     NsSurface {
         ns: &["time"],
         fns: &[
+            e("parse_iso8601", EffectSet::PURE), e("can_parse_iso8601", EffectSet::PURE),
             e("monotonic", EffectSet::TIME), e("monotonic_ns", EffectSet::TIME), e("now", EffectSet::TIME), e("sleep", EffectSet::SYSCALL.union(EffectSet::BLOCK).union(EffectSet::TIME)), e("time_from_unix", EffectSet::PURE),
         ],
         open_prefixes: &[],
@@ -880,6 +881,11 @@ pub const SIGS: &[FnSig] = &[
     sig!(NS_TIME, "sleep", [Duration], Unit),
     sig!(NS_TIME, "now", [], Int),
     sig!(NS_TIME, "time_from_unix", [Int], Time),
+    // #353: the inverse of `time_from_unix`, which already yields
+    // ISO-8601 text. Returns unix seconds. UTC only, and PURE — it
+    // reads no clock and no TZ.
+    sig!(NS_TIME, "parse_iso8601", [Str], Int, "ParseError"),
+    sig!(NS_TIME, "can_parse_iso8601", [Str], Bool),
     // std::env
     sig!(NS_ENV, "args_count", [], Int),
     sig!(NS_ENV, "arg", [Int], Str),


### PR DESCRIPTION
#353 item 3.

`std::time` was `monotonic` / `now` / `sleep` / `time_from_unix` and nothing else, so a long-running service could emit a timestamp into a log or a config and had **no way to read one back**. Every application grows its own parser and they disagree.

## A correction to the issue

The survey called this "time formatting", which was wrong in a useful way. `lotus_time_from_unix` **already returns ISO-8601 text** — Hale's `Time` *is* the formatted string, which is why `println(t)` on a `Time` renders a date. Formatting was never missing.

I had already written a `format_iso8601` before checking that, and deleted it. Only the inverse ships.

## What lands

```hale
let secs = std::time::parse_iso8601("2023-11-14T22:13:20Z") or { -1 };
println(std::time::time_from_unix(secs));   // 2023-11-14T22:13:20Z
```

`fallible(ParseError)` with a `can_parse_iso8601` probe — the same pairing `str::parse_int` / `can_parse_int` already has, so a malformed timestamp is a disposition rather than a sentinel the caller has to know to test for.

## UTC only, deliberately

A timezone database is megabytes and the wasm target carries whatever ships. Local time additionally reads `TZ`, which makes it an **`env` effect** rather than a pure computation — a distinction the effect system can express and that belongs in the API shape rather than being discovered later. Local parsing can arrive as a distinct, effectful call rather than being smuggled in here.

A trailing offset like `+01:00` is **rejected, not ignored**. Silently reading it as UTC produces an hour-wrong timestamp that never announces itself, which is worse than a failure.

## Two implementation notes

- Parsed by hand rather than with `sscanf`. The wasm target does not declare it — caught by the wasm tests, not by review — and a fixed-width format needs no scanner anyway.
- The inverse uses the civil-from-days algorithm rather than `timegm`, which is not portable.

## Tests

2034/2034, zero warnings. Five new: exact round-trip, epoch, three flavours of malformed input, offset rejection, and a `@deterministic @no_syscall` fn using it to confirm it certifies as pure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
