### PR TITLE
spec: document synced-map read snapshots + retirement, scalar-cell fast path

### DIFF
--- a/spec/forms.md
+++ b/spec/forms.md
@@ -789,6 +789,27 @@ into a plain `@form(hashmap)` receiver are typecheck-rejected
 - **Cross-pool, write-heavy, cap unknown / dynamic**:
   `sync = serialized`. Per-map mutex; writers serialize but
   the path is short. Beats striped on 2-core / cheap-payload.
+
+  **Reads are owned snapshots; replaced clones retire
+  (2026-08-03, downstream handoff P1).** Every read path on a
+  serialized map whose cell carries String fields (`get`,
+  `entry_at`, `for` iteration) clones those Strings into the
+  *caller's* arena, inside the same critical section that read
+  the cell. The value a reader holds is therefore a plain owned
+  value — it stays intact regardless of later writes, and a
+  reader never observes a writer's in-place mutations through a
+  previously-read result. That ownership is what lets the map
+  retire replaced clones exactly like a `sync = none` map (the
+  anchor-retirement machinery in `memory.md`): previously a
+  serialized map never retired, because a raw cell pointer held
+  by an off-pool reader could outlive the writer's activation —
+  the leak was the safety mechanism. A continuously-churned
+  serialized map now holds steady-state RSS instead of growing
+  per replace. `striped` and `lockfree` maps do **not** retire
+  yet (their read paths bracket on rwlock / lf_enter rather than
+  the map mutex, and their grow rebuilds slots concurrently — a
+  separate audit); a churned String-bearing cell on those modes
+  still accumulates.
 - **Cross-pool, read-heavy or per-op work is expensive**:
   `sync = striped`. Rwlock lets concurrent readers run in
   parallel; cache-padded cells avoid false-sharing between

--- a/spec/memory.md
+++ b/spec/memory.md
@@ -1146,7 +1146,18 @@ reclaim on a real-world long-running workload:
      nested `TypeRef`, …) keeps its identity-skip — compounds
      don't retire, so sharing there is a mutation-visibility
      caveat, not a use-after-free (tracked in
-     notes/anchor-retirement.md). Note the RMW zero-allocation
+     notes/anchor-retirement.md).
+
+     Scalar-cell fast path (2026-08-03): the snapshot and the
+     owned-clone walk exist solely to keep heap-pointer leaves
+     un-aliased, so a cell whose type tree carries no String /
+     Bytes leaf (directly or through nested structs) skips both
+     at compile time and takes the pre-single-owner codegen —
+     the aliasing hazard cannot arise where there is no pointer
+     to alias. Unrecognized field types conservatively keep the
+     snapshot. (The snapshot's store-to-load round trip had
+     serialized scalar-cell insert loops: +30% on the Int-keyed
+     1M-insert bench.) Note the RMW zero-allocation
      claim above narrows accordingly: same-pointer String/Bytes
      fields carried through a get-then-set now cost one owned
      copy per set, served by the retire freelist (the replaced


### PR DESCRIPTION
#373 and #374 changed user-visible behavior (owned read snapshots + retirement on serialized maps; the scalar-cell single-owner fast path) but merged without the matching spec text — the same-commit rule this repays. Two passages: `forms.md` under the `sync = serialized` guidance (including that `striped`/`lockfree` still accumulate, so nobody re-files the residual as a surprise), and `memory.md`'s cell single-owner section (the scalar gate and why it is not a soundness hole). Docs-only.