### PR TITLE
Library-tier claims: law that travels with an import (#392 thread 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ behavior.
 
 ## Unreleased
 
+### Library-tier claims: law that travels with an import (GH #392 thread 2)
+
+A library seed states its own law in a TOP-LEVEL `claims { }` block
+— no `main locus` required. The block travels with the import and
+re-evaluates in **every closing build** over the merged world:
+checked standalone the seed satisfies itself; when an app quietly
+wires a second subscriber onto the library's topic, the library's
+own `count subscribers(topic Charges) <= 1` refuses the build —
+with seed attribution (``claim `pay::single_settle` violated``,
+never a mangled symbol) and a span pointing at the library's own
+claim line.
+
+The tier split is the enforcement surface for "a dependency may
+not brick downstream builds with world-claims": a seed swears
+about *itself and its own boundary* (it can only name what it can
+see — its own decls, its own imports), world-quantification stays
+main's, and a seed that declares `main locus` writing the
+top-level form is a check error. Traveling blocks are marked at
+the mangle stage (which only ever touches imported seeds); their
+group and topic references canonicalize across the seed boundary
+exactly as group declarations do (#334), and claim names are
+never mangled — attribution is `alias::name`. Claim-name
+uniqueness is per seed.
+
+Grammar: `spec/grammar.ebnf` (`top_decl` gains `claims_block`).
+Spec: `spec/verification.md` § Claims (library tier). Docs: the
+claims chapter (placement + a dedicated section). Tests:
+`library_claims.rs` (tier rejection, standalone evaluation),
+`xseed_library_claims.rs` + the `xseed-library-claims` fixture
+(travel, re-check at close, attribution, demangling).
+
 ### The normalized, provenance-bearing model (GH #392 thread 1)
 
 The architectural milestone every reviewer of the #382 stack named:

--- a/crates/hale-cli/tests/fixtures/xseed-library-claims/app/main.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-library-claims/app/main.hl
@@ -1,0 +1,28 @@
+import "lib/pay" as pay;
+
+// The closing seed quietly adds a SECOND subscriber to the
+// library's topic — legal wiring, but the library's own
+// `single_settle` claim re-evaluates here and refuses it.
+locus Audit {
+    params { seen: Int = 0; }
+    bus { subscribe pay::Charges as on_charge; }
+    fn on_charge(c: pay::Charge) {
+        self.seen = self.seen + 1;
+    }
+}
+
+locus Biller {
+    bus { publish pay::Charges; }
+    fn bill(n: Int) {
+        pay::Charges <- pay::Charge { amount: n };
+    }
+}
+
+main locus App {
+    params {
+        w: pay::Wire = pay::Wire { };
+        aud: Audit = Audit { };
+        b: Biller = Biller { };
+    }
+}
+fn main() { App { }; }

--- a/crates/hale-cli/tests/fixtures/xseed-library-claims/hale.toml
+++ b/crates/hale-cli/tests/fixtures/xseed-library-claims/hale.toml
@@ -1,0 +1,1 @@
+name = "xseed-library-claims"

--- a/crates/hale-cli/tests/fixtures/xseed-library-claims/lib/pay/p.hl
+++ b/crates/hale-cli/tests/fixtures/xseed-library-claims/lib/pay/p.hl
@@ -1,0 +1,21 @@
+// The payments seed. It swears about its own boundary in a
+// TOP-LEVEL claims block — the library tier (#392 thread 2): the
+// law travels with the import and re-evaluates in every closing
+// build over the merged world.
+type Charge { amount: Int; }
+topic Charges { payload: Charge; }
+
+locus Wire {
+    params { seen: Int = 0; }
+    bus { subscribe Charges as on_charge; }
+    fn on_charge(c: Charge) {
+        self.seen = self.seen + c.amount;
+    }
+}
+
+group settlers = { Wire };
+
+claims {
+    single_settle: count subscribers(topic Charges) <= 1;
+    wired: require subscribes(some settlers, topic Charges);
+}

--- a/crates/hale-cli/tests/xseed_library_claims.rs
+++ b/crates/hale-cli/tests/xseed_library_claims.rs
@@ -1,0 +1,76 @@
+//! #392 thread 2 — library-tier claims: a top-level `claims { }`
+//! block in a library seed travels with the import and re-evaluates
+//! in every closing build.
+//!
+//! The fixture is the motivating shape: the payments seed swears
+//! `count subscribers(topic Charges) <= 1` about its own boundary.
+//! Checked alone, it holds (its `Wire` is the one settler). The app
+//! then quietly wires a second subscriber — legal bus plumbing —
+//! and the library's own law refuses the closing build, attributed
+//! (`pay::single_settle`) and pointing at the library's source.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn check(rel: &str) -> String {
+    let target = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/xseed-library-claims")
+        .join(rel);
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(&target)
+        .output()
+        .expect("run hale check");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+/// The library alone satisfies its own law.
+#[test]
+fn the_library_holds_in_its_own_world() {
+    let out = check("lib/pay");
+    assert!(
+        !out.contains("violated") && out.contains("ok"),
+        "the seed's own world satisfies its claims:\n{}",
+        out
+    );
+}
+
+/// CANARY — the closing build re-evaluates the traveled claim over
+/// the merged world and refuses the app's second subscriber, with
+/// seed attribution and demangled names.
+#[test]
+fn the_traveled_claim_refuses_the_closing_build() {
+    let out = check("app");
+    assert!(
+        out.contains("claim `pay::single_settle` violated"),
+        "the library's law must fire at close, attributed:\n{}",
+        out
+    );
+    assert!(
+        out.contains("`Audit`") && out.contains("`pay::Wire`"),
+        "the countermodel must name both subscribers in author \
+         spelling:\n{}",
+        out
+    );
+    assert!(
+        out.contains("p.hl"),
+        "the violation must point at the library's own claim line:\n{}",
+        out
+    );
+    assert!(
+        !out.contains("__lib_"),
+        "no mangled symbol may appear in a law diagnostic:\n{}",
+        out
+    );
+    // The sibling claim that stays satisfied at close reports
+    // nothing — traveling law is still ordinary law.
+    assert!(
+        !out.contains("`pay::wired`"),
+        "a satisfied traveled claim must stay silent:\n{}",
+        out
+    );
+}

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -11265,6 +11265,10 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     // GH #382: groups name decls, not types —
                     // no type-bearing positions.
                 }
+                TopDecl::Claims(_) => {
+                    // #392: claims lower to no code and carry no
+                    // type-bearing positions.
+                }
             }
         }
         Ok(())

