### PR TITLE
perf: five hot-path fixes from bench attribution (scalar cells, drains, literals, obs gates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ behavior.
 
 ## Unreleased
 
+### Two hot-path regressions fixed (bench attribution vs released compilers)
+
+- **`@form` set/put on scalar-only cells no longer pays the cell
+  single-owner tax.** The v0.11.12 single-owner fix emitted a stack
+  snapshot + owned-clone walk on every set/put, but both exist solely
+  to keep heap-pointer (String/Bytes) leaves un-aliased — a cell of
+  pure scalars has nothing to protect, and the snapshot's
+  store-to-load round trip serialized hot insert loops. Now gated on
+  the cell type tree; unrecognized types conservatively keep the
+  snapshot. 1M Int-keyed inserts: 62.7 → 49.7ms.
+- **A no-op bus drain no longer builds its frame.** Codegen emits
+  `lotus_bus_queue_drain` at every statement boundary, scope exit and
+  sleep slice; the drain called `pthread_self` and the transport-loss
+  dispatcher before looking at the queue. In single-threaded mode
+  (`g_bus_has_pinned` unset — set pre-spawn by both pinned
+  registration and pool startup) an empty queue with nothing lost now
+  returns via a call-free fast path. Locus birth+dissolve cycle:
+  2.01 → 1.61ms, 6% faster than the v0.11.3 baseline.
+
 ### The birth-order trap is now diagnosed (downstream handoff)
 
 A params field whose `run()` runs inline on the main thread and never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,29 @@ behavior.
   store-to-load round trip serialized hot insert loops. Now gated on
   the cell type tree; unrecognized types conservatively keep the
   snapshot. 1M Int-keyed inserts: 62.7 → 49.7ms.
+- **`@form` set/put no longer arena-allocates the argument struct
+  literal.** `m.set(Entry { ... })` bump-allocated the literal's
+  shell into the enclosing scope's lifetime arena and then memcpy'd
+  it out — 16 MB of dead shells per million sets. A literal of the
+  exact cell type in set/put argument position now builds in a stack
+  slot (the pattern `lower_send` has used for publish payloads since
+  m67). 1M-insert bench maxrss 92.5 → 81.4 MB.
+- **A bundle that can never enqueue a bus cell emits no drains at
+  all.** Cells come only from subscriber dispatch, wire ingest,
+  cross-pool accept handoff and transport-loss dispatch; a program
+  with no topics, bus blocks, bindings, accepts or perspectives
+  provably has an empty queue at every statement boundary / scope
+  exit / sleep slice, so the drains are elided at emission.
+- **Runtime observation probes are now gated at the call site.** The
+  bus publish/deliver/net probes were called unconditionally from
+  the C dispatch path, paying the probe's prologue before its own
+  `obs_on()` check — +3ns/event on the 3-stage pipeline bench, the
+  v0.11.12 native-obs-emission regression. The C call sites now
+  branch on `lotus_obs_live`, the same dormant-cost gate generated
+  code has used since #328 (set in a pre-main constructor whenever
+  `LOTUS_OBS=1`, so 0 proves the probes are permanently dormant).
+  Pipeline bench restored to byte-parity with v0.11.11; obs
+  emission/fleet-contract suites unchanged.
 - **A no-op bus drain no longer builds its frame.** Codegen emits
   `lotus_bus_queue_drain` at every statement boundary, scope exit and
   sleep slice; the drain called `pthread_self` and the transport-loss

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -6257,9 +6257,30 @@ static __thread int g_bus_drain_active = 0;
 
 /* GH #233: defined with the remote-transport machinery below. */
 void lotus_bus_drain_lost_transports(void);
+extern volatile int g_transport_lost_pending;
 
 void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
     if (!q) return;
+    /* Fast path (2026-08-03, bench attribution): single-threaded
+     * mode + empty queue + no pending transport loss — this call
+     * can have no effect. It matters because codegen emits drains
+     * at every statement boundary, scope exit and sleep slice, so
+     * in a bus-less or idle program EVERY drain lands here; the
+     * full body below costs a 6-register prologue, a pthread_self
+     * call and a lost-transports call before it looks at the
+     * queue (measured: two such no-op drains were ~30% of a
+     * per-instantiation microbench iteration). Keeping this
+     * branch call-free lets shrink-wrapping skip the prologue.
+     *
+     * Soundness of the plain head/tail reads: g_bus_has_pinned is
+     * set (release, pre-spawn) by BOTH pinned-locus registration
+     * and cooperative-pool startup, so 0 here means no second
+     * thread exists at all — the same invariant the unlocked
+     * drain body below already relies on. With one thread there
+     * is no concurrent producer and no foreign drainer. */
+    if (!__atomic_load_n(&g_bus_has_pinned, __ATOMIC_ACQUIRE)
+        && q->head >= q->tail && !g_transport_lost_pending)
+        return;
     /* Owner-only handler execution (see the `owner` field comment).
      * A foreign thread reaching this via its scope-exit flush /
      * sleep-slice must NOT run main-pool subscribers' handlers —

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -5979,6 +5979,16 @@ static void bus_inline_drain_one(lotus_bus_queue_t *q);
  * WEAK: helper binaries that compile this TU alone (transport
  * drivers, model checkers) link without the obs TU; every call
  * site guards on the symbol's presence. */
+/* The #328 dormant-cost gate, exported by lotus_obs.c and set (in a
+ * constructor, before main) whenever LOTUS_OBS=1 — so 0 here proves
+ * obs_on() is 0 forever and the probe call can be skipped at the
+ * CALL SITE. Generated code already branches on this flag; the
+ * unconditional calls below were the same tax paid from C
+ * (measured +3ns/event on the 3-stage pipeline microbench: the
+ * probe's own prologue runs before its internal obs_on() check).
+ * WEAK like the probes; every guard tests a probe SYMBOL first, so
+ * a TU-alone build short-circuits before touching this. */
+extern int lotus_obs_live __attribute__((weak));
 void lotus_obs_bus_publish(const char *subject, void *publisher_self,
                            uint64_t payload_bytes)
     __attribute__((weak));
