### PR TITLE
fix: dissolve let-bound loci when a method returns (GH #383, partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ behavior.
 
 ## Unreleased
 
+### A locus `let`-bound in a method now dissolves when the method `return`s
+
+`lower_return`'s method arms destroyed the per-call scratch and
+returned **without flushing the deferred-dissolve frame**; the
+terminated-body arm then popped that frame unflushed. Only a
+fall-through exit ever ran the dissolves. So a locus bound in any
+method that returns was never torn down — its `dissolve()` never ran,
+its subscriptions stayed registered, its arena and `@form` buffers
+leaked — silently, with no diagnostic:
+
+```hale
+fn step(i: Int) -> Int {
+    let w = Watcher { id: i };   // subscribes, opens an fd, …
+    return i * 2;                // ← w never dissolved
+}
+```
+
+Nothing about factories or cross-seed calls is involved; a plain
+locus literal leaked the same way, on every value and void return
+path. Found while investigating GH #383, which remains open for its
+own (harder) case: a locus returned *by* a free-fn factory still has
+no owner the compiler can name, so it stays program-lifetime.
+
+Ordering is load-bearing and is now pinned by a test: the flush runs
+**before** the scratch destroy, because a dissolve is a method call
+whose call site publishes the caller-arena TLS — flushing afterwards
+publishes a pointer into freed scratch, reproducing the #375/#381
+use-after-free exactly.
+
 ### Element chains: the full vocabulary
 
 The v0.13.0 chain mechanism (`filter` / `count` / `into`) gains the

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -19250,6 +19250,40 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                 } else {
                     if in_method_with_scratch {
+                        // GH #383: dissolve loci bound in this method
+                        // body BEFORE the scratch dies. `return` used
+                        // to leave the deferred-dissolve frame to be
+                        // popped UNFLUSHED by the terminated-body arm
+                        // in locus/method.rs, so a locus `let`-bound
+                        // in any method that returns was never
+                        // dissolved — only fall-through exits ran the
+                        // flush. Independent of factory returns: a
+                        // plain `let w = Watcher { };` leaked the same
+                        // way.
+                        //
+                        // Order is load-bearing. A dissolve is a
+                        // method call, and its call site publishes the
+                        // caller-arena TLS — so flushing AFTER
+                        // `close_method_scratch()` publishes a pointer
+                        // to freed scratch, reproducing the #375/#381
+                        // use-after-free signature. Flush first.
+                        //
+                        // The frame CONTENTS are saved and restored
+                        // for the same reason the scratch state below
+                        // is: the flush pops, and a body with N
+                        // returns must emit dissolves on every path
+                        // while the epilogue's single pop still
+                        // balances.
+                        let saved_frame = self
+                            .deferred_dissolves
+                            .last()
+                            .cloned()
+                            .unwrap_or_default();
+                        self.flush_dissolve_frame_kind(false)?;
+                        self.push_dissolve_frame();
+                        if let Some(f) = self.deferred_dissolves.last_mut() {
+                            *f = saved_frame;
+                        }
                         // Save/restore scratch state so subsequent
                         // `return` statements in the same method
                         // body also emit the destroy. Without this,
@@ -19398,6 +19432,21 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                 } else if in_method_with_scratch {
                     let copied = self.emit_method_return_deep_copy(v, &declared_ty)?;
+                    // GH #383: flush before the scratch dies — see the
+                    // void-return arm for the ordering argument. The
+                    // deep-copy above already moved the return value
+                    // into the caller's arena, so dissolving here
+                    // cannot strand it.
+                    let saved_frame = self
+                        .deferred_dissolves
+                        .last()
+                        .cloned()
+                        .unwrap_or_default();
+                    self.flush_dissolve_frame_kind(false)?;
+                    self.push_dissolve_frame();
+                    if let Some(f) = self.deferred_dissolves.last_mut() {
+                        *f = saved_frame;
+                    }
                     // Multi-return scratch-destroy fix — see
                     // matching note in the void-return arm above.
                     let saved_scratch = self.current_method_scratch;

--- a/crates/hale-codegen/tests/method_return_dissolve.rs
+++ b/crates/hale-codegen/tests/method_return_dissolve.rs
@@ -1,0 +1,177 @@
+//! A locus `let`-bound in a locus method must dissolve even when the
+//! method exits via `return` (GH #383, found while investigating the
+//! factory-return leak — this is the separable half).
+//!
+//! `lower_return`'s method-with-scratch arms destroyed the scratch and
+//! returned without ever flushing the deferred-dissolve frame;
+//! `locus/method.rs`'s terminated-body arm then popped that frame with
+//! a bare `let _ = …pop();`. Only a fall-through exit (`BlockEnd::Open`)
+//! ever flushed. So this leaked, silently, with no diagnostic:
+//!
+//! ```hale,fragment
+//! fn step(i: Int) -> Int {
+//!     let w = Watcher { id: i };   // subscribes, opens an fd, …
+//!     return i * 2;                // ← w never dissolved
+//! }
+//! ```
+//!
+//! Nothing about factories is involved; a plain locus literal leaks
+//! the same way. Verified against the v0.13.0 release binary: the
+//! `dissolve()` body never runs on either return path.
+//!
+//! ## Why the flush must precede the scratch destroy
+//!
+//! A dissolve is a method call, and every call site publishes the
+//! caller-arena TLS before invoking. Flushing *after*
+//! `close_method_scratch()` therefore publishes a pointer into
+//! already-freed scratch, which reproduces the #375/#381
+//! use-after-free signature exactly (observed while developing this).
+//! The frame's CONTENTS are saved and restored around the flush for
+//! the same reason the scratch state is: the flush pops, and a body
+//! with N returns must emit dissolves on every path while the
+//! epilogue's single pop still balances.
+
+use std::process::Command;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+use hale_codegen::build_executable;
+
+fn run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(name);
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        out.status,
+    )
+}
+
+const SRC: &str = r#"
+    locus Watcher {
+        params { id: Int = 0; }
+        birth()    { println("born ", self.id); }
+        dissolve() { println("dissolved ", self.id); }
+    }
+
+    locus Engine {
+        params { n: Int = 0; }
+
+        // value return
+        fn step(i: Int) -> Int {
+            let w = Watcher { id: i };
+            self.n = self.n + 1;
+            return i * 2;
+        }
+
+        // void return
+        fn tick(i: Int) {
+            let w = Watcher { id: 100 + i };
+            if i >= 0 { return; }
+        }
+
+        // several returns in one body: every path must dissolve,
+        // and the scratch must still be destroyed exactly once
+        fn pick(i: Int) -> Int {
+            let w = Watcher { id: 200 + i };
+            if i == 0 { return 10; }
+            if i == 1 { return 20; }
+            return 30;
+        }
+    }
+
+    fn main() {
+        let e = Engine { };
+        print("s="); println(e.step(1));
+        e.tick(1);
+        print("p="); println(e.pick(1));
+        print("n="); println(e.n);
+        println("done");
+    }
+"#;
+
+#[test]
+fn a_let_bound_locus_dissolves_on_every_return_path() {
+    let (out, st) = run("method_return_dissolve", SRC);
+    assert!(st.success(), "non-zero exit: {:?}\n{}", st, out);
+
+    for id in ["1", "101", "201"] {
+        assert!(
+            out.contains(&format!("born {}", id)),
+            "watcher {} must be born: {:?}",
+            id,
+            out
+        );
+        assert!(
+            out.contains(&format!("dissolved {}", id)),
+            "watcher {} must dissolve despite the method returning \
+             (GH #383): {:?}",
+            id,
+            out
+        );
+    }
+    // …and the methods' own work still happened. The birth /
+    // dissolve lines interleave between `print("s=")` and its value
+    // (the callee runs after the label is written), so match the
+    // values on their own lines rather than as `s=2`.
+    let lines: Vec<&str> = out.lines().map(|l| l.trim()).collect();
+    assert!(lines.contains(&"2"), "step returned 2: {:?}", out);
+    assert!(lines.contains(&"20"), "pick returned 20: {:?}", out);
+    assert!(out.contains("n=1"), "got: {:?}", out);
+    assert!(out.contains("done"), "got: {:?}", out);
+}
+
+/// Ordering guard: the dissolve runs BEFORE the method's scratch is
+/// destroyed. If that inverts, the dissolve's call site publishes the
+/// caller-arena TLS into freed memory — the #375/#381 UAF. A body that
+/// allocates in scratch on both sides of the binding gives the
+/// regression somewhere to land.
+#[test]
+fn dissolve_ordering_does_not_strand_the_caller_arena() {
+    const ORDER_SRC: &str = r#"
+        locus Note {
+            params { tag: String = ""; }
+            dissolve() { println("gone ", self.tag); }
+        }
+
+        locus Runner {
+            params { seen: String = ""; }
+            fn work(i: Int) -> String {
+                let pre = "pre-" + to_string(i);
+                let n = Note { tag: pre };
+                let post = pre + "-post";
+                self.seen = post;
+                return post;
+            }
+        }
+
+        fn main() {
+            let r = Runner { };
+            let mut i = 0;
+            while i < 3 {
+                let s = r.work(i);
+                println(s);
+                i = i + 1;
+            }
+            println(r.seen);
+        }
+    "#;
+    let (out, st) = run("method_return_dissolve_order", ORDER_SRC);
+    assert!(st.success(), "non-zero exit: {:?}\n{}", st, out);
+    for i in 0..3 {
+        assert!(
+            out.contains(&format!("gone pre-{}", i)),
+            "note {} must dissolve: {:?}",
+            i,
+            out
+        );
+        assert!(
+            out.contains(&format!("pre-{}-post", i)),
+            "the returned String must survive the dissolve: {:?}",
+            out
+        );
+    }
+}