--- a/crates/hale-codegen/src/mangle.rs
+++ b/crates/hale-codegen/src/mangle.rs
@@ -450,6 +450,12 @@ impl<'a> QualifiedRenameApplier<'a> {
                     }
                 }
             }
+            // #392 thread 2: a library seed's own top-level claims
+            // block — its qualified topic refs (of ITS sub-imports)
+            // canonicalize with the same rule as main's block.
+            TopDecl::Claims(cb) => {
+                rewrite_claim_topic_refs(cb, self.renames);
+            }
         }
     }
 
@@ -544,49 +550,53 @@ impl<'a> QualifiedRenameApplier<'a> {
             // segment. Group names and effect classes are same-seed
             // / interned and need no rewriting.
             LocusMember::Claims(cb) => {
-                let rewrite = |t: &mut TopicRef,
-                               renames: &[(Vec<String>, String)]| {
-                    if t.segments.len() < 2 {
-                        return;
-                    }
-                    let segs: Vec<String> = t
-                        .segments
-                        .iter()
-                        .map(|s| s.name.clone())
-                        .collect();
-                    for (key, mangled) in renames {
-                        if key.len() == segs.len()
-                            && key
-                                .iter()
-                                .zip(segs.iter())
-                                .all(|(k, p)| k == p)
-                        {
-                            let span = t.segments[0].span;
-                            t.segments = vec![Ident {
-                                name: mangled.clone(),
-                                span,
-                            }];
-                            return;
-                        }
-                    }
-                };
-                for e in &mut cb.entries {
-                    match &mut e.form {
-                        ClaimForm::OnlyEdges { grants, .. } => {
-                            for g in grants {
-                                rewrite(&mut g.topic, self.renames);
-                            }
-                        }
-                        ClaimForm::Require { topic, .. }
-                        | ClaimForm::Count { topic, .. } => {
-                            rewrite(topic, self.renames);
-                        }
-                        ClaimForm::ForbidReaches { .. }
-                        | ClaimForm::Bound { .. }
-                        | ClaimForm::Cover { .. } => {}
-                    }
+                rewrite_claim_topic_refs(cb, self.renames);
+            }
+        }
+    }
+}
+
+/// #334-style canonicalization of qualified topic refs inside a
+/// claims block — shared by main-locus blocks and (#392 thread 2)
+/// the library tier's top-level blocks, whose own sub-imports
+/// resolve at ITS import stage with ITS rename table.
+fn rewrite_claim_topic_refs(
+    cb: &mut ClaimsBlock,
+    renames: &[(Vec<String>, String)],
+) {
+    let rewrite = |t: &mut TopicRef| {
+        if t.segments.len() < 2 {
+            return;
+        }
+        let segs: Vec<String> =
+            t.segments.iter().map(|s| s.name.clone()).collect();
+        for (key, mangled) in renames {
+            if key.len() == segs.len()
+                && key.iter().zip(segs.iter()).all(|(k, p)| k == p)
+            {
+                let span = t.segments[0].span;
+                t.segments = vec![Ident {
+                    name: mangled.clone(),
+                    span,
+                }];
+                return;
+            }
+        }
+    };
+    for e in &mut cb.entries {
+        match &mut e.form {
+            ClaimForm::OnlyEdges { grants, .. } => {
+                for g in grants {
+                    rewrite(&mut g.topic);
                 }
             }
+            ClaimForm::Require { topic, .. }
+            | ClaimForm::Count { topic, .. } => {
+                rewrite(topic);
+            }
+            ClaimForm::ForbidReaches { .. }
+            | ClaimForm::Bound { .. }
+            | ClaimForm::Cover { .. } => {}
         }
     }
 }
