### PR TITLE
fix(cli): real argument parsing for check/verify, and claims in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ behavior.
 
 ## Unreleased
 
+### `check` / `verify` argument handling, and claims in the README
+
+The rest of the v0.15.0 claims developer-experience review. The
+critical topology findings shipped in the previous entry; these are
+recommendations 3 and 7.
+
+**Real argument parsing.** `check` took its target from `argv[2]` and
+treated everything else as scenery, so an unknown flag, a stray second
+positional, and `--help` were all ignored while the command still
+reported SUCCESS. A typo'd gate flag meant CI checked nothing and said
+so in green. Now: unknown flags and extra positionals are usage errors
+(exit 2), `--help` prints per-command help instead of being read as a
+path (it used to print `not a file or directory: --help` and exit 0),
+and flags may appear on either side of the target.
+
+**`--dump-topology` takes its destination as `=<path>` only.** Its
+operand is optional, so consuming the following token has no safe
+reading — and once flags became legal before the target, `hale check
+--dump-topology app.hl` OVERWROTE `app.hl` with the artifact. A bare
+`--dump-topology` still writes to stdout. The two `--check-topology*`
+gates take their mandatory operand either way.
+
+**Discoverability.** `hale check --help` documents the topology,
+effects and budget flags with what each one gates; the top-level
+usage points at it. The README gains a claims section — the six
+forms, a worked cross-seed example with its real witness output, the
+group/unknown/library-tier rules, and the artifact commands — since
+the shipped README discussed effects but never mentioned claims.
+
+Recommendations 4, 5, 6 and 8 (secondary provenance for `only edges`
+and `bound`, interface-fanout rendering, `hale claims` inspection
+commands, workspace-level verification) are not in this change.
+
 ### The claims artifact's external contract (downstream handoff)
 
 Four findings from an outside developer-experience review of the

