### PR TITLE
feat(topology): artifact integrity digest (schema 1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ behavior.
 
 ## Unreleased
 
+### Topology artifact schema 1.3: an integrity digest
+
+`shape_hash` is an **identity**, not an integrity check. It covers
+the model half only — deliberately, so a moved comment or a renamed
+claim doesn't churn the model's identity — which leaves `topics`,
+`provenance` and the claim results outside it.
+
+That was fine while the only consumer was the compiler that had just
+produced the document. It stops being fine as soon as anything trusts
+an artifact it did not produce, and two concrete holes follow:
+
+- **The baseline gate could be forged.** `--check-topology-shape`
+  greps the `shape_hash` line out of a committed baseline, and
+  nothing forced the rest of the document to agree with it. Editing
+  that one line made the gate pass.
+- **The cross-binary join key was unverified.** Composing artifacts
+  from separately compiled applications joins endpoints on the
+  `topics` rows (wire subject + payload hash) — a section
+  `shape_hash` does not cover. Verifying the shape hash and then
+  joining on those rows means the key was never checked.
+
+Schema 1.3 adds `artifact_digest`: FNV-1a/64 over the entire body,
+results and provenance included, emitted as the final key so
+everything preceding it is exactly what was hashed — verification is
+a prefix hash, with no re-serialization or canonicalization step.
+Both baseline gates now reject a file whose digest disagrees with its
+contents as *corrupt* (exit 2) rather than reporting it as a
+mismatch.
+
+`verify_artifact_digest` returns `None` for an artifact with no
+digest (anything before 1.3) rather than `true`. A consumer may
+choose to accept an older artifact; it must never read "nothing to
+check" as "checked and intact".
+
 ### `check` / `verify` argument handling, and claims in the README
 
 The rest of the v0.15.0 claims developer-experience review. The

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2834,6 +2834,27 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
                 .map(|v| v.trim().trim_matches(',').trim_matches('"').to_string())
         };
         match std::fs::read_to_string(&path) {
+            Ok(expected) if matches!(
+                hale_types::topology::verify_artifact_digest(&expected),
+                Some(false)
+            ) =>
+            {
+                // This gate greps ONE line out of the baseline, so a
+                // baseline whose `shape_hash` line was edited to match
+                // would pass while the model it claims to describe
+                // says otherwise. The whole-body digest is what makes
+                // the grepped line trustworthy; a baseline that fails
+                // it is not a mismatch to report, it is a file that
+                // cannot be reasoned about.
+                eprintln!(
+                    "topology baseline {} is corrupt: its \
+                     `artifact_digest` does not match its contents. \
+                     Regenerate it:\n  hale check <target> \
+                     --dump-topology > {}",
+                    path, path
+                );
+                return ExitCode::from(2);
+            }
             Ok(expected) => match (hash_of(&expected), hash_of(&current)) {
                 (Some(a), Some(b)) if a != b => {
                     eprintln!(

--- a/crates/hale-cli/tests/xseed_claims_verbs.rs
+++ b/crates/hale-cli/tests/xseed_claims_verbs.rs
@@ -80,7 +80,7 @@ fn cover_catches_an_uncovered_topic_across_seeds() {
 fn the_topology_artifact_round_trips() {
     let dump = dump_artifact();
     assert!(
-        dump.contains("\"schema\": \"1.2\"")
+        dump.contains("\"schema\": \"1.3\"")
             && dump.contains("\"shape_hash\": \""),
         "the artifact must carry schema + shape_hash:\n{}",
         dump

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -83,8 +83,12 @@ use crate::symbol::Bundle;
 /// `provenance` section. 1.2 (#399): unhashed `topics` section —
 /// the per-topic OBSERVATION identity (wire subject, canonical
 /// payload shape, `payload_hash`), the join key a recording/WAL
-/// segment carries; model `shape_hash` values unchanged.
-pub const TOPOLOGY_SCHEMA: &str = "1.2";
+/// segment carries; model `shape_hash` values unchanged. 1.3:
+/// unhashed-by-`shape_hash` but now COVERED `artifact_digest` — a
+/// whole-body integrity hash as the final key, so a consumer that
+/// trusts an artifact it did not produce can verify the sections
+/// `shape_hash` omits (`topics`, `provenance`, claim results).
+pub const TOPOLOGY_SCHEMA: &str = "1.3";
 
 /// Serialize the bundle's model + claim results as the topology
 /// artifact (JSON).
@@ -798,8 +802,58 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
         ));
     }
     trim_trailing_comma(&mut out);
-    out.push_str("  ]\n}\n");
+    out.push_str("  ]");
+
+    // Integrity (schema 1.3). `shape_hash` is an IDENTITY, not an
+    // integrity check: it deliberately covers the model half only,
+    // so `topics`, `provenance` and the claim results all sit
+    // outside it. That is right for what those sections were for —
+    // moving a comment must not churn the model identity — but it
+    // leaves two holes the moment anything TRUSTS an artifact it
+    // did not produce:
+    //
+    //   * cross-binary composition joins endpoints on the `topics`
+    //     rows (wire subject + payload hash). Verifying `shape_hash`
+    //     and then joining on unhashed rows means the join key is
+    //     outside the thing that was verified.
+    //   * a baseline gate that greps `shape_hash` out of a file can
+    //     be defeated by editing that one line — the rest of the
+    //     document need not agree with it.
+    //
+    // So the digest covers the ENTIRE body, results and provenance
+    // included, and is the last key: everything preceding it is
+    // exactly what was hashed, which makes verification a prefix
+    // hash with no need to re-serialize or canonicalize.
+    let digest = fnv1a64(out.as_bytes());
+    out.push_str(&format!(
+        "{}{:016x}\"\n}}\n",
+        ARTIFACT_DIGEST_KEY, digest
+    ));
     out
+}
+
+/// The exact byte sequence introducing the integrity digest. It is
+/// the artifact's final key, so everything before this marker is the
+/// hashed body. Written once and shared by the emitter and the
+/// verifier so the two cannot drift.
+pub const ARTIFACT_DIGEST_KEY: &str = ",\n  \"artifact_digest\": \"";
+
+/// Verify an artifact's integrity digest.
+///
+/// `None` means the document carries no digest — every artifact
+/// emitted before schema 1.3. That is reported distinctly from
+/// `Some(false)` on purpose: a consumer may choose to accept an
+/// older artifact, but it must never mistake "nothing to check"
+/// for "checked and intact".
+pub fn verify_artifact_digest(artifact: &str) -> Option<bool> {
+    // rfind: the digest is the final key, and searching from the end
+    // means a user-authored string that happens to contain the
+    // marker cannot shadow the real one.
+    let at = artifact.rfind(ARTIFACT_DIGEST_KEY)?;
+    let body = &artifact[..at];
+    let rest = &artifact[at + ARTIFACT_DIGEST_KEY.len()..];
+    let claimed = rest.split('"').next()?;
+    Some(claimed == format!("{:016x}", fnv1a64(body.as_bytes())))
 }
 
 fn join_str<'a>(items: impl Iterator<Item = &'a String>) -> String {

--- a/crates/hale-types/tests/artifact_integrity.rs
+++ b/crates/hale-types/tests/artifact_integrity.rs
@@ -1,0 +1,142 @@
+//! The topology artifact's integrity digest (schema 1.3).
+//!
+//! `shape_hash` is an IDENTITY, not an integrity check. It covers
+//! the model half only — deliberately, so that moving a comment or
+//! renaming a claim doesn't churn the model's identity — which
+//! leaves `topics`, `provenance` and the claim results outside it.
+//!
+//! That is fine while the only consumer is the compiler that just
+//! produced the document. It stops being fine the moment anything
+//! trusts an artifact it did not produce:
+//!
+//!  - a cross-binary consumer joins endpoints on the `topics` rows
+//!    (wire subject + payload hash). Verifying `shape_hash` and then
+//!    joining on rows outside it means the join key was never
+//!    checked.
+//!  - a baseline gate that greps the `shape_hash` line out of a file
+//!    can be defeated by editing that one line, since nothing forces
+//!    the rest of the document to agree with it.
+//!
+//! `artifact_digest` covers the whole body and is the final key, so
+//! everything preceding it is exactly what was hashed.
+
+use std::collections::BTreeMap;
+
+use hale_types::topology::{dump_topology, verify_artifact_digest};
+use hale_types::Bundle;
+
+const SRC: &str = r#"
+    type T { v: Int; }
+    topic Tk { payload: T; subject: "app.t"; }
+    locus Sub {
+        params { got: Int = 0; }
+        bus { subscribe Tk as on_t; }
+        fn on_t(t: T) { self.got = t.v; }
+    }
+    group subs = { Sub };
+    main locus App {
+        params { s: Sub = Sub { }; }
+        claims { wired: require subscribes(some subs, topic Tk); }
+    }
+    fn main() { App { }; }
+"#;
+
+fn dump(src: &str) -> String {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    dump_topology(&Bundle::new(programs))
+}
+
+fn artifact() -> String {
+    dump(SRC)
+}
+
+#[test]
+fn a_freshly_emitted_artifact_verifies() {
+    let a = artifact();
+    assert_eq!(
+        verify_artifact_digest(&a),
+        Some(true),
+        "the emitter and verifier must agree:\n{}",
+        a
+    );
+}
+
+/// The digest must cover the sections `shape_hash` omits. This is
+/// the property cross-binary composition depends on: `topics` is the
+/// join key, and it is not part of the model identity.
+#[test]
+fn tampering_with_the_unhashed_topics_section_is_caught() {
+    let a = artifact();
+    assert!(
+        a.contains("app.t"),
+        "fixture must carry a wire subject to tamper with:\n{}",
+        a
+    );
+    let tampered = a.replacen("app.t", "app.EVIL", 1);
+    assert_eq!(
+        verify_artifact_digest(&tampered),
+        Some(false),
+        "a rewritten wire subject must fail the digest — it is the \
+         key a fleet consumer would join endpoints on"
+    );
+}
+
+/// The other hole: forging the identity line itself.
+#[test]
+fn forging_the_shape_hash_line_is_caught() {
+    let a = artifact();
+    let start = a.find("\"shape_hash\": \"").expect("shape_hash present")
+        + "\"shape_hash\": \"".len();
+    let forged =
+        format!("{}dead0000beef0000{}", &a[..start], &a[start + 16..]);
+    assert_ne!(forged, a, "the forgery must actually change the text");
+    assert_eq!(
+        verify_artifact_digest(&forged),
+        Some(false),
+        "a gate that greps one line out of a baseline is only as \
+         trustworthy as the digest over the whole body"
+    );
+}
+
+/// Claim results and provenance are outside `shape_hash` too, and
+/// a consumer that trusts an artifact cares whether they were edited.
+#[test]
+fn tampering_with_a_claim_result_is_caught() {
+    let a = artifact();
+    assert!(a.contains("\"holds\""), "fixture must have a holding claim");
+    let tampered = a.replacen("\"holds\"", "\"violated\"", 1);
+    assert_eq!(verify_artifact_digest(&tampered), Some(false));
+}
+
+/// Absent is reported distinctly from invalid. A consumer may accept
+/// a pre-1.3 artifact, but must never read "nothing to check" as
+/// "checked and intact".
+#[test]
+fn an_artifact_without_a_digest_is_unverifiable_not_valid() {
+    let a = artifact();
+    let at = a
+        .rfind(hale_types::topology::ARTIFACT_DIGEST_KEY)
+        .expect("digest present");
+    let older = format!("{}\n}}\n", &a[..at]);
+    assert_eq!(
+        verify_artifact_digest(&older),
+        None,
+        "no digest must be None, never Some(true)"
+    );
+}
+
+/// The digest changes with the model, so it cannot be a constant that
+/// happens to match.
+#[test]
+fn a_different_program_produces_a_different_digest() {
+    let a = artifact();
+    let other_src = SRC.replace("locus Sub {", "locus Extra { }\n    locus Sub {");
+    let b = dump(&other_src);
+    assert_eq!(verify_artifact_digest(&b), Some(true));
+    assert_ne!(
+        a, b,
+        "adding a locus must change the artifact"
+    );
+}

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -633,11 +633,37 @@ Dumping does **not** change what the command means: a program whose
 claims fail still exits non-zero with its witnesses, it just prints
 the artifact on the way.
 
-The artifact shape (schema `1.2`):
+### Identity vs. integrity
+
+Two different hashes, and conflating them is a trap:
+
+- **`shape_hash`** is an *identity*. It covers the model half only,
+  so claim renames, moved comments, and the `topics`/`provenance`
+  sections don't churn it. That's what makes
+  `--check-topology-shape` usable in CI.
+- **`artifact_digest`** is an *integrity* check. It covers the
+  entire body — model, topics, provenance and claim results alike —
+  and is the final key, so everything before it is exactly what was
+  hashed.
+
+You need the second as soon as anything trusts an artifact it didn't
+produce. A gate that greps `shape_hash` out of a committed baseline
+can be defeated by editing that one line; and a cross-binary
+consumer joining endpoints on the `topics` rows would otherwise be
+joining on data outside the hash it verified. Both baseline gates
+reject a file whose digest doesn't match its contents, as corrupt
+rather than as a mismatch.
+
+An artifact with no `artifact_digest` (anything before schema 1.3)
+reports as *unverifiable* rather than as valid — a consumer may
+choose to accept it, but must never read "nothing to check" as
+"checked and intact".
+
+The artifact shape (schema `1.3`):
 
 ```text
 {
-  "schema": "1.2",
+  "schema": "1.3",
   "shape_hash": "<fnv1a-64 over the model half>",
   "sorts":     { "loci": […], "fns": […], "topics": […] },
   "relations": {

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -235,7 +235,7 @@ earlier in the same file as the family. Companion:
 class along any path, with the same loop/indirect unboundedness
 rules as every per-call dimension.
 
-**The topology artifact** (#382 phase 2; schema 1.2 per #399):
+**The topology artifact** (#382 phase 2; schema 1.3):
 `hale check <t> --dump-topology` emits the serialized model —
 sorts (loci, fns, topics), relations (calls with **weights**: loop
 nesting, unbounded-loop membership, interface-dispatch tags;


### PR DESCRIPTION
Prerequisite for cross-binary artifact composition, and it closes a hole in a gate that already shipped.

### `shape_hash` is an identity, not an integrity check

It covers the model half only — deliberately. A moved comment or a renamed claim must not churn the model's identity, which is exactly what makes `--check-topology-shape` usable in CI. The consequence is that `topics`, `provenance` and the claim results all sit outside it.

That's fine while the only consumer is the compiler that just produced the document. It stops being fine the moment anything trusts an artifact it didn't produce, and there are two concrete holes:

**The baseline gate could be forged.** `--check-topology-shape` greps the `shape_hash` line out of a committed baseline. Nothing forced the rest of the document to agree with it, so editing that one line made the gate pass.

**The cross-binary join key was unverified.** Composing artifacts from separately compiled applications joins endpoints on the `topics` rows — wire subject and payload hash. Verifying `shape_hash` and then joining on rows it doesn't cover means the key was never checked.

Worth being clear that the unhashed `topics` section is not a bug in #399. It's unhashed for a good reason: payload field shape doesn't affect claim evaluation, so folding it into the model identity would make unrelated payload edits churn every baseline. Composition doesn't reveal a mistake — it *promotes* that section from reference data to load-bearing, which is a change in status rather than a defect.

### What this adds

`artifact_digest`: FNV-1a/64 over the entire body, results and provenance included, emitted as the **final key**. Everything preceding it is exactly what was hashed, so verification is a prefix hash — no re-serialization, no canonicalization step, nothing that can drift between emitter and verifier. The marker string is a shared constant for the same reason.

Both baseline gates now reject a file whose digest disagrees with its contents as **corrupt** (exit 2), not as a mismatch. A file that can't be reasoned about isn't a diff to report.

### Absent is not valid

`verify_artifact_digest` returns `None` for an artifact carrying no digest — anything before 1.3 — rather than `true`. A consumer may choose to accept an older artifact, but it must never read "nothing to check" as "checked and intact". The tests pin that distinction directly.

### Tests

`crates/hale-types/tests/artifact_integrity.rs` covers the round trip plus four tampering shapes, each aimed at a section `shape_hash` omits: a rewritten wire subject (the fleet join key), a forged `shape_hash` line (the gate hole), an edited claim result, and a digest-less document. Plus a guard that the digest actually varies with the model, so it can't be a constant that happens to match.

Schema references in `spec/verification.md` and `docs/src/claims.md` move to 1.3, and the claims chapter gains a short identity-vs-integrity section — the two hashes are easy to conflate and the consequences of conflating them are exactly the two holes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)