@@ -610,6 +620,11 @@ fn top_decl_name(d: &TopDecl) -> Option<&str> {
         // GH #382: imported groups get mangled names like any other
         // decl, so two seeds' same-named groups cannot collide.
         TopDecl::Group(g) => Some(&g.name.name),
+        // #392: a claims block declares no name — claim names stay
+        // as written and report with seed attribution instead
+        // (`alias::claim_name`), so a mangled symbol never appears
+        // in a law diagnostic.
+        TopDecl::Claims(_) => None,
     }
 }
 
@@ -686,6 +701,78 @@ impl<'a> Mangler<'a> {
                 for m in &mut g.members {
                     if m.segments.len() == 1 && !m.glob {
                         self.rewrite_ident(&mut m.segments[0].name);
+                    }
+                }
+            }
+            // #392 thread 2: a library seed's top-level claims
+            // block. Its group and topic REFERENCES name this
+            // seed's own decls, whose declarations were just
+            // mangled — rewrite them the same way, or the claim's
+            // vocabulary silently detaches from its decls at the
+            // merge. Claim names stay as written (they report with
+            // seed attribution, never as mangled symbols); `during`
+            // names a locus-local phase; a `cover` alias names this
+            // seed's own import, which is not a decl. The block is
+            // marked `lib_tier` — the mangle stage only ever
+            // touches imported seeds, so the marker is what lets
+            // the claims pass tell a traveling library block from a
+            // closing seed's (illegal) top-level one after the seed
+            // merge flattens both into one program.
+            TopDecl::Claims(cb) => {
+                cb.lib_tier = true;
+                for e in &mut cb.entries {
+                    match &mut e.form {
+                        ClaimForm::ForbidReaches {
+                            src,
+                            dst,
+                            avoiding,
+                            ..
+                        } => {
+                            for set in [src, dst] {
+                                if let ClaimSet::Group(g) = set {
+                                    self.rewrite_ident(&mut g.name);
+                                }
+                            }
+                            if let Some(g) = avoiding {
+                                self.rewrite_ident(&mut g.name);
+                            }
+                        }
+                        ClaimForm::OnlyEdges {
+                            src,
+                            dst,
+                            grants,
+                        } => {
+                            self.rewrite_ident(&mut src.name);
+                            self.rewrite_ident(&mut dst.name);
+                            for g in grants {
+                                if g.topic.segments.len() == 1 {
+                                    self.rewrite_ident(
+                                        &mut g.topic.segments[0].name,
+                                    );
+                                }
+                            }
+                        }
+                        ClaimForm::Bound { from, .. } => {
+                            self.rewrite_ident(&mut from.name);
+                        }
+                        ClaimForm::Require { group, topic, .. } => {
+                            self.rewrite_ident(&mut group.name);
+                            if topic.segments.len() == 1 {
+                                self.rewrite_ident(
+                                    &mut topic.segments[0].name,
+                                );
+                            }
+                        }
+                        ClaimForm::Cover { group, .. } => {
+                            self.rewrite_ident(&mut group.name);
+                        }
+                        ClaimForm::Count { topic, .. } => {
+                            if topic.segments.len() == 1 {
+                                self.rewrite_ident(
+                                    &mut topic.segments[0].name,
+                                );
+                            }
+                        }
                     }
                 }
             }

