### PR TITLE
fix(claims): name interface dispatch in the witness (downstream review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ behavior.
 
 ## Unreleased
 
+### Interface dispatch is named in the witness (downstream review)
+
+A call on an interface fans out to **every** conforming locus, which
+is sound and deliberately conservative. But the witness rendered that
+hop as an ordinary direct call, so a claim could report:
+
+```
+`A::go` -> `notify` -> `Sms::send`
+```
+
+while the line in front of you constructs an `Email`. A correct proof
+that reads as a compiler bug is expensive — people stop trusting the
+checker, or work around it.
+
+The hop is now rendered as what it is, and the "where to edit"
+diagnostic explains the fanout rather than leaving the reader to
+disbelieve it:
+
+```
+witness: `A::go` -> `notify` -(dispatches Notifier.send)-> `Sms::send`
+
+claim `no_sms`: the boundary into `texting` is crossed by this dispatch
+through `Notifier`. A call on an interface reaches EVERY conforming
+locus, whatever this expression happens to construct — so the witness
+names one the claim forbids. Narrow the receiver's type, or exclude
+the conformer from the group.
+```
+
+The fact was already in the model (the artifact tags these edges
+`via_interface`); it just never reached the human. Witnesses with no
+interface in them are unchanged.
+
 ### Topology artifact schema 1.3: an integrity digest
 
 `shape_hash` is an **identity**, not an integrity check. It covers

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -951,6 +951,15 @@ fn unresolved_opaque_receiver(
 enum Step {
     Call {
         span: hale_syntax::Span,
+        /// The interface, when this edge is one alternative of a
+        /// dispatch rather than a direct call. Rendering it is the
+        /// difference between a witness that reads as impossible and
+        /// one that reads as conservative: the compiler fans an
+        /// interface call out to EVERY conformer, so a path can end
+        /// at `Sms::send` while the line in front of you constructs
+        /// an `Email`. Shown as a direct call, that looks like a
+        /// compiler bug; named as a dispatch, it is obviously sound.
+        via_interface: Option<String>,
     },
     Bus {
         subject: String,
@@ -1114,7 +1123,12 @@ fn evaluate_forbid_reaches(
                                 next.clone(),
                                 (
                                     k.clone(),
-                                    Step::Call { span: edge.span },
+                                    Step::Call {
+                                        span: edge.span,
+                                        via_interface: edge
+                                            .via_interface
+                                            .clone(),
+                                    },
                                 ),
                             );
                             queue.push_back(next.clone());
@@ -1897,6 +1911,15 @@ fn render_violation(
     for (node, incoming) in &rev {
         match incoming {
             None => path.push_str(&format!("`{}`", node.display())),
+            Some(Step::Call { via_interface: Some(iface), .. }) => {
+                // `-(dispatches Notifier.send)->` rather than `->`.
+                path.push_str(&format!(
+                    " -(dispatches {}.{})-> `{}`",
+                    iface,
+                    node.fn_name,
+                    node.display()
+                ));
+            }
             Some(Step::Call { .. }) => {
                 path.push_str(&format!(" -> `{}`", node.display()));
             }
@@ -1927,16 +1950,33 @@ fn render_violation(
         // The fn whose body holds the crossing edge.
         let from = rev.len().checked_sub(2).map(|i| &rev[i].0);
         match step {
-            Step::Call { span } => {
+            Step::Call { span, via_interface } => {
                 if from.is_some_and(|f| cx.model.is_bundle_fn(f)) {
-                    diags.push(Diag::ty(
-                        *span,
-                        format!(
+                    // The dispatch case needs the extra sentence.
+                    // Without it the reader looks at a line
+                    // constructing one conformer, sees a witness
+                    // naming another, and concludes the checker is
+                    // wrong — when it is being conservative on
+                    // purpose.
+                    let msg = match via_interface {
+                        Some(iface) => format!(
+                            "claim `{}`: the boundary into `{}` is \
+                             crossed by this dispatch through `{}`. \
+                             A call on an interface reaches EVERY \
+                             conforming locus, whatever this \
+                             expression happens to construct — so the \
+                             witness names one the claim forbids. \
+                             Narrow the receiver's type, or exclude \
+                             the conformer from the group",
+                            c.name.name, dst_disp, iface
+                        ),
+                        None => format!(
                             "claim `{}`: the boundary into `{}` is \
                              crossed by this call",
                             c.name.name, dst_disp
                         ),
-                    ));
+                    };
+                    diags.push(Diag::ty(*span, msg));
                 }
             }
             Step::Bus { publish_span, sub_span, .. } => {

--- a/crates/hale-types/tests/claims_edges.rs
+++ b/crates/hale-types/tests/claims_edges.rs
@@ -956,3 +956,116 @@ fn domain_decl_guards() {
         errs
     );
 }
+
+// =====================================================================
+// Interface dispatch in the witness (downstream review, item 5)
+// =====================================================================
+//
+// The compiler fans an interface call out to EVERY conforming locus,
+// which is sound and deliberately conservative. But the witness used
+// to render that hop as an ordinary direct call, so a reader looking
+// at a line that constructs `Email` and a witness that names
+// `Sms::send` concluded the checker was wrong.
+//
+// A correct proof that reads as a bug is expensive: people stop
+// trusting the checker, or work around it. The fact was already in
+// the model (`via_interface`); it just never reached the human.
+
+const DISPATCH: &str = r#"
+interface Notifier { fn send(msg: String); }
+
+locus Email {
+    params { n: Int = 0; }
+    fn send(msg: String) { self.n = self.n + 1; }
+}
+locus Sms {
+    params { n: Int = 0; }
+    fn send(msg: String) { self.n = self.n + 1; }
+}
+
+locus A {
+    params { n: Int = 0; }
+    fn go() {
+        let e = Email { };
+        notify(e, "hi");
+    }
+}
+
+fn notify(x: Notifier, m: String) { x.send(m); }
+
+group callers = { A };
+group texting = { Sms };
+
+main locus App {
+    params { a: A = A { }; e: Email = Email { }; s: Sms = Sms { }; }
+    claims { no_sms: forbid reaches(callers, texting); }
+}
+fn main() { App { }; }
+"#;
+
+#[test]
+fn the_witness_names_the_dispatch_not_a_direct_call() {
+    let ds = diags(DISPATCH);
+    let witness = ds
+        .iter()
+        .find(|m| m.contains("claim `no_sms` violated"))
+        .unwrap_or_else(|| panic!("expected a violation: {:#?}", ds));
+    assert!(
+        witness.contains("-(dispatches Notifier.send)-> `Sms::send`"),
+        "the interface hop must be rendered AS a dispatch — shown as \
+         a plain `->` it reads as impossible, because the call site \
+         constructs an `Email`:\n{}",
+        witness
+    );
+}
+
+/// And the "where to edit" diagnostic has to explain the fanout,
+/// since that is the part the reader disbelieves.
+#[test]
+fn the_dispatch_site_explains_why_every_conformer_counts() {
+    let ds = diags(DISPATCH);
+    let site = ds
+        .iter()
+        .find(|m| m.contains("crossed by this dispatch"))
+        .unwrap_or_else(|| panic!("expected a dispatch site: {:#?}", ds));
+    assert!(
+        site.contains("`Notifier`") && site.contains("EVERY"),
+        "it must name the interface and say the call reaches every \
+         conformer:\n{}",
+        site
+    );
+    assert!(
+        site.contains("Narrow the receiver") || site.contains("exclude"),
+        "and name a repair:\n{}",
+        site
+    );
+}
+
+/// A direct call must be unaffected — no dispatch vocabulary leaks
+/// into a witness that has no interface in it.
+#[test]
+fn a_direct_call_witness_is_unchanged() {
+    const DIRECT: &str = r#"
+locus Sink { params { n: Int = 0; } fn take() { self.n = 1; } }
+locus Src { params { n: Int = 0; } fn go() { reach(); } }
+fn reach() { let s = Sink { }; s.take(); }
+group srcs = { Src };
+group sinks = { Sink };
+main locus App {
+    params { s: Src = Src { }; k: Sink = Sink { }; }
+    claims { iso: forbid reaches(srcs, sinks); }
+}
+fn main() { App { }; }
+"#;
+    let ds = diags(DIRECT);
+    let witness = ds
+        .iter()
+        .find(|m| m.contains("claim `iso` violated"))
+        .unwrap_or_else(|| panic!("expected a violation: {:#?}", ds));
+    assert!(
+        !witness.contains("dispatches"),
+        "no interface is involved here:\n{}",
+        witness
+    );
+    assert!(witness.contains(" -> "), "plain call arrow:\n{}", witness);
+}


### PR DESCRIPTION
Item 5 from the claims developer-experience review, and the cheapest of the ones left.

### The problem

A call on an interface fans out to **every** conforming locus. That's sound and conservative on purpose. But the witness rendered that hop as an ordinary direct call:

```
claim `no_sms` violated: `callers` reaches `texting` — witness:
  `A::go` -> `notify` -> `Sms::send`
```

…while the line in front of you constructs an `Email`:

```hale
fn go() {
    let e = Email { };
    notify(e, "hi");
}
fn notify(x: Notifier, m: String) { x.send(m); }
```

The reviewer's phrasing was that the witness "can look impossible". A correct proof that reads as a compiler bug is worse than a missing diagnostic — people stop trusting the checker, or work around it.

### After

```
claim `no_sms` violated: `callers` reaches `texting` — witness:
  `A::go` -> `notify` -(dispatches Notifier.send)-> `Sms::send`

iface.hl:20:37: claim `no_sms`: the boundary into `texting` is crossed by this
dispatch through `Notifier`. A call on an interface reaches EVERY conforming
locus, whatever this expression happens to construct — so the witness names one
the claim forbids. Narrow the receiver's type, or exclude the conformer from
the group
    fn notify(x: Notifier, m: String) { x.send(m); }
                                        ^^^^^^^^^
```

Two changes, and the second matters as much as the first: the path names the dispatch, and the "where to edit" diagnostic explains the fanout rather than leaving the reader to disbelieve it. It also names two repairs, since "your claim is right and your intuition is wrong" is not actionable on its own.

### Why it was cheap

The fact was already in the model — the artifact has tagged these edges `via_interface` all along, and `claims_artifact_unknowns` asserts on it. It just never reached the human. This threads it from the call edge onto the path step and renders it.

### Scope

Witnesses with no interface in them are unchanged, pinned by `a_direct_call_witness_is_unchanged` — no dispatch vocabulary leaks into a plain call path.

Three tests in `claims_edges`: the rendering, the explanation at the dispatch site, and the direct-call guard. Ran `claims_edges` (31) and `claims` (16); CI has the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)