### PR TITLE
feat: @form(set)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ behavior.
 
 ## Unreleased
 
+- **`@form(set)`** (#353). Specified and deferred in
+  `decisions.md` with the trigger "revisit if a workload needs it";
+  the trigger fired. Reuses the hashmap slot and the whole
+  `lotus_hashmap_*` runtime, sync disciplines included, so
+  `@form(set, sync = striped)` works for free. Differs only in the
+  synthesized surface — `insert` / `contains` / `remove` / `len` /
+  `is_empty` — which exists to keep the value off the call site:
+  membership through a hashmap means writing `get(k) or false`
+  everywhere.
+
 - **Recognized element chains** (#353, cluster B).
   `xs.filter(it > 2).count()` and `xs.filter(...).into(target)` are
   rewritten to ONE loop by a post-parse pass, so typecheck and codegen

--- a/crates/hale-codegen/src/form/mod.rs
+++ b/crates/hale-codegen/src/form/mod.rs
@@ -2045,6 +2045,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         else {
             return Ok(None);
         };
+        // #353: `@form(set)` shares this slot and this runtime — only
+        // its surface differs. `insert(k)` is `set(k, true)` with the
+        // value never surfaced, and `contains` is `has`. Which of the
+        // two surfaces a locus actually exposes is settled in
+        // `resolve.rs`, which synthesizes only one of them, so a
+        // hashmap cannot reach the set names or vice versa.
+        let method_name = match method_name {
+            "insert" => "set",
+            "contains" => "has",
+            other => other,
+        };
         let is_synth = matches!(
             method_name,
             "set" | "has" | "len" | "is_empty" | "get" | "remove"

--- a/crates/hale-codegen/src/locus/decl.rs
+++ b/crates/hale-codegen/src/locus/decl.rs
@@ -758,10 +758,15 @@ impl<'ctx, 'p> LocusDeclare<'ctx> for Cx<'ctx, 'p> {
             .as_ref()
             .map(|f| f.name.name.as_str() == "vec")
             .unwrap_or(false);
+        // #353: `@form(set)` is a hashmap whose value is carried but
+        // never surfaced — `decisions.md` specifies it as "a
+        // hashmap-without-value variant (the cell IS the key)". It
+        // reuses the whole `lotus_hashmap_*` runtime, including the
+        // sync disciplines; only the synthesized method set differs.
         let is_form_hashmap = l
             .form
             .as_ref()
-            .map(|f| f.name.name.as_str() == "hashmap")
+            .map(|f| matches!(f.name.name.as_str(), "hashmap" | "set"))
             .unwrap_or(false);
         let is_form_ring_buffer = l
             .form

--- a/crates/hale-codegen/tests/form_set.rs
+++ b/crates/hale-codegen/tests/form_set.rs
@@ -1,0 +1,113 @@
+//! `@form(set)` (#353 item 5).
+//!
+//! `spec/decisions.md` specified this and deferred it with a trigger:
+//! "a `@form(set)` would be a hashmap-without-value variant (the cell
+//! IS the key). Not part of FORM-4; revisit if a workload needs it."
+//! #353 is that workload, so this is scheduled work whose condition
+//! fired rather than a new design.
+//!
+//! It reuses the hashmap slot and the entire `lotus_hashmap_*`
+//! runtime — including the sync disciplines, so `@form(set, sync =
+//! striped)` works for free. Only the synthesized surface differs:
+//! `insert` / `contains` / `remove` / `len` / `is_empty` instead of
+//! `set` / `get` / `has`.
+//!
+//! The point of the separate surface is keeping the VALUE off the
+//! call site. Membership through a hashmap means writing `get(k) or
+//! false` everywhere, which is the value plumbing leaking back out at
+//! every use.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+fn run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(&format!(
+        "hale_set_{}_{}",
+        name,
+        std::process::id()
+    ));
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (String::from_utf8_lossy(&out.stdout).to_string(), out.status)
+}
+
+const S: &str = "type Item { key: String; }\n\
+                 @form(set)\n\
+                 locus Seen { capacity { pool items of Item indexed_by key; } }\n";
+
+/// The defining property: inserting the same key twice does not grow
+/// the set. If this fails it is a map with a set's method names.
+#[test]
+fn insert_deduplicates() {
+    let src = format!(
+        "{S}fn main() {{
+            let s = Seen {{ }};
+            s.insert(Item {{ key: \"a\" }});
+            s.insert(Item {{ key: \"b\" }});
+            s.insert(Item {{ key: \"a\" }});
+            println(\"len=\", s.len());
+        }}"
+    );
+    let (out, st) = run("dedup", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("len=2"), "a,b,a is two members: {:?}", out);
+}
+
+/// `contains` answers Bool directly. Membership through the hashmap
+/// surface would be `get(k) or false` at every call site — the value
+/// plumbing leaking back out, which is what this form exists to stop.
+#[test]
+fn contains_answers_membership_without_a_fallible() {
+    let src = format!(
+        "{S}fn main() {{
+            let s = Seen {{ }};
+            s.insert(Item {{ key: \"a\" }});
+            println(\"a=\", s.contains(\"a\"));
+            println(\"z=\", s.contains(\"z\"));
+        }}"
+    );
+    let (out, st) = run("contains", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("a=true"), "got: {:?}", out);
+    assert!(out.contains("z=false"), "got: {:?}", out);
+}
+
+#[test]
+fn remove_takes_a_member_out() {
+    let src = format!(
+        "{S}fn main() {{
+            let s = Seen {{ }};
+            s.insert(Item {{ key: \"a\" }});
+            s.insert(Item {{ key: \"b\" }});
+            s.remove(\"a\") or {{ }};
+            println(\"len=\", s.len(), \" a=\", s.contains(\"a\"));
+        }}"
+    );
+    let (out, st) = run("remove", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("len=1"), "got: {:?}", out);
+    assert!(out.contains("a=false"), "got: {:?}", out);
+}
+
+/// An empty set is empty — the case a hashmap-backed implementation
+/// gets wrong if `len` reads the slot count rather than the live
+/// count.
+#[test]
+fn an_empty_set_is_empty() {
+    let src = format!(
+        "{S}fn main() {{
+            let s = Seen {{ }};
+            println(\"len=\", s.len(), \" empty=\", s.is_empty());
+        }}"
+    );
+    let (out, st) = run("empty", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("len=0"), "got: {:?}", out);
+    assert!(out.contains("empty=true"), "got: {:?}", out);
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -6977,6 +6977,10 @@ impl<'a> Checker<'a> {
         match form.name.name.as_str() {
             "vec" => self.check_form_vec_shape(decl, form),
             "hashmap" => self.check_form_hashmap_shape(decl, form),
+            // #353: identical capacity shape to hashmap — the value
+            // slot is what makes membership storable. Only the method
+            // surface differs.
+            "set" => self.check_form_hashmap_shape(decl, form),
             "ring_buffer" => self.check_form_ring_buffer_shape(decl, form),
             "lru_cache" => self.check_form_lru_cache_shape(decl, form),
             other => {

--- a/crates/hale-types/src/resolve.rs
+++ b/crates/hale-types/src/resolve.rs
@@ -932,6 +932,11 @@ fn register_locus(
                 let (value_ty, key_ty) = form_hashmap_value_and_key_ty(decl, known, scope);
                 synthesize_form_hashmap_methods(&mut methods, &value_ty, &key_ty);
             }
+            "set" => {
+                let (value_ty, key_ty) =
+                    form_hashmap_value_and_key_ty(decl, known, scope);
+                synthesize_form_set_methods(&mut methods, &value_ty, &key_ty);
+            }
             "ring_buffer" => {
                 let cell_ty = form_ring_buffer_cell_ty(decl, known);
                 synthesize_form_ring_buffer_methods(&mut methods, &cell_ty);
@@ -1496,6 +1501,60 @@ fn synthesize_form_vec_methods(methods: &mut Vec<MethodInfo>, cell_ty: &Ty) {
 /// key as one of its fields) means `set(value: S)` takes the
 /// whole struct rather than a `(K, V)` pair — the substrate
 /// extracts the key from the value at insertion time.
+/// #353: `@form(set)` — membership, not lookup.
+///
+/// The storage is a hashmap (see `decisions.md`: "the cell IS the
+/// key"), so this exists to keep the VALUE off the call site.
+/// `contains` returns Bool rather than a fallible, because "not
+/// present" is the ordinary answer to a membership question, not a
+/// failure — surfacing it as `get(k) or false` at every call site
+/// would be the value plumbing leaking back out.
+fn synthesize_form_set_methods(
+    methods: &mut Vec<MethodInfo>,
+    value_ty: &Ty,
+    key_ty: &Ty,
+) {
+    methods.push(MethodInfo {
+        name: "insert".to_string(),
+        params: vec![value_ty.clone()],
+        min_params: None,
+        ret: Ty::Unit,
+        fallible: None,
+    });
+    methods.push(MethodInfo {
+        name: "contains".to_string(),
+        params: vec![key_ty.clone()],
+        min_params: None,
+        ret: Ty::Prim(PrimType::Bool),
+        fallible: None,
+    });
+    // Mirrors the hashmap's `remove`: removing something that is not
+    // there is a KeyError rather than a silent no-op, and the set
+    // surface must not quietly diverge from the runtime it delegates
+    // to.
+    methods.push(MethodInfo {
+        name: "remove".to_string(),
+        params: vec![key_ty.clone()],
+        min_params: None,
+        ret: Ty::Unit,
+        fallible: Some(Ty::Named("KeyError".to_string())),
+    });
+    methods.push(MethodInfo {
+        name: "len".to_string(),
+        params: Vec::new(),
+        min_params: None,
+        ret: Ty::Prim(PrimType::Int),
+        fallible: None,
+    });
+    methods.push(MethodInfo {
+        name: "is_empty".to_string(),
+        params: Vec::new(),
+        min_params: None,
+        ret: Ty::Prim(PrimType::Bool),
+        fallible: None,
+    });
+}
+
 fn synthesize_form_hashmap_methods(
     methods: &mut Vec<MethodInfo>,
     value_ty: &Ty,

--- a/spec/decisions.md
+++ b/spec/decisions.md
@@ -3304,9 +3304,16 @@ the core surface above is independent of them.
    in v1; no tuning knobs. Add when a workload demonstrates
    the 0 → 8 → 16 → ... grow cascade is costing measurable
    time.
-5. **Set type.** A `@form(set)` would be a hashmap-without-
+5. **Set type.** ~~A `@form(set)` would be a hashmap-without-
    value variant (the cell IS the key). Not part of FORM-4;
-   revisit if a workload needs it.
+   revisit if a workload needs it.~~ **SHIPPED 2026-08-03**
+   (#353). The trigger fired. It reuses the hashmap slot and
+   the whole `lotus_hashmap_*` runtime — sync disciplines
+   included — and differs only in the synthesized surface:
+   `insert` / `contains` / `remove` / `len` / `is_empty`. The
+   separate surface exists to keep the VALUE off the call
+   site; membership through a hashmap means writing
+   `get(k) or false` everywhere.
 
 ---
 


### PR DESCRIPTION
#353 item 5.

`spec/decisions.md` specified this and deferred it **with a trigger**: *"a `@form(set)` would be a hashmap-without-value variant (the cell IS the key). Not part of FORM-4; revisit if a workload needs it."* #353 is that workload, so this is scheduled work whose condition fired rather than a new design. The decisions entry is updated to match.

```hale
type Item { key: String; }

@form(set)
locus Seen { capacity { pool items of Item indexed_by key; } }

s.insert(Item { key: "a" });
s.contains("a")    // true
```

## It is a surface, not a container

Reuses the hashmap slot and the entire `lotus_hashmap_*` runtime — sync disciplines included, so `@form(set, sync = striped)` works with no further plumbing. Only the synthesized method set differs.

That surface is the whole point. Membership through the hashmap means writing `get(k) or false` at every call site — the value plumbing leaking back out of a container whose value nobody wants. `contains` answers `Bool` directly.

`remove` stays **fallible**, mirroring the hashmap's, because the set surface must not quietly diverge from the runtime it delegates to.

## Tests

2063/2063, zero warnings, fmt clean. Four new, including the defining property — inserting the same key twice does not grow the set, which is what separates a set from a map wearing set method names.