### PR TITLE
Interface-dispatch edges: closed-world fan-out (#392 thread 4)

### DIFF
--- a/.effects-baseline/corpus.effects
+++ b/.effects-baseline/corpus.effects
@@ -341,7 +341,7 @@ __docs_dir  does={env}
 __render_doc  does={syscall,env,alloc}
 __render_index  does={syscall,env,alloc}
 __wrap_html_page  does={alloc}
-handle_request  does={syscall,block,env,alloc}
+handle_request  does={syscall,block,publish,env,alloc}
 main  does={syscall,env,alloc}
 ### fitter-applier-demo
 ActionLogL::on_action  does={syscall}
@@ -354,7 +354,7 @@ main  does={alloc}
 HelloL::birth  does={syscall}
 main  does={alloc}
 ### http-hello
-handle_request  does={syscall,block,alloc}
+handle_request  does={syscall,block,publish,alloc}
 main  does={syscall,env,alloc}
 ### io-demo
 main  does={syscall,env,alloc}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,69 @@ behavior.
 
 ---
 
+## Unreleased
+
+### Interface-dispatch edges: closed-world fan-out (GH #392 thread 4)
+
+A method call on an interface-typed value
+(`route.handler.handle(ctx)` — the stdlib router's own shape)
+used to land as an unresolved edge that every walker silently
+dropped: the one receiver shape left, after the v0.14.0 root fix,
+where a real call contributed nothing to any judgment. An
+`@effects(none: …)` certificate over a fn dispatching through
+`std::http::Router` certified while the handler performed the
+effect.
+
+The world is closed, so the implementor set is enumerable. The
+summarizer now fans the written edge out to every conforming
+locus (structural name-and-arity conformance over the
+declarations — a superset of the checker's typed conformance;
+over-approximation only adds edges). Reachability and effect
+judgments walk every alternative. Counting judgments — `bound`,
+`@budget`, the quantitative dims — take the **max** over one
+dispatch site's alternatives (a dispatch invokes exactly one
+target; a sum would count phantom calls no execution performs),
+carried by a `dispatch_group` tag on the fanned edges and a
+`join_alternatives` fold in the shared call-graph walker.
+
+An interface **no** locus conforms to has no values in a closed
+world (an interface value only arises by coercing a conformer),
+so its call sites are dead — they contribute nothing, rather than
+failing closed. The everyday instance is the router's
+`m.before(cur)` over an empty middleware list: failing closed
+there would refuse every certificate through the stdlib router.
+The topology artifact records each such site
+(`uninhabited_interface_call:<iface>.<callee>`) inside the hashed
+model half, so a conformer appearing later changes `shape_hash`.
+
+Two adjacent holes closed in the same change:
+
+- **Path-written stdlib types now type receivers.** A param or
+  field written `std::io::tcp::Stream` / `std::http::Router`
+  recorded only its last path segment, a name no summary map is
+  keyed by — so method calls on such receivers were unresolved
+  and invisible. They now resolve through the same std-vs-user
+  rule struct-literal receivers already used. The committed
+  effects baseline gains `publish` on two corpus `handle_request`
+  rows — real: `Stream::recv` publishes to the tcp log-event
+  topic, previously unseen.
+- **`@budget(alloc_per_call)` fails closed on untyped
+  receivers.** The v0.14.0 root fix wrote the dual-cause message
+  but widened only the other walkers' guards; the budget's own
+  guard still tested `indirect` alone, leaving the receiver
+  branch dead and the budget certifiable through a wrapper. The
+  shared predicate (`CallEdge::opaque_method_call`) now backs all
+  five walkers.
+
+Spec: `spec/verification.md` § Claims (fan-out, max-over-
+alternatives, dead-dispatch rules). Docs: the claims chapter's
+fail-closed section and artifact schema. Tests:
+`interface_dispatch.rs` (14: canary + control per judgment form,
+incl. the router end-to-end pair), artifact rows + `shape_hash`
+sensitivity in `claims_artifact_unknowns.rs`.
+
+---
+
 ## v0.14.0 — claims: the program owns the law, the compiler owns the proof (2026-08-04)
 
 ### Receiver typing: the summarizer root fix (GH #382 soundness audit)

--- a/crates/hale-cli/tests/claims_artifact_unknowns.rs
+++ b/crates/hale-cli/tests/claims_artifact_unknowns.rs
@@ -94,3 +94,69 @@ fn an_untyped_receiver_edge_changes_shape_hash() {
         "the unknown class must be part of the shape identity"
     );
 }
