### PR TITLE
feat: recognized element chains (cluster B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ behavior.
 
 ## Unreleased
 
+- **Recognized element chains** (#353, cluster B).
+  `xs.filter(it > 2).count()` and `xs.filter(...).into(target)` are
+  rewritten to ONE loop by a post-parse pass, so typecheck and codegen
+  both see an ordinary `while` and neither learns about chains. A
+  chain is not a value being built — nothing is produced at any stage,
+  so there is no sequence value, no owner for it, and no arena
+  question. Three consequences fall out: it allocates NOTHING (so a
+  chain is legal under `@budget(alloc_per_call = 0)`, unlike a design
+  that returns a new collection); it is eager, so a predicate's
+  effects are attributed to the predicate's own source position rather
+  than to the terminal; and it needs no lambdas at all, because the
+  predicate is an argument position rather than a value — `it` is
+  bound per element by the desugar. Stages fuse: two filters are one
+  pass.
+
 - **A diverging `or` fallback no longer needs a substitute** (#353).
   `v.get(i) or { break; }` was rejected with "fallback type `()` does
   not match success type `Int`" — but `break` never yields, so there

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ behavior.
 
 ## Unreleased
 
+- **A diverging `or` fallback no longer needs a substitute** (#353).
+  `v.get(i) or { break; }` was rejected with "fallback type `()` does
+  not match success type `Int`" — but `break` never yields, so there
+  is no value whose type could match, and the rule asked callers to
+  invent a substitute provably never used. `break` / `continue` /
+  `return` / `fail` / `terminate` in tail position are now accepted.
+  Conservative: only an UNCONDITIONAL divergence counts, since a block
+  that can fall through genuinely does need a value.
+
 - **UTF-8 code-point decoding** (#353). `std::str::cp_count`,
   `cp_at` (by byte offset) and `cp_size`. Hale's `String` stays
   byte-oriented; these let a caller walk code points deliberately

--- a/crates/hale-codegen/tests/element_chains.rs
+++ b/crates/hale-codegen/tests/element_chains.rs
@@ -1,0 +1,166 @@
+//! Recognized element chains (#353 cluster B).
+//!
+//! `xs.filter(it > 2).count()` is not a value being built — it is a
+//! form the compiler recognizes and rewrites to ONE loop.
+//!
+//! The knot that made "add closures, then add iterators" look
+//! expensive was self-inflicted: it assumed each stage must PRODUCE
+//! something, so a chain needs either a lazy object or an intermediate
+//! collection, either of which is a sequence value needing an owner,
+//! which reopens arenas and placement. If the chain is a recognized
+//! form rather than a value, nothing is produced at any step and the
+//! question never arises.
+//!
+//! Three consequences, all of which fall out rather than being
+//! engineered, and all pinned below:
+//!
+//!   - ZERO ALLOCATION, so a chain is legal inside
+//!     `@budget(alloc_per_call = 0)`. A design returning a new
+//!     collection would be illegal in exactly the code Hale exists
+//!     for.
+//!   - EAGER, so a predicate's effects are attributed to the
+//!     predicate's own source position. A lazy chain would run it at
+//!     the terminal and the witness path would name the wrong line.
+//!   - NO LAMBDAS. The predicate is an argument position the compiler
+//!     knows about, not a value, so there is no closure to represent —
+//!     no capture modes, no escape analysis, no cross-thread question.
+//!     `it` is bound per element by the desugar.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+fn run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(&format!(
+        "hale_chain_{}_{}",
+        name,
+        std::process::id()
+    ));
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (String::from_utf8_lossy(&out.stdout).to_string(), out.status)
+}
+
+const V: &str =
+    "@form(vec)\nlocus Nums { capacity { heap items of Int; } }\n";
+
+#[test]
+fn filter_count_evaluates_the_predicate_per_element() {
+    let src = format!(
+        "{V}fn main() {{
+            let v = Nums {{ }};
+            v.push(1); v.push(5); v.push(2); v.push(9);
+            println(\"gt2=\", v.filter(it > 2).count());
+            println(\"all=\", v.filter(it > 0).count());
+            println(\"none=\", v.filter(it > 100).count());
+        }}"
+    );
+    let (out, st) = run("count", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("gt2=2"), "5 and 9 pass: {:?}", out);
+    assert!(out.contains("all=4"), "got: {:?}", out);
+    assert!(out.contains("none=0"), "got: {:?}", out);
+}
+
+/// Two stages fuse into ONE pass — no intermediate exists for the
+/// second stage to read.
+#[test]
+fn two_stages_fuse() {
+    let src = format!(
+        "{V}fn main() {{
+            let v = Nums {{ }};
+            v.push(1); v.push(5); v.push(2); v.push(9);
+            println(\"fused=\", v.filter(it > 2).filter(it < 9).count());
+        }}"
+    );
+    let (out, st) = run("fuse", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("fused=1"), "only 5 survives both: {:?}", out);
+}
+
+/// THE claim. A chain allocates nothing, so it is legal on a hot path.
+/// If this ever fails, the design has regressed to materialising
+/// something, and composition stops being usable in the code Hale is
+/// built for.
+#[test]
+fn a_chain_is_legal_under_a_zero_alloc_budget() {
+    let src = format!(
+        "{V}@budget(alloc_per_call = 0)
+        fn big(v: Nums) -> Int {{
+            return v.filter(it > 2).filter(it < 9).count();
+        }}
+        fn main() {{
+            let v = Nums {{ }};
+            v.push(1); v.push(5); v.push(9);
+            println(\"n=\", big(v));
+        }}"
+    );
+    let (out, st) = run("budget", &src);
+    assert!(
+        st.success(),
+        "a chain must not allocate — @budget(alloc_per_call = 0) \
+         rejected it: {:?}",
+        st
+    );
+    assert!(out.contains("n=1"), "got: {:?}", out);
+}
+
+/// The `into` terminal writes into caller-supplied storage — the same
+/// shape `split_into` uses, and the only point at which anything is
+/// materialised.
+#[test]
+fn into_writes_the_survivors_to_a_target() {
+    let src = format!(
+        "{V}fn main() {{
+            let v = Nums {{ }};
+            v.push(1); v.push(5); v.push(2); v.push(9);
+            let out = Nums {{ }};
+            v.filter(it > 2).into(out);
+            println(\"n=\", out.len(), \" first=\", out.get(0) or -1);
+        }}"
+    );
+    let (out, st) = run("into", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("n=2"), "5 and 9: {:?}", out);
+    assert!(out.contains("first=5"), "in source order: {:?}", out);
+}
+
+/// Two chains in one block must not collide on their loop
+/// temporaries — the desugar numbers them.
+#[test]
+fn two_chains_in_one_block_coexist() {
+    let src = format!(
+        "{V}fn main() {{
+            let v = Nums {{ }};
+            v.push(1); v.push(5);
+            let a = v.filter(it > 0).count();
+            let b = v.filter(it > 4).count();
+            println(\"a=\", a, \" b=\", b);
+        }}"
+    );
+    let (out, st) = run("two", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("a=2"), "got: {:?}", out);
+    assert!(out.contains("b=1"), "got: {:?}", out);
+}
+
+/// A bare `.count()` with no stage is an ordinary form method, not a
+/// chain. The desugar must not swallow it.
+#[test]
+fn a_bare_method_is_not_a_chain() {
+    let src = format!(
+        "{V}fn main() {{
+            let v = Nums {{ }};
+            v.push(1); v.push(2);
+            println(\"len=\", v.len());
+        }}"
+    );
+    let (out, st) = run("bare", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("len=2"), "got: {:?}", out);
+}

