### PR TITLE
The per-topic observation identity, pinned and exported (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ behavior.
 
 ---
 
+## Unreleased
+
+### The per-topic observation identity, pinned and exported (GH #399)
+
+The observer protocol's open item — "exact shape_hash definition,
+needs the canonicalization pinned down with the hale team" — is
+closed, and the reconciliation ruling with it:
+
+- **One implementation.** `hale_types::topic_identity` owns the
+  wire-subject rule (parent-joined `subject:` dot-path, declared
+  name as fallback), the canonical payload shape (`field:tag`
+  list, tags `i f b d t u s y struct`, name-free for compounds;
+  empty for non-struct payloads), and the hash (FNV-1a/64 over
+  `subject ++ ':' ++ shape`). Codegen now calls it for both bus
+  routing and observer shape registration; the pinned test vectors
+  are wire contract.
+- **Emitter fix.** Shape registration previously keyed by the
+  UNJOINED declared subject while publish-side manifest rows key
+  by the parent-joined wire subject — a parented topic's manifest
+  row hashed the empty shape. Registration now uses the joined
+  subject, so parented topics' identities include their payload
+  shape. (Manifest hashes for parented topics change.)
+- **Artifact schema 1.2 — the join document.** The topology
+  artifact gains an unhashed `topics` section: per topic, the
+  author-spelled name, the RAW wire subject (byte-exact manifest
+  join key — a subject-less imported topic registers under its
+  mangled local name; declare `subject:` on shared topics to fuse
+  across binaries), the canonical shape, and `payload_hash`. A
+  recording/WAL segment carrying `(name, shape_hash)` matches a
+  row and names the exact checked topology it ran under. The
+  ruling is REFERENCE, not fusion: payload field shape does not
+  affect claim evaluation, so the model `shape_hash` is unchanged
+  — a payload field edit changes the topic row and no model
+  identity (pinned by test).
+
+Protocol: iris PROTOCOL.md §4 (definition + vectors; open item
+struck). Spec: `spec/verification.md` § Claims. Docs: the claims
+chapter's artifact section. Tests: `topic_identity` unit vectors,
+`topology_v2.rs` identity row + hash-separation canary.
+
+---
+
 ## v0.15.0 — claims: the law travels, the witness says where (2026-08-04)
 
 ### Library-tier claims: law that travels with an import (GH #392 thread 2)

--- a/crates/hale-cli/tests/topology_v2.rs
+++ b/crates/hale-cli/tests/topology_v2.rs
@@ -219,3 +219,47 @@ fn main() { Engine { }; }
         art
     );
 }
+
+/// #399 — the per-topic observation identity: the artifact's
+/// `topics` rows carry the same (subject, shape, hash) the runtime
+/// manifest fuses on, so a WAL segment names the checked topology.
+/// The hash vector here is the protocol's (PROTOCOL.md §4);
+/// changing it is a wire break.
+#[test]
+fn the_artifact_exports_the_observation_identity() {
+    let src = r#"
+type Task { id: Int; label: String; }
+topic Tasks { payload: Task; }
+locus A {
+    bus { publish Tasks; }
+    fn go(n: Int) { Tasks <- Task { id: n, label: "t" }; }
+}
+fn main() { A { }; }
+"#;
+    let art = dump(src, "obs_identity");
+    assert!(
+        art.contains(
+            r#"{"name": "Tasks", "subject": "Tasks", "shape": "id:i;label:s", "payload_hash": "f7d174542aa33437"}"#
+        ),
+        "the topics row must carry the protocol-vector identity:\n{}",
+        art
+    );
+    // Unhashed: an edit to a payload FIELD changes the topic row
+    // but must not change the model shape identity (topology is
+    // unchanged).
+    let renamed = src
+        .replace("label: String", "tag: String")
+        .replace("label: \"t\"", "tag: \"t\"");
+    let a = dump(src, "obs_identity_a");
+    let b = dump(&renamed, "obs_identity_b");
+    assert_ne!(
+        a.lines().find(|l| l.contains("payload_hash")),
+        b.lines().find(|l| l.contains("payload_hash")),
+        "a payload field edit must change the observation identity"
+    );
+    assert_eq!(
+        shape_hash(&a),
+        shape_hash(&b),
+        "a payload field edit must NOT change the model shape_hash"
+    );
+}