+
+// ---- #392: interface dispatch in the artifact ----------------------
+
+const DISPATCHED: &str = r#"
+interface Notifier { fn send(n: Int) -> Int; }
+locus Email { fn send(n: Int) -> Int { return n; } }
+type Route { handler: Notifier; }
+locus A {
+    fn go(n: Int) -> Int {
+        let r = Route { handler: Email { } };
+        return r.handler.send(n);
+    }
+}
+group a_side = { A };
+group sinks = { Email };
+main locus App {
+    params { a: A = A { }; }
+    claims { iso: forbid reaches(a_side, sinks); }
+}
+fn main() { App { }; }
+"#;
+
+/// A dispatch WITH conformers is fanned out to ordinary resolved
+/// call edges — the artifact's call relation carries them, and no
+/// unknown row appears.
+#[test]
+fn a_conforming_dispatch_appears_as_call_edges_not_unknowns() {
+    let art = dump(DISPATCHED, "dispatched");
+    assert!(
+        art.contains(r#"{"from": "A::go", "to": "Email::send"}"#),
+        "the fanned-out edge must land in the call relation:\n{}",
+        art
+    );
+    assert!(
+        !art.contains("uninhabited_interface_call")
+            && !art.contains("untyped_receiver_call"),
+        "a resolved dispatch is not an unknown:\n{}",
+        art
+    );
+}
+
+/// An interface nothing conforms to records its own unknown class —
+/// with the interface AND callee named, so an outside evaluator can
+/// apply the same fail-closed rule — and it changes `shape_hash`.
+#[test]
+fn an_uninhabited_interface_call_is_an_unknown_and_changes_the_hash()
+{
+    // Remove the conformer: same program, `Email::send` renamed so
+    // nothing satisfies `Notifier`.
+    let uninhabited = DISPATCHED.replace(
+        "locus Email { fn send(n: Int) -> Int { return n; } }",
+        "locus Email { fn deliver(n: Int) -> Int { return n; } }",
+    );
+    let art = dump(&uninhabited, "uninhabited");
+    assert!(
+        art.contains("uninhabited_interface_call:Notifier.send")
+            && art.contains("\"A::go\""),
+        "the unknown must name the interface and callee:\n{}",
+        art
+    );
+    assert_ne!(
+        shape_hash(&dump(DISPATCHED, "hash_inhabited")),
+        shape_hash(&art),
+        "losing the last conformer must change the shape identity"
+    );
+}

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -125,7 +125,30 @@ fn is_growing_insert(form_name: &str, method: &str) -> bool {
 /// `path::to::SegVec`), or `None` for primitives / arrays / etc.
 fn type_expr_name(te: &TypeExpr) -> Option<String> {
     match te {
-        TypeExpr::Named { path, .. } => path.segments.last().map(|s| s.name.clone()),
+        TypeExpr::Named { path, .. } => {
+            // #392: a PATH-written stdlib type (`std::http::Router`,
+            // `std::http::RouteHandler`) resolves to the name its
+            // decl actually carries — the same std-vs-user rule
+            // struct-literal receivers already apply. Recording the
+            // bare last segment ("Router") put these values in a
+            // name space no summary map is keyed by, so a receiver
+            // typed by one landed `Unresolved` and every judgment
+            // dropped the edge — including the router chain's
+            // interface dispatch.
+            if path.segments.len() > 1 {
+                let segs: Vec<&str> = path
+                    .segments
+                    .iter()
+                    .map(|s| s.name.as_str())
+                    .collect();
+                if let Some(m) =
+                    crate::stdlib_bodies::mangled_locus_name(&segs)
+                {
+                    return Some(m.to_string());
+                }
+            }
+            path.segments.last().map(|s| s.name.clone())
+        }
         _ => None,
     }
 }
@@ -360,7 +383,54 @@ pub struct CallEdge {
     /// where the slot is implicit from `@form`). The solver (D2) pairs this
     /// with the method name + `LocusShape` to classify a slot insert.
     pub receiver_slot: Option<String>,
+    /// #392: this call dispatches through an INTERFACE-typed receiver
+    /// (`route.handler.handle(ctx)`). Set on two edge shapes, both
+    /// produced by the fan-out pass at the end of summary construction:
+    ///
+    ///  * a `Resolved` alternative — the closed world makes the
+    ///    implementor set enumerable, so the one written call becomes
+    ///    one edge per conforming locus (over-approximation: only adds
+    ///    edges). The interface name is kept for diagnostics and the
+    ///    topology artifact.
+    ///  * a still-`Unresolved` edge whose interface has NO conforming
+    ///    locus in the bundle. That is not an unknown: an interface
+    ///    value only ever comes from coercing a conforming locus, so
+    ///    an uninhabited interface has no values and the call site is
+    ///    DEAD in this build. Walkers contribute nothing for it; the
+    ///    topology artifact records it (inside the hashed model half)
+    ///    so an outside evaluator applies the same rule and a
+    ///    conformer appearing later changes `shape_hash`. (The
+    ///    router's `m.before(cur)` over an empty middleware list is
+    ///    the everyday instance — failing closed there would refuse
+    ///    every certificate through the stdlib router.)
+    pub via_interface: Option<String>,
+    /// #392: groups the fanned-out `Resolved` alternatives of ONE
+    /// dispatch site (unique across the summary). A dispatch invokes
+    /// exactly one alternative at runtime, so counting judgments
+    /// (`bound`, `@budget`, quantitative dims) take the MAX over a
+    /// group where a real call sequence would SUM; reachability and
+    /// effect-union judgments walk every alternative as usual.
+    pub dispatch_group: Option<u32>,
     pub span: Span,
+}
+
+impl CallEdge {
+    /// The shared fail-closed test for an `Unresolved` method call —
+    /// the #382 backstop, in one place for all five walkers. True when
+    /// the receiver was written but could not be typed (an index
+    /// result, a match value, a foreign expression: the callee is a
+    /// method of SOME bundle locus reached through an expression the
+    /// walk cannot see through, possibly a wrapper). Every judgment
+    /// that traverses calls refuses such an edge — unknown ⇒
+    /// violation — so fn-level certificates and bundle-level claims
+    /// agree.
+    ///
+    /// Deliberately NOT included: an unresolved dispatch through an
+    /// uninhabited interface (`via_interface` on an `Unresolved`
+    /// edge). That edge is dead, not unknown — see the field doc.
+    pub fn opaque_method_call(&self) -> bool {
+        self.receiver_present && self.recv_ty.is_none()
+    }
 }
 
 /// A loop in a body. `bounded` carries a const trip count when the loop is
@@ -1622,6 +1692,111 @@ pub fn summarize_programs_with_renames(
     summary.carries = carries;
     summary.unbounded_fns = unbounded_fns;
     summary.locus_shapes = locus_shapes;
+
+    // #392 — interface dispatch. A method call on an interface-typed
+    // value (`route.handler.handle(ctx)`) types its receiver to the
+    // INTERFACE name, which owns no bodies, so the edge lands
+    // `Unresolved` — and before this pass it was silently dropped by
+    // every judgment, the one remaining receiver shape where a real
+    // call contributed nothing. The closed world makes the implementor
+    // set enumerable: fan the one written call out to an edge per
+    // conforming locus (over-approximation — only adds edges), tagged
+    // with a dispatch group so counting judgments take the max over
+    // the alternatives. An interface nothing conforms to has no
+    // values in this build (a value only arises by coercing a
+    // conformer), so its call sites are DEAD: the edge stays
+    // unresolved but tagged, walkers skip it, the artifact records it.
+    //
+    // Conformance here is name + arity over the ASTs — a superset of
+    // the checker's full structural check (which also compares types).
+    // A false extra conformer only adds edges; the direction is safe.
+    let mut ifaces: BTreeMap<String, Vec<(String, usize)>> =
+        BTreeMap::new();
+    let mut locus_methods: BTreeMap<String, BTreeMap<String, usize>> =
+        BTreeMap::new();
+    for program in programs {
+        for item in &program.items {
+            match item {
+                TopDecl::Interface(i) => {
+                    ifaces.insert(
+                        i.name.name.clone(),
+                        i.methods
+                            .iter()
+                            .map(|m| (m.name.name.clone(), m.params.len()))
+                            .collect(),
+                    );
+                }
+                TopDecl::Locus(l) => {
+                    let e = locus_methods
+                        .entry(l.name.name.clone())
+                        .or_default();
+                    for m in &l.members {
+                        if let LocusMember::Fn(fd) = m {
+                            e.insert(
+                                fd.name.name.clone(),
+                                fd.params.len(),
+                            );
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    let mut conformers: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for (iname, methods) in &ifaces {
+        let mut who: Vec<&str> = Vec::new();
+        for (lname, lmethods) in &locus_methods {
+            if methods.iter().all(|(m, arity)| {
+                lmethods.get(m).is_some_and(|a| a == arity)
+            }) {
+                who.push(lname);
+            }
+        }
+        conformers.insert(iname, who);
+    }
+    let mut next_group: u32 = 0;
+    for fs in summary.fns.values_mut() {
+        let mut rewritten: Vec<CallEdge> =
+            Vec::with_capacity(fs.calls.len());
+        for edge in fs.calls.drain(..) {
+            let dispatch = match (&edge.callee, edge.recv_ty.as_deref())
+            {
+                (Callee::Unresolved(m), Some(t))
+                    if edge.receiver_present
+                        && ifaces.contains_key(t) =>
+                {
+                    Some((m.clone(), t.to_string()))
+                }
+                _ => None,
+            };
+            let Some((method, iface)) = dispatch else {
+                rewritten.push(edge);
+                continue;
+            };
+            let targets: Vec<FnKey> = conformers[iface.as_str()]
+                .iter()
+                .map(|l| FnKey::method(l.to_string(), method.clone()))
+                .filter(|k| known.contains(k))
+                .collect();
+            if targets.is_empty() {
+                let mut e = edge;
+                e.via_interface = Some(iface);
+                rewritten.push(e);
+                continue;
+            }
+            let gid = next_group;
+            next_group += 1;
+            for t in targets {
+                let mut e = edge.clone();
+                e.callee = Callee::Resolved(t);
+                e.via_interface = Some(iface.clone());
+                e.dispatch_group = Some(gid);
+                rewritten.push(e);
+            }
+        }
+        fs.calls = rewritten;
+    }
     summary
 }
 
@@ -2710,6 +2885,8 @@ impl<'a> Walker<'a> {
             in_unbounded_loop: self.loop_stack.iter().any(|bounded| !bounded),
             escape,
             receiver_slot: self_slot_receiver(callee),
+            via_interface: None,
+            dispatch_group: None,
             span,
         });
     }

--- a/crates/hale-types/src/budget_check.rs
+++ b/crates/hale-types/src/budget_check.rs
@@ -147,6 +147,17 @@ impl FactVisitor for BudgetVisitor {
     fn is_zero(&self, f: &Count) -> bool {
         !f.nonzero()
     }
+    /// #392: one interface dispatch invokes ONE conforming target, so
+    /// the alternatives of a dispatch group bound the count by their
+    /// max, not their sum.
+    fn join_alternatives(&self, a: Count, b: Count) -> Count {
+        match (a, b) {
+            (Count::Finite(x), Count::Finite(y)) => {
+                Count::Finite(x.max(y))
+            }
+            _ => Count::Unbounded,
+        }
+    }
 
     fn site(&mut self, _key: &FnKey, site: &AllocSite, emit: bool) -> Count {
         if site.loop_depth > 0 {
@@ -186,7 +197,12 @@ impl FactVisitor for BudgetVisitor {
         // "opaque calls are invisible" boundary covers calls whose
         // callee is fixed and simply unmodelled; this one has no fixed
         // callee at all, so it counts as unbounded.
-        if edge.indirect {
+        //
+        // #392: `opaque_method_call` joins the same rule — the #382
+        // untyped-receiver wrapper shape. The guard here previously
+        // tested only `indirect`, leaving the receiver branch of this
+        // message dead and the budget certifiable through a wrapper.
+        if edge.indirect || edge.opaque_method_call() {
             if emit {
                 self.offenders.push(Offender {
                     span: edge.span,

--- a/crates/hale-types/src/callgraph.rs
+++ b/crates/hale-types/src/callgraph.rs
@@ -96,6 +96,19 @@ pub trait FactVisitor {
         sub: Self::Fact,
         emit: bool,
     ) -> Self::Fact;
+    /// #392: fold the facts of two ALTERNATIVES of one interface-
+    /// dispatch site (edges sharing a `dispatch_group`). A dispatch
+    /// invokes exactly one alternative, so this is a join, not a
+    /// sequence: counting visitors should return the pointwise max.
+    /// The default falls back to `combine` (sums the alternatives) —
+    /// over-approximate, never under-counting.
+    fn join_alternatives(
+        &self,
+        a: Self::Fact,
+        b: Self::Fact,
+    ) -> Self::Fact {
+        self.combine(a, b)
+    }
 }
 
 /// Fact-accumulating DFS from `root`. Traversal semantics are
@@ -144,46 +157,93 @@ fn walk_inner<V: FactVisitor>(
     }
 
     path.push(key.clone());
-    for edge in &fs.calls {
+    // #392: fanned-out interface-dispatch alternatives (consecutive
+    // edges sharing a `dispatch_group`) fold via `join_alternatives`
+    // — one dispatch invokes one alternative — before combining into
+    // the running total like any other edge.
+    let mut i = 0;
+    while i < fs.calls.len() {
         *steps += 1;
         if *steps > MAX_STEPS {
             path.pop();
             return visitor.saturated();
         }
-        let in_loop = edge.loop_depth > 0;
-        match &edge.callee {
-            Callee::Resolved(callee_key) => {
-                if path.contains(callee_key) {
-                    let f =
-                        visitor.recursion(key, edge, callee_key, emit);
-                    total = visitor.combine(total, f);
-                    continue;
-                }
-                if in_loop {
-                    let sub = walk_inner(
-                        summary, callee_key, visitor, path, steps, false,
-                    );
-                    if !visitor.is_zero(&sub) {
-                        let f = visitor
-                            .loop_call(key, edge, callee_key, sub, emit);
-                        total = visitor.combine(total, f);
-                    }
-                } else {
-                    let sub = walk_inner(
-                        summary, callee_key, visitor, path, steps, emit,
-                    );
-                    total = visitor.combine(total, sub);
-                }
-            }
-            Callee::Unresolved(name) => {
-                let f =
-                    visitor.unresolved(key, edge, name, in_loop, emit);
+        let edge = &fs.calls[i];
+        match edge.dispatch_group {
+            None => {
+                let f = edge_fact(
+                    summary, key, edge, visitor, path, steps, emit,
+                );
                 total = visitor.combine(total, f);
+                i += 1;
+            }
+            Some(g) => {
+                let mut alt: Option<V::Fact> = None;
+                while i < fs.calls.len()
+                    && fs.calls[i].dispatch_group == Some(g)
+                {
+                    let f = edge_fact(
+                        summary,
+                        key,
+                        &fs.calls[i],
+                        visitor,
+                        path,
+                        steps,
+                        emit,
+                    );
+                    alt = Some(match alt {
+                        None => f,
+                        Some(a) => visitor.join_alternatives(a, f),
+                    });
+                    i += 1;
+                }
+                if let Some(a) = alt {
+                    total = visitor.combine(total, a);
+                }
             }
         }
     }
     path.pop();
     total
+}
+
+/// One call edge's contribution — traversal semantics unchanged from
+/// the original inline loop: ancestor-path callee is `recursion`; a
+/// loop callee is probed silently and only a non-zero probe produces
+/// a `loop_call` event; otherwise the callee's walk folds in
+/// directly; an unresolved callee asks the visitor.
+fn edge_fact<V: FactVisitor>(
+    summary: &AllocSummary,
+    key: &FnKey,
+    edge: &CallEdge,
+    visitor: &mut V,
+    path: &mut Vec<FnKey>,
+    steps: &mut u32,
+    emit: bool,
+) -> V::Fact {
+    let in_loop = edge.loop_depth > 0;
+    match &edge.callee {
+        Callee::Resolved(callee_key) => {
+            if path.contains(callee_key) {
+                return visitor.recursion(key, edge, callee_key, emit);
+            }
+            if in_loop {
+                let sub = walk_inner(
+                    summary, callee_key, visitor, path, steps, false,
+                );
+                if !visitor.is_zero(&sub) {
+                    visitor.loop_call(key, edge, callee_key, sub, emit)
+                } else {
+                    visitor.identity()
+                }
+            } else {
+                walk_inner(summary, callee_key, visitor, path, steps, emit)
+            }
+        }
+        Callee::Unresolved(name) => {
+            visitor.unresolved(key, edge, name, in_loop, emit)
+        }
+    }
 }
 
 /// One step of a witness path: the fn whose body contains the hop,

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -848,10 +848,16 @@ fn resolve_member(
 /// and bundle-level claims agree. `recv_ty: Some` edges
 /// (synthesized form/builtin methods like `counts.set`) are known
 /// non-locus receivers and stay exempt.
-fn unresolved_untyped_receiver(
+///
+/// #392: interface-dispatch calls never reach this predicate — a
+/// dispatch WITH conformers arrives already fanned out to `Resolved`
+/// alternatives, and one through an uninhabited interface is dead
+/// code (no value of the interface can exist in this closed world),
+/// which the walk skips like the summarizer's other non-edges.
+fn unresolved_opaque_receiver(
     edge: &crate::alloc_summary::CallEdge,
 ) -> bool {
-    edge.receiver_present && edge.recv_ty.is_none()
+    edge.opaque_method_call()
 }
 
 // ===================== forbid reaches =============================
@@ -1037,7 +1043,7 @@ fn evaluate_forbid_reaches(
                         // The backstop: an untyped-receiver call
                         // is a method of SOME locus, possibly a
                         // wrapper reaching the target. Fail closed.
-                        if unresolved_untyped_receiver(edge) {
+                        if unresolved_opaque_receiver(edge) {
                             diags.push(Diag::ty(
                                 c.name.span,
                                 format!(
@@ -1200,7 +1206,7 @@ fn evaluate_only_edges(
                         ));
                         return "violated";
                     }
-                    if unresolved_untyped_receiver(edge) {
+                    if unresolved_opaque_receiver(edge) {
                         diags.push(Diag::ty(
                             c.name.span,
                             format!(
@@ -1408,6 +1414,13 @@ fn site_count(
     stack.push(k.clone());
     let mut total: u64 = 0;
     let mut best_child: (u64, Vec<FnKey>) = (0, Vec::new());
+    // #392: fanned-out interface-dispatch alternatives share a group;
+    // a dispatch invokes exactly ONE of them, so the group contributes
+    // its MAX, not its sum — summing would count phantom calls that no
+    // execution performs. (Any unbounded alternative still poisons the
+    // whole count: dispatch may choose it.)
+    let mut group_best: BTreeMap<u32, (u64, Vec<FnKey>)> =
+        BTreeMap::new();
     let mut unbounded = false;
     for edge in &fs.calls {
         match &edge.callee {
@@ -1426,9 +1439,21 @@ fn site_count(
                             unbounded = true;
                             break;
                         }
-                        total = total.saturating_add(w);
-                        if w > best_child.0 {
-                            best_child = (w, p);
+                        match edge.dispatch_group {
+                            Some(g) => {
+                                let e = group_best
+                                    .entry(g)
+                                    .or_insert((0, Vec::new()));
+                                if w > e.0 {
+                                    *e = (w, p);
+                                }
+                            }
+                            None => {
+                                total = total.saturating_add(w);
+                                if w > best_child.0 {
+                                    best_child = (w, p);
+                                }
+                            }
                         }
                     }
                 }
@@ -1440,11 +1465,19 @@ fn site_count(
                     // be a wrapper reaching a carrier — an
                     // uncountable contribution. Fail closed
                     // (unbounded).
-                    || unresolved_untyped_receiver(edge)
+                    || unresolved_opaque_receiver(edge)
                 {
                     unbounded = true;
                     break;
                 }
+            }
+        }
+    }
+    if !unbounded {
+        for (w, p) in group_best.into_values() {
+            total = total.saturating_add(w);
+            if w > best_child.0 {
+                best_child = (w, p);
             }
         }
     }

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -1020,8 +1020,10 @@ fn check_class(
             // STILL cannot be typed (an index result, a match value,
             // a foreign expression) is a method of some bundle locus
             // reached through an opaque expression — same fail-closed
-            // rule as an indirect call.
-            if edge.receiver_present && edge.recv_ty.is_none() {
+            // rule as an indirect call. (#392 interface dispatch
+            // never lands here: with conformers it is fanned out to
+            // resolved edges; without any it is dead code.)
+            if edge.opaque_method_call() {
                 return Some(format!(
                     "`{}` — a method call on a receiver the compiler \
                      cannot type; bind the receiver to a typed field \

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -121,9 +121,10 @@ pub fn infer_effects(
                     // is a method of some bundle locus reached
                     // through an opaque expression. Same fail-closed
                     // treatment as an indirect call: it may do
-                    // anything.
-                    if edge.receiver_present && edge.recv_ty.is_none()
-                    {
+                    // anything. (#392 interface dispatch never lands
+                    // here: fanned out when conformers exist, dead
+                    // code when none do.)
+                    if edge.opaque_method_call() {
                         acc = acc.union(EffectSet::UNCLASSIFIED);
                         continue;
                     }

--- a/crates/hale-types/src/quantitative.rs
+++ b/crates/hale-types/src/quantitative.rs
@@ -263,9 +263,7 @@ fn count_dim(
     for edge in &fs.calls {
         // #382: an untypeable-receiver method call gets the same
         // unbounded treatment as an indirect call.
-        if edge.indirect
-            || (edge.receiver_present && edge.recv_ty.is_none())
-        {
+        if edge.indirect || edge.opaque_method_call() {
             total = total.add(Qty::Unbounded);
         }
     }
@@ -286,8 +284,12 @@ fn count_dim(
             }
         }
     }
-    // Resolved callees.
+    // Resolved callees. #392: fanned-out interface-dispatch
+    // alternatives share a `dispatch_group`; a dispatch invokes
+    // exactly one of them, so a group contributes the MAX over its
+    // alternatives where a real call sequence would sum.
     path.push(key.clone());
+    let mut group_max: BTreeMap<u32, Qty> = BTreeMap::new();
     for edge in &fs.calls {
         *steps += 1;
         if *steps > callgraph::MAX_STEPS {
@@ -295,39 +297,52 @@ fn count_dim(
             return Qty::Unbounded;
         }
         if let Callee::Resolved(callee) = &edge.callee {
+            let mut contrib = Qty::Finite(0);
             if path.contains(callee) {
-                total = total.add(Qty::Unbounded);
-                continue;
-            }
-            // #382 phase 3: a call to a declared CARRIER of the
-            // budgeted user class counts one site (loop-nested is
-            // unbounded, like every per-call contributor).
-            if matches!(dim, QuantDim::UserClass(_)) {
-                let is_carrier = summary
-                    .carries
-                    .get(callee)
-                    .map_or(false, |c| c.0 & carrier_mask.0 != 0);
-                if is_carrier {
-                    total = total.add(if edge.loop_depth > 0 {
-                        Qty::Unbounded
-                    } else {
-                        Qty::Finite(1)
-                    });
-                }
-            }
-            let sub = count_dim(
-                summary, callee, dim, fanout_of, carrier_mask, path,
-                steps,
-            );
-            total = total.add(if edge.loop_depth > 0 {
-                match sub {
-                    Qty::Finite(0) => Qty::Finite(0),
-                    _ => Qty::Unbounded,
-                }
+                contrib = contrib.add(Qty::Unbounded);
             } else {
-                sub
-            });
+                // #382 phase 3: a call to a declared CARRIER of the
+                // budgeted user class counts one site (loop-nested is
+                // unbounded, like every per-call contributor).
+                if matches!(dim, QuantDim::UserClass(_)) {
+                    let is_carrier = summary
+                        .carries
+                        .get(callee)
+                        .map_or(false, |c| c.0 & carrier_mask.0 != 0);
+                    if is_carrier {
+                        contrib = contrib.add(if edge.loop_depth > 0 {
+                            Qty::Unbounded
+                        } else {
+                            Qty::Finite(1)
+                        });
+                    }
+                }
+                let sub = count_dim(
+                    summary, callee, dim, fanout_of, carrier_mask,
+                    path, steps,
+                );
+                contrib = contrib.add(if edge.loop_depth > 0 {
+                    match sub {
+                        Qty::Finite(0) => Qty::Finite(0),
+                        _ => Qty::Unbounded,
+                    }
+                } else {
+                    sub
+                });
+            }
+            match edge.dispatch_group {
+                Some(g) => {
+                    let e = group_max
+                        .entry(g)
+                        .or_insert(Qty::Finite(0));
+                    *e = e.max(contrib);
+                }
+                None => total = total.add(contrib),
+            }
         }
+    }
+    for q in group_max.into_values() {
+        total = total.add(q);
     }
     path.pop();
     total

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -226,6 +226,25 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
                             .entry(fn_name(k))
                             .or_default()
                             .insert("indirect_call".to_string());
+                    } else if let Some(iface) = &edge.via_interface {
+                        // #392: a call through an interface no locus
+                        // in the build conforms to. Not an unknown
+                        // in the fail-closed sense — an uninhabited
+                        // interface has no values in a closed world,
+                        // so every walker treats the site as DEAD.
+                        // Recorded (inside the hashed model half) so
+                        // an outside evaluator applies the same rule
+                        // and a conformer appearing later changes
+                        // `shape_hash`. (A dispatch WITH conformers
+                        // is already fanned out to ordinary resolved
+                        // call edges above and never lands here.)
+                        unknowns.entry(fn_name(k)).or_default().insert(
+                            format!(
+                                "uninhabited_interface_call:{}.{}",
+                                name(iface),
+                                n
+                            ),
+                        );
                     } else if edge.receiver_present
                         && edge.recv_ty.is_none()
                     {

--- a/crates/hale-types/tests/interface_dispatch.rs
+++ b/crates/hale-types/tests/interface_dispatch.rs
@@ -1,0 +1,495 @@
+//! #392 thread 4 — interface-dispatch edges.
+//!
+//! A method call on an interface-typed value used to resolve
+//! `Unresolved` with `recv_ty: Some(<interface>)` and was silently
+//! dropped by every walker — the one receiver shape left where a
+//! real call contributed nothing to any judgment (the #382 root fix
+//! closed the `recv_ty: None` class). The closed world makes the
+//! implementor set enumerable, so the summarizer now fans the one
+//! written call out to an edge per conforming locus; an interface
+//! nothing conforms to fails closed like an untyped receiver.
+//!
+//! Canary + control per judgment form, per the #382 doctrine: a
+//! checker that cannot fail proves nothing.
+
+use hale_syntax::parse_source;
+
+fn diags(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+// =====================================================================
+// Effects: `@effects(none: …)` must see through dispatch
+// =====================================================================
+
+/// CANARY — the audit's router shape (`route.handler.handle(ctx)`):
+/// a carrier reached through an interface-typed STRUCT FIELD must
+/// violate the certificate. Before the fan-out this passed silently.
+#[test]
+fn a_carrier_behind_an_interface_typed_field_fires() {
+    let src = r#"
+        effect money;
+        interface Notifier { fn send(n: Int) -> Int; }
+        locus Email {
+            @effects(is: {money})
+            fn send(n: Int) -> Int { return n; }
+        }
+        type Route { handler: Notifier; }
+        locus A {
+            @effects(none: {money})
+            fn go(n: Int) -> Int {
+                let r = Route { handler: Email { } };
+                return r.handler.send(n);
+            }
+        }
+        fn main() { println(A { }.go(1)); }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("effect assertion violated")),
+        "a carrier behind an interface-typed field must violate: {:?}",
+        ds
+    );
+}
+
+/// CANARY — the stdlib server shape: dispatch through an
+/// interface-typed fn PARAMETER reaches every conformer, so one
+/// carrying implementor among several is found.
+#[test]
+fn a_carrier_among_several_conformers_fires_through_a_param() {
+    let src = r#"
+        effect money;
+        interface Notifier { fn send(n: Int) -> Int; }
+        locus Log {
+            fn send(n: Int) -> Int { return n; }
+        }
+        locus Email {
+            @effects(is: {money})
+            fn send(n: Int) -> Int { return n; }
+        }
+        locus A {
+            @effects(none: {money})
+            fn go(h: Notifier, n: Int) -> Int { return h.send(n); }
+        }
+        fn main() { println(A { }.go(Log { }, 1)); }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("effect assertion violated")),
+        "dispatch must reach every conformer, including the carrier: {:?}",
+        ds
+    );
+}
+
+/// CONTROL — clean conformers keep the certificate: fanning out must
+/// not turn every dispatch into a violation.
+#[test]
+fn a_dispatch_to_clean_conformers_still_certifies() {
+    let src = r#"
+        effect money;
+        interface Notifier { fn send(n: Int) -> Int; }
+        locus Log { fn send(n: Int) -> Int { return n; } }
+        type Route { handler: Notifier; }
+        locus A {
+            @effects(none: {money})
+            fn go(n: Int) -> Int {
+                let r = Route { handler: Log { } };
+                return r.handler.send(n);
+            }
+        }
+        fn main() { println(A { }.go(1)); }
+    "#;
+    let ds = diags(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("effect assertion violated")),
+        "clean conformers must still certify: {:?}",
+        ds
+    );
+}
+
+/// An interface NO locus conforms to has no values in this closed
+/// world — an interface value only arises by coercing a conformer —
+/// so its call sites are DEAD and a certificate over them holds
+/// vacuously. (The everyday instance: the stdlib router's
+/// `m.before(cur)` over an empty middleware list. Failing closed
+/// here would refuse every certificate through the router.)
+#[test]
+fn an_uninhabited_interface_call_is_dead_code() {
+    let src = r#"
+        effect money;
+        interface Ghost { fn vanish(n: Int) -> Int; }
+        locus A {
+            @effects(none: {money})
+            fn go(g: Ghost, n: Int) -> Int { return g.vanish(n); }
+        }
+        fn main() { A { }; }
+    "#;
+    let ds = diags(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("effect assertion violated")),
+        "a call no value can ever reach must certify vacuously: {:?}",
+        ds
+    );
+}
+
+// =====================================================================
+// Claims: `forbid reaches` composes through dispatch
+// =====================================================================
+
+/// CANARY — a bundle claim sees the dispatch edge and produces a
+/// witness naming the conforming implementor.
+#[test]
+fn forbid_reaches_finds_a_path_through_dispatch() {
+    let src = r#"
+        interface Notifier { fn send(n: Int) -> Int; }
+        locus Email { fn send(n: Int) -> Int { return n; } }
+        type Route { handler: Notifier; }
+        locus A {
+            fn go(n: Int) -> Int {
+                let r = Route { handler: Email { } };
+                return r.handler.send(n);
+            }
+        }
+        group a_side = { A };
+        group sinks = { Email };
+        main locus App {
+            params { a: A = A { }; }
+            claims { iso: forbid reaches(a_side, sinks); }
+        }
+        fn main() { App { }; }
+    "#;
+    let ds = diags(src);
+    let hit = ds
+        .iter()
+        .find(|m| m.contains("claim `iso` violated"))
+        .unwrap_or_else(|| {
+            panic!("dispatch must be a reachability edge: {:?}", ds)
+        });
+    assert!(
+        hit.contains("Email"),
+        "the witness must name the implementor: {}",
+        hit
+    );
+}
+
+/// CONTROL — dispatch fan-out adds edges only to CONFORMERS: a locus
+/// with the same method name but different arity is not fanned to,
+/// so a claim against it holds.
+#[test]
+fn forbid_reaches_holds_against_a_non_conformer() {
+    let src = r#"
+        interface Notifier { fn send(n: Int) -> Int; }
+        locus Email { fn send(n: Int) -> Int { return n; } }
+        locus Audit { fn send(a: Int, b: Int) -> Int { return a + b; } }
+        type Route { handler: Notifier; }
+        locus A {
+            fn go(n: Int) -> Int {
+                let r = Route { handler: Email { } };
+                return r.handler.send(n);
+            }
+        }
+        group a_side = { A };
+        group sinks = { Audit };
+        main locus App {
+            params { a: A = A { }; }
+            claims { iso: forbid reaches(a_side, sinks); }
+        }
+        fn main() { App { }; }
+    "#;
+    let ds = diags(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("claim `iso` violated")),
+        "a non-conformer must not receive a dispatch edge: {:?}",
+        ds
+    );
+}
+
+/// The claim-side control for the same rule: a dead dispatch site is
+/// not an unresolvable edge, so a claim whose source group contains
+/// it still certifies (nothing can flow through it).
+#[test]
+fn a_claim_over_an_uninhabited_interface_call_still_certifies() {
+    let src = r#"
+        interface Ghost { fn vanish(n: Int) -> Int; }
+        locus B { fn work(n: Int) -> Int { return n; } }
+        locus A {
+            fn go(g: Ghost, n: Int) -> Int { return g.vanish(n); }
+        }
+        group a_side = { A };
+        group b_side = { B };
+        main locus App {
+            params { a: A = A { }; }
+            claims { iso: forbid reaches(a_side, b_side); }
+        }
+        fn main() { App { }; }
+    "#;
+    let ds = diags(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("violated")
+            || m.contains("cannot be certified")),
+        "a dead dispatch site must not refuse certification: {:?}",
+        ds
+    );
+}
+
+// =====================================================================
+// The stdlib router — the shape that motivated the thread
+// =====================================================================
+
+/// CANARY — end-to-end through `std::http::Router`: the certificate
+/// walk enters `Router::dispatch` -> `__http_run_chain` and the
+/// route-entry dispatch (`e.handler.handle(cur)`) fans out to the
+/// user's carrying handler. Before #392 the whole chain was
+/// invisible past the interface hop.
+#[test]
+fn a_certificate_sees_a_carrier_through_the_stdlib_router() {
+    let src = r#"
+        effect money;
+        locus Hello {
+            @effects(is: {money})
+            fn handle(ctx: std::http::Context) -> std::http::Response {
+                return std::http::Response {
+                    status: 200,
+                    content_type: "text/plain",
+                    body: "hi"
+                };
+            }
+        }
+        locus Gate {
+            @effects(none: {money})
+            fn probe(r: std::http::Router, req: std::http::Request) -> Int {
+                let resp = r.dispatch(req);
+                return resp.status;
+            }
+        }
+        fn main() {
+            let r = std::http::Router { };
+            r.get("/", Hello { });
+            let req = std::http::Request {
+                method: "GET", path: "/", body: ""
+            };
+            println(Gate { }.probe(r, req));
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("effect assertion violated")),
+        "the router chain must expose the handler's effect: {:?}",
+        ds
+    );
+}
+
+/// CONTROL — the same chain with a clean handler certifies: the
+/// empty middleware list (`Middleware` has no conformer here) is
+/// dead, not fail-closed, and clean fan-out targets add nothing.
+#[test]
+fn a_clean_handler_through_the_stdlib_router_still_certifies() {
+    let src = r#"
+        effect money;
+        locus Hello {
+            fn handle(ctx: std::http::Context) -> std::http::Response {
+                return std::http::Response {
+                    status: 200,
+                    content_type: "text/plain",
+                    body: "hi"
+                };
+            }
+        }
+        locus Gate {
+            @effects(none: {money})
+            fn probe(r: std::http::Router, req: std::http::Request) -> Int {
+                let resp = r.dispatch(req);
+                return resp.status;
+            }
+        }
+        fn main() {
+            let r = std::http::Router { };
+            r.get("/", Hello { });
+            let req = std::http::Request {
+                method: "GET", path: "/", body: ""
+            };
+            println(Gate { }.probe(r, req));
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("effect assertion violated")),
+        "a clean handler through the router must certify: {:?}",
+        ds
+    );
+}
+
+// =====================================================================
+// `bound` (and every counting judgment): alternatives take the MAX
+// =====================================================================
+
+/// CANARY of the SEMANTICS — one dispatch invokes ONE conforming
+/// target, so two one-carrier alternatives bound at 1, not 2. A sum
+/// over the fan-out would fail this claim on phantom calls.
+#[test]
+fn dispatch_alternatives_bound_by_their_max_not_their_sum() {
+    let src = r#"
+        effect llm;
+        interface Model { fn ask(p: Int) -> Int; }
+        locus Fast {
+            @effects(is: {llm})
+            fn ask(p: Int) -> Int { return p; }
+        }
+        locus Deep {
+            @effects(is: {llm})
+            fn ask(p: Int) -> Int { return p; }
+        }
+        type Slot { m: Model; }
+        locus Planner {
+            fn plan(n: Int) -> Int {
+                let s = Slot { m: Fast { } };
+                return s.m.ask(n);
+            }
+        }
+        group planners = { Planner };
+        main locus App {
+            params { p: Planner = Planner { }; }
+            claims { one_call: bound llm <= 1 on paths from planners; }
+        }
+        fn main() { App { }; }
+    "#;
+    let ds = diags(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("claim `one_call` violated")),
+        "one dispatch is one call — the bound must take the max over \
+         alternatives, not their sum: {:?}",
+        ds
+    );
+}
+
+/// CANARY — the max is still counted: an alternative whose body
+/// carries TWO sites exceeds a bound of one through dispatch.
+#[test]
+fn a_heavy_alternative_still_violates_the_bound() {
+    let src = r#"
+        effect llm;
+        @effects(is: {llm})
+        fn model_call(p: Int) -> Int { return p; }
+        interface Model { fn ask(p: Int) -> Int; }
+        locus Fast { fn ask(p: Int) -> Int { return model_call(p); } }
+        locus Deep {
+            fn ask(p: Int) -> Int {
+                return model_call(p) + model_call(p);
+            }
+        }
+        type Slot { m: Model; }
+        locus Planner {
+            fn plan(n: Int) -> Int {
+                let s = Slot { m: Fast { } };
+                return s.m.ask(n);
+            }
+        }
+        group planners = { Planner };
+        main locus App {
+            params { p: Planner = Planner { }; }
+            claims { one_call: bound llm <= 1 on paths from planners; }
+        }
+        fn main() { App { }; }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("claim `one_call` violated")),
+        "the heaviest alternative (2 sites) must exceed the bound: {:?}",
+        ds
+    );
+}
+
+// =====================================================================
+// `@budget(alloc_per_call)`: the guard the #382 fix left dead
+// =====================================================================
+
+/// CANARY — an untyped-receiver method call must refuse a zero-alloc
+/// budget. The #382 root fix wrote this message but only widened the
+/// `indirect` guard in the OTHER walkers; the budget's own guard
+/// still let a wrapper certify.
+#[test]
+fn an_untyped_receiver_call_refuses_an_alloc_budget() {
+    let src = r#"
+type P { a: Int; }
+locus Maker {
+    fn make(n: Int) -> P { return P { a: n }; }
+}
+
+@budget(alloc_per_call = 0)
+fn zero(n: Int) -> Int {
+    let xs = [Maker { }];
+    let p = xs[0].make(n);
+    return p.a;
+}
+
+fn main() { }
+"#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("budget")
+            && m.contains("receiver the compiler cannot type")),
+        "an untyped-receiver call must fail the budget closed: {:?}",
+        ds
+    );
+}
+
+/// CANARY — dispatch to an allocating conformer counts against the
+/// budget (the fan-out resolves the edge, the walk enters the body).
+#[test]
+fn a_dispatch_to_an_allocating_conformer_counts() {
+    let src = r#"
+type P { a: Int; }
+interface Maker { fn make(n: Int) -> P; }
+locus Boxed {
+    fn make(n: Int) -> P { return P { a: n }; }
+}
+
+@budget(alloc_per_call = 0)
+fn zero(m: Maker, n: Int) -> Int {
+    let p = m.make(n);
+    return p.a;
+}
+
+fn main() { }
+"#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("budget")),
+        "an allocating conformer must count against the budget: {:?}",
+        ds
+    );
+}
+
+/// CONTROL — dispatch alternatives budget at their max: two
+/// one-alloc conformers satisfy `alloc_per_call = 1`.
+#[test]
+fn budget_counts_dispatch_alternatives_at_their_max() {
+    let src = r#"
+type P { a: Int; }
+interface Maker { fn make(n: Int) -> P; }
+locus Boxed {
+    fn make(n: Int) -> P { return P { a: n }; }
+}
+locus Tagged {
+    fn make(n: Int) -> P { return P { a: n + 1 }; }
+}
+
+@budget(alloc_per_call = 1)
+fn one(m: Maker, n: Int) -> Int {
+    let p = m.make(n);
+    return p.a;
+}
+
+fn main() { }
+"#;
+    let ds = diags(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("budget")),
+        "two one-alloc alternatives must satisfy a budget of 1: {:?}",
+        ds
+    );
+}

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -465,6 +465,29 @@ judgment that traverses calls refuses to certify over:
   subscriber);
 - a walk exceeding the step ceiling.
 
+**Interface dispatch fans out.** A method call on an
+interface-typed value — `route.handler.handle(ctx)`, the stdlib
+router's own shape — is not an unknown: the world is closed, so
+the implementor set is enumerable. The summarizer fans the one
+written edge out to every conforming locus (structural
+name-and-arity conformance over the declarations — a superset of
+the checker's typed conformance, safe because over-approximation
+only adds edges). Reachability and effect judgments walk every
+alternative; counting judgments (`bound`, `@budget`, the
+quantitative dims) take the **max** over one dispatch site's
+alternatives, because an invocation dispatches to exactly one
+target — a sum would count phantom calls no execution performs.
+
+An interface *no* locus conforms to is different again: an
+interface value only ever arises by coercing a conforming locus,
+so in a closed world an uninhabited interface has no values and
+its call sites are **dead** — they contribute nothing to any
+judgment (the router's `m.before(cur)` over an empty middleware
+list is the everyday case). The artifact records each such site
+(`uninhabited_interface_call:<interface>.<callee>`) inside the
+hashed model half, so a conformer appearing in a later build
+changes `shape_hash`.
+
 ## Every diagnostic
 
 The complete catalog, grouped by stage. Parse errors:
@@ -534,6 +557,7 @@ The artifact shape (schema `1.0`):
   "labels":    { "<fn>": [declared effect classes] },
   "unknowns":  [ {"fn": …, "reasons": ["indirect_call" |
                   "untyped_receiver_call:<callee>" |
+                  "uninhabited_interface_call:<iface>.<callee>" |
                   "computed_publish"]} ],
   "claims":    [ {"name", "form", "result": "holds"|"violated"|"invalid"} ]
 }
@@ -543,8 +567,8 @@ Everything renders in author spelling (cross-seed symbols
 demangled). `shape_hash` covers the **model half** — sorts,
 relations, groups, labels, unknowns — and excludes claim
 *results*, so one topology under a different law keeps one shape
-while any graph, vocabulary, carrier, or new fail-closed site
-changes the identity. `--check-topology` diffs against the
+while any graph, vocabulary, carrier, or new fail-closed or
+dead-dispatch site changes the identity. `--check-topology` diffs against the
 committed baseline and fails with a regenerate hint, separating
 two review questions: *does the program still satisfy the law?*
 and *did the graph change in a way reviewers should see?*

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -135,8 +135,30 @@ main locus Org {
   is sound; the edge itself is the uncertainty, and the artifact
   records it (`untyped_receiver_call:<callee>`) inside the hashed
   model half. Synthesized form/builtin methods (`counts.set`)
-  carry a known receiver type and are exempt; the effect system
-  shares the underlying summarizer gap, tracked on #382.
+  carry a known receiver type and are exempt. The rule is one
+  shared predicate applied by every judgment that traverses calls
+  — claims, effect inference, effect certificates, `@budget`, and
+  the quantitative dims — so fn-level certificates and
+  bundle-level claims always agree (#392 closed the `@budget`
+  guard, which had the message but not the test).
+- **Interface dispatch fans out.** A method call on an
+  interface-typed value (`route.handler.handle(ctx)` — the stdlib
+  router's own shape) is resolved by closed-world enumeration
+  (#392): the summarizer fans the one written edge out to every
+  conforming locus. Conformance here is structural name + arity
+  over the declarations — a superset of the checker's typed
+  conformance, safe because over-approximation only adds edges.
+  Reachability and effect judgments walk every alternative;
+  counting judgments (`bound`, `@budget`, the quantitative dims)
+  take the **max** over the alternatives of one dispatch site,
+  because one invocation dispatches to exactly one target — a sum
+  would count phantom calls no execution performs. An interface NO
+  locus conforms to has no values in a closed world (an interface
+  value only arises by coercing a conformer), so its call sites
+  are dead: they contribute nothing to any judgment, and the
+  artifact records each (`uninhabited_interface_call:<iface>.<callee>`)
+  inside the hashed model half so a conformer appearing later
+  changes `shape_hash`.
 - **Placement.** `claims { }` is only legal inside `main locus`
   (parse error elsewhere): main is the closed-world gate, so
   bundle-wide claims cannot be evaluated anywhere earlier, and


### PR DESCRIPTION
The first (and smallest, soundness-adjacent) thread of #392, per the issue's sequencing.

## What

A method call on an interface-typed value — `route.handler.handle(ctx)`, the stdlib router's own shape — resolved `Unresolved` with `recv_ty: Some(<interface>)` and was **silently dropped by every walker**: the one receiver shape left after the v0.14.0 receiver-typing root fix where a real call contributed nothing to any judgment. An `@effects(none: …)` certificate over a fn dispatching through `std::http::Router` certified while the handler performed the effect (probe reproduced before the fix).

## The rule set

- **Fan-out.** The world is closed, so the implementor set is enumerable: summary construction fans the written edge out to one `Resolved` edge per conforming locus (structural name+arity conformance over the declarations — a superset of the checker's typed conformance; over-approximation only adds edges).
- **Counting takes the max.** A dispatch invokes exactly one target, so `bound`, `@budget`, and the quantitative dims fold one site's alternatives with **max**, not sum — a sum would count phantom calls no execution performs. Carried by a `dispatch_group` tag and a `join_alternatives` hook in the shared call-graph walker. Reachability and effect judgments walk every alternative as usual.
- **Uninhabited ⇒ dead, not fail-closed.** An interface value only arises by coercing a conformer, so an interface nothing conforms to has no values in this build and its call sites are dead — they contribute nothing. The everyday instance: the router's `m.before(cur)` over an **empty middleware list**; failing closed there would refuse every certificate through the stdlib router (found by probing, before it shipped). The artifact records each such site (`uninhabited_interface_call:<iface>.<callee>`) inside the hashed model half, so a conformer appearing later changes `shape_hash`.

## Two adjacent holes closed

1. **Path-written stdlib types never typed receivers.** `s: std::io::tcp::Stream`, `r: std::http::Router` recorded only the last path segment — a name no summary map is keyed by — so method calls on such receivers were invisible to every judgment. `type_expr_name` now resolves multi-segment paths through the same std-vs-user rule struct-literal receivers already used. This is what lets the walk enter `Router::dispatch → __http_run_chain` at all.
2. **`@budget(alloc_per_call)` was still open through wrappers.** The v0.14.0 root fix wrote the budget's dual-cause message but never widened its guard past `indirect` — the untyped-receiver branch was dead code and the budget certified through a wrapper. The shared predicate (`CallEdge::opaque_method_call`) now backs all five walkers.

## Evidence

- `interface_dispatch.rs` (14 tests): canary + control per judgment form — effects (struct-field, param, multi-conformer), claims (`forbid reaches` witness through dispatch, non-conformer control, uninhabited control), `bound` (max-not-sum semantics pinned both directions), `@budget` (dead-guard canary, dispatch counting, max control), and the **stdlib router end-to-end pair**. All 8 canaries fail on the pre-fix tree; all 4 controls pass on both.
- Artifact: fanned edges land in the call relation; the uninhabited row + `shape_hash` sensitivity pinned in `claims_artifact_unknowns.rs`.
- Effects baseline: exactly two rows change — corpus `handle_request` fns gain `publish`, real (`Stream::recv` publishes to the tcp log-event topic, previously invisible). Reviewed deliberately, regenerated.
- Full suite: 2221 green. `hale fmt --check` clean.

Spec (`spec/verification.md` § Claims) and the docs claims chapter updated in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)