### PR TITLE
fix(claims): never emit an artifact for a program that fails to typecheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,40 @@ the conformer from the group.
 The fact was already in the model (the artifact tags these edges
 `via_interface`); it just never reached the human. Witnesses with no
 interface in them are unchanged.
+### Topology artifact schema 1.4: one verdict vocabulary, and the document's own verdict
+
+Bundle claims and fn-grained certificates (`@effects`, `@budget`,
+`@phase_effects`) are the same kind of statement at different
+granularity — #392 §8 already reports the second as the claim form it
+is pointwise sugar for. They disagreed about how to spell an outcome:
+claim rows carried three states, `lowered` rows carried a bool.
+
+Both now use `Verdict`, and it distinguishes a case that was
+previously folded away:
+
+| verdict | meaning | repair |
+|---|---|---|
+| `holds` | proved | nothing |
+| `violated` | disproved — a counterexample exists | fix the program |
+| `uncertified` | well-formed but not provable — the graph has an unknown | resolve the unknown edge |
+| `invalid` | the statement is malformed | fix the claim |
+
+`violated` and `uncertified` were one value because **unknown ⇒
+violation** — an indirect call fails closed rather than certifying an
+absence nothing established. That rule is unchanged and both still
+fail the build. What changes is that the artifact records which
+happened: the repairs differ, and composing models across binaries
+needs a propagated unknown to read as "not provable" rather than as
+disproved when nothing disproved it.
+
+The artifact also gains a top-level **`verdict`** (`clean` /
+`law_failed`) — every law reduced to one field, so a consumer does
+not reconstruct it by walking two arrays and knowing which strings
+count as passing. Only `holds` passes: a law that could not be
+checked has not been satisfied. It says nothing about whether the
+program typechecks, because an artifact is only emitted for one that
+does.
+
 ### A topology artifact is only emitted for a program that typechecks
 
 `hale check broken.hl --dump-topology` emitted a **full artifact** for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,34 @@ the conformer from the group.
 The fact was already in the model (the artifact tags these edges
 `via_interface`); it just never reached the human. Witnesses with no
 interface in them are unchanged.
