### PR TITLE
§8: certificates as lowered claim rows; @phase_effects user classes (#392 thread 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,28 @@ spans incl. the foreign-span guard, phase selection, model
 derivation), `topology_v2.rs` (sections, motion-insensitivity
 canary, contracted edges).
 
+### §8 — one schema of record, and `@phase_effects` user classes (GH #392 thread 1)
+
+- **Certificates as lowered claim rows.** The topology artifact
+  gains an unhashed `lowered` array: every fn-grained certificate —
+  each `@effects` assert, each `@phase_effects` phase contract, each
+  `@budget` in both families — reported as the claim form it is
+  pointwise sugar for, with its verdict (`forbid reaches({F},
+  effects(money))`, `bound alloc <= N on paths from {F}`, `only
+  effects {…} on {L} during birth`). Rows come from the same
+  evaluations that gate the build, so the report and the build
+  cannot disagree. One schema of record: all law, bundle-quantified
+  and fn-grained, in one artifact.
+- **`@phase_effects` closes over user classes.** A phase contract is
+  now closed over the live class universe like `only:` — a phase
+  reaching a declared user-class carrier without listing the class
+  violates, and listing it permits it (atomic-only complement;
+  composed classes own no bit). Previously the walker iterated a
+  hardcoded nine-class list and the parser rejected user class
+  names outright — the documented deficiency. Programs with
+  `@phase_effects` AND declared user classes may see new (correct)
+  violations.
+
 ### Interface-dispatch edges: closed-world fan-out (GH #392 thread 4)
 
 A method call on an interface-typed value

--- a/crates/hale-cli/tests/topology_v2.rs
+++ b/crates/hale-cli/tests/topology_v2.rs
@@ -158,3 +158,64 @@ fn main() {
         art
     );
 }
+
+/// #392 §8 — every fn-grained certificate exported as a lowered
+/// claim row (one schema of record), with the verdict of the same
+/// evaluation that gates the build.
+#[test]
+fn certificates_appear_as_lowered_claim_rows() {
+    let src = r#"
+effect money;
+@effects(is: {money})
+fn charge(n: Int) -> Int { return n; }
+
+type P { a: Int; }
+
+@effects(none: {money})
+fn clean(n: Int) -> Int { return n + 1; }
+
+@effects(none: {money})
+fn dirty(n: Int) -> Int { return charge(n); }
+
+@budget(alloc_per_call = 2)
+fn boxed(n: Int) -> P { return P { a: n }; }
+
+@phase_effects(run: {})
+locus Engine {
+    params { seen: Int = 0; }
+    run() { self.seen = charge(1); }
+}
+
+fn main() { Engine { }; }
+"#;
+    let art = dump(src, "lowered");
+    assert!(
+        art.contains(
+            r#"{"subject": "clean", "form": "forbid reaches({clean}, effects(money))", "result": "holds"}"#
+        ),
+        "a holding certificate must appear as a lowered row:\n{}",
+        art
+    );
+    assert!(
+        art.contains(
+            r#"{"subject": "dirty", "form": "forbid reaches({dirty}, effects(money))", "result": "violated"}"#
+        ),
+        "a violated certificate must appear as a lowered row:\n{}",
+        art
+    );
+    assert!(
+        art.contains(
+            r#"{"subject": "boxed", "form": "bound alloc <= 2 on paths from {boxed}", "result": "holds"}"#
+        ),
+        "a budget contract must appear as a lowered bound row:\n{}",
+        art
+    );
+    assert!(
+        art.contains(
+            r#"{"subject": "Engine", "form": "only effects {} on {Engine} during run", "result": "violated"}"#
+        ),
+        "a phase contract must appear as a lowered row (violated by \
+         the unlisted user class):\n{}",
+        art
+    );
+}

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -2538,15 +2538,17 @@ impl Parser {
                         ))
                     }
                 };
