### PR TITLE
receiver typing: the summarizer root fix (#382 soundness audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ behavior.
 
 ## Unreleased
 
+### Receiver typing: the summarizer root fix (GH #382 soundness audit)
+
+The four receiver shapes behind the audit's false-certificate class
+are now TYPED at the source: a struct-literal receiver
+(`B { }.work(n)`), a chained field (`self.mid.inner.work(n)`, via
+the per-locus field maps applied transitively, plain-struct fields
+included), a call-result receiver (`let b = make_b(); b.work(n)`,
+via a free-fn return-type map — methods never return loci, per the
+no-locus-return rule), and a uniform if/else value. Typing also
+covers the iteration shapes real programs walk: `for` binders over
+array-typed fields, capacity slots, array-typed params, array
+literals, and the implicit accepted-children collection (`for
+child in self.children` types from the `accept` param); `or`
+dispositions unwrap to the inner value's type; and a single-slot
+collection's `.get(i)` returns its element type (the stdlib
+chain-runner shape). Net effect on the committed corpus baseline:
+ZERO rows changed — identical certificates, with the
+false-certificate shapes closed and no over-fire. Each resolves to a real call-graph edge,
+so `@effects(none:)`, every `@no_*` certificate, `@budget`, the
+quantitative dimensions, AND the claims evaluators now see the
+path and report real witnesses instead of refusing to certify —
+the audit's repro programs ship as standing negative controls for
+both systems (`receiver_shapes.rs`).
+
+The residue — a receiver that still cannot be typed (an index
+result, a match value, a foreign expression) — now fails closed
+consistently in every judgment that traverses calls: the claims
+backstop, `@effects` classes, `@budget`, and the quantitative
+dimensions all treat the edge as may-do-anything. This closes the
+temporarily inconsistent state where a bundle-level claim refused a
+path that a fn-level certificate quietly passed. The topology
+artifact keeps recording residual edges
+(`untyped_receiver_call:<callee>`) inside the hashed model half.
+
 ### Claims: the unresolved-callee backstop (GH #382 soundness audit)
 
 An adversarial audit of the claims evaluators found a

--- a/crates/hale-cli/tests/claims_artifact_unknowns.rs
+++ b/crates/hale-cli/tests/claims_artifact_unknowns.rs
@@ -44,11 +44,13 @@ fn main() { App { }; }
 "#;
 
 fn untyped() -> String {
-    // Same program, but A reaches Bridge through a receiver the
-    // summarizer cannot type.
+    // Same program, but A reaches Bridge through an INDEX-result
+    // receiver — the shape that stays untypeable at this layer
+    // after the receiver-typing root fix (literals, chained
+    // fields, call results, and branch values all resolve now).
     TYPED.replace(
         "params { br: Bridge = Bridge { }; }\n    fn go(n: Int) -> Int { return self.br.hop(n); }",
-        "fn go(n: Int) -> Int { return Bridge { }.hop(n); }",
+        "fn go(n: Int) -> Int { let xs = [Bridge { }]; return xs[0].hop(n); }",
     )
 }
 

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -1031,7 +1031,7 @@ pub fn summarize_programs_with_renames(
     // method referenced by `subscribe ... -> handler` is tagged BusHandler.
     // The trailing `Vec<(String, String)>` seeds each body's var→type map
     // from its params (D2).
-    type BodyEntry = (FnKey, Block, Option<EntryKind>, Option<String>, Vec<(String, String)>, Vec<String>);
+    type BodyEntry = (FnKey, Block, Option<EntryKind>, Option<String>, Vec<(String, String)>, Vec<String>, Vec<(String, String)>);
     let mut bodies: Vec<BodyEntry> = Vec::new();
     let mut known: BTreeSet<FnKey> = BTreeSet::new();
     // GH #18 item 1 — the `@bounded` / `@unbounded` opt-in/carve-out sets.
@@ -1243,7 +1243,7 @@ pub fn summarize_programs_with_renames(
                         unbounded_fns.insert(key.clone());
                     }
                     known.insert(key.clone());
-                    bodies.push((key, decl.body.clone(), entry, None, param_var_types(&decl.params), fn_typed_params(&decl.params)));
+                    bodies.push((key, decl.body.clone(), entry, None, param_var_types(&decl.params), fn_typed_params(&decl.params), param_var_elem_types(&decl.params)));
                 }
                 TopDecl::Type(td) => {
                     if let TypeDeclBody::Struct(fields) = &td.body {
@@ -1312,6 +1312,7 @@ pub fn summarize_programs_with_renames(
                                     Some(locus.clone()),
                                     param_var_types(&md.params),
                                     fn_typed_params(&md.params),
+                                    param_var_elem_types(&md.params),
                                 ));
                             }
                             LocusMember::Fn(decl) => {
@@ -1336,6 +1337,7 @@ pub fn summarize_programs_with_renames(
                                     Some(locus.clone()),
                                     param_var_types(&decl.params),
                                     fn_typed_params(&decl.params),
+                                    param_var_elem_types(&decl.params),
                                 ));
                             }
                             LocusMember::Lifecycle(lc) => {
@@ -1352,6 +1354,7 @@ pub fn summarize_programs_with_renames(
                                     Some(locus.clone()),
                                     param_var_types(&lc.params),
                                     fn_typed_params(&lc.params),
+                                    param_var_elem_types(&lc.params),
                                 ));
                             }
                             _ => {}