--- a/crates/hale-cli/tests/xseed_claims_verbs.rs
+++ b/crates/hale-cli/tests/xseed_claims_verbs.rs
@@ -63,7 +63,7 @@ fn cover_catches_an_uncovered_topic_across_seeds() {
 fn the_topology_artifact_round_trips() {
     let (dump, _ok) = check(&["--dump-topology"]);
     assert!(
-        dump.contains("\"schema\": \"1.1\"")
+        dump.contains("\"schema\": \"1.2\"")
             && dump.contains("\"shape_hash\": \""),
         "the artifact must carry schema + shape_hash:\n{}",
         dump
@@ -88,9 +88,33 @@ fn the_topology_artifact_round_trips() {
         "the artifact must record the holding claims too:\n{}",
         dump
     );
+    // #399: the `topics` section's `subject` field is deliberately
+    // RAW — it is the byte-exact join key with the runtime
+    // manifest (the hash is computed over it), and a subject-less
+    // imported topic really does register under its mangled local
+    // name (the artifact exposing that non-portable identity is
+    // the point; declare `subject:` to fuse across binaries).
+    // Everything OUTSIDE that section stays author-spelled.
+    let without_topics: String = {
+        let mut skip = false;
+        dump.lines()
+            .filter(|l| {
+                if l.starts_with("  \"topics\": [") {
+                    skip = true;
+                }
+                let keep = !skip;
+                if skip && l.starts_with("  ],") {
+                    skip = false;
+                }
+                keep
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
     assert!(
-        !dump.contains("__lib_"),
-        "the artifact must be in author spelling:\n{}",
+        !without_topics.contains("__lib_"),
+        "the artifact (outside the raw-subject topics section) must \
+         be in author spelling:\n{}",
         dump
     );
 

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -411,24 +411,6 @@ fn bce_ifstmt_safe(ifs: &IfStmt, vkey: &BceVecKey, var: &str) -> bool {
 
 /// True iff evaluating `expr` cannot mutate vec `vkey` (nor pass
 /// `self`/V by-reference somewhere that could). Default-bail.
-/// iris handoff-2 P6: coarse, stable field-type tags for the
-/// canonical topic shape string. Deliberately name-free for
-/// nested user types ("struct") so the hash never depends on a
-/// declaring binary's local type names.
-fn obs_shape_tag(ty: &CodegenTy) -> &'static str {
-    match ty {
-        CodegenTy::Int => "i",
-        CodegenTy::Float => "f",
-        CodegenTy::Bool => "b",
-        CodegenTy::Decimal => "d",
-        CodegenTy::Time => "t",
-        CodegenTy::Duration => "u",
-        CodegenTy::String | CodegenTy::StringView => "s",
-        CodegenTy::Bytes | CodegenTy::BytesView => "y",
-        _ => "struct",
-    }
-}
-
 fn bce_expr_safe(expr: &Expr, vkey: &BceVecKey, var: &str) -> bool {
     // A bare occurrence of V anywhere OTHER than as the receiver of a
     // read-only method call (handled in `bce_call_safe`, which does
@@ -8109,46 +8091,33 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // per topic, consulted lazily if/when observation
         // initializes.
         if !self.is_wasm {
+            // #399: subject and shape both come from the SHARED
+            // identity implementation (`hale_types::topic_identity`),
+            // which the topology artifact also exports — the manifest
+            // a consumer fuses on and the artifact a reviewer commits
+            // cannot drift. Using the parent-JOINED wire subject here
+            // also fixes a registration miss: publish-side manifest
+            // rows key by the joined dot-path, so a parented topic's
+            // shape registered under its bare subject was never found
+            // and its manifest row hashed the empty shape.
+            let wire = hale_types::topic_identity::topic_wire_subjects(
+                &self.program.items,
+            );
             let shapes: Vec<(String, String)> = self
                 .program
                 .items
                 .iter()
                 .filter_map(|it| match it {
                     TopDecl::Topic(t) => {
-                        let subj = t
-                            .subject
-                            .clone()
+                        let subj = wire
+                            .get(&t.name.name)
+                            .cloned()
                             .unwrap_or_else(|| t.name.name.clone());
-                        let shape = match &t.payload {
-                            TypeExpr::Named { path, generic_args, .. }
-                                if path.segments.len() == 1
-                                    && generic_args.is_empty() =>
-                            {
-                                self.user_types
-                                    .get(&path.segments[0].name)
-                                    .map(|ti| {
-                                        ti.field_order
-                                            .iter()
-                                            .filter_map(|f| {
-                                                ti.fields.get(f).map(
-                                                    |(_, fty)| {
-                                                        format!(
-                                                            "{}:{}",
-                                                            f,
-                                                            obs_shape_tag(
-                                                                fty
-                                                            )
-                                                        )
-                                                    },
-                                                )
-                                            })
-                                            .collect::<Vec<_>>()
-                                            .join(";")
-                                    })
-                                    .unwrap_or_default()
-                            }
-                            _ => String::new(),
-                        };
+                        let shape = hale_types::topic_identity::
+                            canonical_topic_shape(
+                                &self.program.items,
+                                t,
+                            );
                         Some((subj, shape))
                     }
                     _ => None,
@@ -10000,54 +9969,13 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         items: &[TopDecl],
         out: &mut BTreeMap<String, String>,
     ) {
-        // First gather raw (name → (parent, subject)) pairs.
-        struct Raw {
-            parent: Option<String>,
-            subject: String,
-        }
-        let mut raw: BTreeMap<String, Raw> = BTreeMap::new();
-        fn walk(items: &[TopDecl], raw: &mut BTreeMap<String, Raw>) {
-            for item in items {
-                match item {
-                    TopDecl::Topic(t) => {
-                        raw.insert(
-                            t.name.name.clone(),
-                            Raw {
-                                parent: t.parent.as_ref().map(|i| i.name.clone()),
-                                subject: t
-                                    .subject
-                                    .clone()
-                                    .unwrap_or_else(|| t.name.name.clone()),
-                            },
-                        );
-                    }
-                    TopDecl::Module(m) => walk(&m.items, raw),
-                    _ => {}
-                }
-            }
-        }
-        walk(items, &mut raw);
-
-        for (name, r) in raw.iter() {
-            let mut chain: Vec<String> = vec![r.subject.clone()];
-            let mut visited: Vec<String> = vec![name.clone()];
-            let mut cur = r.parent.clone();
-            while let Some(p) = cur {
-                if visited.contains(&p) {
-                    break;
-                }
-                visited.push(p.clone());
-                match raw.get(&p) {
-                    Some(pr) => {
-                        chain.push(pr.subject.clone());
-                        cur = pr.parent.clone();
-                    }
-                    None => break,
-                }
-            }
-            chain.reverse();
-            out.insert(name.clone(), chain.join("."));
-        }
+        // #399: the rule moved to `hale_types::topic_identity` so
+        // bus routing, observer shape registration, and the
+        // topology artifact's exported identity all read ONE
+        // implementation.
+        out.extend(hale_types::topic_identity::topic_wire_subjects(
+            items,
+        ));
     }
 
     fn emit_arena_destroy(&mut self) -> Result<(), CodegenError> {

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -30,6 +30,7 @@ pub mod frontier;
 pub mod check;
 pub mod claims;
 pub mod model;
+pub mod topic_identity;
 pub mod topology;
 pub mod stdlib_bodies;
 pub mod stdlib_surface;

--- a/crates/hale-types/src/topic_identity.rs
+++ b/crates/hale-types/src/topic_identity.rs
@@ -1,0 +1,277 @@
+//! #399 — the per-topic observation identity, in ONE place.
+//!
+//! The observer protocol (iris PROTOCOL.md §4) fuses topics across
+//! binaries on `(name, shape_hash)` where `shape_hash` is a content
+//! hash of the topic's wire subject plus its canonical payload
+//! shape. Three parties must compute the SAME value: the native
+//! emitter (codegen registers shapes at startup;
+//! `lotus_obs.c::obs_fnv` hashes them), library emitters in other
+//! languages, and — since #399 — the topology artifact, which
+//! exports the identity so a recording/WAL segment can name the
+//! exact checked topology it ran under.
+//!
+//! This module is the single Rust implementation. Codegen calls it
+//! for both the wire-subject rule and the shape string, so the
+//! artifact and the emitted binary cannot drift; the C hasher is a
+//! byte-for-byte mirror of [`topic_shape_hash`], pinned by the
+//! protocol's test vectors.
+//!
+//! The definition (mirrored in PROTOCOL.md §4):
+//!
+//!  * **wire subject** — the parent-joined dot-path of declared
+//!    `subject:` values, child-last; a topic without `subject:`
+//!    contributes its declared NAME, as written. Only explicitly
+//!    declared subjects are stable across binaries (a name
+//!    fallback carries the declaring binary's local — possibly
+//!    mangled — spelling); shared topics should declare one.
+//!  * **canonical shape** — for a payload written as a bare,
+//!    non-generic named struct: the struct's fields in declaration
+//!    order as `<field>:<tag>` joined by `;`. Tags: `i` Int/Uint,
+//!    `f` Float, `b` Bool, `d` Decimal, `t` Time, `u` Duration,
+//!    `s` String/StringView, `y` Bytes/BytesView/BytesMut,
+//!    `struct` anything else (nested structs deliberately
+//!    name-free so the hash never depends on a declaring binary's
+//!    local type names). Any other payload form hashes the EMPTY
+//!    shape.
+//!  * **hash** — FNV-1a/64 (offset 0xcbf29ce484222325, prime
+//!    0x100000001b3) over the subject bytes, one `:` byte, the
+//!    shape bytes.
+
+use std::collections::BTreeMap;
+
+use hale_syntax::ast::*;
+
+/// Every declared topic's wire subject: parent-joined `subject:`
+/// dot-path (fallback: the declared name), child-last, cycle-safe.
+/// Moved from codegen's `collect_topic_wire_subjects` — bus
+/// routing, observer registration, and the artifact all read THIS
+/// rule.
+pub fn topic_wire_subjects(
+    items: &[TopDecl],
+) -> BTreeMap<String, String> {
+    struct Raw {
+        parent: Option<String>,
+        subject: String,
+    }
+    let mut raw: BTreeMap<String, Raw> = BTreeMap::new();
+    fn walk(items: &[TopDecl], raw: &mut BTreeMap<String, Raw>) {
+        for item in items {
+            match item {
+                TopDecl::Topic(t) => {
+                    raw.insert(
+                        t.name.name.clone(),
+                        Raw {
+                            parent: t
+                                .parent
+                                .as_ref()
+                                .map(|i| i.name.clone()),
+                            subject: t
+                                .subject
+                                .clone()
+                                .unwrap_or_else(|| t.name.name.clone()),
+                        },
+                    );
+                }
+                TopDecl::Module(m) => walk(&m.items, raw),
+                _ => {}
+            }
+        }
+    }
+    walk(items, &mut raw);
+
+    let mut out = BTreeMap::new();
+    for (name, r) in raw.iter() {
+        let mut chain: Vec<String> = vec![r.subject.clone()];
+        let mut visited: Vec<String> = vec![name.clone()];
+        let mut cur = r.parent.clone();
+        while let Some(p) = cur {
+            if visited.contains(&p) {
+                break;
+            }
+            visited.push(p.clone());
+            match raw.get(&p) {
+                Some(pr) => {
+                    chain.push(pr.subject.clone());
+                    cur = pr.parent.clone();
+                }
+                None => break,
+            }
+        }
+        chain.reverse();
+        out.insert(name.clone(), chain.join("."));
+    }
+    out
+}
+
+/// The canonical payload shape for one topic decl, per the pinned
+/// definition. Empty string for every payload form that is not a
+/// bare, non-generic named struct.
+pub fn canonical_topic_shape(
+    items: &[TopDecl],
+    topic: &TopicDecl,
+) -> String {
+    // Type decls by name, modules included, for struct lookup and
+    // alias resolution.
+    let mut types: BTreeMap<&str, &TypeDecl> = BTreeMap::new();
+    fn collect<'a>(
+        items: &'a [TopDecl],
+        out: &mut BTreeMap<&'a str, &'a TypeDecl>,
+    ) {
+        for item in items {
+            match item {
+                TopDecl::Type(t) => {
+                    out.insert(t.name.name.as_str(), t);
+                }
+                TopDecl::Module(m) => collect(&m.items, out),
+                _ => {}
+            }
+        }
+    }
+    collect(items, &mut types);
+
+    let TypeExpr::Named { path, generic_args, .. } = &topic.payload
+    else {
+        return String::new();
+    };
+    if path.segments.len() != 1 || !generic_args.is_empty() {
+        return String::new();
+    }
+    let Some(td) = types.get(path.segments[0].name.as_str()) else {
+        return String::new();
+    };
+    let TypeDeclBody::Struct(fields) = &td.body else {
+        return String::new();
+    };
+    fields
+        .iter()
+        .map(|f| format!("{}:{}", f.name.name, field_tag(&f.ty)))
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+/// One field's coarse tag. Deliberately name-free for anything
+/// compound (nested structs, arrays, tuples), so the hash never
+/// depends on a declaring binary's local type names.
+fn field_tag(ty: &TypeExpr) -> &'static str {
+    match ty {
+        TypeExpr::Primitive(p, _) => match p {
+            PrimType::Int | PrimType::Uint => "i",
+            PrimType::Float => "f",
+            PrimType::Bool => "b",
+            PrimType::Decimal => "d",
+            PrimType::Time => "t",
+            PrimType::Duration => "u",
+            PrimType::String | PrimType::StringView => "s",
+            PrimType::Bytes
+            | PrimType::BytesView
+            | PrimType::BytesMut => "y",
+        },
+        _ => "struct",
+    }
+}
+
+/// FNV-1a/64 over `subject ++ ':' ++ shape` — the byte-for-byte
+/// mirror of `lotus_obs.c::obs_fnv`. The `:` separator is hashed
+/// unconditionally (an empty shape still contributes it), exactly
+/// as the C does.
+pub fn topic_shape_hash(subject: &str, shape: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    let mut eat = |b: u8| {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    };
+    for b in subject.bytes() {
+        eat(b);
+    }
+    eat(b':');
+    for b in shape.bytes() {
+        eat(b);
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hale_syntax::parse_source;
+
+    fn subjects_and(
+        src: &str,
+    ) -> (Vec<TopDecl>, BTreeMap<String, String>) {
+        let p = parse_source(src).expect("parse");
+        let subs = topic_wire_subjects(&p.items);
+        (p.items, subs)
+    }
+
+    /// The protocol's test vectors (PROTOCOL.md §4). Changing any
+    /// of these values is a wire-protocol break.
+    #[test]
+    fn the_protocol_vectors_hold() {
+        let src = r#"
+            type Task { id: Int; label: String; }
+            topic Tasks { payload: Task; }
+        "#;
+        let (items, subs) = subjects_and(src);
+        assert_eq!(subs["Tasks"], "Tasks");
+        let topic = items
+            .iter()
+            .find_map(|i| match i {
+                TopDecl::Topic(t) => Some(t),
+                _ => None,
+            })
+            .unwrap();
+        let shape = canonical_topic_shape(&items, topic);
+        assert_eq!(shape, "id:i;label:s");
+        assert_eq!(
+            format!("{:016x}", topic_shape_hash("Tasks", &shape)),
+            "f7d174542aa33437"
+        );
+        // The empty-shape vector: a subject with no resolvable
+        // struct payload still hashes subject + ':'.
+        assert_eq!(
+            format!("{:016x}", topic_shape_hash("Tasks", "")),
+            "f3573379dcc4dcd5"
+        );
+    }
+
+    /// Parent-joined subjects: the child's wire subject is the
+    /// dot-path, and THAT is what the identity hashes — the
+    /// unjoined declared subject is not an identity.
+    #[test]
+    fn parented_subjects_join_child_last() {
+        let src = r#"
+            type M { n: Int; }
+            topic Org { payload: M; subject: "org"; }
+            topic Metrics : Org {
+                payload: M;
+                subject: "metrics";
+            }
+        "#;
+        let (_items, subs) = subjects_and(src);
+        assert_eq!(subs["Metrics"], "org.metrics");
+        assert_eq!(subs["Org"], "org");
+    }
+
+    /// Nested structs are name-free — a compound field is `struct`
+    /// regardless of what the declaring binary calls it.
+    #[test]
+    fn nested_structs_are_name_free() {
+        let src = r#"
+            type Inner { a: Bool; }
+            type Payload { id: Int; body: Inner; }
+            topic T { payload: Payload; }
+        "#;
+        let (items, _) = subjects_and(src);
+        let topic = items
+            .iter()
+            .find_map(|i| match i {
+                TopDecl::Topic(t) => Some(t),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(
+            canonical_topic_shape(&items, topic),
+            "id:i;body:struct"
+        );
+    }
+}

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -20,7 +20,14 @@
 //!
 //! Names render in AUTHOR spelling (cross-seed symbols demangled)
 //! — an artifact naming `__lib_lib_delta_d_Triage` points at
-//! something that appears nowhere in anyone's source.
+//! something that appears nowhere in anyone's source. ONE
+//! exception (#399): the `topics` section's `subject` field is the
+//! byte-exact runtime-manifest join key and stays RAW — a
+//! subject-less imported topic really does register under its
+//! mangled local name, and the artifact exposing that
+//! non-portable identity is deliberate (declare `subject:` on
+//! shared topics to fuse across binaries). Each row carries the
+//! author-spelled `name` beside it.
 //!
 //! Consumed by `hale check <t> --dump-topology` and diffed by
 //! `--check-topology <path>` — the `.hale.effects` manifest
@@ -73,8 +80,11 @@ use crate::symbol::Bundle;
 /// changes are breaking. 1.1 (#392): weights on call edges,
 /// `calls_via_stdlib`, `phases`, `seeds`, `effects` in the hashed
 /// half (existing `shape_hash` values change); unhashed
-/// `provenance` section.
-pub const TOPOLOGY_SCHEMA: &str = "1.1";
+/// `provenance` section. 1.2 (#399): unhashed `topics` section —
+/// the per-topic OBSERVATION identity (wire subject, canonical
+/// payload shape, `payload_hash`), the join key a recording/WAL
+/// segment carries; model `shape_hash` values unchanged.
+pub const TOPOLOGY_SCHEMA: &str = "1.2";
 
 /// Serialize the bundle's model + claim results as the topology
 /// artifact (JSON).
@@ -670,6 +680,73 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
     }
     trim_trailing_comma(&mut out);
     out.push_str("    }\n  }");
+    // #399: the per-topic OBSERVATION identity — the join between
+    // this artifact and a recording. The runtime manifest fuses
+    // topics on (name, shape_hash) where shape_hash =
+    // FNV-1a/64(wire_subject ++ ':' ++ canonical_shape); a WAL
+    // segment carrying that pair matches a row here, which names
+    // the exact checked topology it ran under. Computed by the
+    // SAME `topic_identity` functions codegen registers shapes
+    // with, so the artifact and the emitted binary cannot drift.
+    // UNHASHED by ruling: payload field shape does not affect
+    // claim evaluation, so it is not part of the model identity —
+    // the artifact document is the reference, not the fusion.
+    out.push_str(",\n  \"topics\": [\n");
+    {
+        let mut rows: BTreeSet<(String, String, String, u64)> =
+            BTreeSet::new();
+        for p in &programs {
+            let wire =
+                crate::topic_identity::topic_wire_subjects(&p.items);
+            fn topics_of<'a>(
+                items: &'a [TopDecl],
+                out: &mut Vec<&'a TopicDecl>,
+            ) {
+                for item in items {
+                    match item {
+                        TopDecl::Topic(t) => out.push(t),
+                        TopDecl::Module(m) => {
+                            topics_of(&m.items, out)
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            let mut ts = Vec::new();
+            topics_of(&p.items, &mut ts);
+            for t in ts {
+                let subj = wire
+                    .get(&t.name.name)
+                    .cloned()
+                    .unwrap_or_else(|| t.name.name.clone());
+                let shape =
+                    crate::topic_identity::canonical_topic_shape(
+                        &p.items, t,
+                    );
+                let h = crate::topic_identity::topic_shape_hash(
+                    &subj, &shape,
+                );
+                rows.insert((
+                    name(&t.name.name),
+                    subj,
+                    shape,
+                    h,
+                ));
+            }
+        }
+        for (tname, subj, shape, h) in &rows {
+            out.push_str(&format!(
+                "    {{\"name\": {}, \"subject\": {}, \"shape\": {}, \
+                 \"payload_hash\": \"{:016x}\"}},\n",
+                quote(tname),
+                quote(subj),
+                quote(shape),
+                h
+            ));
+        }
+    }
+    trim_trailing_comma(&mut out);
+    out.push_str("  ]");
     out.push_str(",\n  \"claims\": [\n");
     for o in &outcomes {
         out.push_str(&format!(

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -620,7 +620,7 @@ The artifact shape (schema `1.0`):
 
 ```text
 {
-  "schema": "1.1",
+  "schema": "1.2",
   "shape_hash": "<fnv1a-64 over the model half>",
   "sorts":     { "loci": […], "fns": […], "topics": […] },
   "relations": {
@@ -641,6 +641,7 @@ The artifact shape (schema `1.0`):
                   "computed_publish"]} ],
   "provenance": { "calls": [+span], "publishes": [+span],
                   "subscribes": [+span], "decls": {name: span} },
+  "topics":    [ {"name", "subject", "shape", "payload_hash"} ],
   "claims":    [ {"name", "form", "result": "holds"|"violated"|"invalid"} ],
   "lowered":   [ {"subject", "form", "result": "holds"|"violated"} ]
 }
@@ -687,6 +688,17 @@ The pieces worth knowing:
   {F}`, `only effects {…} on {L} during birth`. One schema of
   record: the artifact carries all law, bundle-quantified and
   fn-grained, in one place. Unhashed like the claim results.
+- **`topics`.** The per-topic OBSERVATION identity: the wire
+  subject, the canonical payload shape, and `payload_hash` —
+  exactly the `(name, shape_hash)` pair the runtime manifest fuses
+  on (iris PROTOCOL §4), so a recording/WAL segment names the
+  checked topology it ran under. `subject` is deliberately RAW
+  (it is the byte-exact join key; a subject-less imported topic
+  registers under its mangled local name — declare `subject:` on
+  shared topics to fuse across binaries). Unhashed by ruling:
+  payload field shape does not affect claim evaluation, so it is
+  not part of the model identity — the artifact document is the
+  reference between the two identities, not a fusion of them.
 
 v2 scope: every claim verb replays independently over the exported
 relations. Still compiler-certified: `bound` over **built-in**

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -235,7 +235,7 @@ earlier in the same file as the family. Companion:
 class along any path, with the same loop/indirect unboundedness
 rules as every per-call dimension.
 
-**The topology artifact** (#382 phase 2; schema 1.1 per #392):
+**The topology artifact** (#382 phase 2; schema 1.2 per #399):
 `hale check <t> --dump-topology` emits the serialized model —
 sorts (loci, fns, topics), relations (calls with **weights**: loop
 nesting, unbounded-loop membership, interface-dispatch tags;
@@ -255,6 +255,24 @@ topology under different law keeps one shape). A **provenance**
 section carries per-edge and per-decl source spans as
 bundle-global byte offsets; it is excluded from the hash on
 purpose — moving code must not change the shape identity.
+A **`topics`** section (unhashed, #399) carries the per-topic
+OBSERVATION identity: the wire subject, the canonical payload
+shape, and `payload_hash` = FNV-1a/64 over
+`wire_subject ++ ':' ++ shape` — byte-identical to the value the
+native emitter registers in the runtime observation manifest
+(`lotus_obs.c`; the shared implementation is
+`hale_types::topic_identity`, which codegen also calls, so binary
+and artifact cannot drift). This is the reconciliation ruling for
+the compiler-side vs runtime-side identities: they stay separate
+(payload field shape does not affect claim evaluation, so it is
+not part of the model `shape_hash`), and the artifact is the JOIN
+document — a recording/WAL segment carrying `(name, shape_hash)`
+matches a row here and thereby names the exact checked topology
+it ran under. The `subject` field stays raw (it is the join key);
+a subject-less topic registers under its declared — possibly
+mangled — local name, so shared topics should declare `subject:`
+to fuse across binaries. The exact definition and test vectors
+live in iris PROTOCOL.md §4.
 `--check-topology <path>` diffs against a committed baseline and
 fails with a regenerate hint — the `.hale.effects` precedent: an
 unreviewed topology or law change fails CI the way an API break


### PR DESCRIPTION
Delivers #399 — the iris `shape_hash` reconciliation, unblocked by pinning the definition ourselves (with the protocol amendment in iris#1) rather than waiting: the emitter-side hash already existed in `lotus_obs.c`; what was open was the exact canonicalization and the compiler↔runtime join.

## One implementation

`hale_types::topic_identity` owns all three pieces: the **wire-subject rule** (parent-joined `subject:` dot-path, declared-name fallback — moved verbatim from codegen's `collect_topic_wire_subjects`, which now delegates), the **canonical payload shape** (`field:tag` list; tags `i f b d t u s y struct`; name-free for compounds so the hash never depends on a declaring binary's local type names; empty for non-struct payloads), and the **hash** (FNV-1a/64 over `subject ++ ':' ++ shape`, the byte mirror of `obs_fnv`). Codegen calls it for both bus routing and observer shape registration, so the emitted binary and the artifact cannot drift. Unit vectors are pinned and mirrored into iris PROTOCOL.md §4 as wire contract.

## The pinning found an emitter bug

Shape registration keyed by the **unjoined** declared subject while publish-side manifest rows key by the **parent-joined** wire subject — so a parented topic's shape lookup missed and its manifest row hashed the empty shape. Registration now uses the joined subject (manifest hashes for parented topics change, correctly).

## The reconciliation ruling: reference, not fusion

Artifact schema 1.1 → 1.2: an **unhashed** `topics` section per topic — author-spelled `name`, RAW wire `subject` (the byte-exact manifest join key; the one documented exception to the artifact's author-spelling rule, because a subject-less imported topic really does register under its mangled local name — the row exposing that non-portable identity is the point), canonical `shape`, and `payload_hash`. A recording/WAL segment carrying `(name, shape_hash)` matches a row and thereby names the exact checked topology it ran under. Payload field shape doesn't affect claim evaluation, so it stays out of the model `shape_hash` — a payload field edit changes the topic row and **no model identity**, pinned by canary.

## Evidence

- `topic_identity` unit vectors (protocol vectors + parent-join + name-free compounds).
- `topology_v2.rs`: the identity row against the protocol vector, plus the hash-separation canary (payload edit ⇒ row changes, model `shape_hash` doesn't).
- Full suite 2240 green; `hale fmt --check` clean. Spec § Claims and the docs artifact section updated; CHANGELOG under Unreleased (schema bump is an addition — model hashes unchanged, one baseline regenerate for the text diff).

Companion: hale-lang/iris#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)