-                match EffectClass::from_ident(&name) {
-                    Some(c) => classes.push(c),
-                    None => {
-                        return Err(Diag::parse(
-                            t.span,
-                            format!("unknown effect class `{}`", name),
-                        ))
-                    }
-                }
+                // #392 §8: user classes join the phase contract's
+                // closed set — the same interning fallback every
+                // other class position has (`is:`, `only:`, `none:`,
+                // `causes:`). Rejecting them here was the documented
+                // deficiency that made `@phase_effects` blind to the
+                // classes a program declares itself.
+                classes.push(
+                    EffectClass::from_ident(&name).unwrap_or_else(
+                        || EffectClass::User(self.intern_effect(&name)),
+                    ),
+                );
                 self.bump();
                 if matches!(self.peek(), TokenKind::Comma) {
                     self.bump();

--- a/crates/hale-types/src/budget_check.rs
+++ b/crates/hale-types/src/budget_check.rs
@@ -321,17 +321,52 @@ fn budget_diags_inner(
     programs: &[&Program],
     import_renames: &[(Vec<String>, String)],
 ) -> Vec<Diag> {
+    budget_report_inner(programs, import_renames).0
+}
+
+/// #392 §8: every `@budget(alloc_per_call)` contract as a lowered
+/// claim row with its verdict — the same evaluation that produces
+/// the diagnostics, so the two cannot disagree.
+pub fn certificate_rows(
+    programs: &[&Program],
+    import_renames: &[(Vec<String>, String)],
+) -> Vec<crate::effects::LoweredCertificate> {
+    budget_report_inner(programs, import_renames).1
+}
+
+fn budget_report_inner(
+    programs: &[&Program],
+    import_renames: &[(Vec<String>, String)],
+) -> (Vec<Diag>, Vec<crate::effects::LoweredCertificate>) {
     let summary =
         alloc_summary::summarize_programs_with_renames(programs, import_renames);
     let mut diags = Vec::new();
+    let mut rows = Vec::new();
 
+    let one = |key: &FnKey,
+                   budget: u32,
+                   fd: &FnDecl,
+                   diags: &mut Vec<Diag>,
+                   rows: &mut Vec<crate::effects::LoweredCertificate>| {
+        let before = diags.len();
+        check_one(key, budget, fd, &summary, diags);
+        rows.push(crate::effects::LoweredCertificate {
+            subject: key.display(),
+            form: format!(
+                "bound alloc <= {} on paths from {{{}}}",
+                budget,
+                key.display()
+            ),
+            violated: diags.len() > before,
+        });
+    };
     for program in programs {
         for item in &program.items {
             match item {
                 TopDecl::Fn(fd) => {
                     if let Some(budget) = fd.budget {
                         let key = FnKey::free_fn(fd.name.name.clone());
-                        check_one(&key, budget, fd, &summary, &mut diags);
+                        one(&key, budget, fd, &mut diags, &mut rows);
                     }
                 }
                 TopDecl::Locus(l) => {
@@ -342,7 +377,7 @@ fn budget_diags_inner(
                                     l.name.name.clone(),
                                     fd.name.name.clone(),
                                 );
-                                check_one(&key, budget, fd, &summary, &mut diags);
+                                one(&key, budget, fd, &mut diags, &mut rows);
                             }
                         }
                     }
@@ -351,7 +386,7 @@ fn budget_diags_inner(
             }
         }
     }
-    diags
+    (diags, rows)
 }
 
 /// The cap on how many offender pinpoints one violation emits, so a

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -169,14 +169,31 @@ pub(crate) fn declared_of(programs: &[&Program]) -> std::collections::BTreeSet<u
         .unwrap_or_default()
 }
 