--- a/README.md
+++ b/README.md
@@ -210,6 +210,77 @@ will also *report* that — so a handler that quietly starts doing filesystem
 I/O is a one-line diff in review, even though nothing annotated changed.
 [Effects & contracts →](https://hale-lang.org/docs/effects)
 
+## State your architecture as law
+
+Effects bind one function at a time. Architecture is a property of the
+*whole* graph — "billing must never reach research", "exactly one thing
+writes settlements" — and saying that with per-function contracts means
+scattering them across every position and hoping you got them all.
+
+A **claim** is one named sentence about the program graph, declared in
+`main` and checked by `hale check` as an error:
+
+```hale
+import "../pay" as pay;
+import "../research" as research;
+
+group billing  = { pay::* };
+group research_wing = { research::Sandbox };
+
+main locus Org {
+    params { ledger: pay::Ledger = pay::Ledger { }; }
+    claims {
+        tenant_iso: forbid reaches(billing, research_wing);
+        one_writer: count publishers(topic pay::Settled) == 1;
+    }
+}
+```
+
+Violate one and you get a minimal countermodel in your own spelling —
+never a mangled symbol, never a rule number:
+
+```
+claim `tenant_iso` violated: `billing` reaches `research_wing` — witness:
+  `pay::Ledger::on_close` -(publishes "pay::Audit")-> `research::Sandbox::on_audit`
+```
+
+…followed by the three places you'd actually edit: the publish that
+crosses the boundary, the subscription that receives it, and the
+declaration of the destination.
+
+Six forms cover the shapes worth stating. `forbid reaches(A, B)` for
+absence, optionally narrowed `via { calls }` or `via { bus }`;
+`require subscribes(some G, topic T)` for existence; `count
+publishers(topic T) <= 1` for cardinality; `cover topic in seed(a):
+subscribed_by(some G)` so a new topic can't be quietly orphaned;
+`only edges A -> B { publish T; }` for a reviewable boundary
+inventory; and `bound alloc <= N on paths from G` for cost.
+
+Three things make this hold up in practice:
+
+- **Groups are vocabulary, not patterns.** A misspelt member is an
+  error with a did-you-mean, and an empty group is a vacuity error
+  unless it says `may_be_empty` — a `forbid` satisfied by an empty
+  set is a fail-open wearing formal clothing.
+- **Unknown means violation.** An indirect call the compiler can't
+  resolve refuses to certify rather than proving absence it can't see.
+- **Libraries carry their own laws.** A seed states claims about what
+  it can see, and they travel into every application that imports it —
+  so an app that wires a second subscriber onto a library topic breaks
+  the *library's* `count` claim, attributed to the library's own line.
+
+Claims cost nothing at runtime — they compile to no code. And the graph
+they were evaluated against is exportable, so review and CI can gate on
+it directly:
+
+```sh
+hale check .                              # claims are errors
+hale check . --dump-topology=topo.json    # the model, as JSON
+hale check . --check-topology-shape topo.json   # fail if the graph moved
+```
+
+[Claims →](https://hale-lang.org/docs/claims)
+
 ## Verified where it counts
 
 The substrate you stand on is checked, not hoped. Every concurrent primitive

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -110,6 +110,17 @@ fn main() -> ExitCode {
         return run_bench(&rest);
     }
 
+    // `check` / `verify` take flags, so they get real argument
+    // parsing rather than "the target is argv[2] and everything else
+    // is scenery". Devex review of v0.15.0: an unknown flag, a
+    // stray positional, and `--help` were all silently ignored while
+    // the command still reported SUCCESS — the same fail-open that
+    // made the topology gates untrustworthy.
+    if cmd == "check" || cmd == "verify" {
+        let rest: Vec<String> = args.iter().skip(2).cloned().collect();
+        return run_check_cli(&rest, cmd == "verify");
+    }
+
     if args.len() < 3 {
         usage();
         return ExitCode::from(2);
@@ -119,12 +130,6 @@ fn main() -> ExitCode {
     match cmd.as_str() {
         "lex" => run_lex_file(&target),
         "parse" => run_parse_file(&target),
-        "check" => run_check_impl(&target, false),
-        // `verify` is the Layer-2 discipline GATE: identical
-        // analysis surface to `check`, but every finding —
-        // advisory or error — fails the run. No execution
-        // (spec/testing.md's standalone-verify row).
-        "verify" => run_check_impl(&target, true),
         "run" => {
             // `hale run` compiles the program to a temporary binary
             // (the same codegen backend as `hale build`) and executes
@@ -152,6 +157,8 @@ fn usage() {
     eprintln!("    hale lex   <file.hl>          tokenize and print tokens");
     eprintln!("    hale parse <file.hl>          parse and print the AST");
     eprintln!("    hale check <file.hl | dir>    parse + typecheck");
+    eprintln!("        [--dump-topology[=<path>]] [--check-topology[-shape] <path>]");
+    eprintln!("        [--dump-effects-manifest] [--json]   (`--help` for all)");
     eprintln!("    hale verify <file.hl | dir>   check + FAIL on any advisory (discipline gate)");
     eprintln!("    hale run   <file.hl | dir>    compile + run as a native binary");
     eprintln!("    hale build <file.hl | dir>    parse + typecheck + emit native binary");
@@ -2478,6 +2485,152 @@ fn file_of_span(
     best.map(|(_, p)| p.clone())
 }
 
+/// Flags `check` / `verify` accept, and whether each takes a value.
+/// Anything not on this list is a usage error rather than something
+/// quietly ignored.
+///
+/// `--dump-topology` is deliberately absent from the value-taking
+/// set: it takes its destination in the `=<path>` form ONLY, and a
+/// bare `--dump-topology` writes to stdout. Making it consume a
+/// following token would make `hale check --dump-topology app.hl`
+/// ambiguous — is `app.hl` the artifact destination or the target? —
+/// and flags are supposed to be positionable on either side.
+const CHECK_FLAGS: &[(&str, bool)] = &[
+    ("--allow-unowned-subscriber", false),
+    ("--check-effects-manifest", true),
+    ("--check-resource-budget", true),
+    ("--check-topology", true),
+    ("--check-topology-shape", true),
+    ("--dump-alloc-summary", false),
+    ("--dump-effects-manifest", false),
+    ("--dump-resource-budget", false),
+    ("--dump-topology", false),
+    ("--json", false),
+    ("--no-warn-unbounded-alloc", false),
+    // Retired opt-in spelling from when the unbounded-alloc survey
+    // was off by default. It is a no-op now (the survey is on), but
+    // it was accepted for a release and rejecting it would break
+    // pipelines that still pass it. Accepted-because-ignored is
+    // exactly what this list is replacing, so it is written down
+    // rather than left to chance.
+    ("--warn-unbounded-alloc", false),
+    ("--warn-resource-leak", false),
+];
+
+fn check_usage(verify: bool) {
+    let cmd = if verify { "verify" } else { "check" };
+    let what = if verify {
+        "typecheck + analyze; EVERY finding, advisory included, fails \
+         the run"
+    } else {
+        "typecheck + analyze a seed"
+    };
+    println!("hale {} [flags] <file | dir>    {}", cmd, what);
+    println!();
+    println!("A directory is ONE seed: the `.hl` files directly inside");
+    println!("it are checked together, without recursing. Flags may");
+    println!("appear before or after the target.");
+    println!();
+    println!("Claims and topology (spec/verification.md):");
+    println!("  --dump-topology[=<path>]        emit the topology artifact");
+    println!("                                 (JSON; stdout when bare).");
+    println!("                                 Observational: it does not");
+    println!("                                 change the exit status.");
+    println!("  --check-topology <path>         gate on an EXACT artifact");
+    println!("                                 snapshot — law, model and");
+    println!("                                 provenance. Source motion");
+    println!("                                 trips it.");
+    println!("  --check-topology-shape <path>   gate on the model identity");
+    println!("                                 (`shape_hash`) alone. Immune");
+    println!("                                 to comments moving and to");
+    println!("                                 claim renames.");
+    println!();
+    println!("Effects and budgets:");
+    println!("  --dump-effects-manifest         emit the effects manifest");
+    println!("  --check-effects-manifest <path> gate on a manifest baseline");
+    println!("  --dump-resource-budget          emit the resource budget");
+    println!("  --check-resource-budget <path>  gate on a budget baseline");
+    println!("  --dump-alloc-summary            emit the allocation summary");
+    println!();
+    println!("Advisories:");
+    println!("  --warn-resource-leak            enable the resource-leak lint");
+    println!("  --no-warn-unbounded-alloc       silence the unbounded-alloc lint");
+    println!("  --allow-unowned-subscriber      permit a subscriber with no owner");
+    println!("  --json                          machine-readable diagnostics");
+}
+
+/// Parse `check` / `verify` arguments: exactly one positional target,
+/// only known flags, values present where required, `--help`
+/// answered rather than treated as a path.
+fn run_check_cli(rest: &[String], verify: bool) -> ExitCode {
+    let cmd = if verify { "verify" } else { "check" };
+    if rest.iter().any(|a| a == "--help" || a == "-h") {
+        check_usage(verify);
+        return ExitCode::SUCCESS;
+    }
+
+    let mut positionals: Vec<&String> = Vec::new();
+    let mut i = 0;
+    while i < rest.len() {
+        let a = &rest[i];
+        if let Some(name) = a.strip_prefix("--").map(|_| a.as_str()) {
+            // `--flag=value` carries its own value; `--flag value`
+            // consumes the next token so it is never mistaken for
+            // the target.
+            let (base, has_eq) = match name.split_once('=') {
+                Some((b, _)) => (b, true),
+                None => (name, false),
+            };
+            let Some((_, takes_value)) =
+                CHECK_FLAGS.iter().find(|(f, _)| *f == base)
+            else {
+                eprintln!("unknown flag for `hale {}`: {}", cmd, base);
+                eprintln!("Run `hale {} --help` for the flag list.", cmd);
+                return ExitCode::from(2);
+            };
+            if *takes_value && !has_eq {
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        positionals.push(a);
+        i += 1;
+    }
+
+    match positionals.len() {
+        1 => {}
+        0 => {
+            eprintln!("hale {} needs a target (a .hl file or a seed \
+                       directory).", cmd);
+            eprintln!("Run `hale {} --help` for usage.", cmd);
+            return ExitCode::from(2);
+        }
+        _ => {
+            // Silently checking only the first would be the same
+            // fail-open shape as the rest of this review: the
+            // command reports on less than it was handed.
+            eprintln!(
+                "hale {} takes ONE target, got {}: {}",
+                cmd,
+                positionals.len(),
+                positionals
+                    .iter()
+                    .map(|p| p.as_str())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            );
+            eprintln!(
+                "A directory is one seed. Check each seed separately."
+            );
+            return ExitCode::from(2);
+        }
+    }
+
+    run_check_impl(&PathBuf::from(positionals[0]), verify)
+}
+
 
 /// Shared core of `hale check` (advisories print, only errors
 /// fail) and `hale verify` (every finding fails — the CI
@@ -2613,7 +2766,8 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
             return match argv.get(i + 1) {
                 Some(v) if !v.starts_with('-') => Ok(Some(v.clone())),
                 _ => Err(format!(
-                    "{} requires a path (got nothing). Use `{} <path>`                      or `{}=<path>`.",
+                    "{} requires a path. Use `{} <path>` or \
+                     `{}=<path>`.",
                     flag, flag, flag
                 )),
             };
@@ -2622,12 +2776,20 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
     };
 
     let dump_topology = argv.iter().any(|a| a == "--dump-topology");
-    let dump_topology_to = match flag_value("--dump-topology") {
-        Ok(v) => v,
-        // A bare `--dump-topology` is legal (stdout); only the
-        // `=`-with-empty-value form is an error here.
-        Err(_) => None,
-    };
+    // `=<path>` ONLY, never "consume the next token". Sharing
+    // `flag_value` here was destructive: it took the following
+    // argument as the destination, so `hale check --dump-topology
+    // app.hl` — a flag order this command now accepts — OVERWROTE
+    // `app.hl` with the artifact. Losing the file you asked it to
+    // inspect is the worst possible reading of an ambiguous
+    // argument, and the ambiguity is unresolvable in general
+    // because the value is optional. A bare `--dump-topology`
+    // writes to stdout.
+    let dump_topology_to = argv
+        .iter()
+        .find_map(|a| a.strip_prefix("--dump-topology="))
+        .filter(|v| !v.is_empty())
+        .map(|v| v.to_string());
     if dump_topology || dump_topology_to.is_some() {
         let artifact = hale_types::topology::dump_topology(&bundle);
         match &dump_topology_to {

--- a/crates/hale-cli/tests/check_arg_parsing.rs
+++ b/crates/hale-cli/tests/check_arg_parsing.rs
@@ -1,0 +1,155 @@
+//! `hale check` / `hale verify` argument handling.
+//!
+//! From the v0.15.0 claims developer-experience review: `check` took
+//! its target from `argv[2]` and treated everything else as scenery.
+//! An unknown flag, a stray second positional, and `--help` were all
+//! silently ignored while the command still reported SUCCESS — the
+//! same fail-open shape as the topology gates, and worse here,
+//! because a typo'd gate flag means CI checks nothing and says so in
+//! green.
+//!
+//! `--help` was the clearest symptom: it was interpreted as a path,
+//! printed `not a file or directory: --help`, and exited 0.
+
+use std::process::Command;
+
+fn write_tmp(tag: &str, src: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "hale_argparse_{}_{}.hl",
+        std::process::id(),
+        tag
+    ));
+    std::fs::write(&path, src).expect("write program");
+    path
+}
+
+fn hale(args: &[&std::ffi::OsStr]) -> (String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(args)
+        .output()
+        .expect("run hale");
+    (
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+const OK_SRC: &str = r#"
+    type T { v: Int; }
+    locus Q { params { n: Int = 0; } fn go() -> Int { return self.n; } }
+    main locus App { params { q: Q = Q { }; } }
+    fn main() { App { }; }
+"#;
+
+#[test]
+fn help_is_answered_not_treated_as_a_path() {
+    for cmd in ["check", "verify"] {
+        let (out, code) = hale(&[cmd.as_ref(), "--help".as_ref()]);
+        assert_eq!(code, 0, "`hale {} --help` must succeed: {}", cmd, out);
+        assert!(
+            !out.contains("not a file or directory"),
+            "`--help` must not be read as a target: {}",
+            out
+        );
+        // it must document the surface the review found undiscoverable
+        for flag in
+            ["--dump-topology", "--check-topology", "--check-topology-shape"]
+        {
+            assert!(
+                out.contains(flag),
+                "`hale {} --help` must list `{}`: {}",
+                cmd,
+                flag,
+                out
+            );
+        }
+    }
+}
+
+#[test]
+fn an_unknown_flag_is_a_usage_error() {
+    let path = write_tmp("unknown", OK_SRC);
+    let (out, code) =
+        hale(&["check".as_ref(), path.as_os_str(), "--typo-gate".as_ref()]);
+    let _ = std::fs::remove_file(&path);
+    assert_eq!(
+        code, 2,
+        "a misspelled flag must fail — silently ignoring it means a \
+         CI gate that checks nothing and reports green: {}",
+        out
+    );
+    assert!(out.contains("--typo-gate"), "name the offender: {}", out);
+}
+
+#[test]
+fn a_second_positional_is_a_usage_error() {
+    let a = write_tmp("pos_a", OK_SRC);
+    let b = write_tmp("pos_b", OK_SRC);
+    let (out, code) =
+        hale(&["check".as_ref(), a.as_os_str(), b.as_os_str()]);
+    let _ = std::fs::remove_file(&a);
+    let _ = std::fs::remove_file(&b);
+    assert_eq!(
+        code, 2,
+        "checking only the first of two targets reports on less than \
+         it was handed: {}",
+        out
+    );
+}
+
+#[test]
+fn a_missing_target_is_a_usage_error() {
+    let (out, code) = hale(&["check".as_ref(), "--dump-topology".as_ref()]);
+    assert_eq!(code, 2, "no target is a usage error: {}", out);
+}
+
+/// Flags on either side of the target must behave identically.
+#[test]
+fn flags_may_precede_or_follow_the_target() {
+    let path = write_tmp("order", OK_SRC);
+    let (_, after) =
+        hale(&["check".as_ref(), path.as_os_str(), "--json".as_ref()]);
+    let (_, before) =
+        hale(&["check".as_ref(), "--json".as_ref(), path.as_os_str()]);
+    let _ = std::fs::remove_file(&path);
+    assert_eq!(after, 0, "flag after target");
+    assert_eq!(before, 0, "flag before target");
+}
+
+/// The one that matters most: `--dump-topology` takes an OPTIONAL
+/// value, so "consume the next token" is unresolvable — and it used
+/// to consume the target. With flags now legal before the target,
+/// `hale check --dump-topology app.hl` wrote the artifact OVER
+/// `app.hl`. Losing the file you asked the tool to inspect is the
+/// worst available reading of an ambiguous argument.
+///
+/// The destination is `=<path>` only; bare means stdout.
+#[test]
+fn dump_topology_never_overwrites_the_target() {
+    let path = write_tmp("noclobber", OK_SRC);
+    let before = std::fs::read_to_string(&path).expect("read back");
+
+    let (out, code) = hale(&[
+        "check".as_ref(),
+        "--dump-topology".as_ref(),
+        path.as_os_str(),
+    ]);
+    let after = std::fs::read_to_string(&path).expect("source still there");
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(
+        before, after,
+        "the source file must be untouched — it was overwritten with \
+         the artifact"
+    );
+    assert_eq!(code, 0, "the program is valid: {}", out);
+    assert!(
+        out.contains("\"shape_hash\""),
+        "a bare --dump-topology writes the artifact to stdout: {}",
+        out
+    );
+}

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -618,13 +618,22 @@ hale check app --check-topology .hale.topology    # exact snapshot gate
 hale check app --check-topology-shape .hale.topology   # model-only gate
 ```
 
-Both spellings work for every flag operand (`--flag value` and
-`--flag=value`); a missing operand is a usage error rather than a
-silent no-op. And `--dump-topology` does **not** change what the
-command means: a program whose claims fail still exits non-zero
-with its witnesses, it just prints the artifact on the way.
+The two gate flags take their operand either way (`--flag value` or
+`--flag=value`), and a missing operand is a usage error rather than a
+silent no-op — as is an unknown flag or a second target.
 
-The artifact shape (schema `1.0`):
+`--dump-topology` is the exception: its destination is the
+`=<path>` form **only**, and a bare `--dump-topology` writes to
+stdout. Its operand is optional, so "take the next token" has no
+safe reading — `hale check --dump-topology app.hl` would be asking
+whether `app.hl` is the destination or the target, and guessing
+wrong overwrites your source.
+
+Dumping does **not** change what the command means: a program whose
+claims fail still exits non-zero with its witnesses, it just prints
+the artifact on the way.
+
+The artifact shape (schema `1.2`):
 
 ```text
 {


### PR DESCRIPTION
The rest of the v0.15.0 claims developer-experience review. The four critical topology findings shipped in #404; these are the review's recommendations **3** and **7**.

### Argument parsing

`check` took its target from `argv[2]` and treated everything else as scenery:

| input | before | now |
|---|---|---|
| `hale check --help` | `not a file or directory: --help`, **exit 0** | per-command help, exit 0 |
| `hale check app.hl --typo-gate` | ignored, **exit 0** | usage error, exit 2 |
| `hale check a.hl b.hl` | checked `a.hl` only, exit 0 | usage error, exit 2 |
| `hale check --json app.hl` | target parsed as `--json` | works |

The first two are the same fail-open the topology gates had. A misspelled gate flag meant CI checked nothing and reported green — which is strictly worse than not having the flag.

### The destructive one

Making flags positionable exposed a real hazard. The dump destination shared the generic operand reader, which consumes the following token — so with flags now legal before the target:

```sh
hale check --dump-topology app.hl     # wrote the artifact OVER app.hl
```

`--dump-topology`'s operand is *optional*, so "consume the next token" has no safe general reading, and guessing wrong destroys the file you asked the tool to inspect. The destination is now the `=<path>` form only; a bare `--dump-topology` writes to stdout, and the two `--check-topology*` gates take their mandatory operand either way.

`dump_topology_never_overwrites_the_target` pins it by reading the source back and comparing.

### `--warn-unbounded-alloc`

Listed explicitly rather than dropped. It has been a no-op since the unbounded-alloc survey became default-on, but it was accepted for a release and rejecting it would break pipelines still passing it. Accepted-because-ignored is exactly what the flag list replaces, so it is written down instead of left to chance — the workspace suite caught this one, which is the argument for having written it down.

### Discoverability (recommendation 7)

The review's point was that "a developer who already knows the feature can use it; a developer who merely downloads v0.15.0 is unlikely to discover its full surface."

- `hale check --help` now documents the topology, effects and budget flags, saying what each gates and how the two topology gates differ.
- The top-level usage lists the claim flags and points at `--help`.
- The README gains a claims section: the six forms, a worked cross-seed example, the group/unknown-means-violation/library-tier rules, and the artifact commands. The shipped README discussed effects and never mentioned claims.

The README's example and its witness output are **copied from a verified run**, not composed by hand — the first draft had the wrong publish syntax and quoted a subject string where the compiler renders the topic path. Both were caught by compiling it.

### Not in this change

Recommendations 4, 5, 6 and 8 — secondary provenance for `only edges` and `bound`, interface-fanout rendering in witnesses, `hale claims list/explain/graph` inspection commands, and workspace-level verification across seeds. Each is a larger piece of work than the fail-opens here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)