--- a/crates/hale-codegen/tests/cross_seed_imports.rs
+++ b/crates/hale-codegen/tests/cross_seed_imports.rs
@@ -51,6 +51,7 @@ fn top_name(d: &TopDecl) -> Option<&str> {
         TopDecl::Module(_) => None,
         TopDecl::Target(t) => Some(&t.name.name),
         TopDecl::Group(g) => Some(&g.name.name),
+        TopDecl::Claims(_) => None,
     }
 }
 

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -68,6 +68,16 @@ pub enum TopDecl {
     /// names are errors, not empty sets — the misspelt-effect-class
     /// lesson applied at the group layer. Lowers to zero code.
     Group(GroupDecl),
+    /// #392 thread 2: a TOP-LEVEL `claims { }` block — the LIBRARY
+    /// tier. A seed swears about itself and its own boundary; the
+    /// claims travel with the import and re-evaluate in every
+    /// closing build over the merged world. World-quantification
+    /// stays main's: a seed that declares `main locus` states its
+    /// law inside that locus, and a top-level block there is a
+    /// check error (the enforcement surface for "a dependency may
+    /// not brick downstream builds with world-claims" — a library
+    /// can only NAME what it can see, its own decls and imports).
+    Claims(ClaimsBlock),
 }
 
 impl TopDecl {
@@ -84,6 +94,7 @@ impl TopDecl {
             TopDecl::RingLayout(r) => r.span,
             TopDecl::Target(t) => t.span,
             TopDecl::Group(g) => g.span,
+            TopDecl::Claims(c) => c.span,
         }
     }
 }
@@ -150,6 +161,14 @@ impl GroupMember {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ClaimsBlock {
     pub entries: Vec<ClaimDecl>,
+    /// #392 thread 2: true iff this block arrived through the
+    /// import pipeline — set by the mangle stage, which by
+    /// definition only touches imported seeds. The seed merge
+    /// flattens imported items into the closing program, so
+    /// syntactic position alone cannot tell a library's traveling
+    /// block from a closing seed's (illegal) top-level one; this
+    /// marker can. Parse always produces `false`.
+    pub lib_tier: bool,
     pub span: Span,
 }
 
@@ -2745,25 +2764,7 @@ pub fn remap_user_effects(items: &mut [TopDecl], map: &[u16]) {
                         // class in the merged table, the exact
                         // aliasing bug this pass exists to prevent.
                         LocusMember::Claims(cb) => {
-                            for e in &mut cb.entries {
-                                match &mut e.form {
-                                    ClaimForm::ForbidReaches {
-                                        src,
-                                        dst,
-                                        ..
-                                    } => {
-                                        claim_set(src, map);
-                                        claim_set(dst, map);
-                                    }
-                                    ClaimForm::Bound {
-                                        class: c, ..
-                                    } => class(c, map),
-                                    ClaimForm::OnlyEdges { .. }
-                                    | ClaimForm::Require { .. }
-                                    | ClaimForm::Cover { .. }
-                                    | ClaimForm::Count { .. } => {}
-                                }
-                            }
+                            claims_block(cb, map);
                         }
                         _ => {}
                     }
@@ -2776,9 +2777,28 @@ pub fn remap_user_effects(items: &mut [TopDecl], map: &[u16]) {
                     }
                 }
             }
+            // #392 thread 2: library-tier blocks carry the same
+            // class-index positions as main's.
+            TopDecl::Claims(cb) => claims_block(cb, map),
             // Modules nest arbitrarily deep.
             TopDecl::Module(m) => remap_user_effects(&mut m.items, map),
             _ => {}