+### A topology artifact is only emitted for a program that typechecks
+
+`hale check broken.hl --dump-topology` emitted a **full artifact** for
+a program with a type error: populated relations, and claims evaluated
+over a graph derived from source the compiler could not understand. A
+claim would report `"result": "holds"` for a program that cannot
+compile — a certificate asserting a property of something that will
+never run.
+
+That is worse for a consumer than emitting nothing, because it fails
+open: an admission step looking for "no violated claims" *passes* it,
+since there are none.
+
+The artifact's existence now means the model is sound. A program that
+does not typecheck emits no artifact and says why.
+
+A **violated** claim is the opposite case and still emits, unchanged:
+the model is well-defined, the row is a truthful report, and replaying
+a violation independently is the point of publishing the model. The
+new `DiagKind::Claim` separates the two — errors like any other, and
+rendered identically (the message already begins "claim `x`
+violated", so a distinct prefix would only stutter), marked at the one
+place every claim diagnostic funnels through rather than at its ~30
+construction sites.
+
+`check` now runs its analysis once and shares it between the artifact
+gate and the diagnostic report, so this costs nothing on a
+`--dump-topology` run.
 
 ### Topology artifact schema 1.3: an integrity digest
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "hale-corpus",
  "hale-stdlib",
  "hale-syntax",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2790,7 +2790,45 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
         .find_map(|a| a.strip_prefix("--dump-topology="))
         .filter(|v| !v.is_empty())
         .map(|v| v.to_string());
+    // One analysis pass, shared by the artifact gate below and the
+    // diagnostic report further down. `check_bundle_opts` is the
+    // expensive part of `check`, and nothing mutates `bundle`
+    // between the two, so running it twice would just double the
+    // cost of every `--dump-topology` invocation.
+    let allow_unowned =
+        std::env::args().any(|a| a == "--allow-unowned-subscriber");
+    let checked = hale_types::check_bundle_opts(&bundle, allow_unowned);
+
     if dump_topology || dump_topology_to.is_some() {
+        // The artifact's EXISTENCE means the model is sound.
+        //
+        // A program that fails to typecheck still produced a full
+        // artifact — populated relations, and claims evaluated over a
+        // graph derived from source the compiler could not
+        // understand. A claim would report `"result": "holds"` for a
+        // program that cannot compile: a certificate asserting a
+        // property of something that will never run. Worse for a
+        // consumer than no artifact, because an admission step
+        // looking for "no violated claims" passes it.
+        //
+        // A VIOLATED claim is the opposite case and still emits: the
+        // model is well-defined, the row is a truthful report, and
+        // being able to replay a violation independently is the point
+        // of publishing the model at all. `DiagKind::Claim` is what
+        // separates the two.
+        if let Some(d) = checked
+            .iter()
+            .find(|d| d.is_error() && d.kind != hale_syntax::error::DiagKind::Claim)
+        {
+            eprintln!(
+                "refusing to emit a topology artifact: `{}` does not \
+                 typecheck, so its model is not a truthful \
+                 description of any program. Fix the {} first.",
+                target.display(),
+                d.kind_str()
+            );
+            return ExitCode::from(1);
+        }
         let artifact = hale_types::topology::dump_topology(&bundle);
         match &dump_topology_to {
             Some(path) => {
@@ -2979,9 +3017,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
             return ExitCode::from(1);
         }
     }
-    let allow_unowned =
-        std::env::args().any(|a| a == "--allow-unowned-subscriber");
-    let mut diags = hale_types::check_bundle_opts(&bundle, allow_unowned);
+    let mut diags = checked;
     // Advisories about code the target does not own are dropped.
     //
     // `check` resolving imports is what makes cross-seed ERRORS

--- a/crates/hale-cli/tests/claims_artifact_unknowns.rs
+++ b/crates/hale-cli/tests/claims_artifact_unknowns.rs
@@ -144,13 +144,36 @@ fn a_conforming_dispatch_appears_as_call_edges_not_unknowns() {
 #[test]
 fn an_uninhabited_interface_call_is_an_unknown_and_changes_the_hash()
 {
-    // Remove the conformer: same program, `Email::send` renamed so
-    // nothing satisfies `Notifier`.
-    let uninhabited = DISPATCHED.replace(
-        "locus Email { fn send(n: Int) -> Int { return n; } }",
-        "locus Email { fn deliver(n: Int) -> Int { return n; } }",
-    );
-    let art = dump(&uninhabited, "uninhabited");
+    // The interface must be uninhabited in a program that still
+    // TYPECHECKS. The obvious construction — take `DISPATCHED` and
+    // rename `Email::send` — does not: `Route { handler: Email { } }`
+    // then stores a non-conformer in a `Notifier` field, which is a
+    // type error ("locus `Email` does not satisfy interface
+    // `Notifier`"). An artifact is only emitted for a program whose
+    // model is sound, so that construction produced no artifact at
+    // all and this test was asserting against an empty string.
+    //
+    // Take the interface as a PARAMETER instead. The body is
+    // checkable, nothing conforms, and the call site is dead in this
+    // build — which is exactly the case the unknown class exists to
+    // record.
+    const UNINHABITED: &str = r#"
+interface Notifier { fn send(n: Int) -> Int; }
+locus Email { fn deliver(n: Int) -> Int { return n; } }
+locus A {
+    fn go(x: Notifier, n: Int) -> Int {
+        return x.send(n);
+    }
+}
+group a_side = { A };
+group sinks = { Email };
+main locus App {
+    params { a: A = A { }; }
+    claims { iso: forbid reaches(a_side, sinks); }
+}
+fn main() { App { }; }
+"#;
+    let art = dump(UNINHABITED, "uninhabited");
     assert!(
         art.contains("uninhabited_interface_call:Notifier.send")
             && art.contains("\"A::go\""),

--- a/crates/hale-cli/tests/topology_artifact_contract.rs
+++ b/crates/hale-cli/tests/topology_artifact_contract.rs
@@ -323,3 +323,45 @@ fn a_violated_claim_still_emits_its_artifact() {
         stdout
     );
 }
+
+/// A violated **fn-grained certificate** is a law failure, not a type
+/// error, so the artifact must still be emitted — the `lowered` rows
+/// exist precisely to record that verdict.
+///
+/// This is the case CI caught and local runs did not. The soundness
+/// gate first keyed on `DiagKind::Claim`, which only bundle claims
+/// carried, so a program that typechecked but broke a `@budget` or
+/// `@effects` contract was refused an artifact. Its model is
+/// perfectly sound; only a rule was broken.
+#[test]
+fn a_violated_certificate_still_emits_its_artifact() {
+    const OVER_BUDGET: &str = r#"
+        type P { a: Int; }
+        @budget(alloc_per_call = 0)
+        fn boxed(n: Int) -> P { return P { a: n }; }
+        main locus App { params { n: Int = 0; } }
+        fn main() { App { }; let p = boxed(1); }
+    "#;
+    let path = write_tmp("certificate", OVER_BUDGET);
+    let (stdout, code) =
+        hale(&["check".as_ref(), path.as_os_str(), "--dump-topology".as_ref()]);
+    let _ = std::fs::remove_file(&path);
+
+    assert_ne!(code, 0, "the broken contract must fail the run: {}", stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!(
+            "a violated CERTIFICATE is law, not a broken model — the \
+             artifact must still be emitted: {e}\n{stdout}"
+        )
+    });
+    assert!(
+        v["lowered"].as_array().is_some_and(|r| !r.is_empty()),
+        "and carry the lowered rows that record the verdict: {}",
+        stdout
+    );
+    assert_eq!(
+        v["verdict"], "law_failed",
+        "the document verdict covers certificates too: {}",
+        stdout
+    );
+}

--- a/crates/hale-cli/tests/topology_artifact_contract.rs
+++ b/crates/hale-cli/tests/topology_artifact_contract.rs
@@ -257,3 +257,69 @@ fn the_shape_gate_ignores_source_motion_but_not_graph_changes() {
         "adding a locus changes the model and MUST trip the shape gate"
     );
 }
+
+/// A program that does not TYPECHECK must not produce an artifact at
+/// all. This is the other half of "observing a program must not
+/// change its verdict", and it fails in the more dangerous direction.
+///
+/// Verified against the shipped behavior before the fix: a program
+/// with a type error emitted a full artifact — populated relations,
+/// and claims evaluated over a graph derived from source the compiler
+/// could not understand. A claim reported `"result": "holds"` for a
+/// program that cannot compile. That is worse for a consumer than no
+/// artifact, because an admission step looking for "no violated
+/// claims" passes it: there are none.
+///
+/// A VIOLATED claim is the opposite case and must still emit — the
+/// model is well-defined, the row is truthful, and replaying a
+/// violation independently is the point of publishing the model.
+#[test]
+fn a_program_that_does_not_typecheck_emits_no_artifact() {
+    const TYPE_ERROR: &str = r#"
+        type T { v: Int; }
+        topic Tk { payload: T; subject: "app.t"; }
+        locus Sub {
+            params { got: Int = 0; }
+            bus { subscribe Tk as on_t; }
+            fn on_t(t: T) { self.got = t.v; }
+            fn broken() -> Int { return self.no_such_field; }
+        }
+        group subs = { Sub };
+        main locus App {
+            params { s: Sub = Sub { }; }
+            claims { wired: require subscribes(some subs, topic Tk); }
+        }
+        fn main() { App { }; }
+    "#;
+    let path = write_tmp("typeerr", TYPE_ERROR);
+    let (stdout, code) =
+        hale(&["check".as_ref(), path.as_os_str(), "--dump-topology".as_ref()]);
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        stdout.trim().is_empty(),
+        "no artifact may be emitted for a program that does not \
+         typecheck — its model describes no program: {}",
+        stdout
+    );
+    assert_ne!(code, 0, "the type error must still fail the run");
+}
+
+/// The distinction the fix rests on: a violated claim still emits.
+#[test]
+fn a_violated_claim_still_emits_its_artifact() {
+    let path = write_tmp("violated_emits", FAILING);
+    let (stdout, code) =
+        hale(&["check".as_ref(), path.as_os_str(), "--dump-topology".as_ref()]);
+    let _ = std::fs::remove_file(&path);
+
+    assert_ne!(code, 0, "the violated claim must fail the run");
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("a claims-violated program must still emit a parseable artifact: {e}\n{stdout}")
+    });
+    assert!(
+        v["claims"].as_array().is_some_and(|c| !c.is_empty()),
+        "and it must carry the claim rows that explain the failure: {}",
+        stdout
+    );
+}

