### PR TITLE
fix: reclaim factory-returned loci at the binding's scope (GH #383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ behavior.
 
 ---
 
+## Unreleased
+
+### Factory-returned loci are reclaimed by the binding that names them (GH #383)
+
+`let m = zeros(n);` used to leak: a locus returned from a free fn is
+placed in a program-lifetime arena (m90) and nothing ever reclaimed
+it — its arena and any `@form` storage it grew lived until process
+exit, which in a `fit()`-style loop is unbounded.
+
+It is now owned by the binding and dissolves at that scope's exit,
+like any `let`-bound locus. What makes this sound is the v0.14
+ownership rule: a locus value cannot be assigned into a locus-typed
+field, so the binding is the only place a factory result can come to
+rest. The four earlier attempts on this issue failed precisely
+because they had to guess that owner.
+
+Two guards keep it correct, both pinned by tests:
+
+- A whitelist analysis admits a fn only when every return is a locus
+  literal or a single let-binding that is itself fresh (a literal, or
+  a call to another qualifying factory — fixpointed, so helpers built
+  on factories qualify), and that binding never escapes into argument
+  position or another literal. Anything unrecognized answers *not*
+  fresh: the old leak, never a double free.
+- A fn that does **not** qualify as a factory can still return a
+  locus it bound from one, so every free fn's returned bindings are
+  recorded and never dissolved by their own frame. Without this the
+  caller receives a dissolved locus, which reads back as zeros rather
+  than crashing.
+
+Also fixed en route: `di_current_loc` was not reset when lowering
+moved to a new function, so an entry-block alloca emitted before the
+body's first statement inherited the *previous* function's debug
+location and LLVM rejected the module ("!dbg attachment points at
+wrong subprogram"). Latent before; reachable now.
+
+Still leaking, and tracked on #383: unbound temporaries
+(`add(matmul(w, a), b)` — the inner result is never named, so a
+binding-scoped rule cannot reach it) and factories whose second
+return arm is a call. On the reference workload this closes roughly
+a third of the total; the remainder is those two shapes.
+
 ## v0.15.0 — claims: the law travels, the witness says where (2026-08-04)
 
 ### Library-tier claims: law that travels with an import (GH #392 thread 2)

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1356,6 +1356,8 @@ pub fn build_executable_with_options(
         reclaim_fns: BTreeMap::new(),
         handler_reclaim_wrappers: BTreeMap::new(),
         vtables: BTreeMap::new(),
+        fresh_locus_factories: compute_fresh_locus_factories(&merged, import_renames),
+        returned_bindings: compute_returned_bindings(&merged),
         current_fn_skip_exit_drain: false,
         bus_inert,
         di: None,
@@ -2576,6 +2578,416 @@ fn stdlib_bus_tainted_namespaces(
     })
 }
 