+        }
+    }
+
+    fn claims_block(cb: &mut ClaimsBlock, map: &[u16]) {
+        for e in &mut cb.entries {
+            match &mut e.form {
+                ClaimForm::ForbidReaches { src, dst, .. } => {
+                    claim_set(src, map);
+                    claim_set(dst, map);
+                }
+                ClaimForm::Bound { class: c, .. } => class(c, map),
+                ClaimForm::OnlyEdges { .. }
+                | ClaimForm::Require { .. }
+                | ClaimForm::Cover { .. }
+                | ClaimForm::Count { .. } => {}
+            }
         }
     }
 }

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -1032,6 +1032,14 @@ impl Parser {
             TokenKind::Ident(s) if s == "group" => {
                 self.parse_group_decl().map(TopDecl::Group)
             }
+            // #392 thread 2: a top-level `claims { }` block — the
+            // LIBRARY tier: a seed swears about itself and its own
+            // boundary, and the block travels with the import.
+            // World law stays in `main locus`; a closing seed
+            // writing this form is rejected at check.
+            TokenKind::Ident(s) if s == "claims" => {
+                self.parse_claims_block().map(TopDecl::Claims)
+            }
             // `main locus Foo { ... }` — Phase 2 entry-point
             // marker. Same contextual-keyword pattern. The
             // following token must be `locus`.
@@ -1214,6 +1222,7 @@ impl Parser {
         let close = self.expect(TokenKind::RBrace, "}")?;
         Ok(ClaimsBlock {
             entries,
+            lib_tier: false,
             span: kw_tok.span.merge(close.span),
         })
     }

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -5642,6 +5642,12 @@ impl<'a> Checker<'a> {
                 // the target name; no use-site checks here yet.
             }
             TopDecl::RingLayout(r) => self.check_ring_layout(r),
+            TopDecl::Claims(_) => {
+                // #392 thread 2: a library-tier claims block. Its
+                // placement rule (library seeds only, never the
+                // closing seed) and evaluation live in the bundle-
+                // level claims pass — this checker is per-decl.
+            }
         }
     }
 

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -198,38 +198,116 @@ fn claims_report_inner(
     import_renames: &[(Vec<String>, String)],
 ) -> (Vec<Diag>, Vec<ClaimOutcome>) {
     // ---- collect group decls + claims blocks (modules included) ----
+    //
+    // #392 thread 2 — two tiers. Main-locus blocks are the WORLD
+    // tier (bundle-wide law, as shipped). A TOP-LEVEL `claims { }`
+    // block is the LIBRARY tier: a seed swears about itself and its
+    // own boundary, the block travels with the import, and it
+    // re-evaluates here — in the closing build's merged world —
+    // every time. Library claims report with seed attribution
+    // (`alias::name`), never as mangled symbols. A program that
+    // declares `main locus` may not use the top-level form: world
+    // law belongs in main (the closed-world gate), and the tier
+    // split is what keeps a dependency from stating world-claims.
+    let mut diags: Vec<Diag> = Vec::new();
     let mut group_decls: Vec<&GroupDecl> = Vec::new();
-    let mut claims: Vec<&ClaimDecl> = Vec::new();
+    let mut claims: Vec<ClaimDecl> = Vec::new();
+    let mangled_to_alias: BTreeMap<&str, &str> = import_renames
+        .iter()
+        .filter_map(|(segs, mangled)| {
+            segs.first().map(|a| (mangled.as_str(), a.as_str()))
+        })
+        .collect();
     fn walk_items<'a>(
         items: &'a [TopDecl],
         groups: &mut Vec<&'a GroupDecl>,
-        claims: &mut Vec<&'a ClaimDecl>,
+        claims: &mut Vec<ClaimDecl>,
+        top_blocks: &mut Vec<&'a ClaimsBlock>,
+        has_main: &mut bool,
     ) {
         for item in items {
             match item {
                 TopDecl::Group(g) => groups.push(g),
                 TopDecl::Locus(l) if l.is_main => {
+                    *has_main = true;
                     for m in &l.members {
                         if let LocusMember::Claims(cb) = m {
-                            claims.extend(cb.entries.iter());
+                            claims.extend(cb.entries.iter().cloned());
                         }
                     }
                 }
-                TopDecl::Module(m) => {
-                    walk_items(&m.items, groups, claims)
-                }
+                TopDecl::Claims(cb) => top_blocks.push(cb),
+                TopDecl::Module(m) => walk_items(
+                    &m.items,
+                    groups,
+                    claims,
+                    top_blocks,
+                    has_main,
+                ),
                 _ => {}
             }
         }
     }