--- a/crates/hale-cli/tests/xseed_claims_verbs.rs
+++ b/crates/hale-cli/tests/xseed_claims_verbs.rs
@@ -80,7 +80,7 @@ fn cover_catches_an_uncovered_topic_across_seeds() {
 fn the_topology_artifact_round_trips() {
     let dump = dump_artifact();
     assert!(
-        dump.contains("\"schema\": \"1.3\"")
+        dump.contains("\"schema\": \"1.4\"")
             && dump.contains("\"shape_hash\": \""),
         "the artifact must carry schema + shape_hash:\n{}",
         dump

--- a/crates/hale-codegen/tests/effects_conformance.rs
+++ b/crates/hale-codegen/tests/effects_conformance.rs
@@ -36,7 +36,13 @@ fn build_and_run(tag: &str, src: &str) -> (String, bool) {
     let diags = hale_types::check_program(&program);
     let hard: Vec<String> = diags
         .iter()
-        .filter(|d| matches!(d.kind, hale_syntax::DiagKind::Type))
+        // `is_error()` rather than a kind match: a violated
+        // assertion is now `DiagKind::Claim` (law, not a type
+        // error), and matching on `Type` alone would silently stop
+        // seeing the very thing this guard exists to catch. It also
+        // picks up parse and codegen errors, which it always should
+        // have.
+        .filter(|d| d.is_error())
         .map(|d| d.message.clone())
         .collect();
     assert!(

--- a/crates/hale-syntax/src/error.rs
+++ b/crates/hale-syntax/src/error.rs
@@ -17,6 +17,18 @@ pub enum DiagKind {
     Parse,
     /// Type-checker errors.
     Type,
+    /// Claim violations and claim-vocabulary errors. Errors like any
+    /// other, and rendered identically to `Type` on purpose — the
+    /// message already begins "claim `x` violated", so a distinct
+    /// prefix would only stutter.
+    ///
+    /// The kind exists so a consumer can tell "this program does not
+    /// typecheck" from "this program typechecks and breaks a law".
+    /// The topology artifact needs exactly that distinction: a
+    /// violated claim is a truthful report about a sound model, while
+    /// a type error means the model was derived from a program the
+    /// compiler could not understand and must not be published at all.
+    Claim,
     /// GH #241: codegen-raised errors that carry a source span
     /// (CodegenError::UnsupportedAt) — rendered with the same
     /// location + caret treatment as check diagnostics.
@@ -90,6 +102,8 @@ impl Diag {
             DiagKind::Lex => "lex error",
             DiagKind::Parse => "parse error",
             DiagKind::Type => "type error",
+            // deliberately the same label — see the variant's doc
+            DiagKind::Claim => "type error",
             DiagKind::Codegen => "codegen error",
             DiagKind::Warn => "warning",
         }

--- a/crates/hale-types/Cargo.toml
+++ b/crates/hale-types/Cargo.toml
@@ -12,3 +12,7 @@ hale-syntax = { path = "../hale-syntax" }
 
 [dev-dependencies]
 hale-corpus = { path = "../hale-corpus" }
+# The artifact contract tests PARSE the whole document rather than
+# asserting on substrings — the only shape of test that catches a
+# structural error, which is how an unclosed array once shipped.
+serde_json = "1"

--- a/crates/hale-types/src/budget_check.rs
+++ b/crates/hale-types/src/budget_check.rs
@@ -38,6 +38,7 @@
 use hale_syntax::ast::*;
 use hale_syntax::{Diag, Span};
 
+use crate::verdict::Verdict;
 use crate::alloc_summary::{self, AllocKind, AllocSite, AllocSummary,
     CallEdge, FnKey};
 use crate::callgraph::{self, FactVisitor};
@@ -357,7 +358,11 @@ fn budget_report_inner(
                 budget,
                 key.display()
             ),
-            violated: diags.len() > before,
+            result: if diags.len() > before {
+                        Verdict::Violated
+                    } else {
+                        Verdict::Holds
+                    },
         });
     };
     for program in programs {

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -416,6 +416,19 @@ pub fn check_bundle(
     // allocates more than its declared per-call ceiling (0 = zero-alloc
     // certificate). Reuses the `alloc_summary` call graph.
     {
+        // Everything in this block is LAW — fn-grained certificates
+        // (`@budget`, `@effects`, `@phase_effects`, the frontier
+        // contracts) and bundle claims. #392 §8 already reports the
+        // first as the claim form it is pointwise sugar for, and the
+        // artifact records both in one vocabulary.
+        //
+        // They are marked `DiagKind::Claim` as a batch below, which
+        // matters for one thing: a law failure means the program
+        // typechecks and breaks a rule, so its model is sound and the
+        // artifact must still be emitted to record the verdict. A
+        // TYPE error means the model describes no program and the
+        // artifact must not exist. Rendering is identical either way.
+        let law_start = diags.len();
         let programs_vec: Vec<&Program> = bundle.programs.values().copied().collect();
         diags.extend(crate::budget_check::budget_diags_with_renames(
             &programs_vec,
@@ -461,6 +474,11 @@ pub fn check_bundle(
                 &programs_vec,
                 &fanout,
             ));
+        }
+        for d in &mut diags[law_start..] {
+            if d.kind == hale_syntax::error::DiagKind::Type {
+                d.kind = hale_syntax::error::DiagKind::Claim;
+            }
         }
     }
     // 2026-05-29: a bus-subscribing locus instantiated non-owned

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -48,6 +48,7 @@ use hale_syntax::Diag;
 
 use crate::alloc_summary::{AllocSummary, Callee, EffectSiteKind, FnKey};
 use crate::bus_graph::BusGraph;
+use crate::verdict::Verdict;
 use crate::callgraph;
 use crate::effects::{
     close, declared_of, defs_of, effect_names_of, ffi_names,
@@ -60,9 +61,9 @@ pub struct ClaimOutcome {
     pub name: String,
     /// The normalized sentence, rendered.
     pub form: String,
-    /// `"holds"`, `"violated"`, or `"invalid"` (a vocabulary /
-    /// reference error prevented evaluation).
-    pub result: &'static str,
+    /// See [`crate::verdict::Verdict`] — one vocabulary shared with
+    /// the fn-grained certificates in `lowered`.
+    pub result: Verdict,
 }
 
 /// Diagnostics only — the `hale check` entry point.
@@ -457,7 +458,7 @@ fn claims_report_inner(
     for c in &claims {
         let valid = validate_claim(c, &cx, &mut diags);
         let result = if !valid {
-            "invalid"
+            Verdict::Invalid
         } else {
             match &c.form {
                 ClaimForm::ForbidReaches { .. } => {
@@ -984,7 +985,7 @@ fn evaluate_forbid_reaches(
     c: &ClaimDecl,
     cx: &Cx,
     diags: &mut Vec<Diag>,
-) -> &'static str {
+) -> Verdict {
     let ClaimForm::ForbidReaches {
         src,
         dst,
@@ -1003,14 +1004,14 @@ fn evaluate_forbid_reaches(
     if projection_vacuity(
         c, "source", src_name, src_group, &cx.summary, diags,
     ) {
-        return "invalid";
+        return Verdict::Invalid;
     }
     if let ClaimSet::Group(dst_name) = dst {
         let dst_group = &cx.groups[&dst_name.name];
         if projection_vacuity(
             c, "target", dst_name, dst_group, &cx.summary, diags,
         ) {
-            return "invalid";
+            return Verdict::Invalid;
         }
     }
     let mut roots = src_group.fn_set(&cx.summary);
@@ -1039,7 +1040,7 @@ fn evaluate_forbid_reaches(
                     c.name.name, phase.name, src_name.name
                 ),
             ));
-            return "invalid";
+            return Verdict::Invalid;
         }
     }
     // `avoiding G` — the vertex mask. Masked vertices are neither
@@ -1066,7 +1067,7 @@ fn evaluate_forbid_reaches(
     // fired at the group decl if that was unintentional.
     if let DstTest::Group(g) = &dst_test {
         if g.is_empty() {
-            return "holds";
+            return Verdict::Holds;
         }
     }
 
@@ -1094,7 +1095,7 @@ fn evaluate_forbid_reaches(
                     callgraph::MAX_STEPS
                 ),
             ));
-            return "violated";
+            return Verdict::Violated;
         }
         // Membership hit? Roots included: a decl in BOTH groups is a
         // zero-length path — a real boundary confusion `forbid`
@@ -1116,7 +1117,7 @@ fn evaluate_forbid_reaches(
                 cx,
                 diags,
             );
-            return "violated";
+            return Verdict::Violated;
         }
         let Some(fs) = cx.summary.fns.get(&k) else { continue };
         if *via_calls {
@@ -1167,7 +1168,7 @@ fn evaluate_forbid_reaches(
                                     src_name.name
                                 ),
                             ));
-                            return "violated";
+                            return Verdict::Uncertified;
                         }
                         // The backstop: an untyped-receiver call
                         // is a method of SOME locus, possibly a
@@ -1190,7 +1191,7 @@ fn evaluate_forbid_reaches(
                                     name
                                 ),
                             ));
-                            return "violated";
+                            return Verdict::Uncertified;
                         }
                     }
                 }
