### PR TITLE
feat(stdlib): UTF-8 code-point decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ behavior.
 
 ## Unreleased
 
+- **`std::str::join`** (#353). The pair to `split_into`, and note it
+  RETURNS where split writes: a String is already a value in Hale, so
+  joining never meets the sequence-value question that forces split's
+  shape. One arena allocation sized in a first pass, rather than
+  repeated concatenation, so the cost is a single countable
+  allocation.
 - **`std::str::split_into`** (#353). Splitting a string is the most
   common operation in service code and Hale had no way to do it. It
   writes into a caller-supplied `@form(vec)` rather than returning a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ behavior.
 
 ## Unreleased
 
+- **UTF-8 code-point decoding** (#353). `std::str::cp_count`,
+  `cp_at` (by byte offset) and `cp_size`. Hale's `String` stays
+  byte-oriented; these let a caller walk code points deliberately
+  rather than pretending bytes are characters. Normalization, case
+  folding beyond ASCII, grapheme segmentation and locale collation are
+  each a separate commitment with megabytes of tables against a wasm
+  target, and are deliberately NOT provided — half-shipping them is
+  worse than not shipping them. Invalid UTF-8 yields -1 rather than
+  U+FFFD, so corruption cannot be mistaken for content.
 - **`std::str::join`** (#353). The pair to `split_into`, and note it
   RETURNS where split writes: a String is already a value in Hale, so
   joining never meets the sequence-value question that forces split's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ behavior.
 
 ## Unreleased
 
+- **`std::str::split_into`** (#353). Splitting a string is the most
+  common operation in service code and Hale had no way to do it. It
+  writes into a caller-supplied `@form(vec)` rather than returning a
+  sequence, following `text::tokenize_words_into` — because Hale
+  cannot return one: arrays are fixed-size types and growable
+  collections exist only as locus-owned forms. That shape is also the
+  allocation-visible one: the caller owns the storage, so the cost
+  lands in the caller's budget instead of hiding behind a return
+  value, and a `@hot` handler can reuse one vec across calls. Empty
+  fields are preserved — `"a,,b,"` is four fields.
+
 - **`std::time::parse_iso8601`** (#353). `std::time` was
   monotonic/now/sleep/time_from_unix and nothing else, so a service
   could emit a timestamp and had no way to read one back. Formatting

--- a/crates/hale-cli/tests/str_utf8.rs
+++ b/crates/hale-cli/tests/str_utf8.rs
@@ -1,0 +1,114 @@
+//! UTF-8 code-point decoding (#353 item 7).
+//!
+//! ## Scope, stated because unicode is where "add a feature" quietly
+//! ## becomes five commitments
+//!
+//! This provides code-point decoding and nothing else: `cp_count`,
+//! `cp_at` (by byte offset) and `cp_size`. Hale's `String` stays
+//! BYTE-oriented; these let a caller walk code points deliberately
+//! rather than pretending bytes are characters.
+//!
+//! Normalization (NFC/NFD), case folding beyond ASCII, grapheme
+//! cluster segmentation and locale-aware collation are each a
+//! separate commitment carrying its own tables, and those tables are
+//! megabytes against a wasm target that ships whatever it is given.
+//! Half-shipping them is worse than not shipping them — a `to_upper`
+//! that works for ASCII and silently mangles Turkish dotted I is a
+//! correctness bug that reads like a feature.
+//!
+//! Invalid UTF-8 yields -1 rather than U+FFFD, so a caller cannot
+//! mistake corruption for content.
+
+use std::process::Command;
+
+fn run(src: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir()
+        .join(format!("hale-u8-{}-{}", std::process::id(), tag));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let f = dir.join("main.hl");
+    std::fs::write(&f, src).expect("write");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("run")
+        .arg(&f)
+        .output()
+        .expect("run");
+    let _ = std::fs::remove_dir_all(&dir);
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// Code points, not bytes. `"héllo"` is 5 code points in 6 bytes, and
+/// conflating the two is the bug this exists to let people avoid.
+#[test]
+fn counts_code_points_not_bytes() {
+    let out = run(
+        "fn main() {\n\
+             println(std::str::cp_count(\"héllo\"));\n\
+             println(std::str::cp_count(\"日本語\"));\n\
+             println(std::str::cp_count(\"\"));\n\
+         }",
+        "count",
+    );
+    let got: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        got,
+        vec!["5", "3", "0"],
+        "héllo is 5 code points in 6 bytes; 日本語 is 3 in 9: {:?}",
+        got
+    );
+}
+
+#[test]
+fn decodes_each_width() {
+    let out = run(
+        "fn main() {\n\
+             println(std::str::cp_at(\"héllo\", 0));\n\
+             println(std::str::cp_at(\"héllo\", 1));\n\
+             println(std::str::cp_at(\"日本語\", 0));\n\
+             println(std::str::cp_size(\"héllo\", 0));\n\
+             println(std::str::cp_size(\"héllo\", 1));\n\
+             println(std::str::cp_size(\"日本語\", 0));\n\
+         }",
+        "decode",
+    );
+    let got: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        got,
+        // 'h' = 104; 'é' = U+00E9 = 233; '日' = U+65E5 = 26085
+        vec!["104", "233", "26085", "1", "2", "3"],
+        "1-, 2- and 3-byte sequences must all decode: {:?}",
+        got
+    );
+}
+
+/// A byte offset landing mid-sequence is an error, not a plausible
+/// value. Returning something decodable from a continuation byte
+/// would let a caller walk a string wrongly and never find out.
+#[test]
+fn a_continuation_byte_is_rejected() {
+    let out = run(
+        "fn main() {\n\
+             println(std::str::cp_size(\"é\", 1));\n\
+             println(std::str::cp_at(\"é\", 1));\n\
+         }",
+        "midseq",
+    );
+    let got: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        got,
+        vec!["-1", "-1"],
+        "offset 1 is inside a 2-byte sequence: {:?}",
+        got
+    );
+}
+
+/// Pure — usable from a `@deterministic @no_syscall` fn.
+#[test]
+fn decoding_is_pure() {
+    let out = run(
+        "@deterministic @no_syscall\n\
+         fn n(s: String) -> Int { return std::str::cp_count(s); }\n\
+         fn main() { println(n(\"日本語\")); }",
+        "pure",
+    );
+    assert_eq!(out.trim(), "3", "must certify as pure: {}", out);
+}

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -4214,6 +4214,55 @@ static int lotus_text_is_word_byte(unsigned char c) {
  * a trailing empty field — the same convention as every split worth
  * having, so `"a,,b,".split(",")` is 4 fields.
  */
+/*
+ * #353: `std::str::join(v, sep) -> String`, the pair to split_into.
+ *
+ * Note this one RETURNS. A String is already a value in Hale, so
+ * joining does not run into the sequence-value question that forces
+ * `split_into` to write into caller storage — the asymmetry is real
+ * and reflects the language, not an inconsistency in the API.
+ *
+ * Two passes: size, then fill. One arena allocation for the result
+ * rather than repeated concatenation, so the cost is a single
+ * countable allocation in the caller's budget.
+ */
+char *lotus_str_join(void *vec_ptr, const char *sep, void *arena_ptr) {
+    lotus_arena_t *arena = (lotus_arena_t *)arena_ptr;
+    if (!vec_ptr) {
+        char *e = (char *)lotus_arena_alloc(arena, 1, 1);
+        if (e) e[0] = '\0';
+        return e;
+    }
+    if (!sep) sep = "";
+    size_t seplen = strlen(sep);
+    int64_t n = lotus_vec_len(vec_ptr);
+    size_t total = 1;
+    for (int64_t i = 0; i < n; i++) {
+        char *s = NULL;
+        lotus_vec_get(vec_ptr, sizeof(char *), i, &s);
+        if (s) total += strlen(s);
+        if (i + 1 < n) total += seplen;
+    }
+    char *out = (char *)lotus_arena_alloc(arena, total, 1);
+    if (!out) return NULL;
+    size_t off = 0;
+    for (int64_t i = 0; i < n; i++) {
+        char *s = NULL;
+        lotus_vec_get(vec_ptr, sizeof(char *), i, &s);
+        if (s) {
+            size_t l = strlen(s);
+            memcpy(out + off, s, l);
+            off += l;
+        }
+        if (i + 1 < n && seplen) {
+            memcpy(out + off, sep, seplen);
+            off += seplen;
+        }
+    }
+    out[off] = '\0';
+    return out;
+}
+
 void lotus_str_split_into(
     void *target_vec,
     const char *src,

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -4226,6 +4226,74 @@ static int lotus_text_is_word_byte(unsigned char c) {
  * rather than repeated concatenation, so the cost is a single
  * countable allocation in the caller's budget.
  */
+/*
+ * #353: UTF-8 decoding.
+ *
+ * SCOPE, stated because unicode is where "add a feature" quietly
+ * becomes five commitments. This provides code-point decoding and
+ * nothing else:
+ *
+ *   - `lotus_str_cp_count`  — number of code points
+ *   - `lotus_str_cp_at`     — the code point starting at a BYTE offset
+ *   - `lotus_str_cp_size`   — that code point's width in bytes
+ *
+ * Normalization (NFC/NFD), case folding beyond ASCII, grapheme
+ * cluster segmentation and locale-aware collation are each a separate
+ * commitment with its own tables, and the tables are megabytes against
+ * a wasm target that carries whatever ships. Half-shipping them is
+ * worse than not shipping them: a `to_upper` that works for ASCII and
+ * silently mangles Turkish dotted I is a correctness bug that reads
+ * like a feature.
+ *
+ * Hale's String stays BYTE-oriented. These let a caller walk code
+ * points deliberately rather than pretending bytes are characters.
+ * Invalid UTF-8 yields -1 rather than a replacement character, so a
+ * caller cannot mistake corruption for content.
+ */
+int64_t lotus_str_cp_size(const char *s, int64_t byte_off) {
+    if (!s || byte_off < 0) return -1;
+    unsigned char c = (unsigned char)s[byte_off];
+    if (c == 0) return -1;
+    if (c < 0x80) return 1;
+    if ((c & 0xE0) == 0xC0) return 2;
+    if ((c & 0xF0) == 0xE0) return 3;
+    if ((c & 0xF8) == 0xF0) return 4;
+    return -1;                       /* continuation byte or invalid */
+}
+
+int64_t lotus_str_cp_at(const char *s, int64_t byte_off) {
+    int64_t n = lotus_str_cp_size(s, byte_off);
+    if (n < 0) return -1;
+    const unsigned char *p = (const unsigned char *)s + byte_off;
+    /* Every continuation byte must be 10xxxxxx, or the sequence is
+     * truncated / malformed and must not decode to something
+     * plausible. */
+    for (int64_t i = 1; i < n; i++) {
+        if ((p[i] & 0xC0) != 0x80) return -1;
+    }
+    switch (n) {
+        case 1: return p[0];
+        case 2: return ((int64_t)(p[0] & 0x1F) << 6) | (p[1] & 0x3F);
+        case 3: return ((int64_t)(p[0] & 0x0F) << 12)
+                     | ((int64_t)(p[1] & 0x3F) << 6) | (p[2] & 0x3F);
+        default: return ((int64_t)(p[0] & 0x07) << 18)
+                      | ((int64_t)(p[1] & 0x3F) << 12)
+                      | ((int64_t)(p[2] & 0x3F) << 6) | (p[3] & 0x3F);
+    }
+}
+
+int64_t lotus_str_cp_count(const char *s) {
+    if (!s) return 0;
+    int64_t n = 0;
+    for (int64_t i = 0; s[i]; ) {
+        int64_t w = lotus_str_cp_size(s, i);
+        if (w < 0) return -1;        /* invalid UTF-8 anywhere = -1 */
+        i += w;
+        n++;
+    }
+    return n;
+}
+
 char *lotus_str_join(void *vec_ptr, const char *sep, void *arena_ptr) {
     lotus_arena_t *arena = (lotus_arena_t *)arena_ptr;
     if (!vec_ptr) {

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -4193,6 +4193,50 @@ static int lotus_text_is_word_byte(unsigned char c) {
         || c == '\'';
 }
 
+/*
+ * #353: `std::str::split_into(s, sep, target)`.
+ *
+ * Splitting a string is the most common single operation in service
+ * code and Hale had no way to do it. What it could not do is RETURN a
+ * sequence — arrays are fixed-size types and growable collections
+ * exist only as locus-owned forms — so this follows the shape the
+ * stdlib already uses for exactly that reason
+ * (`lotus_text_tokenize_words_into`): write into a caller-supplied
+ * `@form(vec)`.
+ *
+ * That is not a workaround. It is the allocation-visible form: the
+ * caller owns the storage, so the cost shows up in the caller's
+ * budget rather than hiding behind a return value, and a `@hot`
+ * handler can reuse one vec across calls.
+ *
+ * Empty separator is rejected (it would loop forever). Adjacent
+ * separators produce empty fields, and a trailing separator produces
+ * a trailing empty field — the same convention as every split worth
+ * having, so `"a,,b,".split(",")` is 4 fields.
+ */
+void lotus_str_split_into(
+    void *target_vec,
+    const char *src,
+    const char *sep,
+    void *arena_ptr
+) {
+    if (!target_vec || !src || !sep || !*sep) return;
+    lotus_arena_t *arena = (lotus_arena_t *)arena_ptr;
+    size_t seplen = strlen(sep);
+    const char *cur = src;
+    for (;;) {
+        const char *hit = strstr(cur, sep);
+        size_t n = hit ? (size_t)(hit - cur) : strlen(cur);
+        char *field = (char *)lotus_arena_alloc(arena, n + 1, 1);
+        if (!field) return;
+        if (n) memcpy(field, cur, n);
+        field[n] = '\0';
+        lotus_vec_push(target_vec, sizeof(char *), &field);
+        if (!hit) break;
+        cur = hit + seplen;
+    }
+}
+
 void lotus_text_tokenize_words_into(
     void *target_vec,
     const char *src,

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -22483,6 +22483,9 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ["std", "text", "tokenize_words_into"] => {
                 self.lower_std_text_tokenize_words_into(args, scope)
             }
+            ["std", "str", "split_into"] => {
+                self.lower_std_str_split_into(args, scope)
+            }
             // C9: new fallible-only fs surfaces + C4: getrandom +
             // C2: subprocess primitives. Same "use `or`" diagnostic
             // shape as the parse_int family.
@@ -22630,6 +22633,112 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     one.into(),
                 ],
                 "text.tokenize_words.call",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        Ok(())
+    }
+
+    /// #353: `std::str::split_into(s, sep, target: @form(vec))`.
+    ///
+    /// Splitting is the most common operation in service code and
+    /// Hale had no way to do it. What it cannot do is RETURN a
+    /// sequence — arrays are fixed-size and growable collections
+    /// exist only as locus-owned forms — so this uses the shape the
+    /// stdlib already adopted for that reason
+    /// (`text::tokenize_words_into`): write into caller-supplied
+    /// storage. The caller owns the allocation, so the cost lands in
+    /// the caller's budget instead of hiding behind a return value,
+    /// and a `@hot` handler can reuse one vec across calls.
+    fn lower_std_str_split_into(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(), CodegenError> {
+        if args.len() != 3 {
+            return Err(CodegenError::Unsupported(format!(
+                "std::str::split_into expects 2 args (source \
+                 String, target @form(vec) of String); got {}",
+                args.len()
+            )));
+        }
+        let (src_val, src_ty) = self.lower_expr(&args[0], scope)?;
+        if !matches!(src_ty, CodegenTy::String) {
+            return Err(CodegenError::Unsupported(format!(
+                "std::str::split_into: source arg must be \
+                 String, got {:?}",
+                src_ty
+            )));
+        }
+        let (sep_val, sep_ty) = self.lower_expr(&args[1], scope)?;
+        let sep_val = self.unpack_view_if_needed(sep_val, &sep_ty)?;
+        let (target_val, target_ty) = self.lower_expr(&args[2], scope)?;
+        let target_locus_name = match &target_ty {
+            CodegenTy::LocusRef(n) => n.clone(),
+            other => {
+                return Err(CodegenError::Unsupported(format!(
+                    "std::str::split_into: target arg must be a \
+                     @form(vec) of String locus, got {:?}",
+                    other
+                )));
+            }
+        };
+        let locus_info = self
+            .user_loci
+            .get(&target_locus_name)
+            .cloned()
+            .ok_or_else(|| CodegenError::Unsupported(format!(
+                "std::str::split_into: target locus `{}` not \
+                 registered",
+                target_locus_name
+            )))?;
+        // Verify it's a @form(vec) with String cells.
+        let vec_slot = locus_info
+            .capacity_slots
+            .iter()
+            .find(|s| s.form == Some(SlotForm::Vec))
+            .cloned()
+            .ok_or_else(|| CodegenError::Unsupported(format!(
+                "std::str::split_into: target locus `{}` is not \
+                 a @form(vec) — must be `@form(vec) locus X {{ capacity \
+                 {{ heap items of String; }} }}`",
+                target_locus_name
+            )))?;
+        if !matches!(vec_slot.elem_ty, CodegenTy::String) {
+            return Err(CodegenError::Unsupported(format!(
+                "std::str::split_into: target vec `{}` cell type \
+                 must be String, got {:?}",
+                target_locus_name, vec_slot.elem_ty
+            )));
+        }
+        let target_self_ptr = target_val.into_pointer_value();
+        let vec_field_ptr = self
+            .builder
+            .build_struct_gep(
+                locus_info.struct_ty,
+                target_self_ptr,
+                vec_slot.struct_field_idx,
+                &format!("{}.__vec_{}.tokenize.ptr", target_locus_name, vec_slot.name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let arena_ptr = self.current_arena_ptr()?;
+        // lowercase = 1 by default (matches the wordfreq idiom
+        // every agent reaches for). A future overload could take
+        // an Int / Bool flag if case-preserving tokenization
+        // turns out to be a common need.
+        let fn_ = self
+            .module
+            .get_function("lotus_str_split_into")
+            .expect("lotus_str_split_into declared");
+        self.builder
+            .build_call(
+                fn_,
+                &[
+                    vec_field_ptr.into(),
+                    src_val.into(),
+                    sep_val.into(),
+                    arena_ptr.into(),
+                ],
+                "str.split_into.call",
             )
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         Ok(())

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -22840,6 +22840,46 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         Ok((res, CodegenTy::String))
     }
 
+    /// #353: the UTF-8 code-point accessors. All take a String and
+    /// optionally a byte offset, and all return Int, so one lowering
+    /// covers the family.
+    fn lower_str_cp_call(
+        &mut self,
+        sym: &str,
+        arity: usize,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        if args.len() != arity {
+            return Err(CodegenError::Unsupported(format!(
+                "{} takes {} arg(s), got {}",
+                sym,
+                arity,
+                args.len()
+            )));
+        }
+        let (s, s_ty) = self.lower_expr(&args[0], scope)?;
+        let s = self.unpack_view_if_needed(s, &s_ty)?;
+        let mut call_args: Vec<inkwell::values::BasicMetadataValueEnum> =
+            vec![s.into()];
+        if arity == 2 {
+            let (off, _) = self.lower_expr(&args[1], scope)?;
+            call_args.push(off.into());
+        }
+        let f = self
+            .module
+            .get_function(sym)
+            .unwrap_or_else(|| panic!("{} declared", sym));
+        let res = self
+            .builder
+            .build_call(f, &call_args, "str.cp.ret")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .unwrap_or_else(|| panic!("{} returns i64", sym));
+        Ok((res, CodegenTy::Int))
+    }
+
     /// Expression-position dispatcher for `std::*` paths.
     fn lower_stdlib_path_call_expr(
         &mut self,
@@ -23121,6 +23161,18 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 self.lower_std_str_index_of(args, scope)
             }
             ["std", "str", "join"] => self.lower_std_str_join(args, scope),
+            // #353: UTF-8 code-point decoding. Byte-oriented String
+            // stays byte-oriented; these let a caller walk code points
+            // deliberately rather than pretending bytes are characters.
+            ["std", "str", "cp_count"] => {
+                self.lower_str_cp_call("lotus_str_cp_count", 1, args, scope)
+            }
+            ["std", "str", "cp_at"] => {
+                self.lower_str_cp_call("lotus_str_cp_at", 2, args, scope)
+            }
+            ["std", "str", "cp_size"] => {
+                self.lower_str_cp_call("lotus_str_cp_size", 2, args, scope)
+            }
             ["std", "str", "contains"] => self.lower_std_str_predicate(
                 "lotus_str_contains",
                 "contains",

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -22744,6 +22744,102 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         Ok(())
     }
 
+    /// #353: `std::str::join(v: @form(vec) of String, sep) -> String`.
+    ///
+    /// Note this RETURNS where `split_into` writes. A String is
+    /// already a value in Hale, so joining does not meet the
+    /// sequence-value question at all. The asymmetry reflects the
+    /// language rather than an inconsistency in the API.
+    fn lower_std_str_join(
+        &mut self,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        if args.len() != 2 {
+            return Err(CodegenError::Unsupported(format!(
+                "std::str::join expects 2 args (source \
+                 String, target @form(vec) of String); got {}",
+                args.len()
+            )));
+        }
+        let (target_val, target_ty) = self.lower_expr(&args[0], scope)?;
+        let (sep_val, sep_ty) = self.lower_expr(&args[1], scope)?;
+        let sep_val = self.unpack_view_if_needed(sep_val, &sep_ty)?;
+        let target_locus_name = match &target_ty {
+            CodegenTy::LocusRef(n) => n.clone(),
+            other => {
+                return Err(CodegenError::Unsupported(format!(
+                    "std::str::join: target arg must be a \
+                     @form(vec) of String locus, got {:?}",
+                    other
+                )));
+            }
+        };
+        let locus_info = self
+            .user_loci
+            .get(&target_locus_name)
+            .cloned()
+            .ok_or_else(|| CodegenError::Unsupported(format!(
+                "std::str::join: target locus `{}` not \
+                 registered",
+                target_locus_name
+            )))?;
+        // Verify it's a @form(vec) with String cells.
+        let vec_slot = locus_info
+            .capacity_slots
+            .iter()
+            .find(|s| s.form == Some(SlotForm::Vec))
+            .cloned()
+            .ok_or_else(|| CodegenError::Unsupported(format!(
+                "std::str::join: target locus `{}` is not \
+                 a @form(vec) — must be `@form(vec) locus X {{ capacity \
+                 {{ heap items of String; }} }}`",
+                target_locus_name
+            )))?;
+        if !matches!(vec_slot.elem_ty, CodegenTy::String) {
+            return Err(CodegenError::Unsupported(format!(
+                "std::str::join: target vec `{}` cell type \
+                 must be String, got {:?}",
+                target_locus_name, vec_slot.elem_ty
+            )));
+        }
+        let target_self_ptr = target_val.into_pointer_value();
+        let vec_field_ptr = self
+            .builder
+            .build_struct_gep(
+                locus_info.struct_ty,
+                target_self_ptr,
+                vec_slot.struct_field_idx,
+                &format!("{}.__vec_{}.tokenize.ptr", target_locus_name, vec_slot.name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let arena_ptr = self.current_arena_ptr()?;
+        // lowercase = 1 by default (matches the wordfreq idiom
+        // every agent reaches for). A future overload could take
+        // an Int / Bool flag if case-preserving tokenization
+        // turns out to be a common need.
+        let fn_ = self
+            .module
+            .get_function("lotus_str_join")
+            .expect("lotus_str_join declared");
+        let res = self
+            .builder
+            .build_call(
+                fn_,
+                &[
+                    vec_field_ptr.into(),
+                    sep_val.into(),
+                    arena_ptr.into(),
+                ],
+                "str.join.call",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .expect("lotus_str_join returns ptr");
+        Ok((res, CodegenTy::String))
+    }
+
     /// Expression-position dispatcher for `std::*` paths.
     fn lower_stdlib_path_call_expr(
         &mut self,
@@ -23024,6 +23120,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ["std", "str", "index_of"] => {
                 self.lower_std_str_index_of(args, scope)
             }
+            ["std", "str", "join"] => self.lower_std_str_join(args, scope),
             ["std", "str", "contains"] => self.lower_std_str_predicate(
                 "lotus_str_contains",
                 "contains",

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -771,6 +771,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             false,
         );
         self.module.add_function("lotus_str_join", join_ty, None);
+        // #353: UTF-8 code-point decoding. Pure reads over immutable
+        // input.
+        let cp_at_ty = i64_t.fn_type(&[ptr_t.into(), i64_t.into()], false);
+        for name in ["lotus_str_cp_at", "lotus_str_cp_size"] {
+            let f = self.module.add_function(name, cp_at_ty, None);
+            self.mark_pure_read(f);
+        }
+        let cp_count_ty = i64_t.fn_type(&[ptr_t.into()], false);
+        let cp_count_fn =
+            self.module.add_function("lotus_str_cp_count", cp_count_ty, None);
+        self.mark_pure_read(cp_count_fn);
 
         // m84: byte index of substring (or -1 if not found).
         // declare i64 @lotus_str_index_of(ptr s, ptr sub)

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -764,6 +764,13 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         );
         self.module
             .add_function("lotus_str_split_into", split_into_ty, None);
+        // #353: join returns — a String is already a value.
+        // declare ptr @lotus_str_join(ptr vec, ptr sep, ptr arena)
+        let join_ty = ptr_t.fn_type(
+            &[ptr_t.into(), ptr_t.into(), ptr_t.into()],
+            false,
+        );
+        self.module.add_function("lotus_str_join", join_ty, None);
 
         // m84: byte index of substring (or -1 if not found).
         // declare i64 @lotus_str_index_of(ptr s, ptr sub)

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -756,6 +756,14 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             .module
             .add_function("lotus_str_ends_with", str_predicate_ty, None);
         self.mark_pure_read(str_ends_with_fn);
+        // #353: split into a caller-supplied @form(vec).
+        // declare void @lotus_str_split_into(ptr vec, ptr s, ptr sep, ptr arena)
+        let split_into_ty = self.context.void_type().fn_type(
+            &[ptr_t.into(), ptr_t.into(), ptr_t.into(), ptr_t.into()],
+            false,
+        );
+        self.module
+            .add_function("lotus_str_split_into", split_into_ty, None);
 
         // m84: byte index of substring (or -1 if not found).
         // declare i64 @lotus_str_index_of(ptr s, ptr sub)

--- a/crates/hale-codegen/tests/str_split_into.rs
+++ b/crates/hale-codegen/tests/str_split_into.rs
@@ -130,3 +130,55 @@ fn a_multi_byte_separator_works() {
     assert!(stdout.contains("n=3"), "got: {:?}", stdout);
     assert!(stdout.contains("b"), "got: {:?}", stdout);
 }
+
+// ---- join, the pair --------------------------------------------
+//
+// Note `join` RETURNS where `split_into` writes. A String is already
+// a value in Hale, so joining never meets the sequence-value question
+// that forces split's shape. The asymmetry reflects the language, not
+// an inconsistency in the API.
+
+#[test]
+fn split_and_join_round_trip() {
+    let src = r#"
+        @form(vec)
+        locus Fields { capacity { heap items of String; } }
+        fn main() {
+            let f = Fields { };
+            std::str::split_into("alpha,beta,gamma", ",", f);
+            println(std::str::join(f, ","));
+            println(std::str::join(f, "-"));
+            println(std::str::join(f, ""));
+        }
+    "#;
+    let (stdout, status) = build_and_run("join_round", src, &[]);
+    assert!(status.success(), "non-zero: {:?}", status);
+    assert!(
+        stdout.contains("alpha,beta,gamma"),
+        "join(split(s, sep), sep) must reproduce s: {:?}",
+        stdout
+    );
+    assert!(stdout.contains("alpha-beta-gamma"), "got: {:?}", stdout);
+    assert!(stdout.contains("alphabetagamma"), "got: {:?}", stdout);
+}
+
+/// An empty collection joins to the empty string, not to a separator
+/// and not to a crash — the case every hand-rolled join gets wrong.
+#[test]
+fn joining_nothing_is_empty() {
+    let src = r#"
+        @form(vec)
+        locus Fields { capacity { heap items of String; } }
+        fn main() {
+            let e = Fields { };
+            println("[", std::str::join(e, ","), "]");
+        }
+    "#;
+    let (stdout, status) = build_and_run("join_empty", src, &[]);
+    assert!(status.success(), "non-zero: {:?}", status);
+    assert!(
+        stdout.contains("[]"),
+        "empty join must be empty, with no stray separator: {:?}",
+        stdout
+    );
+}

--- a/crates/hale-codegen/tests/str_split_into.rs
+++ b/crates/hale-codegen/tests/str_split_into.rs
@@ -1,0 +1,132 @@
+//! `std::str::split_into` (#353 item 2).
+//!
+//! Splitting a string is the most common single operation in service
+//! code, and Hale had no way to do it.
+//!
+//! What Hale cannot do is RETURN a sequence: arrays are fixed-size
+//! types (`[Int; 3]` and `[Int; 2]` do not unify, and there is no
+//! general slice), and growable collections exist only as locus-owned
+//! `@form(...)`. So rather than guess at the sequence-value model —
+//! the language's largest open question — this uses the shape the
+//! stdlib already adopted for exactly that reason,
+//! `text::tokenize_words_into`: write into caller-supplied storage.
+//!
+//! That is not a workaround. It is the allocation-visible form. The
+//! caller owns the storage, so the cost lands in the caller's budget
+//! instead of hiding behind a return value, and a `@hot` handler can
+//! reuse one vec across calls rather than allocating a fresh
+//! collection per message.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+fn build_and_run(
+    name: &str,
+    src: &str,
+    argv: &[&str],
+) -> (String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(&format!(
+        "hale_split_{}_{}",
+        name,
+        std::process::id()
+    ));
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).args(argv).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        out.status,
+    )
+}
+
+#[test]
+fn it_splits_on_a_separator() {
+    let src = r#"
+        @form(vec)
+        locus Fields { capacity { heap items of String; } }
+        fn main() {
+            let f = Fields { };
+            std::str::split_into("alpha,beta,gamma", ",", f);
+            println("n=", f.len());
+            let mut i = 0;
+            while i < f.len() {
+                println(f.get(i) or "");
+                i = i + 1;
+            }
+        }
+    "#;
+    let (stdout, status) = build_and_run("split_basic", src, &[]);
+    assert!(status.success(), "non-zero: {:?}", status);
+    assert!(stdout.contains("n=3"), "got: {:?}", stdout);
+    for w in ["alpha", "beta", "gamma"] {
+        assert!(stdout.contains(w), "missing {}: {:?}", w, stdout);
+    }
+}
+
+/// Adjacent and trailing separators produce EMPTY fields rather than
+/// being collapsed. `"a,,b,"` is four fields, which is what every
+/// split worth having does — collapsing them silently loses a column
+/// in a CSV row and the loss is invisible at the call site.
+#[test]
+fn empty_fields_are_preserved() {
+    let src = r#"
+        @form(vec)
+        locus Fields { capacity { heap items of String; } }
+        fn main() {
+            let f = Fields { };
+            std::str::split_into("a,,b,", ",", f);
+            println("n=", f.len());
+            println("[", f.get(1) or "?", "]");
+            println("[", f.get(3) or "?", "]");
+        }
+    "#;
+    let (stdout, status) = build_and_run("split_empty", src, &[]);
+    assert!(status.success(), "non-zero: {:?}", status);
+    assert!(stdout.contains("n=4"), "got: {:?}", stdout);
+    assert!(stdout.contains("[]"), "empty fields must survive: {:?}", stdout);
+}
+
+/// A separator that does not occur yields the whole string as one
+/// field — not zero fields, which would silently drop the input.
+#[test]
+fn a_missing_separator_yields_the_whole_string() {
+    let src = r#"
+        @form(vec)
+        locus Fields { capacity { heap items of String; } }
+        fn main() {
+            let f = Fields { };
+            std::str::split_into("nosep", ",", f);
+            println("n=", f.len());
+            println(f.get(0) or "?");
+        }
+    "#;
+    let (stdout, status) = build_and_run("split_nosep", src, &[]);
+    assert!(status.success(), "non-zero: {:?}", status);
+    assert!(stdout.contains("n=1"), "got: {:?}", stdout);
+    assert!(stdout.contains("nosep"), "got: {:?}", stdout);
+}
+
+/// A multi-byte separator, since the naive implementation advances by
+/// one byte and silently mis-splits.
+#[test]
+fn a_multi_byte_separator_works() {
+    let src = r#"
+        @form(vec)
+        locus Fields { capacity { heap items of String; } }
+        fn main() {
+            let f = Fields { };
+            std::str::split_into("a::b::c", "::", f);
+            println("n=", f.len());
+            println(f.get(1) or "?");
+        }
+    "#;
+    let (stdout, status) = build_and_run("split_multi", src, &[]);
+    assert!(status.success(), "non-zero: {:?}", status);
+    assert!(stdout.contains("n=3"), "got: {:?}", stdout);
+    assert!(stdout.contains("b"), "got: {:?}", stdout);
+}

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -607,7 +607,7 @@ pub const SURFACES: &[NsSurface] = &[
         fns: &[
             e("builder_append", EffectSet::PURE), e("builder_finish", EffectSet::PURE), e("builder_len", EffectSet::PURE),
             e("builder_new", EffectSet::PURE), e("byte_at_unchecked", EffectSet::PURE),             e("can_parse_float", EffectSet::PURE), e("can_parse_int", EffectSet::PURE), e("clone", EffectSet::PURE), e("from_bytes", EffectSet::PURE),
-            e("index_of", EffectSet::PURE), e("contains", EffectSet::PURE), e("split_into", EffectSet::PURE), e("starts_with", EffectSet::PURE), e("ends_with", EffectSet::PURE), e("lower", EffectSet::PURE), e("pad_left", EffectSet::PURE), e("pad_right", EffectSet::PURE), e("parse_decimal", EffectSet::PURE),
+            e("index_of", EffectSet::PURE), e("contains", EffectSet::PURE), e("split_into", EffectSet::PURE), e("join", EffectSet::PURE), e("starts_with", EffectSet::PURE), e("ends_with", EffectSet::PURE), e("lower", EffectSet::PURE), e("pad_left", EffectSet::PURE), e("pad_right", EffectSet::PURE), e("parse_decimal", EffectSet::PURE),
             e("parse_float", EffectSet::PURE), e("parse_int", EffectSet::PURE), e("range_eq", EffectSet::PURE), e("range_parse_decimal", EffectSet::PURE),
             e("range_parse_int", EffectSet::PURE), e("repeat", EffectSet::PURE), e("replace", EffectSet::PURE), e("substring", EffectSet::PURE), e("trim", EffectSet::PURE),
             e("upper", EffectSet::PURE),
@@ -921,6 +921,7 @@ pub const SIGS: &[FnSig] = &[
     // `lotus_str_contains` / `_starts_with` all along; `ends_with` is
     // new. Pure reads over immutable data — no effects.
     sig!(NS_STR, "split_into", [Str, Str, Any], Unit),
+    sig!(NS_STR, "join", [Any, Str], Str),
     sig!(NS_STR, "contains", [Str, Str], Bool),
     sig!(NS_STR, "starts_with", [Str, Str], Bool),
     sig!(NS_STR, "ends_with", [Str, Str], Bool),

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -607,7 +607,7 @@ pub const SURFACES: &[NsSurface] = &[
         fns: &[
             e("builder_append", EffectSet::PURE), e("builder_finish", EffectSet::PURE), e("builder_len", EffectSet::PURE),
             e("builder_new", EffectSet::PURE), e("byte_at_unchecked", EffectSet::PURE),             e("can_parse_float", EffectSet::PURE), e("can_parse_int", EffectSet::PURE), e("clone", EffectSet::PURE), e("from_bytes", EffectSet::PURE),
-            e("index_of", EffectSet::PURE), e("contains", EffectSet::PURE), e("starts_with", EffectSet::PURE), e("ends_with", EffectSet::PURE), e("lower", EffectSet::PURE), e("pad_left", EffectSet::PURE), e("pad_right", EffectSet::PURE), e("parse_decimal", EffectSet::PURE),
+            e("index_of", EffectSet::PURE), e("contains", EffectSet::PURE), e("split_into", EffectSet::PURE), e("starts_with", EffectSet::PURE), e("ends_with", EffectSet::PURE), e("lower", EffectSet::PURE), e("pad_left", EffectSet::PURE), e("pad_right", EffectSet::PURE), e("parse_decimal", EffectSet::PURE),
             e("parse_float", EffectSet::PURE), e("parse_int", EffectSet::PURE), e("range_eq", EffectSet::PURE), e("range_parse_decimal", EffectSet::PURE),
             e("range_parse_int", EffectSet::PURE), e("repeat", EffectSet::PURE), e("replace", EffectSet::PURE), e("substring", EffectSet::PURE), e("trim", EffectSet::PURE),
             e("upper", EffectSet::PURE),
@@ -920,6 +920,7 @@ pub const SIGS: &[FnSig] = &[
     // #353: the everyday predicates. The runtime carried
     // `lotus_str_contains` / `_starts_with` all along; `ends_with` is
     // new. Pure reads over immutable data — no effects.
+    sig!(NS_STR, "split_into", [Str, Str, Any], Unit),
     sig!(NS_STR, "contains", [Str, Str], Bool),
     sig!(NS_STR, "starts_with", [Str, Str], Bool),
     sig!(NS_STR, "ends_with", [Str, Str], Bool),

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -607,7 +607,7 @@ pub const SURFACES: &[NsSurface] = &[
         fns: &[
             e("builder_append", EffectSet::PURE), e("builder_finish", EffectSet::PURE), e("builder_len", EffectSet::PURE),
             e("builder_new", EffectSet::PURE), e("byte_at_unchecked", EffectSet::PURE),             e("can_parse_float", EffectSet::PURE), e("can_parse_int", EffectSet::PURE), e("clone", EffectSet::PURE), e("from_bytes", EffectSet::PURE),
-            e("index_of", EffectSet::PURE), e("contains", EffectSet::PURE), e("split_into", EffectSet::PURE), e("join", EffectSet::PURE), e("starts_with", EffectSet::PURE), e("ends_with", EffectSet::PURE), e("lower", EffectSet::PURE), e("pad_left", EffectSet::PURE), e("pad_right", EffectSet::PURE), e("parse_decimal", EffectSet::PURE),
+            e("index_of", EffectSet::PURE), e("contains", EffectSet::PURE), e("split_into", EffectSet::PURE), e("join", EffectSet::PURE), e("cp_count", EffectSet::PURE), e("cp_at", EffectSet::PURE), e("cp_size", EffectSet::PURE), e("starts_with", EffectSet::PURE), e("ends_with", EffectSet::PURE), e("lower", EffectSet::PURE), e("pad_left", EffectSet::PURE), e("pad_right", EffectSet::PURE), e("parse_decimal", EffectSet::PURE),
             e("parse_float", EffectSet::PURE), e("parse_int", EffectSet::PURE), e("range_eq", EffectSet::PURE), e("range_parse_decimal", EffectSet::PURE),
             e("range_parse_int", EffectSet::PURE), e("repeat", EffectSet::PURE), e("replace", EffectSet::PURE), e("substring", EffectSet::PURE), e("trim", EffectSet::PURE),
             e("upper", EffectSet::PURE),
@@ -922,6 +922,9 @@ pub const SIGS: &[FnSig] = &[
     // new. Pure reads over immutable data — no effects.
     sig!(NS_STR, "split_into", [Str, Str, Any], Unit),
     sig!(NS_STR, "join", [Any, Str], Str),
+    sig!(NS_STR, "cp_count", [Str], Int),
+    sig!(NS_STR, "cp_at", [Str, Int], Int),
+    sig!(NS_STR, "cp_size", [Str, Int], Int),
     sig!(NS_STR, "contains", [Str, Str], Bool),
     sig!(NS_STR, "starts_with", [Str, Str], Bool),
     sig!(NS_STR, "ends_with", [Str, Str], Bool),


### PR DESCRIPTION
#353 item 7. Stacked on #361.

`std::text` offered ASCII byte predicates and nothing above them, so a caller had no way to walk a non-ASCII string except by pretending bytes are characters.

```hale
std::str::cp_count("héllo")   // 5 code points, 6 bytes
std::str::cp_at("日本語", 0)   // 26085 = U+65E5
std::str::cp_size("héllo", 1) // 2
```

## Scope, stated deliberately

Unicode is where "add a feature" quietly becomes five commitments. This provides **code-point decoding and nothing else**. Hale's `String` stays byte-oriented — the representation does not change; a caller can now step through code points on purpose.

Normalization (NFC/NFD), case folding beyond ASCII, grapheme cluster segmentation and locale-aware collation are each a separate commitment carrying its own tables, and those tables are megabytes against a wasm target that ships whatever it is given. **Half-shipping them is worse than not shipping them**: a `to_upper` that works for ASCII and silently mangles Turkish dotted I is a correctness bug that reads like a feature.

## Failing loudly

Invalid UTF-8 yields `-1` rather than U+FFFD, and a byte offset landing mid-sequence is likewise `-1` rather than something decodable. A caller must not be able to mistake corruption for content, or walk a string wrongly and never find out — the replacement-character convention is exactly the silent-wrongness this codebase has been removing elsewhere.

2049/2049 tests, zero warnings.