### PR TITLE
fix(check): a diverging or-fallback has no type to match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ behavior.
 
 ## Unreleased
 
+- **A diverging `or` fallback no longer needs a substitute** (#353).
+  `v.get(i) or { break; }` was rejected with "fallback type `()` does
+  not match success type `Int`" — but `break` never yields, so there
+  is no value whose type could match, and the rule asked callers to
+  invent a substitute provably never used. `break` / `continue` /
+  `return` / `fail` / `terminate` in tail position are now accepted.
+  Conservative: only an UNCONDITIONAL divergence counts, since a block
+  that can fall through genuinely does need a value.
+
 - **UTF-8 code-point decoding** (#353). `std::str::cp_count`,
   `cp_at` (by byte offset) and `cp_size`. Hale's `String` stays
   byte-oriented; these let a caller walk code points deliberately

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -4712,6 +4712,28 @@ fn check_bus_cycles(bundle: &Bundle<'_>, diags: &mut Vec<Diag>) {
 
 /// Flow-control / exit primitives whose presence anywhere in an
 /// unbounded loop body rules out the flood: the loop either paces
+/// #353: does this block ALWAYS leave without producing a value?
+///
+/// A fallback that diverges has no type, so `or { break; }` must not
+/// be asked to match the success type. Conservative: only a block
+/// whose LAST statement unconditionally transfers control counts, so
+/// a conditional `break` still requires a substitute.
+fn block_always_diverges(b: &Block) -> bool {
+    if b.tail.is_some() {
+        return false;
+    }
+    matches!(
+        b.stmts.last(),
+        Some(
+            Stmt::Break(_)
+                | Stmt::Continue(_)
+                | Stmt::Return(..)
+                | Stmt::Fail { .. }
+                | Stmt::Terminate(_)
+        )
+    )
+}
+
 /// itself or can leave.
 fn block_has_flow_control(b: &Block) -> bool {
     b.stmts.iter().any(stmt_has_flow_control)
@@ -11203,8 +11225,20 @@ impl<'a> Checker<'a> {
                         // don't false-positive when the
                         // typechecker can't see through a
                         // stdlib path.
+                        // #353: a DIVERGING fallback yields no value,
+                        // so there is no type to match. `or { break; }`
+                        // / `continue` / `return` / `fail` never reach
+                        // the binding, and demanding a typed substitute
+                        // from them forces callers to invent a default
+                        // that is never used — and for a generic
+                        // element type there is no default to invent.
+                        let rhs_diverges = matches!(
+                            rhs.as_ref(),
+                            Expr::Block(b) if block_always_diverges(b)
+                        );
                         if !interface_satisfied
                             && !value_discarded
+                            && !rhs_diverges
                             && !success.assignable_from(&rhs_ty)
                         {
                             self.diags.push(Diag::ty(

--- a/crates/hale-types/tests/diverging_or.rs
+++ b/crates/hale-types/tests/diverging_or.rs
@@ -1,0 +1,110 @@
+//! A diverging `or` fallback has no type (#353).
+//!
+//! `v.get(i) or { break; }` was rejected with "fallback type `()` does
+//! not match success type `Int`" — but `break` never yields, so there
+//! is no value whose type could match. The rule asked callers to
+//! invent a substitute that is provably never used.
+//!
+//! That is a papercut on its own, and a blocker for the recognized-
+//! chain lowering: a desugar over a form cannot invent a typed default
+//! for an arbitrary element type, so `or { continue; }` is the only
+//! shape available to it.
+//!
+//! Deliberately conservative: only a block whose LAST statement
+//! unconditionally transfers control counts. A conditional `break`
+//! still requires a substitute, because the block CAN fall through and
+//! then genuinely does need a value.
+
+use hale_syntax::parse_source;
+
+fn errs(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+const V: &str = "@form(vec)\nlocus Nums { capacity { heap items of Int; } }\n";
+
+#[test]
+fn an_unconditionally_diverging_fallback_needs_no_substitute() {
+    for kw in ["break", "continue"] {
+        let ds = errs(&format!(
+            "{V}fn main() {{\n\
+                 let v = Nums {{ }};\n\
+                 v.push(1);\n\
+                 let mut i = 0;\n\
+                 while i < v.len() {{\n\
+                     let it = v.get(i) or {{ {kw}; }};\n\
+                     println(it);\n\
+                     i = i + 1;\n\
+                 }}\n\
+             }}"
+        ));
+        assert!(
+            !ds.iter().any(|m| m.contains("fallback type")),
+            "`or {{ {}; }}` yields no value, so there is no type to \
+             match: {:?}",
+            kw,
+            ds
+        );
+    }
+}
+
+#[test]
+fn a_return_fallback_needs_no_substitute() {
+    let ds = errs(&format!(
+        "{V}fn first(v: Nums) -> Int {{\n\
+             let it = v.get(0) or {{ return 0; }};\n\
+             return it;\n\
+         }}\n\
+         fn main() {{ let v = Nums {{ }}; v.push(3); println(first(v)); }}"
+    ));
+    assert!(
+        !ds.iter().any(|m| m.contains("fallback type")),
+        "`or {{ return …; }}` diverges: {:?}",
+        ds
+    );
+}
+
+/// The boundary. A block that CAN fall through still needs a value —
+/// otherwise the binding would be uninitialised on the falling-through
+/// path, which is the thing the original rule was protecting.
+#[test]
+fn a_conditional_divergence_still_requires_a_substitute() {
+    let ds = errs(&format!(
+        "{V}fn main() {{\n\
+             let v = Nums {{ }};\n\
+             v.push(1);\n\
+             let mut i = 0;\n\
+             while i < v.len() {{\n\
+                 let it = v.get(i) or {{ if i > 5 {{ break; }} }};\n\
+                 println(it);\n\
+                 i = i + 1;\n\
+             }}\n\
+         }}"
+    ));
+    assert!(
+        ds.iter().any(|m| m.contains("fallback type")),
+        "a conditional break can fall through and then needs a value: \
+         {:?}",
+        ds
+    );
+}
+
+/// An ordinary typed substitute must keep working unchanged.
+#[test]
+fn a_valued_substitute_still_works() {
+    let ds = errs(&format!(
+        "{V}fn main() {{\n\
+             let v = Nums {{ }};\n\
+             println(v.get(0) or 0);\n\
+         }}"
+    ));
+    assert!(
+        !ds.iter().any(|m| m.contains("fallback type")),
+        "`or 0` is the ordinary form and must be unaffected: {:?}",
+        ds
+    );
+}


### PR DESCRIPTION
#353, and a prerequisite for the cluster-B chain lowering.

```hale
let it = v.get(i) or { break; };
// type error: `or <substitute>`: fallback type `()` does not match success type `Int`
```

`break` never yields, so there is no value whose type could match. The rule asked callers to invent a substitute that is **provably never used**.

Found while prototyping the recognized-chain lowering: a desugar over a form cannot invent a typed default for an arbitrary element type, so `or { continue; }` is the only shape available to it. The fix is independently correct regardless.

`break` / `continue` / `return` / `fail` / `terminate` in tail position are now accepted.

## The boundary

Deliberately conservative — only a block whose **last** statement unconditionally transfers control counts. A conditional `break` still requires a substitute, because the block can fall through and the binding would then be uninitialised, which is what the original rule was protecting. Both directions are tested.

2049/2049 tests, zero warnings, fmt clean.