--- a/crates/hale-syntax/src/chains.rs
+++ b/crates/hale-syntax/src/chains.rs
@@ -1,0 +1,326 @@
+//! Recognized element chains (#353 cluster B).
+//!
+//! `xs.filter(it > 2).count()` is not a value being built — it is a
+//! form the compiler recognizes and lowers to ONE loop. That is the
+//! whole point: nothing is produced at any step, so there is no
+//! sequence value, no owner for it, and no arena question. The
+//! knot that made "add closures, then add iterators" look expensive
+//! was self-inflicted by assuming each stage must yield something.
+//!
+//! Consequences of doing it this way, all of which fall out rather
+//! than being engineered:
+//!
+//! - **Zero allocation.** No intermediate exists, so a chain is legal
+//!   inside `@hot` / `@budget(alloc_per_call = 0)` — composition is
+//!   usable in exactly the code Hale is built for. A design that
+//!   returned a new collection would have been illegal there.
+//! - **Effects stay attributed where written.** The chain is eager, so
+//!   a predicate's effects are reached at the predicate's own source
+//!   position. A lazy chain would execute it at the terminal and the
+//!   witness path would name the wrong line.
+//! - **No lambdas.** The predicate is an argument position the
+//!   compiler knows about, not a value, so there is no closure to
+//!   represent — no capture modes, no escape analysis, no `self`
+//!   capture policy, no cross-thread question. `it` is bound per
+//!   element by this desugar.
+//!
+//! Done as a POST-PARSE AST rewrite rather than in codegen, so
+//! typecheck and codegen both see an ordinary `while` loop. No new
+//! machinery in either, and a chain over a non-form receiver fails
+//! with the ordinary "no method `len`" diagnostic.
+//!
+//! v1 surface: `filter` as the elementwise op, `count` and `into` as
+//! terminals. The mechanism is the deliverable; more ops are rows in
+//! the same table.
+
+use crate::ast::*;
+use crate::span::Span;
+
+/// Rewrite every recognized chain in the program.
+pub fn desugar_chains(program: &mut Program) {
+    let mut n = 0usize;
+    for item in &mut program.items {
+        match item {
+            TopDecl::Fn(f) => block(&mut f.body, &mut n),
+            TopDecl::Locus(l) => {
+                for m in &mut l.members {
+                    match m {
+                        LocusMember::Fn(f) => block(&mut f.body, &mut n),
+                        LocusMember::Lifecycle(lc) => block(&mut lc.body, &mut n),
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn block(b: &mut Block, n: &mut usize) {
+    let mut out: Vec<Stmt> = Vec::new();
+    for mut s in std::mem::take(&mut b.stmts) {
+        stmt(&mut s, n);
+        // A chain in STATEMENT position (`xs.filter(..).into(out);`)
+        // lowers to a block-expression with no tail. Splice its
+        // statements into the enclosing block rather than leaving a
+        // bare block expression, which codegen does not accept as a
+        // statement. Loop temporaries are numbered, so two chains in
+        // one block cannot collide.
+        if let Stmt::Expr(Expr::Block(inner)) = &mut s {
+            if inner.tail.is_none() && !inner.stmts.is_empty() {
+                out.append(&mut inner.stmts);
+                continue;
+            }
+        }
+        out.push(s);
+    }
+    b.stmts = out;
+    if let Some(t) = &mut b.tail {
+        expr(t, n);
+    }
+}
+
+fn stmt(s: &mut Stmt, n: &mut usize) {
+    match s {
+        Stmt::Let { value, .. } => expr(value, n),
+        Stmt::Assign { value, .. } => expr(value, n),
+        Stmt::Expr(e) => expr(e, n),
+        Stmt::While { body, .. } => block(body, n),
+        Stmt::For { body, .. } => block(body, n),
+        Stmt::If(i) => if_stmt(i, n),
+        Stmt::Return(Some(e), _) => expr(e, n),
+        _ => {}
+    }
+}
+
+fn if_stmt(i: &mut IfStmt, n: &mut usize) {
+    expr(&mut i.cond, n);
+    block(&mut i.then_block, n);
+    if let Some(e) = &mut i.else_block {
+        match e.as_mut() {
+            ElseBranch::Else(b) => block(b, n),
+            ElseBranch::ElseIf(e) => if_stmt(e, n),
+        }
+    }
+}
+
+/// A chain's shape: the source receiver, the accumulated predicates,
+/// and the terminal.
+struct Chain {
+    src: Expr,
+    preds: Vec<Expr>,
+    terminal: String,
+    term_args: Vec<Expr>,
+}
+
+/// Peel `src.filter(p).filter(q).count()` into its parts. `None` when
+/// this is not a recognized chain — an ordinary method call.
+fn peel(e: &Expr) -> Option<Chain> {
+    let Expr::Call { callee, args, .. } = e else {
+        return None;
+    };
+    let Expr::Field { receiver, name, .. } = callee.as_ref() else {
+        return None;
+    };
+    if !matches!(name.name.as_str(), "count" | "into") {
+        return None;
+    }
+    let terminal = name.name.clone();
+    let term_args = args.clone();
+
+    // Walk down the filter stages.
+    let mut preds = Vec::new();
+    let mut cur = receiver.as_ref();
+    loop {
+        let Expr::Call { callee, args, .. } = cur else { break };
+        let Expr::Field { receiver, name, .. } = callee.as_ref() else {
+            break;
+        };
+        if name.name != "filter" || args.len() != 1 {
+            break;
+        }
+        preds.push(args[0].clone());
+        cur = receiver.as_ref();
+    }
+    // A bare `xs.count()` with no stage is an ordinary method call,
+    // not a chain — leave it alone so existing form methods still
+    // resolve.
+    if preds.is_empty() {
+        return None;
+    }
+    preds.reverse();
+    Some(Chain { src: cur.clone(), preds, terminal, term_args })
+}
+
+fn expr(e: &mut Expr, n: &mut usize) {
+    // Rewrite innermost-first so a chain inside a chain's predicate is
+    // handled before the outer one is consumed.
+    match e {
+        Expr::Call { callee, args, .. } => {
+            expr(callee, n);
+            for a in args {
+                expr(a, n);
+            }
+        }
+        Expr::Field { receiver, .. } => expr(receiver, n),
+        Expr::Binary { left, right, .. } => {
+            expr(left, n);
+            expr(right, n);
+        }
+        Expr::Block(b) => block(b, n),
+        _ => {}
+    }
+    if let Some(c) = peel(e) {
+        *n += 1;
+        *e = lower(c, e.span(), *n);
+    }
+}
+
+// ---- construction helpers -----------------------------------------
+
+fn id(n: &str, sp: Span) -> Ident {
+    Ident { name: n.to_string(), span: sp }
+}
+fn var(n: &str, sp: Span) -> Expr {
+    Expr::Ident(id(n, sp))
+}
+fn int(v: i64, sp: Span) -> Expr {
+    Expr::Literal(Literal::Int(v), sp)
+}
+fn method(recv: Expr, name: &str, args: Vec<Expr>, sp: Span) -> Expr {
+    Expr::Call {
+        callee: Box::new(Expr::Field {
+            receiver: Box::new(recv),
+            name: id(name, sp),
+            span: sp,
+        }),
+        args,
+        span: sp,
+    }
+}
+fn bin(op: BinOp, l: Expr, r: Expr, sp: Span) -> Expr {
+    Expr::Binary {
+        op,
+        left: Box::new(l),
+        right: Box::new(r),
+        span: sp,
+    }
+}
+fn let_mut(n: &str, v: Expr, sp: Span) -> Stmt {
+    Stmt::Let {
+        is_mut: true,
+        name: id(n, sp),
+        ty: None,
+        value: v,
+        span: sp,
+    }
+}
+fn assign(n: &str, v: Expr, sp: Span) -> Stmt {
+    Stmt::Assign {
+        target: LValue { head: id(n, sp), tail: Vec::new(), span: sp },
+        op: AssignOp::Eq,
+        value: v,
+        span: sp,
+    }
+}
+
+/// `src.filter(p)…<terminal>` -> a block containing one loop.
+fn lower(c: Chain, sp: Span, uid: usize) -> Expr {
+    let i_name = format!("__hale_chain_i{}", uid);
+    let acc_name = format!("__hale_chain_n{}", uid);
+    let (i, acc) = (i_name.as_str(), acc_name.as_str());
+
+    // The per-element body, innermost first: the terminal's action,
+    // wrapped in each predicate.
+    let action: Stmt = match c.terminal.as_str() {
+        "count" => assign(
+            acc,
+            bin(BinOp::Add, var(acc, sp), int(1, sp), sp),
+            sp,
+        ),
+        // `into(target)` pushes the element.
+        _ => Stmt::Expr(method(
+            c.term_args
+                .first()
+                .cloned()
+                .unwrap_or_else(|| var("__hale_chain_missing", sp)),
+            "push",
+            vec![var("it", sp)],
+            sp,
+        )),
+    };
+
+    let mut body_stmts = vec![action];
+    for p in c.preds.iter().rev() {
+        body_stmts = vec![Stmt::If(IfStmt {
+            cond: p.clone(),
+            then_block: Block {
+                stmts: body_stmts,
+                tail: None,
+                span: sp,
+            },
+            else_block: None,
+            span: sp,
+        })];
+    }
+
+    // `let it = src.get(i) or { break; };` — the element binding. The
+    // diverging fallback is why #353's diverging-`or` fix had to land
+    // first: there is no typed default to invent for an arbitrary
+    // element type.
+    let bind_it = Stmt::Let {
+        is_mut: false,
+        name: id("it", sp),
+        ty: None,
+        value: Expr::Or {
+            inner: Box::new(method(
+                c.src.clone(),
+                "get",
+                vec![var(i, sp)],
+                sp,
+            )),
+            disposition: OrDisposition::Substitute(Box::new(Expr::Block(
+                Block {
+                    stmts: vec![Stmt::Break(sp)],
+                    tail: None,
+                    span: sp,
+                },
+            ))),
+            span: sp,
+        },
+        span: sp,
+    };
+
+    let mut loop_body = vec![bind_it];
+    loop_body.extend(body_stmts);
+    loop_body.push(assign(
+        i,
+        bin(BinOp::Add, var(i, sp), int(1, sp), sp),
+        sp,
+    ));
+
+    let mut stmts = vec![let_mut(i, int(0, sp), sp)];
+    if c.terminal == "count" {
+        stmts.push(let_mut(acc, int(0, sp), sp));
+    }
+    stmts.push(Stmt::While {
+        cond: bin(
+            BinOp::Lt,
+            var(i, sp),
+            method(c.src.clone(), "len", Vec::new(), sp),
+            sp,
+        ),
+        body: Block { stmts: loop_body, tail: None, span: sp },
+        span: sp,
+    });
+
+    Expr::Block(Block {
+        stmts,
+        tail: if c.terminal == "count" {
+            Some(Box::new(var(acc, sp)))
+        } else {
+            None
+        },
+        span: sp,
+    })
+}

--- a/crates/hale-syntax/src/lib.rs
+++ b/crates/hale-syntax/src/lib.rs
@@ -9,6 +9,7 @@
 //! - [`Diag`] — diagnostic type for errors.
 
 pub mod ast;
+pub mod chains;
 pub mod desugar;
 pub mod error;
 pub mod fmt;

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -19,7 +19,13 @@ pub fn parse(tokens: Vec<Token>, _source: &str) -> Result<Program, Vec<Diag>> {
     let mut p = Parser::new(tokens);
     let prog = p.parse_program();
     match prog {
-        Ok(prog) if p.diags.is_empty() => Ok(prog),
+        Ok(mut prog) if p.diags.is_empty() => {
+            // #353 cluster B: rewrite recognized element chains into
+            // ordinary loops here, so typecheck and codegen both see a
+            // `while` and neither needs to learn about chains.
+            crate::chains::desugar_chains(&mut prog);
+            Ok(prog)
+        }
         Ok(_) => Err(std::mem::take(&mut p.diags)),
         Err(d) => {
             p.diags.push(d);

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -4712,6 +4712,28 @@ fn check_bus_cycles(bundle: &Bundle<'_>, diags: &mut Vec<Diag>) {
 
 /// Flow-control / exit primitives whose presence anywhere in an
 /// unbounded loop body rules out the flood: the loop either paces
+/// #353: does this block ALWAYS leave without producing a value?
+///
+/// A fallback that diverges has no type, so `or { break; }` must not
+/// be asked to match the success type. Conservative: only a block
+/// whose LAST statement unconditionally transfers control counts, so
+/// a conditional `break` still requires a substitute.
+fn block_always_diverges(b: &Block) -> bool {
+    if b.tail.is_some() {
+        return false;
+    }
+    matches!(
+        b.stmts.last(),
+        Some(
+            Stmt::Break(_)
+                | Stmt::Continue(_)
+                | Stmt::Return(..)
+                | Stmt::Fail { .. }
+                | Stmt::Terminate(_)
+        )
+    )
+}
+
 /// itself or can leave.
 fn block_has_flow_control(b: &Block) -> bool {
     b.stmts.iter().any(stmt_has_flow_control)
@@ -11203,8 +11225,20 @@ impl<'a> Checker<'a> {
                         // don't false-positive when the
                         // typechecker can't see through a
                         // stdlib path.
+                        // #353: a DIVERGING fallback yields no value,
+                        // so there is no type to match. `or { break; }`
+                        // / `continue` / `return` / `fail` never reach
+                        // the binding, and demanding a typed substitute
+                        // from them forces callers to invent a default
+                        // that is never used — and for a generic
+                        // element type there is no default to invent.
+                        let rhs_diverges = matches!(
+                            rhs.as_ref(),
+                            Expr::Block(b) if block_always_diverges(b)
+                        );
                         if !interface_satisfied
                             && !value_discarded
+                            && !rhs_diverges
                             && !success.assignable_from(&rhs_ty)
                         {
                             self.diags.push(Diag::ty(

--- a/crates/hale-types/tests/diverging_or.rs
+++ b/crates/hale-types/tests/diverging_or.rs
@@ -1,0 +1,110 @@
+//! A diverging `or` fallback has no type (#353).
+//!
+//! `v.get(i) or { break; }` was rejected with "fallback type `()` does
+//! not match success type `Int`" — but `break` never yields, so there
+//! is no value whose type could match. The rule asked callers to
+//! invent a substitute that is provably never used.
+//!
+//! That is a papercut on its own, and a blocker for the recognized-
+//! chain lowering: a desugar over a form cannot invent a typed default
+//! for an arbitrary element type, so `or { continue; }` is the only
+//! shape available to it.
+//!
+//! Deliberately conservative: only a block whose LAST statement
+//! unconditionally transfers control counts. A conditional `break`
+//! still requires a substitute, because the block CAN fall through and
+//! then genuinely does need a value.
+
+use hale_syntax::parse_source;
+
+fn errs(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+const V: &str = "@form(vec)\nlocus Nums { capacity { heap items of Int; } }\n";
+
+#[test]
+fn an_unconditionally_diverging_fallback_needs_no_substitute() {
+    for kw in ["break", "continue"] {
+        let ds = errs(&format!(
+            "{V}fn main() {{\n\
+                 let v = Nums {{ }};\n\
+                 v.push(1);\n\
+                 let mut i = 0;\n\
+                 while i < v.len() {{\n\
+                     let it = v.get(i) or {{ {kw}; }};\n\
+                     println(it);\n\
+                     i = i + 1;\n\
+                 }}\n\
+             }}"
+        ));
+        assert!(
+            !ds.iter().any(|m| m.contains("fallback type")),
+            "`or {{ {}; }}` yields no value, so there is no type to \
+             match: {:?}",
+            kw,
+            ds
+        );
+    }
+}
+
+#[test]
+fn a_return_fallback_needs_no_substitute() {
+    let ds = errs(&format!(
+        "{V}fn first(v: Nums) -> Int {{\n\
+             let it = v.get(0) or {{ return 0; }};\n\
+             return it;\n\
+         }}\n\
+         fn main() {{ let v = Nums {{ }}; v.push(3); println(first(v)); }}"
+    ));
+    assert!(
+        !ds.iter().any(|m| m.contains("fallback type")),
+        "`or {{ return …; }}` diverges: {:?}",
+        ds
+    );
+}
+
+/// The boundary. A block that CAN fall through still needs a value —
+/// otherwise the binding would be uninitialised on the falling-through
+/// path, which is the thing the original rule was protecting.
+#[test]
+fn a_conditional_divergence_still_requires_a_substitute() {
+    let ds = errs(&format!(
+        "{V}fn main() {{\n\
+             let v = Nums {{ }};\n\
+             v.push(1);\n\
+             let mut i = 0;\n\
+             while i < v.len() {{\n\
+                 let it = v.get(i) or {{ if i > 5 {{ break; }} }};\n\
+                 println(it);\n\
+                 i = i + 1;\n\
+             }}\n\
+         }}"
+    ));
+    assert!(
+        ds.iter().any(|m| m.contains("fallback type")),
+        "a conditional break can fall through and then needs a value: \
+         {:?}",
+        ds
+    );
+}
+
+/// An ordinary typed substitute must keep working unchanged.
+#[test]
+fn a_valued_substitute_still_works() {
+    let ds = errs(&format!(
+        "{V}fn main() {{\n\
+             let v = Nums {{ }};\n\
+             println(v.get(0) or 0);\n\
+         }}"
+    ));
+    assert!(
+        !ds.iter().any(|m| m.contains("fallback type")),
+        "`or 0` is the ordinary form and must be unaffected: {:?}",
+        ds
+    );
+}


### PR DESCRIPTION
Cluster B, answered and built. Items 1 and 6 of #353, rescoped.

## The knot was self-inflicted

I had assumed a chain must **produce something at each stage** — a lazy iterator object, or an eager intermediate collection. Either is a sequence value, which needs an owner, which reopens arenas and placement. That is what made "add closures, then add iterators" look like a language-sized project.

If the chain is **a form the compiler recognizes rather than a value being built**, nothing is produced at any step and the question never arises:

```hale
v.filter(it > 2).filter(it < 9).count()
```

rewrites to one loop. No intermediate, no lazy object, no sequence value anywhere.

## Three consequences, none of them engineered

**Zero allocation** — so a chain is legal inside `@budget(alloc_per_call = 0)`. This is the load-bearing one: a design that returned a new collection would have been illegal in exactly the code Hale exists for, making the compositional stdlib usable only in cold paths. There is a test that fails if this ever regresses.

**Eager** — so a predicate's effects are attributed to the predicate's own source position. A lazy chain would execute it at the terminal and the witness path would name the wrong line, which is corrosive for a language whose diagnostics *are* witness paths.

**No lambdas** — the predicate is an argument position the compiler knows about, not a value. So there is no closure to represent: no capture modes, no escape analysis, no `self`-capture policy, no cross-thread question. The entire "closures must be Hale-native" discussion evaporates because there is no closure. `it` is bound per element by the desugar.

## Implementation

A **post-parse AST rewrite**, not a codegen feature. Typecheck and codegen both see an ordinary `while` loop and neither learns about chains — which also means a chain over a non-form receiver fails with the ordinary "no method `len`" diagnostic rather than a bespoke one, and a bare `.count()` with no stage stays an ordinary form method.

Loop temporaries are numbered per chain so two chains in one block cannot collide (tested). The element binding uses `or { break; }`, which is why #363 had to land first — a desugar cannot invent a typed default for an arbitrary element type.

## Surface

`filter` as the elementwise op; `count` and `into` as terminals. The mechanism is the deliverable; more ops are rows in the same table.

The boundary that falls out and should be enforced as it grows: **elementwise ops fuse; whole-set ops (`sort`, `reverse`, `group`) cannot**, so they are terminals that materialise into caller storage. Over a stream source they are rejected outright — "needs an end" is a property the compiler can decide.

Worth noting `split_into` (#360) and `join` (#361) are already terminals under this design — write-into-caller-storage and value-returning respectively. Consistent retroactively.

## Tests

2059/2059, zero warnings, fmt clean. Six new, including the zero-alloc budget claim, two-stage fusion, and the two negative controls (chains coexisting, bare method not swallowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
