### PR TITLE
test: a snippet + claim harness for spec/styleguide.md

### DIFF
--- a/crates/hale-cli/tests/styleguide_claims.rs
+++ b/crates/hale-cli/tests/styleguide_claims.rs
@@ -1,0 +1,132 @@
+//! `spec/styleguide.md` §7 claims that are about CODEGEN limits.
+//!
+//! Companion to `hale-types/tests/styleguide_snippets.rs`, which pins
+//! the claims a typechecker can see. These two cannot live there,
+//! because `hale check` does not see them at all — they surface only
+//! at `hale build`.
+//!
+//! That is worth stating plainly, because it is the same shape as the
+//! unknown-`std::`-namespace hole (#353 item 9): a reader who trusts
+//! the checker is told nothing is wrong. §7's two headline absences
+//! both behave this way, so a styleguide reader who writes
+//! `Vec<User>` and runs `hale check` gets a clean bill of health and
+//! then a build error.
+//!
+//! Each test asserts the CURRENT truth. If either gap closes, the
+//! test fails and points at the styleguide entry to update.
+
+use std::process::Command;
+
+fn build_fails(src: &str, tag: &str) -> (bool, String) {
+    let dir = std::env::temp_dir()
+        .join(format!("hale-sgclaim-{}-{}", std::process::id(), tag));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let f = dir.join("main.hl");
+    std::fs::write(&f, src).expect("write");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("build")
+        .arg(&f)
+        .output()
+        .expect("run hale build");
+    let _ = std::fs::remove_dir_all(&dir);
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (!out.status.success(), text)
+}
+
+/// §7: "the *mechanism* IS missing … a generic payload enum declares
+/// and compiles, but does not construct."
+///
+/// This entry was WRONG for months in the other direction — it said
+/// generic enums "compile, construct, and match today". Nothing
+/// checked it, so anyone following the styleguide hit an unsupported
+/// error. Pinned now in both directions.
+#[test]
+fn claim_generic_payload_enums_do_not_construct() {
+    // Non-generic constructs. Genericity is the whole difference, and
+    // asserting that here is what makes a future failure legible.
+    let (ng_failed, ng_out) = build_fails(
+        "type Res = enum { Ok(Int), Err(String) };\n\
+         fn main() { let r = Res::Ok(1);\n\
+             match r { Res::Ok(n) -> println(n), Res::Err(m) -> println(m) } }",
+        "nongeneric",
+    );
+    assert!(
+        !ng_failed,
+        "a NON-generic payload enum must still construct; if this \
+         breaks, §7's framing is wrong in a new way:\n{}",
+        ng_out
+    );
+
+    let (failed, out) = build_fails(
+        "type Opt<T> = enum { Some(T), None };\n\
+         fn main() { let r = Opt::Some(1);\n\
+             match r { Opt::Some(n) -> println(n), Opt::None -> println(0) } }",
+        "generic",
+    );
+    assert!(
+        failed,
+        "spec/styleguide.md §7 says a generic payload enum does not \
+         construct. It now does — update that entry, and consider \
+         whether `Option<T>` should ship:\n{}",
+        out
+    );
+}
+
+/// §7: "No parametric collection types (`List<T>` / `Map<K,V>`).
+/// Collections are loci."
+#[test]
+fn claim_no_parametric_collection_types() {
+    let (failed, out) = build_fails(
+        "type User { active: Bool; }\n\
+         fn f(v: Vec<User>) -> Int { return 1; }\n\
+         fn main() { println(1); }",
+        "vec",
+    );
+    assert!(
+        failed,
+        "spec/styleguide.md §7 says there are no parametric collection \
+         types. `Vec<User>` now resolves — update that entry:\n{}",
+        out
+    );
+}
+
+/// The shape that makes both of the above worth pinning HERE rather
+/// than in the typecheck harness: `hale check` accepts them.
+#[test]
+fn these_gaps_are_invisible_to_check() {
+    let dir = std::env::temp_dir()
+        .join(format!("hale-sgvis-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let f = dir.join("main.hl");
+    std::fs::write(
+        &f,
+        "type Opt<T> = enum { Some(T), None };\n\
+         fn main() { let r = Opt::Some(1);\n\
+             match r { Opt::Some(n) -> println(n), Opt::None -> println(0) } }",
+    )
+    .expect("write");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(&f)
+        .output()
+        .expect("run hale check");
+    let _ = std::fs::remove_dir_all(&dir);
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        text.contains("typechecked"),
+        "documenting the current split: `hale check` accepts a generic \
+         enum construction that `hale build` rejects. If check learns \
+         to reject it, delete this test and move the claim into the \
+         typecheck harness — the split is the thing being recorded, \
+         not a behaviour worth preserving:\n{}",
+        text
+    );
+}

--- a/crates/hale-types/tests/styleguide_snippets.rs
+++ b/crates/hale-types/tests/styleguide_snippets.rs
@@ -1,0 +1,228 @@
+//! Every ```hale snippet in `spec/styleguide.md` must be real code.
+//!
+//! `spec/styleguide.md` is the most PRESCRIPTIVE document in the repo
+//! — it tells people what idiomatic Hale is — and until now nothing
+//! checked a line of it. That is how it came to assert, in §7, that
+//! `type Option<T> = enum { Some(T), None };` "compiles, constructs,
+//! and matches today". It does not construct. Anyone following the
+//! styleguide hit an unsupported error, and the claim survived
+//! because no gate had ever executed it.
+//!
+//! ## Why this checks more than the docs harness
+//!
+//! `docs_snippets.rs` checks that snippets PARSE. That is the right
+//! bar for a tutorial full of partial sketches, but parsing is not
+//! what the Option claim failed — `type Opt<T> = enum { … };` parses
+//! fine and builds fine. It fails at USE.
+//!
+//! So a complete styleguide snippet must also TYPECHECK. That is the
+//! cheapest gate that would have caught the claim, and it catches the
+//! whole family: a method that does not exist, an arity that changed,
+//! a form shape that no longer validates.
+//!
+//! ## Info-string conventions
+//!
+//! - ```hale            — a complete program: must parse AND typecheck
+//! - ```hale,fragment   — a partial sketch (a method body, an elided
+//!                        locus): skipped, as in the docs harness
+//! - ```hale,counter    — deliberately-wrong code shown as an
+//!                        anti-pattern. NOT checked, and named
+//!                        distinctly from `fragment` so a reader of
+//!                        the source can tell "incomplete" from
+//!                        "wrong on purpose".
+//!
+//! mdBook and Starlight both key highlighting off the first token, so
+//! rendering is unchanged either way (the `rust,ignore` convention).
+
+use std::path::{Path, PathBuf};
+
+fn styleguide() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("spec")
+        .join("styleguide.md")
+}
+
+struct Snippet {
+    line: usize,
+    body: String,
+}
+
+fn extract(path: &Path) -> Vec<Snippet> {
+    let text = std::fs::read_to_string(path).expect("read styleguide");
+    let mut out = Vec::new();
+    let mut in_block = false;
+    let mut skip = false;
+    let mut start = 0usize;
+    let mut body = String::new();
+    for (i, line) in text.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if !in_block {
+            if let Some(info) = trimmed.strip_prefix("```") {
+                let info = info.trim();
+                if info == "hale" || info.starts_with("hale,") {
+                    in_block = true;
+                    skip = info.contains("fragment") || info.contains("counter");
+                    start = i + 1;
+                    body.clear();
+                }
+            }
+        } else if trimmed.starts_with("```") {
+            in_block = false;
+            if !skip {
+                out.push(Snippet { line: start, body: body.clone() });
+            }
+        } else {
+            body.push_str(line);
+            body.push('\n');
+        }
+    }
+    out
+}
+
+#[test]
+fn every_styleguide_snippet_parses_and_typechecks() {
+    let path = styleguide();
+    let snippets = extract(&path);
+    assert!(
+        !snippets.is_empty(),
+        "no ```hale snippets found in {} — path wiring or the \
+         info-string convention broke, and a silently-empty gate is \
+         worse than no gate",
+        path.display()
+    );
+
+    let mut failures = Vec::new();
+    for s in &snippets {
+        let program = match hale_syntax::parse_source(&s.body) {
+            Ok(p) => p,
+            Err(e) => {
+                failures.push(format!(
+                    "spec/styleguide.md:{}: parse: {:?}",
+                    s.line, e
+                ));
+                continue;
+            }
+        };
+        // The bar that matters: a snippet that parses but does not
+        // typecheck is exactly the Option-claim failure mode.
+        let errs: Vec<String> = hale_types::check_program(&program)
+            .into_iter()
+            .filter(|d| d.message.contains("error") || d.is_error())
+            .map(|d| d.message)
+            .collect();
+        if !errs.is_empty() {
+            failures.push(format!(
+                "spec/styleguide.md:{}: typecheck: {}",
+                s.line,
+                errs.join("; ")
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} styleguide ```hale snippet(s) are not valid Hale.\n\
+         Mark a partial sketch ```hale,fragment and a deliberately-\n\
+         wrong anti-pattern ```hale,counter.\n\n{}",
+        failures.len(),
+        snippets.len(),
+        failures.join("\n")
+    );
+}
+
+// ---- pinning the §7 boundary CLAIMS --------------------------------
+//
+// An honest note about the test above: it would NOT have caught the
+// Option bug. That claim lived in §7 prose with inline code, not in a
+// ```hale block, so a snippet gate never saw it.
+//
+// §7 is where the styleguide makes assertions ABOUT THE LANGUAGE —
+// "deliberate absences", "open gaps", "sharp edges". Those are the
+// claims most likely to rot, because they describe what does NOT work
+// and nobody re-tests absence. When a gap closes, the prose keeps
+// saying it is open; when someone believes an absence is a mechanism
+// gap rather than an idiom choice, the prose says the opposite of the
+// compiler.
+//
+// So the claims are pinned. Each test asserts the CURRENT truth; if
+// the language changes, the test fails and whoever changed it is
+// pointed at the styleguide line to update. That is the only
+// mechanism that keeps prose and reality together.
+//
+// The claims that are about CODEGEN limits rather than typecheck
+// limits live in `hale-cli/tests/styleguide_claims.rs`, because this
+// crate cannot build. That split is itself worth noticing: §7's two
+// headline absences — no parametric collections, generic enums do not
+// construct — are both invisible to `hale check` and surface only at
+// `hale build`. A reader who trusts the checker sees no problem.
+
+fn build_errs(src: &str) -> Vec<String> {
+    match hale_syntax::parse_source(src) {
+        Err(ds) => ds.into_iter().map(|d| d.message).collect(),
+        Ok(p) => hale_types::check_program(&p)
+            .into_iter()
+            .map(|d| d.message)
+            .collect(),
+    }
+}
+
+/// §7 sharp edges: "no char-level `s[i]`" — now qualified by the
+/// UTF-8 accessors, which must exist for that qualification to hold.
+#[test]
+fn claim_utf8_accessors_exist() {
+    assert!(
+        build_errs(
+            "fn main() {\n\
+                 println(std::str::cp_count(\"a\"));\n\
+                 println(std::str::cp_at(\"a\", 0));\n\
+                 println(std::str::cp_size(\"a\", 0));\n\
+             }"
+        )
+        .is_empty(),
+        "spec/styleguide.md §7 points at cp_count / cp_at / cp_size as \
+         the code-point route. They must exist for that to be true."
+    );
+}
+
+/// C6b: `only:` is the closed form and catches a class the contract
+/// never names. If this stops holding, the rule stops being advice
+/// and becomes wrong.
+#[test]
+fn claim_only_catches_an_unnamed_class() {
+    let ds = build_errs(
+        "effect money;\n\
+         @effects(is: { money })\n\
+         fn charge(n: Int) -> Int { return n; }\n\
+         @effects(only: { alloc })\n\
+         fn quote(n: Int) -> Int { return charge(n); }\n\
+         fn main() { println(quote(1)); }",
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("money")),
+        "styleguide C6b claims `only:` catches classes it never names \
+         — that is the entire reason to prefer it over `none:`: {:?}",
+        ds
+    );
+}
+
+/// S13: a chain is legal under a zero-alloc budget. The rule tells
+/// people to prefer chains ON HOT PATHS; if that stopped being true
+/// the advice would be actively harmful.
+#[test]
+fn claim_a_chain_is_zero_alloc() {
+    let ds = build_errs(
+        "@form(vec)\n\
+         locus Nums { capacity { heap items of Int; } }\n\
+         @budget(alloc_per_call = 0)\n\
+         fn big(v: Nums) -> Int { return v.filter(it > 2).count(); }\n\
+         fn main() { let v = Nums { }; v.push(5); println(big(v)); }",
+    );
+    assert!(
+        ds.is_empty(),
+        "styleguide S13 tells people to use chains on hot paths. A \
+         chain must stay legal under @budget(alloc_per_call = 0): {:?}",
+        ds
+    );
+}

--- a/spec/styleguide.md
+++ b/spec/styleguide.md
@@ -160,7 +160,7 @@ A coherent vocabulary of pure helpers wrapped in a locus with
 empty (or config-only) `params { }`. The language's substitute
 for "module of functions" / "static class".
 
-```hale
+```hale,fragment
 locus Morpheme {
     params { flavor: String = "go"; }
     fn lookup_morpheme(m: String) -> String { ... }
@@ -180,7 +180,7 @@ vocabulary becomes visible; leave unrelated helpers as free fns
 
 The full lifecycle for a thing that genuinely runs over time.
 
-```hale
+```hale,fragment
 locus Listener {
     params {
         host: String = "127.0.0.1";
@@ -306,7 +306,7 @@ between recovery (substitute a value) and escalation (drain and
 notify the parent) pairs an `or self.method(err)` clause with an
 `epoch inline` closure:
 
-```hale
+```hale,fragment
 locus DbConnection {
     params { conn_fd: Int = -1; last_error: String = ""; }
     bus { subscribe ExecuteQuery as on_query; publish QueryResult; }
@@ -355,6 +355,31 @@ locus DbConnection {
 Library exports: pick short lowercase import aliases; name decls
 to read naturally under the alias (`fin::Quote`, not
 `fin::FinQuote`). See `spec/projects.md` for the seed model.
+
+### This document is tested
+
+`spec/styleguide.md` is the most prescriptive file in the repo, and
+until 2026-08-03 nothing checked a line of it. That is how §7 came to
+assert that a generic payload enum "compiles, constructs, and matches
+today" when it does not construct — the claim was written once and
+never executed again.
+
+Two gates now run in the normal suite:
+
+- **Snippets.** Every ```hale block must parse *and typecheck*.
+  Partial sketches opt out with ```hale,fragment; deliberately-wrong
+  anti-patterns use ```hale,counter, so a reader of the source can
+  tell "incomplete" from "wrong on purpose".
+  (`hale-types/tests/styleguide_snippets.rs`)
+- **Claims.** §7's assertions about what the language does *not* do
+  are pinned as tests. Absence is the thing nobody re-tests, so when a
+  gap closes the prose keeps saying it is open. If one of these
+  changes, the test fails and names the entry to update.
+  (same file, plus `hale-cli/tests/styleguide_claims.rs` for the
+  claims that are codegen limits rather than typecheck limits — a
+  split worth knowing, because those are invisible to `hale check`.)
+
+If you add a claim about the language here, add the test with it.
 
 ### Canonical form — `hale fmt` is the arbiter
 
@@ -462,7 +487,7 @@ until OOM — the canonical accept-loop leak. Declare
 `release(c: Child)` to make children **flows**, reclaimed when
 their `run()` completes; or `terminate` them from a handler.
 
-```hale
+```hale,fragment
 locus Conn {
     params { fd: Int = -1; }
     run() { while true { let f = recv(...); if f.closed { return; } ... } }
@@ -497,7 +522,7 @@ bounded batch stay silent. **[warn]**
   instances each want their own slice of a topic's traffic, key
   the topic and filter at the subscription:
 
-  ```hale
+```hale,fragment
   topic Posted { payload: Msg; keyed_by room; }
   locus Room {
       params { name: String = "lobby"; }
@@ -526,7 +551,7 @@ bounded batch stay silent. **[warn]**
 String / enum-payload / guard arms) are all first-class. A
 command router over a String field is a `match`:
 
-```hale
+```hale,fragment
 fn on_command(f: Frame) {
     match std::json::find_string_field(f.json, "type") {
         "hello" -> self.on_hello(f),
@@ -545,7 +570,7 @@ positions; expression-position arms must agree on one type.
 
 ### C6b. Prefer `only:` to an enumerated `none:`
 
-```hale
+```hale,fragment
 @effects(only: { alloc })          // closed — future-proof
 @effects(none: { syscall, block, publish, time, entropy, env,
                  ffi, spawn, recursion })   // open — rots
@@ -594,7 +619,7 @@ Each is production-derived. Certify the path when done — S10.
 The single highest-value idiom. A locus that processes frames
 holds its buffers as fields and reuses them every frame:
 
-```hale
+```hale,fragment
 locus WsConn {
     params {
         rx_buf: std::bytes::BytesBuilder = ...;   // frame reassembly
@@ -691,7 +716,7 @@ a `Drain<T>` handler runs once per queue drain with a zero-copy
 
 When a hot path is clean, pin it:
 
-```hale
+```hale,fragment
 @hot @budget(alloc_per_call = 0) fn on_frame(m: Frame) { ... }
 ```
 
@@ -718,7 +743,7 @@ A hot path that looks something up by string key in another locus
 (a metrics counter, a symbol table) resolves the handle **once at
 boot** and stores it as a field:
 
-```hale
+```hale,fragment
 params { c_ticks: metrics::Counter; }      // resolved in main(), threaded in
 fn dispatch(m: Msg) { self.c_ticks.inc(); }
 ```
@@ -757,7 +782,7 @@ is regression-tested. **[convention]**
 
 ### S13. Compose with chains, not hand-rolled loops
 
-```hale
+```hale,fragment
 // idiomatic
 let n = self.users.filter(it.active).count();
 self.users.filter(it.active).into(self.actives);


### PR DESCRIPTION
`spec/styleguide.md` is the most prescriptive file in the repo, and nothing checked a line of it. That is how §7 came to assert that a generic payload enum *"compiles, constructs, and matches today"* when it does not construct — written once, never executed again.

Two gates, because the styleguide fails in two different ways.

## Snippets

Every ```hale block must parse **and typecheck**. Typecheck rather than only parse, because parsing is not what the Option claim failed — `type Opt<T> = enum { … };` parses fine and builds fine, and fails at *use*. The docs harness checks parsing, which is the right bar for a tutorial full of sketches; it is not the right bar for a document that tells people what correct Hale looks like.

Info-string conventions:

- ```hale — a complete program: parses and typechecks
- ```hale,fragment — a partial sketch, skipped
- ```hale,counter — deliberately-wrong code shown as an anti-pattern, skipped

`counter` is distinct from `fragment` on purpose: a reader of the source can then tell "incomplete" from "wrong on purpose". 11 of the 15 existing blocks are genuinely partial (`...` elisions, bare `self`, top-level `let`) and are marked.

## Claims — and an honest note about the gate above

**The snippet gate would not have caught the Option bug.** That claim lived in §7 prose with inline code, not in a fenced block. Shipping only the snippet harness would have looked like a fix without being one.

§7 is where the document asserts things *about the language* — deliberate absences, open gaps, sharp edges. Absence is exactly what nobody re-tests, so when a gap closes the prose keeps saying it is open, and when someone mistakes an idiom choice for a mechanism gap the prose says the opposite of the compiler. Those assertions are now pinned as tests that assert the **current** truth and name the entry to update when it changes.

Pinned: generic enums do not construct (in both directions — the non-generic case must keep working, since genericity is the whole difference), no parametric collection types, the UTF-8 accessors exist, `only:` catches a class it never names, and a chain is legal under a zero-alloc budget.

## The split is itself a finding

The claim tests live in two crates. §7's two headline absences — no parametric collections, generic enums do not construct — are **codegen** limits, invisible to `hale check`:

```
type Opt<T> = enum { Some(T), None };
let r = Opt::Some(1);      →  check: ok    build: rejected
```

So a styleguide reader who writes `Vec<User>`, runs `hale check`, and gets a clean bill of health then hits a build error. Same shape as the unknown-`std::`-namespace hole (#353 item 9). There is a test documenting that split explicitly, with a note to delete it if `check` ever learns to reject these — the split is what is being recorded, not a behaviour worth preserving.

## Also

A short "This document is tested" section in the styleguide itself, ending with the rule that matters: **if you add a claim about the language here, add the test with it.**

2075/2075 tests, zero warnings, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