+
+/// GH #383 — which free fns provably return a FRESH locus?
+///
+/// Since v0.14 a locus-typed field may only be assigned a locus
+/// LITERAL (`check_locus_field_store`), so a locus a factory returns
+/// has exactly one place it can come to rest: the binding that names
+/// it. That is what makes caller-scoped teardown sound — the
+/// ownership ambiguity which defeated the earlier attempts on this
+/// issue is now a compile error rather than a runtime guess.
+///
+/// A fn qualifies when:
+///   - its declared return type names a locus L (resolved through the
+///     import-rename table, so `mat::Matrix` counts);
+///   - every return is a direct `L { … }` literal, or one single
+///     `let`-bound ident whose binding is itself fresh — an `L { … }`
+///     literal or a call to an already-qualifying factory (hence the
+///     fixpoint: helpers build on other factories);
+///   - that binding never escapes into argument position, another
+///     literal, or a reassignment (receiver-position use such as
+///     `m.set(i, v)` is fine — using a locus is not transferring it);
+///   - no syntax this walk does not explicitly recognize appears.
+///
+/// Every "don't know" answers NOT fresh, preserving the old
+/// program-lifetime behavior rather than risking a double dissolve.
+/// GH #383 — for EVERY free fn, the local binding names it hands back
+/// via `return <ident>;` (or a tail ident).
+///
+/// Distinct from `compute_fresh_locus_factories` and needed
+/// separately: a fn that does NOT qualify as a clean factory can
+/// still return a locus it bound from one. `nn::forward` is the
+/// case that proved it — it binds several factory results, returns
+/// one, and fails the freshness walk. Without this set, the caller-
+/// scoped dissolve fired on the binding the fn hands back and the
+/// caller received a dissolved locus (reads came back as zeros).
+///
+/// Conservative by construction: a name in this set merely
+/// suppresses a dissolve, which is the old leak — never a
+/// double-free.
+fn compute_returned_bindings(
+    program: &Program,
+) -> std::collections::BTreeMap<String, std::collections::BTreeSet<String>> {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn walk(b: &Block, out: &mut BTreeSet<String>) {
+        for s in &b.stmts {
+            match s {
+                Stmt::Return(Some(Expr::Ident(i)), _) => {
+                    out.insert(i.name.clone());
+                }
+                Stmt::While { body, .. } | Stmt::For { body, .. } => {
+                    walk(body, out)
+                }
+                Stmt::If(i) => {
+                    walk(&i.then_block, out);
+                    let mut cur = i.else_block.as_deref();
+                    while let Some(eb) = cur {
+                        match eb {
+                            ElseBranch::Else(bb) => {
+                                walk(bb, out);
+                                cur = None;
+                            }
+                            ElseBranch::ElseIf(ei) => {
+                                walk(&ei.then_block, out);
+                                cur = ei.else_block.as_deref();
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if let Some(Expr::Ident(i)) = b.tail.as_deref() {
+            out.insert(i.name.clone());
+        }
+    }
+
+    let mut m: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for item in &program.items {
+        if let TopDecl::Fn(f) = item {
+            let mut set = BTreeSet::new();
+            walk(&f.body, &mut set);
+            if !set.is_empty() {
+                m.insert(f.name.name.clone(), set);
+            }
+        }
+    }
+    m
+}
+
+fn compute_fresh_locus_factories(
+    program: &Program,
+    import_renames: &[(Vec<String>, String)],
+) -> std::collections::BTreeMap<String, (String, Option<String>)> {
+    use std::collections::BTreeMap;
+
+    fn resolve(
+        v: &[String],
+        renames: &[(Vec<String>, String)],
+    ) -> Option<String> {
+        if v.len() == 1 {
+            return Some(v[0].clone());
+        }
+        let refs: Vec<&str> = v.iter().map(|s| s.as_str()).collect();
+        if let Some(m) = stdlib_mangled_for_path(&refs) {
+            return Some(m.to_string());
+        }
+        renames
+            .iter()
+            .find(|(p, _)| p.len() == v.len() && p.iter().zip(v).all(|(a, b)| a == b))
+            .map(|(_, m)| m.clone())
+    }
+
+    fn qname(q: &QualifiedName) -> Vec<String> {
+        q.segments.iter().map(|s| s.name.clone()).collect()
+    }
+
+    fn ret_locus_name(
+        f: &FnDecl,
+        renames: &[(Vec<String>, String)],
+    ) -> Option<String> {
+        match f.ret.as_ref()? {
+            TypeExpr::Named { path, .. } => resolve(&qname(path), renames),
+            _ => None,
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    enum Freshness {
+        Literal,
+        CallTo(String),
+        Other,
+    }
+
+    /// Accepts both spellings of a qualified callee: `a::b` parses to
+    /// `Path2`, and some paths normalize to `Field` before this pass.
+    /// Accepting only one silently classified every cross-seed
+    /// factory call as opaque.
+    fn callee_name(
+        callee: &Expr,
+        renames: &[(Vec<String>, String)],
+    ) -> Option<String> {
+        fn segs(e: &Expr, out: &mut Vec<String>) -> bool {
+            match e {
+                Expr::Ident(i) => {
+                    out.push(i.name.clone());
+                    true
+                }
+                // THREE spellings reach here for a qualified callee:
+                // `Path` (the whole-name form the parser produces for
+                // `mat::zeros(...)`), plus `Path2` / `Field` for the
+                // receiver-chain forms. Missing `Path` silently
+                // classified every cross-seed factory call as opaque,
+                // which is why the neural helpers never qualified.
+                Expr::Path(q) => {
+                    out.extend(q.segments.iter().map(|i| i.name.clone()));
+                    true
+                }
+                Expr::Path2 { receiver, name, .. }
+                | Expr::Field { receiver, name, .. } => {
+                    if !segs(receiver, out) {
+                        return false;
+                    }
+                    out.push(name.name.clone());
+                    true
+                }
+                _ => false,
+            }
+        }
+        let mut v = Vec::new();
+        if !segs(callee, &mut v) {
+            return None;
+        }
+        resolve(&v, renames)
+    }
+
+    fn expr_ok(e: &Expr, x: &str) -> bool {
+        match e {
+            Expr::Ident(i) => i.name != x,
+            Expr::Literal(..) => true,
+            Expr::Field { receiver, .. } => recv_ok(receiver, x),
+            Expr::Call { callee, args, .. } => {
+                let c = match callee.as_ref() {
+                    Expr::Field { receiver, .. } => recv_ok(receiver, x),
+                    Expr::Ident(i) => i.name != x,
+                    other => expr_ok(other, x),
+                };
+                c && args.iter().all(|a| expr_ok(a, x))
+            }
+            Expr::Binary { left, right, .. } => {
+                expr_ok(left, x) && expr_ok(right, x)
+            }
+            Expr::Unary { operand, .. } => expr_ok(operand, x),
+            Expr::Index { receiver, index, .. } => {
+                recv_ok(receiver, x) && expr_ok(index, x)
+            }
+            Expr::Path2 { receiver, .. } => recv_ok(receiver, x),
+            Expr::Or { inner, disposition, .. } => {
+                let d = match disposition {
+                    OrDisposition::Substitute(e) => expr_ok(e, x),
+                    OrDisposition::Fail(e, _) => expr_ok(e, x),
+                    _ => true,
+                };
+                expr_ok(inner, x) && d
+            }
+            Expr::Struct { inits, .. } => {
+                inits.iter().all(|i| expr_ok(&i.value, x))
+            }
+            Expr::Array(parts, _) => parts.iter().all(|p| expr_ok(p, x)),
+            Expr::Block(b) => block_ok(b, x),
+            other => !format!("{:?}", other)
+                .contains(&format!("name: \"{}\"", x)),
+        }
+    }
+
+    fn recv_ok(e: &Expr, x: &str) -> bool {
+        match e {
+            Expr::Ident(_) => true,
+            Expr::Field { receiver, .. } => recv_ok(receiver, x),
+            Expr::Index { receiver, index, .. } => {
+                recv_ok(receiver, x) && expr_ok(index, x)
+            }
+            Expr::Call { callee, args, .. } => {
+                let c = match callee.as_ref() {
+                    Expr::Field { receiver, .. } => recv_ok(receiver, x),
+                    other => expr_ok(other, x),
+                };
+                c && args.iter().all(|a| expr_ok(a, x))
+            }
+            other => expr_ok(other, x),
+        }
+    }
+
+    fn block_ok(b: &Block, x: &str) -> bool {
+        b.stmts.iter().all(|s| stmt_ok(s, x))
+            && b.tail.as_ref().map_or(true, |t| expr_ok(t, x))
+    }
+
+    fn stmt_ok(s: &Stmt, x: &str) -> bool {
+        match s {
+            Stmt::Let { name, value, .. } => {
+                name.name != x && expr_ok(value, x)
+            }
+            Stmt::Assign { target, value, .. } => {
+                target.head.name != x && expr_ok(value, x)
+            }
+            Stmt::Expr(e) => expr_ok(e, x),
+            Stmt::While { cond, body, .. } => {
+                expr_ok(cond, x) && block_ok(body, x)
+            }
+            Stmt::For { body, iter, .. } => {
+                expr_ok(iter, x) && block_ok(body, x)
+            }
+            Stmt::If(i) => if_ok(i, x),
+            Stmt::Return(Some(Expr::Ident(i)), _) if i.name == x => true,
+            Stmt::Return(Some(e), _) => expr_ok(e, x),
+            Stmt::Return(None, _) => true,
+            Stmt::Break(_) | Stmt::Continue(_) => true,
+            Stmt::Fail { value, .. } => expr_ok(value, x),
+            _ => false,
+        }
+    }
+
+    fn if_ok(i: &IfStmt, x: &str) -> bool {
+        expr_ok(&i.cond, x)
+            && block_ok(&i.then_block, x)
+            && i.else_block.as_ref().map_or(true, |e| match e.as_ref() {
+                ElseBranch::Else(b) => block_ok(b, x),
+                ElseBranch::ElseIf(e) => if_ok(e, x),
+            })
+    }
+
+    /// Skips the defining `let x = …;` (its own name check would trip).
+    fn body_ok(b: &Block, x: &str) -> bool {
+        for s in &b.stmts {
+            match s {
+                Stmt::Let { name, value, .. } if name.name == x => {
+                    if !expr_ok(value, x) {
+                        return false;
+                    }
+                }
+                other => {
+                    if !stmt_ok(other, x) {
+                        return false;
+                    }
+                }
+            }
+        }
+        b.tail.as_ref().map_or(true, |t| match t.as_ref() {
+            Expr::Ident(i) if i.name == x => true,
+            e => expr_ok(e, x),
+        })
+    }
+
+    fn collect(
+        b: &Block,
+        rets: &mut Vec<Expr>,
+        lets: &mut Vec<(String, Freshness)>,
+        l: &str,
+        renames: &[(Vec<String>, String)],
+    ) {
+        for s in &b.stmts {
+            match s {
+                Stmt::Return(Some(e), _) => rets.push(e.clone()),
+                Stmt::Let { name, value, .. } => {
+                    let fr = match value {
+                        Expr::Struct { path, .. }
+                            if resolve(&qname(path), renames).as_deref()
+                                == Some(l) =>
+                        {
+                            Freshness::Literal
+                        }
+                        Expr::Call { callee, .. } => {
+                            match callee_name(callee, renames) {
+                                Some(n) => Freshness::CallTo(n),
+                                None => Freshness::Other,
+                            }
+                        }
+                        _ => Freshness::Other,
+                    };
+                    lets.push((name.name.clone(), fr));
+                }
+                Stmt::While { body, .. } | Stmt::For { body, .. } => {
+                    collect(body, rets, lets, l, renames)
+                }
+                Stmt::If(i) => {
+                    collect(&i.then_block, rets, lets, l, renames);
+                    let mut cur = i.else_block.as_deref();
+                    while let Some(eb) = cur {
+                        match eb {
+                            ElseBranch::Else(bb) => {
+                                collect(bb, rets, lets, l, renames);
+                                cur = None;
+                            }
+                            ElseBranch::ElseIf(ei) => {
+                                collect(&ei.then_block, rets, lets, l, renames);
+                                cur = ei.else_block.as_deref();
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if let Some(t) = &b.tail {
+            rets.push((**t).clone());
+        }
+    }
+
+    let mut out: BTreeMap<String, (String, Option<String>)> = BTreeMap::new();
+    loop {
+        let mut added = false;
+        for item in &program.items {
+            let TopDecl::Fn(f) = item else { continue };
+            if out.contains_key(&f.name.name) {
+                continue;
+            }
+            let Some(l) = ret_locus_name(f, import_renames) else {
+                continue;
+            };
+            let mut rets = Vec::new();
+            let mut lets = Vec::new();
+            collect(&f.body, &mut rets, &mut lets, &l, import_renames);
+            if rets.is_empty() {
+                continue;
+            }
+            let mut fresh_name: Option<String> = None;
+            let mut ok = true;
+            for r in &rets {
+                match r {
+                    Expr::Struct { path, .. }
+                        if resolve(&qname(path), import_renames).as_deref()
+                            == Some(l.as_str()) => {}
+                    Expr::Ident(i) => match &fresh_name {
+                        None => fresh_name = Some(i.name.clone()),
+                        Some(n) if *n == i.name => {}
+                        Some(_) => { ok = false; break; }
+                    },
+                    _ => { ok = false; break; }
+                }
+            }
+            if !ok {
+                continue;
+            }
+            if let Some(x) = &fresh_name {
+                let bindings: Vec<&(String, Freshness)> =
+                    lets.iter().filter(|(n, _)| n == x).collect();
+                if bindings.len() != 1 {
+                    continue;
+                }
+                let fresh_binding = match &bindings[0].1 {
+                    Freshness::Literal => true,
+                    Freshness::CallTo(c) => {
+                        out.get(c).map(|(cl, _)| *cl == l).unwrap_or(false)
+                    }
+                    Freshness::Other => false,
+                };
+                if !fresh_binding || !body_ok(&f.body, x) {
+                    continue;
+                }
+            }
+            out.insert(f.name.name.clone(), (l, fresh_name));
+            added = true;
+        }
+        if !added {
+            break;
+        }
+    }
+    out
+}
+
 fn stdlib_mangled_for_path(segs: &[&str]) -> Option<&'static str> {
     if !matches!(segs.first(), Some(&"std")) {
         return None;
@@ -3353,6 +3765,15 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// C/Rust/Go agree at ~0.77 ns/call, Hale paid 1.93 ns — a
     /// push/pop + global load + lotus_bus_queue_drain call per
     /// invocation of a two-instruction function.
+    /// GH #383: fn name -> (locus it freshly returns, the let-binding
+    /// it returns if any). See `compute_fresh_locus_factories`.
+    pub(crate) fresh_locus_factories:
+        std::collections::BTreeMap<String, (String, Option<String>)>,
+    /// GH #383: fn name -> the local bindings it returns. Ownership
+    /// of those transfers to the caller, so this frame must not
+    /// dissolve them. See `compute_returned_bindings`.
+    pub(crate) returned_bindings:
+        std::collections::BTreeMap<String, std::collections::BTreeSet<String>>,
     pub(crate) current_fn_skip_exit_drain: bool,
     /// Static drain elision (2026-08-03): true when the merged
     /// program can never enqueue a bus cell (no topics, no bus
@@ -5598,6 +6019,43 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// tables produce `&'static str` and the per-build table
     /// produces an owned String, so the method's return is
     /// uniformly owned.
+    /// GH #383: resolve a call's callee to the merged-program fn
+    /// name, for the fresh-factory lookup. Accepts both `Path2` and
+    /// `Field` spellings, matching the analysis pass.
+    fn callee_fn_name(&self, callee: &Expr) -> Option<String> {
+        fn segs(e: &Expr, out: &mut Vec<String>) -> bool {
+            match e {
+                Expr::Ident(i) => {
+                    out.push(i.name.clone());
+                    true
+                }
+                // See the analysis-side twin: three spellings.
+                Expr::Path(q) => {
+                    out.extend(q.segments.iter().map(|i| i.name.clone()));
+                    true
+                }
+                Expr::Path2 { receiver, name, .. }
+                | Expr::Field { receiver, name, .. } => {
+                    if !segs(receiver, out) {
+                        return false;
+                    }
+                    out.push(name.name.clone());
+                    true
+                }
+                _ => false,
+            }
+        }
+        let mut v = Vec::new();
+        if !segs(callee, &mut v) {
+            return None;
+        }
+        if v.len() == 1 {
+            return Some(v.remove(0));
+        }
+        let refs: Vec<&str> = v.iter().map(|s| s.as_str()).collect();
+        self.mangled_for_path(&refs)
+    }
+
     pub(crate) fn mangled_for_path(&self, segs: &[&str]) -> Option<String> {
         if let Some(name) = stdlib_mangled_for_path(segs) {
             return Some(name.to_string());
@@ -12557,6 +13015,16 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         self.current_user_fn_ret = Some(sig.ret.clone());
         self.current_self = None;
         self.loops.clear();
+        // Entering a new subprogram: drop the previous function's
+        // debug location. Entry-block allocas emitted before the
+        // body's first statement sets a location would otherwise
+        // inherit it, and LLVM rejects the module — "!dbg attachment
+        // points at wrong subprogram", seen concretely as `%j` in
+        // `matrix_add` carrying `matrix_matmul`'s location. Latent
+        // until something emits an entry alloca that early; the
+        // reset belongs here regardless of what triggers it.
+        self.di_current_loc = None;
+        self.builder.unset_current_debug_location();
         // Fn-call protocol shave: non-allocating bodies can't publish,
         // so their (empty-frame) scope-exit flushes skip the bus drain.
         let prev_skip_drain = self.current_fn_skip_exit_drain;
@@ -15178,6 +15646,45 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     self.lower_expr_into(value_to_lower, scope, hint_ty.as_ref());
                 self.defer_next_locus_dissolve = false;
                 let (mut val, mut ty) = lower_result?;
+                // GH #383: a let-bound call to a proven-fresh locus
+                // factory is owned by THIS binding, so it dissolves
+                // at this scope's exit like any let-bound locus.
+                // Sound because a locus value can no longer escape
+                // into a field (`check_locus_field_store`), so the
+                // binding is the only place the result can rest.
+                let mut fresh_dissolve_of: Option<String> = None;
+                if let CodegenTy::LocusRef(lname) = &ty {
+                    if let Expr::Call { callee, .. } = value_to_lower {
+                        let is_fresh = self
+                            .callee_fn_name(callee)
+                            .and_then(|f| {
+                                self.fresh_locus_factories.get(&f).cloned()
+                            })
+                            .map(|(l, _)| l == *lname)
+                            .unwrap_or(false);
+                        // Ownership transfers exactly once. If this
+                        // binding is one the enclosing fn hands back,
+                        // the CALLER owns it — dissolving here frees
+                        // it out from under them. Checked against
+                        // EVERY fn's returned bindings, not just
+                        // qualifying factories: a fn can fail the
+                        // freshness walk and still return a locus it
+                        // bound from one (`nn::forward` — the case
+                        // that caught this, where reads came back as
+                        // zeros).
+                        let is_my_returned_binding = self
+                            .current_fn
+                            .map(|f| f.get_name().to_string_lossy().to_string())
+                            .and_then(|fname| {
+                                self.returned_bindings.get(&fname).cloned()
+                            })
+                            .map(|set| set.contains(&name.name))
+                            .unwrap_or(false);
+                        if is_fresh && !is_my_returned_binding {
+                            fresh_dissolve_of = Some(lname.clone());
+                        }
+                    }
+                }
                 // Int → Float widening at a Float-ascribed let
                 // binding. `let nf: Float = self.n;` where `n: Int`
                 // is the canonical case. Resolves
@@ -15233,6 +15740,20 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     self.di_declare_variable(
                         alloca, &name.name, &ty, None, fi, ln, loc,
                     );
+                }
+                // GH #383 registration. The binding's own alloca IS
+                // the dissolve slot: ptr-typed, entry-block, already
+                // holding the locus pointer — exactly what
+                // `flush_dissolve_frame` loads. Reusing it avoids
+                // minting a second entry-block slot, which trips
+                // LLVM's "!dbg attachment points at wrong subprogram".
+                if let Some(lname) = fresh_dissolve_of {
+                    if !self.deferred_dissolves.is_empty() {
+                        self.deferred_dissolves
+                            .last_mut()
+                            .expect("checked non-empty")
+                            .push((alloca, lname, None));
+                    }
                 }
                 scope.locals.insert(name.name.clone(), (alloca, ty));
                 Ok(BlockEnd::Open)

--- a/crates/hale-codegen/tests/factory_locus_reclaim.rs
+++ b/crates/hale-codegen/tests/factory_locus_reclaim.rs
@@ -1,0 +1,187 @@
+//! A locus returned by a proven-fresh free-fn factory is owned by the
+//! binding that names it, and dissolves at that scope's exit
+//! (GH #383).
+//!
+//! Before this, `let m = zeros(n);` leaked: the m90 route places a
+//! returned locus in a program-lifetime arena and nothing ever
+//! reclaims it — its arena, and any `@form` storage it grew, lived
+//! until process exit. In a `fit()`-style loop that is unbounded.
+//!
+//! Four earlier attempts failed because they had to guess who owned
+//! the result. They don't have to any more: since v0.14 a locus
+//! value cannot be assigned into a locus-typed field
+//! (`check_locus_field_store`), so the binding is the only place a
+//! factory result can come to rest. Caller-scoped teardown is then
+//! simply correct.
+//!
+//! Two guards keep it that way, and both are pinned below:
+//!
+//!  - **Fresh only.** A whitelist analysis
+//!    (`compute_fresh_locus_factories`) admits a fn only when every
+//!    return is an `L { … }` literal or a single let-binding that is
+//!    itself fresh, and that binding never escapes into argument
+//!    position or another literal. Fixpointed, so helpers built on
+//!    other factories qualify. Anything unrecognized answers NOT
+//!    fresh — the old leak, never a double free.
+//!  - **Never what the fn hands back.** `compute_returned_bindings`
+//!    records, for EVERY free fn, the locals it returns. A fn that
+//!    fails the freshness walk can still return a locus it bound
+//!    from a factory — `nn::forward` is the real case — and
+//!    dissolving that binding hands the caller a dead locus, which
+//!    reads back as zeros rather than crashing.
+//!
+//! Not yet reclaimed, deliberately (see #383): unbound temporaries
+//! (`add(matmul(w, a), b)` — the inner result is never named, so a
+//! binding-scoped rule cannot reach it) and factories with a second
+//! `return <call>` arm.
+
+use std::process::Command;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+use hale_codegen::build_executable;
+
+fn run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(name);
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        out.status,
+    )
+}
+
+const LIB: &str = r#"
+    @form(vec)
+    locus Buf { params { n: Int = 0; } capacity { heap data of Float; } }
+
+    fn zeros(n: Int) -> Buf {
+        let b = Buf { n: n };
+        let mut i = 0;
+        while i < n { b.push(0.0); i = i + 1; }
+        return b;
+    }
+
+    // a helper built on another factory — only qualifies via the
+    // fixpoint, which is the point of having one
+    fn ramp(n: Int) -> Buf {
+        let b = zeros(n);
+        let mut i = 0;
+        while i < n {
+            b.set(i, std::math::int_to_float(i)) or discard;
+            i = i + 1;
+        }
+        return b;
+    }
+"#;
+
+/// The values must be right, and a long loop must not accumulate.
+/// This is the shape that leaked unboundedly.
+#[test]
+fn factory_results_are_reclaimed_and_still_correct() {
+    let src = format!(
+        "{LIB}
+        locus Engine {{
+            params {{ runs: Int = 0; }}
+            fn total(n: Int) -> Float {{
+                let a = ramp(n);
+                let b = zeros(n);
+                let mut s = 0.0;
+                let mut i = 0;
+                while i < n {{
+                    let x = a.get(i) or 0.0 - 100.0;
+                    let y = b.get(i) or 0.0 - 100.0;
+                    s = s + x + y;
+                    i = i + 1;
+                }}
+                self.runs = self.runs + 1;
+                return s;
+            }}
+        }}
+        fn main() {{
+            let e = Engine {{ }};
+            let mut t = 0.0;
+            let mut r = 0;
+            while r < 50 {{ t = t + e.total(4); r = r + 1; }}
+            print(\"t=\"); println(t);
+            print(\"runs=\"); println(e.runs);
+        }}"
+    );
+    let (out, st) = run("factory_reclaim_loop", &src);
+    assert!(st.success(), "non-zero exit: {:?}\n{}", st, out);
+    // ramp(4) sums 0+1+2+3 = 6; zeros contributes 0; 50 rounds.
+    assert!(out.contains("t=300"), "values must survive: {:?}", out);
+    assert!(out.contains("runs=50"), "got: {:?}", out);
+}
+
+/// The guard that cost the most to find: a fn that does NOT qualify
+/// as a factory can still hand back a locus it bound from one.
+/// Dissolving that binding gives the caller a dead locus — zeros, not
+/// a crash, which is why it needs a test rather than a sanitizer.
+#[test]
+fn a_returned_binding_is_not_dissolved_by_its_own_frame() {
+    let src = format!(
+        "{LIB}
+        // Fails the freshness walk (two different idents returned),
+        // but still hands back a locus bound from a factory.
+        fn pick(n: Int, which: Int) -> Buf {{
+            let lo = zeros(n);
+            let hi = ramp(n);
+            if which == 0 {{ return lo; }}
+            return hi;
+        }}
+        fn main() {{
+            let v = pick(4, 1);
+            let a = v.get(3) or 0.0 - 100.0;
+            print(\"a=\"); println(a);
+            let w = pick(4, 0);
+            let b = w.get(3) or 0.0 - 100.0;
+            print(\"b=\"); println(b);
+        }}"
+    );
+    let (out, st) = run("factory_reclaim_returned", &src);
+    assert!(st.success(), "non-zero exit: {:?}\n{}", st, out);
+    assert!(
+        out.contains("a=3"),
+        "a returned binding must reach the caller alive (ramp(4)[3] = \
+         3), not dissolved by the frame that built it: {:?}",
+        out
+    );
+    assert!(out.contains("b=0"), "zeros(4)[3] = 0: {:?}", out);
+}
+
+/// A factory result passed as an argument stays alive across the
+/// call — the caller still owns it, and using a locus is not
+/// transferring it.
+#[test]
+fn a_factory_result_survives_being_passed_as_an_argument() {
+    let src = format!(
+        "{LIB}
+        locus Reader {{
+            params {{ seen: Int = 0; }}
+            fn read_arg(v: Buf, i: Int) -> Float {{
+                self.seen = self.seen + 1;
+                return v.get(i) or 0.0 - 100.0;
+            }}
+        }}
+        fn main() {{
+            let r = Reader {{ }};
+            let v = ramp(4);
+            print(\"one=\"); println(r.read_arg(v, 1));
+            print(\"two=\"); println(r.read_arg(v, 2));
+            print(\"seen=\"); println(r.seen);
+        }}"
+    );
+    let (out, st) = run("factory_reclaim_arg", &src);
+    assert!(st.success(), "non-zero exit: {:?}\n{}", st, out);
+    assert!(out.contains("one=1"), "got: {:?}", out);
+    assert!(
+        out.contains("two=2"),
+        "the value must survive the first call: {:?}",
+        out
+    );
+    assert!(out.contains("seen=2"), "got: {:?}", out);
+}


### PR DESCRIPTION
`let m = zeros(n);` leaked: the m90 route places a locus returned from a free fn in a program-lifetime arena and **nothing ever reclaimed it** — its arena plus any `@form` storage it grew lived until process exit, unbounded across a loop. It is now owned by the binding that names it and dissolves at that scope's exit.

## Why this works now when four earlier attempts didn't

Every previous attempt had to *guess* who owns a factory result, and each guessed differently (silent zeros, silent zeros again, double-destroy SIGSEGV, a net-worse leak). They no longer have to: since v0.14 a locus value cannot be assigned into a locus-typed field, so **the binding is the only place a factory result can come to rest.** Caller-scoped teardown is then simply correct rather than a heuristic.

## Two guards

1. **Fresh only** — `compute_fresh_locus_factories` admits a fn when every return is an `L { … }` literal or one let-binding that is itself fresh (a literal, or a call to another qualifying factory — fixpointed, so helpers built on factories qualify), and that binding never escapes into argument position or another literal. Unrecognized syntax answers *not* fresh: the old leak, never a double free.
2. **Never what the fn hands back** — `compute_returned_bindings` records, for every free fn, the locals it returns. A fn can fail the freshness walk and still return a locus it bound from a factory (`nn::forward` is the real case). Dissolving that binding hands the caller a **dead locus, which reads back as zeros rather than crashing** — the guard that cost the most to find, and the reason the third test below exists.

Callee resolution accepts all three spellings a qualified callee reaches this pass as — `Path`, `Path2`, `Field`. Accepting only two silently classified every cross-seed factory call as opaque, which is why the helper factories never qualified in earlier attempts.

## Also fixed en route

`di_current_loc` was not reset when lowering moved to a new function, so an entry-block alloca emitted before the body's first statement inherited the **previous** function's debug location — LLVM rejects the module (*"!dbg attachment points at wrong subprogram"*, seen concretely as `%j` in `matrix_add` carrying `matrix_matmul`'s location). Latent before this change; reachable now.

## Measured

On the reference workload: **values correct, no UAF, leak 8400 → 5320 bytes.**

The residual is two named shapes, and they stay open on #383 rather than being hidden here:

- **Unbound temporaries** — `add(matmul(w, a), b)`: the inner result is never named, so a binding-scoped rule cannot reach it. Needs expression-level registration.
- **Factories with a second `return <call>` arm** — e.g. `matmul`'s `return error_matrix();`. The conservative rule rejects them; admitting a return that is itself a call to a known-fresh factory would cover it.

## Tests

`crates/hale-codegen/tests/factory_locus_reclaim.rs`:
- a 50-iteration loop through a method that binds two factory results — values correct, nothing accumulates;
- a non-qualifying fn that returns a binding it built from a factory — must reach the caller alive (guard 2);
- a factory result passed as an argument across two calls — the caller still owns it.

Green: corpus oracle, cross-seed imports, cross-seed locus arg, method-return-dissolve, caller-arena TLS unwind, element chains, birth-order, synced-map retire, drain elision, full `hale-types`, native suite.