@@ -1217,7 +1218,7 @@ fn evaluate_forbid_reaches(
                             src_name.name
                         ),
                     ));
-                    return "violated";
+                    return Verdict::Uncertified;
                 };
                 for (sub_locus, sub_handler, sub_span) in
                     subscribers_of(cx.graph, subj)
@@ -1247,7 +1248,7 @@ fn evaluate_forbid_reaches(
             }
         }
     }
-    "holds"
+    Verdict::Holds
 }
 
 // ===================== only edges =================================
@@ -1260,7 +1261,7 @@ fn evaluate_only_edges(
     c: &ClaimDecl,
     cx: &Cx,
     diags: &mut Vec<Diag>,
-) -> &'static str {
+) -> Verdict {
     let ClaimForm::OnlyEdges { src, dst, grants } = &c.form else {
         unreachable!("dispatched on form")
     };
@@ -1271,7 +1272,7 @@ fn evaluate_only_edges(
             c, "target", dst, dst_g, &cx.summary, diags,
         )
     {
-        return "invalid";
+        return Verdict::Invalid;
     }
     let granted: BTreeSet<&str> = grants
         .iter()
@@ -1335,7 +1336,7 @@ fn evaluate_only_edges(
                                 k.display()
                             ),
                         ));
-                        return "violated";
+                        return Verdict::Uncertified;
                     }
                     if unresolved_opaque_receiver(edge) {
                         diags.push(Diag::ty(
@@ -1353,7 +1354,7 @@ fn evaluate_only_edges(
                                 name
                             ),
                         ));
-                        return "violated";
+                        return Verdict::Uncertified;
                     }
                 }
             }
@@ -1374,7 +1375,7 @@ fn evaluate_only_edges(
                         k.display()
                     ),
                 ));