@@ -8793,7 +8803,7 @@ void lotus_bus_local_dispatch(lotus_bus_queue_t *queue,
      * matched target below (enqueue-time — see lotus_obs.c v0
      * scope notes). Publisher attribution rides the caller-arena
      * TLS owner when available; v0 passes NULL (unattributed). */
-    if (lotus_obs_bus_publish) {
+    if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)payload_size);
     }
     size_t delivered = 0;
@@ -8813,7 +8823,7 @@ void lotus_bus_local_dispatch(lotus_bus_queue_t *queue,
         if (e->key_filter_kind != 0) continue;
         delivered += (size_t)lotus_bus_post_entry(
             e, queue, payload, payload_size);
-        if (lotus_obs_bus_deliver) {
+        if (lotus_obs_bus_deliver && lotus_obs_live) {
             lotus_obs_bus_deliver(subject, e->self_ptr,
                                   (uint64_t)payload_size);
         }
@@ -8910,7 +8920,7 @@ void lotus_bus_local_dispatch_keyed(lotus_bus_queue_t *queue,
      * feeds — recorded zero BUS_PUBLISH and a zero published counter.
      * Emit here (publisher-only path; never a reader re-dispatch
      * target) exactly as the non-keyed local fanout does. */
-    if (lotus_obs_bus_publish) {
+    if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)payload_size);
     }
     int matched_specific = 0;
@@ -8939,7 +8949,7 @@ void lotus_bus_local_dispatch_keyed(lotus_bus_queue_t *queue,
         /* iris handoff-4 P15: BUS_DELIVER per matched keyed target
          * (sibling of the non-keyed local_dispatch probe — the keyed
          * flavor had none, so keyed deliveries never counted). */
-        if (lotus_obs_bus_deliver) {
+        if (lotus_obs_bus_deliver && lotus_obs_live) {
             lotus_obs_bus_deliver(subject, e->self_ptr,
                                   (uint64_t)payload_size);
         }
@@ -8956,7 +8966,7 @@ void lotus_bus_local_dispatch_keyed(lotus_bus_queue_t *queue,
             if (!lotus_subject_match(e->subject, subject)) continue;
             if (e->key_filter_kind != 2) continue;
             (void)lotus_bus_post_entry(e, queue, payload, payload_size);
-            if (lotus_obs_bus_deliver) {
+            if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
                                       (uint64_t)payload_size);
             }
@@ -13686,7 +13696,7 @@ static void lotus_bus_unix_serve(lotus_bus_remote_entry_t *entry) {
             /* iris P4: NET_DELIVER — framed mode carries the wire
              * seq (t->last_seq); datagram/legacy falls back to the
              * local deliver count. */
-            if (lotus_obs_net_deliver && lotus_obs_binding_register) {
+            if (lotus_obs_net_deliver && lotus_obs_live && lotus_obs_binding_register) {
                 if (entry->obs_binding_id == 0) {
                     int64_t id = lotus_obs_binding_register(
                         entry->subject ? entry->subject : "?", 0);
@@ -14046,7 +14056,7 @@ static void *lotus_bus_udp_reader_thread_main(void *arg) {
         if (lotus_obs_end_redispatch) lotus_obs_end_redispatch();
         uint64_t dseq2 = LOTUS_CTR_BUMP(args->entry->ctr_msgs_delivered);
         LOTUS_CTR_ADD(args->entry->ctr_bytes_delivered, n);
-        if (lotus_obs_net_deliver && lotus_obs_binding_register) {
+        if (lotus_obs_net_deliver && lotus_obs_live && lotus_obs_binding_register) {
             if (args->entry->obs_binding_id == 0) {
                 int64_t id = lotus_obs_binding_register(
                     args->entry->subject ? args->entry->subject : "?",
@@ -14743,7 +14753,7 @@ void lotus_bus_remote_fanout(const char *subject,
                  * carries (origin, seq) — the wire identity the
                  * reader echoes. Manifest binding id kept for the
                  * per-binding counter line only. */
-                if (lotus_obs_net_send && lotus_obs_binding_register) {
+                if (lotus_obs_net_send && lotus_obs_live && lotus_obs_binding_register) {
                     if (e->obs_binding_id == 0) {
                         int64_t id = lotus_obs_binding_register(
                             e->subject ? e->subject : "?", 1);
@@ -14779,7 +14789,7 @@ void lotus_bus_remote_fanout(const char *subject,
             LOTUS_CTR_ADD(e->ctr_bytes_sent, payload_size);
             /* iris P4: NET_SEND with the per-binding monotonic seq.
              * Lazy binding registration on first observed send. */
-            if (lotus_obs_net_send && lotus_obs_binding_register) {
+            if (lotus_obs_net_send && lotus_obs_live && lotus_obs_binding_register) {
                 if (e->obs_binding_id == 0) {
                     int64_t id = lotus_obs_binding_register(
                         e->subject ? e->subject : "?", 0);
@@ -14937,7 +14947,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
     /* iris handoff-4 P15: keyed publish probe (sibling of the
      * non-keyed dispatch_wire path). This is the serialize-present
      * keyed local fanout — publisher-only, so no redispatch guard. */
-    if (lotus_obs_bus_publish) {
+    if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)wire_size);
     }
     char *struct_buf = g_tls_bus_struct_buf;   /* off the coro stack */
@@ -14967,7 +14977,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
             (void)lotus_bus_post_entry(e, g_bus_queue_for_remote,
                 wire_bytes, wire_size);
             g_bus_pending_wire_deser = NULL;
-            if (lotus_obs_bus_deliver) {
+            if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
                                       (uint64_t)wire_size);
             }
@@ -14998,7 +15008,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
                 struct_buf, (size_t)struct_size);
         }
         /* iris handoff-4 P15: BUS_DELIVER per matched keyed target. */
-        if (lotus_obs_bus_deliver) {
+        if (lotus_obs_bus_deliver && lotus_obs_live) {
             lotus_obs_bus_deliver(subject, e->self_ptr,
                                   (uint64_t)wire_size);
         }
@@ -15017,7 +15027,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
                 (void)lotus_bus_post_entry(e, g_bus_queue_for_remote,
                     wire_bytes, wire_size);
                 g_bus_pending_wire_deser = NULL;
-                if (lotus_obs_bus_deliver) {
+                if (lotus_obs_bus_deliver && lotus_obs_live) {
                     lotus_obs_bus_deliver(subject, e->self_ptr,
                                           (uint64_t)wire_size);
                 }
@@ -15042,7 +15052,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
                     g_bus_queue_for_remote, e->handler, e->self_ptr,
                     struct_buf, (size_t)struct_size);
             }
-            if (lotus_obs_bus_deliver) {
+            if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
                                       (uint64_t)wire_size);
             }
@@ -15067,7 +15077,7 @@ void lotus_bus_dispatch_wire(const char *subject,
     if (!subject || !wire_bytes || wire_size == 0) return;
     /* iris P4: BUS_PUBLISH for the cross-thread wire path (the
      * deliver probe rides the per-subscriber fanout below). */
-    if (lotus_obs_bus_publish) {
+    if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)wire_size);
     }
     /* Phase-3 Task 9 (2026-05-20): per-subscriber arena routing.
@@ -15128,7 +15138,7 @@ void lotus_bus_dispatch_wire(const char *subject,
             /* handoff-8 P21: BUS_DELIVER per matched target — the
              * plain wire flavor was the one fanout without it (its
              * keyed sibling gained the probe in handoff-4). */
-            if (lotus_obs_bus_deliver) {
+            if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
                                       (uint64_t)wire_size);
             }
@@ -15157,7 +15167,7 @@ void lotus_bus_dispatch_wire(const char *subject,
                                  struct_buf, (size_t)struct_size)) {
             /* handoff-8 P21: BUS_DELIVER per matched target (see the
              * cross-thread branch above). */
-            if (lotus_obs_bus_deliver) {
+            if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
                                       (uint64_t)wire_size);
             }
@@ -15223,7 +15233,7 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
         /* Verbatim local fanout (mirror lotus_bus_local_dispatch). */
         size_t delivered = 0;
         /* iris P4 (mirrors the dynamic path). */
-        if (lotus_obs_bus_publish) {
+        if (lotus_obs_bus_publish && lotus_obs_live) {
             lotus_obs_bus_publish(subject, NULL, (uint64_t)struct_size);
         }
         if (b) {
@@ -15231,7 +15241,7 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
                 lotus_bus_entry_t *e = &g_bus_entries[b->idx[k]];
                 if (!e->subject) continue;           /* quarantined */
                 if (e->key_filter_kind != 0) continue;
-                if (lotus_obs_bus_deliver) {
+                if (lotus_obs_bus_deliver && lotus_obs_live) {
                     lotus_obs_bus_deliver(subject, e->self_ptr,
                                           (uint64_t)struct_size);
                 }
@@ -15287,7 +15297,7 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
      * Counted before the serialize so a serialize FAILURE still
      * records the publish that was attempted; the drop is visible
      * separately via LOTUS_BUS_LOG_DROP. */
-    if (lotus_obs_bus_publish) {
+    if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)struct_size);
     }
 
@@ -15356,7 +15366,7 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
              * so a String/Bytes payload delivered correctly — the
              * handler ran — while `dlv` stayed 0 alongside the `pub`
              * gap. Both halves of the same omission. */
-            if (lotus_obs_bus_deliver) {
+            if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
                                       (uint64_t)struct_size);
             }
@@ -15446,7 +15456,7 @@ void lotus_bus_dispatch_static_direct(uint32_t id,
      * subject on this path was invisible to observation (no topic
      * registration, no counters, no BUS records). Publish once,
      * deliver per matched target, exactly as the other flavors. */
-    if (lotus_obs_bus_publish) {
+    if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, size);
     }
     if (b) {
@@ -15469,7 +15479,7 @@ void lotus_bus_dispatch_static_direct(uint32_t id,
                 /* same-thread: the whole point — run it now. */
                 ((lotus_handler_fn)e->handler)(e->self_ptr, (void *)payload);
             }
-            if (lotus_obs_bus_deliver) {
+            if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr, size);
             }
             delivered++;

--- a/crates/hale-codegen/src/bus/runtime.rs
+++ b/crates/hale-codegen/src/bus/runtime.rs
@@ -109,6 +109,12 @@ impl<'ctx, 'p> BusRuntime<'ctx> for Cx<'ctx, 'p> {
     }
 
     fn emit_bus_drain(&mut self) -> Result<(), CodegenError> {
+        // Static drain elision: nothing in this bundle can ever
+        // enqueue a cell, so the drain is a provable no-op — emit
+        // nothing. See `Cx::bus_inert`.
+        if self.bus_inert {
+            return Ok(());
+        }
         let ptr_t = self.context.ptr_type(AddressSpace::default());
         let queue_global = self
             .module

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1206,6 +1206,35 @@ pub fn build_executable_with_options(
     module.set_data_layout(&target_data.get_data_layout());
     module.set_triple(&triple);
 
+    // Static drain elision (2026-08-03, bench attribution): a bundle
+    // that can never enqueue a bus cell makes every emitted
+    // `lotus_bus_queue_drain` a provable no-op — and codegen emits one
+    // at every statement boundary, scope exit, `yield` and sleep
+    // slice, so a compute-only program pays the call thousands of
+    // times for nothing (two per locus instantiation on the
+    // birth+dissolve microbench). Cells are produced only by
+    // subscriber dispatch, wire ingest into a registered subscriber,
+    // the cross-pool accept handoff, and transport-loss dispatch —
+    // so a merged program with NO topic declarations, NO bus blocks,
+    // NO bindings blocks, NO accept lifecycles and NO perspectives
+    // (their serve contract implies a bus surface) provably has an
+    // empty queue at every drain point, and the drains are elided at
+    // emission. Runtime bus config (LOTUS_BUS_CONFIG) cannot defeat
+    // this: with no declared topics there is nothing to bind, and
+    // with no subscribers an ingested message registers no cell.
+    // Any construct not positively recognized keeps the drains.
+    let bus_inert = program.items.iter().all(|it| match it {
+        TopDecl::Topic(_) | TopDecl::Perspective(_) => false,
+        TopDecl::Locus(l) => l.members.iter().all(|m| match m {
+            LocusMember::Bus(_) | LocusMember::Bindings(_) => false,
+            LocusMember::Lifecycle(ld) => {
+                ld.kind != LifecycleKind::Accept
+            }
+            _ => true,
+        }),
+        _ => true,
+    });
+
     let mut cx = Cx {
         context: &context,
         module,
@@ -1286,6 +1315,7 @@ pub fn build_executable_with_options(
         handler_reclaim_wrappers: BTreeMap::new(),
         vtables: BTreeMap::new(),
         current_fn_skip_exit_drain: false,
+        bus_inert,
         di: None,
         di_loc_stack: Vec::new(),
         di_current_loc: None,
@@ -3204,6 +3234,14 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// push/pop + global load + lotus_bus_queue_drain call per
     /// invocation of a two-instruction function.
     pub(crate) current_fn_skip_exit_drain: bool,
+    /// Static drain elision (2026-08-03): true when the merged
+    /// program can never enqueue a bus cell (no topics, no bus
+    /// blocks, no bindings, no accepts, no perspectives) — every
+    /// emitted drain would be a no-op, so `emit_bus_drain` /
+    /// `emit_pinned_mailbox_drain_pending` emit nothing. Computed
+    /// once in `build_executable_with_options`; see the comment
+    /// there for the producer enumeration.
+    pub(crate) bus_inert: bool,
     pub(crate) di: Option<DiState<'ctx>>,
     /// Per-statement debug-location stack: (function the location
     /// was set in, the location live before this statement). The
@@ -21755,6 +21793,12 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// at every cooperative yield point so a pinned locus's
     /// long-running run() body sees mid-program bus deliveries.
     pub(crate) fn emit_pinned_mailbox_drain_pending(&mut self) -> Result<(), CodegenError> {
+        // Static drain elision: a pinned mailbox only ever holds
+        // subscriber-dispatch or accept-handoff cells; an inert
+        // bundle has neither. See `Cx::bus_inert`.
+        if self.bus_inert {
+            return Ok(());
+        }
         let get_current_fn = self
             .module
             .get_function("lotus_mailbox_get_current")

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -947,6 +947,11 @@ pub fn build_executable_with_options(
                 .join("; ");
             CodegenError::Unsupported(format!("stdlib parse: {}", summary))
         })?;
+    // Tier-3 drain-elision taint is computed from the parsed stdlib
+    // (below) before its items are moved into `merged`; the result
+    // is process-cached, so this is a one-time cost.
+    let stdlib_taint: &'static [String] =
+        stdlib_bus_tainted_namespaces(&stdlib_program);
     let mut merged = program.clone();
     merged.items.extend(stdlib_program.items);
 
@@ -1214,26 +1219,63 @@ pub fn build_executable_with_options(
     // times for nothing (two per locus instantiation on the
     // birth+dissolve microbench). Cells are produced only by
     // subscriber dispatch, wire ingest into a registered subscriber,
-    // the cross-pool accept handoff, and transport-loss dispatch —
-    // so a merged program with NO topic declarations, NO bus blocks,
-    // NO bindings blocks, NO accept lifecycles and NO perspectives
-    // (their serve contract implies a bus surface) provably has an
-    // empty queue at every drain point, and the drains are elided at
-    // emission. Runtime bus config (LOTUS_BUS_CONFIG) cannot defeat
-    // this: with no declared topics there is nothing to bind, and
-    // with no subscribers an ingested message registers no cell.
-    // Any construct not positively recognized keeps the drains.
-    let bus_inert = program.items.iter().all(|it| match it {
-        TopDecl::Topic(_) | TopDecl::Perspective(_) => false,
-        TopDecl::Locus(l) => l.members.iter().all(|m| match m {
-            LocusMember::Bus(_) | LocusMember::Bindings(_) => false,
-            LocusMember::Lifecycle(ld) => {
-                ld.kind != LifecycleKind::Accept
-            }
+    // the cross-pool accept handoff, and transport-loss dispatch.
+    //
+    // Three tiers, each conservative:
+    //  1. The USER program (all user seeds — imports are merged
+    //     before codegen) must declare no topics, no bus blocks, no
+    //     bindings, no accepts and no perspectives. Runtime bus
+    //     config (LOTUS_BUS_CONFIG) cannot defeat this: with no
+    //     declared topics there is nothing to bind, and with no
+    //     subscribers an ingested message registers no cell.
+    //  2. The STDLIB also carries bus surface (`std::log` sinks,
+    //     `std::http`, `std::io::tcp`, `std::bus`) — merged below,
+    //     so tier 1 alone was unsound (the log_routing CI failure:
+    //     a bus-free user program whose `std::log` sink never got
+    //     its events drained). A user program that references no
+    //     stdlib path at all (`name: "std"` absent from its AST,
+    //     and no direct `__Std` mention) cannot instantiate a
+    //     stdlib subscriber, so it stays inert.
+    //  3. A program that DOES reference `std::` paths is inert only
+    //     if none of the referenced namespaces can transitively
+    //     reach a bus-surfaced stdlib decl
+    //     (`stdlib_bus_tainted_namespaces`, a decl-level taint
+    //     fixpoint over the parsed stdlib).
+    //
+    // The reference checks run on the Debug rendering of the user
+    // AST. Deliberate: a hand-rolled expression walker would
+    // silently MISS newly-added Expr variants — an unsound elision —
+    // while substring containment can only over-match, which merely
+    // keeps the drains. A user identifier that happens to be named
+    // like a tainted namespace ("log", "http") costs the
+    // optimization, never correctness.
+    let bus_inert = {
+        let user_clean = program.items.iter().all(|it| match it {
+            TopDecl::Topic(_) | TopDecl::Perspective(_) => false,
+            TopDecl::Locus(l) => l.members.iter().all(|m| match m {
+                LocusMember::Bus(_) | LocusMember::Bindings(_) => false,
+                LocusMember::Lifecycle(ld) => {
+                    ld.kind != LifecycleKind::Accept
+                }
+                _ => true,
+            }),
             _ => true,
-        }),
-        _ => true,
-    });
+        });
+        if !user_clean {
+            false
+        } else {
+            let dbg = format!("{:?}", program.items);
+            if dbg.contains("__Std") {
+                false
+            } else if !dbg.contains("name: \"std\"") {
+                true
+            } else {
+                !stdlib_taint.iter().any(|ns| {
+                    dbg.contains(&format!("name: \"{}\"", ns))
+                })
+            }
+        }
+    };
 
     let mut cx = Cx {
         context: &context,
@@ -2456,6 +2498,84 @@ fn locate_ts_shim_staticlib() -> Option<PathBuf> {
 /// Look up the mangled name for a bundled-stdlib path (`std::*`).
 /// Returns `None` when the path isn't recognized; callers then
 /// surface the path-as-typed in their error message.
+/// Which `std::` namespaces (second path segment) can transitively
+/// reach a bus-surfaced stdlib decl? Drives tier 3 of the static
+/// drain elision above. Decl-level taint fixpoint over the parsed
+/// stdlib: seeds are loci with a bus / bindings block or an accept
+/// lifecycle (and perspectives); taint propagates to any decl whose
+/// AST mentions a tainted decl's name (checked as the exact
+/// `name: "<ident>"` Debug rendering, so short names can't
+/// over-cascade), covering stdlib free fns that instantiate a
+/// subscriber internally (`std::http::serve` → `Server`). Tainted
+/// decls map to user-reachable namespaces through PATH_RENAMES —
+/// the complete user-visible stdlib surface (stdlib_mangled_for_path
+/// is table-driven from it); tainted decls with no table entry are
+/// reachable only via a literal `__Std` mention, which tier 2
+/// rejects wholesale. Computed once per process: AP_SOURCE is a
+/// compile-time constant.
+fn stdlib_bus_tainted_namespaces(
+    stdlib: &hale_syntax::ast::Program,
+) -> &'static [String] {
+    use std::sync::OnceLock;
+    static TAINT: OnceLock<Vec<String>> = OnceLock::new();
+    TAINT.get_or_init(|| {
+        let mut decls: Vec<(String, bool, String)> = Vec::new();
+        for it in &stdlib.items {
+            let (name, surface) = match it {
+                TopDecl::Locus(l) => (
+                    l.name.name.clone(),
+                    l.members.iter().any(|m| match m {
+                        LocusMember::Bus(_)
+                        | LocusMember::Bindings(_) => true,
+                        LocusMember::Lifecycle(ld) => {
+                            ld.kind == LifecycleKind::Accept
+                        }
+                        _ => false,
+                    }),
+                ),
+                TopDecl::Perspective(p) => (p.name.name.clone(), true),
+                TopDecl::Fn(f) => (f.name.name.clone(), false),
+                TopDecl::Type(t) => (t.name.name.clone(), false),
+                TopDecl::Topic(t) => (t.name.name.clone(), false),
+                TopDecl::Const(c) => (c.name.name.clone(), false),
+                _ => continue,
+            };
+            decls.push((name, surface, format!("{:?}", it)));
+        }
+        let mut tainted: std::collections::BTreeSet<String> = decls
+            .iter()
+            .filter(|(_, s, _)| *s)
+            .map(|(n, _, _)| n.clone())
+            .collect();
+        loop {
+            let mut changed = false;
+            for (n, _, dbg) in &decls {
+                if tainted.contains(n) {
+                    continue;
+                }
+                if tainted
+                    .iter()
+                    .any(|t| dbg.contains(&format!("name: \"{}\"", t)))
+                {
+                    tainted.insert(n.clone());
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+        let mut ns: Vec<String> = hale_stdlib::PATH_RENAMES
+            .iter()
+            .filter(|(_, m)| tainted.contains(*m))
+            .filter_map(|(p, _)| p.get(1).map(|s| s.to_string()))
+            .collect();
+        ns.sort();
+        ns.dedup();
+        ns
+    })
+}
+
 fn stdlib_mangled_for_path(segs: &[&str]) -> Option<&'static str> {
     if !matches!(segs.first(), Some(&"std")) {
         return None;

--- a/crates/hale-codegen/src/form/mod.rs
+++ b/crates/hale-codegen/src/form/mod.rs
@@ -51,6 +51,47 @@ pub(crate) fn cell_tree_has_heap_leaves(
     }
 }
 
+/// Lower a form-method value argument, building a struct LITERAL of
+/// the cell type on the STACK instead of the arena (2026-08-03 —
+/// same pattern `lower_send` has used for publish payloads since
+/// m67). Sound because every consumer of the value copies out of it
+/// before the statement ends: hashmap set / lru put / ring push /
+/// vec push memcpy the bytes (and the heap-leaf walk clones what it
+/// keeps), so the shell never escapes. Before this, EVERY
+/// `m.set(Entry { ... })` in a hot loop bump-allocated the shell
+/// into the enclosing scope's lifetime arena — 16 MB of dead shells
+/// per million sets on the insert microbench, and the allocation
+/// call itself on the hot path. Anything that is not a
+/// single-segment literal of the exact cell type falls through to
+/// the ordinary lowering.
+fn lower_form_value_arg<'ctx>(
+    cx: &mut Cx<'ctx, '_>,
+    arg: &Expr,
+    cell_name: &str,
+    scope: &Scope<'ctx>,
+) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+    if let Expr::Struct { path, inits, .. } = arg {
+        if path.segments.len() == 1
+            && path.segments[0].name == cell_name
+        {
+            if let Some(info) = cx.user_types.get(cell_name).cloned() {
+                let slot = cx.alloca_in_entry(
+                    info.struct_ty.into(),
+                    &format!("{}.cellarg", cell_name),
+                )?;
+                cx.populate_user_type_fields(
+                    cell_name, &info, inits, slot, scope,
+                )?;
+                return Ok((
+                    slot.into(),
+                    CodegenTy::TypeRef(cell_name.to_string()),
+                ));
+            }
+        }
+    }
+    cx.lower_expr(arg, scope)
+}
+
 use crate::codegen::{
     BceVecKey, CapacitySlotLayout, CodegenError, CodegenTy, Cx,
     FallibleCallResult, LocusInfo, Scope, SlotForm, TypeInfo,
@@ -2162,7 +2203,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     )))?;
 
                 let (arg_val, arg_ty) =
-                    self.lower_expr(&args[0], scope)?;
+                    lower_form_value_arg(self, &args[0], &cell_name, scope)?;
                 let expected_value_ty = CodegenTy::TypeRef(cell_name.clone());
                 if arg_ty != expected_value_ty {
                     return Err(CodegenError::Unsupported(format!(
@@ -2996,7 +3037,8 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         locus_name, field_name, cell_name
                     )))?;
 
-                let (arg_val, arg_ty) = self.lower_expr(&args[0], scope)?;
+                let (arg_val, arg_ty) =
+                    lower_form_value_arg(self, &args[0], &cell_name, scope)?;
                 let expected_value_ty = CodegenTy::TypeRef(cell_name.clone());
                 if arg_ty != expected_value_ty {
                     return Err(CodegenError::Unsupported(format!(

--- a/crates/hale-codegen/src/form/mod.rs
+++ b/crates/hale-codegen/src/form/mod.rs
@@ -14,6 +14,43 @@ use inkwell::types::BasicType;
 use inkwell::values::{BasicValueEnum, IntValue, PointerValue};
 use inkwell::AddressSpace;
 
+/// Does this cell type tree contain any heap-pointer leaf (String /
+/// Bytes, directly or through a nested struct)? The cell single-owner
+/// machinery — the stack snapshot before the anchor walk and the
+/// owned-clone variants during it — exists solely to keep heap
+/// pointers un-aliased; a cell of pure scalars has nothing to
+/// protect, and emitting the snapshot anyway serializes the hot set
+/// loop through a store-to-load round trip (measured +30% on the
+/// Int-keyed 1M-insert microbench — the v0.11.12/13 regression the
+/// stale v0.11.3 baselines were hiding). Conservative: any type this
+/// doesn't positively recognize as scalar counts as heap-bearing, so
+/// new variants fail SAFE (keep the snapshot).
+pub(crate) fn cell_tree_has_heap_leaves(
+    ty: &CodegenTy,
+    user_types: &std::collections::BTreeMap<String, crate::codegen::TypeInfo<'_>>,
+    depth: u32,
+) -> bool {
+    if depth > 8 {
+        return true; // recursion guard: assume the worst
+    }
+    match ty {
+        CodegenTy::Int
+        | CodegenTy::Float
+        | CodegenTy::Bool
+        | CodegenTy::Duration
+        | CodegenTy::Decimal => false,
+        CodegenTy::TypeRef(name) => match user_types.get(name) {
+            Some(info) => info.fields.values().any(|(_, fty)| {
+                cell_tree_has_heap_leaves(fty, user_types, depth + 1)
+            }),
+            None => true,
+        },
+        // String, Bytes, Time (pointer-repr'd), views, loci,
+        // everything else: heap-bearing or unknown.
+        _ => true,
+    }
+}
+
 use crate::codegen::{
     BceVecKey, CapacitySlotLayout, CodegenError, CodegenTy, Cx,
     FallibleCallResult, LocusInfo, Scope, SlotForm, TypeInfo,
@@ -2190,34 +2227,52 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 // dangles the other). Snapshotting first leaves the
                 // source untouched; entry-block alloca so a hot
                 // loop reuses one slot.
-                let snap = self.alloca_in_entry(
-                    cell_info.struct_ty.into(),
-                    &format!("{}.set.snap", locus_name),
-                )?;
-                let snap_size = cell_info
-                    .struct_ty
-                    .size_of()
-                    .expect("cell struct has known size");
-                self.builder
-                    .build_memcpy(
-                        snap,
-                        8,
-                        arg_val.into_pointer_value(),
-                        8,
-                        snap_size,
-                    )
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                let arg_val: BasicValueEnum = snap.into();
-                let prev_owned = self.cell_owned_clone;
-                self.cell_owned_clone = true;
-                let walk_res = self.emit_cross_arena_store_deep_copy(
-                    arg_val,
+                // Scalar-cell fast path (2026-08-03): both the
+                // snapshot and the walk protect HEAP-POINTER
+                // leaves. A cell of pure scalars has none — the
+                // set below memcpys the bytes and the aliasing
+                // hazard cannot arise — so skip both. (This
+                // restores the pre-single-owner codegen for the
+                // Int-keyed/Int-valued shape: the snapshot's
+                // store-to-load round trip measured +30% on the
+                // 1M-insert microbench.)
+                let arg_val = if cell_tree_has_heap_leaves(
                     &expected_value_ty,
-                    dest_arena,
-                    &format!("{}.hashmap_set", locus_name),
-                );
-                self.cell_owned_clone = prev_owned;
-                let arg_val = walk_res?;
+                    &self.user_types,
+                    0,
+                ) {
+                    let snap = self.alloca_in_entry(
+                        cell_info.struct_ty.into(),
+                        &format!("{}.set.snap", locus_name),
+                    )?;
+                    let snap_size = cell_info
+                        .struct_ty
+                        .size_of()
+                        .expect("cell struct has known size");
+                    self.builder
+                        .build_memcpy(
+                            snap,
+                            8,
+                            arg_val.into_pointer_value(),
+                            8,
+                            snap_size,
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    let arg_val: BasicValueEnum = snap.into();
+                    let prev_owned = self.cell_owned_clone;
+                    self.cell_owned_clone = true;
+                    let walk_res = self.emit_cross_arena_store_deep_copy(
+                        arg_val,
+                        &expected_value_ty,
+                        dest_arena,
+                        &format!("{}.hashmap_set", locus_name),
+                    );
+                    self.cell_owned_clone = prev_owned;
+                    walk_res?
+                } else {
+                    let _ = dest_arena; // unused on the scalar path
+                    arg_val
+                };
                 // The value lowered to a TypeRef arrives as a
                 // pointer to the struct (user_type instantiations
                 // return `*StructTy`). Pass it directly as
@@ -2990,34 +3045,44 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 // dangles the other). Snapshotting first leaves the
                 // source untouched; entry-block alloca so a hot
                 // loop reuses one slot.
-                let snap = self.alloca_in_entry(
-                    cell_info.struct_ty.into(),
-                    &format!("{}.put.snap", locus_name),
-                )?;
-                let snap_size = cell_info
-                    .struct_ty
-                    .size_of()
-                    .expect("cell struct has known size");
-                self.builder
-                    .build_memcpy(
-                        snap,
-                        8,
-                        arg_val.into_pointer_value(),
-                        8,
-                        snap_size,
-                    )
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-                let arg_val: BasicValueEnum = snap.into();
-                let prev_owned = self.cell_owned_clone;
-                self.cell_owned_clone = true;
-                let walk_res = self.emit_cross_arena_store_deep_copy(
-                    arg_val,
+                // Scalar-cell fast path: see the hashmap-set twin.
+                let arg_val = if cell_tree_has_heap_leaves(
                     &expected_value_ty,
-                    dest_arena,
-                    &format!("{}.lru_put", locus_name),
-                );
-                self.cell_owned_clone = prev_owned;
-                let arg_val = walk_res?;
+                    &self.user_types,
+                    0,
+                ) {
+                    let snap = self.alloca_in_entry(
+                        cell_info.struct_ty.into(),
+                        &format!("{}.put.snap", locus_name),
+                    )?;
+                    let snap_size = cell_info
+                        .struct_ty
+                        .size_of()
+                        .expect("cell struct has known size");
+                    self.builder
+                        .build_memcpy(
+                            snap,
+                            8,
+                            arg_val.into_pointer_value(),
+                            8,
+                            snap_size,
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    let arg_val: BasicValueEnum = snap.into();
+                    let prev_owned = self.cell_owned_clone;
+                    self.cell_owned_clone = true;
+                    let walk_res = self.emit_cross_arena_store_deep_copy(
+                        arg_val,
+                        &expected_value_ty,
+                        dest_arena,
+                        &format!("{}.lru_put", locus_name),
+                    );
+                    self.cell_owned_clone = prev_owned;
+                    walk_res?
+                } else {
+                    let _ = dest_arena; // unused on the scalar path
+                    arg_val
+                };
                 let value_ptr = arg_val.into_pointer_value();
                 let key_field_ptr = self
                     .builder

--- a/crates/hale-codegen/tests/drain_elision.rs
+++ b/crates/hale-codegen/tests/drain_elision.rs
@@ -1,0 +1,140 @@
+//! Static drain elision (2026-08-03) — both directions.
+//!
+//! A bundle that can never enqueue a bus cell emits no
+//! `lotus_bus_queue_drain` calls at all. The gate is three-tier:
+//! the USER program must be bus-free, and it must not reference a
+//! stdlib namespace that can transitively reach a bus-surfaced
+//! stdlib decl (`std::log`'s sinks were the CI failure that forced
+//! tier 2/3: a bus-free user program whose log events were enqueued
+//! by `std::log::Logger` and then never drained — empty stdout).
+//!
+//! The behavioral direction (std::log still delivers) is pinned by
+//! `log_routing.rs`; this file pins the structural direction — that
+//! elision actually HAPPENS for the programs it is meant for, and
+//! does NOT happen when a tainted stdlib namespace is referenced.
+//! Disassembly-based, so Linux-only (macOS runners lack binutils
+//! objdump); the behavioral tests carry the other platforms.
+
+#![cfg(target_os = "linux")]
+
+use std::process::Command;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+use hale_codegen::build_executable;
+
+/// Count `lotus_bus_queue_drain` call sites in the binary's `main`.
+fn drain_call_sites(bin: &std::path::Path) -> usize {
+    let out = Command::new("objdump")
+        .args(["-d", "--disassemble=main"])
+        .arg(bin)
+        .output()
+        .expect("objdump runs");
+    let text = String::from_utf8_lossy(&out.stdout);
+    text.lines()
+        .filter(|l| l.contains("call") && l.contains("lotus_bus_queue_drain"))
+        .count()
+}
+
+fn build(name: &str, src: &str) -> std::path::PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(name);
+    build_executable(&program, &bin).expect("build");
+    bin
+}
+
+/// A compute-only program — loci, methods, sleeps, `std::time` and
+/// `std::process` references, but no bus surface anywhere — carries
+/// zero drain call sites. The two per-instantiation drains were ~30%
+/// of the birth+dissolve microbench.
+#[test]
+fn compute_only_program_has_no_drain_sites() {
+    const SRC: &str = r#"
+        locus Empty {
+            params { v: Int = 0; }
+            fn read() -> Int { return self.v; }
+        }
+        fn one(seed: Int) -> Int {
+            let e = Empty { v: seed };
+            return e.read();
+        }
+        fn main() {
+            let t0 = std::time::monotonic();
+            let mut sink = 0;
+            let mut i = 0;
+            while i < 100 { sink = sink ^ one(i); i = i + 1; }
+            let t1 = std::time::monotonic();
+            if t1 < t0 { println("clock went backwards"); }
+            println(sink);
+        }
+    "#;
+    let bin = build("drain_elision_inert", SRC);
+    let out = Command::new(&bin).output().expect("run");
+    assert!(out.status.success(), "program must still run");
+    let sites = drain_call_sites(&bin);
+    let _ = std::fs::remove_file(&bin);
+    assert_eq!(
+        sites, 0,
+        "a bus-inert program must emit no drain calls in main"
+    );
+}
+
+/// Referencing `std::log` (a tainted namespace: its sinks are bus
+/// subscribers) keeps the drains — this is the exact shape whose
+/// events were silently dropped when tier 1 gated alone.
+#[test]
+fn std_log_reference_keeps_the_drains() {
+    const SRC: &str = r#"
+        fn main() {
+            std::log::StdoutSink { };
+            let log = std::log::Logger { name: "t" };
+            log.info("delivered");
+        }
+    "#;
+    let bin = build("drain_elision_log", SRC);
+    let out = Command::new(&bin).output().expect("run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let sites = drain_call_sites(&bin);
+    let _ = std::fs::remove_file(&bin);
+    assert!(
+        sites > 0,
+        "a std::log-using program must keep its drain calls"
+    );
+    assert!(
+        stdout.contains("delivered"),
+        "and the log event must actually be delivered: {:?}",
+        stdout
+    );
+}
+
+/// A user program with its own bus surface obviously keeps the
+/// drains — tier 1.
+#[test]
+fn user_bus_surface_keeps_the_drains() {
+    const SRC: &str = r#"
+        type T { v: Int; }
+        locus Sub {
+            params { got: Int = 0; }
+            bus { subscribe "s.t" as on_t of type T; }
+            fn on_t(t: T) { self.got = t.v; }
+        }
+        fn main() {
+            let s = Sub { };
+            "s.t" <- T { v: 7 };
+            yield;
+            println(s.got);
+        }
+    "#;
+    let bin = build("drain_elision_userbus", SRC);
+    let out = Command::new(&bin).output().expect("run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let sites = drain_call_sites(&bin);
+    let _ = std::fs::remove_file(&bin);
+    assert!(sites > 0, "a subscribing program keeps its drains");
+    assert!(
+        stdout.contains('7'),
+        "and delivery works: {:?}",
+        stdout
+    );
+}


### PR DESCRIPTION
Bench attribution work (A/B-ing every released compiler against HEAD on the same machine, 9-run medians, `fn_call` flat across all five versions as the null control) found where the post-v0.11.3 drift actually lives. This PR delivers five fixes — all pure codegen/runtime, no semantic change.

## 1. Scalar cells were paying the single-owner tax (+30% at v0.11.12/13)

`form_hashmap_set` (1M Int-keyed inserts): 43.5ms at v0.11.11 → 56.6ms at v0.11.13, never recovered. The C runtime is **byte-identical** across versions — the diff is in the generated loop: the cell single-owner fix emits a stack **snapshot** of the value struct plus the owned-clone walk on every `@form` set/put. Both exist solely to keep *heap-pointer leaves* un-aliased; `Entry { id: Int, v: Int }` has none, and the snapshot's store-to-load round trip serializes the loop. Now gated on `cell_tree_has_heap_leaves` (recursive through nested structs; unknown types fail SAFE toward keeping the snapshot).

## 2. No-op bus drains no longer build their frame

`lotus_bus_queue_drain` did a 6-register, 584-byte prologue, a `pthread_self` call and a `lotus_bus_drain_lost_transports` call **before looking at the queue** — twice per locus instantiation, in a program with no bus declarations. New call-free fast path when `g_bus_has_pinned` is 0 (set pre-spawn by both pinned registration and pool startup, so 0 proves single-threaded — the same invariant the unlocked drain body already relies on); shrink-wrapping keeps the prologue off that path.

## 3. Bus-inert bundles emit no drains at all

Cells are produced only by subscriber dispatch, wire ingest into a registered subscriber, the cross-pool accept handoff, and transport-loss dispatch. A merged program with **no topics, no bus blocks, no bindings, no accepts, no perspectives** provably has an empty queue at every drain point, so `emit_bus_drain` / `emit_pinned_mailbox_drain_pending` emit nothing (`Cx::bus_inert`, computed once per build; unrecognized constructs keep the drains). Runtime `LOTUS_BUS_CONFIG` can't defeat it: no declared topics means nothing to bind, no subscribers means ingest registers no cell. Verified: zero drain call sites in the compiled microbench binary.

## 4. Form-call struct literals build on the stack

`m.set(Entry { ... })` bump-allocated the literal's shell into the enclosing scope's **lifetime** arena, then the set memcpy'd it out — 16 MB of dead shells per million sets plus the allocation call on the hot path. A literal of the exact cell type in hashmap-set / lru-put argument position now builds in an entry-block stack slot — the same pattern `lower_send` has used for publish payloads since m67. Everything else keeps the ordinary lowering.

## 5. Runtime obs probes gated at the call site (the v0.11.12 pipeline regression)

The bus publish/deliver/net probes were called **unconditionally** from `lotus_bus_local_dispatch` and friends — every event paid the probe's prologue before its internal `obs_on()` check ran. This is the same disease #328 cured on the codegen side. The 23 C call sites now branch on `lotus_obs_live` first (weak-declared beside the weak probe symbols; every guard tests a probe *symbol* before touching the flag, so TU-alone builds short-circuit). Soundness: the flag is set in a pre-main constructor whenever `LOTUS_OBS=1`, so 0 proves `obs_on()` is 0 forever — the gate can never skip a live probe.

## Measured (cumulative, same machine, vs the freshly re-measured v0.11.3 compiler)

| bench | this morning | after | v0.11.3 |
|---|---|---|---|
| `form_hashmap_set` | 62.7ms (+40%) | **39.7–42.0ms** (−13%) | 47.0ms |
| `locus_instantiation` | 2.01ms (+17%) | **1.55–1.61ms** (−7%) | 1.72ms |
| `pipeline_3stage` (400k) | 11.82ms (+8%) | **10.917ms** | 10.918ms (v0.11.11) |
| `form_hashmap_set` maxrss | 92.5 MB | **81.3 MB** | 92.5 MB |

Full 22-bench sweep: zero regressions flagged. `fn_call`, `json_parse`, dispatch and shm-ring benches unchanged.

## Verification

Form suites (hashmap/serialized/lru/aliasing), bus suites (cross-thread drain, devirt differential, backpressure, bounded), obs suites (`obs_emission`, `obs_fleet_contract` — asserts live counter values under `LOTUS_OBS=1` — `obs_net_seq`), corpus oracle, native suite: all green locally. GenMC: the drain fast path stays inside the single-threaded regime `bus_queue_model.c` models; the locked path is unchanged.

## Still open (documented, not taken)

- `bench/baselines.json` re-pin — stale at v0.11.3, gate fires on noise. Deliberately left so the drift record survives until this merges.
- Transient-locus stack allocation (escape-analyzed birth/dissolve without arena create/destroy) — the remaining big lever on `locus_instantiation`.
