### PR TITLE
feat(lint): the hot-path advisory now sees factory calls (GH #402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,28 @@ mode for something whose job is to gate CI.
 `crates/hale-cli/tests/topology_artifact_contract.rs` pins all
 four, in both directions where a gate is involved — a loose gate
 that never fires is the same fail-open wearing a different hat.
+### The hot-path lint now sees factory calls (GH #402)
+
+The advisory that flags a locus allocated per loop iteration matched
+a locus **literal** only. But a method cannot return a locus (m90), so
+factoring construction out of a body leaves a free-fn factory — and
+`let m = zeros(rows, cols)` in a loop allocates a fresh arena every
+iteration exactly as `Matrix { }` would, reclaimed only when the
+enclosing fn returns.
+
+The result was silence precisely where it mattered. A workload built
+entirely on factories — the #402 reference workload is — grew linearly
+with no diagnostic at all. The lint now resolves a call's callee to
+its signature and fires when the return type is a locus, naming both
+the factory and the locus it returns. Cross-seed calls resolve too
+(the callee keeps its author spelling while the symbol is merged
+mangled); an ambiguous tail name is dropped rather than guessed.
+
+Only the `let`-bound form warns: since the previous release an unbound
+factory result is registered and reclaimed at its statement, so
+dropping the binding is a *fix* the advisory suggests, not a finding it
+reports. Straight-line calls outside a loop or handler stay silent, as
+they always have. The in-tree corpus produces zero new warnings.
 
 ### The per-topic observation identity, pinned and exported (GH #399)
 

--- a/crates/hale-cli/tests/fixtures/hot-factory-ambig/plain.hl
+++ b/crates/hale-cli/tests/fixtures/hot-factory-ambig/plain.hl
@@ -1,0 +1,5 @@
+/// Same tail name as the factory next door, different return type.
+/// Neither seed can be told apart from a bare `build` at this layer.
+fn build(n: Int) -> Int {
+    return n * 2;
+}

--- a/crates/hale-cli/tests/fixtures/hot-factory-app/main.hl
+++ b/crates/hale-cli/tests/fixtures/hot-factory-app/main.hl
@@ -1,0 +1,19 @@
+import "../hot-factory-lib" as mat;
+import "../hot-factory-ambig" as plain;
+
+fn main() {
+    let mut i = 0;
+    // `zeros` has a unique tail: this must warn.
+    while i < 3 {
+        let m = mat::zeros(i);
+        i = i + 1;
+    }
+    // `build` is exported by BOTH seeds with different return types,
+    // so the tail is ambiguous and must stay silent.
+    let mut j = 0;
+    while j < 3 {
+        let b = mat::build(j);
+        j = j + 1;
+    }
+    println("done");
+}

--- a/crates/hale-cli/tests/fixtures/hot-factory-lib/matrix.hl
+++ b/crates/hale-cli/tests/fixtures/hot-factory-lib/matrix.hl
@@ -1,0 +1,15 @@
+/// A locus factory. `build` here returns a locus; the same tail name
+/// in `hot-factory-ambig` does not.
+locus Matrix {
+    params { n: Int = 0; }
+}
+
+fn build(n: Int) -> Matrix {
+    let m = Matrix { n: n };
+    return m;
+}
+
+fn zeros(n: Int) -> Matrix {
+    let m = Matrix { n: n };
+    return m;
+}

--- a/crates/hale-cli/tests/hot_factory_xseed.rs
+++ b/crates/hale-cli/tests/hot_factory_xseed.rs
@@ -1,0 +1,80 @@
+//! GH #402: the hot-path advisory across a seed boundary.
+//!
+//! This lives at the CLI layer because the behavior only exists once
+//! seeds are merged. At a cross-seed call the callee keeps its author
+//! spelling (`mat::zeros`) while the symbol is merged under a mangled
+//! one (`__lib_<id>_<stem>_<fn>`), so neither the joined path nor the
+//! bare tail resolves and the lint falls back to scanning for the
+//! mangled spelling. A single-source unit test never reaches that
+//! path — resolution there is exact — so it cannot pin any of this.
+//!
+//! Two properties, and the second is the one worth the fixture:
+//!
+//!  - a **unique** tail resolves, so the finding survives the seed
+//!    boundary. Without this the lint would be silent on exactly the
+//!    codebases it was written for (#402's reference workload calls
+//!    its factories cross-seed).
+//!  - an **ambiguous** tail — two seeds exporting the same name, one
+//!    returning a locus and one not — is dropped rather than guessed.
+//!    This layer has no alias table to tell them apart (the same
+//!    limitation `topic_tail` documents), and a lint must not invent
+//!    a finding out of an ambiguity.
+//!
+//! The ambiguity verdict is also order-independent: both kinds of
+//! candidate are counted before deciding, rather than short-circuiting
+//! mid-scan, so a non-factory encountered *before* the factory poisons
+//! the tail exactly as one encountered after it does. An earlier draft
+//! short-circuited and silently depended on `symbols` iteration order.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn check_app() -> String {
+    let app = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/hot-factory-app");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(&app)
+        .output()
+        .expect("run hale check");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+#[test]
+fn a_cross_seed_factory_call_in_a_loop_is_flagged() {
+    let out = check_app();
+    assert!(
+        out.contains("`mat::zeros` returns the locus"),
+        "a factory call must resolve across the seed boundary, in \
+         author spelling on both halves:\n{}",
+        out
+    );
+    assert!(
+        !out.contains("__lib_"),
+        "no mangled symbol may reach the author:\n{}",
+        out
+    );
+}
+
+#[test]
+fn an_ambiguous_tail_name_is_never_guessed() {
+    let out = check_app();
+    assert!(
+        !out.contains("`mat::build` returns the locus"),
+        "`build` is exported by two seeds with different return \
+         types — the call cannot be resolved, so it must produce no \
+         finding rather than a guessed one:\n{}",
+        out
+    );
+    // Guard against the assertion above passing because the lint
+    // stopped working altogether.
+    assert!(
+        out.contains("returns the locus"),
+        "the unambiguous call in the same file must still fire:\n{}",
+        out
+    );
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -1550,6 +1550,79 @@ fn hot_locus_name(path: &QualifiedName, top: &TopScope) -> Option<String> {
     None
 }
 
+/// GH #402: does `callee` name a free fn whose return type is a locus?
+/// Returns `(display spelling, locus name)`.
+///
+/// Factories are how loci get built once construction is factored out
+/// — m90 forbids a method returning a locus, so a free fn is the only
+/// shape available — which is precisely why the literal-only lint had
+/// a hole here.
+fn hot_factory_locus(
+    callee: &Expr,
+    top: &TopScope,
+) -> Option<(String, String)> {
+    let (disp, sym) = match callee {
+        Expr::Ident(id) => (id.name.clone(), top.lookup(&id.name)?),
+        Expr::Path(qn) => {
+            let segs: Vec<&str> =
+                qn.segments.iter().map(|s| s.name.as_str()).collect();
+            let disp = segs.join("::");
+            // An imported seed's fn is merged under a MANGLED name
+            // (`__lib_<id>_<stem>_<fn>`) while the call site keeps
+            // its author spelling (`lb::make`), so neither the
+            // joined form nor the bare tail resolves. Fall back to
+            // scanning for the mangled spelling.
+            //
+            // Two seeds can export the same tail name, and this
+            // layer has no alias table to tell them apart (the same
+            // limitation `topic_tail` documents). A lint must not
+            // invent a finding from an ambiguity, so a tail that
+            // matches candidates DISAGREEING about whether they
+            // return a locus is dropped.
+            let tail = *segs.last()?;
+            let sym = top.lookup(&disp).or_else(|| top.lookup(tail));
+            match sym {
+                Some(sym) => (disp, sym),
+                None => {
+                    let mut hit: Option<&TopSymbol> = None;
+                    for (k, v) in &top.symbols {
+                        let matches_tail = k
+                            .strip_prefix("__lib_")
+                            .is_some_and(|r| {
+                                r.rsplit('_').next() == Some(tail)
+                            });
+                        if !matches_tail {
+                            continue;
+                        }
+                        let is_factory = matches!(v, TopSymbol::Fn(sig)
+                            if matches!(&sig.ret, Ty::Named(n)
+                                if matches!(
+                                    top.lookup(n),
+                                    Some(TopSymbol::Locus(_))
+                                )));
+                        match (&hit, is_factory) {
+                            (None, true) => hit = Some(v),
+                            // a same-tail candidate that is NOT a
+                            // locus factory makes the tail ambiguous
+                            (_, false) if hit.is_some() => return None,
+                            (Some(_), true) => return None,
+                            _ => {}
+                        }
+                    }
+                    (disp, hit?)
+                }
+            }
+        }
+        _ => return None,
+    };
+    let TopSymbol::Fn(sig) = sym else { return None };
+    let Ty::Named(ret) = &sig.ret else { return None };
+    match top.lookup(ret) {
+        Some(TopSymbol::Locus(_)) => Some((disp, ret.clone())),
+        _ => None,
+    }
+}
+
 /// An allocating recv path-call (the result Bytes/String lands in the
 /// caller's scratch). `recv_into` is the zero-alloc alternative.
 fn allocating_recv_name(callee: &Expr) -> Option<String> {
@@ -1628,8 +1701,52 @@ fn hot_walk_stmt(s: &Stmt, cx: &mut HotPathCx) {
             hot_walk_block(body, cx);
             cx.loop_depth -= 1;
         }
-        Stmt::Let { value, .. } | Stmt::LetTuple { value, .. } => {
-            hot_walk_expr(value, cx)
+        Stmt::Let { value, span, .. } | Stmt::LetTuple { value, span, .. } => {
+            hot_walk_expr(value, cx);
+            // GH #402: a locus does not have to be spelled as a
+            // LITERAL to be allocated here. `let m = mat::zeros(r, c)`
+            // in a loop body allocates a fresh Matrix — its own arena
+            // — every iteration and, being let-bound, is reclaimed
+            // only when the enclosing fn returns, exactly like the
+            // literal the advisory above already covers. The lint saw
+            // only `Expr::Struct`, so a codebase that factors its
+            // construction behind factory functions (the idiomatic
+            // shape, and the one m90 pushes you toward since a method
+            // cannot return a locus) got no warning at all while
+            // leaking linearly.
+            //
+            // Only the LET form warns. An unbound temporary in
+            // statement position is registered and reclaimed at the
+            // statement since #403, so it is the recommended fix
+            // rather than a finding.
+            if cx.loop_depth > 0 || cx.in_handler {
+                if let Expr::Call { callee, .. } = value {
+                    if let Some((fn_disp, locus)) =
+                        hot_factory_locus(callee, cx.top)
+                    {
+                        let where_ = if cx.loop_depth > 0 {
+                            "every iteration"
+                        } else {
+                            "every message"
+                        };
+                        cx.emit(
+                            *span,
+                            format!(
+                                "hot-path allocation: `{}` returns the locus `{}`, so a \
+                                 fresh instance (its own arena / heap buffer) is \
+                                 allocated {} and, being let-bound, is only reclaimed \
+                                 when the enclosing fn returns. Hoist the result to a \
+                                 reused field and refill it, drop the binding if the \
+                                 value is only passed on (an unbound factory result is \
+                                 reclaimed at the statement), or acknowledge an \
+                                 intentional shape with `@unbounded` on the enclosing \
+                                 fn/hook.",
+                                fn_disp, locus, where_
+                            ),
+                        );
+                    }
+                }
+            }
         }
         Stmt::Assign { target, value, span, .. } => {
             hot_walk_expr(value, cx);

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -1585,6 +1585,7 @@ fn hot_factory_locus(
                 Some(sym) => (disp, sym),
                 None => {
                     let mut hit: Option<&TopSymbol> = None;
+                    let (mut factories, mut others) = (0usize, 0usize);
                     for (k, v) in &top.symbols {
                         let matches_tail = k
                             .strip_prefix("__lib_")
@@ -1600,14 +1601,23 @@ fn hot_factory_locus(
                                     top.lookup(n),
                                     Some(TopSymbol::Locus(_))
                                 )));
-                        match (&hit, is_factory) {
-                            (None, true) => hit = Some(v),
-                            // a same-tail candidate that is NOT a
-                            // locus factory makes the tail ambiguous
-                            (_, false) if hit.is_some() => return None,
-                            (Some(_), true) => return None,
-                            _ => {}
+                        if is_factory {
+                            hit = Some(v);
+                            factories += 1;
+                        } else {
+                            others += 1;
                         }
+                    }
+                    // Ambiguous either way: two seeds exporting a
+                    // locus factory under this tail, or one that does
+                    // and one that doesn't. Counting BOTH kinds
+                    // rather than short-circuiting keeps the verdict
+                    // independent of `symbols` iteration order — a
+                    // non-factory seen BEFORE the factory has to
+                    // poison the tail exactly as one seen after it
+                    // does.
+                    if factories != 1 || others > 0 {
+                        return None;
                     }
                     (disp, hit?)
                 }

--- a/crates/hale-types/tests/hot_path_alloc.rs
+++ b/crates/hale-types/tests/hot_path_alloc.rs
@@ -479,3 +479,96 @@ fn main() { }
         ds
     );
 }
+
+// ---- GH #402: the factory shape -------------------------------------
+//
+// The lint matched `Expr::Struct` only, so it saw a locus LITERAL in a
+// loop and nothing else. But m90 forbids a method returning a locus,
+// which means factoring construction out leaves you with a free fn —
+// and `let m = zeros(r, c)` in a loop allocates exactly the same fresh
+// arena per iteration, reclaimed only when the enclosing fn returns.
+//
+// That silence is what let the #402 residual go unnoticed: the leaking
+// workload allocated entirely through factories, so the compiler had
+// nothing to say while it grew 3888 bytes per training step.
+
+fn factory_warnings(src: &str) -> Vec<String> {
+    let prog = parse_source(src).expect("parse failed");
+    check_program(&prog)
+        .into_iter()
+        .map(|d| d.message)
+        .filter(|m| m.contains("returns the locus"))
+        .collect()
+}
+
+const FACTORY: &str = r#"
+locus Matrix { params { n: Int = 0; } }
+
+fn zeros(n: Int) -> Matrix {
+    let m = Matrix { n: n };
+    return m;
+}
+"#;
+
+#[test]
+fn a_let_bound_factory_result_in_a_loop_is_flagged() {
+    let src = format!(
+        "{}\nfn main() {{\n  let mut i = 0;\n  while i < 10 {{\n    \
+         let m = zeros(i);\n    i = i + 1;\n  }}\n}}",
+        FACTORY
+    );
+    let w = factory_warnings(&src);
+    assert_eq!(w.len(), 1, "expected exactly one finding: {:?}", w);
+    assert!(
+        w[0].contains("`zeros`") && w[0].contains("`Matrix`"),
+        "the finding must name both the factory and the locus it \
+         returns — the author has to know WHICH call allocates: {:?}",
+        w
+    );
+}
+
+/// The advisory tells you to drop the binding, so the unbound form
+/// must actually be silent — #403 registers and reclaims an unbound
+/// factory temporary at the statement. A lint that flags the fix it
+/// recommends is worse than no lint.
+#[test]
+fn an_unbound_factory_result_in_a_loop_is_silent() {
+    let src = format!(
+        "{}\nfn size_of(m: Matrix) -> Int {{ return m.n; }}\n\
+         fn main() {{\n  let mut i = 0;\n  while i < 10 {{\n    \
+         let t = size_of(zeros(i));\n    i = i + 1;\n  }}\n}}",
+        FACTORY
+    );
+    assert!(
+        factory_warnings(&src).is_empty(),
+        "an unbound factory result is reclaimed at the statement: {:?}",
+        factory_warnings(&src)
+    );
+}
+
+/// Depth 0 is not a hot path — a factory call in straight-line code
+/// dissolves at fn exit, which is simply the documented `let` rule.
+#[test]
+fn a_factory_result_outside_a_loop_is_silent() {
+    let src = format!("{}\nfn main() {{ let m = zeros(3); }}", FACTORY);
+    assert!(
+        factory_warnings(&src).is_empty(),
+        "straight-line construction is not a finding"
+    );
+}
+
+/// A fn that returns a plain value, not a locus, must never trip it.
+#[test]
+fn a_non_locus_returning_fn_in_a_loop_is_silent() {
+    let src = "
+fn double(n: Int) -> Int { return n * 2; }
+fn main() {
+  let mut i = 0;
+  while i < 10 { let d = double(i); i = i + 1; }
+}
+";
+    assert!(
+        factory_warnings(src).is_empty(),
+        "only locus-returning fns allocate an arena per call"
+    );
+}

--- a/docs/src/services/lifecycle.md
+++ b/docs/src/services/lifecycle.md
@@ -148,6 +148,24 @@ fire-and-forget. When several `let`-bound loci share a scope,
 they dissolve in reverse order of creation (the later one, which
 may depend on the earlier, goes first).
 
+**The scope is the enclosing function, not the enclosing block.** A
+`let` inside a loop body therefore doesn't dissolve per iteration — the
+whole run accumulates and releases at once when the function returns:
+
+```hale,fragment
+while i < steps {
+    let m = zeros(rows, cols);   // a fresh arena every iteration…
+    i = i + 1;
+}                                // …none of them reclaimed yet
+```
+
+That's fine for a bounded loop and a real problem for a long-running
+one. Both spellings behave identically here — a factory call allocates
+just as a `Matrix { }` literal would — and the compiler warns about
+each of them. The fixes are to hoist one instance out of the loop and
+refill it, or, if the value is only passed straight on, to drop the
+binding: an unbound result is reclaimed at the end of its statement.
+
 ### Replacing a locus held in a field
 
 If a locus holds another locus in a field — say a server that

--- a/docs/src/systems/performance.md
+++ b/docs/src/systems/performance.md
@@ -137,6 +137,15 @@ These are advisory warnings, not build failures:
   an instantiation outside a loop in a plain method reclaims at method
   exit — only the per-iteration / per-message cases, the unambiguous
   ones, warn.
+
+  This covers **factory calls**, not just literals: `let m =
+  zeros(r, c)` in a loop allocates a fresh `Matrix` — its own arena —
+  every iteration exactly as `Matrix { }` would. That case matters more
+  than it looks, because a method can't return a locus, so any codebase
+  that factors construction out is calling free-fn factories
+  everywhere. Only the **`let`-bound** form warns: an unbound factory
+  result is reclaimed at the statement, which is why "drop the binding
+  if you're only passing the value on" is one of the suggested fixes.
 - One structural warning: **`accept` without `release` on a locus whose
   `run()` loops forever**. Without a `release(c: C)` declaration every
   accepted child is *resident* — it lives until the accepting locus


### PR DESCRIPTION
Found while closing out #402, and it explains why that leak went unreported downstream for as long as it did.

### The hole

The hot-path advisory that flags a locus allocated per loop iteration matched `Expr::Struct` — a locus **literal** — and nothing else. So this warns:

```hale
while i < steps {
    let m = Matrix { rows: r, cols: c };   // warns
    i = i + 1;
}
```

and this, which allocates exactly the same fresh arena every iteration and is reclaimed at exactly the same time (when the enclosing fn returns), was silent:

```hale
while i < steps {
    let m = zeros(r, c);                   // silent
    i = i + 1;
}
```

That second shape isn't an edge case, it's the normal one. m90 forbids a method returning a locus, so the moment you factor construction out of a body the only tool available is a free-fn factory. A codebase that has done that consistently — #402's reference workload has — got **no diagnostic at all** while growing 3888 bytes per training step.

Pointed at that workload, the lint now names the exact lines ASan attributes the leak to (`model.hl:334`, `:335`, `:336`, `:340`, …), naming both the factory and the locus it returns so you know which call on the line allocates.

### Scope, and what stays silent

Only the **`let`-bound** form warns. Since #403 an unbound factory result is registered and reclaimed at its statement, so "drop the binding if you're only passing the value on" is one of the fixes the advisory *suggests* — flagging it would mean flagging its own recommendation. Straight-line calls outside a loop or handler stay silent as before, and a fn returning a non-locus never trips it.

The in-tree corpus produces **zero** new warnings.

### Cross-seed resolution

The interesting part of the implementation. At a cross-seed call the callee keeps its author spelling (`mat::zeros`) while the symbol is merged under a mangled one (`__lib_<id>_<stem>_<fn>`), so neither the joined path nor the bare tail resolves — hence a scan for the mangled spelling.

Two seeds can export the same tail name and this layer has no alias table to separate them (the same limitation `topic_tail` documents). A tail whose candidates **disagree** about whether they return a locus is dropped rather than guessed. A lint must not invent a finding out of an ambiguity.

### On #402 itself

Worth being explicit, because it changes what that issue is asking for: the residual there is not a bug in the reclamation logic. It is the **documented `let` rule** — a `let`-bound locus dissolves at the end of the enclosing *function*, not the enclosing block — which the lifecycle chapter has always stated and which the literal-shaped lint has always warned about. The minimal repro is 20 lines and behaves identically for a literal and a factory: three born, one dissolved.

So the compiler was correct and merely silent. Making it not-silent is this PR. Changing the rule so a loop-body `let` dissolves per iteration would be a language semantic change and is deliberately **not** proposed here.

### Docs

`docs/src/services/lifecycle.md` now states the function-not-block scope explicitly with the loop example, and `docs/src/systems/performance.md` records that the advisory covers factory calls and why only the let-bound form fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)