-                return "violated";
+                return Verdict::Uncertified;
             };
             for (sub_locus, sub_handler, _sub_span) in
                 subscribers_of(cx.graph, subj)
@@ -1415,9 +1416,9 @@ fn evaluate_only_edges(
         }
     }
     if violated {
-        "violated"
+        Verdict::Violated
     } else {
-        "holds"
+        Verdict::Holds
     }
 }
 
@@ -1433,7 +1434,7 @@ fn evaluate_bound(
     c: &ClaimDecl,
     cx: &Cx,
     diags: &mut Vec<Diag>,
-) -> &'static str {
+) -> Verdict {
     let ClaimForm::Bound {
         class,
         class_name,
@@ -1448,7 +1449,7 @@ fn evaluate_bound(
     let group = &cx.groups[&from.name];
     if projection_vacuity(c, "source", from, group, &cx.summary, diags)
     {
-        return "invalid";
+        return Verdict::Invalid;
     }
     let mut worst: Heaviest = Some((0, Vec::new()));
     let mut worst_is_unbounded = false;
@@ -1483,11 +1484,11 @@ fn evaluate_bound(
                 c.name.name, from.name, class_name, limit
             ),
         ));
-        return "violated";
+        return Verdict::Violated;
     }
     let (w, path) = worst.expect("finite worst");
     if w <= *limit {
-        return "holds";
+        return Verdict::Holds;
     }
     let chain = path
         .iter()
@@ -1502,7 +1503,7 @@ fn evaluate_bound(
             c.name.name, from.name, w, class_name, limit, chain
         ),
     ));
-    "violated"
+    Verdict::Violated
 }
 
 /// DFS: total carrier sites reachable from `k` per invocation — a
@@ -1668,7 +1669,7 @@ fn evaluate_require(
     c: &ClaimDecl,
     cx: &Cx,
     diags: &mut Vec<Diag>,
-) -> &'static str {
+) -> Verdict {
     let ClaimForm::Require {
         publishers,
         group,
@@ -1691,7 +1692,7 @@ fn evaluate_require(
         }
     });
     if hit {
-        return "holds";
+        return Verdict::Holds;
     }
     diags.push(Diag::ty(
         c.name.span,
@@ -1703,7 +1704,7 @@ fn evaluate_require(
             topic.display()
         ),
     ));
-    "violated"
+    Verdict::Violated
 }
 
 /// `cover topic in seed(a): subscribed_by(some G)` — every topic the
@@ -1713,7 +1714,7 @@ fn evaluate_cover(
     c: &ClaimDecl,
     cx: &Cx,
     diags: &mut Vec<Diag>,
-) -> &'static str {
+) -> Verdict {
     let ClaimForm::Cover { alias, group } = &c.form else {
         unreachable!("dispatched on form")
     };
@@ -1732,7 +1733,7 @@ fn evaluate_cover(
         }
     }
     if uncovered.is_empty() {
-        return "holds";
+        return Verdict::Holds;
     }
     let list = uncovered
         .iter()
@@ -1751,7 +1752,7 @@ fn evaluate_cover(
             list
         ),
     ));
-    "violated"
+    Verdict::Violated
 }
 
 /// `count publishers/subscribers(topic T) cmp N` — distinct loci on
@@ -1760,7 +1761,7 @@ fn evaluate_count(
     c: &ClaimDecl,
     cx: &Cx,
     diags: &mut Vec<Diag>,
-) -> &'static str {
+) -> Verdict {
     let ClaimForm::Count {
         publishers,
         topic,
@@ -1785,7 +1786,7 @@ fn evaluate_count(
     }
     let actual = loci.len() as u64;
     if cmp.holds(actual, *n) {
-        return "holds";
+        return Verdict::Holds;
     }
     let who = if loci.is_empty() {
         String::new()
@@ -1816,7 +1817,7 @@ fn evaluate_count(
             n
         ),
     ));
-    "violated"
+    Verdict::Violated
 }
 
 // ===================== shared helpers =============================

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -85,6 +85,16 @@ pub fn claims_report(
     let (mut out, outcomes) =
         claims_report_inner(programs, graph, import_renames);
     crate::stdlib_bodies::demangle_imports(&mut out, import_renames);
+    // Mark the whole batch at the one place they all funnel through,
+    // rather than at ~30 construction sites. Rendering is unchanged
+    // (`DiagKind::Claim` prints "type error" too); the kind exists so
+    // a consumer can separate "does not typecheck" from "typechecks
+    // and breaks a law" — see `DiagKind::Claim`.
+    for d in &mut out {
+        if d.kind == hale_syntax::error::DiagKind::Type {
+            d.kind = hale_syntax::error::DiagKind::Claim;
+        }
+    }
     (out, outcomes)
 }
 

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -35,6 +35,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use hale_syntax::ast::*;
 use hale_syntax::{Diag, Span};
 
+use crate::verdict::Verdict;
 use crate::alloc_summary::{self, AllocSummary, FnKey};
 use crate::callgraph::{self, Probe};
 
@@ -181,7 +182,10 @@ pub struct LoweredCertificate {
     pub subject: String,
     /// The lowered claim form, display voice.
     pub form: String,
-    pub violated: bool,
+    /// See [`crate::verdict::Verdict`]. A certificate is a claim at
+    /// fn granularity, so it reports in the same vocabulary the
+    /// bundle claims use rather than a private bool.
+    pub result: Verdict,
 }
 
 fn phase_effects_diags(
@@ -335,7 +339,11 @@ fn phase_effects_diags(
                         l.name.name,
                         phase
                     ),
-                    violated: out.len() > phase_before,
+                    result: if out.len() > phase_before {
+                        Verdict::Violated
+                    } else {
+                        Verdict::Holds
+                    },
                 });
             }
         }
@@ -718,7 +726,11 @@ fn effect_report_inner(
                                 key.display(),
                                 cls_name(*c, &names)
                             ),