+/// #392 §8: a fn-grained certificate lowered to the claim IR's
+/// vocabulary, with its verdict. The engines stay what they are —
+/// the shared call-graph substrate (R1) plus per-class probes — but
+/// every annotation is REPORTED as the claim form it is pointwise
+/// sugar for, so the topology artifact carries all law (bundle
+/// claims and fn certificates) in one schema of record.
+pub struct LoweredCertificate {
+    /// The annotated fn / locus, post-mangle (demangled at
+    /// serialization like every artifact name).
+    pub subject: String,
+    /// The lowered claim form, display voice.
+    pub form: String,
+    pub violated: bool,
+}
+
 fn phase_effects_diags(
     programs: &[&Program],
     summary: &AllocSummary,
     ffi: &BTreeSet<String>,
+    rows: &mut Vec<LoweredCertificate>,
 ) -> Vec<Diag> {
     let mut out = Vec::new();
     let names = &effect_names_of(programs);
     let defs = &defs_of(programs);
+    let declared = declared_of(programs);
     for p in programs {
         for item in &p.items {
             let TopDecl::Locus(l) = item else { continue };
@@ -267,7 +284,14 @@ fn phase_effects_diags(
                 };
                 let key = FnKey::method(l.name.name.clone(), phase.clone());
                 // The frontier/graph classes: anything NOT allowed.
-                for class in [
+                // #392 §8: DECLARED user classes join the closed set
+                // — a phase contract is closed over the live class
+                // universe, exactly like `only:` (and with the same
+                // atomic-only complement: a composed class owns no
+                // bit of its own). The hardcoded built-in list was
+                // the documented deficiency that made the contract
+                // blind to the classes a program declares itself.
+                let mut classes: Vec<EffectClass> = vec![
                     EffectClass::Alloc,
                     EffectClass::Syscall,
                     EffectClass::Block,
@@ -277,7 +301,15 @@ fn phase_effects_diags(
                     EffectClass::Ffi,
                     EffectClass::Publish,
                     EffectClass::Spawn,
-                ] {
+                ];
+                classes.extend(declared.iter().filter_map(|i| {
+                    match defs.get(*i as usize) {
+                        Some(Some(_)) => None, // composed: atomic-only
+                        _ => Some(EffectClass::User(*i)),
+                    }
+                }));
+                let phase_before = out.len();
+                for class in classes {
                     if allowed.contains(&class) {
                         continue;
                     }
@@ -291,6 +323,20 @@ fn phase_effects_diags(
                         );
                     }
                 }
+                rows.push(LoweredCertificate {
+                    subject: l.name.name.clone(),
+                    form: format!(
+                        "only effects {{{}}} on {{{}}} during {}",
+                        allowed
+                            .iter()
+                            .map(|c| cls_name(*c, names))
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                        l.name.name,
+                        phase
+                    ),
+                    violated: out.len() > phase_before,
+                });
             }
         }
     }
@@ -483,6 +529,26 @@ fn effect_diags_inner(
     programs: &[&Program],
     import_renames: &[(Vec<String>, String)],
 ) -> Vec<Diag> {
+    effect_report_inner(programs, import_renames).0
+}
+
+/// #392 §8: every fn-grained effect certificate (incl. the phase
+/// contracts) as a lowered claim row with its verdict — evaluated
+/// by the SAME pass that produces the diagnostics, so the two can
+/// never disagree. The topology artifact serializes these beside
+/// the bundle claims: one schema of record for all law.
+pub fn certificate_rows(
+    programs: &[&Program],
+    import_renames: &[(Vec<String>, String)],
+) -> Vec<LoweredCertificate> {
+    effect_report_inner(programs, import_renames).1
+}
+
+fn effect_report_inner(
+    programs: &[&Program],
+    import_renames: &[(Vec<String>, String)],
+) -> (Vec<Diag>, Vec<LoweredCertificate>) {
+    let mut rows: Vec<LoweredCertificate> = Vec::new();
     let mut roots: Vec<(FnKey, Vec<EffectAssert>, Span)> = Vec::new();
     for program in programs {
         for item in &program.items {
@@ -521,9 +587,11 @@ fn effect_diags_inner(
     let mut placement = placement_implied_diags(programs, &summary);
     // #265 step 6: phase-indexed effect contracts on loci.
     let ffi_all = ffi_names(programs);
-    placement.extend(phase_effects_diags(programs, &summary, &ffi_all));
+    placement.extend(phase_effects_diags(
+        programs, &summary, &ffi_all, &mut rows,
+    ));
     if roots.is_empty() {
-        return placement;
+        return (placement, rows);
     }
     let ffi = ffi_names(programs);
     let names = effect_names_of(programs);
@@ -638,10 +706,20 @@ fn effect_diags_inner(
                 EffectAssert::Carries(_) => {}
                 EffectAssert::Forbid(classes) => {
                     for c in classes {
+                        let before = diags.len();
                         check_class(
                             &summary, key, *span, *c, &ffi, &names, &defs_v,
                             &mut diags,
                         );
+                        rows.push(LoweredCertificate {
+                            subject: key.display(),
+                            form: format!(
+                                "forbid reaches({{{}}}, effects({}))",
+                                key.display(),
+                                cls_name(*c, &names)
+                            ),
+                            violated: diags.len() > before,
+                        });
                     }
                 }
                 // #354: the closed dual. Checked as `none:` over the
@@ -654,6 +732,7 @@ fn effect_diags_inner(
                 EffectAssert::Only(allowed) => {
                     let set: Vec<String> =
                         allowed.iter().map(|c| cls_name(*c, &names)).collect();
+                    let only_before = diags.len();
                     for c in class_universe(&declared) {
                         if allowed.contains(&c) {
                             continue;
@@ -706,24 +785,54 @@ fn effect_diags_inner(
                             );
                         }
                     }
+                    rows.push(LoweredCertificate {
+                        subject: key.display(),
+                        form: format!(
+                            "only effects {{{}}} on {{{}}}",
+                            set.join(", "),
+                            key.display()
+                        ),
+                        violated: diags.len() > only_before,
+                    });
                 }
                 EffectAssert::PublishSet(allowed) => {
+                    let before = diags.len();
                     check_publish_set(&summary, key, *span, allowed, &mut diags);
+                    rows.push(LoweredCertificate {
+                        subject: key.display(),
+                        form: format!(
+                            "only publishes {{{}}} from {{{}}}",
+                            allowed.join(", "),
+                            key.display()
+                        ),
+                        violated: diags.len() > before,
+                    });
                 }
                 EffectAssert::NoPanic => {
+                    let before = diags.len();
                     check_no_panic(programs, key, *span, &mut diags);
+                    rows.push(LoweredCertificate {
+                        subject: key.display(),
+                        form: format!(
+                            "forbid reaches({{{}}}, panic)",
+                            key.display()
+                        ),
+                        violated: diags.len() > before,
+                    });
                 }
                 EffectAssert::Causes(classes) => {
                     // Cross-actor causality needs the bus graph;
                     // effect_diags is graph-free, so the check runs
                     // in `check.rs` where the graph is built (see
-                    // `frontier::causes_diags`). Nothing to do here.
+                    // `frontier::causes_diags`). Nothing to do here
+                    // — and no lowered row: the row belongs to the
+                    // pass that owns the verdict.
                     let _ = classes;
                 }
             }
         }
     }
-    diags
+    (diags, rows)
 }
 
 /// GH #265 coherence: ONE dispatcher over the effect classes. Every

--- a/crates/hale-types/src/quantitative.rs
+++ b/crates/hale-types/src/quantitative.rs
@@ -355,6 +355,23 @@ pub fn quantitative_diags(
     programs: &[&Program],
     fanout_of: &dyn Fn(&str) -> u64,
 ) -> Vec<Diag> {
+    quantitative_report(programs, fanout_of).0
+}
+
+/// #392 §8: every quantitative `@budget(<dim> = N)` contract as a
+/// lowered claim row with its verdict — same evaluation as the
+/// diagnostics, so the two cannot disagree.
+pub fn certificate_rows(
+    programs: &[&Program],
+    fanout_of: &dyn Fn(&str) -> u64,
+) -> Vec<crate::effects::LoweredCertificate> {
+    quantitative_report(programs, fanout_of).1
+}
+
+fn quantitative_report(
+    programs: &[&Program],
+    fanout_of: &dyn Fn(&str) -> u64,
+) -> (Vec<Diag>, Vec<crate::effects::LoweredCertificate>) {
     let mut roots: Vec<(FnKey, Vec<(QuantDim, u64)>, Span)> = Vec::new();
     for program in programs {
         for item in &program.items {
@@ -385,7 +402,7 @@ pub fn quantitative_diags(
         }
     }
     if roots.is_empty() {
-        return Vec::new();
+        return (Vec::new(), Vec::new());
     }
     let summary = alloc_summary::summarize_programs(programs);
     let frames = frame_map(programs);
@@ -393,6 +410,7 @@ pub fn quantitative_diags(
     let declared = crate::effects::declared_of(programs);
     let defs = crate::effects::defs_of(programs);
     let mut diags = Vec::new();
+    let mut rows = Vec::new();
     for (key, dims, span) in &roots {
         for (dim, cap) in dims {
             // #382 phase 3: a user-class dimension must name a
@@ -459,6 +477,16 @@ pub fn quantitative_diags(
                     )
                 }
             };
+            rows.push(crate::effects::LoweredCertificate {
+                subject: key.display(),
+                form: format!(
+                    "bound {} <= {} on paths from {{{}}}",
+                    dim_display(*dim, &names),
+                    cap,
+                    key.display()
+                ),
+                violated: measured.exceeds(*cap),
+            });
             if !measured.exceeds(*cap) {
                 continue;
             }
@@ -496,5 +524,5 @@ pub fn quantitative_diags(
             ));
         }
     }
-    diags
+    (diags, rows)
 }

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -680,6 +680,41 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
         ));
     }
     trim_trailing_comma(&mut out);
