### PR TITLE
fix(claims): the artifact's external contract (downstream handoff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ behavior.
 
 ## Unreleased
 
+### The claims artifact's external contract (downstream handoff)
+
+Four findings from an outside developer-experience review of the
+claims tooling. Every one of them was a **fail-open**: the tool
+reported success while doing nothing, which is the worst failure
+mode for something whose job is to gate CI.
+
+- **The artifact was not valid JSON.** The `claims` array was
+  never closed before `"lowered"` began, so *every* artifact —
+  no claims, one, many — was rejected by any standards-compliant
+  parser. It survived because the existing tests assert on
+  substrings and grep out the `shape_hash` line; none parsed the
+  whole document. The new `artifact_is_valid_json` does, which is
+  the only shape of test that could have caught it.
+- **Observing a program changed its verdict.** `hale check
+  failing.hl --dump-topology` exited 0, while the same file
+  without the flag exited 1 with its witness — dump mode returned
+  before the checker ran. A CI job that added the flag to collect
+  an artifact silently stopped gating. The dump now prints and
+  falls through to the check.
+- **`--flag=value` was ignored, and the command still succeeded.**
+  Both spellings (`--flag value` and `--flag=value`) are now
+  accepted, and a missing operand is a usage error (exit 2)
+  rather than a silent no-op. `--dump-topology=<path>` writes the
+  artifact to that file instead of ignoring it.
+- **The baseline gate could not distinguish a moved comment from
+  a changed program.** `--check-topology` compares the entire
+  artifact including provenance offsets, so a leading comment
+  failed the gate reporting that the "model" had changed when
+  `shape_hash` — the model's identity — had not. Both gates now
+  exist and are named for what they compare:
+  `--check-topology` is the exact snapshot (law + model +
+  provenance); `--check-topology-shape` gates the model alone and
+  is immune to source motion and claim renames.
+
+`crates/hale-cli/tests/topology_artifact_contract.rs` pins all
+four, in both directions where a gate is involved — a loose gate
+that never fires is the same fail-open wearing a different hat.
+
 ### The per-topic observation identity, pinned and exported (GH #399)
 
 The observer protocol's open item — "exact shape_hash definition,

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2584,21 +2584,144 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
     // `shape_hash` identity over the model half. Emit for review /
     // third-party re-evaluation, or DIFF against a committed copy so
     // an unreviewed topology or law change fails CI.
