### PR TITLE
docs(spec): say what @budget(stack_bytes) rests on, and pin it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ behavior.
 
 ## Unreleased
 
+- **`@budget(stack_bytes)`: the spec now states what the estimate
+  rests on and what it does not cover** (#326). The entry previously
+  asserted that frames "over-approximate, so the bound is safe to
+  assert on" — the claim under question, stated without evidence. It
+  now gives the actual argument (Hale arena-allocates arrays, structs
+  and string buffers, so almost nothing but scalars is on the stack,
+  which is why an 8-bytes-per-local unit is close to right here and
+  would be wrong by orders of magnitude in C; and inlining removes
+  call levels, the term the model spends most of its budget on), and
+  states the limitation (register spills are invisible to any
+  source-level model — at `-O3 -march=native` a spilled AVX-512
+  register is 64 bytes against a model whose unit is 8). The bound is
+  structural, over program shape, not a machine-level guarantee.
+  The load-bearing premise is now pinned by tests.
+
 - **`std::regex`** (#353). A linear-time Thompson NFA:
   `matches` (full match), `find` (leftmost byte offset, -1 if absent)
   and `valid`. The engine class was forced rather than chosen —

--- a/crates/hale-codegen/tests/stack_budget_premises.rs
+++ b/crates/hale-codegen/tests/stack_budget_premises.rs
@@ -1,0 +1,240 @@
+//! The premises `@budget(stack_bytes)` rests on (#326).
+//!
+//! The estimator is 32 bytes of call overhead, 8 per parameter, 8 per
+//! local. Whether that is sound has nothing to do with the arithmetic
+//! and everything to do with a fact about Hale's memory model:
+//!
+//!     ALMOST NOTHING IS ON THE STACK.
+//!
+//! Fixed arrays, structs and string/bytes buffers are arena-allocated,
+//! so a local is a pointer and 8 bytes is close to *correct* for the
+//! scalars that remain. The same estimator in C would be wrong by
+//! orders of magnitude — a `char buf[65536]` local is 8 bytes to this
+//! model and 64 KiB to the machine.
+//!
+//! That premise is load-bearing and invisible. If a shape ever became
+//! stack-allocated — for performance, for a new backend, for wasm —
+//! the estimate would silently under-count by the size of that shape,
+//! and every `@budget(stack_bytes)` certificate in the tree would
+//! quietly become wrong. Nothing would fail; the numbers would just
+//! stop meaning anything.
+//!
+//! So the premise is pinned here rather than assumed. These tests do
+//! not check the budget arithmetic (that has its own tests) — they
+//! check the fact the arithmetic depends on.
+//!
+//! What they deliberately do NOT establish: that the estimate bounds
+//! actual machine stack. It does not, and cannot. Register spills are
+//! invisible to any source-level model, and at `-O3` with
+//! `target-cpu=native` a spilled AVX-512 register is 64 bytes against
+//! a model whose unit is 8. See spec/verification.md for the full
+//! statement; settling that needs post-codegen measurement
+//! (`.stack_sizes`), which is not wired up.
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+/// Emit pre-optimization IR for a program and return it.
+fn ir_for(name: &str, src: &str) -> String {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(&format!(
+        "hale_stackprem_{}_{}",
+        name,
+        std::process::id()
+    ));
+    std::env::set_var("LOTUS_DUMP_IR", "1");
+    build_executable(&program, &bin).expect("build");
+    std::env::remove_var("LOTUS_DUMP_IR");
+    let ll = bin.with_extension("ll");
+    let ir = std::fs::read_to_string(&ll).expect("IR dumped");
+    let _ = std::fs::remove_file(&bin);
+    let _ = std::fs::remove_file(&ll);
+    ir
+}
+
+/// Stack bytes an `alloca` reserves, when that is statically
+/// obvious. Only the TYPE position is parsed — matching digits
+/// anywhere in the line picks up SSA names (`%req96`) and `align 8`,
+/// which is how the first version of this test reported a String
+/// local as a 96-byte stack buffer.
+///
+/// Handles the two shapes that matter: `alloca [N x T]` and
+/// `alloca T, i64 N`. Anything else counts as small, which is the
+/// safe direction for a premise check — a missed shape shows up as a
+/// passing test, not a false alarm, and the budget arithmetic has its
+/// own coverage.
+fn alloca_extent(line: &str) -> usize {
+    let Some(rest) = line.split_once("alloca ").map(|(_, r)| r) else {
+        return 0;
+    };
+    let rest = rest.trim();
+    // `[4096 x i64]`
+    if let Some(inner) = rest.strip_prefix('[') {
+        if let Some((n, _)) = inner.split_once(" x ") {
+            return n.trim().parse::<usize>().unwrap_or(0);
+        }
+    }
+    // An aggregate type contains its own commas — `{ i64, i64 }` was
+    // matching the explicit-count branch below and reporting its
+    // alignment as a size. Only a SIMPLE type can carry a count.
+    if rest.starts_with('{') || rest.starts_with('<') {
+        return 0;
+    }
+    // `i8, i64 65536, align 16`
+    if let Some((_, count)) = rest.split_once(", i64 ") {
+        return count
+            .split(|c: char| !c.is_ascii_digit())
+            .find(|s| !s.is_empty())
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(0);
+    }
+    0
+}
+
+fn big_allocas(ir: &str, min_elems: usize) -> Vec<String> {
+    ir.lines()
+        .filter(|l| l.contains("alloca"))
+        .filter(|l| alloca_extent(l) > min_elems)
+        .map(|l| l.trim().to_string())
+        .collect()
+}
+
+/// THE premise. A large fixed-size array local must not become a
+/// stack allocation, or the estimator's 8-bytes-per-local under-counts
+/// it by 32 KiB.
+#[test]
+fn a_large_array_local_is_not_on_the_stack() {
+    let ir = ir_for(
+        "array",
+        "@budget(stack_bytes = 64)\n\
+         fn big(n: Int) -> Int {\n\
+             let mut buf: [Int; 4096] = [0; 4096];\n\
+             let mut i = 0;\n\
+             while i < 4096 { buf[i] = i * n; i = i + 1; }\n\
+             return buf[n];\n\
+         }\n\
+         fn main() { println(big(3)); }",
+    );
+    let big = big_allocas(&ir, 1024);
+    assert!(
+        big.is_empty(),
+        "a [Int; 4096] local became a stack allocation. \
+         `@budget(stack_bytes)` estimates 8 bytes for it, so every \
+         such certificate now under-counts by ~32 KiB — see \
+         spec/verification.md § stack_bytes. Offending alloca(s):\n{}",
+        big.join("\n")
+    );
+}
+
+/// Same premise for a wide struct: the estimator charges 8 for the
+/// local regardless of the struct's size.
+#[test]
+fn a_wide_struct_local_is_not_on_the_stack() {
+    let ir = ir_for(
+        "struct",
+        "type Wide {\n\
+             a: Int; b: Int; c: Int; d: Int; e: Int; f: Int;\n\
+             g: Int; h: Int; i: Int; j: Int; k: Int; l: Int;\n\
+         }\n\
+         @budget(stack_bytes = 64)\n\
+         fn mk(n: Int) -> Int {\n\
+             let w = Wide { a: n, b: n, c: n, d: n, e: n, f: n,\n\
+                            g: n, h: n, i: n, j: n, k: n, l: n };\n\
+             return w.a + w.l;\n\
+         }\n\
+         fn main() { println(mk(2)); }",
+    );
+    let big = big_allocas(&ir, 64);
+    assert!(
+        big.is_empty(),
+        "a wide struct local became a stack allocation; the estimator \
+         charges 8 bytes for it regardless of width:\n{}",
+        big.join("\n")
+    );
+}
+
+/// A String local is a pointer — the buffer is arena/heap. The
+/// estimator's `Bytes/String local carries a pointer` comment is the
+/// claim; this is the check.
+#[test]
+fn a_string_local_is_a_pointer() {
+    let ir = ir_for(
+        "string",
+        "@budget(stack_bytes = 64)\n\
+         fn s(n: Int) -> Int {\n\
+             let t = \"abcdefghijklmnopqrstuvwxyz\";\n\
+             return std::str::index_of(t, \"z\") + n;\n\
+         }\n\
+         fn main() { println(s(1)); }",
+    );
+    let big = big_allocas(&ir, 64);
+    assert!(
+        big.is_empty(),
+        "a String local put its buffer on the stack:\n{}",
+        big.join("\n")
+    );
+}
+
+/// The budget must still FIRE — a premise test that passed because
+/// the analysis had been disabled would be worthless.
+#[test]
+fn the_budget_still_rejects_an_over_deep_chain() {
+    let src = "@budget(stack_bytes = 8)\n\
+               fn a(n: Int) -> Int { let x = n; return b(x); }\n\
+               fn b(n: Int) -> Int { let y = n; return y; }\n\
+               fn main() { println(a(1)); }";
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let ds: Vec<String> = hale_types::check_program(&program)
+        .into_iter()
+        .map(|d| d.message)
+        .collect();
+    assert!(
+        ds.iter().any(|m| m.contains("budget exceeded")
+            && m.contains("stack_bytes")),
+        "an 8-byte budget over a two-frame chain must be rejected — \
+         if this stops firing the premise tests above are guarding \
+         nothing: {:?}",
+        ds
+    );
+}
+
+/// Negative control for the detector itself.
+///
+/// The three tests above pass by finding NO large alloca, so they are
+/// only as good as `alloca_extent`. The first version of it matched
+/// digits anywhere in the line and read `%req96` as a 96-byte buffer —
+/// a detector that cried wolf. Overcorrecting to one that never fires
+/// would be worse: every premise test would pass forever and guard
+/// nothing.
+#[test]
+fn the_detector_recognises_a_stack_buffer() {
+    assert_eq!(
+        alloca_extent("  %buf = alloca [4096 x i64], align 8"),
+        4096,
+        "the `[N x T]` shape must be measured"
+    );
+    assert_eq!(
+        alloca_extent("  %b = alloca i8, i64 65536, align 16"),
+        65536,
+        "the explicit-count shape must be measured"
+    );
+    // ...and must NOT fire on an ordinary scalar slot whose SSA name
+    // or alignment happens to contain a large number.
+    assert_eq!(
+        alloca_extent("  %req96 = alloca { i64, i64 }, align 8"),
+        0,
+        "an SSA name is not a size"
+    );
+    assert_eq!(
+        alloca_extent("  %x = alloca i64, align 8"),
+        0,
+        "a scalar slot is not a buffer"
+    );
+    assert!(
+        !big_allocas("  %buf = alloca [4096 x i64], align 8", 1024)
+            .is_empty(),
+        "big_allocas must report a genuine 4096-element buffer"
+    );
+}

--- a/crates/hale-codegen/tests/support/harness.rs
+++ b/crates/hale-codegen/tests/support/harness.rs
@@ -65,6 +65,17 @@ pub fn unique_bin(name: &str) -> PathBuf {
 /// handed back, so it is *free*, not *reserved*. That is still
 /// strictly better than a fixed number, because the kernel does not
 /// hand out a port already bound by a concurrent test.
+/// NOTE: this does not RESERVE the port. It binds an ephemeral port,
+/// reads the number, and drops the listener — so between the return
+/// and whoever binds it next there is a window in which a parallel
+/// test can take it. The window cannot be closed: holding the port is
+/// exactly what would stop the caller (often a child process) from
+/// binding it.
+///
+/// A test that must actually bind the port should therefore retry the
+/// acquire-and-bind pair as a unit rather than trusting one draw —
+/// see `tcp_listener_exclusive_bind.rs`, which flaked in CI on
+/// 2026-08-03 for exactly this reason.
 pub fn free_port() -> u16 {
     std::net::TcpListener::bind("127.0.0.1:0")
         .expect("bind an ephemeral port")

--- a/crates/hale-codegen/tests/tcp_listener_exclusive_bind.rs
+++ b/crates/hale-codegen/tests/tcp_listener_exclusive_bind.rs
@@ -30,7 +30,43 @@ fn free_tcp_port() -> u16 {
 
 #[test]
 fn second_bind_of_same_port_fails() {
-    let port = free_tcp_port();
+    // Acquiring a port and binding it in a CHILD are two steps, and
+    // nothing holds the port between them: `free_tcp_port` binds
+    // 127.0.0.1:0, reads the assigned port, and drops the listener so
+    // the child can bind it. In a parallel run another test can take
+    // that port in the gap, and the child's FIRST bind fails — which
+    // looks like this test's subject failing when it is really port
+    // allocation losing a race. Observed in CI 2026-08-03.
+    //
+    // The gap cannot be closed: holding the port is exactly what
+    // stops the child binding it. So the acquire-and-bind pair is
+    // retried as a unit. The property under test — a SECOND bind of
+    // the same live port is refused — is unaffected by which port we
+    // end up on.
+    let mut last = String::new();
+    for _ in 0..8 {
+        let stdout = run_double_bind(free_tcp_port());
+        if stdout.contains("fd1_ok=true") {
+            assert!(
+                stdout.contains("fd2_ok=false"),
+                "a second bind of a live port must be refused \
+                 (SO_REUSEPORT is deliberately not set); got:\n{}",
+                stdout
+            );
+            return;
+        }
+        last = stdout;
+    }
+    panic!(
+        "could not acquire a bindable port in 8 attempts — this is \
+         port-allocation contention, not the property under test. \
+         Last output:\n{}",
+        last
+    );
+}
+
+/// Build and run a program that binds `port` twice; return stdout.
+fn run_double_bind(port: u16) -> String {
     let src = format!(
         r#"
         fn main() {{
@@ -49,17 +85,5 @@ fn second_bind_of_same_port_fails() {
     build_executable(&program, &bin).expect("build");
     let out = Command::new(&bin).output().expect("run");
     let _ = std::fs::remove_file(&bin);
-    let stdout = String::from_utf8_lossy(&out.stdout);
-
-    assert!(
-        stdout.contains("fd1_ok=true"),
-        "first bind should succeed; got:\n{}",
-        stdout
-    );
-    assert!(
-        stdout.contains("fd2_ok=false"),
-        "second live bind of the same port must be refused (exclusive bind — \
-         SO_REUSEPORT must not be set); got:\n{}",
-        stdout
-    );
+    String::from_utf8_lossy(&out.stdout).to_string()
 }

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -261,9 +261,43 @@ assume the others in a build:
   - `stack_bytes` — worst-case stack depth as a **DAG longest path**
     over estimated frame sizes. Acyclicity is the precondition, which
     is why this pairs with `@no_recursion`: a cycle reports
-    *unbounded*. Frames are estimated from declared shapes and
-    over-approximate, so the bound is safe to assert on but is not
-    WCET.
+    *unbounded*.
+
+    **What the estimate rests on** (#326, examined 2026-08-03). Frames
+    are estimated from declared shapes: 32 bytes of call overhead, 8
+    per parameter, 8 per local. That unit is close to right *because
+    of Hale's memory model, not by luck* — fixed arrays, structs and
+    string/bytes buffers are arena-allocated, so a local is a pointer
+    and almost nothing but scalars is ever on the stack. The same
+    estimator in C would be wrong by orders of magnitude. The premise
+    is pinned by tests (`hale-codegen/tests/stack_budget_premises.rs`)
+    precisely because it is load-bearing: if a shape ever became
+    stack-allocated, the estimate would silently under-count by the
+    size of that shape.
+
+    Inlining, the other obvious worry, cuts the safe way: the model
+    charges `CALL_OVERHEAD` per level of call depth and inlining
+    removes levels, so it strictly reduces the term the model spends
+    most of its budget on.
+
+    **What the estimate does NOT cover.** Storage the optimizer
+    introduces is invisible to any source-level model — register
+    spills above all. We build `-O3` with `target-cpu=native`, so on
+    an AVX-512 host a spilled vector register is **64 bytes** against
+    a model whose unit is 8, and a vectorized loop can consume
+    hundreds of bytes with no source local to explain it. Inlining
+    amplifies this by merging live ranges, which is what produces
+    spills — the risk is merged *pressure*, not merged locals.
+
+    So: the bound is a **structural** estimate over declared shapes,
+    not a machine-level guarantee and not WCET. It is sound against
+    everything the frontend can see and silent about everything the
+    backend adds. Treat it as a bound on *program shape* — call depth
+    and declared locals — and not as a promise about bytes of hardware
+    stack. Settling the latter needs post-codegen measurement
+    (LLVM's `.stack_sizes` section), which is not wired up; `hale
+    check`'s diagnostic already says "estimated from declared shapes",
+    and this entry now matches that honesty rather than exceeding it.
   - `block_points` — how many blocking operations one call may reach
     (`0` is `@no_block`; `1` is "may wait once, on its own socket").
   - `publish` — publishes per call. `@budget(publish = 1)` **is** the


### PR DESCRIPTION
Closes #326 by taking the third of the three outcomes that issue named — "an explicit statement" — and adding the thing that keeps it true.

## The spec was the problem

`spec/verification.md` asserted that frames *"over-approximate, so the bound is safe to assert on"*. That is exactly the claim #326 asks about, stated without evidence, and it made the canonical document the most confident artifact in the chain — `hale check`'s own diagnostic is more honest, saying "estimated from declared shapes".

## What examining it found

**The estimate holds better than it looks, for a reason the spec never gave.** I expected `8 bytes per local` to be badly wrong and tested the obvious counterexample:

```hale
@budget(stack_bytes = 64)
fn big(n: Int) -> Int {
    let mut buf: [Int; 4096] = [0; 4096];   // 32 KiB?
    ...
}
```

It typechecks — and it is **not** a soundness bug. There is no 4096-element `alloca` in the emitted IR. Hale arena-allocates fixed arrays, structs and string/bytes buffers, so a local is a pointer and almost nothing but scalars reaches the stack. The same estimator in C would be wrong by orders of magnitude.

**Inlining, the worry the issue was filed about, cuts the safe way.** The model charges `CALL_OVERHEAD` per level of call depth; inlining removes levels, so it strictly reduces the term the model spends most of its budget on.

**What it does not cover is storage the optimizer introduces.** Register spills are invisible to any source-level model, and we build `-O3` with `target-cpu=native` — so on an AVX-512 host a spilled vector register is **64 bytes** against a model whose unit is 8, and a vectorized loop can consume hundreds of bytes with no source local to explain it. Inlining amplifies this by merging live *ranges*, which is what produces spills: the risk is merged pressure, not merged locals.

There is a sharper version of the same point. Trying to measure this, I could not find the certified function in the binary — it had been inlined away. **`@budget(stack_bytes)` certifies a function the optimizer deletes.**

So the entry now says the bound is **structural**, over program shape, and silent about what the backend adds. Settling the machine-level question needs post-codegen measurement (LLVM's `.stack_sizes` section); inkwell does not expose `EmitStackSizeSection` today, so that is written up as the route rather than attempted here.

## Pinning the premise

The soundness argument rests entirely on "almost nothing is on the stack", which is load-bearing and invisible. If a shape ever became stack-allocated — for performance, a new backend, wasm — every `stack_bytes` certificate in the tree would silently under-count by the size of that shape and **nothing would fail**. So it is pinned rather than assumed: large array locals, wide struct locals and String locals must not produce stack buffers, plus a check that the budget analysis still fires at all (a premise test guarding a disabled analysis would be worthless).

## The detector has a negative control, and it earned its place twice

The premise tests pass by finding *no* large alloca, so they are only as good as the detector. The first version matched digits anywhere in the line and read the SSA name `%req96` as a 96-byte buffer. The corrected version then read `alloca { i64, i64 }`'s **alignment** as a size. Both were caught by the control, not by review — which is the argument for writing the control at all.

2080/2080 tests, zero warnings, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