+    // #392 §8: every fn-grained certificate — `@effects` asserts,
+    // `@phase_effects` contracts, `@budget` in both families —
+    // lowered to the claim IR's vocabulary with its verdict, from
+    // the same evaluations that gate the build. One schema of
+    // record: the artifact carries ALL law, bundle-quantified and
+    // fn-grained, in one place. Unhashed like the claim results —
+    // rows are law + verdicts, not topology.
+    let mut lowered = crate::effects::certificate_rows(
+        &programs,
+        &bundle.import_renames,
+    );
+    lowered.extend(crate::budget_check::certificate_rows(
+        &programs,
+        &bundle.import_renames,
+    ));
+    let fanout = |subj: &str| -> u64 {
+        graph
+            .subjects
+            .get(subj)
+            .map(|si| si.subscribers.len().max(1) as u64)
+            .unwrap_or(1)
+    };
+    lowered.extend(crate::quantitative::certificate_rows(
+        &programs, &fanout,
+    ));
+    out.push_str(",\n  \"lowered\": [\n");
+    for r in &lowered {
+        out.push_str(&format!(
+            "    {{\"subject\": {}, \"form\": {}, \"result\": {}}},\n",
+            quote(&demangle_str(&r.subject)),
+            quote(&demangle_str(&r.form)),
+            quote(if r.violated { "violated" } else { "holds" })
+        ));
+    }
+    trim_trailing_comma(&mut out);
     out.push_str("  ]\n}\n");
     out
 }

