### PR TITLE
form: clone-on-read for synced hashmaps, enabling retirement

### DIFF
--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -438,6 +438,22 @@ typedef struct lotus_arena {
      * the bind is a no-op and the arena allocates normally. Set at
      * create time via `lotus_arena_create_labeled_on_node`. */
     int                  numa_node;
+    /* Synced-map retirement (2026-08-03, downstream handoff P1).
+     * A `sync = serialized` @form(hashmap) is written from more
+     * than one pool, so its retire lists (pending / shells / free /
+     * free_small) are touched by more than one thread: pushes come
+     * from the set path under the MAP's mutex, but flushes come
+     * from each writer's own activation boundary with no map lock
+     * held, and pops come from the allocator. This mutex serializes
+     * all three. It is DISTINCT from subregion_lock on purpose —
+     * the push path allocates a shell via lotus_arena_alloc, which
+     * takes subregion_lock when shared_concurrent is set, so a
+     * single lock would self-deadlock. Lock order is retire_lock
+     * then subregion_lock, never the reverse.
+     *
+     * Taken only when shared_concurrent is set, so every
+     * single-threaded arena keeps the untouched lock-free path. */
+    pthread_mutex_t      retire_lock;
 } lotus_arena_t;
 
 /* Per-thread freelist of default-sized chunks (2026-05-21
@@ -1549,6 +1565,7 @@ static lotus_arena_t *lotus_arena_alloc_struct(void) {
     a->next_slot  = 0;
     a->fixed_size = 0;
     a->shared_concurrent = 0;
+    pthread_mutex_init(&a->retire_lock, NULL);
     a->chunk_byte_total = 0;
     a->chunk_byte_cap   = 0;
     a->cap_diag_name    = NULL;
@@ -1990,6 +2007,16 @@ void *lotus_arena_alloc(lotus_arena_t *a, uint64_t size, uint64_t align) {
     return lotus_arena_alloc_nolock(a, size, align);
 }
 
+/* Mark an arena as concurrently reachable: serializes the bump
+ * allocator on subregion_lock and the retire lists on retire_lock.
+ * Codegen emits this at instantiation for a @form locus hosting a
+ * SYNCED hashmap, whose blobs are allocated, retired and flushed
+ * from more than one pool. Idempotent. */
+void lotus_arena_mark_shared(void *arena_ptr) {
+    lotus_arena_t *a = (lotus_arena_t *)arena_ptr;
+    if (a) a->shared_concurrent = 1;
+}
+
 void lotus_arena_destroy(lotus_arena_t *a) {
     if (!a) return;
 
@@ -2068,6 +2095,10 @@ void lotus_arena_destroy(lotus_arena_t *a) {
      * mutex holds no resources to release (perf opt, 2026-05-29;
      * reuses mt_barrier read above). */
     if (mt_barrier) pthread_mutex_destroy(&a->subregion_lock);
+    /* retire_lock is pthread_mutex_init'd unconditionally at create
+     * (unlike subregion_lock's static init), so it is destroyed
+     * unconditionally too. */
+    pthread_mutex_destroy(&a->retire_lock);
     free(a);
 }
 
@@ -3928,7 +3959,55 @@ static size_t lotus_hashmap_find_slot_striped(lotus_hashmap_t *m,
     }
 }
 