@@ -1377,10 +1380,170 @@ pub fn summarize_programs_with_renames(
         .map(|(segs, mangled)| (segs.join("::"), mangled.clone()))
         .collect();
 
+    // #382 receiver-typing: struct TYPE field -> type-name map (a
+    // chained receiver may pass through a plain struct: `route.
+    // handler` where `route` is a struct value), and per-locus
+    // ELEMENT types for iterables (array-typed params fields +
+    // capacity slots), so a `for child in self.children` binder
+    // gets a type instead of landing as an untypeable receiver.
+    let mut struct_field_types: BTreeMap<String, BTreeMap<String, String>> =
+        BTreeMap::new();
+    let mut locus_elem_types: BTreeMap<String, BTreeMap<String, String>> =
+        BTreeMap::new();
+    {
+        fn elem_type_name(te: &TypeExpr) -> Option<String> {
+            match te {
+                TypeExpr::Array { elem, .. } => type_expr_name(elem),
+                _ => None,
+            }
+        }
+        fn collect_maps(
+            items: &[TopDecl],
+            structs: &mut BTreeMap<String, BTreeMap<String, String>>,
+            elems: &mut BTreeMap<String, BTreeMap<String, String>>,
+        ) {
+            for item in items {
+                match item {
+                    TopDecl::Type(td) => {
+                        if let TypeDeclBody::Struct(fields) = &td.body {
+                            let mut m = BTreeMap::new();
+                            for f in fields {
+                                if let Some(tn) = type_expr_name(&f.ty)
+                                {
+                                    m.insert(f.name.name.clone(), tn);
+                                }
+                            }
+                            structs.insert(td.name.name.clone(), m);
+                        }
+                    }
+                    TopDecl::Locus(l) => {
+                        let mut m = BTreeMap::new();
+                        for member in &l.members {
+                            match member {
+                                LocusMember::Params(pb) => {
+                                    for pd in &pb.params {
+                                        if let Some(tn) = pd
+                                            .ty
+                                            .as_ref()
+                                            .and_then(elem_type_name)
+                                        {
+                                            m.insert(
+                                                pd.name.name.clone(),
+                                                tn,
+                                            );
+                                        }
+                                    }
+                                }
+                                LocusMember::Capacity(cb) => {
+                                    for slot in &cb.slots {
+                                        if let Some(tn) =
+                                            type_expr_name(
+                                                &slot.elem_ty,
+                                            )
+                                        {
+                                            m.insert(
+                                                slot.name.name.clone(),
+                                                tn,
+                                            );
+                                        }
+                                    }
+                                }
+                                // The implicit accepted-children
+                                // collection: `for child in
+                                // self.children` iterates what
+                                // `accept(le: T)` registered, so
+                                // the element type is the accept
+                                // param's. A declared field named
+                                // `children` wins (entry API is
+                                // first-insert via or_insert).
+                                LocusMember::Lifecycle(lc)
+                                    if matches!(
+                                        lc.kind,
+                                        LifecycleKind::Accept
+                                    ) =>
+                                {
+                                    if let Some(tn) = lc
+                                        .params
+                                        .first()
+                                        .and_then(|p| {
+                                            type_expr_name(&p.ty)
+                                        })
+                                    {
+                                        m.entry(
+                                            "children".to_string(),
+                                        )
+                                        .or_insert(tn);
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        if !m.is_empty() {
+                            elems.insert(l.name.name.clone(), m);
+                        }
+                    }
+                    TopDecl::Module(md) => {
+                        collect_maps(&md.items, structs, elems)
+                    }
+                    _ => {}
+                }
+            }
+        }
+        for program in programs {
+            collect_maps(
+                &program.items,
+                &mut struct_field_types,
+                &mut locus_elem_types,
+            );
+        }
+    }
+
+    // #382 receiver-typing: free-fn name -> declared LOCUS return
+    // type. `let b = make_b(); b.work(n)` was an unresolved edge —
+    // the call-result receiver had no type — which made every
+    // effect certificate and claim blind to the call (the audit's
+    // false-certificate shape 6). Methods never appear here: the
+    // no-locus-return rule forbids locus returns from methods.
+    let mut fn_ret_types: BTreeMap<String, String> = BTreeMap::new();
+    {
+        fn collect_ret(
+            items: &[TopDecl],
+            locus_type_names: &BTreeSet<String>,
+            out: &mut BTreeMap<String, String>,
+        ) {
+            for item in items {
+                match item {
+                    TopDecl::Fn(f) => {
+                        if let Some(tn) =
+                            f.ret.as_ref().and_then(type_expr_name)
+                        {
+                            if locus_type_names.contains(&tn) {
+                                out.insert(f.name.name.clone(), tn);
+                            }
+                        }
+                    }
+                    TopDecl::Module(m) => collect_ret(
+                        &m.items,
+                        locus_type_names,
+                        out,
+                    ),
+                    _ => {}
+                }
+            }
+        }
+        for program in programs {
+            collect_ret(
+                &program.items,
+                &locus_type_names,
+                &mut fn_ret_types,
+            );
+        }
+    }
+
     // Phase 2 — walk each body.
     let mut summary = AllocSummary::default();
     summary.eager_only_loci = eager_only_loci;
-    for (key, body, entry, enclosing_locus, param_types, fn_params) in &bodies {
+    for (key, body, entry, enclosing_locus, param_types, fn_params, param_elems) in &bodies {
         let escaping = collect_escaping_names(body);
         let field_types = enclosing_locus
             .as_ref()
@@ -1407,7 +1570,12 @@ pub fn summarize_programs_with_renames(
             const_ints: &const_ints,
             store_target: None,
             var_types: param_types.iter().cloned().collect(),
+            var_elem_types: param_elems.iter().cloned().collect(),
             field_types,
+            all_field_types: &locus_field_types,
+            all_struct_fields: &struct_field_types,
+            all_elem_types: &locus_elem_types,
+            fn_ret_types: &fn_ret_types,
             inline_array_fields,
             form_of: &form_of,
             retirable_structs: &retirable_structs,
@@ -1468,6 +1636,20 @@ fn fn_typed_params(params: &[Param]) -> Vec<String> {
         .iter()
         .filter(|p| matches!(p.ty, TypeExpr::Function { .. }))
         .map(|p| p.name.name.clone())
+        .collect()
+}
+
+/// #382 receiver-typing: array-typed params' ELEMENT types, so a
+/// free fn iterating an array parameter (`__http_run_chain(entries,
+/// …) { for e in entries { … } }`) types the binder.
+fn param_var_elem_types(params: &[Param]) -> Vec<(String, String)> {
+    params
+        .iter()
+        .filter_map(|p| match &p.ty {
+            TypeExpr::Array { elem, .. } => type_expr_name(elem)
+                .map(|t| (p.name.name.clone(), t)),
+            _ => None,
+        })
         .collect()
 }
 
@@ -1745,6 +1927,24 @@ struct Walker<'a> {
     /// seeded from this fn's params and grown by typed `let`s. Lets a
     /// `v.push(x)` resolve `v`'s type to ask whether it is a growing form.
     var_types: BTreeMap<String, String>,
+    /// #382 receiver-typing: local/param name -> ELEMENT type for
+    /// array-typed bindings, so `for e in entries` types the binder
+    /// when `entries` is an array param or an array-literal let.
+    var_elem_types: BTreeMap<String, String>,
+    /// #382 receiver-typing: EVERY locus's field->type map, for
+    /// chained receivers (`self.mid.inner.work()` types `mid` via
+    /// the enclosing locus, then `inner` via Mid's map).
+    all_field_types: &'a BTreeMap<String, BTreeMap<String, String>>,
+    /// #382 receiver-typing: struct TYPE field->type maps, the
+    /// fallback for chained receivers passing through plain
+    /// structs (`route.handler.handle()`).
+    all_struct_fields: &'a BTreeMap<String, BTreeMap<String, String>>,
+    /// #382 receiver-typing: per-locus ELEMENT types (array params
+    /// fields + capacity slots), for `for`-binder typing.
+    all_elem_types: &'a BTreeMap<String, BTreeMap<String, String>>,
+    /// #382 receiver-typing: free-fn -> declared locus return type,
+    /// for call-result receivers (`make_b().work()`).
+    fn_ret_types: &'a BTreeMap<String, String>,
     /// The enclosing locus's param fields → declared type name, so a
     /// `self.<field>.push(x)` resolves `<field>`'s type the same way.
     field_types: &'a BTreeMap<String, String>,
@@ -1845,19 +2045,150 @@ impl<'a> Walker<'a> {
         }
     }
 
-    /// The *declared* type name of a receiver expression: a bare var
-    /// via `var_types`, a `self.<field>` via `field_types`. Used both
-    /// to spot growing-`@form` receivers (D2) and to resolve
+    /// The declared/inferable LOCUS type of a receiver expression
+    /// (#382 receiver-typing root fix). Beyond the original two
+    /// shapes (bare var via `var_types`, `self.<field>` via
+    /// `field_types`), this types the four audit shapes that were
+    /// silently-dropped unresolved edges: a struct-literal receiver
+    /// (`B { }.work()`), a chained field (`self.mid.inner.work()`),
+    /// a call result (`make_b().work()`), and a uniform if/else
+    /// value. Anything genuinely untypeable at this layer (an index
+    /// result, a match value, a foreign expression) returns `None`
+    /// and downstream soundness judgments fail closed on the edge.
+    /// Used to spot growing-`@form` receivers (D2) and to resolve
     /// handle-method call edges (`record_call`).
-    fn receiver_type_name(&self, recv: &Expr) -> Option<&String> {
+    fn receiver_type_name(&self, recv: &Expr) -> Option<String> {
         match recv {
-            Expr::Ident(v) => self.var_types.get(&v.name),
-            Expr::Field { receiver, name, .. } | Expr::Path2 { receiver, name, .. }
-                if matches!(receiver.as_ref(), Expr::KwSelf(_)) =>
-            {
-                self.field_types.get(&name.name)
+            Expr::Ident(v) => self.var_types.get(&v.name).cloned(),
+            Expr::KwSelf(_) => self.enclosing_locus.clone(),
+            Expr::Field { receiver, name, .. }
+            | Expr::Path2 { receiver, name, .. } => {
+                if matches!(receiver.as_ref(), Expr::KwSelf(_)) {
+                    self.field_types.get(&name.name).cloned()
+                } else {
+                    // Chained: type the receiver, then look the
+                    // field up on THAT type's map — locus params
+                    // first, plain-struct fields as the fallback.
+                    let rt = self.receiver_type_name(receiver)?;
+                    self.all_field_types
+                        .get(&rt)
+                        .and_then(|m| m.get(&name.name))
+                        .or_else(|| {
+                            self.all_struct_fields
+                                .get(&rt)
+                                .and_then(|m| m.get(&name.name))
+                        })
+                        .cloned()
+                }
+            }
+            Expr::Struct { path, .. } => {
+                // Same std-vs-user resolution as the `let`-literal
+                // inference below.
+                let segs: Vec<&str> = path
+                    .segments
+                    .iter()
+                    .map(|s| s.name.as_str())
+                    .collect();
+                crate::stdlib_bodies::mangled_locus_name(&segs)
+                    .map(|m| m.to_string())
+                    .or_else(|| {
+                        path.segments.last().map(|s| s.name.clone())
+                    })
+            }
+            Expr::Call { callee, .. } => match callee.as_ref() {
+                Expr::Ident(f) => {
+                    self.fn_ret_types.get(&f.name).cloned()
+                }
+                // `entries.get(j)` on a collection locus with ONE
+                // element slot returns that element type — the
+                // form-getter shape stdlib chains iterate with.
+                Expr::Field { receiver, name, .. }
+                | Expr::Path2 { receiver, name, .. }
+                    if name.name == "get" =>
+                {
+                    let owner = self.receiver_type_name(receiver)?;
+                    let elems = self.all_elem_types.get(&owner)?;
+                    if elems.len() == 1 {
+                        elems.values().next().cloned()
+                    } else {
+                        None
+                    }
+                }
+                Expr::Path(qp) => {
+                    let path = qp
+                        .segments
+                        .iter()
+                        .map(|s| s.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join("::");
+                    let name = self
+                        .rename_map
+                        .get(&path)
+                        .cloned()
+                        .unwrap_or(path);
+                    self.fn_ret_types.get(&name).cloned()
+                }
+                _ => None,
+            },
+            Expr::If(ifs) => self.if_locus_type(ifs),
+            // `mws.get(i) or raise` — the disposition unwraps the
+            // fallible; the VALUE'S type is the inner call's.
+            Expr::Or { inner, .. } => self.receiver_type_name(inner),
+            _ => None,
+        }
+    }
+
+    /// The ELEMENT type of an iterable expression: `self.field` /
+    /// chained fields via the per-locus element maps (array params
+    /// fields + capacity slots), or a uniform array literal.
+    fn iter_elem_type(&self, iter: &Expr) -> Option<String> {
+        match iter {
+            Expr::Field { receiver, name, .. }
+            | Expr::Path2 { receiver, name, .. } => {
+                let owner = self.receiver_type_name(receiver)?;
+                self.all_elem_types
+                    .get(&owner)?
+                    .get(&name.name)
+                    .cloned()
+            }
+            Expr::Ident(v) => {
+                self.var_elem_types.get(&v.name).cloned()
+            }
+            Expr::Array(elems, _) => {
+                let mut ty: Option<String> = None;
+                for e in elems {
+                    let t = self.receiver_type_name(e)?;
+                    match &ty {
+                        None => ty = Some(t),
+                        Some(prev) if *prev == t => {}
+                        Some(_) => return None,
+                    }
+                }
+                ty
             }
             _ => None,
+        }
+    }
+
+    /// A uniform if/else VALUE's locus type: every branch's tail
+    /// must type to the same locus, else `None`.
+    fn if_locus_type(&self, ifs: &IfStmt) -> Option<String> {
+        let then_ty = ifs
+            .then_block
+            .tail
+            .as_ref()
+            .and_then(|t| self.receiver_type_name(t))?;
+        let else_ty = match ifs.else_block.as_deref()? {
+            ElseBranch::Else(b) => b
+                .tail
+                .as_ref()
+                .and_then(|t| self.receiver_type_name(t))?,
+            ElseBranch::ElseIf(inner) => self.if_locus_type(inner)?,
+        };
+        if then_ty == else_ty {
+            Some(then_ty)
+        } else {
+            None
         }
     }
 
@@ -1865,7 +2196,7 @@ impl<'a> Walker<'a> {
     /// `@form(vec | hashmap)` locus, the form name.
     fn growing_form_of_receiver(&self, recv: &Expr) -> Option<String> {
         let ty_name = self.receiver_type_name(recv)?;
-        let form = self.form_of.get(ty_name)?;
+        let form = self.form_of.get(&ty_name)?;
         if form_grows(form) {
             Some(form.clone())
         } else {
@@ -1907,29 +2238,42 @@ impl<'a> Walker<'a> {
             Stmt::Let { name, ty, value, .. } => {
                 // D2: a typed `let v: T = …` extends the var→type map so a
                 // later `v.push(x)` can resolve `v`'s form.
+                if let Some(et) = ty.as_ref().and_then(|t| match t {
+                    TypeExpr::Array { elem, .. } => type_expr_name(elem),
+                    _ => None,
+                }) {
+                    self.var_elem_types.insert(name.name.clone(), et);
+                } else if let Expr::Array(elems, _) = value {
+                    // `let xs = [B { }, make_b()];` — a uniform
+                    // locus array literal types the elements.
+                    let mut et: Option<String> = None;
+                    let mut uniform = true;
+                    for e in elems {
+                        match (self.receiver_type_name(e), &et) {
+                            (Some(t), None) => et = Some(t),
+                            (Some(t), Some(prev)) if t == *prev => {}
+                            _ => {
+                                uniform = false;
+                                break;
+                            }
+                        }
+                    }
+                    if uniform {
+                        if let Some(t) = et {
+                            self.var_elem_types
+                                .insert(name.name.clone(), t);
+                        }
+                    }
+                }
                 if let Some(tn) = ty.as_ref().and_then(type_expr_name) {
                     self.var_types.insert(name.name.clone(), tn);
-                } else if let Expr::Struct { path, .. } = value {
-                    // GH #265: `let r = Reader { … }` is the common
-                    // shape — an annotated `let` is the exception, not
-                    // the rule. Without inferring the type from the
-                    // struct literal, `r.method()` stays an unresolved
-                    // edge and every effect assertion is blind to it.
-                    // A std path (`std::io::file::File`) names a locus
-                    // the Hale-source stdlib declares under a MANGLED
-                    // name (`__StdIoFileFile`), so go through the
-                    // rename table; a user type is just its last
-                    // segment.
-                    let segs: Vec<&str> =
-                        path.segments.iter().map(|s| s.name.as_str()).collect();
-                    let ty = crate::stdlib_bodies::mangled_locus_name(&segs)
-                        .map(|m| m.to_string())
-                        .or_else(|| {
-                            path.segments.last().map(|s| s.name.clone())
-                        });
-                    if let Some(ty) = ty {
-                        self.var_types.insert(name.name.clone(), ty);
-                    }
+                } else if let Some(ty) = self.receiver_type_name(value) {
+                    // GH #265 / #382: `let r = Reader { … }`, `let b =
+                    // make_b();`, and the uniform if/else value all
+                    // bind a locus the walker can type. Without this,
+                    // `b.method()` stays an unresolved edge and every
+                    // effect assertion and claim is blind to it.
+                    self.var_types.insert(name.name.clone(), ty);
                 }
                 let esc = self.escaping.get(&name.name).copied().unwrap_or(Escape::Local);
                 self.walk_expr(value, depth, esc);
@@ -2011,8 +2355,19 @@ impl<'a> Walker<'a> {
                 self.walk_expr(subject, depth, Escape::Local);
                 self.walk_expr(value, depth, Escape::Sent);
             }
-            Stmt::For { iter, body, span, .. } => {
+            Stmt::For { name, iter, body, span } => {
                 self.walk_expr(iter, depth, Escape::Local);
+                // #382 receiver-typing: type the loop BINDER from the
+                // iterable's element type, so `for child in
+                // self.children { child.m() }` is a resolved edge
+                // rather than an untypeable receiver.
+                let elem = self.iter_elem_type(iter);
+                let shadowed = match &elem {
+                    Some(t) => self
+                        .var_types
+                        .insert(name.name.clone(), t.clone()),
+                    None => self.var_types.remove(&name.name),
+                };
                 let kind = for_loop_kind(iter);
                 let bounded = matches!(kind, LoopKind::ForRange { bounded: Some(_) });
                 self.loops.push(LoopInfo { kind, depth, span: *span });
@@ -2021,6 +2376,14 @@ impl<'a> Walker<'a> {
                 self.walk_block(body, depth + 1, Escape::Local);
                 self.loop_stack.pop();
                 self.infinite_stack.pop();
+                match shadowed {
+                    Some(prev) => {
+                        self.var_types.insert(name.name.clone(), prev);
+                    }
+                    None => {
+                        self.var_types.remove(&name.name);
+                    }
+                }
             }
             Stmt::While { cond, body, span } => {
                 self.walk_expr(cond, depth, Escape::Local);
@@ -2310,7 +2673,7 @@ impl<'a> Walker<'a> {
                     // to method calls on loci — which is the idiomatic
                     // way to do I/O in Hale, making `@no_syscall`
                     // decorative outside free-fn code.
-                    self.receiver_type_name(receiver).cloned()
+                    self.receiver_type_name(receiver)
                 };
                 recv_ty = owner.clone();
                 match owner {

--- a/crates/hale-types/src/budget_check.rs
+++ b/crates/hale-types/src/budget_check.rs
@@ -191,10 +191,16 @@ impl FactVisitor for BudgetVisitor {
                 self.offenders.push(Offender {
                     span: edge.span,
                     note: format!(
-                        "`{}` is an indirect call through a \
-                         function-typed parameter — its target, and so \
-                         its allocation count, is chosen by the caller",
-                        name
+                        "`{}` is {} — its target, and so its \
+                         allocation count, is not knowable here",
+                        name,
+                        if edge.indirect {
+                            "an indirect call through a \
+                             function-typed parameter"
+                        } else {
+                            "a method call on a receiver the \
+                             compiler cannot type"
+                        }
                     ),
                 });
             }

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -831,20 +831,23 @@ fn resolve_member(
 
 // ===================== unresolved-callee backstop =================
 
-/// The unresolved-callee backstop (#382 soundness audit, round 2).
+/// The unresolved-callee backstop (#382 soundness audit).
 ///
-/// The summarizer resolves receivers it can type (params fields,
-/// annotated locals, direct-literal lets); a receiver it cannot —
-/// a struct-literal receiver, a chained `self.a.b`, a call result,
-/// a branch value — lands as `Unresolved` with `recv_ty: None` and
+/// After the receiver-typing root fix, the summarizer types struct-
+/// literal receivers, chained fields, call results, and uniform
+/// branch values — those all resolve to real edges now. What lands
+/// here is the RESIDUE: a receiver that still cannot be typed at
+/// this layer (an index result, a match value, a foreign
+/// expression), recorded as `Unresolved` with `recv_ty: None` and
 /// `receiver_present: true`. Such a call is a method of SOME bundle
-/// locus, reached through an expression the walk cannot see
-/// through — and because it may be a WRAPPER that reaches the
-/// target transitively, no name comparison against the target set
-/// is sound (the wrapper's name matches nothing). Any judgment
-/// that traverses calls must fail closed on the edge itself.
-/// `recv_ty: Some` edges (synthesized form/builtin methods like
-/// `counts.set`) are known non-locus receivers and stay exempt.
+/// locus reached through an opaque expression — and because it may
+/// be a WRAPPER that reaches the target transitively, no name
+/// comparison against the target set is sound. Any judgment that
+/// traverses calls fails closed on the edge itself; the effect and
+/// budget walkers apply the same rule, so fn-level certificates
+/// and bundle-level claims agree. `recv_ty: Some` edges
+/// (synthesized form/builtin methods like `counts.set`) are known
+/// non-locus receivers and stay exempt.
 fn unresolved_untyped_receiver(
     edge: &crate::alloc_summary::CallEdge,
 ) -> bool {

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -1016,6 +1016,19 @@ fn check_class(
                     name
                 ));
             }
+            // #382 receiver-typing: a method call on a receiver that
+            // STILL cannot be typed (an index result, a match value,
+            // a foreign expression) is a method of some bundle locus
+            // reached through an opaque expression — same fail-closed
+            // rule as an indirect call.
+            if edge.receiver_present && edge.recv_ty.is_none() {
+                return Some(format!(
+                    "`{}` — a method call on a receiver the compiler \
+                     cannot type; bind the receiver to a typed field \
+                     or local so the call resolves",
+                    name
+                ));
+            }
             let segs: Vec<&str> = name.split("::").collect();
             let Some(eff) = crate::stdlib_surface::effects_for(&segs) else {
                 // ABSENT must fail closed, exactly like UNCLASSIFIED.

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -114,6 +114,19 @@ pub fn infer_effects(
                         acc = acc.union(EffectSet::UNCLASSIFIED);
                         continue;
                     }
+                    // #382 receiver-typing: a method call on a
+                    // receiver the summarizer STILL cannot type (an
+                    // index result, a match value, a foreign
+                    // expression — the common shapes now resolve)
+                    // is a method of some bundle locus reached
+                    // through an opaque expression. Same fail-closed
+                    // treatment as an indirect call: it may do
+                    // anything.
+                    if edge.receiver_present && edge.recv_ty.is_none()
+                    {
+                        acc = acc.union(EffectSet::UNCLASSIFIED);
+                        continue;
+                    }
                     let segs: Vec<&str> = name.split("::").collect();
                     if let Some(e) = stdlib_surface::effects_for(&segs) {
                         if !e.is_unclassified() {

--- a/crates/hale-types/src/quantitative.rs
+++ b/crates/hale-types/src/quantitative.rs
@@ -261,7 +261,11 @@ fn count_dim(
     // `return f(v);` passed while the callee allocated, which is the
     // budget half of the same certificate hole as the effect classes.
     for edge in &fs.calls {
-        if edge.indirect {
+        // #382: an untypeable-receiver method call gets the same
+        // unbounded treatment as an indirect call.
+        if edge.indirect
+            || (edge.receiver_present && edge.recv_ty.is_none())
+        {
             total = total.add(Qty::Unbounded);
         }
     }

--- a/crates/hale-types/tests/claims_edges.rs
+++ b/crates/hale-types/tests/claims_edges.rs
@@ -694,17 +694,18 @@ fn a_projection_empty_group_is_an_error_at_either_endpoint() {
 }
 
 // =====================================================================
-// The unresolved-callee backstop (#382 soundness audit)
+// Receiver typing (#382 soundness audit — the root fix)
 // =====================================================================
 //
-// Four receiver shapes land in the call graph as `Unresolved` with
-// no receiver type — a struct-literal receiver, a chained field, a
-// call result, a branch value — and a walk that ignored them
-// certified a `forbid` while the forbidden path executed at
-// runtime. The backstop fails closed when such a call's NAME
-// matches a method of the claim's target set.
+// Four receiver shapes — a struct-literal receiver, a chained
+// field, a call result, a branch value — used to land as untyped
+// unresolved edges the walk silently dropped: a claim certified
+// while the forbidden path executed at runtime. The summarizer now
+// TYPES those receivers, so each shape resolves to a real edge and
+// the claim reports a real witness. The fail-closed backstop
+// remains for what stays genuinely untypeable (an index result).
 
-fn backstop_fixture(go_body: &str) -> String {
+fn typing_fixture(go_body: &str) -> String {
     format!(
         r#"
         locus B {{ fn work(n: Int) -> Int {{ return n * 2; }} }}
@@ -725,83 +726,68 @@ fn backstop_fixture(go_body: &str) -> String {
     )
 }
 
-fn assert_fails_closed(body: &str, shape: &str) {
-    let ds = diags(&backstop_fixture(body));
+fn assert_real_witness(body: &str, shape: &str) {
+    let ds = diags(&typing_fixture(body));
+    let hit = ds
+        .iter()
+        .find(|m| m.contains("claim `iso` violated"))
+        .unwrap_or_else(|| {
+            panic!("{} must resolve to a real violation: {:?}", shape, ds)
+        });
     assert!(
-        ds.iter().any(|m| m.contains("claim `iso` cannot be certified")
-            && m.contains("receiver the compiler cannot type")),
-        "{} must fail closed, not certify: {:?}",
+        hit.contains("B::work"),
+        "{} must produce a witness reaching the target: {}",
         shape,
-        ds
+        hit
+    );
+    assert!(
+        !hit.contains("cannot be certified"),
+        "{} must be a resolved edge, not a fail-closed one: {}",
+        shape,
+        hit
     );
 }
 
-/// AUDIT SHAPE 3: struct-literal receiver.
+/// AUDIT SHAPE 3: struct-literal receiver — resolved.
 #[test]
-fn a_literal_receiver_call_fails_closed() {
-    assert_fails_closed("return B { }.work(n);", "a literal receiver");
+fn a_literal_receiver_resolves_to_a_real_witness() {
+    assert_real_witness("return B { }.work(n);", "a literal receiver");
 }
 
-/// AUDIT SHAPE 5: chained field receiver.
+/// AUDIT SHAPE 5: chained field receiver — resolved through the
+/// per-locus field maps.
 #[test]
-fn a_chained_field_receiver_call_fails_closed() {
-    assert_fails_closed(
+fn a_chained_field_receiver_resolves_to_a_real_witness() {
+    assert_real_witness(
         "return self.mid.inner.work(n);",
         "a chained field receiver",
     );
 }
 
-/// AUDIT SHAPE 6: call-result receiver.
+/// AUDIT SHAPE 6: call-result receiver — resolved through the
+/// free-fn return-type map.
 #[test]
-fn a_call_result_receiver_call_fails_closed() {
-    assert_fails_closed(
+fn a_call_result_receiver_resolves_to_a_real_witness() {
+    assert_real_witness(
         "let b = make_b(); return b.work(n);",
         "a call-result receiver",
     );
 }
 
-/// AUDIT SHAPE 8: branch-valued receiver.
+/// AUDIT SHAPE 8: branch-valued receiver — resolved when every
+/// branch types to the same locus.
 #[test]
-fn a_branch_valued_receiver_call_fails_closed() {
-    assert_fails_closed(
+fn a_branch_valued_receiver_resolves_to_a_real_witness() {
+    assert_real_witness(
         "let b = if n > 0 { B { } } else { B { } }; return b.work(n);",
         "a branch-valued receiver",
     );
 }
 
-/// EVERY untyped-receiver call fails closed, even one whose name
-/// the target set does not declare — it could be a WRAPPER
-/// reaching the target transitively (the follow-up review's
-/// counterexample class), so no name comparison is sound.
+/// The follow-up review's wrapper counterexample — now a RESOLVED
+/// two-hop witness, not a fail-closed refusal.
 #[test]
-fn an_unresolved_call_fails_closed_regardless_of_name() {
-    let src = r#"
-        locus B { fn work(n: Int) -> Int { return n * 2; } }
-        locus C { fn other(n: Int) -> Int { return n + 1; } }
-        locus A {
-            fn go(n: Int) -> Int { return C { }.other(n); }
-        }
-        group a_side = { A };
-        group b_side = { B };
-        main locus App {
-            params { a: A = A { }; }
-            claims { iso: forbid reaches(a_side, b_side); }
-        }
-        fn main() { App { }; }
-    "#;
-    let ds = diags(src);
-    assert!(
-        ds.iter().any(|m| m.contains("cannot be certified")),
-        "an untyped receiver must fail closed even when the name \
-         is outside the target set — it could be a wrapper: {:?}",
-        ds
-    );
-}
-
-/// The reviewer's wrapper counterexamples: an untyped-receiver
-/// call to a WRAPPER that reaches the target/carrier transitively.
-#[test]
-fn an_untyped_receiver_wrapper_reaching_the_group_target_fails_closed() {
+fn a_wrapper_through_an_untyped_receiver_resolves_end_to_end() {
     let src = r#"
         locus B { fn work(n: Int) -> Int { return n * 2; } }
         locus Bridge {
@@ -820,17 +806,53 @@ fn an_untyped_receiver_wrapper_reaching_the_group_target_fails_closed() {
         fn main() { App { }; }
     "#;
     let ds = diags(src);
+    let hit = ds
+        .iter()
+        .find(|m| m.contains("claim `iso` violated"))
+        .unwrap_or_else(|| {
+            panic!("the wrapper must resolve to a violation: {:?}", ds)
+        });
     assert!(
-        ds.iter().any(|m| m.contains("claim `iso` cannot be certified")
-            && m.contains("`hop`")),
-        "the wrapper hop must fail closed: {:?}",
+        hit.contains("Bridge::hop") && hit.contains("B::work"),
+        "the witness must carry the full wrapper path: {}",
+        hit
+    );
+}
+
+/// The resolution CONTROL: a resolved edge to a locus OUTSIDE the
+/// target group certifies — typing the receiver means no more
+/// blanket fail-closed on these shapes.
+#[test]
+fn a_resolved_receiver_outside_the_target_certifies() {
+    let src = r#"
+        locus B { fn work(n: Int) -> Int { return n * 2; } }
+        locus C { fn other(n: Int) -> Int { return n + 1; } }
+        locus A {
+            fn go(n: Int) -> Int { return C { }.other(n); }
+        }
+        group a_side = { A };
+        group b_side = { B };
+        main locus App {
+            params { a: A = A { }; }
+            claims { iso: forbid reaches(a_side, b_side); }
+        }
+        fn main() { App { }; }
+    "#;
+    let ds = diags(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("violated")
+            || m.contains("cannot be certified")),
+        "a typed literal receiver outside the target must certify: {:?}",
         ds
     );
 }
 
+/// Wrapper reaching an effect carrier / bound carrier — resolved
+/// with real verdicts (the follow-up review's other two
+/// counterexamples).
 #[test]
-fn an_untyped_receiver_wrapper_reaching_an_effect_carrier_fails_closed() {
-    let src = r#"
+fn wrapper_effect_and_bound_carriers_resolve() {
+    let effects = r#"
         effect money;
         @effects(is: {money})
         fn charge(n: Int) -> Int { return n; }
@@ -847,18 +869,13 @@ fn an_untyped_receiver_wrapper_reaching_an_effect_carrier_fails_closed() {
         }
         fn main() { App { }; }
     "#;
-    let ds = diags(src);
+    let ds = diags(effects);
     assert!(
-        ds.iter()
-            .any(|m| m.contains("claim `no_spend` cannot be certified")),
-        "the wrapper to the carrier must fail closed: {:?}",
+        ds.iter().any(|m| m.contains("claim `no_spend` violated")),
+        "the wrapper to the carrier must be a real violation: {:?}",
         ds
     );
-}
-
-#[test]
-fn an_untyped_receiver_wrapper_reaching_a_bound_carrier_fails_closed() {
-    let src = r#"
+    let bound = r#"
         effect llm;
         @effects(is: {llm})
         fn ask(n: Int) -> Int { return n; }
@@ -875,50 +892,44 @@ fn an_untyped_receiver_wrapper_reaching_a_bound_carrier_fails_closed() {
         }
         fn main() { App { }; }
     "#;
-    let ds = diags(src);
+    let ds = diags(bound);
     assert!(
         ds.iter().any(|m| m.contains("claim `none` violated")
-            && m.contains("unbounded")),
-        "the wrapper to the bound carrier must be unbounded: {:?}",
+            && m.contains("carries 1")),
+        "the wrapper carrier must COUNT (one site, limit zero): {:?}",
         ds
     );
 }
 
-/// The backstop covers `only edges` and `bound` too.
+// =====================================================================
+// The fail-closed backstop, for what stays genuinely untypeable
+// =====================================================================
+
+/// An INDEX-result receiver has no declared type at this layer —
+/// the backstop still refuses to certify over it.
 #[test]
-fn the_backstop_covers_only_edges_and_bound() {
-    let only = backstop_fixture("return B { }.work(n);").replace(
-        "iso: forbid reaches(a_side, b_side);",
-        "gate: only edges a_side -> b_side { };",
-    );
-    let ds = diags(&only);
-    assert!(
-        ds.iter().any(|m| m.contains("claim `gate` cannot be certified")),
-        "only edges must fail closed on the untyped receiver: {:?}",
-        ds
-    );
-    let bound = r#"
-        effect llm;
-        locus Model {
-            @effects(is: {llm})
-            fn ask(p: Int) -> Int { return p; }
+fn an_index_receiver_still_fails_closed() {
+    let src = r#"
+        locus B { fn work(n: Int) -> Int { return n * 2; } }
+        locus A {
+            fn go(n: Int) -> Int {
+                let xs = [B { }];
+                return xs[0].work(n);
+            }
         }
-        locus Planner {
-            fn plan(n: Int) -> Int { return Model { }.ask(n); }
-        }
-        group planners = { Planner };
+        group a_side = { A };
+        group b_side = { B };
         main locus App {
-            params { p: Planner = Planner { }; }
-            claims { one: bound llm <= 5 on paths from planners; }
+            params { a: A = A { }; }
+            claims { iso: forbid reaches(a_side, b_side); }
         }
         fn main() { App { }; }
     "#;
-    let ds = diags(bound);
+    let ds = diags(src);
     assert!(
-        ds.iter().any(|m| m.contains("claim `one` violated")
-            && m.contains("unbounded")),
-        "bound must treat an untyped carrier-named call as \
-         unbounded: {:?}",
+        ds.iter().any(|m| m.contains("claim `iso` cannot be certified")
+            && m.contains("receiver the compiler cannot type")),
+        "an index receiver must fail closed: {:?}",
         ds
     );
 }

--- a/crates/hale-types/tests/receiver_shapes.rs
+++ b/crates/hale-types/tests/receiver_shapes.rs
@@ -1,0 +1,120 @@
+//! #382 receiver-typing root fix — the EFFECT SYSTEM's negative
+//! controls.
+//!
+//! Four receiver shapes used to land as untyped unresolved call
+//! edges that `@effects(none:)` (and every `@no_*` certificate)
+//! silently dropped: a fn could reach a declared carrier through
+//! any of them and still certify. The summarizer now types those
+//! receivers, so each shape is a resolved edge the engine walks.
+//! These are the audit's four repro programs as standing negative
+//! controls — a checker that cannot fail proves nothing.
+
+use hale_syntax::parse_source;
+
+fn errs(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+const CARRIER: &str = r#"
+    effect money;
+    locus B {
+        @effects(is: {money})
+        fn work(n: Int) -> Int { return n; }
+    }
+    locus Mid { params { inner: B = B { }; } }
+    fn make_b() -> B { return B { }; }
+"#;
+
+fn fires(body: &str, shape: &str) {
+    let src = format!(
+        "{CARRIER}\
+         locus A {{\n\
+             params {{ mid: Mid = Mid {{ }}; }}\n\
+             @effects(none: {{money}})\n\
+             fn go(n: Int) -> Int {{ {body} }}\n\
+         }}\n\
+         fn main() {{ println(A {{ }}.go(1)); }}"
+    );
+    let ds = errs(&src);
+    assert!(
+        ds.iter().any(|m| m.contains("effect assertion violated")),
+        "{}: reaching the carrier must violate: {:?}",
+        shape,
+        ds
+    );
+}
+
+#[test]
+fn a_literal_receiver_carrier_fires() {
+    fires("return B { }.work(n);", "struct-literal receiver");
+}
+
+#[test]
+fn a_chained_field_receiver_carrier_fires() {
+    fires("return self.mid.inner.work(n);", "chained field receiver");
+}
+
+#[test]
+fn a_call_result_receiver_carrier_fires() {
+    fires(
+        "let b = make_b(); return b.work(n);",
+        "call-result receiver",
+    );
+}
+
+#[test]
+fn a_branch_valued_receiver_carrier_fires() {
+    fires(
+        "let b = if n > 0 { B { } } else { B { } }; return b.work(n);",
+        "branch-valued receiver",
+    );
+}
+
+/// The control: the same shapes reaching a NON-carrier stay
+/// certifiable — typing receivers must not turn every method call
+/// into a violation.
+#[test]
+fn a_typed_receiver_to_a_clean_locus_still_certifies() {
+    let src = r#"
+        effect money;
+        locus C { fn calc(n: Int) -> Int { return n + 1; } }
+        locus A {
+            @effects(none: {money})
+            fn go(n: Int) -> Int { return C { }.calc(n); }
+        }
+        fn main() { println(A { }.go(1)); }
+    "#;
+    let ds = errs(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("effect assertion violated")),
+        "a clean resolved path must certify: {:?}",
+        ds
+    );
+}
+
+/// The wrapper variant (the follow-up review's counterexample) —
+/// the carrier is one resolved hop past the newly-typed receiver.
+#[test]
+fn a_wrapper_behind_a_literal_receiver_fires() {
+    let src = r#"
+        effect money;
+        @effects(is: {money})
+        fn charge(n: Int) -> Int { return n; }
+        locus Bridge { fn hop(n: Int) -> Int { return charge(n); } }
+        locus A {
+            @effects(none: {money})
+            fn go(n: Int) -> Int { return Bridge { }.hop(n); }
+        }
+        fn main() { println(A { }.go(1)); }
+    "#;
+    let ds = errs(src);
+    assert!(
+        ds.iter().any(|m| m.contains("effect assertion violated")),
+        "the carrier one wrapper hop away must violate: {:?}",
+        ds
+    );
+}


### PR DESCRIPTION
The receiver-typing root fix — the change both soundness reviews converged on as the immediate next step after the claims stack. Stacked on #387.

## What it fixes

The summarizer's `receiver_type_name` knew exactly two receiver shapes (bare typed var, `self.<field>`). Everything else became an untyped unresolved edge that `@effects(none:)`, every `@no_*` certificate, `@budget`, the quantitative dimensions, and (until the backstop) the claims evaluators silently dropped — the confirmed false-certificate class from the adversarial audit, and after the claims backstop landed, the "inconsistent judgments" state the follow-up review flagged as urgent (a bundle-level claim refusing a path a fn-level certificate quietly passed).

## The fix, in two halves

**Typing** — `receiver_type_name` generalizes to an expression-typing helper covering: struct-literal receivers, chained fields (per-locus field maps applied transitively, with plain-struct fields as fallback), call-result receivers (free-fn return-type map; methods never return loci per the no-locus-return rule), uniform if/else values, `or`-disposition unwrapping, single-slot collection `.get(i)` (the stdlib chain-runner shape), and `for`-binder element typing from array fields, capacity slots, array params, array literals, and the implicit accepted-children collection.

**Consistent fail-closed residue** — what still can't be typed (index results, match values, foreign expressions) now gets the same may-do-anything treatment in EVERY judgment that traverses calls: `frontier::infer_effects`, `effects::check_class` (with an actionable witness probe), `budget_check`, `quantitative::count_dim`, and the claims walks. The claims backstop relaxes from "every untyped receiver" to this genuine residue, and fn-level certificates now agree with bundle-level claims everywhere.

## The evidence

- **Zero-delta corpus baseline.** After the fix, `scripts/effects-baseline.sh` reproduces the committed `.hale.effects` corpus fingerprint byte-for-byte: identical certificates, no over-fire, holes closed. (Intermediate states were worse in both directions — the typing-only version left two corpus rows `unclassified` through stdlib chain internals, which drove the `or`-unwrap/getter/binder coverage.)
- **The audit's four repro shapes** ship as negative controls for BOTH systems: `receiver_shapes.rs` (effects — `none:` fires through each shape plus the wrapper variant, with a clean-locus control) and the reworked `claims_edges.rs` section (claims — each shape resolves to a REAL witness now, pinned as `..._resolves_to_a_real_witness`, with the resolution control showing typed receivers outside the target certify).
- **The residue stays covered**: index-receiver claims still fail closed, and the artifact still records `untyped_receiver_call:<callee>` rows in the hashed model half (tests moved to the index shape).

## Also in the stack's orbit (separate PRs, cross-linked)

- hale-lang/tree-sitter-hale#4 — grammar + highlights for the whole claims surface, closing the pre-existing `target_decl` gap.
- hale-lang/hale-lang.org#3 — the "Claim-Driven Development in Hale" article + site-grammar keywords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