+    let mut top_blocks: Vec<&ClaimsBlock> = Vec::new();
+    let mut has_main = false;
     for p in programs {
-        walk_items(&p.items, &mut group_decls, &mut claims);
+        walk_items(
+            &p.items,
+            &mut group_decls,
+            &mut claims,
+            &mut top_blocks,
+            &mut has_main,
+        );
+    }
+    for cb in top_blocks {
+        // The seed merge flattens imported items into the closing
+        // program, so position cannot tell the tiers apart — the
+        // mangle stage's `lib_tier` marker can: it only ever
+        // touches imported seeds. An unmarked top-level block in a
+        // bundle that closes (declares main) is the closing seed's
+        // own — the world-claim surface the tier split forbids.
+        if !cb.lib_tier && has_main {
+            diags.push(Diag::ty(
+                cb.span,
+                "a top-level `claims { }` block is the LIBRARY \
+                 tier — a seed swearing about itself and its own \
+                 boundary. This seed declares `main locus`, the \
+                 closed-world gate: state world law inside it"
+                    .to_string(),
+            ));
+            continue;
+        }
+        // Attribution: the block's own group/topic refs were
+        // canonicalized to mangled decl names, which map back to
+        // the import alias — so a library claim reports as
+        // `alias::name`, never as a mangled symbol.
+        let alias = cb.entries.iter().find_map(|e| {
+            let name = match &e.form {
+                ClaimForm::ForbidReaches { src, .. } => match src {
+                    ClaimSet::Group(g) => Some(&g.name),
+                    _ => None,
+                },
+                ClaimForm::OnlyEdges { src, .. } => Some(&src.name),
+                ClaimForm::Bound { from, .. } => Some(&from.name),
+                ClaimForm::Require { group, .. }
+                | ClaimForm::Cover { group, .. } => Some(&group.name),
+                ClaimForm::Count { topic, .. } => {
+                    topic.segments.first().map(|s| &s.name)
+                }
+            }?;
+            mangled_to_alias.get(name.as_str()).copied()
+        });
+        for e in &cb.entries {
+            let mut c = e.clone();
+            if let Some(a) = alias {
+                c.name.name = format!("{}::{}", a, c.name.name);
+            }
+            claims.push(c);
+        }
     }
     if group_decls.is_empty() && claims.is_empty() {
-        return (Vec::new(), Vec::new());
+        return (diags, Vec::new());
     }
-
-    let mut diags: Vec<Diag> = Vec::new();
 
     // ---- decl indexes for member / topic resolution ----
     let mut locus_names: BTreeSet<String> = BTreeSet::new();

--- a/crates/hale-types/src/resolve.rs
+++ b/crates/hale-types/src/resolve.rs
@@ -499,6 +499,10 @@ fn register_top_decls(
                 // resolves group members against the merged bundle
                 // itself, where imported decls are visible.
             }
+            TopDecl::Claims(_) => {
+                // #392 thread 2: a library-tier claims block — law,
+                // not a symbol. Evaluated by the same claims pass.
+            }
         }
     }
 }

--- a/crates/hale-types/tests/library_claims.rs
+++ b/crates/hale-types/tests/library_claims.rs
@@ -1,0 +1,90 @@
+//! #392 thread 2 — library-tier claims, the in-crate half: the
+//! tier split (a closing seed may not write the top-level form) and
+//! standalone-library evaluation. The cross-seed travel-and-recheck
+//! path lives in `hale-cli/tests/xseed_library_claims.rs`.
+
+use hale_syntax::parse_source;
+
+fn diags(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+/// A seed that closes the world (declares `main locus`) states its
+/// law inside main — the top-level form is the library tier and is
+/// rejected here. This is the enforcement surface for "a dependency
+/// may not brick downstream builds with world-claims": the tier is
+/// syntactic, and a library can only name what it can see.
+#[test]
+fn a_closing_seed_may_not_use_the_top_level_form() {
+    let src = r#"
+        locus B { fn work(n: Int) -> Int { return n; } }
+        group b_side = { B };
+        claims {
+            iso: require subscribes(some b_side, topic T);
+        }
+        type M { n: Int; }
+        topic T { payload: M; }
+        main locus App { params { b: B = B { }; } }
+        fn main() { App { }; }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("LIBRARY tier")
+            && m.contains("state world law inside it")),
+        "a closing seed's top-level block must be rejected: {:?}",
+        ds
+    );
+}
+
+/// A library checked standalone (no main anywhere) evaluates its
+/// top-level claims over its own world — canary and control.
+#[test]
+fn a_standalone_library_evaluates_its_own_claims() {
+    let violated = r#"
+        type M { n: Int; }
+        topic T { payload: M; }
+        locus A {
+            params { s: Int = 0; }
+            bus { subscribe T as on_m; }
+            fn on_m(m: M) { self.s = self.s + m.n; }
+        }
+        locus B {
+            params { s: Int = 0; }
+            bus { subscribe T as on_m; }
+            fn on_m(m: M) { self.s = self.s + m.n; }
+        }
+        group subs = { A, B };
+        claims {
+            single: count subscribers(topic T) <= 1;
+        }
+    "#;
+    let ds = diags(violated);
+    assert!(
+        ds.iter().any(|m| m.contains("claim `single` violated")),
+        "two subscribers must violate the library's own claim: {:?}",
+        ds
+    );
+    let control = r#"
+        type M { n: Int; }
+        topic T { payload: M; }
+        locus A {
+            params { s: Int = 0; }
+            bus { subscribe T as on_m; }
+            fn on_m(m: M) { self.s = self.s + m.n; }
+        }
+        group subs = { A };
+        claims {
+            single: count subscribers(topic T) <= 1;
+        }
+    "#;
+    let ds = diags(control);
+    assert!(
+        !ds.iter().any(|m| m.contains("violated")),
+        "one subscriber satisfies the library's claim: {:?}",
+        ds
+    );
+}

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -83,6 +83,8 @@ effect_family_decl
                   = "effect" , IDENTIFIER , "(" , IDENTIFIER , ")" , ";" ;
 
 claims_block      = "claims" , "{" , { claim_entry } , "}" ;
