### PR TITLE
feat(chains): the full vocabulary — map, sum, any/all, find family, each

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,12 @@ surprises:
 
 - Bus subscriber declared after publisher fired → instantiate
   subscribers first.
+- Process boots, then idles — a handler "never fires", a socket
+  "never opened" → check params order. An inline-on-main child
+  whose `run()` never returns blocks every LATER param from being
+  born (its `birth()` never runs). Declare the keep-alive child
+  last, or place it `pinned` / on a non-`main` pool. `hale check`
+  warns on the provable shape.
 - Topic ref used as expression value → topics aren't values;
   they address bus channels only.
 - `self` outside a method body → you're in a free fn or top

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ behavior.
 
 ## Unreleased
 
+### Element chains: the full vocabulary
+
+The v0.13.0 chain mechanism (`filter` / `count` / `into`) gains the
+rest of its table. Stages: `map(expr)` rebinds the element.
+Terminals: `sum()` (Int elements; `map` first to project), `any(pred?)`
+/ `all(pred)` (Bool, with spec'd vacuous truth — `any` on empty is
+false, `all` on empty is true), `first()` / `find(pred?)` /
+`min(key?)` / `max(key?)` (element-valued, **fallible on empty** —
+they lower to an index search whose value is the source's own
+`get(idx)`, so an empty result is the ordinary IndexError and
+`or raise` / `or fallback` / `or handler(err)` apply with zero new
+error machinery), and `each { … }` (the block is spliced as the fused
+loop's body with `it` bound — no closure exists, and `break` /
+`continue` act on the loop; the desugared loop increments first, so
+`continue` advances rather than spinning).
+
+Everything still fuses to one loop with nothing produced between
+stages, so every chain remains legal under `@budget(alloc_per_call =
+0)` / `@hot`, and predicates' effects stay attributed to their own
+source lines. Recognition stays conservative: user facade methods
+named like terminals resolve normally — stage-less recognition
+requires an argument that mentions `it` (unbound outside a chain) or
+`each`'s block, both shapes no ordinary call can have. `min`/`max`
+return the *element* with the least/greatest key (`min_by_key`
+shape). `map` does not compose with the fallible terminals (the `or`
+fallback would need the mapped type while `get` yields the element);
+project after the find. `sort` / `reverse` / `group` remain future
+materializing terminals into caller storage.
+
 ### The caller-arena TLS can no longer outlive the arena it points to (GH #375)
 
 A free-fn factory that builds and grows a `@form(vec)` locus

--- a/crates/hale-codegen/tests/element_chains.rs
+++ b/crates/hale-codegen/tests/element_chains.rs
@@ -164,3 +164,223 @@ fn a_bare_method_is_not_a_chain() {
     assert!(st.success(), "non-zero: {:?}", st);
     assert!(out.contains("len=2"), "got: {:?}", out);
 }
