### PR TITLE
release: v0.14.0 — claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.14.0 — claims: the program owns the law, the compiler owns the proof (2026-08-04)
 
 ### Receiver typing: the summarizer root fix (GH #382 soundness audit)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "hale-corpus",
  "hale-stdlib",
@@ -71,11 +71,11 @@ dependencies = [
 
 [[package]]
 name = "hale-corpus"
-version = "0.13.0"
+version = "0.14.0"
 
 [[package]]
 name = "hale-lsp"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -84,18 +84,18 @@ dependencies = [
 
 [[package]]
 name = "hale-stdlib"
-version = "0.13.0"
+version = "0.14.0"
 
 [[package]]
 name = "hale-syntax"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "hale-corpus",
 ]
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "hale-corpus",
  "hale-stdlib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump + CHANGELOG cut for the #382 claims release (stack #386/#387/#388, merged). Same shape as the v0.13.0 cut (#371). After merge, tag the merge commit `v0.14.0` to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)