-int lotus_hashmap_get(void *map_ptr, const void *key, void *out_value) {
+/* Clone-on-get for SYNCED maps (2026-08-03, downstream handoff P1).
+ *
+ * A plain get memcpy's the cell, so its String fields come out as
+ * raw pointers into the MAP's arena. For `sync = none` that is fine:
+ * one thread, and retirement is deferred to that thread's activation
+ * boundary, so the pointer stays valid for exactly as long as the
+ * reader can hold it. For a SYNCED map it is not — the reader is on
+ * another pool and can hold the pointer across the writer's
+ * boundaries. That is why synced maps never installed a retire
+ * descriptor at all: the leak WAS the safety mechanism.
+ *
+ * Cloning the strings out, under the same lock that read the cell,
+ * makes the reader own its copy. The writer's blobs then have no
+ * off-thread readers and can retire exactly like `sync = none` —
+ * reusing the whole shipped retirement path instead of needing an
+ * epoch scheme.
+ *
+ * The clone MUST happen inside the critical section: between an
+ * unlock and the clone, a writer could overwrite the slot, retire
+ * the old blob, and flush it onto the reuse freelist.
+ *
+ * Destination is the CALLER's arena (its method scratch, in
+ * practice), which is where the returned cell buffer already lives —
+ * so the clone shares the lifetime of the struct that holds it.
+ * `dest == NULL`, or a map with no String fields, is a plain get. */
+char *lotus_str_clone(lotus_arena_t *a, const char *s);
+
+static void lotus_hashmap_clone_out_strings(const lotus_hashmap_t *m,
+                                            void *out_value,
+                                            void *dest_arena) {
+    if (!dest_arena || m->retire_n == 0) return;
+    char *v = (char *)out_value;
+    for (int32_t ri = 0; ri < m->retire_n; ri++) {
+        int32_t off = m->retire_offsets[ri];
+        char *p;
+        memcpy(&p, v + off, sizeof(char *));
+        if (!p) continue;
+        /* Static literals and pointers already in `dest` pass
+         * through untouched (lotus_str_clone's own fast paths).
+         * Two fields aliasing one blob become two blobs — that is
+         * the single-owner rule, not a regression. */
+        char *c = lotus_str_clone((lotus_arena_t *)dest_arena, p);
+        if (!c) continue;
+        memcpy(v + off, &c, sizeof(char *));
+    }
+}
+
+static int lotus_hashmap_get_into(void *map_ptr, const void *key,
+                                  void *out_value, void *dest_arena) {
     if (!map_ptr || !key || !out_value) return 0;
     lotus_hashmap_t *m = (lotus_hashmap_t *)map_ptr;
     if (m->sync_mode == LOTUS_HASHMAP_SYNC_LOCKFREE) {
@@ -3941,6 +4020,7 @@ int lotus_hashmap_get(void *map_ptr, const void *key, void *out_value) {
             if (i < m->cap) {
                 char *slot = m->slots + i * lotus_hashmap_entry_size(m);
                 memcpy(out_value, slot + 1 + m->key_size, m->value_size);
+                lotus_hashmap_clone_out_strings(m, out_value, dest_arena);
                 r = 1;
             }
         }
@@ -3955,6 +4035,7 @@ int lotus_hashmap_get(void *map_ptr, const void *key, void *out_value) {
             if (i < m->cap) {
                 char *slot = m->slots + i * lotus_hashmap_entry_size(m);
                 memcpy(out_value, slot + 1 + m->key_size, m->value_size);
+                lotus_hashmap_clone_out_strings(m, out_value, dest_arena);
                 r = 1;
             }
         }
@@ -3973,11 +4054,23 @@ int lotus_hashmap_get(void *map_ptr, const void *key, void *out_value) {
             r = 0;
         } else {
             memcpy(out_value, slot + 1 + m->key_size, m->value_size);
+            lotus_hashmap_clone_out_strings(m, out_value, dest_arena);
             r = 1;
         }
     }
     lotus_hashmap_unlock(m);
     return r;
+}
+
+int lotus_hashmap_get(void *map_ptr, const void *key, void *out_value) {
+    return lotus_hashmap_get_into(map_ptr, key, out_value, NULL);
+}
+
+/* Codegen emits this instead of `lotus_hashmap_get` when the slot is
+ * a synced map with String cell fields. See the note above. */
+int lotus_hashmap_get_cloned(void *map_ptr, const void *key,
+                             void *out_value, void *dest_arena) {
+    return lotus_hashmap_get_into(map_ptr, key, out_value, dest_arena);
 }
 
 int lotus_hashmap_has(void *map_ptr, const void *key) {
@@ -4819,9 +4912,11 @@ int64_t lotus_hashmap_iter_next(void *map_ptr, int64_t start_slot,
  * BATCH instead of per element — the follow-up to iter_next that
  * closes the per-element call overhead against native iterators.
  * Occupancy/locking discipline mirrors iter_next. */
-int64_t lotus_hashmap_iter_batch(void *map_ptr, int64_t start_slot,
-                                 void *out_buf, int64_t max,
-                                 int64_t *out_next) {
+static int64_t lotus_hashmap_iter_batch_into(void *map_ptr,
+                                            int64_t start_slot,
+                                            void *out_buf, int64_t max,
+                                            int64_t *out_next,
+                                            void *dest_arena) {
     if (!map_ptr || !out_buf || !out_next || start_slot < 0 || max <= 0) {
         if (out_next) *out_next = -1;
         return 0;
@@ -4844,6 +4939,7 @@ int64_t lotus_hashmap_iter_batch(void *map_ptr, int64_t start_slot,
                 __atomic_load_n((unsigned char *)slot, __ATOMIC_ACQUIRE);
             if (occ == LOTUS_CELL_COMMITTED) {
                 memcpy(dst, slot + 1 + m->key_size, m->value_size);
+                lotus_hashmap_clone_out_strings(m, dst, dest_arena);
                 dst += m->value_size;
                 n++;
             }
@@ -4858,6 +4954,7 @@ int64_t lotus_hashmap_iter_batch(void *map_ptr, int64_t start_slot,
         char *slot = m->slots + s * es;
         if (*(unsigned char *)slot) {
             memcpy(dst, slot + 1 + m->key_size, m->value_size);
+                lotus_hashmap_clone_out_strings(m, dst, dest_arena);
             dst += m->value_size;
             n++;
         }
@@ -4865,6 +4962,26 @@ int64_t lotus_hashmap_iter_batch(void *map_ptr, int64_t start_slot,
     if (s < m->cap) *out_next = (int64_t)s;
     lotus_hashmap_unlock(m);
     return n;
+}
+
+int64_t lotus_hashmap_iter_batch(void *map_ptr, int64_t start_slot,
+                                 void *out_buf, int64_t max,
+                                 int64_t *out_next) {
+    return lotus_hashmap_iter_batch_into(map_ptr, start_slot, out_buf,
+                                         max, out_next, NULL);
+}
+
+/* Synced-map iteration: clone each cell's Strings into the caller's
+ * arena so the writer may retire its own. Without this, enabling
+ * retirement on synced maps would turn the old leak into a
+ * use-after-free the moment an iteration outlived a concurrent set.
+ * See lotus_hashmap_get_cloned. */
+int64_t lotus_hashmap_iter_batch_cloned(void *map_ptr, int64_t start_slot,
+                                        void *out_buf, int64_t max,
+                                        int64_t *out_next,
+                                        void *dest_arena) {
+    return lotus_hashmap_iter_batch_into(map_ptr, start_slot, out_buf,
+                                         max, out_next, dest_arena);
 }
 
 /* Pointer-mode batch for PLAIN (sync = none, single-pool) maps:
@@ -4901,6 +5018,16 @@ int64_t lotus_hashmap_iter_batch_ptrs(void *map_ptr, int64_t start_slot,
 
 int lotus_arena_contains_ptr(const lotus_arena_t *a, const void *p);
 
+/* Retire-list guards. No-ops on a private arena (the overwhelming
+ * majority); a real lock only on an arena backing a synced map.
+ * See the retire_lock field comment for the ordering rule. */
+static inline void lotus_retire_lock(lotus_arena_t *a) {
+    if (a->shared_concurrent) pthread_mutex_lock(&a->retire_lock);
+}
+static inline void lotus_retire_unlock(lotus_arena_t *a) {
+    if (a->shared_concurrent) pthread_mutex_unlock(&a->retire_lock);
+}
+
 typedef struct lotus_retire_shell {
     void *blob;                    /* [i64 len][bytes][NUL] blob   */
     size_t size;                   /* full block size              */
@@ -4915,18 +5042,20 @@ static void lotus_arena_retire_sized(lotus_arena_t *a, void *blob,
                                      size_t size) {
     if (!a || !blob) return;
     if (!lotus_arena_contains_ptr(a, blob)) return;
+    lotus_retire_lock(a);
     lotus_retire_shell_t *sh = (lotus_retire_shell_t *)a->retire_shells;
     if (sh) {
         a->retire_shells = sh->next;
     } else {
         sh = (lotus_retire_shell_t *)lotus_arena_alloc(
             a, sizeof(lotus_retire_shell_t), 8);
-        if (!sh) return;
+        if (!sh) { lotus_retire_unlock(a); return; }
     }
     sh->blob = blob;
     sh->size = size;
     sh->next = (lotus_retire_shell_t *)a->retire_pending;
     a->retire_pending = sh;
+    lotus_retire_unlock(a);
 }
 
 /* Hale Strings are NUL-terminated char* — the clone family
@@ -5081,6 +5210,7 @@ void lotus_form_retire_replaced(void *arena_ptr, void *old_blob,
 void lotus_arena_flush_retired(void *arena_ptr) {
     lotus_arena_t *a = (lotus_arena_t *)arena_ptr;
     if (!a) return;
+    lotus_retire_lock(a);
     lotus_retire_shell_t *sh = (lotus_retire_shell_t *)a->retire_pending;
     a->retire_pending = NULL;
     while (sh) {
@@ -5109,6 +5239,7 @@ void lotus_arena_flush_retired(void *arena_ptr) {
         }
         sh = next;
     }
+    lotus_retire_unlock(a);
 }
 
 /* Bounded first-fit pop for the allocator (mirrors the
@@ -5184,9 +5315,14 @@ void *lotus_arena_alloc_reusable(void *arena_ptr, uint64_t size,
      * candidate ADDRESS alignment, so a 16-align request simply
      * skips under-aligned blocks. */
     if (align <= 16) {
+        /* Lock released before the fall-through: lotus_arena_alloc
+         * takes subregion_lock, and holding both would invert the
+         * documented order on the push path. */
+        lotus_retire_lock(a);
         void *b = size >= 16
             ? lotus_retire_free_pop(a, (size_t)size, (size_t)align)
             : lotus_retire_free_small_pop(a, (size_t)size, (size_t)align);
+        lotus_retire_unlock(a);
         if (b) return b;
     }
     return lotus_arena_alloc(a, size, align);
@@ -5242,7 +5378,9 @@ int lotus_hashmap_key_at(void *map_ptr, int64_t i, void *out_key) {
     return r;
 }
 
-int lotus_hashmap_value_at(void *map_ptr, int64_t i, void *out_value) {
+static int lotus_hashmap_value_at_into(void *map_ptr, int64_t i,
+                                      void *out_value,
+                                      void *dest_arena) {
     if (!map_ptr || !out_value || i < 0) return 0;
     lotus_hashmap_t *m = (lotus_hashmap_t *)map_ptr;
     if (m->sync_mode == LOTUS_HASHMAP_SYNC_LOCKFREE) {
@@ -5255,6 +5393,7 @@ int lotus_hashmap_value_at(void *map_ptr, int64_t i, void *out_value) {
                 size_t es = lotus_hashmap_entry_size(m);
                 char *slot = m->slots + s * es;
                 memcpy(out_value, slot + 1 + m->key_size, m->value_size);
+                lotus_hashmap_clone_out_strings(m, out_value, dest_arena);
                 r = 1;
             }
         }
@@ -5271,6 +5410,7 @@ int lotus_hashmap_value_at(void *map_ptr, int64_t i, void *out_value) {
                 size_t es = lotus_hashmap_entry_size(m);
                 char *slot = m->slots + s * es;
                 memcpy(out_value, slot + 1 + m->key_size, m->value_size);
+                lotus_hashmap_clone_out_strings(m, out_value, dest_arena);
                 r = 1;
             }
         }
@@ -5285,11 +5425,23 @@ int lotus_hashmap_value_at(void *map_ptr, int64_t i, void *out_value) {
             size_t es = lotus_hashmap_entry_size(m);
             char *slot = m->slots + s * es;
             memcpy(out_value, slot + 1 + m->key_size, m->value_size);
+                lotus_hashmap_clone_out_strings(m, out_value, dest_arena);
             r = 1;
         }
     }
     lotus_hashmap_unlock(m);
     return r;
+}
+
+int lotus_hashmap_value_at(void *map_ptr, int64_t i, void *out_value) {
+    return lotus_hashmap_value_at_into(map_ptr, i, out_value, NULL);
+}
+
+/* Synced-map read: clone the cell's Strings into the caller's arena
+ * so the writer may retire its own. See lotus_hashmap_get_cloned. */
+int lotus_hashmap_value_at_cloned(void *map_ptr, int64_t i,
+                                  void *out_value, void *dest_arena) {
+    return lotus_hashmap_value_at_into(map_ptr, i, out_value, dest_arena);
 }
 
 void lotus_hashmap_destroy(void *map_ptr) {

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -18285,32 +18285,68 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // fill: one batch call; count entries land in buf, the
         // resume slot (or -1) lands in cursor_slot.
         self.builder.position_at_end(fill_bb);
-        let batch_fn = self
-            .module
-            .get_function(if ptr_mode {
-                "lotus_hashmap_iter_batch_ptrs"
-            } else {
-                "lotus_hashmap_iter_batch"
-            })
-            .expect("iter_batch declared");
-        let count = self
-            .builder
-            .build_call(
-                batch_fn,
-                &[
-                    map_handle.into(),
-                    cursor.into(),
-                    buf.into(),
-                    i64_t.const_int(BATCH, false).into(),
-                    cursor_slot.into(),
-                ],
-                "for.entries.batch",
-            )
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
-            .try_as_basic_value()
-            .left()
-            .expect("iter_batch returns i64")
-            .into_int_value();
+        // Downstream handoff P1 (2026-08-03): iterating a synced
+        // String-bearing map clones each cell's Strings into this
+        // activation's arena, for the same reason `get` does.
+        // Without it, enabling the writer's retirement would turn
+        // the old leak into a use-after-free the moment an
+        // iteration overlapped a concurrent set.
+        let synced_clone_reads = slot.sync_mode == SyncMode::Serialized
+            && cell_info
+                .fields
+                .values()
+                .any(|(_, t)| matches!(t, CodegenTy::String));
+        let count = if synced_clone_reads {
+            let dest = self.current_arena_ptr()?;
+            let batch_fn = self
+                .module
+                .get_function("lotus_hashmap_iter_batch_cloned")
+                .expect("iter_batch_cloned declared");
+            self.builder
+                .build_call(
+                    batch_fn,
+                    &[
+                        map_handle.into(),
+                        cursor.into(),
+                        buf.into(),
+                        i64_t.const_int(BATCH, false).into(),
+                        cursor_slot.into(),
+                        dest.into(),
+                    ],
+                    "for.entries.batch.cloned",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                .try_as_basic_value()
+                .left()
+                .expect("iter_batch returns i64")
+                .into_int_value()
+        } else {
+            let batch_fn = self
+                .module
+                .get_function(if ptr_mode {
+                    "lotus_hashmap_iter_batch_ptrs"
+                } else {
+                    "lotus_hashmap_iter_batch"
+                })
+                .expect("iter_batch declared");
+            self.builder
+                .build_call(
+                    batch_fn,
+                    &[
+                        map_handle.into(),
+                        cursor.into(),
+                        buf.into(),
+                        i64_t.const_int(BATCH, false).into(),
+                        cursor_slot.into(),
+                    ],
+                    "for.entries.batch",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                .try_as_basic_value()
+                .left()
+                .expect("iter_batch returns i64")
+                .into_int_value()
+        };
         self.builder
             .build_store(count_slot, count)
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
@@ -28858,11 +28894,14 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                                     matches!(
                                         sl.form,
                                         Some(SlotForm::Hashmap)
-                                    ) && sl.sync_mode == SyncMode::None
-                                        && matches!(
-                                            sl.elem_ty,
-                                            CodegenTy::TypeRef(_)
-                                        )
+                                    ) && matches!(
+                                        sl.sync_mode,
+                                        SyncMode::None
+                                            | SyncMode::Serialized
+                                    ) && matches!(
+                                        sl.elem_ty,
+                                        CodegenTy::TypeRef(_)
+                                    )
                                 })
                             })
                             .unwrap_or(false)
@@ -28932,11 +28971,13 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                                 matches!(
                                     sl.form,
                                     Some(SlotForm::Hashmap)
-                                ) && sl.sync_mode == SyncMode::None
-                                    && matches!(
-                                        sl.elem_ty,
-                                        CodegenTy::TypeRef(_)
-                                    )
+                                ) && matches!(
+                                    sl.sync_mode,
+                                    SyncMode::None | SyncMode::Serialized
+                                ) && matches!(
+                                    sl.elem_ty,
+                                    CodegenTy::TypeRef(_)
+                                )
                             },
                         );
                         if retires {

--- a/crates/hale-codegen/src/form/mod.rs
+++ b/crates/hale-codegen/src/form/mod.rs
@@ -9,6 +9,7 @@
 
 pub(crate) mod bounded;
 
+use crate::codegen::SyncMode;
 use hale_syntax::ast::Expr;
 use inkwell::types::BasicType;
 use inkwell::values::{BasicValueEnum, IntValue, PointerValue};
@@ -1221,6 +1222,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 .map(Some);
         }
 
+        // Downstream handoff P1 (2026-08-03): a `sync = serialized`
+        // map's cell Strings are cloned into the reader's arena at
+        // every read, which is what lets the writer retire the
+        // blobs it replaces. Only cells that actually carry Strings
+        // pay for it; everything else keeps the plain read.
+        let synced_clone_reads = slot.sync_mode == SyncMode::Serialized
+            && cell_info
+                .fields
+                .values()
+                .any(|(_, t)| matches!(t, CodegenTy::String));
+
         let payload_ty = CodegenTy::TypeRef("KeyError".to_string());
 
         if args.len() != 1 {
@@ -1276,26 +1288,53 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 self.builder
                     .build_store(out_val_slot, value_buf_ptr)
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                let get_fn = self
-                    .module
-                    .get_function("lotus_hashmap_get")
-                    .expect("lotus_hashmap_get declared");
-                let c_ret = self
-                    .builder
-                    .build_call(
-                        get_fn,
-                        &[
-                            hashmap_field_ptr.into(),
-                            key_alloca.into(),
-                            value_buf_ptr.into(),
-                        ],
-                        &format!("{}.get.call", locus_name),
-                    )
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
-                    .try_as_basic_value()
-                    .left()
-                    .expect("lotus_hashmap_get returns i32")
-                    .into_int_value();
+                // Synced map: clone the cell's Strings out into the
+                // arena that already owns `value_buf_ptr`, inside
+                // the lock that read the cell, so the writer may
+                // retire its own blobs (downstream handoff P1).
+                let c_ret = if synced_clone_reads {
+                    let dest = self.current_arena_ptr()?;
+                    let get_fn = self
+                        .module
+                        .get_function("lotus_hashmap_get_cloned")
+                        .expect("lotus_hashmap_get_cloned declared");
+                    self.builder
+                        .build_call(
+                            get_fn,
+                            &[
+                                hashmap_field_ptr.into(),
+                                key_alloca.into(),
+                                value_buf_ptr.into(),
+                                dest.into(),
+                            ],
+                            &format!("{}.get.cloned.call", locus_name),
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                        .try_as_basic_value()
+                        .left()
+                        .expect("lotus_hashmap_get_cloned returns i32")
+                        .into_int_value()
+                } else {
+                    let get_fn = self
+                        .module
+                        .get_function("lotus_hashmap_get")
+                        .expect("lotus_hashmap_get declared");
+                    self.builder
+                        .build_call(
+                            get_fn,
+                            &[
+                                hashmap_field_ptr.into(),
+                                key_alloca.into(),
+                                value_buf_ptr.into(),
+                            ],
+                            &format!("{}.get.call", locus_name),
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                        .try_as_basic_value()
+                        .left()
+                        .expect("lotus_hashmap_get returns i32")
+                        .into_int_value()
+                };
                 (c_ret, Some(out_val_slot), Some(value_codegen_ty.clone()))
             }
             "remove" => {
@@ -1381,7 +1420,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     pub(crate) fn lower_form_hashmap_index_method(
         &mut self,
         _info: &LocusInfo<'ctx>,
-        _slot: &CapacitySlotLayout,
+        slot_decl: &CapacitySlotLayout,
         cell_info: &TypeInfo<'ctx>,
         _cell_name: String,
         key_codegen_ty: CodegenTy,
@@ -1447,26 +1486,61 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             _ => unreachable!("matched by caller"),
         };
 
-        let c_fn = self
-            .module
-            .get_function(c_fn_name)
-            .expect("hashmap index primitive declared");
-        let c_ret = self
-            .builder
-            .build_call(
-                c_fn,
-                &[
-                    hashmap_field_ptr.into(),
-                    idx_int.into(),
-                    out_buf_ptr.into(),
-                ],
-                &format!("{}.{}.call", locus_name, method_name),
-            )
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
-            .try_as_basic_value()
-            .left()
-            .expect("hashmap index primitive returns i32")
-            .into_int_value();
+        // Downstream handoff P1 (2026-08-03): `entry_at` on a
+        // synced String-bearing map takes the cloning variant, for
+        // the same reason `get` does — a raw cell pointer handed
+        // off-thread would be freed under the reader once the
+        // writer's retirement is enabled. `key_at` copies a key,
+        // not a cell, so it is unaffected.
+        let synced_clone_reads = c_fn_name == "lotus_hashmap_value_at"
+            && slot_decl.sync_mode == SyncMode::Serialized
+            && cell_info
+                .fields
+                .values()
+                .any(|(_, t)| matches!(t, CodegenTy::String));
+        let c_ret = if synced_clone_reads {
+            let dest = self.current_arena_ptr()?;
+            let c_fn = self
+                .module
+                .get_function("lotus_hashmap_value_at_cloned")
+                .expect("lotus_hashmap_value_at_cloned declared");
+            self.builder
+                .build_call(
+                    c_fn,
+                    &[
+                        hashmap_field_ptr.into(),
+                        idx_int.into(),
+                        out_buf_ptr.into(),
+                        dest.into(),
+                    ],
+                    &format!("{}.{}.cloned.call", locus_name, method_name),
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                .try_as_basic_value()
+                .left()
+                .expect("hashmap index primitive returns i32")
+                .into_int_value()
+        } else {
+            let c_fn = self
+                .module
+                .get_function(c_fn_name)
+                .expect("hashmap index primitive declared");
+            self.builder
+                .build_call(
+                    c_fn,
+                    &[
+                        hashmap_field_ptr.into(),
+                        idx_int.into(),
+                        out_buf_ptr.into(),
+                    ],
+                    &format!("{}.{}.call", locus_name, method_name),
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                .try_as_basic_value()
+                .left()
+                .expect("hashmap index primitive returns i32")
+                .into_int_value()
+        };
 
         // For key_at, we need to materialize the surface value
         // from the buffer (the C primitive memcpyd into it but

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -1514,19 +1514,75 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                             CodegenTy::TypeRef(n) => Some(n.clone()),
                             _ => None,
                         };
-                        // sync = none ONLY: synced maps are read
-                        // cross-pool, and a reader on another
-                        // thread can hold a cell copy's string
-                        // pointer across THIS pool's activation
-                        // boundaries — retirement there needs an
-                        // epoch scheme, not a flush.
-                        let cell_name = if slot.sync_mode
-                            == SyncMode::None
-                        {
+                        // 2026-08-03 (downstream handoff P1):
+                        // synced maps retire too, now that their
+                        // READ paths clone the cell's Strings into
+                        // the caller's arena
+                        // (lotus_hashmap_*_cloned). Previously the
+                        // descriptor was withheld for sync != none
+                        // because a reader on another pool could
+                        // hold a cell copy's string pointer across
+                        // this pool's activation boundaries — the
+                        // leak was what kept that pointer valid.
+                        // Clone-on-read removes the off-thread
+                        // reader, so the ordinary flush is sound
+                        // and no epoch scheme is needed.
+                        //
+                        // `striped` and `lockfree` stay excluded:
+                        // their read paths are bracketed by
+                        // lf_enter/rwlock rather than the map
+                        // mutex, and their grow path rebuilds
+                        // slots concurrently — a separate audit.
+                        let cell_name = if matches!(
+                            slot.sync_mode,
+                            SyncMode::None | SyncMode::Serialized
+                        ) {
                             cell_name
                         } else {
                             None
                         };
+                        // A serialized map's arena is written from
+                        // more than one pool: serialize its bump
+                        // allocator and retire lists.
+                        if slot.sync_mode == SyncMode::Serialized {
+                            let arena_field = self
+                                .builder
+                                .build_struct_gep(
+                                    info.struct_ty,
+                                    self_ptr,
+                                    info.arena_field_idx,
+                                    "shared.arena.ptr",
+                                )
+                                .map_err(|e| {
+                                    CodegenError::LlvmEmit(e.to_string())
+                                })?;
+                            let ptr_ty = self
+                                .context
+                                .ptr_type(AddressSpace::default());
+                            let arena = self
+                                .builder
+                                .build_load(
+                                    ptr_ty,
+                                    arena_field,
+                                    "shared.arena",
+                                )
+                                .map_err(|e| {
+                                    CodegenError::LlvmEmit(e.to_string())
+                                })?;
+                            let mark_fn = self
+                                .module
+                                .get_function("lotus_arena_mark_shared")
+                                .expect("mark_shared declared");
+                            self.builder
+                                .build_call(
+                                    mark_fn,
+                                    &[arena.into()],
+                                    "arena.mark_shared",
+                                )
+                                .map_err(|e| {
+                                    CodegenError::LlvmEmit(e.to_string())
+                                })?;
+                        }
                         if let Some(cn) = cell_name {
                             if let Some(ci) = self.user_types.get(&cn) {
                                 let mut offs: Vec<u32> = Vec::new();

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -476,6 +476,55 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             i32_t.fn_type(&[ptr_t.into(), ptr_t.into(), ptr_t.into()], false);
         self.module
             .add_function("lotus_hashmap_get", hashmap_get_ty, None);
+        // Synced-map read variants (2026-08-03, downstream handoff
+        // P1): same shape plus a destination arena. They clone the
+        // cell's String fields into the CALLER's arena, inside the
+        // critical section that read the cell, so the map's writer
+        // is free to retire its own blobs. Emitted only for a slot
+        // with `sync != none` and a String-bearing cell — the plain
+        // entry points are unchanged.
+        let hashmap_get_cloned_ty = i32_t.fn_type(
+            &[ptr_t.into(), ptr_t.into(), ptr_t.into(), ptr_t.into()],
+            false,
+        );
+        self.module.add_function(
+            "lotus_hashmap_get_cloned",
+            hashmap_get_cloned_ty,
+            None,
+        );
+        let hashmap_value_at_cloned_ty = i32_t.fn_type(
+            &[ptr_t.into(), i64_t.into(), ptr_t.into(), ptr_t.into()],
+            false,
+        );
+        self.module.add_function(
+            "lotus_hashmap_value_at_cloned",
+            hashmap_value_at_cloned_ty,
+            None,
+        );
+        let hashmap_iter_batch_cloned_ty = i64_t.fn_type(
+            &[
+                ptr_t.into(),
+                i64_t.into(),
+                ptr_t.into(),
+                i64_t.into(),
+                ptr_t.into(),
+                ptr_t.into(),
+            ],
+            false,
+        );
+        self.module.add_function(
+            "lotus_hashmap_iter_batch_cloned",
+            hashmap_iter_batch_cloned_ty,
+            None,
+        );
+        // Marks a @form locus's arena as concurrently reachable
+        // (bump allocator + retire lists both serialize).
+        let arena_mark_shared_ty = void_t.fn_type(&[ptr_t.into()], false);
+        self.module.add_function(
+            "lotus_arena_mark_shared",
+            arena_mark_shared_ty,
+            None,
+        );
         let hashmap_has_ty =
             i32_t.fn_type(&[ptr_t.into(), ptr_t.into()], false);
         self.module

--- a/crates/hale-codegen/tests/form_hashmap_synced_retire.rs
+++ b/crates/hale-codegen/tests/form_hashmap_synced_retire.rs
@@ -1,0 +1,203 @@
+//! `@form(hashmap, sync = serialized)` clone-on-read + retirement
+//! (2026-08-03, downstream handoff P1).
+//!
+//! Until now a synced map never installed a retire descriptor, so
+//! replaced String clones accumulated in its arena for the life of
+//! the process. The reason was not oversight: a synced map's `get`
+//! memcpy's the cell, so its String fields come out as raw pointers
+//! into the MAP's arena, and a reader on another pool can hold one
+//! across the writer's activation boundaries. **The leak was the
+//! safety mechanism** — nothing was ever freed, so nothing dangled.
+//!
+//! The fix makes the reader own its copy: every read path on a
+//! synced String-bearing map (`get`, `entry_at`, and `for` iteration)
+//! clones the cell's Strings into the CALLER's arena, inside the same
+//! critical section that read the cell. With no off-thread reader of
+//! the map's blobs, the writer can retire exactly like `sync = none`
+//! and the shipped flush is sound — no epoch scheme needed.
+//!
+//! Covering all three read paths is load-bearing, not thoroughness:
+//! enabling the writer's retirement while leaving ANY read path
+//! handing out raw cell pointers would convert the old leak into a
+//! use-after-free, which is strictly worse than what it replaced.
+//! These tests exist mostly to be run under the ASan corpus oracle,
+//! where that failure is loud.
+
+use std::process::Command;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+use hale_codegen::build_executable;
+
+fn run_src(name: &str, src: &str) -> String {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(name);
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(
+        out.status.success(),
+        "binary exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// A value read out of a synced map stays intact across later
+/// activations that churn the same key. Without clone-on-get the
+/// held pointer is a retired blob that a subsequent set may already
+/// have recycled.
+#[test]
+fn value_read_from_a_synced_map_survives_later_churn() {
+    const SRC: &str = r#"
+        type Bal { acct: String; amt: String; }
+
+        @form(hashmap, sync = serialized)
+        locus Table { capacity { pool entries of Bal indexed_by acct; } }
+
+        main locus App {
+            params { t: Table = Table { }; seen: String = ""; }
+
+            fn seed() {
+                self.t.set(Bal { acct: "a" + "1", amt: "original-value" });
+            }
+            fn read_one() {
+                let r = self.t.get("a1") or { return; };
+                self.seen = r.amt;
+            }
+            fn churn(i: Int) {
+                self.t.set(Bal { acct: "a" + "1", amt: "replacement-" + to_string(i) });
+            }
+
+            run() {
+                self.seed();
+                self.read_one();
+                let mut i = 0;
+                while i < 500 { self.churn(i); i = i + 1; }
+                print("held="); println(self.seen);
+                let cur = self.t.get("a1") or { return; };
+                print("cur="); println(cur.amt);
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let out = run_src("synced_retire_survives", SRC);
+    assert!(
+        out.contains("held=original-value"),
+        "the earlier read must still hold its own copy after 500 \
+         replacements of the same key:\n{}",
+        out
+    );
+    assert!(
+        out.contains("cur=replacement-499"),
+        "the map must still hold the latest write:\n{}",
+        out
+    );
+}
+
+/// Iteration is the third read path. A `for` over a synced map
+/// batches VALUES out of the slots; those cells' Strings need the
+/// same clone, or an iteration overlapping a set reads freed bytes.
+#[test]
+fn iterating_a_synced_map_copies_its_strings() {
+    const SRC: &str = r#"
+        type Bal { acct: String; amt: String; }
+
+        @form(hashmap, sync = serialized)
+        locus Table { capacity { pool entries of Bal indexed_by acct; } }
+
+        main locus App {
+            params { t: Table = Table { }; total: Int = 0; }
+
+            fn fill(i: Int) {
+                self.t.set(Bal {
+                    acct: "k" + to_string(i),
+                    amt: "amount-" + to_string(i),
+                });
+            }
+            fn sweep() {
+                let mut n = 0;
+                for e in self.t.entries {
+                    if e.amt != "" { n = n + 1; }
+                }
+                self.total = n;
+            }
+
+            run() {
+                let mut i = 0;
+                while i < 64 { self.fill(i); i = i + 1; }
+                let mut r = 0;
+                while r < 20 { self.sweep(); r = r + 1; }
+                print("count="); println(self.total);
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let out = run_src("synced_retire_iter", SRC);
+    assert!(
+        out.contains("count=64"),
+        "every cell's cloned String must be readable:\n{}",
+        out
+    );
+}
+
+/// The shape that forces `sync = serialized` in the first place: two
+/// pools writing one map, with the owner reading it. Exercises the
+/// retire push (under the map mutex) against the flush (at each
+/// writer's own activation boundary, no map lock held) — the race
+/// the arena's `retire_lock` exists to serialize.
+#[test]
+fn cross_pool_churn_with_reads_stays_consistent() {
+    const SRC: &str = r#"
+        type Bal { acct: String; amt: String; }
+
+        @form(hashmap, sync = serialized)
+        locus Table { capacity { pool entries of Bal indexed_by acct; } }
+
+        locus Writer {
+            params { t: Table = Table { }; }
+            fn put(i: Int) {
+                self.t.set(Bal {
+                    acct: "k" + to_string(i % 32),
+                    amt: "written-" + to_string(i),
+                });
+            }
+            run() {
+                let mut i = 0;
+                while i < 4000 { self.put(i); i = i + 1; }
+                println("writer done");
+            }
+        }
+
+        main locus App {
+            params { w: Writer = Writer { }; hits: Int = 0; }
+            placement { w: cooperative(pool = io); }
+
+            fn probe(i: Int) {
+                let r = self.w.t.get("k" + to_string(i % 32)) or { return; };
+                if r.amt != "" { self.hits = self.hits + 1; }
+            }
+            run() {
+                let mut i = 0;
+                while i < 4000 { self.probe(i); i = i + 1; }
+                std::time::sleep(200ms);
+                print("hits_positive="); println(self.hits > 0);
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let out = run_src("synced_retire_crosspool", SRC);
+    assert!(
+        out.contains("hits_positive=true"),
+        "cross-pool reads must return live cloned values:\n{}",
+        out
+    );
+    assert!(
+        out.contains("writer done"),
+        "the io-pool writer must finish:\n{}",
+        out
+    );
+}

--- a/crates/hale-codegen/tests/form_hashmap_synced_retire.rs
+++ b/crates/hale-codegen/tests/form_hashmap_synced_retire.rs
@@ -149,6 +149,16 @@ fn iterating_a_synced_map_copies_its_strings() {
 /// retire push (under the map mutex) against the flush (at each
 /// writer's own activation boundary, no map lock held) — the race
 /// the arena's `retire_lock` exists to serialize.
+///
+/// The probe loop asserts EVENTUAL visibility, not instantaneous:
+/// main's `run()` starts as soon as the writer's run() is posted to
+/// the io worker, so a single up-front probe sweep races the
+/// worker's spawn — on a slow CI runner all 4000 probes completed
+/// before the writer had inserted anything (0 hits, red). The
+/// first fix for that race was accidental: the per-statement bus
+/// drains used to slow the probe loop enough for the writer to win,
+/// and #374's drain elision (this program is bus-inert) removed
+/// them. Probe in bounded sleep-separated rounds instead.
 #[test]
 fn cross_pool_churn_with_reads_stays_consistent() {
     const SRC: &str = r#"
@@ -180,9 +190,18 @@ fn cross_pool_churn_with_reads_stays_consistent() {
                 let r = self.w.t.get("k" + to_string(i % 32)) or { return; };
                 if r.amt != "" { self.hits = self.hits + 1; }
             }
-            run() {
+            fn sweep() {
                 let mut i = 0;
                 while i < 4000 { self.probe(i); i = i + 1; }
+            }
+            run() {
+                let mut round = 0;
+                while round < 200 {
+                    self.sweep();
+                    if self.hits > 0 { break; }
+                    std::time::sleep(10ms);
+                    round = round + 1;
+                }
                 std::time::sleep(200ms);
                 print("hits_positive="); println(self.hits > 0);
             }

--- a/notes/anchor-retirement.md
+++ b/notes/anchor-retirement.md
@@ -87,8 +87,7 @@ struct-field in-place shrink collapses the recorded capacity
 (strlen / len-prefix at retire under-reports after a fit-path
 shrink → reuse degrades on oscillating lengths, still sound — now
 applies to Bytes too); user methods on a @form locus never flush
-(the form-locus early-return); synced maps (needs an epoch scheme
-— cross-thread readers), vec cells (no retire; String elements
+(the form-locus early-return); vec cells (no retire; String elements
 pushed from self-storage still skip-share — benign until vec
 retire exists), run-loop direct sets (no activation boundary —
 pending list just holds; no worse than before). The TP-3 class
@@ -154,3 +153,55 @@ fields recurse to their own String leaves via the anchor walk).
 - The unbounded-alloc analysis keeps flagging these sites until the
   verdict model learns "anchor sites retire" — flip that only after
   the RSS bench proves the runtime behavior (no false bounded).
+
+SYNCED MAPS via CLONE-ON-READ (2026-08-03, downstream handoff P1).
+Previously listed here as "needs an epoch scheme — cross-thread
+readers". It does not. The reason a `sync = serialized` map never
+installed a retire descriptor is that `get` memcpy's the cell, so
+its String fields come out as raw pointers into the MAP's arena and
+an off-pool reader can hold one across the writer's activation
+boundaries — i.e. THE LEAK WAS THE SAFETY MECHANISM. Making the
+reader own its copy removes the off-thread reader entirely, and the
+ordinary flush becomes sound with no epoch machinery:
+
+ 1. Every read path on a synced String-bearing map clones the
+    cell's Strings into the CALLER's arena, INSIDE the critical
+    section that read the cell (between an unlock and the clone a
+    writer could overwrite, retire and flush the blob):
+    `lotus_hashmap_{get,value_at,iter_batch}_cloned`. Covering all
+    three is load-bearing — enabling retirement while leaving any
+    read path handing out raw cell pointers converts the leak into
+    a use-after-free, which is strictly worse.
+ 2. The descriptor is installed for `SyncMode::Serialized`, and the
+    activation-boundary flush gate widened to match. `striped` and
+    `lockfree` stay excluded: their reads bracket on lf_enter /
+    rwlock rather than the map mutex and their grow path rebuilds
+    slots concurrently — a separate audit.
+ 3. A serialized map's arena is marked `shared_concurrent`, which
+    serializes the bump allocator (existing) and the retire lists
+    (new `retire_lock`). Needed because pushes come from the set
+    path under the MAP mutex while flushes come from each writer's
+    own activation boundary with no map lock held. `retire_lock` is
+    DISTINCT from `subregion_lock` because the push path allocates
+    a shell through `lotus_arena_alloc`, which takes subregion_lock
+    — one lock would self-deadlock. Order: retire_lock, then
+    subregion_lock, never the reverse.
+
+MEASUREMENT CAVEAT — READ BEFORE CLAIMING P1 CLOSED. The safety
+properties are covered (tests/form_hashmap_synced_retire.rs, three
+read paths, cross-pool churn, plus the ASan corpus oracle). The
+SPACE win is NOT demonstrated: two reproducers built to the reported
+shape (bounded key domain, fresh key+value Strings per set, 64-byte
+values, 50k vs 400k sets, sets from a per-call method so the
+activation boundary actually flushes) show byte-identical RSS before
+and after — and, more to the point, show no growth with set count on
+the SHIPPED v0.13.0 either, so they do not reproduce the reported
+leak at all. Either the leak needs a shape neither reproducer
+captures, or something since the report already addressed it. Get
+the downstream team's own reproducer before recording P1 as fixed.
+Note the leak DOES reproduce for sets issued directly from a long
+`run()` body (66 MB -> 120 MB over 50k -> 400k), but that is the
+separate known residual above — a `run()` loop is one activation, so
+no flush boundary is ever crossed, and the growth there is method
+scratch rather than the map.
+


### PR DESCRIPTION
> **Please read the measurement caveat before merging.** The safety properties here are covered; the space win that motivated the work is **not demonstrated**. I would not record the upstream item as closed on the strength of this PR alone.

A `sync = serialized` `@form(hashmap)` never installed a retire descriptor, so replaced String clones accumulated in its arena for the life of the process. That was not an oversight. `get` memcpy's the cell, so its String fields come out as raw pointers into the **map's** arena, and a reader on another pool can hold one across the writer's activation boundaries. **The leak was the safety mechanism** — nothing was ever freed, so nothing dangled. `notes/anchor-retirement.md` recorded the remedy as "needs an epoch scheme — cross-thread readers".

It doesn't. Making the reader own its copy removes the off-thread reader entirely, and the already-shipped flush becomes sound with no epoch machinery at all.

## What changed

1. **Every read path** on a synced String-bearing map clones the cell's Strings into the *caller's* arena, **inside the critical section that read the cell** — between an unlock and the clone, a writer could overwrite, retire and flush the blob. That's `lotus_hashmap_{get,value_at,iter_batch}_cloned`.

   Covering all three is load-bearing rather than thorough: enabling the writer's retirement while leaving *any* read path handing out raw cell pointers would convert the old leak into a **use-after-free**, which is strictly worse than what it replaced. `get` alone was my first cut and it would have been a regression.

2. The descriptor is installed for `Serialized`, and the activation-boundary flush gate widened to match. `striped` and `lockfree` stay excluded — their reads bracket on `lf_enter`/rwlock rather than the map mutex, and their grow path rebuilds slots concurrently. Separate audit.

3. A serialized map's arena is marked `shared_concurrent`, serializing the bump allocator (existing) and the retire lists (new `retire_lock`). Pushes come from the set path under the **map** mutex; flushes come from each writer's own activation boundary with no map lock held. `retire_lock` is deliberately **distinct** from `subregion_lock`: the push path allocates a shell via `lotus_arena_alloc`, which takes `subregion_lock`, so a single lock would self-deadlock. Order is `retire_lock` then `subregion_lock`, never the reverse.

## Measurement caveat

Two reproducers built to the reported shape — bounded key domain, fresh key+value Strings per set, 64-byte values, 50k vs 400k sets, sets issued from a per-call method so the activation boundary actually flushes — show **byte-identical RSS before and after**. More to the point, they show **no growth with set count on the shipped v0.13.0 either**, so they do not reproduce the reported leak in the first place.

Either the leak needs a shape neither reproducer captures, or something since the report already addressed it. The upstream item should not be marked fixed until their own reproducer confirms it.

For completeness: the leak *does* reproduce for sets issued directly from a long `run()` body (66 MB → 120 MB across 50k → 400k sets), but that is the separate, already-known residual — a `run()` loop is a single activation, so no flush boundary is ever crossed, and the growth there is method scratch rather than the map.

## Tests

`crates/hale-codegen/tests/form_hashmap_synced_retire.rs` — three tests covering all three read paths, including cross-pool churn with concurrent reads. These are safety nets for the newly-enabled retirement (they pass on the old compiler too, where nothing is ever retired), and they earn their keep under the ASan corpus oracle. Existing hashmap/aliasing suites green: `form_hashmap_serialized`, `hashmap_cell_alias`, `hashmap`, `form_hashmap_codegen`, `form_hashmap_lockfree`, `self_field_alias`.
