### PR TITLE
The normalized, provenance-bearing model (#392 thread 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ behavior.
 
 ## Unreleased
 
+### The normalized, provenance-bearing model (GH #392 thread 1)
+
+The architectural milestone every reviewer of the #382 stack named:
+one derived model — declaration provenance, the phase relation, the
+seed sort — consumed by every judgment and exported whole.
+
+- **Witnesses say where to edit.** A `forbid` violation now emits
+  secondary diagnostics in the effect system's root + leaf shape:
+  the call that crosses the boundary (or, for a bus hop, the
+  publish site and the subscription declaration) and the forbidden
+  destination's declaration. Spans are emitted only for bundle
+  decls — stdlib bodies parse in their own offset space, and a span
+  from there attributed to a user file names the wrong line (a
+  pre-existing misattribution this change also stops).
+- **`during` rides the phase relation.** Lifecycle hooks and modes
+  are hook-phases, methods their own source-slice phase; the
+  relation is explicit, exported, and what the evaluator reads.
+- **Topology artifact schema 1.1 — the model export.** The hashed
+  model half gains call-edge weights (`loop`, `unbounded`,
+  `via_interface`), the through-stdlib contraction
+  (`calls_via_stdlib`: user→user paths with stdlib interiors,
+  collapsed with a conservative loop flag), the `phases` relation,
+  the `seeds` sort, and compiler-derived per-fn `effects`. A new
+  UNHASHED `provenance` section carries per-edge and per-decl spans
+  as bundle-global byte offsets — moving code changes every span
+  and no identity. v2 scope: every claim verb replays independently
+  over the exported relations; still compiler-certified: `bound`
+  over built-in classes and walks past the step ceiling. Existing
+  `shape_hash` values change (the hashed half grew).
+
+Spec: `spec/verification.md` § Claims (witness provenance, phase
+relation, artifact scope). Docs: the claims chapter (witness,
+`during`, artifact schema). Tests: `model_provenance.rs` (witness
+spans incl. the foreign-span guard, phase selection, model
+derivation), `topology_v2.rs` (sections, motion-insensitivity
+canary, contracted edges).
+
 ### Interface-dispatch edges: closed-world fan-out (GH #392 thread 4)
 
 A method call on an interface-typed value

--- a/crates/hale-cli/tests/claims_artifact_unknowns.rs
+++ b/crates/hale-cli/tests/claims_artifact_unknowns.rs
@@ -123,8 +123,11 @@ fn main() { App { }; }
 fn a_conforming_dispatch_appears_as_call_edges_not_unknowns() {
     let art = dump(DISPATCHED, "dispatched");
     assert!(
-        art.contains(r#"{"from": "A::go", "to": "Email::send"}"#),
-        "the fanned-out edge must land in the call relation:\n{}",
+        art.contains(
+            r#"{"from": "A::go", "to": "Email::send", "via_interface": "Notifier"}"#
+        ),
+        "the fanned-out edge must land in the call relation, tagged \
+         with its interface:\n{}",
         art
     );
     assert!(

--- a/crates/hale-cli/tests/topology_v2.rs
+++ b/crates/hale-cli/tests/topology_v2.rs
@@ -1,0 +1,160 @@
+//! #392 thread 1 — the topology artifact's v2 model export:
+//! phases, seeds, derived effects, weights, through-stdlib
+//! contraction, and the unhashed provenance half.
+
+use std::process::Command;
+
+fn dump(src: &str, tag: &str) -> String {
+    let path = std::env::temp_dir().join(format!(
+        "hale_topology_v2_{}_{}.hl",
+        std::process::id(),
+        tag
+    ));
+    std::fs::write(&path, src).expect("write program");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(&path)
+        .arg("--dump-topology")
+        .output()
+        .expect("run hale check");
+    let _ = std::fs::remove_file(&path);
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn shape_hash(artifact: &str) -> String {
+    artifact
+        .lines()
+        .find(|l| l.contains("\"shape_hash\""))
+        .expect("shape_hash line")
+        .to_string()
+}
+
+const BASE: &str = r#"
+effect money;
+locus B {
+    @effects(is: {money})
+    fn work(n: Int) -> Int { return n * 2; }
+}
+locus A {
+    params { b: B = B { }; n: Int = 0; }
+    birth { self.n = self.b.work(1); }
+    fn go(k: Int) -> Int {
+        let mut acc = 0;
+        for i in 0..k { acc = acc + self.b.work(i); }
+        return acc;
+    }
+}
+group a_side = { A };
+group b_side = { B };
+main locus App {
+    params { a: A = A { }; }
+    claims { iso: forbid reaches(a_side, b_side); }
+}
+fn main() { App { }; }
+"#;
+
+/// The v2 hashed sections: the phase relation (hooks vs methods),
+/// the derived per-fn effect sets, and call-edge weights.
+#[test]
+fn the_artifact_exports_phases_effects_and_weights() {
+    let art = dump(BASE, "sections");
+    assert!(
+        art.contains(r#""A::birth": {"phase": "birth", "kind": "hook"}"#),
+        "a lifecycle hook is a hook-phase row:\n{}",
+        art
+    );
+    assert!(
+        art.contains(r#""A::go": {"phase": "go", "kind": "method"}"#),
+        "an ordinary method is a method-phase row:\n{}",
+        art
+    );
+    assert!(
+        art.contains(r#""B::work": ["money"]"#),
+        "the declared carrier appears in derived effects:\n{}",
+        art
+    );
+    assert!(
+        art.contains(
+            r#"{"from": "A::go", "to": "B::work", "loop": true, "unbounded": true}"#
+        ),
+        "the loop-nested (runtime-bounded → unbounded) call edge \
+         carries its weights:\n{}",
+        art
+    );
+    assert!(
+        art.contains(r#"{"from": "A::birth", "to": "B::work"}"#),
+        "the plain call edge stays a plain row:\n{}",
+        art
+    );
+}
+
+/// Provenance is exported — and excluded from the hash: moving code
+/// (a comment line at the top) changes every span but must not
+/// change the shape identity.
+#[test]
+fn moving_code_changes_provenance_but_not_shape_hash() {
+    let a = dump(BASE, "motion_a");
+    let moved = format!("// moved down by one comment line\n{}", BASE);
+    let b = dump(&moved, "motion_b");
+    assert_eq!(
+        shape_hash(&a),
+        shape_hash(&b),
+        "shape identity must be motion-insensitive"
+    );
+    let spans_of = |art: &str| -> String {
+        art.lines()
+            .skip_while(|l| !l.contains("\"provenance\""))
+            .take_while(|l| !l.contains("\"claims\""))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    assert_ne!(
+        spans_of(&a),
+        spans_of(&b),
+        "provenance spans must track the moved source"
+    );
+    assert!(
+        a.contains("\"decls\": {") && a.contains("\"A\": ["),
+        "decl spans are exported:\n{}",
+        a
+    );
+}
+
+/// The through-stdlib contraction: a user→user path whose interior
+/// is stdlib bodies lands as a `calls_via_stdlib` edge, so
+/// reachability replay over the artifact matches the evaluator.
+#[test]
+fn a_through_stdlib_path_lands_as_a_contracted_edge() {
+    let src = r#"
+locus Hello {
+    fn handle(ctx: std::http::Context) -> std::http::Response {
+        return std::http::Response {
+            status: 200,
+            content_type: "text/plain",
+            body: "hi"
+        };
+    }
+}
+locus Gate {
+    fn probe(r: std::http::Router, req: std::http::Request) -> Int {
+        let resp = r.dispatch(req);
+        return resp.status;
+    }
+}
+fn main() {
+    let r = std::http::Router { };
+    r.get("/", Hello { });
+    let req = std::http::Request { method: "GET", path: "/", body: "" };
+    println(Gate { }.probe(r, req));
+}
+"#;
+    let art = dump(src, "contracted");
+    assert!(
+        art.contains(
+            r#"{"from": "Gate::probe", "to": "Hello::handle", "loop": true}"#
+        ),
+        "the contracted edge must appear with its conservative loop \
+         flag:\n{}",
+        art
+    );
+}

--- a/crates/hale-cli/tests/xseed_claims_verbs.rs
+++ b/crates/hale-cli/tests/xseed_claims_verbs.rs
@@ -63,7 +63,7 @@ fn cover_catches_an_uncovered_topic_across_seeds() {
 fn the_topology_artifact_round_trips() {
     let (dump, _ok) = check(&["--dump-topology"]);
     assert!(
-        dump.contains("\"schema\": \"1.0\"")
+        dump.contains("\"schema\": \"1.1\"")
             && dump.contains("\"shape_hash\": \""),
         "the artifact must carry schema + shape_hash:\n{}",
         dump

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -187,6 +187,9 @@ struct Cx<'a> {
     defs: Vec<Option<Vec<EffectClass>>>,
     declared: BTreeSet<u16>,
     effect_names: Vec<String>,
+    /// #392: the normalized model — decl provenance (witness spans,
+    /// origin gating), the phase relation (`during`), the seed sort.
+    model: crate::model::Model,
 }
 
 fn claims_report_inner(
@@ -358,6 +361,7 @@ fn claims_report_inner(
         defs: defs_of(programs),
         declared: declared_of(programs),
         effect_names: effect_names_of(programs),
+        model: crate::model::Model::derive(programs, import_renames),
     };
 
     // ---- validate, then evaluate ----
@@ -862,10 +866,19 @@ fn unresolved_opaque_receiver(
 
 // ===================== forbid reaches =============================
 
-/// One step of a witness path.
+/// One step of a witness path. #392: each step carries the span of
+/// the source decision that introduced the edge — the callsite, or
+/// the publish site + subscription decl — so a violation can say
+/// where to edit, not just which names are involved.
 enum Step {
-    Call,
-    Bus { subject: String },
+    Call {
+        span: hale_syntax::Span,
+    },
+    Bus {
+        subject: String,
+        publish_span: hale_syntax::Span,
+        sub_span: hale_syntax::Span,
+    },
 }
 
 /// Evaluate `forbid reaches(src, dst)` by BFS over the composed
@@ -904,11 +917,20 @@ fn evaluate_forbid_reaches(
         }
     }
     let mut roots = src_group.fn_set(&cx.summary);
-    // `during P` — restrict sources to the named phase / method of
-    // each source locus. Free fns have no phases and drop out.
+    // `during P` — restrict sources to the named phase of each
+    // source locus, evaluated against the model's PHASE RELATION
+    // (#392): lifecycle hooks and modes carry their runtime-driven
+    // phase, ordinary methods their own name (the shipped
+    // source-slice doctrine, now an explicit exported relation the
+    // artifact carries — which is what makes a `during` row
+    // independently re-derivable). Free fns have no phases and
+    // drop out.
     if let Some(phase) = during {
         roots.retain(|k| {
-            k.locus.is_some() && k.fn_name == phase.name
+            cx.model
+                .phases
+                .get(k)
+                .is_some_and(|p| p.phase == phase.name)
         });
         if roots.is_empty() && !src_group.is_empty() {
             diags.push(Diag::ty(
@@ -988,13 +1010,15 @@ fn evaluate_forbid_reaches(
             }
         };
         if hit {
-            diags.push(render_violation(
+            render_violation(
                 c,
                 src_name,
                 &dst.display(),
                 &k,
                 &parent,
-            ));
+                cx,
+                diags,
+            );
             return "violated";
         }
         let Some(fs) = cx.summary.fns.get(&k) else { continue };
@@ -1010,7 +1034,10 @@ fn evaluate_forbid_reaches(
                         if seen.insert(next.clone()) {
                             parent.insert(
                                 next.clone(),
-                                (k.clone(), Step::Call),
+                                (
+                                    k.clone(),
+                                    Step::Call { span: edge.span },
+                                ),
                             );
                             queue.push_back(next.clone());
                         }
@@ -1090,7 +1117,7 @@ fn evaluate_forbid_reaches(
                     ));
                     return "violated";
                 };
-                for (sub_locus, sub_handler) in
+                for (sub_locus, sub_handler, sub_span) in
                     subscribers_of(cx.graph, subj)
                 {
                     let next =
@@ -1107,6 +1134,8 @@ fn evaluate_forbid_reaches(
                                 k.clone(),
                                 Step::Bus {
                                     subject: subj.clone(),
+                                    publish_span: site.span,
+                                    sub_span,
                                 },
                             ),
                         );
@@ -1245,7 +1274,7 @@ fn evaluate_only_edges(
                 ));
                 return "violated";
             };
-            for (sub_locus, sub_handler) in
+            for (sub_locus, sub_handler, _sub_span) in
                 subscribers_of(cx.graph, subj)
             {
                 if !dst_g.loci.contains(&sub_locus) {
@@ -1490,7 +1519,7 @@ fn site_count(
                 unbounded = true;
                 break;
             };
-            for (sub_locus, sub_handler) in
+            for (sub_locus, sub_handler, _sub_span) in
                 subscribers_of(cx.graph, subj)
             {
                 let next = FnKey::method(sub_locus, sub_handler);
@@ -1696,7 +1725,7 @@ fn evaluate_count(
 fn subscribers_of(
     graph: &BusGraph,
     subject: &str,
-) -> Vec<(String, String)> {
+) -> Vec<(String, String, hale_syntax::Span)> {
     let mut out = Vec::new();
     for (key, info) in &graph.subjects {
         let covers = key == subject
@@ -1706,7 +1735,7 @@ fn subscribers_of(
             continue;
         }
         for s in &info.subscribers {
-            out.push((s.locus.clone(), s.handler.clone()));
+            out.push((s.locus.clone(), s.handler.clone(), s.span));
         }
     }
     out
@@ -1766,7 +1795,9 @@ fn render_violation(
     dst_disp: &str,
     hit: &FnKey,
     parent: &BTreeMap<FnKey, (FnKey, Step)>,
-) -> Diag {
+    cx: &Cx,
+    diags: &mut Vec<Diag>,
+) {
     // Walk hit -> root collecting (node, incoming step), then
     // render forward.
     let mut rev: Vec<(FnKey, Option<&Step>)> = Vec::new();
@@ -1788,10 +1819,10 @@ fn render_violation(
     for (node, incoming) in &rev {
         match incoming {
             None => path.push_str(&format!("`{}`", node.display())),
-            Some(Step::Call) => {
+            Some(Step::Call { .. }) => {
                 path.push_str(&format!(" -> `{}`", node.display()));
             }
-            Some(Step::Bus { subject }) => {
+            Some(Step::Bus { subject, .. }) => {
                 path.push_str(&format!(
                     " -(publishes \"{}\")-> `{}`",
                     subject,
@@ -1800,11 +1831,70 @@ fn render_violation(
             }
         }
     }
-    Diag::ty(
+    diags.push(Diag::ty(
         c.name.span,
         format!(
             "claim `{}` violated: `{}` reaches `{}` — witness: {}",
             c.name.name, src_name.name, dst_disp, path,
         ),
-    )
+    ));
+    // #392 provenance: the witness names WHO; these point at WHERE
+    // to edit — the source decision that introduced the crossing
+    // edge, and the destination's declaration. Spans are emitted
+    // only for bundle decls (`Model::is_bundle_fn`): stdlib bodies
+    // parse in their own offset space, and a span from there
+    // attributed to a bundle file would point at the wrong source.
+    if let Some((entered, Some(step))) = rev.last().map(|(n, s)| (n, s))
+    {
+        // The fn whose body holds the crossing edge.
+        let from = rev.len().checked_sub(2).map(|i| &rev[i].0);
+        match step {
+            Step::Call { span } => {
+                if from.is_some_and(|f| cx.model.is_bundle_fn(f)) {
+                    diags.push(Diag::ty(
+                        *span,
+                        format!(
+                            "claim `{}`: the boundary into `{}` is \
+                             crossed by this call",
+                            c.name.name, dst_disp
+                        ),
+                    ));
+                }
+            }
+            Step::Bus { publish_span, sub_span, .. } => {
+                if from.is_some_and(|f| cx.model.is_bundle_fn(f)) {
+                    diags.push(Diag::ty(
+                        *publish_span,
+                        format!(
+                            "claim `{}`: the crossing publish \
+                             happens here",
+                            c.name.name
+                        ),
+                    ));
+                }
+                if cx.model.is_bundle_fn(entered) {
+                    diags.push(Diag::ty(
+                        *sub_span,
+                        format!(
+                            "claim `{}`: delivered at this \
+                             subscription",
+                            c.name.name
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+    let dst_decl =
+        hit.locus.as_deref().unwrap_or(hit.fn_name.as_str());
+    if let Some(span) = cx.model.decl_span(dst_decl) {
+        diags.push(Diag::ty(
+            span,
+            format!(
+                "claim `{}`: the forbidden destination `{}` is \
+                 declared here",
+                c.name.name, dst_decl
+            ),
+        ));
+    }
 }

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -29,6 +29,7 @@ pub mod effects;
 pub mod frontier;
 pub mod check;
 pub mod claims;
+pub mod model;
 pub mod topology;
 pub mod stdlib_bodies;
 pub mod stdlib_surface;

--- a/crates/hale-types/src/model.rs
+++ b/crates/hale-types/src/model.rs
@@ -1,0 +1,245 @@
+//! #392 thread 1 — the normalized, provenance-bearing model.
+//!
+//! Every reviewer of the #382 stack independently converged on this
+//! as the next architectural milestone: one typed model — sorts,
+//! relations, labels, weights, per-edge source spans — derived once
+//! and consumed by every judgment form. The relations themselves
+//! already live in one place (`AllocSummary` for calls,
+//! `BusGraph` for bus ends, both span-carrying since birth); what
+//! was missing is what THIS module derives:
+//!
+//!  * **Declaration provenance** — which seed declared each decl,
+//!    and where. Witnesses use it to say *where to edit* (the
+//!    callsite that introduced the crossing edge, the destination's
+//!    declaration) and to refuse to point a span into a source
+//!    space the diag renderer can't map (stdlib bodies parse in
+//!    their own offset space; a span from there attributed to a
+//!    user file is a lie).
+//!  * **The phase relation** — fn → phase, with lifecycle hooks
+//!    (`birth`, `accept`, `release`, `run`, `drain`, `dissolve`)
+//!    and modes (`bulk`, `harmonic`, `resolution`) distinguished
+//!    from ordinary methods. `during P` evaluates against this
+//!    relation, and the topology artifact exports it, which is what
+//!    makes a `during` claim row independently re-derivable.
+//!  * **The seed sort** — alias → member decls, from the bundle's
+//!    import renames. `cover ... of <alias>` rows become
+//!    re-derivable the same way.
+//!
+//! The model is DERIVED, never authored: `Model::derive` reads the
+//! merged programs and the rename table, nothing else. It must stay
+//! cheap — it is built once per `claims_report` and once per
+//! artifact dump.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use hale_syntax::ast::*;
+use hale_syntax::Span;
+
+use crate::alloc_summary::FnKey;
+
+/// Which compilation unit declared a name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeclOrigin {
+    /// The main seed — the bundle the user is checking. Spans from
+    /// here are in the bundle's own offset space and safe to point
+    /// diagnostics at.
+    Main,
+    /// An imported seed, by alias. Its decls arrive mangled
+    /// (`__lib_<id>_<stem>_<name>`); spans are in the bundle space
+    /// (the merge preserves them) and safe to point at.
+    Seed(String),
+}
+
+/// A declared top-level name: where it came from and where it is.
+#[derive(Debug, Clone)]
+pub struct DeclInfo {
+    pub origin: DeclOrigin,
+    pub span: Span,
+}
+
+/// One row of the phase relation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PhaseEntry {
+    /// The phase name — the hook/mode/method name (`birth`, `run`,
+    /// `plan`, …). `during P` matches against this.
+    pub phase: String,
+    /// True for lifecycle hooks and modes — the phases the RUNTIME
+    /// drives — false for ordinary methods (a source-slice phase,
+    /// per the shipped `during` doctrine).
+    pub hook: bool,
+}
+
+/// The derived model: declaration provenance, the phase relation,
+/// and the seed sort. Relations (calls, publishes, subscribes) stay
+/// where they always were — `AllocSummary` and `BusGraph`, both
+/// span-carrying — this is the half no single place held.
+#[derive(Debug, Clone, Default)]
+pub struct Model {
+    /// Every top-level decl the bundle owns (loci, free fns, types,
+    /// interfaces, groups) → origin + decl span. Keyed by the
+    /// POST-MERGE name (mangled for imported decls), because that is
+    /// the name every graph node carries.
+    pub decls: BTreeMap<String, DeclInfo>,
+    /// The phase relation over locus-owned fns.
+    pub phases: BTreeMap<FnKey, PhaseEntry>,
+    /// Seed sort: alias → the mangled names of its member decls.
+    pub seeds: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl Model {
+    pub fn derive(
+        programs: &[&Program],
+        import_renames: &[(Vec<String>, String)],
+    ) -> Model {
+        let mut seeds: BTreeMap<String, BTreeSet<String>> =
+            BTreeMap::new();
+        let mut seed_of: BTreeMap<&str, &str> = BTreeMap::new();
+        for (segs, mangled) in import_renames {
+            let Some(alias) = segs.first() else { continue };
+            seeds
+                .entry(alias.clone())
+                .or_default()
+                .insert(mangled.clone());
+            seed_of.insert(mangled, alias);
+        }
+
+        let mut decls: BTreeMap<String, DeclInfo> = BTreeMap::new();
+        let mut phases: BTreeMap<FnKey, PhaseEntry> = BTreeMap::new();
+        fn walk(
+            items: &[TopDecl],
+            seed_of: &BTreeMap<&str, &str>,
+            decls: &mut BTreeMap<String, DeclInfo>,
+            phases: &mut BTreeMap<FnKey, PhaseEntry>,
+        ) {
+            let origin = |name: &str| match seed_of.get(name) {
+                Some(alias) => DeclOrigin::Seed(alias.to_string()),
+                None => DeclOrigin::Main,
+            };
+            for item in items {
+                match item {
+                    TopDecl::Locus(l) => {
+                        let locus = l.name.name.clone();
+                        decls.insert(
+                            locus.clone(),
+                            DeclInfo {
+                                origin: origin(&locus),
+                                span: l.name.span,
+                            },
+                        );
+                        for m in &l.members {
+                            let (name, hook): (String, bool) = match m
+                            {
+                                LocusMember::Fn(fd) => {
+                                    (fd.name.name.clone(), false)
+                                }
+                                LocusMember::Lifecycle(lc) => (
+                                    match lc.kind {
+                                        LifecycleKind::Birth => "birth",
+                                        LifecycleKind::Accept => {
+                                            "accept"
+                                        }
+                                        LifecycleKind::Release => {
+                                            "release"
+                                        }
+                                        LifecycleKind::Run => "run",
+                                        LifecycleKind::Drain => "drain",
+                                        LifecycleKind::Dissolve => {
+                                            "dissolve"
+                                        }
+                                    }
+                                    .to_string(),
+                                    true,
+                                ),
+                                LocusMember::Mode(md) => (
+                                    match md.kind {
+                                        ModeKind::Bulk => "bulk",
+                                        ModeKind::Harmonic => {
+                                            "harmonic"
+                                        }
+                                        ModeKind::Resolution => {
+                                            "resolution"
+                                        }
+                                    }
+                                    .to_string(),
+                                    true,
+                                ),
+                                _ => continue,
+                            };
+                            phases.insert(
+                                FnKey::method(
+                                    locus.clone(),
+                                    name.clone(),
+                                ),
+                                PhaseEntry { phase: name, hook },
+                            );
+                        }
+                    }
+                    TopDecl::Fn(f) => {
+                        decls.insert(
+                            f.name.name.clone(),
+                            DeclInfo {
+                                origin: origin(&f.name.name),
+                                span: f.name.span,
+                            },
+                        );
+                    }
+                    TopDecl::Type(t) => {
+                        decls.insert(
+                            t.name.name.clone(),
+                            DeclInfo {
+                                origin: origin(&t.name.name),
+                                span: t.name.span,
+                            },
+                        );
+                    }
+                    TopDecl::Interface(i) => {
+                        decls.insert(
+                            i.name.name.clone(),
+                            DeclInfo {
+                                origin: origin(&i.name.name),
+                                span: i.name.span,
+                            },
+                        );
+                    }
+                    TopDecl::Group(g) => {
+                        decls.insert(
+                            g.name.name.clone(),
+                            DeclInfo {
+                                origin: origin(&g.name.name),
+                                span: g.name.span,
+                            },
+                        );
+                    }
+                    TopDecl::Module(md) => {
+                        walk(&md.items, seed_of, decls, phases)
+                    }
+                    _ => {}
+                }
+            }
+        }
+        for p in programs {
+            walk(&p.items, &seed_of, &mut decls, &mut phases);
+        }
+        Model { decls, phases, seeds }
+    }
+
+    /// The decl a graph node belongs to: its locus for methods,
+    /// itself for free fns.
+    fn owning_decl<'k>(k: &'k FnKey) -> &'k str {
+        k.locus.as_deref().unwrap_or(&k.fn_name)
+    }
+
+    /// Is this fn's decl part of the checked bundle (main or an
+    /// imported seed)? False for stdlib bodies and synthesized
+    /// fns — their spans live in a DIFFERENT offset space, so a
+    /// diagnostic must never point at them as if they were bundle
+    /// source.
+    pub fn is_bundle_fn(&self, k: &FnKey) -> bool {
+        self.decls.contains_key(Self::owning_decl(k))
+    }
+
+    /// The decl span for a bundle decl name.
+    pub fn decl_span(&self, name: &str) -> Option<Span> {
+        self.decls.get(name).map(|d| d.span)
+    }
+}

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -27,23 +27,40 @@
 //! precedent: emit for review, commit, and an unreviewed topology
 //! change fails CI the way an API break does.
 //!
-//! v1 SCOPE (honest contract): the artifact carries the sorts, the
-//! call/publish/subscribe relations, the declared groups, the
-//! effect labels (declared carriers), and the UNKNOWNS (fns with
-//! indirect calls, untyped-receiver method calls — recorded with
-//! the callee name so an outside evaluator can apply the same
-//! fail-closed rule — or computed publish subjects: every place
-//! the evaluator failed closed). What that supports independently
-//! replaying: the serialized USER call/bus graph, group
-//! boundaries, declared bus-end existence/cardinality
-//! (`require`/`count`), and declared user-effect carrier labels.
-//! Every other claim result — anything needing the phase relation
-//! (`during`), seed membership (`cover`), compiler-derived
-//! built-in effects, or the stdlib-expanded call summary the
-//! evaluator itself walks — remains a COMPILER-CERTIFIED report
-//! row until the normalized verification model lands (per-edge
-//! spans, weights, phase relation, seed sort — the architectural
-//! milestone tracked on #382).
+//! v2 SCOPE (schema 1.1, #392 thread 1 — the normalized model
+//! export): the hashed model half carries the sorts, the
+//! call/publish/subscribe relations WITH WEIGHTS (loop nesting,
+//! unbounded-loop membership, interface-dispatch tags), the
+//! through-stdlib CONTRACTED user→user call edges
+//! (`calls_via_stdlib` — the paths the evaluator walks through
+//! stdlib bodies, collapsed to their user endpoints with a
+//! conservative loop flag), the declared groups, the effect labels
+//! (declared carriers), the PHASE RELATION (`phases` — lifecycle
+//! hooks and modes vs. ordinary methods, what `during` evaluates
+//! against), the SEED SORT (`seeds` — alias → member decls, what
+//! `cover` evaluates against), the compiler-DERIVED per-fn effect
+//! sets (`effects` — the full-walk inference, what effect-class
+//! claim endpoints evaluate against), and the UNKNOWNS (fns with
+//! indirect calls, untyped-receiver method calls, dead
+//! uninhabited-interface dispatch, or computed publish subjects —
+//! each recorded so an outside evaluator applies the same rule).
+//!
+//! What that supports independently replaying: every claim verb
+//! over the exported relations — `forbid`/`only edges` incl.
+//! through-stdlib reachability, `require`/`count` bus-end
+//! cardinality, `cover` via the seed sort, `during` via the phase
+//! relation, and `bound` over USER classes via labels + weights
+//! (dispatch alternatives group by (from fn, interface, method)
+//! and fold with max). Remaining compiler-certified: `bound` over
+//! BUILT-IN classes (site counting through the stdlib interior,
+//! which the artifact deliberately does not serialize) and any
+//! walk past the step ceiling.
+//!
+//! PROVENANCE (unhashed): a `provenance` section carries per-edge
+//! and per-decl source spans as bundle-global byte offsets
+//! (`[start, end]`). It is excluded from `shape_hash` on purpose —
+//! moving code must not change the shape identity — and sits with
+//! the claim results in the unhashed half.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -53,8 +70,11 @@ use crate::alloc_summary::{self, Callee, EffectSiteKind, FnKey};
 use crate::symbol::Bundle;
 
 /// The artifact's schema version. Additions are minor versions;
-/// changes are breaking.
-pub const TOPOLOGY_SCHEMA: &str = "1.0";
+/// changes are breaking. 1.1 (#392): weights on call edges,
+/// `calls_via_stdlib`, `phases`, `seeds`, `effects` in the hashed
+/// half (existing `shape_hash` values change); unhashed
+/// `provenance` section.
+pub const TOPOLOGY_SCHEMA: &str = "1.1";
 
 /// Serialize the bundle's model + claim results as the topology
 /// artifact (JSON).
@@ -140,9 +160,24 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
         }
     }
 
-    // ---- relations (with provenance implicit in the names) ----
-    let mut calls: BTreeSet<(String, String)> = BTreeSet::new();
+    // ---- relations, with weights (#392) ----
+    // A call row's weights: merged over parallel edges between one
+    // (from, to) pair, in the conservative direction (any loop-
+    // nested edge marks the row looped).
+    #[derive(Default)]
+    struct EdgeMeta {
+        looped: bool,
+        unbounded: bool,
+        via_interface: Option<String>,
+    }
+    let mut calls: BTreeMap<(String, String), EdgeMeta> =
+        BTreeMap::new();
     let mut publishes: BTreeSet<(String, String)> = BTreeSet::new();
+    // Provenance (unhashed): bundle-global byte-offset spans.
+    let mut call_spans: BTreeSet<(String, String, u32, u32)> =
+        BTreeSet::new();
+    let mut publish_spans: BTreeSet<(String, String, u32, u32)> =
+        BTreeSet::new();
     for (k, fs) in &summary.fns {
         if !user_key(k) {
             continue;
@@ -150,17 +185,93 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
         for edge in &fs.calls {
             if let Callee::Resolved(next) = &edge.callee {
                 if user_key(next) {
-                    calls.insert((fn_name(k), fn_name(next)));
+                    let m = calls
+                        .entry((fn_name(k), fn_name(next)))
+                        .or_default();
+                    m.looped |= edge.loop_depth > 0;
+                    m.unbounded |= edge.in_unbounded_loop;
+                    if let Some(i) = &edge.via_interface {
+                        m.via_interface = Some(name(i));
+                    }
+                    call_spans.insert((
+                        fn_name(k),
+                        fn_name(next),
+                        edge.span.start.as_usize() as u32,
+                        edge.span.end.as_usize() as u32,
+                    ));
                 }
             }
         }
         for site in &fs.effect_sites {
             if let EffectSiteKind::Publish(Some(s)) = &site.kind {
                 publishes.insert((fn_name(k), name(s)));
+                publish_spans.insert((
+                    fn_name(k),
+                    name(s),
+                    site.span.start.as_usize() as u32,
+                    site.span.end.as_usize() as u32,
+                ));
+            }
+        }
+    }
+
+    // ---- through-stdlib contraction (#392) ----
+    // The evaluator walks the stdlib-merged summary; the artifact
+    // deliberately serializes only user rows. Collapse every path
+    // that ENTERS non-user bodies and re-emerges at a user fn into
+    // one contracted edge, so reachability over the artifact matches
+    // reachability as evaluated. `looped` is conservative: true if
+    // ANY contraction path crosses a loop-nested or unbounded edge.
+    let merged = crate::stdlib_bodies::summarize_with_stdlib_and_renames(
+        &programs,
+        &bundle.import_renames,
+    );
+    let mut via_stdlib: BTreeMap<(String, String), bool> =
+        BTreeMap::new();
+    for (k, fs) in &merged.fns {
+        if !user_key(k) {
+            continue;
+        }
+        let mut stack: Vec<(FnKey, bool)> = Vec::new();
+        let mut seen: BTreeSet<FnKey> = BTreeSet::new();
+        for edge in &fs.calls {
+            if let Callee::Resolved(next) = &edge.callee {
+                if !user_key(next) && seen.insert(next.clone()) {
+                    stack.push((
+                        next.clone(),
+                        edge.loop_depth > 0 || edge.in_unbounded_loop,
+                    ));
+                }
+            }
+        }
+        let mut steps = 0u32;
+        while let Some((n, lp)) = stack.pop() {
+            steps += 1;
+            if steps > crate::callgraph::MAX_STEPS {
+                break;
+            }
+            let Some(nfs) = merged.fns.get(&n) else { continue };
+            for edge in &nfs.calls {
+                let Callee::Resolved(next) = &edge.callee else {
+                    continue;
+                };
+                let l2 = lp
+                    || edge.loop_depth > 0
+                    || edge.in_unbounded_loop;
+                if user_key(next) {
+                    let e = via_stdlib
+                        .entry((fn_name(k), fn_name(next)))
+                        .or_insert(false);
+                    *e |= l2;
+                } else if seen.insert(next.clone()) {
+                    stack.push((next.clone(), l2));
+                }
             }
         }
     }
     let mut subscribes: BTreeSet<(String, String, String)> =
+        BTreeSet::new();
+    let mut subscribe_spans: BTreeSet<(String, String, String, u32, u32)> =
         BTreeSet::new();
     for (subject, info) in &graph.subjects {
         for s in &info.subscribers {
@@ -169,7 +280,65 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
                 name(&s.locus),
                 s.handler.clone(),
             ));
+            subscribe_spans.insert((
+                name(subject),
+                name(&s.locus),
+                s.handler.clone(),
+                s.span.start.as_usize() as u32,
+                s.span.end.as_usize() as u32,
+            ));
         }
+    }
+
+    // ---- the normalized model (#392): phases, seeds, decl spans ----
+    let vmodel =
+        crate::model::Model::derive(&programs, &bundle.import_renames);
+    // Phase relation, user loci only (the sort the artifact serializes).
+    let mut phase_rows: BTreeMap<String, (String, bool)> =
+        BTreeMap::new();
+    for (k, p) in &vmodel.phases {
+        if user_key(k) {
+            phase_rows
+                .insert(fn_name(k), (p.phase.clone(), p.hook));
+        }
+    }
+    // Seed sort: alias -> author-spelled member decls.
+    let mut seed_rows: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (alias, members) in &vmodel.seeds {
+        seed_rows.insert(
+            alias.clone(),
+            members.iter().map(|m| name(m)).collect(),
+        );
+    }
+    // Compiler-derived per-fn effect sets over the stdlib-merged
+    // walk — what an effect-class claim endpoint evaluates against.
+    // PURE fns are omitted; an unclassifiable walk renders as
+    // ["unclassified"], honestly.
+    let effect_names = crate::effects::effect_names_of(&programs);
+    let ffi = crate::effects::ffi_names(&programs);
+    let mut derived_effects: BTreeMap<String, Vec<String>> =
+        BTreeMap::new();
+    for k in merged.fns.keys() {
+        if !user_key(k) {
+            continue;
+        }
+        let e = crate::frontier::infer_effects(&merged, k, &ffi);
+        let classes =
+            crate::frontier::render_effects_named(e, &effect_names);
+        if !classes.is_empty() {
+            derived_effects.insert(fn_name(k), classes);
+        }
+    }
+    // Decl spans (unhashed provenance).
+    let mut decl_spans: BTreeMap<String, (u32, u32)> = BTreeMap::new();
+    for (decl, info) in &vmodel.decls {
+        decl_spans.insert(
+            name(decl),
+            (
+                info.span.start.as_usize() as u32,
+                info.span.end.as_usize() as u32,
+            ),
+        );
     }
 
     // ---- groups (the claim vocabulary, as declared) ----
@@ -195,7 +364,6 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
     }
 
     // ---- labels: declared effect carriers (`is:` tags) ----
-    let effect_names = crate::effects::effect_names_of(&programs);
     let mut labels: BTreeMap<String, Vec<String>> = BTreeMap::new();
     for (k, set) in &summary.carries {
         if !user_key(k) {
@@ -312,12 +480,40 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
     ));
     model.push_str("  },\n");
     model.push_str("  \"relations\": {\n    \"calls\": [\n");
-    for (from, to) in &calls {
-        model.push_str(&format!(
-            "      {{\"from\": {}, \"to\": {}}},\n",
+    for ((from, to), meta) in &calls {
+        let mut row = format!(
+            "      {{\"from\": {}, \"to\": {}",
             quote(from),
             quote(to)
-        ));
+        );
+        if meta.looped {
+            row.push_str(", \"loop\": true");
+        }
+        if meta.unbounded {
+            row.push_str(", \"unbounded\": true");
+        }
+        if let Some(i) = &meta.via_interface {
+            row.push_str(&format!(", \"via_interface\": {}", quote(i)));
+        }
+        row.push_str("},\n");
+        model.push_str(&row);
+    }
+    trim_trailing_comma(&mut model);
+    // Contracted through-stdlib user→user edges (#392): what the
+    // evaluator's stdlib-merged walk reaches, collapsed to user
+    // endpoints. Reachability replay composes `calls` ∪ this.
+    model.push_str("    ],\n    \"calls_via_stdlib\": [\n");
+    for ((from, to), looped) in &via_stdlib {
+        let mut row = format!(
+            "      {{\"from\": {}, \"to\": {}",
+            quote(from),
+            quote(to)
+        );
+        if *looped {
+            row.push_str(", \"loop\": true");
+        }
+        row.push_str("},\n");
+        model.push_str(&row);
     }
     trim_trailing_comma(&mut model);
     model.push_str("    ],\n    \"publishes\": [\n");
@@ -363,6 +559,38 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
         ));
     }
     trim_trailing_comma(&mut model);
+    // #392: the phase relation, the seed sort, and the compiler-
+    // derived per-fn effect sets — the rows `during`, `cover`, and
+    // effect-class endpoints evaluate against. Hashed: each is
+    // verification-relevant, so changing one changes the identity.
+    model.push_str("  },\n  \"phases\": {\n");
+    for (f, (phase, hook)) in &phase_rows {
+        model.push_str(&format!(
+            "    {}: {{\"phase\": {}, \"kind\": {}}},\n",
+            quote(f),
+            quote(phase),
+            quote(if *hook { "hook" } else { "method" })
+        ));
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("  },\n  \"seeds\": {\n");
+    for (alias, members) in &seed_rows {
+        model.push_str(&format!(
+            "    {}: [{}],\n",
+            quote(alias),
+            join_str(members.iter())
+        ));
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("  },\n  \"effects\": {\n");
+    for (f, classes) in &derived_effects {
+        model.push_str(&format!(
+            "    {}: [{}],\n",
+            quote(f),
+            join_str(classes.iter())
+        ));
+    }
+    trim_trailing_comma(&mut model);
     model.push_str("  },\n  \"unknowns\": [\n");
     for (f, reasons) in &unknowns {
         let rs = reasons
@@ -392,6 +620,56 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
         shape_hash
     ));
     out.push_str(&model);
+    // Provenance (#392): source spans as bundle-global byte offsets
+    // [start, end]. UNHASHED on purpose — moving code must not
+    // change the shape identity — so it sits in the results half
+    // beside the claim rows.
+    out.push_str(",\n  \"provenance\": {\n    \"calls\": [\n");
+    for (from, to, s, e) in &call_spans {
+        out.push_str(&format!(
+            "      {{\"from\": {}, \"to\": {}, \"span\": [{}, {}]}},\n",
+            quote(from),
+            quote(to),
+            s,
+            e
+        ));
+    }
+    trim_trailing_comma(&mut out);
+    out.push_str("    ],\n    \"publishes\": [\n");
+    for (f, subj, s, e) in &publish_spans {
+        out.push_str(&format!(
+            "      {{\"fn\": {}, \"subject\": {}, \"span\": [{}, {}]}},\n",
+            quote(f),
+            quote(subj),
+            s,
+            e
+        ));
+    }
+    trim_trailing_comma(&mut out);
+    out.push_str("    ],\n    \"subscribes\": [\n");
+    for (subj, locus, handler, s, e) in &subscribe_spans {
+        out.push_str(&format!(
+            "      {{\"subject\": {}, \"locus\": {}, \"handler\": {}, \
+             \"span\": [{}, {}]}},\n",
+            quote(subj),
+            quote(locus),
+            quote(handler),
+            s,
+            e
+        ));
+    }
+    trim_trailing_comma(&mut out);
+    out.push_str("    ],\n    \"decls\": {\n");
+    for (decl, (s, e)) in &decl_spans {
+        out.push_str(&format!(
+            "      {}: [{}, {}],\n",
+            quote(decl),
+            s,
+            e
+        ));
+    }
+    trim_trailing_comma(&mut out);
+    out.push_str("    }\n  }");
     out.push_str(",\n  \"claims\": [\n");
     for o in &outcomes {
         out.push_str(&format!(

--- a/crates/hale-types/tests/model_provenance.rs
+++ b/crates/hale-types/tests/model_provenance.rs
@@ -1,0 +1,282 @@
+//! #392 thread 1 — the normalized model: witness provenance and the
+//! phase relation.
+//!
+//! A violation used to name WHO (a path of names); with the model's
+//! decl provenance it also says WHERE TO EDIT — the callsite that
+//! introduces the crossing edge, the publish site and subscription
+//! for a bus hop, and the destination's declaration — as secondary
+//! diagnostics whose spans point at real source, following the
+//! effect system's root + leaf precedent. Spans are emitted only
+//! for bundle decls: stdlib bodies parse in their own offset space,
+//! and pointing a bundle diagnostic at one would name the wrong
+//! source line.
+
+use hale_syntax::{parse_source, Diag};
+
+fn all_diags(src: &str) -> Vec<Diag> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+}
+
+/// The span of `needle`'s first occurrence in `src`.
+fn at(src: &str, needle: &str) -> (usize, usize) {
+    let s = src.find(needle).expect("needle present");
+    (s, s + needle.len())
+}
+
+fn within(d: &Diag, (s, e): (usize, usize)) -> bool {
+    d.span.start.as_usize() >= s && d.span.start.as_usize() < e
+}
+
+// =====================================================================
+// Call-crossing provenance
+// =====================================================================
+
+#[test]
+fn a_call_witness_points_at_the_crossing_call_and_the_destination() {
+    let src = r#"
+        locus B { fn work(n: Int) -> Int { return n * 2; } }
+        locus A {
+            params { b: B = B { }; }
+            fn go(n: Int) -> Int { return self.b.work(n); }
+        }
+        group a_side = { A };
+        group b_side = { B };
+        main locus App {
+            params { a: A = A { }; }
+            claims { iso: forbid reaches(a_side, b_side); }
+        }
+        fn main() { App { }; }
+    "#;
+    let ds = all_diags(src);
+    assert!(
+        ds.iter().any(|d| d.message.contains("claim `iso` violated")),
+        "the claim must be violated: {:?}",
+        ds.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let cross = ds
+        .iter()
+        .find(|d| d.message.contains("is crossed by this call"))
+        .expect("a crossing-call secondary must be emitted");
+    assert!(
+        within(cross, at(src, "self.b.work(n)")),
+        "the crossing secondary must point at the callsite, got span \
+         {:?}",
+        cross.span
+    );
+    let decl = ds
+        .iter()
+        .find(|d| {
+            d.message.contains(
+                "the forbidden destination `B` is declared here",
+            )
+        })
+        .expect("a destination-decl secondary must be emitted");
+    assert!(
+        within(decl, at(src, "B {")),
+        "the decl secondary must point at the destination's \
+         declaration, got span {:?}",
+        decl.span
+    );
+}
+
+// =====================================================================
+// Bus-crossing provenance
+// =====================================================================
+
+#[test]
+fn a_bus_witness_points_at_the_publish_and_the_subscription() {
+    let src = r#"
+        type M { n: Int; }
+        topic T { payload: M; }
+        locus A {
+            bus { publish T; }
+            fn go(n: Int) { T <- M { n: n }; }
+        }
+        locus B {
+            params { t: Int = 0; }
+            bus { subscribe T as on_m; }
+            fn on_m(m: M) { self.t = self.t + m.n; }
+        }
+        group a_side = { A };
+        group b_side = { B };
+        main locus App {
+            params { a: A = A { }; b: B = B { }; }
+            claims { iso: forbid reaches(a_side, b_side); }
+        }
+        fn main() { App { }; }
+    "#;
+    let ds = all_diags(src);
+    let publ = ds
+        .iter()
+        .find(|d| {
+            d.message.contains("the crossing publish happens here")
+        })
+        .expect("a publish-site secondary must be emitted");
+    assert!(
+        within(publ, at(src, "T <- M { n: n }")),
+        "the publish secondary must point at the publish site, got \
+         span {:?}",
+        publ.span
+    );
+    let sub = ds
+        .iter()
+        .find(|d| {
+            d.message.contains("delivered at this subscription")
+        })
+        .expect("a subscription secondary must be emitted");
+    assert!(
+        within(sub, at(src, "subscribe T as on_m")),
+        "the subscription secondary must point at the subscription \
+         decl, got span {:?}",
+        sub.span
+    );
+}
+
+// =====================================================================
+// Origin gating — no span may point into a foreign offset space
+// =====================================================================
+
+/// A witness whose crossing edge lives in a STDLIB body must not
+/// emit a callsite span (stdlib parses at offset 0 of its own
+/// source; the offset would name the wrong line of the user file).
+/// The destination decl (a bundle decl) still gets its span.
+#[test]
+fn a_stdlib_interior_crossing_emits_no_foreign_span() {
+    let src = r#"
+        locus Hello {
+            fn handle(ctx: std::http::Context) -> std::http::Response {
+                return std::http::Response {
+                    status: 200,
+                    content_type: "text/plain",
+                    body: "hi"
+                };
+            }
+        }
+        locus Gate {
+            fn probe(r: std::http::Router, req: std::http::Request) -> Int {
+                let resp = r.dispatch(req);
+                return resp.status;
+            }
+        }
+        group gates = { Gate };
+        group handlers = { Hello };
+        main locus App {
+            params { g: Gate = Gate { }; }
+            claims { iso: forbid reaches(gates, handlers); }
+        }
+        fn main() {
+            let r = std::http::Router { };
+            r.get("/", Hello { });
+            let req = std::http::Request {
+                method: "GET", path: "/", body: ""
+            };
+            println(Gate { }.probe(r, req));
+        }
+    "#;
+    let ds = all_diags(src);
+    assert!(
+        ds.iter().any(|d| d.message.contains("claim `iso` violated")),
+        "the through-stdlib path must violate: {:?}",
+        ds.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    for d in &ds {
+        assert!(
+            d.span.start.as_usize() < src.len(),
+            "no diagnostic may carry a span outside the bundle \
+             source (a stdlib offset misattributed): {:?} `{}`",
+            d.span,
+            d.message
+        );
+    }
+    assert!(
+        ds.iter().any(|d| d.message.contains(
+            "the forbidden destination `Hello` is declared here"
+        )),
+        "the bundle-side destination decl still gets its span: {:?}",
+        ds.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// =====================================================================
+// The phase relation
+// =====================================================================
+
+/// `during` evaluates against the model's phase relation: a
+/// lifecycle hook is a phase, and restricting to it excludes paths
+/// rooted in other phases.
+#[test]
+fn during_selects_the_hook_phase_via_the_relation() {
+    let base = r#"
+        locus B { fn work(n: Int) -> Int { return n * 2; } }
+        locus A {
+            params { b: B = B { }; n: Int = 0; }
+            birth { self.n = self.b.work(1); }
+            fn later(n: Int) -> Int { return n; }
+        }
+        group a_side = { A };
+        group b_side = { B };
+        main locus App {
+            params { a: A = A { }; }
+            claims { iso: forbid reaches(a_side, b_side) during PHASE; }
+        }
+        fn main() { App { }; }
+    "#;
+    // The birth hook reaches B — a `during birth` claim violates.
+    let ds = all_diags(&base.replace("PHASE", "birth"));
+    assert!(
+        ds.iter().any(|d| d.message.contains("claim `iso` violated")),
+        "the birth-phase path must violate: {:?}",
+        ds.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    // `later` does not reach B — restricting to that phase holds.
+    let ds = all_diags(&base.replace("PHASE", "later"));
+    assert!(
+        !ds.iter().any(|d| d.message.contains("violated")),
+        "a phase that never reaches B must hold: {:?}",
+        ds.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// The derived model itself: hooks and modes are `hook` rows,
+/// ordinary methods are `method` rows, and seed decls carry their
+/// alias.
+#[test]
+fn the_model_classifies_phases_and_seed_origin() {
+    let src = r#"
+        locus W {
+            params { n: Int = 0; }
+            birth { self.n = 1; }
+            fn step(k: Int) -> Int { return k; }
+        }
+        fn main() { W { }; }
+    "#;
+    let program = parse_source(src).expect("parse");
+    let renames: Vec<(Vec<String>, String)> = vec![(
+        vec!["dep".into(), "Helper".into()],
+        "__lib_1_dep_Helper".into(),
+    )];
+    let model =
+        hale_types::model::Model::derive(&[&program], &renames);
+    let birth = model
+        .phases
+        .get(&hale_types::alloc_summary::FnKey::method(
+            "W".to_string(),
+            "birth".to_string(),
+        ))
+        .expect("birth phase row");
+    assert!(birth.hook && birth.phase == "birth");
+    let step = model
+        .phases
+        .get(&hale_types::alloc_summary::FnKey::method(
+            "W".to_string(),
+            "step".to_string(),
+        ))
+        .expect("method phase row");
+    assert!(!step.hook && step.phase == "step");
+    assert_eq!(
+        model.seeds.get("dep").map(|s| s.len()),
+        Some(1),
+        "the seed sort carries the alias's members"
+    );
+}

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -300,14 +300,17 @@ nothing: the claim holds. An empty SRC likewise. Both are only
 reachable through the explicit opt-out; everything else fails the
 group guards first.
 
-**`during <phase>`.** Restricts SRC's projection to the fns named
-`<phase>` on each member locus — a lifecycle name (`birth`,
-`accept`, `release`, `run`, `drain`, `dissolve`) or any method or
-handler name. Free fns have no phases and drop out. If the filter
-empties a non-empty projection, that is an error ("phase names
-nothing in group"), not a vacuous pass. This is a source slice,
-not a temporal logic; a real phase relation belongs to the
-normalized model if state-dependent claims are ever needed.
+**`during <phase>`.** Restricts SRC's projection to the members of
+`<phase>` in the model's **phase relation**: lifecycle hooks
+(`birth`, `accept`, `release`, `run`, `drain`, `dissolve`) and
+modes (`bulk`, `harmonic`, `resolution`) are hook-phases the
+runtime drives; any method or handler name is its own source-slice
+phase. Free fns have no phases and drop out. If the filter empties
+a non-empty projection, that is an error ("phase names nothing in
+group"), not a vacuous pass. The relation is exported in the
+topology artifact (`phases`), which is what makes a `during` row
+independently re-derivable; it is still a source slice, not a
+temporal logic.
 
 **`avoiding <group>`.** Masks the named group's vertices out of
 the walk entirely — neither traversed nor tested. This is the
@@ -324,6 +327,15 @@ Modifiers stack in any order:
 path from a source root to the hit, calls rendered `->`, bus hops
 rendered `-(publishes "subject")->`, every name in author spelling
 (cross-seed symbols demangled).
+
+**Where to edit.** The witness names *who*; secondary diagnostics
+point at *where* — the call that crosses the boundary (or, for a
+bus hop, the publish site and the subscription declaration) and
+the forbidden destination's declaration, in the effect system's
+root + leaf shape. A hop whose source lives inside a stdlib body
+renders by name alone: stdlib source parses in its own offset
+space, and a span from there would point at the wrong line of your
+file.
 
 ## `only edges A -> B { … }` — the boundary form
 
@@ -549,37 +561,69 @@ The artifact shape (schema `1.0`):
 
 ```text
 {
-  "schema": "1.0",
+  "schema": "1.1",
   "shape_hash": "<fnv1a-64 over the model half>",
   "sorts":     { "loci": […], "fns": […], "topics": […] },
-  "relations": { "calls": […], "publishes": […], "subscribes": […] },
+  "relations": {
+    "calls": [ {"from", "to",
+                "loop"?: true, "unbounded"?: true,
+                "via_interface"?: "<iface>"} ],
+    "calls_via_stdlib": [ {"from", "to", "loop"?: true} ],
+    "publishes": […], "subscribes": […]
+  },
   "groups":    { "<name>": [members as declared] },
   "labels":    { "<fn>": [declared effect classes] },
+  "phases":    { "<fn>": {"phase", "kind": "hook"|"method"} },
+  "seeds":     { "<alias>": [member decls] },
+  "effects":   { "<fn>": [derived effect classes] },
   "unknowns":  [ {"fn": …, "reasons": ["indirect_call" |
                   "untyped_receiver_call:<callee>" |
                   "uninhabited_interface_call:<iface>.<callee>" |
                   "computed_publish"]} ],
+  "provenance": { "calls": [+span], "publishes": [+span],
+                  "subscribes": [+span], "decls": {name: span} },
   "claims":    [ {"name", "form", "result": "holds"|"violated"|"invalid"} ]
 }
 ```
 
 Everything renders in author spelling (cross-seed symbols
 demangled). `shape_hash` covers the **model half** — sorts,
-relations, groups, labels, unknowns — and excludes claim
-*results*, so one topology under a different law keeps one shape
-while any graph, vocabulary, carrier, or new fail-closed or
-dead-dispatch site changes the identity. `--check-topology` diffs against the
-committed baseline and fails with a regenerate hint, separating
-two review questions: *does the program still satisfy the law?*
-and *did the graph change in a way reviewers should see?*
+relations (with weights and the through-stdlib contraction),
+groups, labels, phases, seeds, derived effects, unknowns — and
+excludes claim *results* and *provenance*: one topology under a
+different law keeps one shape, and moving code changes every span
+but no identity, while any graph, vocabulary, carrier, phase, or
+new fail-closed or dead-dispatch site changes it.
+`--check-topology` diffs against the committed baseline and fails
+with a regenerate hint, separating two review questions: *does the
+program still satisfy the law?* and *did the graph change in a way
+reviewers should see?*
 
-v1 scope, stated honestly: the artifact supports independent
-replay of the serialized user call/bus graph, group boundaries,
-declared bus-end existence and cardinality, and declared carrier
-labels. Results needing the phase relation (`during`), seed
-membership (`cover`), compiler-derived built-in effects, or the
-stdlib-expanded walk remain compiler-certified report rows until
-the normalized verification model lands.
+The pieces worth knowing:
+
+- **Weights.** A call row marked `"loop": true` sits inside a
+  loop; `"unbounded": true` inside a loop with no compile-time
+  trip bound. `bound` replay reads these. A `"via_interface"` row
+  is one fanned-out dispatch alternative — alternatives sharing
+  (from, interface, method) fold with **max**, one dispatch
+  invokes one target.
+- **`calls_via_stdlib`.** The evaluator walks stdlib bodies; the
+  artifact serializes user rows. Every user→user path whose
+  interior is stdlib collapses to one contracted edge (loop flag
+  conservative: true if *any* such path crosses a loop), so
+  reachability over the artifact matches reachability as
+  evaluated.
+- **`phases` / `seeds` / `effects`.** What `during`, `cover`, and
+  effect-class endpoints evaluate against, exported — the rows
+  that used to be compiler-certified-only.
+- **`provenance`.** Bundle-global byte-offset spans (`[start,
+  end]`) for every user edge and decl — the "where to edit" data,
+  unhashed by design.
+
+v2 scope: every claim verb replays independently over the exported
+relations. Still compiler-certified: `bound` over **built-in**
+classes (site counting through the stdlib interior, deliberately
+not serialized) and any walk past the step ceiling.
 
 ## What claims are not
 

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -119,7 +119,15 @@ main locus Org {
   author spelling — `` `delta::Triage::on_task` -(publishes
   "org.metrics")-> `gamma::Research::on_metric` `` — cross-seed
   symbols demangled. One witness per claim (the minimal
-  countermodel, not an enumeration).
+  countermodel, not an enumeration). **Provenance** (#392): the
+  witness also says where to edit, as secondary diagnostics in the
+  effect system's root + leaf shape — the callsite that crosses the
+  boundary (or the publish site and the subscription decl for a bus
+  hop) and the forbidden destination's declaration. Spans are
+  emitted only for bundle decls: stdlib bodies parse in their own
+  offset space, and a span from there attributed to a bundle file
+  would name the wrong source, so a stdlib-interior hop renders by
+  name alone.
 - **Unknown ⇒ violation.** An indirect call (function-typed
   parameter, #353) or a computed publish subject on a path from a
   `forbid` source cannot be certified and is reported as a
@@ -198,9 +206,15 @@ The remaining verbs (#382 phases 2–5):
   behind every single-writer pattern, and a violation names the
   competing writers.
 - **`during P`** on `forbid` — restricts sources to the named
-  lifecycle phase / method of each source locus (`during birth` is
-  the quiet-boot claim). A phase naming nothing in the group is an
-  error, not a vacuously-holding claim.
+  phase of each source locus (`during birth` is the quiet-boot
+  claim), evaluated against the model's **phase relation** (#392):
+  lifecycle hooks (`birth`, `accept`, `release`, `run`, `drain`,
+  `dissolve`) and modes (`bulk`, `harmonic`, `resolution`) are
+  hook-phases the runtime drives; an ordinary method is its own
+  source-slice phase. The relation is exported in the topology
+  artifact, which is what makes a `during` row independently
+  re-derivable. A phase naming nothing in the group is an error,
+  not a vacuously-holding claim.
 - **`avoiding G`** on `forbid` — masks G's vertices out of the
   walk, which makes it the interposition form: "every path from A
   to B passes through the gate" is `forbid reaches(A, B) avoiding
@@ -221,33 +235,43 @@ earlier in the same file as the family. Companion:
 class along any path, with the same loop/indirect unboundedness
 rules as every per-call dimension.
 
-**The topology artifact** (#382 phase 2): `hale check <t>
---dump-topology` emits the serialized model — sorts (loci, fns,
-topics), relations (calls, publishes, subscribes), the declared
-**groups**, the effect **labels** (declared carriers), and the
-**unknowns** (fns with indirect calls or computed publish subjects
-— the places evaluation failed closed), all in author spelling —
-plus every named claim's normalized form and result, under a
-schema version and a `shape_hash` (FNV-1a/64 over the canonical
-model half, which includes groups/labels/unknowns; claim RESULTS
-are excluded, so one topology under different law keeps one
-shape). `--check-topology <path>` diffs against a committed
-baseline and fails with a regenerate hint — the `.hale.effects`
-precedent: an unreviewed topology or law change fails CI the way
-an API break does. v1 scope, stated honestly: the artifact
-supports independent replay of the serialized user call/bus graph,
-group boundaries, declared bus-end existence/cardinality, and
-declared user-effect carrier labels; every other claim result —
-anything needing the phase relation (`during`), seed membership
-(`cover`), compiler-derived built-in effects, or the
-stdlib-expanded summary the evaluator itself walks — remains a
-compiler-certified report row until the normalized verification
-model lands (that export is the architectural milestone tracked on
-#382). The derivation (source → model) remains the trust root.
+**The topology artifact** (#382 phase 2; schema 1.1 per #392):
+`hale check <t> --dump-topology` emits the serialized model —
+sorts (loci, fns, topics), relations (calls with **weights**: loop
+nesting, unbounded-loop membership, interface-dispatch tags;
+publishes; subscribes), the through-stdlib **contracted** edges
+(`calls_via_stdlib`: user→user paths whose interior is stdlib
+bodies, collapsed to their endpoints with a conservative loop
+flag, so reachability over the artifact matches reachability as
+evaluated), the declared **groups**, the effect **labels**
+(declared carriers), the **phase relation**, the **seed sort**,
+the compiler-**derived** per-fn effect sets, and the **unknowns**
+(fns with indirect calls, untyped-receiver calls, dead
+uninhabited-interface dispatch, or computed publish subjects), all
+in author spelling — plus every named claim's normalized form and
+result, under a schema version and a `shape_hash` (FNV-1a/64 over
+the canonical model half; claim RESULTS are excluded, so one
+topology under different law keeps one shape). A **provenance**
+section carries per-edge and per-decl source spans as
+bundle-global byte offsets; it is excluded from the hash on
+purpose — moving code must not change the shape identity.
+`--check-topology <path>` diffs against a committed baseline and
+fails with a regenerate hint — the `.hale.effects` precedent: an
+unreviewed topology or law change fails CI the way an API break
+does. v2 scope: every claim verb replays independently over the
+exported relations — `forbid`/`only edges` including
+through-stdlib reachability, `require`/`count` cardinality,
+`cover` via the seed sort, `during` via the phase relation,
+`bound` over user classes via labels + weights (dispatch
+alternatives group by (from, interface, method) and fold with
+max). Remaining compiler-certified: `bound` over built-in classes
+(site counting through the stdlib interior, deliberately not
+serialized) and any walk past the step ceiling. The derivation
+(source → model) remains the trust root.
 
-Still later (#382): library-tier claims that travel with imports,
+Still later (#392): library-tier claims that travel with imports,
 and the annotations-lower-to-claim-IR unification (§8 of the
-issue) once the claim IR has survived real use.
+original issue) riding this model.
 
 ## Structural & design rules
 


### PR DESCRIPTION
Stacked on #393. The architectural milestone every reviewer of the #382 stack independently named: one derived model — declaration provenance, the phase relation, the seed sort — consumed by every judgment and exported whole (`crates/hale-types/src/model.rs`, `Model::derive`).

## Witnesses say where to edit

A `forbid` violation keeps its one-line countermodel and now also emits secondary diagnostics in the effect system's root + leaf shape:

- the **call that crosses the boundary** (callsite span), or for a bus hop the **publish site** and the **subscription declaration**;
- the **forbidden destination's declaration**.

Spans are emitted only for bundle decls (`Model::is_bundle_fn`). Stdlib bodies parse in their own offset space — a span from there attributed to a user file names the wrong line, a pre-existing misattribution (observable before this change as bogus "reached here" locations) that the origin gate now stops. The guard is a standing test: no diagnostic may carry a span outside the bundle source.

## `during` rides the phase relation

Lifecycle hooks (`birth`/`accept`/`release`/`run`/`drain`/`dissolve`) and modes (`bulk`/`harmonic`/`resolution`) are hook-phases the runtime drives; a method is its own source-slice phase. Verdicts unchanged; the relation is now explicit, exported, and what the evaluator reads — which is what makes a `during` claim row independently re-derivable.

## Topology artifact schema 1.1 — the model export

Hashed model half gains:
- **weights** on call rows: `loop`, `unbounded`, `via_interface`;
- **`calls_via_stdlib`** — the through-stdlib contraction: every user→user path whose interior is stdlib bodies, collapsed to its endpoints with a conservative loop flag, so reachability over the artifact matches reachability as evaluated (this was the "stdlib-expanded walk" caveat);
- **`phases`**, **`seeds`**, and compiler-derived per-fn **`effects`**.

New **unhashed** `provenance` section: per-edge and per-decl spans as bundle-global byte offsets. Excluded from `shape_hash` deliberately — moving code changes every span and no identity (pinned by the motion-insensitivity canary: a comment line added at the top keeps the hash and moves every span).

v2 scope, stated in the header and docs: every claim verb replays independently over the exported relations — `forbid`/`only edges` incl. through-stdlib reachability, `require`/`count`, `cover` via seeds, `during` via phases, `bound` over user classes via labels + weights (dispatch alternatives group by (from, interface, method), fold with max). Still compiler-certified: `bound` over built-in classes (stdlib-interior site counting, deliberately not serialized) and walks past the step ceiling. Existing `shape_hash` values change — the hashed half grew; schema bumped to 1.1.

## Evidence

- `model_provenance.rs` (5): callsite + destination-decl spans asserted against actual source offsets; publish + subscription spans; the foreign-span guard over a through-stdlib witness; `during` phase selection both directions; model derivation (hook vs method rows, seed membership).
- `topology_v2.rs` (3): sections + weights, motion-insensitivity canary, contracted-edge presence (`Gate::probe → Hello::handle, loop: true` — the route-match loop, correctly conservative).
- Full suite 2229 green; `hale fmt --check` clean. Spec + docs chapters updated in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)