### PR TITLE
fix(wasm): compile and link a package's [ffi] csrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ behavior.
 
 ## Unreleased
 
+- **wasm32: a package's `[ffi] csrc` is compiled and linked** (#213).
+  `link_wasm` was called without the build options, so `csrc_files`
+  never reached the wasm path: every `@ffi("c")` symbol a package
+  defined in C became an undefined `env` import, `--allow-undefined`
+  swallowed it, and the JS loader stubbed unknown imports with
+  `() => 0`. The build reported success and every call returned 0
+  forever. Two constraints follow from the wasm build being
+  freestanding: a translation unit that includes system headers will
+  not compile (a build error naming the file, rather than a missing
+  symbol), and `[ffi] link = [...]` is rejected outright because wasm
+  has no dynamic linker. Note Hale's `Int` is 64-bit, so the C must
+  declare `long long` — a mismatch links and then traps with a wasm
+  `signature_mismatch`, which is louder than the native ABI's silent
+  truncation and far louder than the stub it replaces.
+
 - **`@budget(stack_bytes)`: the spec now states what the estimate
   rests on and what it does not cover** (#326). The entry previously
   asserted that frames "over-approximate, so the bound is safe to

--- a/crates/hale-cli/tests/wasm_package_csrc.rs
+++ b/crates/hale-cli/tests/wasm_package_csrc.rs
@@ -1,0 +1,132 @@
+//! wasm32: a package's `[ffi] csrc` must actually be compiled (#213).
+//!
+//! `link_wasm` was called without `options`, so `csrc_files` and
+//! `link_libs` never reached the wasm path. Every `@ffi("c")` symbol a
+//! package defined in C surfaced as an undefined `env` import, which
+//! `--allow-undefined` swallowed, and the generated JS loader stubbed
+//! unknown imports with `() => 0`. The build reported success and
+//! every call returned 0 forever — the worst available failure mode,
+//! because nothing anywhere said anything.
+//!
+//! ## How these tests discriminate
+//!
+//! Before the fix the build SUCCEEDED, so "it builds" proves nothing.
+//! The discriminator is that a *broken* C source must now break the
+//! build: if csrc is compiled, a syntax error in it is a compile
+//! error; if csrc is ignored, the build sails past. That is a
+//! one-bit signal requiring no wasm parsing.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// A package with an `[ffi] csrc`, imported by an app. `[ffi]` is read
+/// from imported PACKAGES (paths resolve against the lib dir), not
+/// from the entry program's own manifest.
+fn workspace(tag: &str, c_body: &str, link_line: &str) -> PathBuf {
+    let root = std::env::temp_dir()
+        .join(format!("hale-w213-{}-{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("app")).expect("mkdir app");
+    std::fs::create_dir_all(root.join("lib/glue")).expect("mkdir lib");
+    std::fs::write(root.join("hale.toml"), "name = \"w213\"\n").unwrap();
+    std::fs::write(
+        root.join("lib/glue/hale.toml"),
+        format!("name = \"glue\"\n\n[ffi]\ncsrc = [\"glue.c\"]\n{}", link_line),
+    )
+    .unwrap();
+    std::fs::write(root.join("lib/glue/glue.c"), c_body).unwrap();
+    std::fs::write(
+        root.join("lib/glue/g.hl"),
+        "@ffi(\"c\")\nfn tsa_answer(n: Int) -> Int;\n\n\
+         fn ask(n: Int) -> Int { return tsa_answer(n); }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("app/main.hl"),
+        "import \"lib/glue\" as glue;\n\n\
+         @export\nfn go(n: Int) -> Int { return glue::ask(n); }\n\n\
+         fn main() { println(glue::ask(7)); }\n",
+    )
+    .unwrap();
+    root
+}
+
+fn build_wasm(root: &PathBuf) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("build")
+        .arg(root.join("app/main.hl"))
+        .arg("--target")
+        .arg("wasm32")
+        .output()
+        .expect("run hale build");
+    (
+        out.status.success(),
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+    )
+}
+
+/// Hale's `Int` is i64, so the C must be `long long`. A plain `int`
+/// links but traps at call time with a wasm signature mismatch —
+/// which is itself an improvement over the old silent stub, and is
+/// pinned separately below.
+const GOOD_C: &str = "long long tsa_answer(long long n) { return n * 6; }\n";
+
+#[test]
+fn a_package_csrc_builds_for_wasm() {
+    let root = workspace("good", GOOD_C, "");
+    let (ok, out) = build_wasm(&root);
+    let _ = std::fs::remove_dir_all(&root);
+    assert!(ok, "a well-formed package csrc must build for wasm32:\n{}", out);
+}
+
+/// THE discriminator. Before the fix this passed, because the source
+/// was never handed to a compiler.
+#[test]
+fn a_broken_package_csrc_fails_the_wasm_build() {
+    let root = workspace("broken", "this is not C at all;\n", "");
+    let (ok, out) = build_wasm(&root);
+    let _ = std::fs::remove_dir_all(&root);
+    assert!(
+        !ok,
+        "a package csrc with a syntax error must fail the wasm build. \
+         If this passes, csrc is being ignored again and every \
+         @ffi(\"c\") symbol it defines is silently a stub:\n{}",
+        out
+    );
+    assert!(
+        out.contains("csrc") || out.contains("freestanding"),
+        "the diagnostic should say which csrc failed and that the wasm \
+         build is freestanding — a bare clang error leaves the reader \
+         guessing why a source that builds natively does not build \
+         here:\n{}",
+        out
+    );
+}
+
+/// `link = [...]` names a system dynamic library. wasm has neither a
+/// dynamic linker nor system libraries, so this must be refused rather
+/// than dropped — dropping it silently is the same class of bug this
+/// issue is about, one level up.
+#[test]
+fn a_system_link_dependency_is_refused_on_wasm() {
+    let root = workspace("link", GOOD_C, "link = [\"m\"]\n");
+    let (ok, out) = build_wasm(&root);
+    let _ = std::fs::remove_dir_all(&root);
+    assert!(
+        !ok,
+        "`[ffi] link` cannot be satisfied on wasm32 and must be an \
+         error, not a silent drop:\n{}",
+        out
+    );
+    assert!(
+        out.contains("no system dynamic libraries")
+            || out.contains("cannot be satisfied"),
+        "the diagnostic must say why, and point at csrc as the \
+         alternative:\n{}",
+        out
+    );
+}

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1678,7 +1678,13 @@ pub fn build_executable_with_options(
         // Compile the self-contained wasm runtime (arena core + bundled
         // libc) and link it into the user object with wasm-ld, producing
         // a runnable `.wasm`. No native libs / no clang link line.
-        link_wasm(&obj_path, output_path, &cx.wasm_exports)?;
+        link_wasm(
+            &obj_path,
+            output_path,
+            &cx.wasm_exports,
+            &options.csrc_files,
+            &options.link_libs,
+        )?;
         let _ = std::fs::remove_file(&obj_path);
         return Ok(());
     }
@@ -2099,6 +2105,16 @@ fn link_wasm(
     user_obj: &Path,
     output: &Path,
     extra_exports: &[String],
+    // #213: a package's `[ffi] csrc` translation units. These never
+    // reached the wasm path — `options` was simply not passed — so
+    // every `@ffi("c")` symbol they define surfaced as an undefined
+    // `env` import, which `--allow-undefined` swallowed and the JS
+    // loader stubbed with `() => 0`. The build reported success and
+    // every call returned 0 forever.
+    csrc_files: &[std::path::PathBuf],
+    // `[ffi] link` names system dynamic libraries. There is no such
+    // thing on wasm, so this is rejected rather than ignored.
+    link_libs: &[String],
 ) -> Result<(), CodegenError> {
     let mkerr = |m: String| CodegenError::Link(m);
     // Unique temp dir for the staged runtime sources.
@@ -2158,10 +2174,49 @@ fn link_wasm(
     // (println -> printf/puts) as host imports the JS loader provides.
     // (A richer export policy — @export, plus the _hale_start/_hale_tick
     // entry inversion for run()-driven programs — is the next slice.)
+    // #213: `link = [...]` is a system-dylib reference. wasm has no
+    // dynamic linker and no system libraries, so silently dropping it
+    // would reproduce exactly the failure this fixes one level up:
+    // a build that looks fine and is missing its symbols.
+    if !link_libs.is_empty() {
+        return Err(mkerr(format!(
+            "`[ffi] link = {:?}` cannot be satisfied on wasm32 — there \
+             are no system dynamic libraries to link against. Provide \
+             the code as `[ffi] csrc` so it can be compiled into the \
+             module, or gate the dependency out of the wasm build.",
+            link_libs
+        )));
+    }
+
+    // Compile each package csrc translation unit with the same
+    // freestanding wasm toolchain used for the runtime. No sysroot and
+    // no libc headers exist here (see the shim's forward declarations),
+    // so a source that `#include`s libc will fail to compile — LOUDLY,
+    // which is the point. The previous behaviour was to not compile it
+    // at all and let the symbol vanish.
+    let mut csrc_objs: Vec<std::path::PathBuf> = Vec::new();
+    for (i, src) in csrc_files.iter().enumerate() {
+        let o = dir.join(format!("csrc{}.o", i));
+        cc(src, &o, &[]).map_err(|e| {
+            mkerr(format!(
+                "compiling `[ffi] csrc` {:?} for wasm32 failed: {}. The \
+                 wasm build is freestanding — there is no libc sysroot, \
+                 so a translation unit that includes system headers \
+                 cannot be built for this target.",
+                src, e
+            ))
+        })?;
+        csrc_objs.push(o);
+    }
+
     let mut cmd = Command::new(&wasm_ld);
     cmd.arg(user_obj)
         .arg(&arena_o)
-        .arg(&libc_o)
+        .arg(&libc_o);
+    for o in &csrc_objs {
+        cmd.arg(o);
+    }
+    cmd
         .arg("--no-entry")
         .arg("--export-if-defined=main")
         .arg("--export=__heap_base")

--- a/docs/src/systems/webassembly.md
+++ b/docs/src/systems/webassembly.md
@@ -213,3 +213,38 @@ state cell exists for the free-fn path and for hand-rolled layouts.
 
 See [`spec/ffi.md` § WASM host interface](https://github.com/hale-lang/hale/blob/main/spec/ffi.md) for the
 exact marshalling and diagnostic rules.
+
+## C from a package
+
+If a package ships C alongside its Hale — a `[ffi] csrc` list in its
+`hale.toml` — those sources are compiled for wasm32 and linked into
+your module, the same as the runtime's own C.
+
+Two things are different here from a native build, and both will stop
+you rather than surprise you later.
+
+**The wasm build is freestanding.** There is no libc sysroot: the
+runtime compiles against a small forward-declared shim, not wasi-sdk.
+A C file that `#include`s `<string.h>` builds natively and does not
+build for wasm. You get a build error naming the file.
+
+**`link = [...]` doesn't exist here.** It names a system dynamic
+library, and the browser has no dynamic linker. That's an error, not a
+silent omission — if you need the code, it has to come in as `csrc`.
+
+One footgun worth knowing before you write the C. Hale's `Int` is
+**64-bit**, so the declaration must be `long long`:
+
+```c
+long long tsa_answer(long long n) { return n * 6; }   /* right */
+int       tsa_answer(int n)       { return n * 6; }   /* links, then traps */
+```
+
+The second one links and then fails at the call with a wasm
+`signature_mismatch`. That's abrupt, but it is the good outcome: on a
+native target the same mismatch quietly truncates instead.
+
+*(Before Hale 0.12, package `csrc` was skipped for wasm entirely and
+those symbols became stubs returning 0 — a build that looked fine and
+a program that silently did nothing. If you have a workaround
+supplying them from JS, it can go.)*

--- a/spec/ffi.md
+++ b/spec/ffi.md
@@ -344,6 +344,37 @@ host rather than a C library. The same `@ffi` machinery serves the
 inbound direction, and a dual annotation `@export` serves the
 outbound direction.
 
+### Package `[ffi]` under wasm32
+
+A package's `[ffi] csrc` translation units **are compiled for wasm32**
+and linked into the module (#213, 2026-08-03). Before that they were
+silently skipped: `link_wasm` was invoked without the build options,
+so every `@ffi("c")` symbol a package defined in C surfaced as an
+undefined `env` import, `--allow-undefined` swallowed it, and the
+generated JS loader stubbed unknown imports with `() => 0`. The build
+reported success and every such call returned 0 forever.
+
+Two constraints follow from the wasm build being **freestanding**:
+
+- **No libc sysroot.** The runtime is compiled with bare
+  `--target=wasm32` against a forward-declared shim, not wasi-sdk.
+  There are no system headers, so a translation unit that
+  `#include`s `<string.h>` will not compile for this target. That is
+  now a build error naming the file, rather than a silently missing
+  symbol.
+- **`[ffi] link = [...]` is rejected.** It names a system dynamic
+  library, and wasm has neither a dynamic linker nor system
+  libraries. Dropping it silently would reproduce the same failure one
+  level up, so it is an error that points at `csrc` as the
+  alternative.
+
+One sharp edge worth stating, because linking the C is what exposes
+it: **Hale's `Int` is 64-bit, so a C declaration must use `long long`,
+not `int`.** A mismatch links, and then traps at call time with a wasm
+`signature_mismatch`. That is louder than the native ABI, which would
+quietly truncate — and far louder than the previous behaviour, where
+the symbol was a stub and the mismatch could not be observed at all.
+
 ### The `target` declaration + stdlib gating
 
 The program opts into the wasm backend with a top-level `target`


### PR DESCRIPTION
Closes #213 — both parts, and the feature turned out to subsume the diagnostic.

## The bug was one missing argument

```rust
link_wasm(&obj_path, output_path, &cx.wasm_exports)   // `options` never passed
```

So `csrc_files` and `link_libs` never reached the wasm path at all. Every `@ffi("c")` symbol a package defined in C surfaced as an undefined `env` import; `--allow-undefined` swallowed it (it's there so libc-output residue can be host-provided), and the JS loader stubbed unknown imports with `() => 0`. **The build reported success and every call returned 0 forever.**

The machinery was already present — `link_wasm` has a `cc` closure compiling C to wasm32 objects, which is how the arena core and bundled libc get built. The fix threads the options through and runs each csrc unit through that same closure.

## Two constraints, both now errors rather than silence

**No libc sysroot.** The wasm build is freestanding — the runtime compiles against a forward-declared shim, not wasi-sdk. A unit that `#include`s system headers cannot build for this target. The diagnostic names the file and says *why* a source that builds natively doesn't build here; a bare clang error would leave the reader guessing.

**`[ffi] link = [...]` is rejected.** It names a system dynamic library and wasm has no dynamic linker. Dropping it silently would reproduce this exact bug one level up, so it errors and points at `csrc` as the alternative.

## A sharp edge that only appeared once the C actually linked

Hale's `Int` is 64-bit, so the C must declare `long long`:

```c
long long tsa_answer(long long n) { return n * 6; }   /* right */
int       tsa_answer(int n)       { return n * 6; }   /* links, then traps */
```

The second links and then fails at the call with a wasm `signature_mismatch`. I hit this while verifying the fix. It's abrupt, but it's the good outcome — the native ABI would quietly truncate, and the previous behaviour made the mismatch unobservable because the symbol was a stub. Documented rather than papered over.

## The tests discriminate on the right bit

Before the fix, the build **succeeded** — so "it builds" proves nothing. The discriminator is that a csrc with a syntax error must now *fail* the build, which can only happen if the source reaches a compiler. No wasm parsing needed for a one-bit signal.

Verified end to end separately: `wasm-ld` reports the symbol *"defined as (i32) -> i32 in csrc0.o"* rather than importing it, and the exported entry returns the right value (`go(7) = 42n`).

## Docs

`spec/ffi.md` said nothing about package csrc under wasm — the issue called this out — and neither did the WebAssembly chapter. Both now specify it, including the `long long` footgun and a note that any JS-side workaround supplying those symbols can be deleted.

2083/2083 tests, zero warnings, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
