### PR TITLE
fix: the caller-arena TLS can no longer outlive its arena (GH #375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ behavior.
 
 ## Unreleased
 
+### The caller-arena TLS can no longer outlive the arena it points to (GH #375)
+
+A free-fn factory that builds and grows a `@form(vec)` locus
+segfaulted deterministically when called after a locus-method failure
+was caught with an `or` handler — the cross-seed shape downstream
+worked around with inline construction. Root cause: the caller-arena
+TLS is a set-and-forget channel. A fallible method chain that
+published its own method scratch and then exited down the error edge
+left the TLS pointing at the destroyed scratch, and the next TLS
+reader without its own preceding publish allocated out of freed
+memory (ASan: heap-use-after-free in `lotus_arena_alloc`).
+
+Three layers, each independently sound:
+
+1. `lotus_arena_destroy` clears the TLS when it points at the dying
+   arena — the single point every arena death passes through, so a
+   destroyed (or recycled) arena is never reachable via the TLS
+   again; readers fall back to the documented global-arena path.
+2. Free-fn prologues publish their `__caller_arena` param to the
+   TLS, re-healing it on entry and giving TLS readers the same
+   lifetime an inlined body would have used. Gated on the body
+   containing a construct that can read the TLS (an instantiation
+   or a call) so scalar leaf fns skip the publish — ungated it
+   measured +86% on the 2ns/call microbench.
+3. Method epilogues restore the entry-time snapshot on both the ok
+   and the error exit, making method calls TLS-neutral.
+
+The reported reproducer (two pond seeds + probe) runs 10/10 clean,
+ASan-clean; a minimal two-seed regression test is pinned in-tree —
+notable because every single-file reduction stays clean, which is
+why the issue's toy matrix could not reproduce it.
+
 ### Synced `@form(hashmap)` maps now retire replaced String clones (downstream handoff P1)
 
 A `sync = serialized` map never installed a retire descriptor, so

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -2017,8 +2017,28 @@ void lotus_arena_mark_shared(void *arena_ptr) {
     if (a) a->shared_concurrent = 1;
 }
 
+extern __thread lotus_arena_t *lotus_current_caller_arena;
+
 void lotus_arena_destroy(lotus_arena_t *a) {
     if (!a) return;
+    /* GH #375: the caller-arena TLS is a set-and-forget channel —
+     * stdlib call sites publish before each call, but nothing ever
+     * UN-publishes. A method whose body published its own scratch
+     * and then exited (the ERROR path of a fallible method was the
+     * reported shape) left the TLS pointing at this dying arena;
+     * the next TLS reader without a preceding publish — a free-fn
+     * locus factory was the reproducer — allocated out of freed
+     * (or, worse, RECYCLED: the subregion path below returns the
+     * slot for reuse) memory. Deterministic 5/5 SIGSEGV downstream.
+     * Invariant restored here, at the single point every arena
+     * death passes through: a destroyed arena is never reachable
+     * via the TLS. Readers then fall back to the capped global
+     * payload arena (`lotus_caller_arena_or_global`'s documented
+     * fallback) — a valid arena with a coarser lifetime, never a
+     * dangling one. */
+    if (lotus_current_caller_arena == a) {
+        lotus_current_caller_arena = NULL;
+    }
 
     /* m22: if this is a sub-region, return its slot to the
      * parent's free-list so a future create_subregion can reuse

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -12678,6 +12678,49 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
 
         self.current_user_fn_caller_arena = Some(caller_arena_alloca);
         self.current_user_fn_arena = Some(fn_arena_alloca);
+        // GH #375: publish the caller's arena to the caller-arena
+        // TLS at fn entry. The TLS is set-and-forget, and a callee
+        // chain that exited (especially via a failure edge) can
+        // leave it pointing at a destroyed method scratch; any
+        // TLS-reading allocation site in this body without its own
+        // preceding publish — a locus instantiation's C-primitive
+        // work was the reproducer — would then allocate out of
+        // freed memory. Publishing the __caller_arena param here
+        // re-heals the TLS on every free-fn entry AND gives those
+        // readers the arena the caller would have used had the
+        // body been inlined (the same m49 lifetime argument as
+        // `current_user_fn_caller_arena` itself).
+        //
+        // Gated on the body actually containing a construct that
+        // can read the TLS — a locus/struct instantiation or any
+        // call (method entry snapshots, `or` handler invocations).
+        // Every direct TLS-reading lowering lives under one of
+        // those; scalar-only leaf fns (the 2ns fn_call shape) skip
+        // the publish, which otherwise measured +86% on that
+        // bench. Same fail-safe direction as the drain-elision
+        // gate: over-matching only costs one call.
+        let body_can_read_tls = {
+            let dbg = format!("{:?}", f.body);
+            dbg.contains("Call {") || dbg.contains("Struct {")
+        };
+        if body_can_read_tls {
+            let ptr_t2 = self.context.ptr_type(AddressSpace::default());
+            let ca = self
+                .builder
+                .build_load(
+                    ptr_t2,
+                    caller_arena_alloca,
+                    "fn.caller_arena.publish",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let set_fn = self
+                .module
+                .get_function("lotus_set_caller_arena")
+                .expect("lotus_set_caller_arena declared");
+            self.builder
+                .build_call(set_fn, &[ca.into()], "fn.tls.publish")
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        }
         self.current_user_fn_exit_bb = Some(exit_bb);
         self.current_user_fn_ret_alloca = ret_alloca;
         self.current_user_fn_fallible = fallible_ctx;
@@ -28853,6 +28896,28 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 "method.scratch.destroy",
             )
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        // GH #375: restore the caller-arena TLS to the value
+        // snapshotted at method entry. Body code published its own
+        // scratch (and callees published theirs); with the scratch
+        // now destroyed, a stale TLS would dangle until the next
+        // publish — the destroy above clears an exact match as a
+        // backstop, but restoring the snapshot re-establishes the
+        // CALLER's published context on both the ok and the error
+        // exit (both run this epilogue), making method calls
+        // TLS-neutral.
+        if let Some(ca_slot) = self.current_method_caller_arena {
+            let ca = self
+                .builder
+                .build_load(ptr_t, ca_slot, "method.caller_arena.restore")
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let set_fn = self
+                .module
+                .get_function("lotus_set_caller_arena")
+                .expect("lotus_set_caller_arena declared");
+            self.builder
+                .build_call(set_fn, &[ca.into()], "method.tls.restore")
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        }
         // Anchor retirement (2026-07-03): the method activation is
         // over — clones retired by this activation's hashmap sets/
         // removes become reusable. Sound here by the same argument

--- a/crates/hale-codegen/tests/caller_arena_tls_unwind.rs
+++ b/crates/hale-codegen/tests/caller_arena_tls_unwind.rs
@@ -1,0 +1,154 @@
+//! GH #375 — the caller-arena TLS must not outlive the arena it
+//! points to.
+//!
+//! The TLS (`lotus_current_caller_arena`) is a set-and-forget
+//! channel: call sites publish before stdlib/method calls, and
+//! nothing ever un-published. A fallible method chain that
+//! published its own method scratch and then exited down the ERROR
+//! edge left the TLS pointing at the destroyed scratch; the next
+//! TLS reader without its own preceding publish — a cross-seed
+//! free-fn factory building a `@form(vec)` locus was the reported
+//! shape — allocated out of freed memory. Deterministic 5/5
+//! SIGSEGV downstream; ASan shows heap-use-after-free inside
+//! `lotus_arena_alloc` via `lotus_bus_payload_arena_alloc`.
+//!
+//! Three-layer fix, each pinned by this file running green:
+//!  1. `lotus_arena_destroy` clears the TLS when it points at the
+//!     dying arena (kills the UAF class at the single point every
+//!     arena death passes through);
+//!  2. free-fn prologues publish their `__caller_arena` param to
+//!     the TLS (re-heals it on every fn entry, and gives TLS
+//!     readers the inlined-call lifetime);
+//!  3. method epilogues restore the entry-time snapshot on both
+//!     the ok and error exits (method calls are TLS-neutral).
+//!
+//! The failing shape needs BOTH seeds — every single-file toy in
+//! the issue's reduction matrix stayed clean, and so did ours
+//! until the import dimension was added. The lib carries the
+//! `@form(vec)` locus + a Runner whose fallible method publishes
+//! TLS from its scratch (the String concat) before failing through
+//! a nested `or raise` hop; the consumer catches with `or` and
+//! then calls the factory. Verified to reproduce the ASan UAF on
+//! the pre-fix compiler exactly as written here.
+
+use std::process::Command;
+
+use hale_codegen::build_executable_with_imports;
+use hale_codegen::mangle;
+use hale_syntax::ast::{Program, TopDecl};
+use hale_syntax::parse_source;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+const LIB_SRC: &str = r#"
+type Rec { version: Int; name: String; sql: String; }
+type LibErr { kind: String; detail: String; }
+
+@form(vec)
+locus Recs {
+    params { n: Int = 0; }
+    capacity { heap data of Rec; }
+    fn add(version: Int, name: String, sql: String) {
+        self.push(Rec { version: version, name: name, sql: sql });
+        self.n = self.n + 1;
+    }
+}
+
+locus Runner {
+    params { set: Recs = Recs { }; }
+    fn __validate() -> Int fallible(LibErr) {
+        // The load-bearing line: a String concat in THIS scratch
+        // publishes the TLS right before the failure unwinds.
+        let label = "validate:" + to_string(self.set.n);
+        if self.set.n == 0 {
+            fail LibErr { kind: "bad_set", detail: label };
+        }
+        return self.set.n;
+    }
+    fn up() -> Int fallible(LibErr) {
+        let n = self.__validate() or raise;
+        return n;
+    }
+}
+"#;
+
+const PROBE_SRC: &str = r#"
+import "../lib" as lib;
+
+fn caught(e: lib::LibErr) -> Int { return 0 - 1; }
+
+fn factory() -> lib::Recs {
+    let s = lib::Recs { };
+    s.add(1, "one", "CREATE TABLE a (id int)");
+    s.add(2, "two", "CREATE TABLE b (id int)");
+    s.add(3, "three", "CREATE TABLE c (id int)");
+    return s;
+}
+
+fn rec0() -> lib::Rec { return lib::Rec { version: 0, name: "?", sql: "" }; }
+
+fn main() {
+    let empty = lib::Recs { };
+    let r = lib::Runner { set: empty };
+    let b = r.up() or caught(err);
+    print("caught="); println(b);
+    let s = factory();
+    print("n="); println(s.n);
+    let first = s.get(0) or rec0();
+    print("first="); println(first.name);
+    println("clean exit");
+}
+"#;
+
+/// Mirror of the cross_seed_imports.rs helper: parse the lib
+/// source as seed "lib", mangle, and produce (items, renames).
+fn mangle_lib(alias: &str) -> (Vec<TopDecl>, Vec<(Vec<String>, String)>) {
+    let prog = parse_source(LIB_SRC).expect("parse lib");
+    let parsed: Vec<(String, Program)> = vec![("lib".to_string(), prog)];
+    let stem_refs: Vec<(String, &Program)> =
+        parsed.iter().map(|(s, p)| (s.clone(), p)).collect();
+    let seed_renames = mangle::build_seed_renames(&stem_refs, alias);
+    let mut renames: Vec<(Vec<String>, String)> = Vec::new();
+    for (name, mangled) in &seed_renames {
+        renames.push((vec![alias.to_string(), name.clone()], mangled.clone()));
+    }
+    let mut items: Vec<TopDecl> = Vec::new();
+    for (_, mut prog) in parsed {
+        mangle::mangle_with_renames(&mut prog, &seed_renames);
+        items.extend(prog.items);
+    }
+    (items, renames)
+}
+
+#[test]
+fn factory_after_caught_cross_seed_failure_is_clean() {
+    let mut consumer = parse_source(PROBE_SRC).expect("parse probe");
+    consumer.imports.clear();
+    let (lib_items, renames) = mangle_lib("lib");
+    consumer.items.extend(lib_items);
+
+    let bin = harness::unique_bin("caller_arena_tls_unwind");
+    build_executable_with_imports(&consumer, &bin, &renames)
+        .expect("build 2-seed probe");
+
+    let out = Command::new(&bin).output().expect("run probe");
+    let _ = std::fs::remove_file(&bin);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "the factory after a caught cross-seed failure must not \
+         crash (GH #375; pre-fix this was a deterministic SIGSEGV \
+         / ASan heap-use-after-free): {:?}\nstdout:\n{}\nstderr:\n{}",
+        out.status,
+        stdout,
+        String::from_utf8_lossy(&out.stderr),
+    );
+    // Output correctness matters too: pre-fix, a plain (non-ASan)
+    // build could survive the UAF by reading recycled memory and
+    // produce garbage instead of crashing.
+    assert!(stdout.contains("caught=-1"), "bad catch: {:?}", stdout);
+    assert!(stdout.contains("n=3"), "bad count: {:?}", stdout);
+    assert!(stdout.contains("first=one"), "bad element: {:?}", stdout);
+    assert!(stdout.contains("clean exit"), "no clean exit: {:?}", stdout);
+}


### PR DESCRIPTION
Closes #375.

The reported shape — a free-fn factory that builds and grows a `@form(vec)` locus, called after a locus-method failure was caught with an `or` handler — segfaulted 5/5. The reproducer (two pond seeds + probe, exactly as filed) now runs **10/10 clean and ASan-clean**.

## Root cause

`lotus_current_caller_arena` — the TLS that stdlib primitives and free-fn machinery allocate through — is a **set-and-forget channel**: call sites publish before stdlib/method calls, and nothing ever un-publishes. The failing chain's `__validate` published its **own method scratch** to the TLS (the String work in its body) and then exited down the error edge; the scratch was destroyed (correctly), but the TLS kept pointing at it. The next TLS reader without its own preceding publish — the factory's cross-seed instantiation path — allocated out of the freed arena struct. ASan: heap-use-after-free in `lotus_arena_alloc` via `lotus_bus_payload_arena_alloc`, freed-by and allocated-by both inside `__validate`'s scratch lifecycle.

This is also why the issue's toy-reduction matrix came up empty: **every single-file reduction stays clean**. The failing shape needs the cross-seed import dimension — our minimal two-seed toy reproduces the ASan UAF on the pre-fix compiler exactly as written into the regression test.

## The fix — three layers, each independently sound

1. **`lotus_arena_destroy` clears the TLS on an exact match.** The single point every arena death passes through, so a destroyed arena is never reachable via the TLS again; readers fall back to `lotus_caller_arena_or_global`'s documented global-arena path. This also covers the subregion-**recycle** path, where a stale TLS would otherwise silently alias a *reused* arena — wrong-lifetime allocations with no fault, arguably worse than the crash.
2. **Free-fn prologues publish their `__caller_arena` param to the TLS** — re-healing it on every fn entry and giving TLS readers the same lifetime an inlined body would have used (the existing m49 argument). Gated on the body containing an instantiation or a call — the constructs every TLS-reading lowering lives under — because ungated the publish measured **+86% on `fn_call`** (a call added to a 2ns/call path). Fail-safe direction: over-matching costs one call, never correctness.
3. **Method epilogues restore the entry-time caller-arena snapshot** at scratch destroy, which runs on both the ok and the error exit — method calls become TLS-neutral.

## Verification

- The filed reproducer: 10/10 clean, ASan-clean (was 5/5 SIGSEGV).
- `tests/caller_arena_tls_unwind.rs`: minimal two-seed regression (lib with `@form(vec)` + fallible chain that publishes-then-fails through a nested `or raise` hop; consumer catches and calls the factory), **verified to reproduce the ASan UAF on the pre-fix compiler**. Asserts exit status *and* output correctness, since a plain build can survive the UAF by reading recycled memory.
- Corpus oracle, cross-seed suites, form/hashmap/aliasing suites, bus devirt differential, drain elision, log routing, birth-order, native suite: green.
- Perf: `fn_call` and `locus_instantiation` at parity or better vs the v0.11.3 released compiler after the gating.

## Note for the second survivor

The issue mentions a possibly-related zero-reads manifestation (Matrix allocated after a receiver's form-vec growth reads as zeros). The recycle-path hazard fixed by layer 1 — a stale TLS aliasing a *reused* arena produces exactly wrong-arena allocations with no fault — is a plausible mechanism for that family, so it's worth a downstream retest at this commit before deeper digging.