-                            violated: diags.len() > before,
+                            result: if diags.len() > before {
+                        Verdict::Violated
+                    } else {
+                        Verdict::Holds
+                    },
                         });
                     }
                 }
@@ -792,7 +804,11 @@ fn effect_report_inner(
                             set.join(", "),
                             key.display()
                         ),
-                        violated: diags.len() > only_before,
+                        result: if diags.len() > only_before {
+                        Verdict::Violated
+                    } else {
+                        Verdict::Holds
+                    },
                     });
                 }
                 EffectAssert::PublishSet(allowed) => {
@@ -805,7 +821,11 @@ fn effect_report_inner(
                             allowed.join(", "),
                             key.display()
                         ),
-                        violated: diags.len() > before,
+                        result: if diags.len() > before {
+                        Verdict::Violated
+                    } else {
+                        Verdict::Holds
+                    },
                     });
                 }
                 EffectAssert::NoPanic => {
@@ -817,7 +837,11 @@ fn effect_report_inner(
                             "forbid reaches({{{}}}, panic)",
                             key.display()
                         ),
-                        violated: diags.len() > before,
+                        result: if diags.len() > before {
+                        Verdict::Violated
+                    } else {
+                        Verdict::Holds
+                    },
                     });
                 }
                 EffectAssert::Causes(classes) => {

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -32,6 +32,7 @@ pub mod claims;
 pub mod model;
 pub mod topic_identity;
 pub mod topology;
+pub mod verdict;
 pub mod stdlib_bodies;
 pub mod stdlib_surface;
 pub mod ownership_graph;

--- a/crates/hale-types/src/quantitative.rs
+++ b/crates/hale-types/src/quantitative.rs
@@ -33,6 +33,7 @@ use std::collections::BTreeMap;
 use hale_syntax::ast::*;
 use hale_syntax::{Diag, Span};
 
+use crate::verdict::Verdict;
 use crate::alloc_summary::{self, AllocSummary, Callee, FnKey};
 use crate::callgraph;
 
@@ -485,7 +486,11 @@ fn quantitative_report(
                     cap,
                     key.display()
                 ),
-                violated: measured.exceeds(*cap),
+                result: if measured.exceeds(*cap) {
+                        Verdict::Violated
+                    } else {
+                        Verdict::Holds
+                    },
             });
             if !measured.exceeds(*cap) {
                 continue;

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -87,8 +87,12 @@ use crate::symbol::Bundle;
 /// unhashed-by-`shape_hash` but now COVERED `artifact_digest` — a
 /// whole-body integrity hash as the final key, so a consumer that
 /// trusts an artifact it did not produce can verify the sections
-/// `shape_hash` omits (`topics`, `provenance`, claim results).
-pub const TOPOLOGY_SCHEMA: &str = "1.3";
+/// `shape_hash` omits (`topics`, `provenance`, claim results). 1.4:
+/// `verdict` (`clean` / `law_failed`), the document's own outcome;
+/// and one result vocabulary across `claims` and `lowered` — see
+/// [`crate::verdict::Verdict`], which adds `uncertified` as a state
+/// distinct from `violated`.
+pub const TOPOLOGY_SCHEMA: &str = "1.4";
 
 /// Serialize the bundle's model + claim results as the topology
 /// artifact (JSON).
@@ -757,7 +761,7 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
             "    {{\"name\": {}, \"form\": {}, \"result\": {}}},\n",
             quote(&o.name),
             quote(&demangle_str(&o.form)),
-            quote(o.result)
+            quote(o.result.as_str())
         ));
     }
     trim_trailing_comma(&mut out);
@@ -798,11 +802,34 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
             "    {{\"subject\": {}, \"form\": {}, \"result\": {}}},\n",
             quote(&demangle_str(&r.subject)),
             quote(&demangle_str(&r.form)),
-            quote(if r.violated { "violated" } else { "holds" })
+            quote(r.result.as_str())
         ));
     }
     trim_trailing_comma(&mut out);
     out.push_str("  ]");
+
+    // The document's own verdict (schema 1.4). Every law in this
+    // artifact — bundle claims and fn-grained certificates alike —
+    // reduces to one field a consumer can read without scanning
+    // rows.
+    //
+    // Composing artifacts across binaries requires "did this
+    // component pass?" as a precondition, and reconstructing that by
+    // walking two arrays and knowing which verdict strings count as
+    // passing is exactly the kind of thing a consumer gets subtly
+    // wrong. `Verdict::passed()` is the single definition, and only
+    // `holds` passes — `uncertified` does not, because a law that
+    // could not be checked has not been satisfied.
+    //
+    // Note this says nothing about whether the program TYPECHECKS.
+    // It does not have to: an artifact is only emitted for a program
+    // that does, so its existence already carries that.
+    let all_pass = outcomes.iter().all(|o| o.result.passed())
+        && lowered.iter().all(|r| r.result.passed());
+    out.push_str(&format!(
+        ",\n  \"verdict\": {}",
+        quote(if all_pass { "clean" } else { "law_failed" })
+    ));
 
     // Integrity (schema 1.3). `shape_hash` is an IDENTITY, not an
     // integrity check: it deliberately covers the model half only,