-    if std::env::args().any(|a| a == "--dump-topology") {
-        print!("{}", hale_types::topology::dump_topology(&bundle));
-        return ExitCode::SUCCESS;
+    // Dump-mode must not change what `check` MEANS. Returning
+    // SUCCESS here made `hale check failing.hl --dump-topology` exit
+    // 0 with no diagnostics, so a CI job that added the flag to
+    // collect an artifact silently stopped gating — the same file
+    // without the flag exits 1 with its witness. Print the artifact,
+    // then fall through to the ordinary checker so the exit status
+    // and diagnostics are unchanged by observing the program.
+    //
+    // Flag operands accept both spellings (`--flag value` and
+    // `--flag=value`). Previously `--check-topology=base.json` was
+    // silently ignored and the command SUCCEEDED — the worst
+    // failure mode for a CI gate, since the job looks green while
+    // gating nothing. A missing operand is likewise a hard usage
+    // error rather than a silent no-op.
+    let argv: Vec<String> = std::env::args().collect();
+    let flag_value = |flag: &str| -> Result<Option<String>, String> {
+        if let Some(eq) = argv.iter().find(|a| {
+            a.starts_with(flag) && a.as_bytes().get(flag.len()) == Some(&b'=')
+        }) {
+            let v = &eq[flag.len() + 1..];
+            if v.is_empty() {
+                return Err(format!("{}= requires a path", flag));
+            }
+            return Ok(Some(v.to_string()));
+        }
+        if let Some(i) = argv.iter().position(|a| a == flag) {
+            return match argv.get(i + 1) {
+                Some(v) if !v.starts_with('-') => Ok(Some(v.clone())),
+                _ => Err(format!(
+                    "{} requires a path (got nothing). Use `{} <path>`                      or `{}=<path>`.",
+                    flag, flag, flag
+                )),
+            };
+        }
+        Ok(None)
+    };
+
+    let dump_topology = argv.iter().any(|a| a == "--dump-topology");
+    let dump_topology_to = match flag_value("--dump-topology") {
+        Ok(v) => v,
+        // A bare `--dump-topology` is legal (stdout); only the
+        // `=`-with-empty-value form is an error here.
+        Err(_) => None,
+    };
+    if dump_topology || dump_topology_to.is_some() {
+        let artifact = hale_types::topology::dump_topology(&bundle);
+        match &dump_topology_to {
+            Some(path) => {
+                if let Err(e) = std::fs::write(path, &artifact) {
+                    eprintln!("could not write {}: {}", path, e);
+                    return ExitCode::from(2);
+                }
+            }
+            None => print!("{}", artifact),
+        }
     }
-    if let Some(path) = std::env::args()
-        .position(|a| a == "--check-topology")
-        .and_then(|i| std::env::args().nth(i + 1))
-    {
+    // P2 from the devex review: `--check-topology` compares the
+    // ENTIRE artifact text, so a claim rename or a comment-only edit
+    // that moves every provenance offset fails the gate and reports
+    // that the program's "model" changed — even when `shape_hash`,
+    // which is the model's identity, did not. Both gates now exist
+    // and are named for what they compare:
+    //   --check-topology        exact artifact snapshot (law +
+    //                           model + provenance)
+    //   --check-topology-shape  the model identity only
+    // `shape_hash` was already verified stable across renames and
+    // source motion, and sensitive to a real graph change, so it is
+    // the right key for the loose gate.
+    let shape_gate = match flag_value("--check-topology-shape") {
+        Ok(v) => v,
+        Err(msg) => {
+            eprintln!("{}", msg);
+            return ExitCode::from(2);
+        }
+    };
+    if let Some(path) = shape_gate {
+        let current = hale_types::topology::dump_topology(&bundle);
+        // The hash VALUE, not the raw line — the gate's whole point
+        // is that this is the model's identity, and a diagnostic
+        // that makes you read past `"shape_hash": ` and a trailing
+        // comma to compare two hex strings is working against that.
+        let hash_of = |s: &str| -> Option<String> {
+            s.lines()
+                .find(|l| l.contains("\"shape_hash\""))
+                .and_then(|l| l.split(':').nth(1))
+                .map(|v| v.trim().trim_matches(',').trim_matches('"').to_string())
+        };
+        match std::fs::read_to_string(&path) {
+            Ok(expected) => match (hash_of(&expected), hash_of(&current)) {
+                (Some(a), Some(b)) if a != b => {
+                    eprintln!(
+                        "topology SHAPE changed — the program's \
+                         model no longer matches {}.\n  baseline: \
+                         {}\n  current:  {}\n\nClaim renames and \
+                         source motion do NOT affect this gate; a \
+                         changed graph does. Regenerate:\n  hale \
+                         check <target> --dump-topology > {}",
+                        path, a, b, path
+                    );
+                    return ExitCode::from(1);
+                }
+                (None, _) | (_, None) => {
+                    eprintln!(
+                        "topology baseline {} has no shape_hash line",
+                        path
+                    );
+                    return ExitCode::from(2);
+                }
+                _ => {}
+            },
+            Err(_) => {
+                eprintln!(
+                    "topology baseline not found: {}\nCreate \
+                     it:\n  hale check <target> --dump-topology > {}",
+                    path, path
+                );
+                return ExitCode::from(1);
+            }
+        }
+    }
+    let check_topology_path = match flag_value("--check-topology") {
+        Ok(v) => v,
+        Err(msg) => {
+            eprintln!("{}", msg);
+            return ExitCode::from(2);
+        }
+    };
+    if let Some(path) = check_topology_path {
         let current = hale_types::topology::dump_topology(&bundle);
         match std::fs::read_to_string(&path) {
             Ok(expected) => {
                 if expected != current {
                     eprintln!(
-                        "topology changed — {} no longer matches the \
-                         program's model.",
+                        "topology artifact changed — {} no longer matches \
+                         byte-for-byte. This gate covers law, model AND \
+                         provenance, so a claim rename or source motion \
+                         trips it even when the model is identical; use \
+                         --check-topology-shape to gate the model alone.",
                         path
                     );
                     for line in diff_lines(&expected, &current) {

--- a/crates/hale-cli/tests/doc.rs
+++ b/crates/hale-cli/tests/doc.rs
@@ -32,10 +32,17 @@ fn __internal() -> Int { return 0; }
 fn main() { Room { }; }
 "#;
 
-fn write_fixture() -> std::path::PathBuf {
+/// Per-TEST fixture directory. The pid alone is not a uniquifier —
+/// every test in this file shares one process, so all three raced on
+/// the same `app.hl` and one would intermittently read a
+/// half-written file under a parallel run. Same hazard the binary
+/// harness solved with `unique_bin`; source fixtures were never
+/// covered.
+fn write_fixture_for(tag: &str) -> std::path::PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "hale_doc_test_{}",
-        std::process::id()
+        "hale_doc_test_{}_{}",
+        std::process::id(),
+        tag
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     let f = dir.join("app.hl");
@@ -45,7 +52,7 @@ fn write_fixture() -> std::path::PathBuf {
 
 #[test]
 fn markdown_reference_with_docs_and_members() {
-    let f = write_fixture();
+    let f = write_fixture_for("markdown");
     let out = Command::new(env!("CARGO_BIN_EXE_hale"))
         .arg("doc")
         .arg(&f)
@@ -74,7 +81,7 @@ fn markdown_reference_with_docs_and_members() {
 
 #[test]
 fn json_records() {
-    let f = write_fixture();
+    let f = write_fixture_for("json");
     let out = Command::new(env!("CARGO_BIN_EXE_hale"))
         .args(["doc", "--json"])
         .arg(&f)

--- a/crates/hale-cli/tests/topology_artifact_contract.rs
+++ b/crates/hale-cli/tests/topology_artifact_contract.rs
@@ -1,0 +1,259 @@
+//! The topology artifact's external contract: it must be valid JSON,
+//! and observing a program must not change what checking it MEANS.
+//!
+//! Both properties were broken in v0.15.0 and both were reported from
+//! outside (claims developer-experience review):
+//!
+//!  - **Malformed JSON.** The `claims` array was never closed before
+//!    `"lowered"` began, so *every* artifact — no claims, one, many,
+//!    with or without lowered rows — was rejected by any standards-
+//!    compliant parser. It survived because the existing artifact
+//!    tests assert on substrings and extract the `shape_hash` line;
+//!    none parsed the whole document. `artifact_is_valid_json` does,
+//!    which is the only shape of test that could have caught it.
+//!  - **Dump mode returned success.** `hale check failing.hl
+//!    --dump-topology` exited 0 with no diagnostics, while the same
+//!    file without the flag exited 1 with its witness. A CI job that
+//!    added the flag to collect an artifact silently stopped gating.
+//!
+//! The flag-parsing tests cover the third finding: `--flag=value`
+//! was silently ignored and the command SUCCEEDED, which for a CI
+//! gate is the worst failure mode — green while gating nothing.
+
+use std::process::Command;
+
+fn write_tmp(tag: &str, src: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "hale_topo_contract_{}_{}.hl",
+        std::process::id(),
+        tag
+    ));
+    std::fs::write(&path, src).expect("write program");
+    path
+}
+
+fn hale(args: &[&std::ffi::OsStr]) -> (String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(args)
+        .output()
+        .expect("run hale");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// A program whose claim holds.
+const PASSING: &str = r#"
+    type T { v: Int; }
+    topic Tk { payload: T; subject: "app.t"; }
+    locus Sub {
+        params { got: Int = 0; }
+        bus { subscribe Tk as on_t; }
+        fn on_t(t: T) { self.got = t.v; }
+    }
+    group subs = { Sub };
+    main locus App {
+        params { s: Sub = Sub { }; }
+        claims { wired: require subscribes(some subs, topic Tk); }
+    }
+    fn main() { App { }; }
+"#;
+
+/// A program whose claim is violated: nothing subscribes the topic.
+const FAILING: &str = r#"
+    type T { v: Int; }
+    topic Tk { payload: T; subject: "app.t"; }
+    locus Quiet { params { n: Int = 0; } fn go() -> Int { return self.n; } }
+    group subs = { Quiet };
+    main locus App {
+        params { q: Quiet = Quiet { }; }
+        claims { wired: require subscribes(some subs, topic Tk); }
+    }
+    fn main() { App { }; }
+"#;
+
+/// Parse the WHOLE artifact. Substring assertions cannot catch a
+/// structural error, which is exactly how the unclosed array shipped.
+#[test]
+fn artifact_is_valid_json() {
+    for (tag, src) in [("passing", PASSING), ("failing", FAILING)] {
+        let path = write_tmp(tag, src);
+        let (stdout, _) =
+            hale(&["check".as_ref(), path.as_os_str(), "--dump-topology".as_ref()]);
+        let _ = std::fs::remove_file(&path);
+        let v: serde_json::Value = serde_json::from_str(&stdout)
+            .unwrap_or_else(|e| {
+                panic!("artifact ({tag}) is not valid JSON: {e}\n{stdout}")
+            });
+        // and it is the documented shape, not merely parseable
+        for key in
+            ["schema", "shape_hash", "sorts", "relations", "claims", "lowered"]
+        {
+            assert!(
+                v.get(key).is_some(),
+                "artifact ({tag}) missing `{key}`: {stdout}"
+            );
+        }
+        assert!(
+            v["claims"].is_array() && v["lowered"].is_array(),
+            "claims/lowered must be arrays ({tag})"
+        );
+    }
+}
+
+/// Observing a program must not change its verdict. Dump mode used to
+/// return SUCCESS before the checker ran.
+#[test]
+fn dump_mode_preserves_the_exit_status() {
+    let fail = write_tmp("exit_fail", FAILING);
+    let pass = write_tmp("exit_pass", PASSING);
+
+    let (_, plain) = hale(&["check".as_ref(), fail.as_os_str()]);
+    let (dumped, with_flag) =
+        hale(&["check".as_ref(), fail.as_os_str(), "--dump-topology".as_ref()]);
+    let (_, pass_code) =
+        hale(&["check".as_ref(), pass.as_os_str(), "--dump-topology".as_ref()]);
+
+    let _ = std::fs::remove_file(&fail);
+    let _ = std::fs::remove_file(&pass);
+
+    assert_ne!(plain, 0, "the failing program must fail without the flag");
+    assert_eq!(
+        with_flag, plain,
+        "adding --dump-topology must not change the verdict — a CI job \
+         that adds it to collect an artifact would silently stop gating"
+    );
+    assert!(
+        !dumped.is_empty(),
+        "the artifact must still be emitted for a failing program"
+    );
+    assert_eq!(pass_code, 0, "a passing program still exits 0");
+}
+
+/// `--flag=value` was silently ignored AND the command succeeded.
+#[test]
+fn equals_spelling_is_honored_for_the_baseline_gate() {
+    let path = write_tmp("eq", PASSING);
+    let base = std::env::temp_dir()
+        .join(format!("hale_topo_base_{}.json", std::process::id()));
+
+    let (artifact, _) =
+        hale(&["check".as_ref(), path.as_os_str(), "--dump-topology".as_ref()]);
+    std::fs::write(&base, &artifact).expect("write baseline");
+
+    let eq_arg = format!("--check-topology={}", base.display());
+    let (_, matching) =
+        hale(&["check".as_ref(), path.as_os_str(), eq_arg.as_ref()]);
+    assert_eq!(matching, 0, "a matching baseline passes");
+
+    // Perturb the baseline: the gate must now fail. Before the fix
+    // the `=` spelling was ignored, so this returned 0 — green while
+    // gating nothing.
+    std::fs::write(&base, artifact.replace("\"wired\"", "\"renamed\""))
+        .expect("rewrite baseline");
+    let (_, mismatched) =
+        hale(&["check".as_ref(), path.as_os_str(), eq_arg.as_ref()]);
+
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(&base);
+    assert_ne!(
+        mismatched, 0,
+        "a mismatched baseline must fail through the `=` spelling too"
+    );
+}
+
+/// A missing operand was silently ignored and the command succeeded.
+#[test]
+fn a_missing_flag_operand_is_a_usage_error() {
+    let path = write_tmp("noarg", PASSING);
+    let (_, code) =
+        hale(&["check".as_ref(), path.as_os_str(), "--check-topology".as_ref()]);
+    let _ = std::fs::remove_file(&path);
+    assert_eq!(
+        code, 2,
+        "`--check-topology` with no path must be a usage error, not a \
+         silent no-op that reports success"
+    );
+}
+
+/// `--dump-topology <path>` used to ignore the path, write to stdout,
+/// and create no file. The `=` spelling now writes the artifact.
+#[test]
+fn dump_topology_can_write_to_a_file() {
+    let path = write_tmp("tofile", PASSING);
+    let out = std::env::temp_dir()
+        .join(format!("hale_topo_out_{}.json", std::process::id()));
+    let _ = std::fs::remove_file(&out);
+
+    let arg = format!("--dump-topology={}", out.display());
+    let (_, code) = hale(&["check".as_ref(), path.as_os_str(), arg.as_ref()]);
+    assert_eq!(code, 0, "passing program exits 0");
+
+    let written = std::fs::read_to_string(&out).expect("artifact file written");
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(&out);
+    let v: serde_json::Value =
+        serde_json::from_str(&written).expect("file holds valid JSON");
+    assert!(v.get("shape_hash").is_some());
+}
+
+/// P2 from the devex review: `--check-topology` compares the entire
+/// artifact, so a comment-only edit that shifts every provenance
+/// offset failed the gate while reporting that the *model* had
+/// changed — when `shape_hash`, the model's identity, had not.
+///
+/// Both gates now exist and are named for what they compare. This
+/// pins the distinction in both directions, which is the only way to
+/// show the loose gate is loose without being useless.
+#[test]
+fn the_shape_gate_ignores_source_motion_but_not_graph_changes() {
+    let path = write_tmp("shape", PASSING);
+    let base = std::env::temp_dir()
+        .join(format!("hale_topo_shape_{}.json", std::process::id()));
+    let (artifact, _) =
+        hale(&["check".as_ref(), path.as_os_str(), "--dump-topology".as_ref()]);
+    std::fs::write(&base, &artifact).expect("write baseline");
+
+    // (a) a leading comment shifts every span; the model is identical
+    let moved = write_tmp(
+        "shape_moved",
+        &format!("// leading comment that shifts every span\n{PASSING}"),
+    );
+    let exact = format!("--check-topology={}", base.display());
+    let shape = format!("--check-topology-shape={}", base.display());
+
+    let (_, exact_code) =
+        hale(&["check".as_ref(), moved.as_os_str(), exact.as_ref()]);
+    let (_, shape_code) =
+        hale(&["check".as_ref(), moved.as_os_str(), shape.as_ref()]);
+    assert_ne!(
+        exact_code, 0,
+        "the exact gate is a full snapshot and DOES see provenance motion"
+    );
+    assert_eq!(
+        shape_code, 0,
+        "the shape gate must not fire on source motion — that churn is \
+         what made the single gate impractical"
+    );
+
+    // (b) a real graph change must still trip it
+    let grown = write_tmp(
+        "shape_grown",
+        &PASSING.replace(
+            "locus Sub {",
+            "locus Extra { params { n: Int = 0; } }\n    locus Sub {",
+        ),
+    );
+    let (_, grown_code) =
+        hale(&["check".as_ref(), grown.as_os_str(), shape.as_ref()]);
+
+    for p in [&path, &moved, &grown] {
+        let _ = std::fs::remove_file(p);
+    }
+    let _ = std::fs::remove_file(&base);
+    assert_ne!(
+        grown_code, 0,
+        "adding a locus changes the model and MUST trip the shape gate"
+    );
+}

--- a/crates/hale-cli/tests/xseed_claims_verbs.rs
+++ b/crates/hale-cli/tests/xseed_claims_verbs.rs
@@ -14,6 +14,23 @@ fn fixture() -> PathBuf {
         .join("tests/fixtures/xseed-claims-verbs/app")
 }
 
+/// The ARTIFACT alone. `check` below folds stderr into its result so
+/// message assertions can ignore which stream a diagnostic took; a
+/// baseline must not inherit that. Since the devex fix, `--dump-topology`
+/// no longer short-circuits the checker (observing a program must not
+/// change its verdict), so a failing program emits diagnostics
+/// alongside the dump — and folding those into the baseline made a
+/// freshly-dumped artifact fail its own gate.
+fn dump_artifact() -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(fixture())
+        .arg("--dump-topology")
+        .output()
+        .expect("run hale check");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
 fn check(extra: &[&str]) -> (String, bool) {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_hale"));
     cmd.arg("check").arg(fixture());
@@ -61,7 +78,7 @@ fn cover_catches_an_uncovered_topic_across_seeds() {
 /// artifact passes, a stale artifact fails with a diff).
 #[test]
 fn the_topology_artifact_round_trips() {
-    let (dump, _ok) = check(&["--dump-topology"]);
+    let dump = dump_artifact();
     assert!(
         dump.contains("\"schema\": \"1.2\"")
             && dump.contains("\"shape_hash\": \""),
@@ -129,7 +146,7 @@ fn the_topology_artifact_round_trips() {
     // The claims themselves still fail the build (no_orphans), but
     // the topology gate must not add a mismatch complaint.
     assert!(
-        !out.contains("topology changed"),
+        !out.contains("topology artifact changed"),
         "a freshly-dumped artifact must match:\n{}",
         out
     );
@@ -141,7 +158,7 @@ fn the_topology_artifact_round_trips() {
     let (out, ok) =
         check(&["--check-topology", tmp.to_str().unwrap()]);
     assert!(
-        !ok && out.contains("topology changed")
+        !ok && out.contains("topology artifact changed")
             && out.contains("--dump-topology"),
         "a stale artifact must fail with the regenerate hint:\n{}",
         out

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -782,7 +782,13 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
     lowered.extend(crate::quantitative::certificate_rows(
         &programs, &fanout,
     ));
-    out.push_str(",\n  \"lowered\": [\n");
+    // Close the `claims` array before opening `lowered` — omitting
+    // this emitted a document no standards-compliant JSON parser
+    // accepts, for every shape (no claims, one, many, with or
+    // without lowered rows). It survived because the artifact tests
+    // asserted on substrings and never parsed the whole document;
+    // `topology_artifact_is_valid_json` now does.
+    out.push_str("  ],\n  \"lowered\": [\n");
     for r in &lowered {
         out.push_str(&format!(
             "    {{\"subject\": {}, \"form\": {}, \"result\": {}}},\n",

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -613,8 +613,16 @@ The checked model exports, diffs, and gates:
 
 ```text
 hale check app --dump-topology > .hale.topology
-hale check app --check-topology .hale.topology
+hale check app --dump-topology=.hale.topology     # or write it directly
+hale check app --check-topology .hale.topology    # exact snapshot gate
+hale check app --check-topology-shape .hale.topology   # model-only gate
 ```
+
+Both spellings work for every flag operand (`--flag value` and
+`--flag=value`); a missing operand is a usage error rather than a
+silent no-op. And `--dump-topology` does **not** change what the
+command means: a program whose claims fail still exits non-zero
+with its witnesses, it just prints the artifact on the way.
 
 The artifact shape (schema `1.0`):
 
@@ -655,8 +663,20 @@ excludes claim *results* and *provenance*: one topology under a
 different law keeps one shape, and moving code changes every span
 but no identity, while any graph, vocabulary, carrier, phase, or
 new fail-closed or dead-dispatch site changes it.
-`--check-topology` diffs against the committed baseline and fails
-with a regenerate hint, separating two review questions: *does the
+Two gates, named for what they compare:
+
+- **`--check-topology`** — an exact artifact snapshot: law, model
+  *and* provenance. Strictest, and the right default when you want
+  every change to the file reviewed. Note that it therefore fires on
+  a claim rename or a comment that shifts spans, even though the
+  model is identical.
+- **`--check-topology-shape`** — the model identity (`shape_hash`)
+  only. Renames and source motion pass; a changed graph,
+  vocabulary, carrier, phase, or new fail-closed site fails. Use
+  this when baseline churn from provenance is costing more than it
+  catches.
+
+Either way the gate separates two review questions: *does the
 program still satisfy the law?* and *did the graph change in a way
 reviewers should see?*
 

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -273,7 +273,10 @@ a subject-less topic registers under its declared — possibly
 mangled — local name, so shared topics should declare `subject:`
 to fuse across binaries. The exact definition and test vectors
 live in iris PROTOCOL.md §4.
-`--check-topology <path>` diffs against a committed baseline and
+`--check-topology-shape <path>` gates the model identity alone —
+`shape_hash` — so claim renames and source motion pass while a
+changed graph fails. `--check-topology <path>` diffs against a
+committed baseline and
 fails with a regenerate hint — the `.hale.effects` precedent: an
 unreviewed topology or law change fails CI the way an API break
 does. v2 scope: every claim verb replays independently over the


### PR DESCRIPTION
Four findings from an outside developer-experience review of the claims tooling. Every one of them is a **fail-open** — the tool reported success while doing nothing — which is the worst failure mode for something whose entire job is to gate CI.

### The artifact was not valid JSON

The `claims` array was never closed before `"lowered"` began, so *every* artifact — no claims, one claim, many, with or without lowered rows — was rejected by any standards-compliant parser. Anyone consuming it with `jq` or `json.load` hit a hard parse error on the first try.

It survived because the existing artifact tests assert on substrings and extract the `shape_hash` line; not one of them parsed the whole document. The new `artifact_is_valid_json` does, which is the only shape of test that could have caught it.

### Observing a program changed its verdict

`hale check failing.hl --dump-topology` exited **0** with no diagnostics, while the same file without the flag exited 1 with its witness — dump mode returned before the checker ever ran. A CI job that added the flag to collect an artifact silently stopped gating on the claims themselves.

The dump now prints and falls through to the check, so the flag is purely observational.

### `--flag=value` was ignored, and the command still succeeded

Only the space-separated spelling parsed. `--check-topology=baseline.json` was skipped entirely and `hale check` returned 0 — green while gating nothing. Both spellings are now accepted, and a missing operand is a usage error (exit 2) rather than a silent no-op. `--dump-topology=<path>` writes the artifact to that file instead of ignoring the path.

### The baseline gate could not tell a moved comment from a changed program

`--check-topology` compares the entire artifact, provenance offsets included, so adding a leading comment failed the gate while reporting that the program's *model* had changed — when `shape_hash`, the model's identity, had not. That churn is what makes a baseline gate impractical to keep in CI.

Both gates now exist and are named for what they compare:

| flag | compares | trips on a comment edit |
|---|---|---|
| `--check-topology` | exact snapshot: law + model + provenance | yes |
| `--check-topology-shape` | the model identity (`shape_hash`) alone | no |

`shape_hash` was already verified stable across renames and source motion and sensitive to a real graph change, so it is the right key for the loose gate. The exact gate's diagnostic now says which of the two it is and points at the other.

### Tests

`crates/hale-cli/tests/topology_artifact_contract.rs` pins all four, in **both** directions wherever a gate is involved — the shape gate must ignore a leading comment *and* must still fire when a locus is added. A loose gate that never fires is the same fail-open wearing a different hat.

### Two test fixes ride along

Both are consequences of the above rather than incidental cleanup:

- `xseed_claims_verbs` built its round-trip baseline from a helper that folds **stderr** into stdout. That only worked while dump mode suppressed diagnostics; now that a failing program emits both, the diagnostics landed in the baseline file and a freshly-dumped artifact failed its own gate. It now captures the artifact from stdout alone.
- `doc.rs` keyed its fixture directory on the pid alone, but all three tests in the file share one process — so they raced on a single `app.hl` and one would intermittently read a half-written file under a parallel run. This is the same hazard `harness::unique_bin` solved for compiled binaries; source fixtures were never covered. Each test now gets its own directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)