+                  (* inside main locus: the world tier;
+                     at top level: the library tier (#392) *)
 claim_entry       = IDENTIFIER , ":" , claim_form , ";" ;
 claim_form        = forbid_form | only_edges_form | bound_form
                   | require_form | cover_form | count_form ;
@@ -233,11 +235,21 @@ built-ins keep their own spellings: `alloc_per_call`, `publish`,
 
 ## `claims { }` — placement and naming
 
-The block is only legal inside `main locus` — a parse error
-anywhere else. Main is the closed-world gate: bundle-wide sentences
-cannot be evaluated before the whole application graph exists, and
-one-main-per-bundle makes the claims root unique. A main locus may
-carry several `claims { }` blocks; their entries concatenate.
+The block has two homes, one per tier:
+
+- **Inside `main locus`** — the WORLD tier. Main is the
+  closed-world gate: bundle-wide sentences cannot be evaluated
+  before the whole application graph exists, and
+  one-main-per-bundle makes the claims root unique. Inside any
+  other locus it is a parse error.
+- **At top level in a LIBRARY seed** — the library tier (see
+  [Library-tier claims](#library-tier-claims) below): a seed
+  swears about itself and its own boundary, and the block travels
+  with the import. A seed that declares `main locus` writing the
+  top-level form is a check error — world law belongs in main.
+
+A main locus may carry several `claims { }` blocks; their entries
+concatenate.
 
 Every entry is `name: form;`. The **name is the contract of
 record** — it is what the diagnostic, the CI check, the review
@@ -435,6 +447,53 @@ actual count and names the participating loci. These are counts
 over declarations, not a runtime census of replicated instances —
 exact instance claims belong to deployment elaboration, when it
 lands.
+
+## Library-tier claims
+
+A library seed states its own law in a **top-level** `claims { }`
+block — no `main locus` required:
+
+```hale,fragment
+type Charge { amount: Int; }
+topic Charges { payload: Charge; }
+
+locus Wire {
+    params { seen: Int = 0; }
+    bus { subscribe Charges as on_charge; }
+    fn on_charge(c: Charge) { self.seen = self.seen + c.amount; }
+}
+
+group settlers = { Wire };
+
+claims {
+    single_settle: count subscribers(topic Charges) <= 1;
+    wired: require subscribes(some settlers, topic Charges);
+}
+```
+
+Two properties make this the *library* tier:
+
+- **The law travels.** Import the seed and its claims come along,
+  re-evaluating in **every closing build** over the merged world.
+  Checked standalone, the seed satisfies itself; when an app
+  quietly wires a second subscriber onto `Charges`, the library's
+  own `single_settle` refuses the build — reported with seed
+  attribution (``claim `pay::single_settle` violated``, never a
+  mangled symbol) and pointing at the library's own claim line.
+  Getting stricter as the world grows is the point: the claim
+  quantifies over whatever the merge added.
+- **The tier is the enforcement surface.** A seed swears about
+  *itself and its own boundary* — it can only name what it can
+  see: its own decls, its own imports. World-quantification stays
+  main's, and a seed that declares `main locus` writing the
+  top-level form is a check error. A dependency cannot brick a
+  downstream build with world-claims because it has no way to
+  state one.
+
+Claim names stay per-seed (`pay::single_settle` and your own
+`single_settle` coexist); group and topic references inside a
+traveling block canonicalize across the seed boundary exactly as
+group declarations do.
 
 ## The evaluation model
 

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -40,7 +40,17 @@ top_decl          = locus_decl
                   | ring_layout_decl
                   | target_decl
                   | group_decl
+                  | claims_block          (* #392: library tier *)
                   ;
+
+(* #392 thread 2 — a TOP-LEVEL claims_block is the LIBRARY tier: a
+   seed swears about itself and its own boundary, and the block
+   travels with the import, re-evaluating in every closing build
+   over the merged world (attributed `alias::name`). A seed that
+   declares `main locus` states its law inside that locus; its
+   writing the top-level form is a check error — the tier split is
+   the enforcement surface keeping world-claims out of
+   dependencies. *)
 
 (* GH #382 phase 1 — `group NAME = { member, ... };` declares claim
    vocabulary: a named set of declared program elements (loci, free

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -282,7 +282,26 @@ cannot disagree. The traversal substrate is already one engine
 shared fail-closed predicate); the annotation voices keep their
 diagnostics.
 
-Still later (#392): library-tier claims that travel with imports.
+**Library-tier claims** (#392 thread 2): a TOP-LEVEL `claims { }`
+block — legal outside any locus — is the LIBRARY tier: a seed
+swears about **itself and its own boundary**, the block travels
+with the import, and it re-evaluates in every closing build over
+the merged world. Checked standalone, a library's claims evaluate
+over its own world; at close, the same sentences quantify over
+everything the merge added — a second subscriber the app wires
+onto a library topic violates the library's own
+`count subscribers(topic T) <= 1`, reported with seed attribution
+(`pay::single_settle`, never a mangled symbol) and pointing at the
+library's own claim line. World-quantification stays main's: a
+seed that declares `main locus` states its law inside that locus,
+and its writing the top-level form is a check error. That tier
+split is the enforcement surface for "a dependency may not brick
+downstream builds with world-claims" — a library can only NAME
+what it can see (its own decls and its own imports), and its
+traveling block is marked at the mangle stage, which only ever
+touches imported seeds. Group and topic references inside a
+traveling block canonicalize to mangled decls exactly as group
+decls do (#334); claim names are never mangled.
 
 ## Structural & design rules
 


### PR DESCRIPTION
Stacked on #395. The two-tier scoping story from the #382 issue body, delivered.

## The feature

A library seed states its own law in a **top-level** `claims { }` block — no `main locus` required:

```hale
group settlers = { Wire };

claims {
    single_settle: count subscribers(topic Charges) <= 1;
    wired: require subscribes(some settlers, topic Charges);
}
```

- **The law travels.** Import the seed and its claims come along, re-evaluating in **every closing build** over the merged world. Checked standalone, the payments seed satisfies itself; when the app quietly wires a second subscriber onto `Charges` (legal bus plumbing), the library's own `single_settle` refuses the closing build:

  ```
  p.hl:19:5: type error: claim `pay::single_settle` violated: counted 2 subscriber(s)
  (`Audit`, `pay::Wire`) of `pay::Charges`, claim requires <= 1
  ```

  Seed-attributed name, demangled countermodel, and the span points at the **library's own claim line** (bundle-global spans + the file-base mapping make that exact).

- **The tier split is the enforcement surface** for the issue's open design question ("a dependency may not brick downstream builds with world-claims"): a seed swears about *itself and its own boundary* — it can only name what it can see, its own decls and imports. World-quantification stays main's, and a seed that declares `main locus` writing the top-level form is a check error.

## Mechanics worth reviewing

- The seed merge flattens imported items into the closing program, so syntactic position cannot tell a traveling library block from a closing seed's (illegal) top-level one. The marker is `ClaimsBlock.lib_tier`, set by the **mangle stage** — which by definition only touches imported seeds. Parse always produces `false`.
- The full #334 canonicalization set: `Mangler` rewrites the traveling block's group refs and single-segment topic refs to the mangled decls (or the vocabulary silently detaches at the merge); `QualifiedRenameApplier` collapses its qualified topic refs (factored helper shared with main-locus blocks); `remap_user_effects` covers `TopDecl::Claims` (a missed carrier silently aliases classes across seeds — the known trap).
- Claim names are never mangled; attribution is `alias::name`, so uniqueness is per seed and `pay::single_settle` coexists with your own `single_settle`.

## Evidence

- `xseed_library_claims.rs` + the `xseed-library-claims` fixture: standalone-holds control, the travel-and-refuse canary (attribution, demangled countermodel, library-line span, the satisfied sibling claim staying silent, no `__lib_` leakage).
- `library_claims.rs`: the closing-seed rejection; standalone library evaluation canary + control.
- Full suite 2236 green; `hale fmt --check` clean. Grammar (`top_decl` gains `claims_block`), spec § Claims, and a dedicated docs section land in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)