### PR DESCRIPTION
The separable half of #383, which turned out to be a wider defect than the issue's headline and is fixable without touching the ownership question that blocks the rest.

## The defect

`lower_return`'s method-with-scratch arms destroyed the per-call scratch and built the return **without flushing the deferred-dissolve frame**; `locus/method.rs`'s terminated-body arm then popped that frame with a bare `let _ = …pop();`. Only a fall-through exit (`BlockEnd::Open`) ever flushed. So a locus `let`-bound in any method that `return`s was never torn down — `dissolve()` never ran, subscriptions stayed registered, its arena and `@form` buffers leaked:

```hale
fn step(i: Int) -> Int {
    let w = Watcher { id: i };   // subscribes, opens an fd, …
    return i * 2;                // ← w never dissolved
}
```

Silent, no diagnostic, and nothing to do with factories or cross-seed calls — a plain locus literal leaks identically. Verified against the **v0.13.0 release binary**: the `dissolve()` body never runs on either return path. With this change it runs on all of them.

## Ordering is load-bearing

A dissolve is a method call, and every call site publishes the caller-arena TLS before invoking. Flushing *after* `close_method_scratch()` therefore publishes a pointer into already-freed scratch — reproducing the #375/#381 use-after-free signature exactly (observed while developing this, not theorised). The flush precedes the destroy, and the frame's **contents** are saved and restored around it for the same reason the scratch state just below it is: the flush pops, and a body with N returns must emit dissolves on every path while the epilogue's single pop still balances.

## What this does NOT fix

#383 stays **open** for its headline case: a locus returned *by* a free-fn factory has no owner the compiler can name, so it remains program-lifetime. Three candidate fixes for that were built and measured this session, all documented on the issue with their failure modes:

| approach | result |
|---|---|
| caller-scoped dissolve at the `let` | silent zeros when the result escapes |
| + factory-body escape analysis | same — the escape is caller-side |
| caller-arena placement + destroy cascade | 87% of the leak, correct values, then a double-destroy SIGSEGV when the result is also owned by a field |

The real fix is a return-slot ABI (caller supplies the storage ⇒ exactly one owner by construction). That is design-sized and deliberately not attempted here.

## Verification

`tests/method_return_dissolve.rs` — dissolves fire on value-return, void-return, and multi-return paths, plus an ordering guard whose body allocates scratch on both sides of the binding so an inverted order has somewhere to land.

Green locally: corpus oracle, cross-seed imports, cross-seed locus arg, caller-arena TLS unwind, method-scratch reclaim, release-reclaims-flow, terminate-reclaims-child, birth-order trap, synced-map retire, drain elision, log routing, element chains. The #381 differential probe still reads `0.16499 / 0.16499` (values, not just leak counts — the check that caught two of the three failed attempts above).