--- a/crates/hale-types/tests/phase_effects.rs
+++ b/crates/hale-types/tests/phase_effects.rs
@@ -207,3 +207,61 @@ fn handler_name_works_as_a_phase() {
         ds
     );
 }
+
+// =====================================================================
+// #392 §8 — user classes join the phase contract's closed set
+// =====================================================================
+
+/// CANARY: a phase reaching a declared USER-class carrier without
+/// listing the class violates — the hardcoded built-in list made
+/// the contract blind to the classes a program declares itself.
+#[test]
+fn a_user_class_carrier_violates_an_unlisted_phase() {
+    let src = r#"
+        effect money;
+        @effects(is: {money})
+        fn charge(n: Int) -> Int { return n; }
+        @phase_effects(run: {})
+        locus Engine {
+            params { seen: Int = 0; }
+            run() {
+                self.seen = charge(1);
+            }
+        }
+        fn main() { Engine { }; }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        ds.iter().any(|m| m.contains("phase `run`")
+            && m.contains("money")),
+        "an unlisted user class reached in the phase must violate: {:?}",
+        ds
+    );
+}
+
+/// CONTROL: listing the user class in the phase's allowed set
+/// permits it — and parses (rejecting user classes at parse was
+/// the other half of the deficiency).
+#[test]
+fn a_listed_user_class_is_allowed_in_the_phase() {
+    let src = r#"
+        effect money;
+        @effects(is: {money})
+        fn charge(n: Int) -> Int { return n; }
+        @phase_effects(run: {money})
+        locus Engine {
+            params { seen: Int = 0; }
+            run() {
+                self.seen = charge(1);
+            }
+        }
+        fn main() { Engine { }; }
+    "#;
+    let ds = diags_for(src);
+    assert!(
+        !ds.iter().any(|m| m.contains("phase `run`")
+            && m.contains("money")),
+        "a listed user class must be allowed in the phase: {:?}",
+        ds
+    );
+}

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -582,7 +582,8 @@ The artifact shape (schema `1.0`):
                   "computed_publish"]} ],
   "provenance": { "calls": [+span], "publishes": [+span],
                   "subscribes": [+span], "decls": {name: span} },
