### PR TITLE
feat(stdlib): std::str::split_into

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ behavior.
 
 ## Unreleased
 
+- **`std::str::split_into`** (#353). Splitting a string is the most
+  common operation in service code and Hale had no way to do it. It
+  writes into a caller-supplied `@form(vec)` rather than returning a
+  sequence, following `text::tokenize_words_into` — because Hale
+  cannot return one: arrays are fixed-size types and growable
+  collections exist only as locus-owned forms. That shape is also the
+  allocation-visible one: the caller owns the storage, so the cost
+  lands in the caller's budget instead of hiding behind a return
+  value, and a `@hot` handler can reuse one vec across calls. Empty
+  fields are preserved — `"a,,b,"` is four fields.
+
 - **`std::time::parse_iso8601`** (#353). `std::time` was
   monotonic/now/sleep/time_from_unix and nothing else, so a service
   could emit a timestamp and had no way to read one back. Formatting

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -4193,6 +4193,50 @@ static int lotus_text_is_word_byte(unsigned char c) {
         || c == '\'';
 }
 
+/*
+ * #353: `std::str::split_into(s, sep, target)`.
+ *
+ * Splitting a string is the most common single operation in service
+ * code and Hale had no way to do it. What it could not do is RETURN a
+ * sequence — arrays are fixed-size types and growable collections
+ * exist only as locus-owned forms — so this follows the shape the
+ * stdlib already uses for exactly that reason
+ * (`lotus_text_tokenize_words_into`): write into a caller-supplied
+ * `@form(vec)`.
+ *
+ * That is not a workaround. It is the allocation-visible form: the
+ * caller owns the storage, so the cost shows up in the caller's
+ * budget rather than hiding behind a return value, and a `@hot`
+ * handler can reuse one vec across calls.
+ *
+ * Empty separator is rejected (it would loop forever). Adjacent
+ * separators produce empty fields, and a trailing separator produces
+ * a trailing empty field — the same convention as every split worth
+ * having, so `"a,,b,".split(",")` is 4 fields.
+ */
+void lotus_str_split_into(
+    void *target_vec,
+    const char *src,
+    const char *sep,
+    void *arena_ptr
+) {
+    if (!target_vec || !src || !sep || !*sep) return;
+    lotus_arena_t *arena = (lotus_arena_t *)arena_ptr;
+    size_t seplen = strlen(sep);
+    const char *cur = src;
+    for (;;) {
+        const char *hit = strstr(cur, sep);
+        size_t n = hit ? (size_t)(hit - cur) : strlen(cur);
+        char *field = (char *)lotus_arena_alloc(arena, n + 1, 1);
+        if (!field) return;
+        if (n) memcpy(field, cur, n);
+        field[n] = '\0';
+        lotus_vec_push(target_vec, sizeof(char *), &field);
+        if (!hit) break;
+        cur = hit + seplen;
+    }
+}
+
 void lotus_text_tokenize_words_into(
     void *target_vec,
     const char *src,

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -22483,6 +22483,9 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ["std", "text", "tokenize_words_into"] => {
                 self.lower_std_text_tokenize_words_into(args, scope)
             }
+            ["std", "str", "split_into"] => {
+                self.lower_std_str_split_into(args, scope)
+            }
             // C9: new fallible-only fs surfaces + C4: getrandom +
             // C2: subprocess primitives. Same "use `or`" diagnostic
             // shape as the parse_int family.
@@ -22630,6 +22633,112 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     one.into(),
                 ],
                 "text.tokenize_words.call",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        Ok(())
+    }
+
+    /// #353: `std::str::split_into(s, sep, target: @form(vec))`.
+    ///
+    /// Splitting is the most common operation in service code and
+    /// Hale had no way to do it. What it cannot do is RETURN a
+    /// sequence — arrays are fixed-size and growable collections
+    /// exist only as locus-owned forms — so this uses the shape the
+    /// stdlib already adopted for that reason
+    /// (`text::tokenize_words_into`): write into caller-supplied
+    /// storage. The caller owns the allocation, so the cost lands in
+    /// the caller's budget instead of hiding behind a return value,
+    /// and a `@hot` handler can reuse one vec across calls.
+    fn lower_std_str_split_into(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(), CodegenError> {
+        if args.len() != 3 {
+            return Err(CodegenError::Unsupported(format!(
+                "std::str::split_into expects 2 args (source \
+                 String, target @form(vec) of String); got {}",
+                args.len()
+            )));
+        }
+        let (src_val, src_ty) = self.lower_expr(&args[0], scope)?;
+        if !matches!(src_ty, CodegenTy::String) {
+            return Err(CodegenError::Unsupported(format!(
+                "std::str::split_into: source arg must be \
+                 String, got {:?}",
+                src_ty
+            )));
+        }
+        let (sep_val, sep_ty) = self.lower_expr(&args[1], scope)?;
+        let sep_val = self.unpack_view_if_needed(sep_val, &sep_ty)?;
+        let (target_val, target_ty) = self.lower_expr(&args[2], scope)?;
+        let target_locus_name = match &target_ty {
+            CodegenTy::LocusRef(n) => n.clone(),
+            other => {
+                return Err(CodegenError::Unsupported(format!(
+                    "std::str::split_into: target arg must be a \
+                     @form(vec) of String locus, got {:?}",
+                    other
+                )));
+            }
+        };
+        let locus_info = self
+            .user_loci
+            .get(&target_locus_name)
+            .cloned()
+            .ok_or_else(|| CodegenError::Unsupported(format!(
+                "std::str::split_into: target locus `{}` not \
+                 registered",
+                target_locus_name
+            )))?;
+        // Verify it's a @form(vec) with String cells.
+        let vec_slot = locus_info
+            .capacity_slots
+            .iter()
+            .find(|s| s.form == Some(SlotForm::Vec))
+            .cloned()
+            .ok_or_else(|| CodegenError::Unsupported(format!(
+                "std::str::split_into: target locus `{}` is not \
+                 a @form(vec) — must be `@form(vec) locus X {{ capacity \
+                 {{ heap items of String; }} }}`",
+                target_locus_name
+            )))?;
+        if !matches!(vec_slot.elem_ty, CodegenTy::String) {
+            return Err(CodegenError::Unsupported(format!(
+                "std::str::split_into: target vec `{}` cell type \
+                 must be String, got {:?}",
+                target_locus_name, vec_slot.elem_ty
+            )));
+        }
+        let target_self_ptr = target_val.into_pointer_value();
+        let vec_field_ptr = self
+            .builder
+            .build_struct_gep(
+                locus_info.struct_ty,
+                target_self_ptr,
+                vec_slot.struct_field_idx,
+                &format!("{}.__vec_{}.tokenize.ptr", target_locus_name, vec_slot.name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let arena_ptr = self.current_arena_ptr()?;
+        // lowercase = 1 by default (matches the wordfreq idiom
+        // every agent reaches for). A future overload could take
+        // an Int / Bool flag if case-preserving tokenization
+        // turns out to be a common need.
+        let fn_ = self
+            .module
+            .get_function("lotus_str_split_into")
+            .expect("lotus_str_split_into declared");
+        self.builder
+            .build_call(
+                fn_,
+                &[
+                    vec_field_ptr.into(),
+                    src_val.into(),
+                    sep_val.into(),
+                    arena_ptr.into(),
+                ],
+                "str.split_into.call",
             )
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         Ok(())

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -756,6 +756,14 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             .module
             .add_function("lotus_str_ends_with", str_predicate_ty, None);
         self.mark_pure_read(str_ends_with_fn);
+        // #353: split into a caller-supplied @form(vec).
+        // declare void @lotus_str_split_into(ptr vec, ptr s, ptr sep, ptr arena)
+        let split_into_ty = self.context.void_type().fn_type(
+            &[ptr_t.into(), ptr_t.into(), ptr_t.into(), ptr_t.into()],
+            false,
+        );
+        self.module
+            .add_function("lotus_str_split_into", split_into_ty, None);
 
         // m84: byte index of substring (or -1 if not found).
         // declare i64 @lotus_str_index_of(ptr s, ptr sub)

--- a/crates/hale-codegen/tests/str_split_into.rs
+++ b/crates/hale-codegen/tests/str_split_into.rs
@@ -1,0 +1,132 @@
+//! `std::str::split_into` (#353 item 2).
+//!
+//! Splitting a string is the most common single operation in service
+//! code, and Hale had no way to do it.
+//!
+//! What Hale cannot do is RETURN a sequence: arrays are fixed-size
+//! types (`[Int; 3]` and `[Int; 2]` do not unify, and there is no
+//! general slice), and growable collections exist only as locus-owned
+//! `@form(...)`. So rather than guess at the sequence-value model —
+//! the language's largest open question — this uses the shape the
+//! stdlib already adopted for exactly that reason,
+//! `text::tokenize_words_into`: write into caller-supplied storage.
+//!
+//! That is not a workaround. It is the allocation-visible form. The
+//! caller owns the storage, so the cost lands in the caller's budget
+//! instead of hiding behind a return value, and a `@hot` handler can
+//! reuse one vec across calls rather than allocating a fresh
+//! collection per message.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+fn build_and_run(
+    name: &str,
+    src: &str,
+    argv: &[&str],
+) -> (String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(&format!(
+        "hale_split_{}_{}",
+        name,
+        std::process::id()
+    ));
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).args(argv).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        out.status,
+    )
+}
+
+#[test]
+fn it_splits_on_a_separator() {
+    let src = r#"
+        @form(vec)
+        locus Fields { capacity { heap items of String; } }
+        fn main() {
+            let f = Fields { };
+            std::str::split_into("alpha,beta,gamma", ",", f);
+            println("n=", f.len());
+            let mut i = 0;
+            while i < f.len() {
+                println(f.get(i) or "");
+                i = i + 1;
+            }
+        }
+    "#;
+    let (stdout, status) = build_and_run("split_basic", src, &[]);
+    assert!(status.success(), "non-zero: {:?}", status);
+    assert!(stdout.contains("n=3"), "got: {:?}", stdout);
+    for w in ["alpha", "beta", "gamma"] {
+        assert!(stdout.contains(w), "missing {}: {:?}", w, stdout);
+    }
+}
+
+/// Adjacent and trailing separators produce EMPTY fields rather than
+/// being collapsed. `"a,,b,"` is four fields, which is what every
+/// split worth having does — collapsing them silently loses a column
+/// in a CSV row and the loss is invisible at the call site.
+#[test]
+fn empty_fields_are_preserved() {
+    let src = r#"
+        @form(vec)
+        locus Fields { capacity { heap items of String; } }
+        fn main() {
+            let f = Fields { };
+            std::str::split_into("a,,b,", ",", f);
+            println("n=", f.len());
+            println("[", f.get(1) or "?", "]");
+            println("[", f.get(3) or "?", "]");
+        }
+    "#;
+    let (stdout, status) = build_and_run("split_empty", src, &[]);
+    assert!(status.success(), "non-zero: {:?}", status);
+    assert!(stdout.contains("n=4"), "got: {:?}", stdout);
+    assert!(stdout.contains("[]"), "empty fields must survive: {:?}", stdout);
+}
+
+/// A separator that does not occur yields the whole string as one
+/// field — not zero fields, which would silently drop the input.
+#[test]
+fn a_missing_separator_yields_the_whole_string() {
+    let src = r#"
+        @form(vec)
+        locus Fields { capacity { heap items of String; } }
+        fn main() {
+            let f = Fields { };
+            std::str::split_into("nosep", ",", f);
+            println("n=", f.len());
+            println(f.get(0) or "?");
+        }
+    "#;
+    let (stdout, status) = build_and_run("split_nosep", src, &[]);
+    assert!(status.success(), "non-zero: {:?}", status);
+    assert!(stdout.contains("n=1"), "got: {:?}", stdout);
+    assert!(stdout.contains("nosep"), "got: {:?}", stdout);
+}
+
+/// A multi-byte separator, since the naive implementation advances by
+/// one byte and silently mis-splits.
+#[test]
+fn a_multi_byte_separator_works() {
+    let src = r#"
+        @form(vec)
+        locus Fields { capacity { heap items of String; } }
+        fn main() {
+            let f = Fields { };
+            std::str::split_into("a::b::c", "::", f);
+            println("n=", f.len());
+            println(f.get(1) or "?");
+        }
+    "#;
+    let (stdout, status) = build_and_run("split_multi", src, &[]);
+    assert!(status.success(), "non-zero: {:?}", status);
+    assert!(stdout.contains("n=3"), "got: {:?}", stdout);
+    assert!(stdout.contains("b"), "got: {:?}", stdout);
+}

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -607,7 +607,7 @@ pub const SURFACES: &[NsSurface] = &[
         fns: &[
             e("builder_append", EffectSet::PURE), e("builder_finish", EffectSet::PURE), e("builder_len", EffectSet::PURE),
             e("builder_new", EffectSet::PURE), e("byte_at_unchecked", EffectSet::PURE),             e("can_parse_float", EffectSet::PURE), e("can_parse_int", EffectSet::PURE), e("clone", EffectSet::PURE), e("from_bytes", EffectSet::PURE),
-            e("index_of", EffectSet::PURE), e("contains", EffectSet::PURE), e("starts_with", EffectSet::PURE), e("ends_with", EffectSet::PURE), e("lower", EffectSet::PURE), e("pad_left", EffectSet::PURE), e("pad_right", EffectSet::PURE), e("parse_decimal", EffectSet::PURE),
+            e("index_of", EffectSet::PURE), e("contains", EffectSet::PURE), e("split_into", EffectSet::PURE), e("starts_with", EffectSet::PURE), e("ends_with", EffectSet::PURE), e("lower", EffectSet::PURE), e("pad_left", EffectSet::PURE), e("pad_right", EffectSet::PURE), e("parse_decimal", EffectSet::PURE),
             e("parse_float", EffectSet::PURE), e("parse_int", EffectSet::PURE), e("range_eq", EffectSet::PURE), e("range_parse_decimal", EffectSet::PURE),
             e("range_parse_int", EffectSet::PURE), e("repeat", EffectSet::PURE), e("replace", EffectSet::PURE), e("substring", EffectSet::PURE), e("trim", EffectSet::PURE),
             e("upper", EffectSet::PURE),
@@ -920,6 +920,7 @@ pub const SIGS: &[FnSig] = &[
     // #353: the everyday predicates. The runtime carried
     // `lotus_str_contains` / `_starts_with` all along; `ends_with` is
     // new. Pure reads over immutable data — no effects.
+    sig!(NS_STR, "split_into", [Str, Str, Any], Unit),
     sig!(NS_STR, "contains", [Str, Str], Bool),
     sig!(NS_STR, "starts_with", [Str, Str], Bool),
     sig!(NS_STR, "ends_with", [Str, Str], Bool),


### PR DESCRIPTION
#353 item 2, second slice. Stacked on #359 (now merged, rebased onto main).

Splitting a string is the most common single operation in service code and Hale had no way to do it.

## Why it writes instead of returns

Hale cannot **return** a sequence: arrays are fixed-size types (`[Int; 3]` and `[Int; 2]` do not unify, and there is no general slice), and growable collections exist only as locus-owned `@form(...)`. Rather than guess at the sequence-value model — the language's largest open question, and one a stdlib function has no business settling by accident — this uses the shape the stdlib already adopted for exactly that reason, `text::tokenize_words_into`:

```hale
@form(vec)
locus Fields { capacity { heap items of String; } }

let f = Fields { };
std::str::split_into("alpha,beta,gamma", ",", f);
```

That is not a workaround, it is the **allocation-visible** form. The caller owns the storage, so the cost lands in the caller's budget instead of hiding behind a return value, and a `@hot` handler can reuse one vec across calls rather than allocating a fresh collection per message. If cluster B later introduces sequence values, a returning `split` can be added beside this one — it does not have to replace it.

## Semantics chosen deliberately

Empty fields are **preserved**: `"a,,b,"` is four fields. Collapsing them silently loses a column in a CSV row and the loss is invisible at the call site. A separator that never occurs yields the whole string as one field, not zero — dropping the input would be worse. Multi-byte separators advance by the separator's length, tested because the naive implementation advances by one byte and mis-splits quietly.

2043/2043 tests, zero warnings, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)