### PR TITLE
fix: reclaim unbound factory temporaries and call-valued return arms (GH #402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,30 @@ struck). Spec: `spec/verification.md` § Claims. Docs: the claims
 chapter's artifact section. Tests: `topic_identity` unit vectors,
 `topology_v2.rs` identity row + hash-separation canary.
 
+### Factory-returned loci: unbound temporaries and call-valued return arms (GH #402)
+
+Two shapes #383 left on the program-lifetime path now reclaim too.
+
+**Unbound temporaries.** `add(matmul(w, a), b)` — the inner result is
+consumed as an argument and never named, so #383's binding-scoped
+rule had nothing to attach ownership to. The frame that evaluates it
+owns it now. The suppression flags that say "this value's owner is
+already decided" (a `let` RHS, a `return` expression) are one-shot
+rather than sticky: left sticky they swallow the whole subtree, and
+the nested temporary in `let z = add(matmul(..), b);` goes unowned
+again — which is the bug itself.
+
+**Call-valued return arms.** A factory whose guard arm is
+`return error_matrix();` was disqualified wholesale, even though that
+arm hands back a value as fresh as the main one. Freshness is
+transitive there for the same reason it is for let-bindings, and the
+fixpoint already had the machinery to decide it.
+
+Measured on the reference workload: leak 5320 → 3888 bytes, values
+correct, no use-after-free. The residual is still linear in call
+count, so #402 stays open — the remaining allocations are matrices
+the analysis does not yet prove fresh, not a new mechanism.
+
 ### Factory-returned loci are reclaimed by the binding that names them (GH #383)
 
 `let m = zeros(n);` used to leak: a locus returned from a free fn is

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1340,6 +1340,8 @@ pub fn build_executable_with_options(
         vtables: BTreeMap::new(),
         fresh_locus_factories: compute_fresh_locus_factories(&merged, import_renames),
         returned_bindings: compute_returned_bindings(&merged),
+        suppress_fresh_temp: false,
+        in_fresh_temp_hook: false,
         current_fn_skip_exit_drain: false,
         bus_inert,
         di: None,
@@ -2932,6 +2934,21 @@ fn compute_fresh_locus_factories(
                     Expr::Struct { path, .. }
                         if resolve(&qname(path), import_renames).as_deref()
                             == Some(l.as_str()) => {}
+                    // GH #402 shape 2: a return arm that is itself a
+                    // call to an already-qualifying factory of the
+                    // same locus. `matmul`'s guard arm — `if bad {
+                    // return error_matrix(); }` — disqualified the
+                    // whole fn under the original literal-or-ident
+                    // rule, even though that arm hands back a value
+                    // as fresh as the main one. Freshness is
+                    // transitive here for the same reason it is for
+                    // let-bindings, and the fixpoint already decides
+                    // it.
+                    Expr::Call { callee, .. }
+                        if callee_name(callee, import_renames)
+                            .and_then(|c| out.get(&c).cloned())
+                            .map(|(cl, _)| cl == l)
+                            .unwrap_or(false) => {}
                     Expr::Ident(i) => match &fresh_name {
                         None => fresh_name = Some(i.name.clone()),
                         Some(n) if *n == i.name => {}
@@ -3756,6 +3773,16 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// dissolve them. See `compute_returned_bindings`.
     pub(crate) returned_bindings:
         std::collections::BTreeMap<String, std::collections::BTreeSet<String>>,
+    /// GH #402: set while lowering an expression whose fresh-factory
+    /// result already has an owner decided by the caller — a `let`'s
+    /// direct RHS (the binding owns it) or a `return`'s expression
+    /// (the CALLER owns it). Temporary registration is suppressed
+    /// there; everywhere else a fresh-factory call produces a value
+    /// nothing names, and this frame owns it.
+    pub(crate) suppress_fresh_temp: bool,
+    /// GH #402: re-entry guard for the fresh-temp hook, cleared
+    /// immediately on entry so nested calls still get their own.
+    pub(crate) in_fresh_temp_hook: bool,
     pub(crate) current_fn_skip_exit_drain: bool,
     /// Static drain elision (2026-08-03): true when the merged
     /// program can never enqueue a bus cell (no topics, no bus
@@ -15570,8 +15597,15 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 let hint_ty = ascribed
                     .as_ref()
                     .and_then(|asc| self.type_expr_to_codegen_ty(asc).ok());
+                // GH #402: the binding decides ownership for its own
+                // RHS (below), so suppress temporary registration for
+                // the top-level call — otherwise the value would be
+                // registered twice and dissolved twice.
+                let prev_sft = self.suppress_fresh_temp;
+                self.suppress_fresh_temp = true;
                 let lower_result =
                     self.lower_expr_into(value_to_lower, scope, hint_ty.as_ref());
+                self.suppress_fresh_temp = prev_sft;
                 self.defer_next_locus_dissolve = false;
                 let (mut val, mut ty) = lower_result?;
                 // GH #383: a let-bound call to a proven-fresh locus
@@ -19606,6 +19640,24 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         expr: Option<&Expr>,
         scope: &Scope<'ctx>,
     ) -> Result<BlockEnd, CodegenError> {
+        // GH #402: a fresh-factory call in return position is handed
+        // to the CALLER, who owns it — this frame must not register
+        // it as a temporary and dissolve it on the way out. Same
+        // rule the returned-BINDING guard enforces for `return m;`,
+        // applied to `return make(...)` .
+        let _sft_guard = ();
+        let prev_sft = self.suppress_fresh_temp;
+        self.suppress_fresh_temp = true;
+        let r = self.lower_return_inner(expr, scope);
+        self.suppress_fresh_temp = prev_sft;
+        return r;
+    }
+
+    fn lower_return_inner(
+        &mut self,
+        expr: Option<&Expr>,
+        scope: &Scope<'ctx>,
+    ) -> Result<BlockEnd, CodegenError> {
         if self.in_main {
             // Return from main maps to the C entry point's i32
             // exit code. A bare `return;` exits 0; `return n;`
@@ -20076,6 +20128,61 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         e: &Expr,
         scope: &Scope<'ctx>,
     ) -> Result<(BasicValueEnum<'ctx>, CodegenTy), CodegenError> {
+        // GH #402 shape 1: a fresh-factory call whose result nothing
+        // names — `add(matmul(w, a), b)`, where the inner value is
+        // consumed as an argument and dropped. #383's rule attaches
+        // ownership to a BINDING, so a temporary had no owner and
+        // stayed on the program-lifetime path. Give it one: this
+        // frame.
+        //
+        // Both flags are ONE-SHOT (`mem::replace`), and that is the
+        // whole subtlety. `suppress_fresh_temp` says "the owner of
+        // the NEXT call is already decided" — a `let` RHS (the
+        // binding owns it) or a `return` expression (the caller
+        // does). Left sticky it would swallow the entire subtree,
+        // and the nested `matmul` in a `let z = add(matmul(..), b);`
+        // would go unowned again — which is exactly the bug this
+        // shape is. `in_fresh_temp_hook` is the re-entry guard for
+        // the single node being re-lowered, cleared immediately so
+        // nested calls still get their own hook.
+        let reentry = std::mem::replace(&mut self.in_fresh_temp_hook, false);
+        if !reentry {
+            if let Expr::Call { callee, .. } = e {
+                if let Some((lname, _)) = self
+                    .callee_fn_name(callee)
+                    .and_then(|f| self.fresh_locus_factories.get(&f).cloned())
+                {
+                    let owned_elsewhere =
+                        std::mem::replace(&mut self.suppress_fresh_temp, false);
+                    self.in_fresh_temp_hook = true;
+                    let res = self.lower_expr(e, scope);
+                    self.in_fresh_temp_hook = false;
+                    let (val, ty) = res?;
+                    if !owned_elsewhere
+                        && ty == CodegenTy::LocusRef(lname.clone())
+                        && !self.deferred_dissolves.is_empty()
+                        && val.is_pointer_value()
+                    {
+                        let ptr_t =
+                            self.context.ptr_type(AddressSpace::default());
+                        let slot = self.alloca_in_entry(
+                            ptr_t.into(),
+                            &format!("{}.fresh_temp", lname),
+                        )?;
+                        self.builder
+                            .build_store(slot, val)
+                            .map_err(|e| {
+                                CodegenError::LlvmEmit(e.to_string())
+                            })?;
+                        self.deferred_dissolves
+                            .last_mut()
+                            .expect("checked non-empty")
+                            .push((slot, lname, None));
+                    }
+                    return Ok((val, ty));
+                }
+            }
+        }
         match e {
             // m46: `sum(expr)` inside a closure assertion is the
             // accumulator load (sample-update already ran);

--- a/crates/hale-codegen/tests/factory_locus_reclaim.rs
+++ b/crates/hale-codegen/tests/factory_locus_reclaim.rs
@@ -185,3 +185,117 @@ fn a_factory_result_survives_being_passed_as_an_argument() {
     );
     assert!(out.contains("seen=2"), "got: {:?}", out);
 }
+
+// ==== GH #402: the two residual shapes ==========================
+
+/// Shape 1 — an unbound temporary. `outer(inner(...), x)`: the inner
+/// factory result is consumed as an argument and never named, so
+/// #383's binding-scoped rule had nothing to attach ownership to.
+/// This frame owns it now.
+///
+/// The subtlety worth pinning: the suppression flags are ONE-SHOT.
+/// A `let z = outer(inner(..), b);` decides ownership for the OUTER
+/// call only — left sticky, the suppression would swallow the whole
+/// subtree and the inner temporary would go unowned again, which is
+/// precisely the bug.
+#[test]
+fn unbound_temporaries_are_reclaimed() {
+    let src = format!(
+        "{LIB}
+        fn combine(a: Buf, b: Buf, n: Int) -> Buf {{
+            let out = zeros(n);
+            let mut i = 0;
+            while i < n {{
+                let x = a.get(i) or 0.0;
+                let y = b.get(i) or 0.0;
+                out.set(i, x + y) or discard;
+                i = i + 1;
+            }}
+            return out;
+        }}
+        locus Engine {{
+            params {{ runs: Int = 0; }}
+            fn step(n: Int) -> Float {{
+                // `ramp(n)` and `zeros(n)` here are UNBOUND
+                // temporaries — arguments, never named.
+                let z = combine(ramp(n), zeros(n), n);
+                let mut s = 0.0;
+                let mut i = 0;
+                while i < n {{
+                    let v = z.get(i) or 0.0 - 100.0;
+                    s = s + v;
+                    i = i + 1;
+                }}
+                self.runs = self.runs + 1;
+                return s;
+            }}
+        }}
+        fn main() {{
+            let e = Engine {{ }};
+            let mut t = 0.0;
+            let mut r = 0;
+            while r < 40 {{ t = t + e.step(4); r = r + 1; }}
+            print(\"t=\"); println(t);
+            print(\"runs=\"); println(e.runs);
+        }}"
+    );
+    let (out, st) = run("gh402_temporaries", &src);
+    assert!(st.success(), "non-zero exit: {:?}\n{}", st, out);
+    // ramp(4) = 0+1+2+3 = 6, zeros contributes 0, 40 rounds.
+    assert!(
+        out.contains("t=240"),
+        "temporaries must be reclaimed WITHOUT disturbing the value \
+         that outlives them: {:?}",
+        out
+    );
+    assert!(out.contains("runs=40"), "got: {:?}", out);
+}
+
+/// Shape 2 — a factory whose guard arm returns a CALL rather than a
+/// literal or a binding. `matmul`'s `if bad { return error_matrix(); }`
+/// disqualified the whole fn under the original rule, even though
+/// that arm hands back a value as fresh as the main one.
+#[test]
+fn a_call_valued_return_arm_still_qualifies() {
+    let src = format!(
+        "{LIB}
+        fn empty_buf() -> Buf {{
+            let e = Buf {{ n: 0 }};
+            return e;
+        }}
+        // two return arms: one a call to another factory, one a
+        // let-bound fresh value
+        fn guarded(n: Int) -> Buf {{
+            if n <= 0 {{ return empty_buf(); }}
+            let b = ramp(n);
+            return b;
+        }}
+        locus Engine {{
+            params {{ runs: Int = 0; }}
+            fn use_it(n: Int) -> Float {{
+                let g = guarded(n);
+                let bad = guarded(0);
+                self.runs = self.runs + 1;
+                let v = g.get(2) or 0.0 - 100.0;
+                let w = bad.get(0) or 0.0 - 7.0;
+                return v + w;
+            }}
+        }}
+        fn main() {{
+            let e = Engine {{ }};
+            let mut t = 0.0;
+            let mut r = 0;
+            while r < 30 {{ t = t + e.use_it(4); r = r + 1; }}
+            print(\"t=\"); println(t);
+        }}"
+    );
+    let (out, st) = run("gh402_call_return_arm", &src);
+    assert!(st.success(), "non-zero exit: {:?}\n{}", st, out);
+    // ramp(4)[2] = 2; guarded(0) is empty so the `or` substitutes
+    // -7.0; (2 - 7) x 30 = -150.
+    assert!(
+        out.contains("t=-150"),
+        "both return arms must hand back live values: {:?}",
+        out
+    );
+}


### PR DESCRIPTION
Both shapes named in #402, fixed. The issue stays open — see the measurement at the end.

## 1. Unbound temporaries

```hale
let z = mat::add(mat::matmul(w, a), b);
```

The inner `matmul` result is consumed as an argument and never named, so #383's binding-scoped rule had nothing to attach ownership to. The frame that evaluates it owns it now.

**The subtlety is that the suppression flags must be one-shot.** `suppress_fresh_temp` means "the owner of the next call is already decided" — a `let` RHS (the binding owns it) or a `return` expression (the caller does). Left sticky, it swallows the entire subtree, so the nested temporary in exactly the line above goes unowned again — which is the bug being fixed. `in_fresh_temp_hook` is a separate re-entry guard for the single node being re-lowered, cleared immediately so nested calls still get their own hook. I got this wrong on the first pass and the measurement caught it (no reduction at all).

## 2. Call-valued return arms

```hale
fn matmul(a: Matrix, b: Matrix) -> Matrix {
    if bad { return error_matrix(); }   // ← disqualified the whole fn
    let out = zeros(a.rows, b.cols);
    ...
    return out;
}
```

Freshness is transitive there for the same reason it is for let-bindings, and the fixpoint already had the machinery to decide it.

## Measured

Reference workload (pond `math/matrix` + `ml/neural`): **5320 → 3888 bytes**, values correct (`0.16499` both sides of the #381 differential probe), no use-after-free.

**#402 stays open.** The residual is still linear in call count (5 train_steps ≈ 15.5 KB, 40 ≈ 152 KB), and the trace shows it is the same mechanism — `zeros` results the whitelist does not yet prove fresh, roughly 12 per step — not a new one. Closing the rest is more coverage of the same analysis, not another design question.

## Tests

`factory_locus_reclaim.rs` gains both shapes:
- a 40-iteration loop where two factory results are passed as unbound arguments, and the value built from them must survive the temporaries being reclaimed around it;
- a two-arm factory (`return empty_buf();` / `return b;`) where both arms must hand back live values.

Green: corpus oracle, factory reclaim, cross-seed imports, cross-seed locus arg, method-return dissolve, caller-arena TLS unwind, element chains, birth-order, drain elision, synced-map retire, full `hale-types`, native suite.
