### PR TITLE
types: a locus-typed field may only be assigned a locus literal (GH #383 ownership decision)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ behavior.
 
 ## Unreleased
 
+### A locus-typed field may only be assigned a locus literal
+
+`self.conn = Connection { url: next };` stays what it always was — a
+lifecycle transition, break-before-make, the new instance built into
+this locus's arena and owned by the field. But assigning a locus
+value produced **elsewhere** — `self.held = make_row(…);`, or
+`let c = Conn { … }; self.conn = c;` — is now a typecheck error.
+
+The reason is ownership: the field claims the instance (its teardown
+reclaims it when self dissolves) and so does the frame that produced
+the value (its scope exit reclaims what it built), and nothing in the
+language decides between them. That ambiguity was previously hidden
+rather than resolved — a locus returned from a free fn is routed to a
+program-lifetime arena and never reclaimed, so such a store *appeared*
+to work only because nothing ever freed it. **The leak was the safety
+mechanism**, the same shape as the synced-map clone-on-read and the
+form-vec zero-reads earlier in this cycle.
+
+Two remedies, both existing shapes: assign a literal (construction in
+place), or route membership through `accept(c: L)`. This is the same
+principle as the no-locus-return rule on methods — a locus is
+structure, not a value to hand around. Ordinary `let`-bound loci,
+including factory results, are unaffected.
+
+Surveyed before adopting: **zero occurrences across 60 bundles in five
+downstream repositories**, so the restriction forbids a pattern nobody
+writes. It is the ownership decision GH #383 was blocked on; the
+codegen half of that issue (reclaiming factory-returned loci) remains
+open, but the semantics it needs are now settled.
+
 ### A locus `let`-bound in a method now dissolves when the method `return`s
 
 `lower_return`'s method arms destroyed the per-call scratch and

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -8666,6 +8666,86 @@ impl<'a> Checker<'a> {
         ty
     }
 
+    /// GH #383: a locus-typed field may only be assigned a locus
+    /// LITERAL, never a locus value produced elsewhere.
+    ///
+    /// `self.conn = Connection { url: next };` is a documented
+    /// lifecycle event: break-before-make, the new instance built
+    /// directly into this locus's arena, owned by the field. But
+    /// `self.held = make_row(...)` stores a locus somebody else
+    /// constructed, and the language has no way to say who owns it
+    /// afterwards — the field, or the frame that produced it.
+    ///
+    /// Today that question is dodged by never freeing: a locus
+    /// returned from a free fn is routed to a program-lifetime arena
+    /// (m90), so the field's pointer stays valid because nothing
+    /// reclaims it. **The leak is the safety mechanism** — the same
+    /// shape as the synced-map clone-on-read (#373) and the
+    /// zero-reads (#381), and the reason every attempt to give those
+    /// loci a real lifetime produced either a use-after-free or
+    /// silently wrong values (see #383 for the four measured
+    /// attempts).
+    ///
+    /// Forbidding the store is what closes the question: with no way
+    /// for a factory result to escape into a field, its owner is the
+    /// binding that named it, and ordinary scope-exit teardown is
+    /// correct. This is the same principle the language already
+    /// applies to locus RETURNS from methods (CQRS / no-locus-return
+    /// — `fn get() -> SomeLocus` is rejected); a locus is structure,
+    /// not a value to be handed around.
+    ///
+    /// Scope: only a whole-field store of a locus-typed field.
+    /// Non-locus fields, index/tail stores, and locus literals are
+    /// untouched.
+    fn check_locus_field_store(
+        &mut self,
+        target: &LValue,
+        value: &Expr,
+        span: Span,
+    ) {
+        // whole-field store only (`self.x = …` / `x.y = …`, one
+        // segment), and the field must be locus-typed
+        if target.tail.len() != 1 {
+            return;
+        }
+        let want = self.lvalue_ty(target);
+        let Ty::Named(tname) = &want else { return };
+        if !matches!(self.top.lookup(tname), Some(TopSymbol::Locus(_))) {
+            return;
+        }
+        // A literal is construction-in-place: allowed, and the
+        // documented reassignment lifecycle event.
+        if matches!(value, Expr::Struct { .. }) {
+            return;
+        }
+        // Anything else naming a locus value is the ambiguous case.
+        // index stores (`x[i] = …`) are not whole-field stores
+        let Some(LValueSeg::Field(fid)) = target.tail.first() else {
+            return;
+        };
+        let field = fid.name.clone();
+        self.diags.push(Diag::ty(
+            span,
+            format!(
+                "cannot assign an existing locus value into locus-typed \
+                 field `{}`: ownership would be ambiguous — the field \
+                 and the frame that produced the value would both \
+                 claim it.\n\n\
+                 Assign a locus LITERAL instead, which builds the new \
+                 instance directly into this locus's arena and is the \
+                 documented reassignment lifecycle event:\n\
+                 \n    self.{} = {} {{ ... }};\n\n\
+                 If the value must come from a factory, route the \
+                 membership through `accept(c: {})` instead of a \
+                 field, or have the factory hand back the data and \
+                 build the locus here. Same principle as the \
+                 no-locus-return rule on methods: a locus is \
+                 structure, not a value to hand around.",
+                field, field, tname, tname
+            ),
+        ));
+    }
+
     fn check_stmt(&mut self, stmt: &Stmt) {
         match stmt {
             Stmt::Let { is_mut, name, ty, value, .. } => {
@@ -8757,6 +8837,7 @@ impl<'a> Checker<'a> {
                         ),
                     ));
                 }
+                self.check_locus_field_store(target, value, *span);
                 // m50: bare-head reassignment to a non-mut local is
                 // a compile-time error per spec/types.md "Mutability"
                 // + design-rationale §E. Field/index segments

--- a/crates/hale-types/tests/locus_field_store.rs
+++ b/crates/hale-types/tests/locus_field_store.rs
@@ -1,0 +1,159 @@
+//! A locus-typed field may only be assigned a locus LITERAL
+//! (GH #383 — the ownership decision that closes the factory-return
+//! leak).
+//!
+//! `self.conn = Connection { url: next };` is a documented lifecycle
+//! event: break-before-make, the new instance built directly into
+//! this locus's arena, unambiguously owned by the field. But
+//! `self.held = make_row(...)` stores a locus somebody else built,
+//! and nothing in the language says who owns it afterwards — the
+//! field, or the frame that produced it.
+//!
+//! Today that question is dodged by never freeing: a locus returned
+//! from a free fn is routed to a program-lifetime arena (m90), so
+//! the field's pointer stays valid because nothing reclaims it.
+//! **The leak is the safety mechanism** — the same shape as the
+//! synced-map clone-on-read and the form-vec zero-reads, and the
+//! reason every attempt to give those loci a real lifetime produced
+//! either a use-after-free or silently wrong values (four measured
+//! attempts on #383).
+//!
+//! Forbidding the store settles it: with no way for a factory result
+//! to escape into a field, its owner is the binding that named it,
+//! and ordinary scope-exit teardown is correct. Same principle the
+//! language already applies to locus returns from methods (CQRS /
+//! no-locus-return): a locus is structure, not a value to hand
+//! around.
+//!
+//! Surveyed before adopting: **zero occurrences** across 60 bundles
+//! in five downstream repositories, so this forbids a pattern nobody
+//! writes — which is what made the restriction (rather than a silent
+//! deep copy) the right call.
+
+use hale_syntax::parse_source;
+use hale_types::check_program;
+
+fn msgs(src: &str) -> Vec<String> {
+    let prog = parse_source(src).expect("parse failed");
+    check_program(&prog).into_iter().map(|d| d.message).collect()
+}
+
+fn fires(src: &str) -> bool {
+    msgs(src).iter().any(|m| m.contains("ownership would be ambiguous"))
+}
+
+#[test]
+fn assigning_a_factory_result_into_a_locus_field_is_rejected() {
+    let src = r#"
+        @form(vec)
+        locus Row { params { tag: Int = 0; } capacity { heap data of Float; } }
+
+        fn make_row(tag: Int) -> Row {
+            let r = Row { tag: tag };
+            r.push(1.0);
+            return r;
+        }
+
+        locus Holder {
+            params { held: Row = Row { }; }
+            fn fill(t: Int) { self.held = make_row(t); }
+        }
+
+        fn main() { let h = Holder { }; h.fill(1); }
+    "#;
+    assert!(fires(src), "expected the diagnostic:\n{:#?}", msgs(src));
+    let m = msgs(src)
+        .into_iter()
+        .find(|m| m.contains("ownership would be ambiguous"))
+        .expect("checked above");
+    // The message must teach the remedy, not just refuse: this is a
+    // restriction people will meet without context.
+    assert!(m.contains("LITERAL"), "must name the allowed form: {}", m);
+    assert!(m.contains("accept("), "must offer accept(): {}", m);
+}
+
+#[test]
+fn assigning_a_let_bound_locus_into_a_field_is_rejected() {
+    // Same ambiguity via a local binding rather than a direct call.
+    let src = r#"
+        locus Conn { params { url: String = ""; } }
+        locus Server {
+            params { conn: Conn = Conn { }; }
+            fn swap(u: String) {
+                let c = Conn { url: u };
+                self.conn = c;
+            }
+        }
+        fn main() { let s = Server { }; s.swap("x"); }
+    "#;
+    assert!(fires(src), "expected the diagnostic:\n{:#?}", msgs(src));
+}
+
+// === negative controls ==========================================
+
+/// The documented reassignment lifecycle event must stay legal —
+/// this is the shape `docs/services/lifecycle.md` teaches.
+#[test]
+fn literal_reassignment_stays_legal() {
+    let src = r#"
+        locus Conn { params { url: String = ""; } }
+        locus Server {
+            params { conn: Conn = Conn { }; n: Int = 0; }
+            fn reconnect(next: String) {
+                self.conn = Conn { url: next };
+                self.n = self.n + 1;
+            }
+        }
+        fn main() { let s = Server { }; s.reconnect("x"); println(s.n); }
+    "#;
+    assert!(!fires(src), "literal reassign must be clean:\n{:#?}", msgs(src));
+}
+
+#[test]
+fn non_locus_fields_are_untouched() {
+    let src = r#"
+        type Rec { a: Int; }
+        fn make_rec(a: Int) -> Rec { return Rec { a: a }; }
+        fn label(i: Int) -> String { return "n" + to_string(i); }
+
+        locus Holder {
+            params { r: Rec = Rec { a: 0 }; s: String = ""; n: Int = 0; }
+            fn fill(i: Int) {
+                self.r = make_rec(i);      // struct value — fine
+                self.s = label(i);         // String value — fine
+                self.n = i;
+            }
+        }
+        fn main() { let h = Holder { }; h.fill(1); println(h.n); }
+    "#;
+    assert!(
+        !fires(src),
+        "only LOCUS-typed fields are restricted:\n{:#?}",
+        msgs(src)
+    );
+}
+
+/// Ordinary locals of locus type are unaffected — the restriction is
+/// about *field* storage, which is what creates the second owner.
+#[test]
+fn locus_locals_are_unaffected() {
+    let src = r#"
+        locus Row { params { tag: Int = 0; } }
+        fn make_row(t: Int) -> Row { let r = Row { tag: t }; return r; }
+        locus User {
+            params { n: Int = 0; }
+            fn use_it(t: Int) -> Int {
+                let r = make_row(t);
+                self.n = r.tag;
+                return r.tag;
+            }
+        }
+        fn main() { let u = User { }; println(u.use_it(3)); }
+    "#;
+    assert!(
+        !fires(src),
+        "a let-bound factory result is the OWNED shape and must stay \
+         legal — it is what the restriction makes sound:\n{:#?}",
+        msgs(src)
+    );
+}

--- a/docs/src/services/lifecycle.md
+++ b/docs/src/services/lifecycle.md
@@ -172,6 +172,26 @@ To *reconfigure the same instance* instead of replacing it, mutate
 in place — `self.conn.url = next;` — which keeps the connection
 and triggers no teardown.
 
+One rule comes with this: the right-hand side has to be a **literal**.
+
+```hale,fragment
+self.conn = Connection { url: next };   // fine — built in place
+self.conn = make_connection(next);      // error
+```
+
+The second line looks reasonable and is rejected on purpose. Two
+things would claim that connection — the field, which tears it down
+when this locus dissolves, and the function that built it, which
+tears down what it made. The language has no way to pick, so it asks
+you to. Build it here with a literal, or if the thing genuinely
+belongs to you as a child rather than a field, take it through
+[`accept`](./parents-children.md).
+
+This is the same idea as a method not being allowed to *return* a
+locus: a locus is structure, not a value you pass around. Plain
+`let`-bound loci are unaffected — a factory result you bind and use
+locally is owned by that binding, and that's fine.
+
 ## Shutdown cascades
 
 `drain()` is always **depth-first cascading**. Calling it on a

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -828,6 +828,36 @@ no teardown. v1 scope: the new instance inherits the parent's pool;
 reassigning a *pinned*-placed field does not re-apply the pinned
 placement.
 
+**The right-hand side must be a locus LITERAL** (error). Assigning
+a locus value produced somewhere else — `self.held = make_row(…);`,
+or `let c = Conn { … }; self.conn = c;` — is rejected, because
+ownership would be ambiguous: the field claims the instance (its
+teardown reclaims it when self dissolves) and so does the frame
+that produced the value (its scope exit reclaims what it built).
+Nothing in the language decides between them.
+
+That ambiguity is not hypothetical. Until this rule, a locus
+returned from a free fn was routed to a program-lifetime arena and
+never reclaimed, which is what made such a store *appear* to work:
+the field's pointer stayed valid because nothing ever freed it —
+the leak was the safety mechanism. Every attempt to give those loci
+a real lifetime produced either a use-after-free or silently wrong
+values.
+
+Two remedies, both existing shapes:
+
+- **Assign a literal** — construction in place, the lifecycle
+  transition above, unambiguously owned by the field.
+- **Route membership through `accept(c: L)`** — parent/child
+  ownership, which is the language's answer for "this locus holds
+  that one" whenever the child is not a `params` field.
+
+This is the same principle as the no-locus-return rule on methods
+(`fn get() -> SomeLocus` is rejected): **a locus is structure, not
+a value to hand around.** Ordinary `let`-bound loci — including
+factory results — are unaffected; they are owned by the binding
+that names them.
+
 ## Mode invocation
 
 `self.bulk()` / `self.harmonic()` / `self.resolution()` invoke


### PR DESCRIPTION
The ownership decision GH #383 was blocked on, taken as **option C** (forbid) after a survey showed it costs nothing.

## The rule

Assigning a locus value produced *elsewhere* into a locus-typed field is now a typecheck error:

```hale
self.conn = Connection { url: next };   // unchanged — lifecycle transition, built in place
self.held = make_row(t);                // error
let c = Conn { url: u }; self.conn = c; // error
```

## Why

On a locus-value store, **two things claim the instance**: the field (its teardown reclaims it when self dissolves) and the frame that produced the value (its scope exit reclaims what it built). Nothing in the language decides between them.

That ambiguity was never resolved — it was *hidden*. A locus returned from a free fn is routed to a program-lifetime arena and never reclaimed, so the store appeared to work because nothing ever freed it. **The leak was the safety mechanism** — the third instance of that exact shape this cycle, after the synced-map clone-on-read and the form-vec zero-reads. It is also why all four attempts on #383 to give those loci a real lifetime produced either a use-after-free or silently wrong values: they were guessing at an owner the language had never named.

Two remedies, both existing shapes and both named in the diagnostic: assign a literal (construction in place), or route membership through `accept(c: L)`. Same principle as the no-locus-return rule on methods — a locus is structure, not a value to hand around.

`let`-bound loci, **factory results included**, are unaffected. They are owned by the binding that names them — which is precisely what this rule makes true, and what the eventual reclamation work will rely on.

## Survey first

A restriction is only defensible if it forbids something nobody needs, so I measured before adopting it:

- **Zero occurrences across 60 bundles** in `pond`, `fathom`, `iris`, `crumb`, `causality` (plus file-level sweeps of `iris-observer`, `graft`, `silt`).
- Positive control: fires on `self.held = make_row(...)`.
- Negative control: silent on `self.conn = Connection { url: next }`.

So the deep-copy alternative (silently clone into self's arena on such a store) was not needed — no downstream code pays for the restriction.

## Scope

This is the **semantics** half of #383. The codegen half — actually reclaiming factory-returned loci — stays open there, but it now has an unambiguous owner to reclaim on behalf of, which is what every previous attempt lacked.

## Verification

`crates/hale-types/tests/locus_field_store.rs` — 2 positive (direct factory call, let-bound locus), 3 negative (literal reassignment stays legal; non-locus fields untouched; locus *locals* unaffected — the owned shape the rule makes sound). Full `hale-types` suite, corpus oracle, cross-seed, chains, birth-order, method-return-dissolve, TLS-unwind suites green. `spec/semantics.md` under "Reassigning a locus-typed field"; `docs/src/services/lifecycle.md` carries the everyday version; snippet gates green.