--- a/crates/hale-types/src/verdict.rs
+++ b/crates/hale-types/src/verdict.rs
@@ -1,0 +1,66 @@
+//! One outcome vocabulary for every law the compiler evaluates.
+//!
+//! Bundle claims and fn-grained certificates (`@effects`, `@budget`,
+//! `@phase_effects`) are the same kind of statement at different
+//! granularity — #392 §8 already reports the second as the claim form
+//! it is pointwise sugar for. They should not disagree about how to
+//! spell an outcome, and before this type they did: claim rows
+//! carried three states while lowered rows carried a bool.
+//!
+//! The four states are distinguished by **what the reader should do
+//! about them**, which is the only distinction worth encoding:
+//!
+//! | verdict | meaning | repair |
+//! |---|---|---|
+//! | `holds` | proved | nothing |
+//! | `violated` | disproved — a counterexample exists | fix the program (the witness says where) |
+//! | `uncertified` | not provable — the graph has unknowns | resolve the unknown edge, or accept that this law cannot be checked here |
+//! | `invalid` | the statement itself is malformed | fix the claim (an unknown group member, an undeclared effect class) |
+//!
+//! `violated` and `uncertified` were previously one value, because
+//! **unknown ⇒ violation** — an indirect call fails closed rather
+//! than certifying an absence it cannot see. That rule is unchanged
+//! and both still fail the build. What changes is that the artifact
+//! now records which happened, because the repairs are different and
+//! because composing models across binaries needs the distinction: a
+//! propagated unknown must make an exact-cardinality claim
+//! `uncertified`, not report it as disproved when nothing disproved
+//! it.
+
+/// The outcome of evaluating one law.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Proved.
+    Holds,
+    /// Disproved — a counterexample exists.
+    Violated,
+    /// Well-formed but not provable here: the graph carries an
+    /// unknown (an indirect call, an untypeable receiver, a computed
+    /// subject) that fails closed.
+    Uncertified,
+    /// The statement is malformed — an unknown group member, an
+    /// undeclared effect class. Evaluation never ran.
+    Invalid,
+}
+
+impl Verdict {
+    /// The wire spelling, as it appears in the topology artifact.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Verdict::Holds => "holds",
+            Verdict::Violated => "violated",
+            Verdict::Uncertified => "uncertified",
+            Verdict::Invalid => "invalid",
+        }
+    }
+
+    /// Did this law pass?
+    ///
+    /// Only `Holds` does. `Uncertified` deliberately does not: a law
+    /// that could not be checked has not been satisfied, and treating
+    /// "we could not tell" as success is the fail-open this whole
+    /// vocabulary exists to prevent.
+    pub fn passed(self) -> bool {
+        matches!(self, Verdict::Holds)
+    }
+}

--- a/crates/hale-types/tests/artifact_integrity.rs
+++ b/crates/hale-types/tests/artifact_integrity.rs
@@ -1,4 +1,4 @@
-//! The topology artifact's integrity digest (schema 1.3).
+//! The topology artifact's integrity digest (schema 1.3+).
 //!
 //! `shape_hash` is an IDENTITY, not an integrity check. It covers
 //! the model half only — deliberately, so that moving a comment or
@@ -139,4 +139,92 @@ fn a_different_program_produces_a_different_digest() {
         a, b,
         "adding a locus must change the artifact"
     );
+}
+
+// ---- schema 1.4: one verdict vocabulary --------------------------
+//
+// Claims and lowered certificates are the same kind of statement at
+// different granularity, so they must not disagree about how to
+// spell an outcome. Before 1.4 claim rows carried three states while
+// lowered rows carried a bool, and `violated` did double duty for
+// "disproved" and "could not be proved".
+
+use hale_types::verdict::Verdict;
+
+#[test]
+fn only_holds_passes() {
+    assert!(Verdict::Holds.passed());
+    for v in [Verdict::Violated, Verdict::Uncertified, Verdict::Invalid] {
+        assert!(
+            !v.passed(),
+            "{:?} must not pass — a law that could not be checked has \
+             not been satisfied, and treating that as success is the \
+             fail-open this vocabulary exists to prevent",
+            v
+        );
+    }
+}
+
+#[test]
+fn the_document_verdict_reflects_its_rows() {
+    let a = artifact();
+    let v: serde_json::Value = serde_json::from_str(&a).expect("valid JSON");
+    assert_eq!(v["schema"], "1.4");
+    assert_eq!(
+        v["verdict"], "clean",
+        "every claim in the fixture holds: {}",
+        a
+    );
+
+    // A claim naming a topic nothing subscribes fails, and the
+    // document says so without the reader scanning rows.
+    let failing = SRC.replace(
+        "bus { subscribe Tk as on_t; }",
+        "",
+    ).replace("fn on_t(t: T) { self.got = t.v; }", "");
+    let b = dump(&failing);
+    let w: serde_json::Value = serde_json::from_str(&b).expect("valid JSON");
+    assert_ne!(
+        w["verdict"], "clean",
+        "a claim that no longer holds must move the document verdict: {}",
+        b
+    );
+}
+
+/// An unresolvable edge is `uncertified`, not `violated`. Both fail
+/// the build — unknown still means fail-closed — but the artifact
+/// must record which happened, because the repairs differ and
+/// because cross-binary composition needs a propagated unknown to
+/// read as "not provable" rather than "disproved".
+#[test]
+fn an_unresolvable_edge_is_uncertified_not_violated() {
+    const INDIRECT: &str = r#"
+        locus Sink { params { n: Int = 0; } fn take(x: Int) { self.n = x; } }
+        locus Src {
+            params { n: Int = 0; }
+            fn go(f: fn(Int)) { f(self.n); }
+        }
+        group srcs = { Src };
+        group sinks = { Sink };
+        main locus App {
+            params { s: Src = Src { }; k: Sink = Sink { }; }
+            claims { iso: forbid reaches(srcs, sinks); }
+        }
+        fn main() { App { }; }
+    "#;
+    let a = dump(INDIRECT);
+    let v: serde_json::Value = serde_json::from_str(&a).expect("valid JSON");
+    let claims = v["claims"].as_array().expect("claims array");
+    let iso = claims
+        .iter()
+        .find(|c| c["name"] == "iso")
+        .expect("the claim is recorded");
+    assert_eq!(
+        iso["result"], "uncertified",
+        "a call through a fn-typed param is not knowable statically — \
+         nothing disproved the claim, so it must not read as \
+         `violated`: {}",
+        a
+    );
+    assert_ne!(v["verdict"], "clean", "and it still does not pass");
 }

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -633,6 +633,35 @@ Dumping does **not** change what the command means: a program whose
 claims fail still exits non-zero with its witnesses, it just prints
 the artifact on the way.
 