+
+// ==== 2026-08-04 vocabulary tranche ================================
+//
+// map / sum / any / all / first / find / min / max / each. Same
+// mechanism, more rows in the table. The struct-element source
+// exercises `it`-substitution through field access; the fallible
+// terminals ride the source's own `get` (IndexError + ordinary
+// `or`), which is also why they refuse to compose with `map`.
+
+const U: &str = r#"
+    type User { id: Int; age: Int; name: String; }
+
+    @form(vec)
+    locus Users { capacity { heap data of User; } }
+
+    @form(vec)
+    locus Ints { capacity { heap data of Int; } }
+
+    fn seed(us: Users) {
+        us.push(User { id: 1, age: 30, name: "ann" });
+        us.push(User { id: 2, age: 17, name: "bob" });
+        us.push(User { id: 3, age: 45, name: "cid" });
+        us.push(User { id: 4, age: 22, name: "dee" });
+    }
+"#;
+
+#[test]
+fn map_sum_and_stage_composition() {
+    let src = format!(
+        "{U}fn main() {{
+            let us = Users {{ }};
+            seed(us);
+            println(\"s=\", us.map(it.age).sum());
+            println(\"a=\", us.filter(it.age >= 18).map(it.age).sum());
+            println(\"c=\", us.filter(it.age >= 18).count());
+        }}"
+    );
+    let (out, st) = run("map_sum", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("s=114"), "got: {:?}", out);
+    assert!(out.contains("a=97"), "got: {:?}", out);
+    assert!(out.contains("c=3"), "got: {:?}", out);
+}
+
+#[test]
+fn any_all_including_vacuous_truth() {
+    let src = format!(
+        "{U}fn main() {{
+            let us = Users {{ }};
+            seed(us);
+            println(\"minor=\", us.any(it.age < 18));
+            println(\"all_adult=\", us.all(it.age >= 18));
+            println(\"all_named=\", us.all(len(it.name) > 0));
+            // vacuous cases on an emptied selection
+            println(\"v_any=\", us.filter(it.age > 100).any(true));
+            println(\"v_all=\", us.filter(it.age > 100).all(false));
+        }}"
+    );
+    let (out, st) = run("any_all", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("minor=true"), "got: {:?}", out);
+    assert!(out.contains("all_adult=false"), "got: {:?}", out);
+    assert!(out.contains("all_named=true"), "got: {:?}", out);
+    // any over nothing is false; all over nothing is true — spec'd
+    // vacuous truth, pinned here so nobody "fixes" it.
+    assert!(out.contains("v_any=false"), "got: {:?}", out);
+    assert!(out.contains("v_all=true"), "got: {:?}", out);
+}
+
+#[test]
+fn find_first_min_max_are_fallible_on_empty() {
+    let src = format!(
+        "{U}fn main() {{
+            let us = Users {{ }};
+            seed(us);
+            let bob = us.find(it.id == 2) or User {{ id: 0, age: 0, name: \"?\" }};
+            let ghost = us.find(it.id == 99) or User {{ id: 0, age: 0, name: \"ghost\" }};
+            let fm = us.filter(it.age < 18).first() or User {{ id: 0, age: 0, name: \"none\" }};
+            let young = us.min(it.age) or User {{ id: 0, age: 0, name: \"?\" }};
+            let old = us.max(it.age) or User {{ id: 0, age: 0, name: \"?\" }};
+            let none = us.filter(it.age > 100).min(it.age) or User {{ id: 0, age: 0, name: \"empty\" }};
+            println(\"bob=\", bob.name);
+            println(\"ghost=\", ghost.name);
+            println(\"fm=\", fm.name);
+            println(\"young=\", young.name);
+            println(\"old=\", old.name);
+            println(\"none=\", none.name);
+        }}"
+    );
+    let (out, st) = run("find_min_max", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("bob=bob"), "got: {:?}", out);
+    assert!(out.contains("ghost=ghost"), "got: {:?}", out);
+    assert!(out.contains("fm=bob"), "got: {:?}", out);
+    assert!(out.contains("young=bob"), "got: {:?}", out);
+    assert!(out.contains("old=cid"), "got: {:?}", out);
+    assert!(out.contains("none=empty"), "got: {:?}", out);
+}
+
+#[test]
+fn map_into_lands_mapped_elements() {
+    let src = format!(
+        "{U}fn main() {{
+            let us = Users {{ }};
+            seed(us);
+            let ages = Ints {{ }};
+            us.filter(it.age >= 18).map(it.age).into(ages);
+            println(\"n=\", ages.len());
+            println(\"s=\", ages.filter(true).sum());
+        }}"
+    );
+    let (out, st) = run("map_into", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("n=3"), "got: {:?}", out);
+    assert!(out.contains("s=97"), "got: {:?}", out);
+}
+
+/// `each { ... }` is the fused loop's body: side effects run per
+/// surviving element, and `continue` / `break` act on the loop —
+/// `continue` must advance to the NEXT element (the increment-first
+/// loop shape; an end-of-body increment would spin forever).
+#[test]
+fn each_block_with_continue_and_break() {
+    let src = format!(
+        "{U}fn main() {{
+            let us = Users {{ }};
+            seed(us);
+            let mut total = 0;
+            us.filter(it.age >= 18).each {{
+                total = total + it.age;
+                println(\"visit=\", it.name);
+            }}
+            println(\"total=\", total);
+            let mut seen = 0;
+            us.each {{
+                if it.id == 2 {{ continue; }}
+                if it.id == 3 {{ break; }}
+                seen = seen + it.age;
+            }}
+            println(\"seen=\", seen);
+        }}"
+    );
+    let (out, st) = run("each", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("visit=ann"), "got: {:?}", out);
+    assert!(out.contains("visit=cid"), "got: {:?}", out);
+    assert!(out.contains("visit=dee"), "got: {:?}", out);
+    assert!(out.contains("total=97"), "got: {:?}", out);
+    assert!(out.contains("seen=30"), "got: {:?}", out);
+}
+
+/// User facade methods that share terminal names keep resolving:
+/// stage-less calls whose arguments do not mention `it` are ordinary
+/// method calls, never chains. The hijack-safety half of the
+/// recognition gate.
+#[test]
+fn user_methods_named_like_terminals_still_resolve() {
+    let src = r#"
+        locus Counterish {
+            params { hits: Int = 0; }
+            fn any(v: Int) -> Bool { self.hits = self.hits + 1; return v > 0; }
+            fn find(v: Int) -> Int { return v * 2; }
+        }
+        fn main() {
+            let c = Counterish { };
+            println("a=", c.any(5));
+            println("f=", c.find(21));
+        }
+    "#;
+    let (out, st) = run("facade", src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    assert!(out.contains("a=true"), "got: {:?}", out);
+    assert!(out.contains("f=42"), "got: {:?}", out);
+}
+
+/// A chain nested inside another chain's predicate.
+#[test]
+fn nested_chain_in_a_predicate() {
+    let src = format!(
+        "{U}fn main() {{
+            let us = Users {{ }};
+            seed(us);
+            let above = us.filter(it.age > us.map(it.age).sum() / 4).count();
+            println(\"above=\", above);
+        }}"
+    );
+    let (out, st) = run("nested", &src);
+    assert!(st.success(), "non-zero: {:?}", st);
+    // avg = 114/4 = 28 -> ages 30, 45 above.
+    assert!(out.contains("above=2"), "got: {:?}", out);
+}
+
+/// A find miss under `or raise` diverges like any raised fallible —
+/// the process exits non-zero rather than fabricating an element.
+#[test]
+fn find_miss_or_raise_diverges() {
+    let src = format!(
+        "{U}fn main() {{
+            let us = Users {{ }};
+            seed(us);
+            let hit = us.find(it.id == 2) or raise;
+            println(\"hit=\", hit.name);
+            let gone = us.find(it.id == 99) or raise;
+            println(\"unreachable=\", gone.name);
+        }}"
+    );
+    let (out, st) = run("find_raise", &src);
+    assert!(
+        !st.success(),
+        "a raised find miss must not exit clean: {:?}\n{}",
+        st,
+        out
+    );
+    assert!(out.contains("hit=bob"), "the hit path runs first: {:?}", out);
+    assert!(
+        !out.contains("unreachable="),
+        "the miss must diverge: {:?}",
+        out
+    );
+}

--- a/crates/hale-syntax/src/chains.rs
+++ b/crates/hale-syntax/src/chains.rs
@@ -22,16 +22,60 @@
 //!   compiler knows about, not a value, so there is no closure to
 //!   represent — no capture modes, no escape analysis, no `self`
 //!   capture policy, no cross-thread question. `it` is bound per
-//!   element by this desugar.
+//!   element by this desugar. (`each { ... }` LOOKS lambda-shaped
+//!   but is spliced as the fused loop's body in the enclosing scope
+//!   — no capture semantics exist to define.)
 //!
 //! Done as a POST-PARSE AST rewrite rather than in codegen, so
 //! typecheck and codegen both see an ordinary `while` loop. No new
 //! machinery in either, and a chain over a non-form receiver fails
 //! with the ordinary "no method `len`" diagnostic.
 //!
-//! v1 surface: `filter` as the elementwise op, `count` and `into` as
-//! terminals. The mechanism is the deliverable; more ops are rows in
-//! the same table.
+//! ## Vocabulary (2026-08-04 tranche; v1 was filter/count/into)
+//!
+//! Elementwise stages — fuse into the one loop:
+//!   - `filter(pred)`  — `it`-predicate, drops non-matching elements
+//!   - `map(expr)`     — `it`-expression, rebinds the element
+//!
+//! Terminals:
+//!   - `count()`            → Int
+//!   - `into(target)`       → pushes surviving (mapped) elements
+//!   - `sum()`              → Int (v1: Int elements only — the
+//!                            accumulator's typed zero needs literal
+//!                            suffixes for Float/Decimal/Duration)
+//!   - `any(pred?)`         → Bool; empty ⇒ false (vacuous)
+//!   - `all(pred)`          → Bool; empty ⇒ true  (vacuous)
+//!   - `first()`            → element, FALLIBLE on empty (IndexError,
+//!                            handled with ordinary `or`)
+//!   - `find(pred?)`        → first(); `find(p)` ≡ `filter(p).first()`
+//!   - `min(key?)`/`max(key?)` → the ELEMENT with the least/greatest
+//!                            key (`min_by_key` shape); bare form
+//!                            compares elements themselves; FALLIBLE
+//!                            on empty like `first`
+//!   - `each { ... }`       → side-effectful visitation; the block is
+//!                            the fused loop body with `it` bound
+//!
+//! Recognition is deliberately conservative so user-declared facade
+//! methods never get hijacked:
+//!   - with ≥1 stage, every terminal is recognized (stages make the
+//!     expression impossible as an ordinary method chain);
+//!   - stage-less, a terminal is recognized ONLY when it carries an
+//!     argument that mentions `it` (`xs.any(it.v > 3)`) — `it` is
+//!     unbound outside a chain, so no valid user call looks like
+//!     this — or when it is `each` with a block argument (no user
+//!     surface takes a block).
+//!   Bare `xs.sum()` / `xs.first()` therefore stay ordinary method
+//!   calls (`first` stage-less is just `xs.get(0) or …`).
+//!
+//! The element-valued fallible terminals (`first`/`find`/`min`/`max`)
+//! reuse the source's OWN fallible `get`: the loop finds an index,
+//! and the chain's value is `src.get(idx)` — a miss produces the
+//! ordinary IndexError, so `or raise` / `or fallback` / `or
+//! handler(err)` all work with zero new error machinery. This is
+//! also why they do not compose with `map` (the `or` fallback would
+//! need the mapped type while `get` yields the source type): project
+//! AFTER the find, on the returned element. A mapped find is left
+//! unrecognized and fails with the ordinary no-method diagnostic.
 
 use crate::ast::*;
 use crate::span::Span;
@@ -104,17 +148,52 @@ fn if_stmt(i: &mut IfStmt, n: &mut usize) {
     }
 }
 
-/// A chain's shape: the source receiver, the accumulated predicates,
-/// and the terminal.
+/// One elementwise stage.
+enum Stage {
+    Filter(Expr),
+    Map(Expr),
+}
+
+/// A chain's shape: the source receiver, the accumulated stages, and
+/// the terminal.
 struct Chain {
     src: Expr,
-    preds: Vec<Expr>,
+    stages: Vec<Stage>,
     terminal: String,
     term_args: Vec<Expr>,
 }
 
-/// Peel `src.filter(p).filter(q).count()` into its parts. `None` when
-/// this is not a recognized chain — an ordinary method call.
+const TERMINALS: &[&str] = &[
+    "count", "into", "sum", "any", "all", "first", "find", "min", "max",
+    "each",
+];
+
+/// Does this expression tree mention the identifier `it`? Used for
+/// the stage-less recognition gate: `it` is unbound outside a chain,
+/// so an argument that mentions it cannot be a valid ordinary call.
+/// Conservative direction: an unrecognized Expr variant returns
+/// false, which merely leaves the call as an ordinary method call —
+/// and if it truly used `it`, typecheck rejects the unbound name.
+fn mentions_it(e: &Expr) -> bool {
+    match e {
+        Expr::Ident(i) => i.name == "it",
+        Expr::Field { receiver, .. } => mentions_it(receiver),
+        Expr::Call { callee, args, .. } => {
+            mentions_it(callee) || args.iter().any(mentions_it)
+        }
+        Expr::Binary { left, right, .. } => {
+            mentions_it(left) || mentions_it(right)
+        }
+        Expr::Unary { operand, .. } => mentions_it(operand),
+        Expr::Index { receiver, index, .. } => {
+            mentions_it(receiver) || mentions_it(index)
+        }
+        _ => false,
+    }
+}
+
+/// Peel `src.filter(p).map(f).<terminal>(…)` into its parts. `None`
+/// when this is not a recognized chain — an ordinary method call.
 fn peel(e: &Expr) -> Option<Chain> {
     let Expr::Call { callee, args, .. } = e else {
         return None;
@@ -122,37 +201,209 @@ fn peel(e: &Expr) -> Option<Chain> {
     let Expr::Field { receiver, name, .. } = callee.as_ref() else {
         return None;
     };
-    if !matches!(name.name.as_str(), "count" | "into") {
+    if !TERMINALS.contains(&name.name.as_str()) {
         return None;
     }
     let terminal = name.name.clone();
     let term_args = args.clone();
 
-    // Walk down the filter stages.
-    let mut preds = Vec::new();
+    // Walk down the stages.
+    let mut stages = Vec::new();
     let mut cur = receiver.as_ref();
     loop {
         let Expr::Call { callee, args, .. } = cur else { break };
         let Expr::Field { receiver, name, .. } = callee.as_ref() else {
             break;
         };
-        if name.name != "filter" || args.len() != 1 {
-            break;
-        }
-        preds.push(args[0].clone());
+        let stage = match name.name.as_str() {
+            "filter" if args.len() == 1 => Stage::Filter(args[0].clone()),
+            "map" if args.len() == 1 => Stage::Map(args[0].clone()),
+            _ => break,
+        };
+        stages.push(stage);
         cur = receiver.as_ref();
     }
-    // A bare `xs.count()` with no stage is an ordinary method call,
-    // not a chain — leave it alone so existing form methods still
-    // resolve.
-    if preds.is_empty() {
+    stages.reverse();
+
+    let has_map = stages.iter().any(|s| matches!(s, Stage::Map(_)));
+
+    // Arity / shape gates per terminal. Anything that does not match
+    // is left as an ordinary method call (fail closed: user facade
+    // methods keep resolving; a genuine mistake gets the ordinary
+    // no-method / arity diagnostic).
+    let shape_ok = match terminal.as_str() {
+        "count" | "sum" | "first" => term_args.is_empty(),
+        "into" => term_args.len() == 1,
+        "any" | "find" => term_args.len() <= 1,
+        "all" => term_args.len() == 1,
+        "min" | "max" => term_args.len() <= 1,
+        "each" => {
+            term_args.len() == 1
+                && matches!(term_args[0], Expr::Block(_))
+        }
+        _ => false,
+    };
+    if !shape_ok {
         return None;
     }
-    preds.reverse();
-    Some(Chain { src: cur.clone(), preds, terminal, term_args })
+    // The element-valued fallible terminals return via the source's
+    // `get`, so a mapped element has nowhere to live — see module
+    // docs. Not recognized; project after the find instead.
+    if has_map && matches!(terminal.as_str(), "first" | "find" | "min" | "max")
+    {
+        return None;
+    }
+
+    // Recognition gate.
+    let recognized = if !stages.is_empty() {
+        true
+    } else {
+        match terminal.as_str() {
+            // A stage-less predicate/key form is unambiguous exactly
+            // when its argument mentions `it`.
+            "any" | "all" | "find" | "min" | "max" => {
+                term_args.first().map_or(false, mentions_it)
+            }
+            // No user surface takes a block argument.
+            "each" => true,
+            _ => false,
+        }
+    };
+    if !recognized {
+        return None;
+    }
+    Some(Chain { src: cur.clone(), stages, terminal, term_args })
+}
+
+// ---- `it` substitution --------------------------------------------
+//
+// Stage/terminal expressions are written against the literal name
+// `it`; the lowering binds each chain's element to a numbered local
+// (`__hale_it<uid>`) so nested chains cannot capture each other's
+// element. The walkers below rewrite `it` → that local. An Expr
+// variant the walker does not descend into leaves any inner `it`
+// untouched, which fails CLOSED: the unbound name is a typecheck
+// error at the chain's site, never a silently wrong binding.
+
+fn subst_expr(e: &mut Expr, to: &str) {
+    match e {
+        Expr::Ident(i) if i.name == "it" => {
+            i.name = to.to_string();
+        }
+        Expr::Field { receiver, .. } => subst_expr(receiver, to),
+        Expr::Call { callee, args, .. } => {
+            subst_expr(callee, to);
+            for a in args {
+                subst_expr(a, to);
+            }
+        }
+        Expr::Binary { left, right, .. } => {
+            subst_expr(left, to);
+            subst_expr(right, to);
+        }
+        Expr::Unary { operand, .. } => subst_expr(operand, to),
+        Expr::Index { receiver, index, .. } => {
+            subst_expr(receiver, to);
+            subst_expr(index, to);
+        }
+        Expr::Path2 { receiver, .. } => subst_expr(receiver, to),
+        Expr::Block(b) => subst_block(b, to),
+        Expr::Or { inner, disposition, .. } => {
+            subst_expr(inner, to);
+            match disposition {
+                OrDisposition::Substitute(e) => subst_expr(e, to),
+                OrDisposition::Fail(e, _) => subst_expr(e, to),
+                _ => {}
+            }
+        }
+        Expr::Struct { inits, .. } => {
+            for init in inits {
+                subst_expr(&mut init.value, to);
+            }
+        }
+        Expr::Array(parts, _) => {
+            for p in parts {
+                subst_expr(p, to);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn subst_block(b: &mut Block, to: &str) {
+    for s in &mut b.stmts {
+        subst_stmt(s, to);
+    }
+    if let Some(t) = &mut b.tail {
+        subst_expr(t, to);
+    }
+}
+
+fn subst_stmt(s: &mut Stmt, to: &str) {
+    match s {
+        Stmt::Let { value, .. } => subst_expr(value, to),
+        Stmt::Assign { value, target, .. } => {
+            subst_expr(value, to);
+            // `it` cannot be assigned (it names an element copy the
+            // loop rebinds) — but an index expression in the lvalue
+            // tail may mention it. Leave the head; heads named `it`
+            // become the unbound-name error, fail closed.
+            let _ = target;
+        }
+        Stmt::Expr(e) => subst_expr(e, to),
+        Stmt::While { cond, body, .. } => {
+            subst_expr(cond, to);
+            subst_block(body, to);
+        }
+        Stmt::If(i) => subst_if(i, to),
+        Stmt::Return(Some(e), _) => subst_expr(e, to),
+        Stmt::Fail { value, .. } => subst_expr(value, to),
+        Stmt::Send { subject, value, .. } => {
+            subst_expr(subject, to);
+            subst_expr(value, to);
+        }
+        _ => {}
+    }
+}
+
+fn subst_if(i: &mut IfStmt, to: &str) {
+    subst_expr(&mut i.cond, to);
+    subst_block(&mut i.then_block, to);
+    if let Some(e) = &mut i.else_block {
+        match e.as_mut() {
+            ElseBranch::Else(b) => subst_block(b, to),
+            ElseBranch::ElseIf(e) => subst_if(e, to),
+        }
+    }
 }
 
 fn expr(e: &mut Expr, n: &mut usize) {
+    // The element-valued fallible terminals bind to a user-written
+    // `or` (`xs.filter(p).first() or fallback`). Rewrite at the Or
+    // node so the disposition moves INSIDE the lowered block, onto
+    // the `src.get(idx)` tail — the shape the existing or-machinery
+    // already lowers.
+    if let Expr::Or { inner, disposition, span } = e {
+        if let Some(c) = peel(inner) {
+            if matches!(
+                c.terminal.as_str(),
+                "first" | "find" | "min" | "max"
+            ) {
+                *n += 1;
+                let lowered = lower_indexed(
+                    c,
+                    *span,
+                    *n,
+                    Some(disposition.clone()),
+                );
+                *e = lowered;
+                // The moved disposition's own sub-expressions still
+                // deserve chain rewriting.
+                expr(e, n);
+                return;
+            }
+        }
+    }
     // Rewrite innermost-first so a chain inside a chain's predicate is
     // handled before the outer one is consumed.
     match e {
@@ -168,11 +419,18 @@ fn expr(e: &mut Expr, n: &mut usize) {
             expr(right, n);
         }
         Expr::Block(b) => block(b, n),
+        Expr::Or { inner, .. } => expr(inner, n),
         _ => {}
     }
     if let Some(c) = peel(e) {
         *n += 1;
-        *e = lower(c, e.span(), *n);
+        let sp = e.span();
+        *e = match c.terminal.as_str() {
+            "first" | "find" | "min" | "max" => {
+                lower_indexed(c, sp, *n, None)
+            }
+            _ => lower(c, sp, *n),
+        };
     }
 }
 
@@ -186,6 +444,9 @@ fn var(n: &str, sp: Span) -> Expr {
 }
 fn int(v: i64, sp: Span) -> Expr {
     Expr::Literal(Literal::Int(v), sp)
+}
+fn boolean(v: bool, sp: Span) -> Expr {
+    Expr::Literal(Literal::Bool(v), sp)
 }
 fn method(recv: Expr, name: &str, args: Vec<Expr>, sp: Span) -> Expr {
     Expr::Call {
@@ -206,9 +467,21 @@ fn bin(op: BinOp, l: Expr, r: Expr, sp: Span) -> Expr {
         span: sp,
     }
 }
+fn not(e: Expr, sp: Span) -> Expr {
+    Expr::Unary { op: UnaryOp::Not, operand: Box::new(e), span: sp }
+}
 fn let_mut(n: &str, v: Expr, sp: Span) -> Stmt {
     Stmt::Let {
         is_mut: true,
+        name: id(n, sp),
+        ty: None,
+        value: v,
+        span: sp,
+    }
+}
+fn let_val(n: &str, v: Expr, sp: Span) -> Stmt {
+    Stmt::Let {
+        is_mut: false,
         name: id(n, sp),
         ty: None,
         value: v,
@@ -223,60 +496,28 @@ fn assign(n: &str, v: Expr, sp: Span) -> Stmt {
         span: sp,
     }
 }
-
-/// `src.filter(p)…<terminal>` -> a block containing one loop.
-fn lower(c: Chain, sp: Span, uid: usize) -> Expr {
-    let i_name = format!("__hale_chain_i{}", uid);
-    let acc_name = format!("__hale_chain_n{}", uid);
-    let (i, acc) = (i_name.as_str(), acc_name.as_str());
-
-    // The per-element body, innermost first: the terminal's action,
-    // wrapped in each predicate.
-    let action: Stmt = match c.terminal.as_str() {
-        "count" => assign(
-            acc,
-            bin(BinOp::Add, var(acc, sp), int(1, sp), sp),
-            sp,
-        ),
-        // `into(target)` pushes the element.
-        _ => Stmt::Expr(method(
-            c.term_args
-                .first()
-                .cloned()
-                .unwrap_or_else(|| var("__hale_chain_missing", sp)),
-            "push",
-            vec![var("it", sp)],
-            sp,
-        )),
-    };
-
-    let mut body_stmts = vec![action];
-    for p in c.preds.iter().rev() {
-        body_stmts = vec![Stmt::If(IfStmt {
-            cond: p.clone(),
-            then_block: Block {
-                stmts: body_stmts,
-                tail: None,
-                span: sp,
-            },
-            else_block: None,
-            span: sp,
-        })];
-    }
-
-    // `let it = src.get(i) or { break; };` — the element binding. The
-    // diverging fallback is why #353's diverging-`or` fix had to land
-    // first: there is no typed default to invent for an arbitrary
-    // element type.
-    let bind_it = Stmt::Let {
+fn if_then(cond: Expr, then: Vec<Stmt>, sp: Span) -> Stmt {
+    Stmt::If(IfStmt {
+        cond,
+        then_block: Block { stmts: then, tail: None, span: sp },
+        else_block: None,
+        span: sp,
+    })
+}
+fn get_or_break(src: &Expr, idx_var: &str, bind: &str, sp: Span) -> Stmt {
+    // `let <bind> = src.get(i) or { break; };` — the diverging
+    // fallback is why #353's diverging-`or` fix had to land first:
+    // there is no typed default to invent for an arbitrary element
+    // type.
+    Stmt::Let {
         is_mut: false,
-        name: id("it", sp),
+        name: id(bind, sp),
         ty: None,
         value: Expr::Or {
             inner: Box::new(method(
-                c.src.clone(),
+                src.clone(),
                 "get",
-                vec![var(i, sp)],
+                vec![var(idx_var, sp)],
                 sp,
             )),
             disposition: OrDisposition::Substitute(Box::new(Expr::Block(
@@ -289,38 +530,300 @@ fn lower(c: Chain, sp: Span, uid: usize) -> Expr {
             span: sp,
         },
         span: sp,
-    };
-
-    let mut loop_body = vec![bind_it];
-    loop_body.extend(body_stmts);
-    loop_body.push(assign(
-        i,
-        bin(BinOp::Add, var(i, sp), int(1, sp), sp),
-        sp,
-    ));
-
-    let mut stmts = vec![let_mut(i, int(0, sp), sp)];
-    if c.terminal == "count" {
-        stmts.push(let_mut(acc, int(0, sp), sp));
     }
-    stmts.push(Stmt::While {
-        cond: bin(
-            BinOp::Lt,
-            var(i, sp),
-            method(c.src.clone(), "len", Vec::new(), sp),
+}
+
+/// Wrap `action` in the chain's stages, innermost-out. Returns the
+/// statements forming the per-element body, and binds the running
+/// element name: stage k's expressions see the element as `elem`,
+/// and a `map` rebinds it to a fresh local for the stages after it.
+fn apply_stages(
+    stages: &[Stage],
+    elem0: &str,
+    uid: usize,
+    mut action: Vec<Stmt>,
+    sp: Span,
+) -> Vec<Stmt> {
+    // Compute the element name seen AFTER each stage prefix.
+    let mut names: Vec<String> = vec![elem0.to_string()];
+    let mut mapn = 0usize;
+    for s in stages {
+        match s {
+            Stage::Filter(_) => {
+                names.push(names.last().unwrap().clone());
+            }
+            Stage::Map(_) => {
+                mapn += 1;
+                names.push(format!("__hale_m{}_{}", uid, mapn));
+            }
+        }
+    }
+    // Innermost-out: wrap the action with each stage, last first.
+    for (k, s) in stages.iter().enumerate().rev() {
+        let seen = names[k].clone(); // element name THIS stage reads
+        match s {
+            Stage::Filter(p) => {
+                let mut p = p.clone();
+                subst_expr(&mut p, &seen);
+                action = vec![if_then(p, action, sp)];
+            }
+            Stage::Map(f) => {
+                let mut f = f.clone();
+                subst_expr(&mut f, &seen);
+                let bound = names[k + 1].clone();
+                let mut stmts = vec![let_val(&bound, f, sp)];
+                stmts.extend(action);
+                action = stmts;
+            }
+        }
+    }
+    action
+}
+
+/// The element name the TERMINAL sees (after all stages).
+fn final_elem(stages: &[Stage], elem0: &str, uid: usize) -> String {
+    let mapn = stages.iter().filter(|s| matches!(s, Stage::Map(_))).count();
+    if mapn == 0 {
+        elem0.to_string()
+    } else {
+        format!("__hale_m{}_{}", uid, mapn)
+    }
+}
+
+/// Shared loop skeleton:
+/// `let mut i = -1; while true { i = i + 1;
+///  let elem = src.get(i) or { break; }; <body> }`.
+///
+/// The increment comes FIRST and the fallible `get` is the loop's
+/// only terminator. Two properties hang on this shape:
+///  - `continue` inside an `each { ... }` body skips to the next
+///    element instead of spinning forever on the same index (an
+///    end-of-body increment would be skipped by the `continue`);
+///  - no `len()` call per iteration — `get` already bounds-checks,
+///    and its `or { break; }` is the exit.
+fn build_loop(
+    src: &Expr,
+    uid: usize,
+    body: Vec<Stmt>,
+    sp: Span,
+) -> Vec<Stmt> {
+    let i_name = format!("__hale_chain_i{}", uid);
+    let elem = format!("__hale_it{}", uid);
+    let mut loop_body = vec![
+        assign(
+            &i_name,
+            bin(BinOp::Add, var(&i_name, sp), int(1, sp), sp),
             sp,
         ),
-        body: Block { stmts: loop_body, tail: None, span: sp },
-        span: sp,
-    });
+        get_or_break(src, &i_name, &elem, sp),
+    ];
+    loop_body.extend(body);
+    vec![
+        let_mut(&i_name, int(-1, sp), sp),
+        Stmt::While {
+            cond: boolean(true, sp),
+            body: Block { stmts: loop_body, tail: None, span: sp },
+            span: sp,
+        },
+    ]
+}
 
+/// Value-accumulating and side-effect terminals:
+/// count / into / sum / any / all / each.
+fn lower(mut c: Chain, sp: Span, uid: usize) -> Expr {
+    let acc_name = format!("__hale_chain_n{}", uid);
+    let acc = acc_name.as_str();
+    let elem0 = format!("__hale_it{}", uid);
+
+    // Predicate-form `any(p)` is `filter(p).any()`.
+    if c.terminal == "any" && !c.term_args.is_empty() {
+        c.stages.push(Stage::Filter(c.term_args.remove(0)));
+    }
+
+    let fin = final_elem(&c.stages, &elem0, uid);
+
+    // The innermost per-element action + (init, tail) for the block.
+    let (action, init, tail): (Vec<Stmt>, Option<Stmt>, Option<Expr>) =
+        match c.terminal.as_str() {
+            "count" => (
+                vec![assign(
+                    acc,
+                    bin(BinOp::Add, var(acc, sp), int(1, sp), sp),
+                    sp,
+                )],
+                Some(let_mut(acc, int(0, sp), sp)),
+                Some(var(acc, sp)),
+            ),
+            // v1: Int elements only — see module docs.
+            "sum" => (
+                vec![assign(
+                    acc,
+                    bin(BinOp::Add, var(acc, sp), var(&fin, sp), sp),
+                    sp,
+                )],
+                Some(let_mut(acc, int(0, sp), sp)),
+                Some(var(acc, sp)),
+            ),
+            "any" => (
+                vec![assign(acc, boolean(true, sp), sp), Stmt::Break(sp)],
+                Some(let_mut(acc, boolean(false, sp), sp)),
+                Some(var(acc, sp)),
+            ),
+            "all" => {
+                let mut p = c.term_args[0].clone();
+                subst_expr(&mut p, &fin);
+                (
+                    vec![if_then(
+                        not(p, sp),
+                        vec![
+                            assign(acc, boolean(false, sp), sp),
+                            Stmt::Break(sp),
+                        ],
+                        sp,
+                    )],
+                    Some(let_mut(acc, boolean(true, sp), sp)),
+                    Some(var(acc, sp)),
+                )
+            }
+            "each" => {
+                let Expr::Block(mut b) = c.term_args.remove(0) else {
+                    unreachable!("peel gated each on a block arg");
+                };
+                subst_block(&mut b, &fin);
+                let mut stmts = b.stmts;
+                if let Some(t) = b.tail {
+                    stmts.push(Stmt::Expr(*t));
+                }
+                (stmts, None, None)
+            }
+            // `into(target)` pushes the (mapped) element.
+            _ => (
+                vec![Stmt::Expr(method(
+                    c.term_args
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| var("__hale_chain_missing", sp)),
+                    "push",
+                    vec![var(&fin, sp)],
+                    sp,
+                ))],
+                None,
+                None,
+            ),
+        };
+
+    let body = apply_stages(&c.stages, &elem0, uid, action, sp);
+    let mut stmts = Vec::new();
+    if let Some(i) = init {
+        stmts.push(i);
+    }
+    stmts.extend(build_loop(&c.src, uid, body, sp));
     Expr::Block(Block {
         stmts,
-        tail: if c.terminal == "count" {
-            Some(Box::new(var(acc, sp)))
-        } else {
-            None
+        tail: tail.map(Box::new),
+        span: sp,
+    })
+}
+
+/// Element-valued fallible terminals: first / find / min / max.
+///
+/// The loop resolves an INDEX; the chain's value is `src.get(idx)`.
+/// idx starts at -1, so an empty result is the ordinary IndexError
+/// from the source's own fallible `get` — `or` handles it with zero
+/// new machinery. `disposition`, when present, is the user's `or`
+/// moved onto that tail.
+fn lower_indexed(
+    mut c: Chain,
+    sp: Span,
+    uid: usize,
+    disposition: Option<OrDisposition>,
+) -> Expr {
+    let idx_name = format!("__hale_chain_idx{}", uid);
+    let idx = idx_name.as_str();
+    let elem0 = format!("__hale_it{}", uid);
+
+    // `find(p)` is `filter(p).first()`.
+    if c.terminal == "find" && !c.term_args.is_empty() {
+        c.stages.push(Stage::Filter(c.term_args.remove(0)));
+    }
+
+    let i_name = format!("__hale_chain_i{}", uid);
+    let action: Vec<Stmt> = match c.terminal.as_str() {
+        "first" | "find" => vec![
+            assign(idx, var(&i_name, sp), sp),
+            Stmt::Break(sp),
+        ],
+        // min/max: keep the index of the best element so far. The
+        // best's key is re-derived through the source's own `get` —
+        // its `or { break; }` can never fire (idx is a previously
+        // visited index) — so no accumulator of unknown type exists.
+        _ => {
+            let is_min = c.terminal == "min";
+            let key_of = |e: Expr, sp: Span| -> Expr {
+                match c.term_args.first() {
+                    Some(k) => {
+                        // Key expression over the candidate.
+                        let kname = format!("__hale_k{}", uid);
+                        let mut ke = k.clone();
+                        subst_expr(&mut ke, &kname);
+                        Expr::Block(Block {
+                            stmts: vec![let_val(&kname, e, sp)],
+                            tail: Some(Box::new(ke)),
+                            span: sp,
+                        })
+                    }
+                    None => e,
+                }
+            };
+            let best_bind = format!("__hale_best{}", uid);
+            let cand_key = key_of(var(&elem0, sp), sp);
+            let best_key = key_of(var(&best_bind, sp), sp);
+            let cmp = bin(
+                if is_min { BinOp::Lt } else { BinOp::Gt },
+                cand_key,
+                best_key,
+                sp,
+            );
+            vec![if_then(
+                bin(BinOp::Lt, var(idx, sp), int(0, sp), sp),
+                vec![assign(idx, var(&i_name, sp), sp)],
+                sp,
+            ), if_then(
+                bin(BinOp::GtEq, var(idx, sp), int(0, sp), sp),
+                vec![
+                    get_or_break(&c.src, idx, &best_bind, sp),
+                    if_then(
+                        cmp,
+                        vec![assign(idx, var(&i_name, sp), sp)],
+                        sp,
+                    ),
+                ],
+                sp,
+            )]
+        }
+    };
+
+    // NOTE: the min/max action above compares even on the iteration
+    // that seeded idx (best == candidate; strict compare is false, so
+    // idx stays) — one redundant compare per seed keeps the shape to
+    // two ifs with no else machinery.
+
+    let body = apply_stages(&c.stages, &elem0, uid, action, sp);
+    let mut stmts = vec![let_mut(idx, int(-1, sp), sp)];
+    stmts.extend(build_loop(&c.src, uid, body, sp));
+
+    let get_tail = method(c.src.clone(), "get", vec![var(idx, sp)], sp);
+    let tail = match disposition {
+        Some(d) => Expr::Or {
+            inner: Box::new(get_tail),
+            disposition: d,
+            span: sp,
         },
+        None => get_tail,
+    };
+    Expr::Block(Block {
+        stmts,
+        tail: Some(Box::new(tail)),
         span: sp,
     })
 }

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -5344,6 +5344,20 @@ impl Parser {
             stmts.push(Stmt::Expr(expr));
             return Ok(None);
         }
+        // An `each { ... }` chain terminal is block-shaped: like
+        // `while`/`if`, it stands as a statement without a
+        // trailing `;`.
+        if let Expr::Call { callee, args, .. } = &expr {
+            if matches!(args.as_slice(), [Expr::Block(_)])
+                && matches!(
+                    callee.as_ref(),
+                    Expr::Field { name, .. } if name.name == "each"
+                )
+            {
+                stmts.push(Stmt::Expr(expr));
+                return Ok(None);
+            }
+        }
         if self.at(&TokenKind::RBrace) {
             return Ok(Some(expr));
         }
@@ -5580,6 +5594,32 @@ impl Parser {
                         self.expect_member_name()?
                     };
                     let span = expr.span().merge(name.span);
+                    // Chain terminal `each { ... }` (2026-08-04):
+                    // the ONLY place a block argument exists. Safe
+                    // to claim unconditionally after `.each` — no
+                    // type is named `each`, so `{` here can never
+                    // open a struct literal, and a user method
+                    // cannot take a block. The block becomes the
+                    // call's sole argument; the chain desugar
+                    // splices it as the fused loop's body with `it`
+                    // bound (no closure semantics — see chains.rs).
+                    if name.name == "each"
+                        && matches!(self.peek(), TokenKind::LBrace)
+                    {
+                        let b = self.parse_block()?;
+                        let bspan = b.span;
+                        let span2 = span.merge(bspan);
+                        expr = Expr::Call {
+                            callee: Box::new(Expr::Field {
+                                receiver: Box::new(expr),
+                                name,
+                                span,
+                            }),
+                            args: vec![Expr::Block(b)],
+                            span: span2,
+                        };
+                        continue;
+                    }
                     expr = Expr::Field {
                         receiver: Box::new(expr),
                         name,

--- a/docs/src/everyday/collections.md
+++ b/docs/src/everyday/collections.md
@@ -192,12 +192,50 @@ let n = users.filter(it.active).count();
 users.filter(it.active).into(actives);
 ```
 
-`it` is the current element. Chain as many `filter`s as you like; they
+`it` is the current element. Chain as many stages as you like; they
 run in a single pass:
 
 ```hale,fragment
 let n = readings.filter(it > 10).filter(it < 100).count();
+let total = users.filter(it.active).map(it.age).sum();
 ```
+
+`map` rebinds the element; `sum` adds it up (Int elements — project
+with `map` first). Yes-or-no questions have their own terminals:
+
+```hale,fragment
+if users.any(it.age < 18) { restrict(); }
+if users.all(len(it.name) > 0) { proceed(); }
+```
+
+On an empty selection `any` is `false` and `all` is `true` — the
+usual vacuous-truth convention.
+
+Looking *for* an element is fallible — an empty result is handled
+with the same `or` you already use everywhere:
+
+```hale,fragment
+let bob = users.find(it.id == want) or User { id: 0, age: 0, name: "?" };
+let oldest = users.max(it.age) or raise;
+let youngest = users.min(it.age) or raise;
+```
+
+`find` returns the element itself (project after, not before —
+`map` doesn't compose with `find`), and `min`/`max` take a key and
+return the *element* that had it, not the key.
+
+And when the point is the side effect, `each` takes a block:
+
+```hale,fragment
+users.filter(it.age >= 18).each {
+    total = total + it.age;
+    "user.greet" <- Greeting { id: it.id };
+}
+```
+
+The block *is* the loop body — `it` is in scope, `break` and
+`continue` do what they do in any loop, and nothing is captured
+because there is no closure.
 
 This looks like an iterator chain from another language, and it is
 deliberately not one. There is no intermediate collection between the

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -2215,10 +2215,67 @@ end" is a property the compiler can decide.
 
 A bare method call with no stage (`v.count()`) is an ordinary form
 method, not a chain, and is left alone. A chain over a non-form
-receiver fails with the ordinary "no method `len`" diagnostic.
+receiver fails with the ordinary "no method `get`" diagnostic.
 
-v1 surface: `filter` as the elementwise operation; `count` and `into`
-as terminals.
+### Vocabulary
+
+Elementwise **stages** (fuse into the one loop):
+
+| stage | meaning |
+|---|---|
+| `filter(pred)` | drop elements where the `it`-predicate is false |
+| `map(expr)` | rebind the element to the `it`-expression's value |
+
+**Terminals**:
+
+| terminal | result |
+|---|---|
+| `count()` | Int |
+| `sum()` | Int — v1 requires Int elements (`map` first); the accumulator's typed zero for Float/Decimal/Duration needs literal suffixes that do not exist yet |
+| `into(target)` | pushes each surviving (mapped) element |
+| `any(pred?)` | Bool; **empty selection ⇒ `false`** (vacuous) |
+| `all(pred)` | Bool; **empty selection ⇒ `true`** (vacuous) |
+| `first()` | the first surviving element — **fallible** on empty |
+| `find(pred?)` | `find(p)` ≡ `filter(p).first()` |
+| `min(key?)` / `max(key?)` | the **element** with the least/greatest key (`min_by_key` shape; bare form compares elements) — fallible on empty |
+| `each { … }` | run the block per surviving element |
+
+**Fallible terminals ride the source's own `get`.** `first` / `find`
+/ `min` / `max` lower to an index search whose value is
+`src.get(idx)` — an empty result is the ordinary `IndexError`, so
+`or raise` / `or fallback` / `or handler(err)` all apply with no new
+error machinery:
+
+```hale,fragment
+let bob = users.find(it.id == want) or User { id: 0, age: 0, name: "?" };
+let oldest = users.max(it.age) or raise;
+```
+
+For the same reason they do **not** compose with `map` (the `or`
+fallback would need the mapped type while `get` yields the source
+element): project *after* the find, on the returned element.
+
+**`each` takes a block, not a lambda.** The block is spliced as the
+fused loop's body with `it` bound — it executes in the enclosing
+scope, so there are no capture semantics to define, and `break` /
+`continue` act on the fused loop (`continue` advances to the next
+element):
+
+```hale,fragment
+users.filter(it.age >= 18).each {
+    total = total + it.age;
+}
+```
+
+**Recognition is conservative** so user facade methods sharing these
+names never get hijacked: with at least one stage, every terminal is
+recognized (no ordinary method chain looks like that); stage-less, a
+terminal is recognized only when its argument mentions `it` — which
+is unbound outside a chain, so no valid ordinary call can look like
+that — or when it is `each` with a block. Bare `xs.sum()` /
+`xs.first()` therefore stay ordinary method calls (stage-less first
+is just `xs.get(0) or …`; a stage-less sum can be written
+`xs.map(it).sum()`).
 
 ## Bus subscription dispatch
 

--- a/spec/styleguide.md
+++ b/spec/styleguide.md
@@ -472,6 +472,16 @@ websocket's client is the reference). **[convention]**
 - **One non-returning `run()` per classic cooperative pool** —
   a second never starts. Give daemons their own pool or pin
   them. **[convention]**
+- **Declare non-returning inline children last.** Params birth in
+  declaration order and an inline-on-main child's `run()` runs
+  synchronously during its own birth — so a keep-alive child
+  declared early means every later param is never **born**: its
+  `birth()` never runs, its subscriptions and sockets never
+  exist, and the process looks like it booted and idles. Declare
+  the blocker last, or move it off the main thread (`pinned` /
+  a non-`main` pool) — only the blocker's placement matters. The
+  compiler warns where it can prove the shape; absence of the
+  warning is not a guarantee. **[warn]**
 - A single-writer state locus read from other pools: pin it, and
   poll scalar fields across pools rather than sharing heap
   values. **[convention]**
@@ -928,9 +938,14 @@ Write the workaround knowing it's a placeholder.
   retire** (String leaves do, since v0.11.3). Until then:
   genuinely-churning Bytes fields in a reused `BytesBuilder`;
   nested compound fields in their own locus or flattened.
-- **Synced (cross-pool) `@form` maps don't retire** replaced
-  cells (needs an epoch scheme). Churned shared maps on hot
-  paths stay single-pool for now.
+- **`striped` / `lockfree` `@form` maps don't retire** replaced
+  cells — a churned String-bearing cell on those modes still
+  accumulates. (`sync = serialized` retires since 2026-08-03:
+  reads are owned snapshots cloned into the caller's arena, so
+  churned shared maps no longer need to stay single-pool. The
+  clone is per String field per read — a read-heavy hot path on
+  a String-bearing cell now pays it, so weigh serialized against
+  single-pool on read-dominated shapes.)
 - **Dynamic per-instance bus subjects** (the conversation-per-
   topic shape). Keyed routing covers the *bounded/known* key-set
   case — including String keys — but an unbounded,

--- a/spec/styleguide.md
+++ b/spec/styleguide.md
@@ -796,6 +796,9 @@ is regression-tested. **[convention]**
 // idiomatic
 let n = self.users.filter(it.active).count();
 self.users.filter(it.active).into(self.actives);
+let total = self.users.map(it.age).sum();
+let oldest = self.users.max(it.age) or raise;
+self.users.filter(it.active).each { self.greet(it); }
 
 // not this
 let mut i = 0;


### PR DESCRIPTION
The v0.13.0 chain mechanism (`filter`/`count`/`into`) gains the rest of its table, per the settled design: **stages** `map(expr)`; **terminals** `sum()`, `any(pred?)`, `all(pred)`, `first()`, `find(pred?)`, `min(key?)`, `max(key?)`, `each { … }`. Everything still fuses to one loop with nothing produced between stages — the pre-existing `a_chain_is_legal_under_a_zero_alloc_budget` test passes unchanged.

## The three design decisions, as implemented

**Fallible-on-empty rides the source's own `get`.** `first`/`find`/`min`/`max` lower to an index search whose value is `src.get(idx)` — an empty result is the ordinary `IndexError`, so `or raise` / `or fallback` / `or handler(err)` all work with **zero new error machinery** (the user's `or` is hoisted onto that `get` tail at desugar time). This is also why they don't compose with `map` — the fallback would need the mapped type while `get` yields the element — so a mapped find is left unrecognized; project after. `min`/`max` are `min_by_key`-shaped (return the *element*), and the running best is re-derived through `get(best_idx)`, so no accumulator of statically-unknown type ever exists.

**`each` takes a block, and the block is honestly a loop body.** Parsed as the call's sole argument — the only block-argument surface in the language, claimed unconditionally after `.each` since no type is named `each` and `{` can never open a struct literal there. Spliced into the fused loop with `it` bound: no closure, no capture semantics to define. `break`/`continue` act on the loop, and the desugared loop **increments first**, so `continue` advances to the next element instead of spinning forever on one index (this restructure also drops the per-iteration `len()` call — `get`'s bounds check is the loop's terminator). Statement-position `each` needs no trailing `;`, like `while`.

**`sum` is a bare terminal over Int elements**, with `map` doing projection (`xs.map(it.price).sum()`). Float/Decimal/Duration sums need typed zero literals that don't exist yet; documented in the spec table.

## Hijack-proofing

Recognition stays conservative: with ≥1 stage every terminal is recognized (no ordinary method chain looks like that); stage-less, only when an argument mentions `it` — unbound outside a chain, so no valid ordinary call can look like that — or for `each`'s block. User facade methods named `any`/`find`/etc. keep resolving, pinned by test. `it` substitution binds each chain's element to a numbered local so nested chains can't capture each other's element; any substitution-walker gap leaves `it` unbound = a typecheck error at the chain site, never a silently wrong binding.

## Verification

`element_chains.rs` 6 → 14 tests: vacuous truth (`any` empty = false, `all` empty = true) pinned so nobody "fixes" it; facade safety; `continue`/`break` inside `each`; nested chain in a predicate; `or raise` divergence on a find miss; `map`+`into` type flow. Full `hale-syntax` + `hale-types` suites, corpus oracle, native suite green. `hale fmt` round-trips `.each { }` (verified on a probe: format → reparse → typecheck clean).

`spec/semantics.md` gains the vocabulary table plus the get-ride and each-block contracts; styleguide S13 and the everyday-collections chapter show the new surface; snippet gates green.

## Left for later, deliberately

`take`/`skip` (trivial counters, next tranche), `enumerate` (needs a second implicit binding — bigger surface decision than its utility), `sort`/`reverse`/`group` (materializing terminals into caller-owned storage, per the boundary already in the spec), non-Int `sum`, and stream sources. Grammar note: `.each { }` is new surface for tree-sitter-hale's corpus (tracked repo-side as the existing gap list).