-  "claims":    [ {"name", "form", "result": "holds"|"violated"|"invalid"} ]
+  "claims":    [ {"name", "form", "result": "holds"|"violated"|"invalid"} ],
+  "lowered":   [ {"subject", "form", "result": "holds"|"violated"} ]
 }
 ```
 
@@ -619,6 +620,14 @@ The pieces worth knowing:
 - **`provenance`.** Bundle-global byte-offset spans (`[start,
   end]`) for every user edge and decl — the "where to edit" data,
   unhashed by design.
+- **`lowered`.** Every fn-grained certificate — each `@effects`
+  assert, each `@phase_effects` phase contract, each `@budget` —
+  as the claim form it is pointwise sugar for, with the verdict of
+  the same evaluation that gates the build: `forbid
+  reaches({F}, effects(money))`, `bound alloc <= N on paths from
+  {F}`, `only effects {…} on {L} during birth`. One schema of
+  record: the artifact carries all law, bundle-quantified and
+  fn-grained, in one place. Unhashed like the claim results.
 
 v2 scope: every claim verb replays independently over the exported
 relations. Still compiler-certified: `bound` over **built-in**

--- a/docs/src/effects.md
+++ b/docs/src/effects.md
@@ -156,6 +156,12 @@ only `params` still has a birth. A phase that names *nothing* on the
 locus — a typo, or a handler you renamed — is an error, because a
 contract nobody checks is worse than no contract.
 
+The closed set covers **your own effect classes** too: a phase that
+reaches a declared `money` carrier without listing `money` violates,
+and `run: {money}` permits it — the same closed-universe rule as
+`only:`, composed classes excluded from the complement (they own no
+bit of their own).
+
 **Empty braces and omission are opposites**, and this is the part to
 get right:
 

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -269,9 +269,20 @@ max). Remaining compiler-certified: `bound` over built-in classes
 serialized) and any walk past the step ceiling. The derivation
 (source → model) remains the trust root.
 
-Still later (#392): library-tier claims that travel with imports,
-and the annotations-lower-to-claim-IR unification (§8 of the
-original issue) riding this model.
+**§8 — one schema of record** (#392): every fn-grained certificate
+— each `@effects` assert, each `@phase_effects` phase contract,
+each `@budget` in both families — is REPORTED as the claim form it
+is pointwise sugar for, with its verdict, in the artifact's
+`lowered` array (`forbid reaches({F}, effects(money))`,
+`bound alloc <= N on paths from {F}`,
+`only effects {…} on {L} during birth`, …). Rows come from the
+same evaluations that gate the build, so the report and the build
+cannot disagree. The traversal substrate is already one engine
+(the shared call-graph walker plus the shared summary and the
+shared fail-closed predicate); the annotation voices keep their
+diagnostics.
+
+Still later (#392): library-tier claims that travel with imports.
 
 ## Structural & design rules
 
@@ -527,11 +538,14 @@ assume the others in a build:
   `@phase_effects(birth: {alloc}, run: {})` **is** the DO-178 "no
   dynamic memory after initialization" discipline, stated directly
   rather than assembled from two unrelated flags. Each phase names
-  the classes it may perform (`alloc`, plus the `@effects` classes);
-  a phase omitted is unconstrained, a phase with `{}` forbids
-  everything. Phases resolve to lifecycle hooks (`birth`, `run`,
-  `drain`, `dissolve`, `accept`, `release`) or to any member fn /
-  handler by name.
+  the classes it may perform (`alloc`, plus the `@effects` classes,
+  **including declared user classes** — #392 closed the contract
+  over the live class universe like `only:`, with the same
+  atomic-only complement; the hardcoded built-in list was the
+  documented deficiency); a phase omitted is unconstrained, a phase
+  with `{}` forbids everything. Phases resolve to lifecycle hooks
+  (`birth`, `run`, `drain`, `dissolve`, `accept`, `release`) or to
+  any member fn / handler by name.
 - **`@no_panic` — disposition coverage** (GH #265, 2026-07-29).
   Deliberately *not* an effect class: this is a syntactic property of
   a body, not a query over the classified frontier. A fn asserting


### PR DESCRIPTION
Stacked on #394. The §8 unification from the original #382 build order, riding the model as the issue prescribes.

## One schema of record

The topology artifact gains an unhashed `lowered` array: every fn-grained certificate — each `@effects` assert, each `@phase_effects` phase contract, each `@budget` in both families — reported as the claim form it is pointwise sugar for, with its verdict:

```json
{"subject": "dirty", "form": "forbid reaches({dirty}, effects(money))", "result": "violated"}
{"subject": "boxed", "form": "bound alloc <= 2 on paths from {boxed}", "result": "holds"}
{"subject": "Engine", "form": "only effects {} on {Engine} during run", "result": "violated"}
```

Rows are produced by the **same evaluation passes that gate the build** (the `before`/`len` pattern `phase_effects` already used internally for message re-labeling), so the report and the build cannot disagree — no second engine, no drift channel. The traversal substrate is already one engine (the R1 shared call-graph walker + the shared summary + the shared fail-closed predicate from #393); the annotation voices keep their diagnostics byte-for-byte, which is why the whole existing effect/budget test corpus passes untouched.

## `@phase_effects` closes over user classes

The deficiency documented at #382 close: the walker iterated a hardcoded nine-class list and the parser rejected user class names outright, so a phase contract was blind to the classes a program declares itself. Now a phase contract is closed over the live class universe like `only:` — a phase reaching a declared `money` carrier without listing `money` violates; `run: {money}` permits it; composed classes stay out of the complement (atomic-only, the #382 rule). Behavior note: programs combining `@phase_effects` with declared user classes may see new — correct — violations; flagged in the CHANGELOG.

## Evidence

- `phase_effects.rs`: canary (unlisted user-class carrier violates) + control (listed class permitted, and the annotation parses).
- `topology_v2.rs`: lowered rows across all three families, both verdicts.
- Full suite 2232 green — zero wording or verdict changes to existing certificates. `hale fmt --check` clean. Spec (`§8 — one schema of record`, phase-effects bullet) and docs (claims chapter schema + effects chapter) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)