### PR TITLE
release: v0.15.0 — claims: the law travels, the witness says where

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.15.0 — claims: the law travels, the witness says where (2026-08-04)
 
 ### Library-tier claims: law that travels with an import (GH #392 thread 2)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "hale-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "hale-corpus",
  "hale-stdlib",
@@ -71,11 +71,11 @@ dependencies = [
 
 [[package]]
 name = "hale-corpus"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "hale-lsp"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -84,18 +84,18 @@ dependencies = [
 
 [[package]]
 name = "hale-stdlib"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "hale-syntax"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "hale-corpus",
 ]
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "hale-corpus",
  "hale-stdlib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
The #392 train as a release: interface-dispatch fan-out, the normalized model (witness provenance, phase relation, artifact schema 1.1), §8 lowered certificate rows + `@phase_effects` user classes, and library-tier claims.

One `release:` commit — root `Cargo.toml` 0.14.0 → 0.15.0, CHANGELOG `## Unreleased` → titled section, `cargo update -w`. Suite green on merged main (2236) before cutting.

Minor rather than patch, as discussed: new grammar surface (top-level `claims { }`), schema 1.0 → 1.1 means committed `.hale.topology` baselines need regeneration, and the soundness/closure changes can fail programs that certified under v0.14.0.

After merge I'll tag the merge commit `v0.15.0` (tag push triggers release.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)