+### One verdict vocabulary
+
+Bundle claims and fn-grained certificates (`@effects`, `@budget`,
+`@phase_effects`) are the same kind of statement at different
+granularity, so they report in the same words. Four states, told
+apart by what you should do about each:
+
+| verdict | meaning | repair |
+|---|---|---|
+| `holds` | proved | nothing |
+| `violated` | disproved — a counterexample exists | fix the program; the witness says where |
+| `uncertified` | well-formed but not provable here — the graph has an unknown (an indirect call, an untypeable receiver, a computed subject) | resolve the unknown edge, or accept that this law can't be checked here |
+| `invalid` | the statement itself is malformed — an unknown group member, an undeclared effect class | fix the claim |
+
+`violated` and `uncertified` used to be one value, because **unknown
+⇒ violation**: an indirect call fails closed rather than certifying
+an absence nothing established. That rule is unchanged and both
+still fail the build. What changed is that the artifact records
+which happened, because the repairs are different — and because
+composing models across binaries needs a propagated unknown to make
+a claim `uncertified` rather than report it as disproved when
+nothing disproved it.
+
+The document's own `verdict` is `clean` only if every row — claims
+and lowered alike — reports `holds`. `uncertified` does not pass: a
+law that could not be checked has not been satisfied. It says
+nothing about whether the program typechecks, because it doesn't
+have to — an artifact is only emitted for a program that does.
+
 ### Identity vs. integrity
 
 Two different hashes, and conflating them is a trap:
@@ -659,11 +688,11 @@ reports as *unverifiable* rather than as valid — a consumer may
 choose to accept it, but must never read "nothing to check" as
 "checked and intact".
 
-The artifact shape (schema `1.3`):
+The artifact shape (schema `1.4`):
 
 ```text
 {
-  "schema": "1.3",
+  "schema": "1.4",
   "shape_hash": "<fnv1a-64 over the model half>",
   "sorts":     { "loci": […], "fns": […], "topics": […] },
   "relations": {
@@ -685,8 +714,9 @@ The artifact shape (schema `1.3`):
   "provenance": { "calls": [+span], "publishes": [+span],
                   "subscribes": [+span], "decls": {name: span} },
   "topics":    [ {"name", "subject", "shape", "payload_hash"} ],
-  "claims":    [ {"name", "form", "result": "holds"|"violated"|"invalid"} ],
-  "lowered":   [ {"subject", "form", "result": "holds"|"violated"} ]
+  "claims":    [ {"name", "form", "result": <verdict>} ],
+  "lowered":   [ {"subject", "form", "result": <verdict>} ],
+  "verdict":   "clean" | "law_failed"
 }
 ```
 

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -235,7 +235,7 @@ earlier in the same file as the family. Companion:
 class along any path, with the same loop/indirect unboundedness
 rules as every per-call dimension.
 
-**The topology artifact** (#382 phase 2; schema 1.3):
+**The topology artifact** (#382 phase 2; schema 1.4):
 `hale check <t> --dump-topology` emits the serialized model —
 sorts (loci, fns, topics), relations (calls with **weights**: loop
 nesting, unbounded-loop membership, interface-dispatch tags;


### PR DESCRIPTION
Found while answering an open question on #408. Verified against shipped behavior before the fix.

### The bug

```
$ hale check both.hl --dump-topology     # both.hl has a type error
exit=1
artifact bytes: 771
claims: [{"name": "wired", "form": "require subscribes(...)", "result": "holds"}]
```

A program that doesn't typecheck emitted a **full** artifact — populated relations, and claims evaluated over a graph derived from source the compiler couldn't understand. The claim reports `"holds"` for a program that cannot compile: a certificate asserting a property of something that will never run.

That's worse for a consumer than emitting nothing, because it fails **open**. An admission step looking for "no violated claims" *passes* it — there are none. Cross-artifact composition (#408) would have trusted it.

### The rule

**The artifact's existence means the model is sound.** A program that doesn't typecheck emits no artifact and says why:

```
refusing to emit a topology artifact: `both.hl` does not typecheck, so its
model is not a truthful description of any program. Fix the type error first.
```

A **violated claim** is the opposite case and still emits, unchanged. The model is well-defined there, the row is a truthful report, and being able to replay a violation independently is the whole point of publishing the model — `"result": "violated"` would be dead vocabulary otherwise. Both directions are pinned by tests.

### `DiagKind::Claim`

Separating the two cases needs a way to ask "does this program typecheck?" when claim violations are themselves errors in the same stream.

The new variant is an error like any other and renders **identically** to `Type` — the message already begins "claim `x` violated", so a distinct prefix would only stutter, and no existing diagnostic output changes. It's applied at the single funnel every claim diagnostic passes through (`claims_report`, which already post-processes the whole batch to demangle cross-seed symbols) rather than at its ~30 construction sites.

It's independently useful: tooling can now categorize claim diagnostics without matching on message text.

### Cost

`check` previously ran `check_bundle_opts` once; a naive gate would have run it twice on every `--dump-topology`. Since nothing mutates the bundle between the two points, the analysis is computed once and shared between the artifact gate and the diagnostic report — so the gate is free.

### Verification

| program | artifact | exit |
|---|---|---|
| type error | **none** | 1 |
| claim violated | emitted, 1028 B, claim rows present | 1 |
| clean | emitted, 1156 B | 0 |

Plain `check` (no dump) is unaffected in all three.

Ran the affected binaries rather than the full suite: `topology_artifact_contract` (8), `xseed_claims_verbs` (5), `check_arg_parsing` (6), `hot_factory_xseed` (2), `artifact_integrity` (6), `claims` (16), `claims_edges` (28), `claims_phases` (27), `library_claims` (2), plus the three that filter on `DiagKind` — `effects_conformance`, `instance_aliasing`, `lsp`. All green; CI has the rest.

Closes the first item under "Resolved since filing" in #408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)