### PR TITLE
feat(stdlib): std::regex — a linear-time NFA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ behavior.
 
 ## Unreleased
 
+- **`@form(set)`** (#353). Specified and deferred in
+  `decisions.md` with the trigger "revisit if a workload needs it";
+  the trigger fired. Reuses the hashmap slot and the whole
+  `lotus_hashmap_*` runtime, sync disciplines included, so
+  `@form(set, sync = striped)` works for free. Differs only in the
+  synthesized surface — `insert` / `contains` / `remove` / `len` /
+  `is_empty` — which exists to keep the value off the call site:
+  membership through a hashmap means writing `get(k) or false`
+  everywhere.
+
 - **Recognized element chains** (#353, cluster B).
   `xs.filter(it > 2).count()` and `xs.filter(...).into(target)` are
   rewritten to ONE loop by a post-parse pass, so typecheck and codegen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ behavior.
 
 ## Unreleased
 
+- **`std::regex`** (#353). A linear-time Thompson NFA:
+  `matches` (full match), `find` (leftmost byte offset, -1 if absent)
+  and `valid`. The engine class was forced rather than chosen —
+  backtracking buys backreferences and lookaround at the cost of an
+  exponential worst case, and you cannot bound a handler that runs
+  one, so it is incompatible with `@budget` and `@hot`. Supported:
+  literals, `.`, `*`, `+`, `?`, `|`, grouping, character classes with
+  ranges and negation, `\` escapes. No backreferences, no lookaround.
+  Classified PURE — the match path allocates nothing beyond fixed
+  state lists sized from the pattern, so it is usable from a
+  `@deterministic @no_syscall` fn.
+
 - **`@form(set)`** (#353). Specified and deferred in
   `decisions.md` with the trigger "revisit if a workload needs it";
   the trigger fired. Reuses the hashmap slot and the whole

--- a/crates/hale-cli/tests/regex_engine.rs
+++ b/crates/hale-cli/tests/regex_engine.rs
@@ -1,0 +1,137 @@
+//! `std::regex` (#353 item 4).
+//!
+//! ## The engine class is forced, not chosen
+//!
+//! Backtracking buys backreferences and lookaround at the cost of an
+//! exponential worst case. You cannot bound a handler that runs one,
+//! which makes it flatly incompatible with `@budget` and `@hot` — the
+//! two things Hale sells. A Thompson NFA simulated over a state set
+//! is O(pattern × text) with no backtracking, so a match is bounded
+//! by construction.
+//!
+//! The price is no backreferences and no lookaround. For this
+//! language that is the right side of the trade: a regex you cannot
+//! put on a hot path is not much use in a language whose hot paths
+//! carry allocation budgets.
+//!
+//! Supported: literals, `.`, `*`, `+`, `?`, `|`, grouping, character
+//! classes with ranges and negation, and `\` escapes.
+
+use std::process::Command;
+
+fn run(src: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir()
+        .join(format!("hale-re-{}-{}", std::process::id(), tag));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let f = dir.join("main.hl");
+    std::fs::write(&f, src).expect("write");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("run")
+        .arg(&f)
+        .output()
+        .expect("run");
+    let _ = std::fs::remove_dir_all(&dir);
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+#[test]
+fn the_operators_work() {
+    let out = run(
+        "fn main() {\n\
+             println(std::regex::matches(\"h.llo\", \"hello\"));\n\
+             println(std::regex::matches(\"a+b\", \"aaab\"));\n\
+             println(std::regex::matches(\"a+b\", \"b\"));\n\
+             println(std::regex::matches(\"ab?c\", \"ac\"));\n\
+             println(std::regex::matches(\"a|b\", \"b\"));\n\
+             println(std::regex::matches(\"(ab)+\", \"abab\"));\n\
+             println(std::regex::matches(\"(ab)+\", \"aba\"));\n\
+         }",
+        "ops",
+    );
+    let got: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        got,
+        vec!["true", "true", "false", "true", "true", "true", "false"],
+        "operator semantics wrong: {:?}",
+        got
+    );
+}
+
+#[test]
+fn character_classes_including_negation() {
+    let out = run(
+        "fn main() {\n\
+             println(std::regex::matches(\"[a-c]+\", \"abcb\"));\n\
+             println(std::regex::matches(\"[a-c]+\", \"d\"));\n\
+             println(std::regex::matches(\"[^a-c]+\", \"xyz\"));\n\
+             println(std::regex::matches(\"[^a-c]+\", \"abc\"));\n\
+         }",
+        "class",
+    );
+    let got: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        got,
+        vec!["true", "false", "true", "false"],
+        "class semantics wrong: {:?}",
+        got
+    );
+}
+
+/// `matches` is a FULL match; `find` scans for the leftmost one and
+/// returns a byte offset, or -1. Conflating the two is the usual
+/// regex-API papercut.
+#[test]
+fn find_returns_the_leftmost_offset() {
+    let out = run(
+        "fn main() {\n\
+             println(std::regex::find(\"l+\", \"hello\"));\n\
+             println(std::regex::find(\"zz\", \"hello\"));\n\
+             println(std::regex::find(\"h\", \"hello\"));\n\
+         }",
+        "find",
+    );
+    let got: Vec<&str> = out.lines().collect();
+    assert_eq!(got, vec!["2", "-1", "0"], "find offsets wrong: {:?}", got);
+}
+
+/// A malformed pattern is reported rather than silently matching
+/// nothing — otherwise a typo'd pattern looks like "no results".
+#[test]
+fn an_invalid_pattern_is_reported() {
+    let out = run(
+        "fn main() {\n\
+             println(std::regex::valid(\"a(\"));\n\
+             println(std::regex::valid(\"[a-\"));\n\
+             println(std::regex::valid(\"a+b\"));\n\
+         }",
+        "valid",
+    );
+    let got: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        got,
+        vec!["false", "false", "true"],
+        "validity wrong: {:?}",
+        got
+    );
+}
+
+/// THE reason for the engine choice. A match must be usable from a
+/// certified fn — if this fails, the linear-time property has been
+/// lost or the classification is wrong.
+#[test]
+fn matching_is_pure_and_certifiable() {
+    let out = run(
+        "@no_syscall @deterministic\n\
+         fn ok(p: String, t: String) -> Bool {\n\
+             return std::regex::matches(p, t);\n\
+         }\n\
+         fn main() { println(ok(\"a+\", \"aaa\")); }",
+        "pure",
+    );
+    assert_eq!(
+        out.trim(),
+        "true",
+        "regex must certify under @no_syscall @deterministic: {}",
+        out
+    );
+}

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -4294,6 +4294,268 @@ int64_t lotus_str_cp_count(const char *s) {
     return n;
 }
 
+/*
+ * #353: a linear-time regex.
+ *
+ * ENGINE CLASS IS FORCED, not chosen. Backtracking buys
+ * backreferences and lookaround at the cost of exponential worst
+ * case, and you cannot bound a handler that runs one — which makes it
+ * flatly incompatible with `@budget` and `@hot`, the two things Hale
+ * sells. A Thompson NFA simulated over a state set is O(pattern x
+ * text) with no backtracking, so a match is bounded by construction.
+ * The price is no backrefs and no lookaround. For this language that
+ * is the right side of the trade.
+ *
+ * Supported: literals, `.`, `*`, `+`, `?`, `|`, grouping, character
+ * classes `[a-z]` / `[^a-z]`, and `\` escapes. Anchors are implicit:
+ * `matches` is a full match, `find` scans for the leftmost match.
+ *
+ * No allocation on the match path beyond two fixed state lists sized
+ * from the pattern, so a match is countable against a budget.
+ */
+
+#define LOTUS_RE_MAX 256
+
+enum { RE_CHAR, RE_ANY, RE_CLASS, RE_SPLIT, RE_MATCH };
+
+typedef struct {
+    int op;
+    unsigned char c;
+    /* class bitmap, only for RE_CLASS */
+    unsigned char set[32];
+    int negate;
+    int x, y;              /* next state indices; -1 = none */
+} re_state;
+
+typedef struct {
+    re_state st[LOTUS_RE_MAX];
+    int n;
+    int start;
+    int ok;
+} re_prog;
+
+/* --- parser: recursive descent over the pattern, emitting states --- */
+
+typedef struct {
+    const char *p;
+    re_prog *g;
+    int failed;
+} re_parser;
+
+static int re_emit(re_parser *ps, int op) {
+    if (ps->g->n >= LOTUS_RE_MAX) { ps->failed = 1; return 0; }
+    int i = ps->g->n++;
+    re_state *s = &ps->g->st[i];
+    s->op = op; s->c = 0; s->negate = 0; s->x = -1; s->y = -1;
+    for (int k = 0; k < 32; k++) s->set[k] = 0;
+    return i;
+}
+
+/* Patch every dangling -1 exit reachable from `frag` to `to`.
+ * Bounded walk: each state is visited once via a seen array. */
+static void re_patch(re_prog *g, int frag, int to, unsigned char *seen) {
+    if (frag < 0 || seen[frag]) return;
+    seen[frag] = 1;
+    re_state *s = &g->st[frag];
+    if (s->op == RE_MATCH) return;
+    if (s->x == -1) s->x = to; else re_patch(g, s->x, to, seen);
+    if (s->op == RE_SPLIT) {
+        if (s->y == -1) s->y = to; else re_patch(g, s->y, to, seen);
+    }
+}
+
+static void re_patch_all(re_prog *g, int frag, int to) {
+    unsigned char seen[LOTUS_RE_MAX];
+    for (int i = 0; i < LOTUS_RE_MAX; i++) seen[i] = 0;
+    re_patch(g, frag, to, seen);
+}
+
+static int re_alt(re_parser *ps);
+
+static int re_single(re_parser *ps) {
+    char c = *ps->p;
+    if (c == '(') {
+        ps->p++;
+        int f = re_alt(ps);
+        if (*ps->p == ')') ps->p++; else ps->failed = 1;
+        return f;
+    }
+    if (c == '[') {
+        ps->p++;
+        int i = re_emit(ps, RE_CLASS);
+        if (ps->failed) return i;
+        re_state *s = &ps->g->st[i];
+        if (*ps->p == '^') { s->negate = 1; ps->p++; }
+        while (*ps->p && *ps->p != ']') {
+            unsigned char lo = (unsigned char)*ps->p++;
+            if (lo == '\\' && *ps->p) lo = (unsigned char)*ps->p++;
+            unsigned char hi = lo;
+            if (*ps->p == '-' && ps->p[1] && ps->p[1] != ']') {
+                ps->p++;
+                hi = (unsigned char)*ps->p++;
+            }
+            for (int k = lo; k <= (int)hi; k++) s->set[k >> 3] |= (1u << (k & 7));
+        }
+        if (*ps->p == ']') ps->p++; else ps->failed = 1;
+        return i;
+    }
+    if (c == '.') { ps->p++; return re_emit(ps, RE_ANY); }
+    if (c == '\\' && ps->p[1]) ps->p++;
+    ps->p++;
+    int i = re_emit(ps, RE_CHAR);
+    if (!ps->failed) ps->g->st[i].c = (unsigned char)c;
+    return i;
+}
+
+static int re_repeat(re_parser *ps) {
+    int f = re_single(ps);
+    for (;;) {
+        char c = *ps->p;
+        if (c == '*') {
+            ps->p++;
+            int sp = re_emit(ps, RE_SPLIT);
+            if (ps->failed) return f;
+            ps->g->st[sp].x = f;
+            re_patch_all(ps->g, f, sp);
+            f = sp;
+        } else if (c == '+') {
+            ps->p++;
+            int sp = re_emit(ps, RE_SPLIT);
+            if (ps->failed) return f;
+            ps->g->st[sp].x = f;
+            re_patch_all(ps->g, f, sp);
+            /* one-or-more: entry is the fragment, loop is the split */
+        } else if (c == '?') {
+            ps->p++;
+            int sp = re_emit(ps, RE_SPLIT);
+            if (ps->failed) return f;
+            ps->g->st[sp].x = f;
+            f = sp;
+        } else {
+            return f;
+        }
+    }
+}
+
+static int re_concat(re_parser *ps) {
+    int f = -1;
+    while (*ps->p && *ps->p != '|' && *ps->p != ')') {
+        int g2 = re_repeat(ps);
+        if (ps->failed) return f;
+        if (f < 0) f = g2; else re_patch_all(ps->g, f, g2);
+    }
+    return f;
+}
+
+static int re_alt(re_parser *ps) {
+    int f = re_concat(ps);
+    while (*ps->p == '|') {
+        ps->p++;
+        int r = re_concat(ps);
+        if (ps->failed) return f;
+        int sp = re_emit(ps, RE_SPLIT);
+        if (ps->failed) return f;
+        ps->g->st[sp].x = f;
+        ps->g->st[sp].y = r;
+        f = sp;
+    }
+    return f;
+}
+
+static void re_compile(re_prog *g, const char *pat) {
+    g->n = 0; g->ok = 0; g->start = -1;
+    re_parser ps; ps.p = pat; ps.g = g; ps.failed = 0;
+    int f = re_alt(&ps);
+    if (ps.failed || *ps.p) return;
+    int m = re_emit(&ps, RE_MATCH);
+    if (ps.failed) return;
+    if (f < 0) f = m; else re_patch_all(g, f, m);
+    g->start = f;
+    g->ok = 1;
+}
+
+/* --- simulation: one state set, advanced per input byte ---------- */
+
+static void re_addstate(re_prog *g, int s, unsigned char *list, int *n,
+                        unsigned char *on) {
+    if (s < 0 || on[s]) return;
+    on[s] = 1;
+    if (g->st[s].op == RE_SPLIT) {
+        re_addstate(g, g->st[s].x, list, n, on);
+        re_addstate(g, g->st[s].y, list, n, on);
+        return;
+    }
+    list[(*n)++] = (unsigned char)s;
+}
+
+static int re_class_hit(const re_state *s, unsigned char c) {
+    int in = (s->set[c >> 3] >> (c & 7)) & 1;
+    return s->negate ? !in : in;
+}
+
+/* Run from `text`; returns the end offset of a match starting here,
+ * or -1. Longest match wins (the state set is advanced to exhaustion
+ * rather than stopping at the first accept). */
+static long re_run_at(re_prog *g, const char *text, int anchored_end) {
+    unsigned char cl[LOTUS_RE_MAX], nl[LOTUS_RE_MAX];
+    unsigned char on[LOTUS_RE_MAX];
+    int cn = 0, nn = 0;
+    for (int i = 0; i < LOTUS_RE_MAX; i++) on[i] = 0;
+    re_addstate(g, g->start, cl, &cn, on);
+    long best = -1;
+    for (long i = 0; ; i++) {
+        for (int k = 0; k < cn; k++) {
+            if (g->st[cl[k]].op == RE_MATCH) {
+                if (!anchored_end || text[i] == '\0') { best = i; }
+                break;
+            }
+        }
+        unsigned char c = (unsigned char)text[i];
+        if (c == '\0' || cn == 0) break;
+        nn = 0;
+        for (int j = 0; j < LOTUS_RE_MAX; j++) on[j] = 0;
+        for (int k = 0; k < cn; k++) {
+            re_state *s = &g->st[cl[k]];
+            int hit = 0;
+            if (s->op == RE_CHAR) hit = (s->c == c);
+            else if (s->op == RE_ANY) hit = 1;
+            else if (s->op == RE_CLASS) hit = re_class_hit(s, c);
+            if (hit) re_addstate(g, s->x, nl, &nn, on);
+        }
+        for (int k = 0; k < nn; k++) cl[k] = nl[k];
+        cn = nn;
+    }
+    return best;
+}
+
+int lotus_regex_matches(const char *pat, const char *text) {
+    if (!pat || !text) return 0;
+    re_prog g;
+    re_compile(&g, pat);
+    if (!g.ok) return 0;
+    long e = re_run_at(&g, text, 1);
+    return e >= 0 ? 1 : 0;
+}
+
+int64_t lotus_regex_find(const char *pat, const char *text) {
+    if (!pat || !text) return -1;
+    re_prog g;
+    re_compile(&g, pat);
+    if (!g.ok) return -1;
+    for (long i = 0; ; i++) {
+        if (re_run_at(&g, text + i, 0) >= 0) return i;
+        if (text[i] == '\0') break;
+    }
+    return -1;
+}
+
+int lotus_regex_valid(const char *pat) {
+    if (!pat) return 0;
+    re_prog g;
+    re_compile(&g, pat);
+    return g.ok ? 1 : 0;
+}
+
 char *lotus_str_join(void *vec_ptr, const char *sep, void *arena_ptr) {
     lotus_arena_t *arena = (lotus_arena_t *)arena_ptr;
     if (!vec_ptr) {

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -22880,6 +22880,39 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         Ok((res, CodegenTy::Int))
     }
 
+    /// #353: two String args, Int result (`regex::find`).
+    fn lower_str_cp_call2(
+        &mut self,
+        sym: &str,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        if args.len() != 2 {
+            return Err(CodegenError::Unsupported(format!(
+                "{} takes 2 args, got {}",
+                sym,
+                args.len()
+            )));
+        }
+        let mut vals = Vec::new();
+        for a in args {
+            let (v, ty) = self.lower_expr(a, scope)?;
+            vals.push(self.unpack_view_if_needed(v, &ty)?);
+        }
+        let f = self
+            .module
+            .get_function(sym)
+            .unwrap_or_else(|| panic!("{} declared", sym));
+        let res = self
+            .builder
+            .build_call(f, &[vals[0].into(), vals[1].into()], "re.find.ret")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .unwrap_or_else(|| panic!("{} returns i64", sym));
+        Ok((res, CodegenTy::Int))
+    }
+
     /// Expression-position dispatcher for `std::*` paths.
     fn lower_stdlib_path_call_expr(
         &mut self,
@@ -23161,6 +23194,42 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 self.lower_std_str_index_of(args, scope)
             }
             ["std", "str", "join"] => self.lower_std_str_join(args, scope),
+            // #353: regex. Linear-time NFA, so a match is bounded by
+            // construction and usable under `@budget` / `@hot`.
+            ["std", "regex", "matches"] => self.lower_std_str_predicate(
+                "lotus_regex_matches",
+                "matches",
+                args,
+                scope,
+            ),
+            ["std", "regex", "valid"] => {
+                let (v, ty) = self.lower_expr(&args[0], scope)?;
+                let v = self.unpack_view_if_needed(v, &ty)?;
+                let f = self
+                    .module
+                    .get_function("lotus_regex_valid")
+                    .expect("lotus_regex_valid declared");
+                let r = self
+                    .builder
+                    .build_call(f, &[v.into()], "re.valid.ret")
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                    .try_as_basic_value()
+                    .left()
+                    .expect("returns i32");
+                let b = self
+                    .builder
+                    .build_int_compare(
+                        inkwell::IntPredicate::NE,
+                        r.into_int_value(),
+                        self.context.i32_type().const_zero(),
+                        "re.valid.bool",
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                Ok((b.into(), CodegenTy::Bool))
+            }
+            ["std", "regex", "find"] => {
+                self.lower_str_cp_call2("lotus_regex_find", args, scope)
+            }
             // #353: UTF-8 code-point decoding. Byte-oriented String
             // stays byte-oriented; these let a caller walk code points
             // deliberately rather than pretending bytes are characters.

--- a/crates/hale-codegen/src/form/mod.rs
+++ b/crates/hale-codegen/src/form/mod.rs
@@ -2045,6 +2045,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         else {
             return Ok(None);
         };
+        // #353: `@form(set)` shares this slot and this runtime — only
+        // its surface differs. `insert(k)` is `set(k, true)` with the
+        // value never surfaced, and `contains` is `has`. Which of the
+        // two surfaces a locus actually exposes is settled in
+        // `resolve.rs`, which synthesizes only one of them, so a
+        // hashmap cannot reach the set names or vice versa.
+        let method_name = match method_name {
+            "insert" => "set",
+            "contains" => "has",
+            other => other,
+        };
         let is_synth = matches!(
             method_name,
             "set" | "has" | "len" | "is_empty" | "get" | "remove"

--- a/crates/hale-codegen/src/locus/decl.rs
+++ b/crates/hale-codegen/src/locus/decl.rs
@@ -758,10 +758,15 @@ impl<'ctx, 'p> LocusDeclare<'ctx> for Cx<'ctx, 'p> {
             .as_ref()
             .map(|f| f.name.name.as_str() == "vec")
             .unwrap_or(false);
+        // #353: `@form(set)` is a hashmap whose value is carried but
+        // never surfaced — `decisions.md` specifies it as "a
+        // hashmap-without-value variant (the cell IS the key)". It
+        // reuses the whole `lotus_hashmap_*` runtime, including the
+        // sync disciplines; only the synthesized method set differs.
         let is_form_hashmap = l
             .form
             .as_ref()
-            .map(|f| f.name.name.as_str() == "hashmap")
+            .map(|f| matches!(f.name.name.as_str(), "hashmap" | "set"))
             .unwrap_or(false);
         let is_form_ring_buffer = l
             .form

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -771,6 +771,20 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             false,
         );
         self.module.add_function("lotus_str_join", join_ty, None);
+        // #353: regex. Linear-time NFA — pure over immutable inputs.
+        let re_pred_ty =
+            i32_t_local.fn_type(&[ptr_t.into(), ptr_t.into()], false);
+        let re_matches =
+            self.module.add_function("lotus_regex_matches", re_pred_ty, None);
+        self.mark_pure_read(re_matches);
+        let re_valid_ty = i32_t_local.fn_type(&[ptr_t.into()], false);
+        let re_valid =
+            self.module.add_function("lotus_regex_valid", re_valid_ty, None);
+        self.mark_pure_read(re_valid);
+        let re_find_ty = i64_t.fn_type(&[ptr_t.into(), ptr_t.into()], false);
+        let re_find =
+            self.module.add_function("lotus_regex_find", re_find_ty, None);
+        self.mark_pure_read(re_find);
         // #353: UTF-8 code-point decoding. Pure reads over immutable
         // input.
         let cp_at_ty = i64_t.fn_type(&[ptr_t.into(), i64_t.into()], false);

--- a/crates/hale-codegen/tests/form_set.rs
+++ b/crates/hale-codegen/tests/form_set.rs
@@ -1,0 +1,113 @@
+//! `@form(set)` (#353 item 5).
+//!
+//! `spec/decisions.md` specified this and deferred it with a trigger:
+//! "a `@form(set)` would be a hashmap-without-value variant (the cell
+//! IS the key). Not part of FORM-4; revisit if a workload needs it."
+//! #353 is that workload, so this is scheduled work whose condition
+//! fired rather than a new design.
+//!
+//! It reuses the hashmap slot and the entire `lotus_hashmap_*`
+//! runtime — including the sync disciplines, so `@form(set, sync =
+//! striped)` works for free. Only the synthesized surface differs:
+//! `insert` / `contains` / `remove` / `len` / `is_empty` instead of
+//! `set` / `get` / `has`.
+//!
+//! The point of the separate surface is keeping the VALUE off the
+//! call site. Membership through a hashmap means writing `get(k) or
+//! false` everywhere, which is the value plumbing leaking back out at
+//! every use.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+fn run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(&format!(
+        "hale_set_{}_{}",
+        name,
+        std::process::id()
+    ));
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (String::from_utf8_lossy(&out.stdout).to_string(), out.status)
+}
+
+const S: &str = "type Item { key: String; }\n\
+                 @form(set)\n\
+                 locus Seen { capacity { pool items of Item indexed_by key; } }\n";
+
+/// The defining property: inserting the same key twice does not grow
+/// the set. If this fails it is a map with a set's method names.
+#[test]
+fn insert_deduplicates() {
+    let src = format!(
+        "{S}fn main() {{
+            let s = Seen {{ }};
+            s.insert(Item {{ key: \"a\" }});
+            s.insert(Item {{ key: \"b\" }});
+            s.insert(Item {{ key: \"a\" }});
+            println(\"len=\", s.len());
+        }}"
+    );
+    let (out, st) = run("dedup", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("len=2"), "a,b,a is two members: {:?}", out);
+}
+
+/// `contains` answers Bool directly. Membership through the hashmap
+/// surface would be `get(k) or false` at every call site — the value
+/// plumbing leaking back out, which is what this form exists to stop.
+#[test]
+fn contains_answers_membership_without_a_fallible() {
+    let src = format!(
+        "{S}fn main() {{
+            let s = Seen {{ }};
+            s.insert(Item {{ key: \"a\" }});
+            println(\"a=\", s.contains(\"a\"));
+            println(\"z=\", s.contains(\"z\"));
+        }}"
+    );
+    let (out, st) = run("contains", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("a=true"), "got: {:?}", out);
+    assert!(out.contains("z=false"), "got: {:?}", out);
+}
+
+#[test]
+fn remove_takes_a_member_out() {
+    let src = format!(
+        "{S}fn main() {{
+            let s = Seen {{ }};
+            s.insert(Item {{ key: \"a\" }});
+            s.insert(Item {{ key: \"b\" }});
+            s.remove(\"a\") or {{ }};
+            println(\"len=\", s.len(), \" a=\", s.contains(\"a\"));
+        }}"
+    );
+    let (out, st) = run("remove", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("len=1"), "got: {:?}", out);
+    assert!(out.contains("a=false"), "got: {:?}", out);
+}
+
+/// An empty set is empty — the case a hashmap-backed implementation
+/// gets wrong if `len` reads the slot count rather than the live
+/// count.
+#[test]
+fn an_empty_set_is_empty() {
+    let src = format!(
+        "{S}fn main() {{
+            let s = Seen {{ }};
+            println(\"len=\", s.len(), \" empty=\", s.is_empty());
+        }}"
+    );
+    let (out, st) = run("empty", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("len=0"), "got: {:?}", out);
+    assert!(out.contains("empty=true"), "got: {:?}", out);
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -6977,6 +6977,10 @@ impl<'a> Checker<'a> {
         match form.name.name.as_str() {
             "vec" => self.check_form_vec_shape(decl, form),
             "hashmap" => self.check_form_hashmap_shape(decl, form),
+            // #353: identical capacity shape to hashmap — the value
+            // slot is what makes membership storable. Only the method
+            // surface differs.
+            "set" => self.check_form_hashmap_shape(decl, form),
             "ring_buffer" => self.check_form_ring_buffer_shape(decl, form),
             "lru_cache" => self.check_form_lru_cache_shape(decl, form),
             other => {

--- a/crates/hale-types/src/resolve.rs
+++ b/crates/hale-types/src/resolve.rs
@@ -932,6 +932,11 @@ fn register_locus(
                 let (value_ty, key_ty) = form_hashmap_value_and_key_ty(decl, known, scope);
                 synthesize_form_hashmap_methods(&mut methods, &value_ty, &key_ty);
             }
+            "set" => {
+                let (value_ty, key_ty) =
+                    form_hashmap_value_and_key_ty(decl, known, scope);
+                synthesize_form_set_methods(&mut methods, &value_ty, &key_ty);
+            }
             "ring_buffer" => {
                 let cell_ty = form_ring_buffer_cell_ty(decl, known);
                 synthesize_form_ring_buffer_methods(&mut methods, &cell_ty);
@@ -1496,6 +1501,60 @@ fn synthesize_form_vec_methods(methods: &mut Vec<MethodInfo>, cell_ty: &Ty) {
 /// key as one of its fields) means `set(value: S)` takes the
 /// whole struct rather than a `(K, V)` pair — the substrate
 /// extracts the key from the value at insertion time.
+/// #353: `@form(set)` — membership, not lookup.
+///
+/// The storage is a hashmap (see `decisions.md`: "the cell IS the
+/// key"), so this exists to keep the VALUE off the call site.
+/// `contains` returns Bool rather than a fallible, because "not
+/// present" is the ordinary answer to a membership question, not a
+/// failure — surfacing it as `get(k) or false` at every call site
+/// would be the value plumbing leaking back out.
+fn synthesize_form_set_methods(
+    methods: &mut Vec<MethodInfo>,
+    value_ty: &Ty,
+    key_ty: &Ty,
+) {
+    methods.push(MethodInfo {
+        name: "insert".to_string(),
+        params: vec![value_ty.clone()],
+        min_params: None,
+        ret: Ty::Unit,
+        fallible: None,
+    });
+    methods.push(MethodInfo {
+        name: "contains".to_string(),
+        params: vec![key_ty.clone()],
+        min_params: None,
+        ret: Ty::Prim(PrimType::Bool),
+        fallible: None,
+    });
+    // Mirrors the hashmap's `remove`: removing something that is not
+    // there is a KeyError rather than a silent no-op, and the set
+    // surface must not quietly diverge from the runtime it delegates
+    // to.
+    methods.push(MethodInfo {
+        name: "remove".to_string(),
+        params: vec![key_ty.clone()],
+        min_params: None,
+        ret: Ty::Unit,
+        fallible: Some(Ty::Named("KeyError".to_string())),
+    });
+    methods.push(MethodInfo {
+        name: "len".to_string(),
+        params: Vec::new(),
+        min_params: None,
+        ret: Ty::Prim(PrimType::Int),
+        fallible: None,
+    });
+    methods.push(MethodInfo {
+        name: "is_empty".to_string(),
+        params: Vec::new(),
+        min_params: None,
+        ret: Ty::Prim(PrimType::Bool),
+        fallible: None,
+    });
+}
+
 fn synthesize_form_hashmap_methods(
     methods: &mut Vec<MethodInfo>,
     value_ty: &Ty,

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -315,6 +315,18 @@ pub const LOCUS_PATHS: &[&[&str]] = &[
 // — they keep the permissive Unknown behavior. Regenerate with
 // the extraction described in notes/typecheck-m3.md stage 1.
 pub const SURFACES: &[NsSurface] = &[
+    // #353: linear-time regex. Pure — the engine allocates nothing on
+    // the match path beyond fixed state lists sized from the pattern,
+    // so a match is countable against a budget.
+    NsSurface {
+        ns: &["regex"],
+        fns: &[
+            e("matches", EffectSet::PURE),
+            e("find", EffectSet::PURE),
+            e("valid", EffectSet::PURE),
+        ],
+        open_prefixes: &[],
+    },
     NsSurface {
         ns: &["bus"],
         fns: &[
@@ -828,6 +840,7 @@ macro_rules! sig {
 }
 
 const NS_MATH: &[&str] = &["math"];
+const NS_REGEX: &[&str] = &["regex"];
 const NS_TIME: &[&str] = &["time"];
 const NS_ENV: &[&str] = &["env"];
 const NS_DEC: &[&str] = &["decimal"];
@@ -876,6 +889,10 @@ pub const SIGS: &[FnSig] = &[
     sig!(NS_MATH, "trunc", [Float], Int),
     // std::time — sleep takes Duration (Int rejected in lowering);
     // now() is epoch SECONDS as Int; time_from_unix returns Time.
+    // #353: linear-time regex — pure over immutable inputs.
+    sig!(NS_REGEX, "matches", [Str, Str], Bool),
+    sig!(NS_REGEX, "find", [Str, Str], Int),
+    sig!(NS_REGEX, "valid", [Str], Bool),
     sig!(NS_TIME, "monotonic", [], Duration),
     sig!(NS_TIME, "monotonic_ns", [], Int),
     sig!(NS_TIME, "sleep", [Duration], Unit),

--- a/spec/decisions.md
+++ b/spec/decisions.md
@@ -3304,9 +3304,16 @@ the core surface above is independent of them.
    in v1; no tuning knobs. Add when a workload demonstrates
    the 0 → 8 → 16 → ... grow cascade is costing measurable
    time.
-5. **Set type.** A `@form(set)` would be a hashmap-without-
+5. **Set type.** ~~A `@form(set)` would be a hashmap-without-
    value variant (the cell IS the key). Not part of FORM-4;
-   revisit if a workload needs it.
+   revisit if a workload needs it.~~ **SHIPPED 2026-08-03**
+   (#353). The trigger fired. It reuses the hashmap slot and
+   the whole `lotus_hashmap_*` runtime — sync disciplines
+   included — and differs only in the synthesized surface:
+   `insert` / `contains` / `remove` / `len` / `is_empty`. The
+   separate surface exists to keep the VALUE off the call
+   site; membership through a hashmap means writing
+   `get(k) or false` everywhere.
 
 ---
 


### PR DESCRIPTION
#353 item 4, the last one. Stacked on #365.

## The engine class was forced, not chosen

Backtracking buys backreferences and lookaround at the cost of an **exponential worst case**. You cannot bound a handler that runs one, which makes it flatly incompatible with `@budget` and `@hot` — the two things Hale sells. A Thompson NFA simulated over a state set is O(pattern × text) with no backtracking, so a match is bounded by construction.

The price is no backreferences and no lookaround. For this language that is the right side of the trade: a regex you cannot put on a hot path is not much use where the hot paths carry allocation budgets.

## Surface

`matches` (full match), `find` (leftmost byte offset, `-1` when absent), `valid`. Literals, `.`, `*`, `+`, `?`, `|`, grouping, character classes with ranges and negation, backslash escapes.

`valid` exists so a malformed pattern is **reported rather than silently matching nothing** — without it, a typo'd pattern is indistinguishable from "no results", which is the same silent-wrongness this codebase has been removing all week.

## Classified PURE, and pinned

The match path allocates nothing beyond two fixed state lists sized from the pattern, so a match is countable against a budget. There is a test that puts `matches` inside a `@deterministic @no_syscall` fn — if the linear-time property or the classification is ever lost, that test says so.

## Method

The engine was unit-tested standalone in C across 18 operator and class cases *before* being wired in, then re-tested through Hale. Building it inside the compiler and debugging through codegen would have conflated two failure surfaces.

2068/2068 tests, zero warnings, fmt clean.