### PR TITLE
fix(claims): provenance for only-edges and bound (downstream review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ behavior.
 
 ## Unreleased
 
+### `only edges` and `bound` say where to edit (downstream review)
+
+`forbid` names the crossing call, or the publish and the receiving
+subscription. The other two path claims anchored only at the claim
+line, which for `only edges` defeats the point — it is explicitly a
+*reviewable boundary inventory*, and making the reviewer hand-find
+the crossing is the work it exists to save.
+
+**`only edges`** now points at the un-granted publish, at the
+subscription that receives it (with the exact grant line to add), and
+at an un-grantable call — with why a grant is not the fix there.
+
+**`bound`** knew which of four conditions made a count unbounded and
+printed all four:
+
+> a recursion cycle, loop-nested carrier, indirect call, or computed
+> publish subject makes the count unbounded
+
+Now it names the one that applies and points at it:
+
+```
+claim `one` violated: paths from `planners` carry an unbounded number of
+`llm` sites (limit 1) — a carrier is reached from inside a loop in
+`Planner::go`, so it repeats per iteration
+
+bnd.hl:10:22: claim `one`: this is the loop-nested carrier
+                self.n = model_call(i);
+                         ^^^^^^^^^^^^^
+```
+
+The classification was always computed — reaching the verdict
+requires it — and then discarded. Keeping it costs one enum on the
+unbounded side of the heaviest-path result. Recursion and the step
+ceiling are properties of a walk rather than of one expression, so
+they name the fn and omit the caret; the other three carry a site.
+
+Secondary spans follow the same bundle-only rule as the `forbid`
+witness: stdlib bodies parse in their own offset space, so a span
+from there would point at the wrong source.
+
 ### Interface dispatch is named in the witness (downstream review)
 
 A call on an interface fans out to **every** conforming locus, which

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -1305,6 +1305,28 @@ fn evaluate_only_edges(
                                     dst.name
                                 ),
                             ));
+                            // #392 provenance, to `forbid` quality:
+                            // the claim line says WHAT, this says
+                            // WHERE. `only edges` is explicitly a
+                            // reviewable boundary inventory, so
+                            // anchoring only at the claim left the
+                            // reviewer to find the crossing by hand
+                            // — the one thing the inventory exists
+                            // to save them.
+                            if cx.model.is_bundle_fn(&k) {
+                                diags.push(Diag::ty(
+                                    edge.span,
+                                    format!(
+                                        "claim `{}`: this call \
+                                         crosses the boundary. A \
+                                         call cannot be granted — \
+                                         route it through a topic \
+                                         named in the grant list, or \
+                                         move the callee out of `{}`",
+                                        c.name.name, dst.name
+                                    ),
+                                ));
+                            }
                             violated = true;
                         }
                     }
@@ -1366,7 +1388,7 @@ fn evaluate_only_edges(
                 ));
                 return "violated";
             };
-            for (sub_locus, sub_handler, _sub_span) in
+            for (sub_locus, sub_handler, sub_span) in
                 subscribers_of(cx.graph, subj)
             {
                 if !dst_g.loci.contains(&sub_locus) {
@@ -1399,6 +1421,25 @@ fn evaluate_only_edges(
                             granted_disp
                         ),
                     ));
+                    if cx.model.is_bundle_fn(&k) {
+                        diags.push(Diag::ty(
+                            site.span,
+                            format!(
+                                "claim `{}`: the un-granted publish \
+                                 happens here",
+                                c.name.name
+                            ),
+                        ));
+                    }
+                    diags.push(Diag::ty(
+                        sub_span,
+                        format!(
+                            "claim `{}`: received here. Grant this \
+                             edge with `publish {};` if it is \
+                             intended",
+                            c.name.name, subj
+                        ),
+                    ));
                     violated = true;
                 }
             }
@@ -1413,9 +1454,94 @@ fn evaluate_only_edges(
 
 // ===================== bound ======================================
 
-/// Heaviest-path result: `None` = unbounded (cycle, loop-nested
-/// carrier, indirect call, or computed subject on the path).
-type Heaviest = Option<(u64, Vec<FnKey>)>;
+/// Why a count is unbounded — the construct AND where it is.
+///
+/// The checker has always had to classify this to reach the verdict
+/// at all; it just threw the classification away and printed a
+/// four-way disjunction at the claim line ("a recursion cycle,
+/// loop-nested carrier, indirect call, or computed publish subject
+/// makes the count unbounded"), leaving the reader to work out which
+/// of the four applied to their program. Keeping it costs one enum.
+enum Unbounded {
+    /// A recursion cycle: the walk re-entered a fn already on the
+    /// stack, so the count repeats per recursion.
+    Cycle(FnKey),
+    /// A carrier reached from inside a loop: it repeats per
+    /// iteration, exactly like every per-call contributor in
+    /// `@budget`.
+    LoopCarrier { at: FnKey, span: hale_syntax::Span },
+    /// A call the walk cannot follow — through a fn-typed parameter,
+    /// or on a receiver the compiler cannot type. Fails closed.
+    Unfollowable { at: FnKey, span: hale_syntax::Span },
+    /// A publish whose subject is computed: it could route to any
+    /// subscriber, so the contribution is uncountable.
+    ComputedSubject { at: FnKey, span: hale_syntax::Span },
+    /// The walk hit the step ceiling before settling.
+    StepCeiling,
+}
+
+impl Unbounded {
+    /// The clause that goes in the primary diagnostic.
+    fn why(&self) -> String {
+        match self {
+            Unbounded::Cycle(k) => format!(
+                "`{}` is reachable from itself, so the count repeats \
+                 per recursion",
+                k.display()
+            ),
+            Unbounded::LoopCarrier { at, .. } => format!(
+                "a carrier is reached from inside a loop in `{}`, so \
+                 it repeats per iteration",
+                at.display()
+            ),
+            Unbounded::Unfollowable { at, .. } => format!(
+                "`{}` makes a call the walk cannot follow, so the \
+                 contribution beyond it is unknown",
+                at.display()
+            ),
+            Unbounded::ComputedSubject { at, .. } => format!(
+                "`{}` publishes to a computed subject, which could \
+                 route to any subscriber",
+                at.display()
+            ),
+            Unbounded::StepCeiling => {
+                "the walk hit its step ceiling before settling".into()
+            }
+        }
+    }
+
+    /// Where to look, when there is a single site to point at. A
+    /// cycle and a step ceiling are properties of a walk rather than
+    /// of one expression, so they have none.
+    fn site(&self) -> Option<(hale_syntax::Span, &'static str)> {
+        match self {
+            Unbounded::LoopCarrier { span, .. } => {
+                Some((*span, "this is the loop-nested carrier"))
+            }
+            Unbounded::Unfollowable { span, .. } => {
+                Some((*span, "this is the call the walk cannot follow"))
+            }
+            Unbounded::ComputedSubject { span, .. } => {
+                Some((*span, "this is the computed publish subject"))
+            }
+            Unbounded::Cycle(_) | Unbounded::StepCeiling => None,
+        }
+    }
+
+    /// The fn whose body holds the site, for the bundle-span guard.
+    fn at(&self) -> Option<&FnKey> {
+        match self {
+            Unbounded::LoopCarrier { at, .. }
+            | Unbounded::Unfollowable { at, .. }
+            | Unbounded::ComputedSubject { at, .. } => Some(at),
+            Unbounded::Cycle(k) => Some(k),
+            Unbounded::StepCeiling => None,
+        }
+    }
+}
+
+/// Heaviest-path result: `Err` = unbounded, carrying why.
+type Heaviest = Result<(u64, Vec<FnKey>), Unbounded>;
 
 /// Evaluate `bound C <= N on paths from G` — sum of carrier sites
 /// along a path, max at joins, over the composed call ∘ bus graph.
@@ -1440,8 +1566,8 @@ fn evaluate_bound(
     {
         return "invalid";
     }
-    let mut worst: Heaviest = Some((0, Vec::new()));
-    let mut worst_is_unbounded = false;
+    let mut worst: (u64, Vec<FnKey>) = (0, Vec::new());
+    let mut why: Option<Unbounded> = None;
     for root in group.fn_set(&cx.summary) {
         let mut stack = Vec::new();
         let mut memo: BTreeMap<FnKey, (u64, Vec<FnKey>)> =
@@ -1450,32 +1576,48 @@ fn evaluate_bound(
         match site_count(
             &root, cx, mask, &mut stack, &mut memo, &mut steps,
         ) {
-            None => {
-                worst_is_unbounded = true;
+            Err(u) => {
+                why = Some(u);
                 break;
             }
-            Some((w, p)) => {
-                if worst.as_ref().map_or(true, |(bw, _)| w > *bw) {
-                    worst = Some((w, p));
+            Ok((w, p)) => {
+                if w > worst.0 {
+                    worst = (w, p);
                 }
             }
         }
     }
-    if worst_is_unbounded {
+    if let Some(u) = why {
+        // The checker classified the condition to reach this verdict.
+        // Saying "a recursion cycle, loop-nested carrier, indirect
+        // call, or computed publish subject" made the reader
+        // re-derive which of the four applied — from a diagnostic
+        // anchored at the claim, nowhere near the construct.
         diags.push(Diag::ty(
             c.name.span,
             format!(
                 "claim `{}` violated: paths from `{}` carry an \
-                 unbounded number of `{}` sites (limit {}) — a \
-                 recursion cycle, loop-nested carrier, indirect \
-                 call, or computed publish subject makes the count \
-                 unbounded",
-                c.name.name, from.name, class_name, limit
+                 unbounded number of `{}` sites (limit {}) — {}",
+                c.name.name,
+                from.name,
+                class_name,
+                limit,
+                u.why()
             ),
         ));
+        // …and point at it, on the same bundle-span rule the
+        // `forbid` witness uses.
+        if let (Some((span, label)), Some(at)) = (u.site(), u.at()) {
+            if cx.model.is_bundle_fn(at) {
+                diags.push(Diag::ty(
+                    span,
+                    format!("claim `{}`: {}", c.name.name, label),
+                ));
+            }
+        }
         return "violated";
     }
-    let (w, path) = worst.expect("finite worst");
+    let (w, path) = worst;
     if w <= *limit {
         return "holds";
     }
@@ -1513,14 +1655,14 @@ fn site_count(
     steps: &mut u32,
 ) -> Heaviest {
     if let Some(hit) = memo.get(k) {
-        return Some(hit.clone());
+        return Ok(hit.clone());
     }
     if stack.contains(k) {
-        return None; // cycle
+        return Err(Unbounded::Cycle(k.clone()));
     }
     *steps += 1;
     if *steps > callgraph::MAX_STEPS {
-        return None;
+        return Err(Unbounded::StepCeiling);
     }
     let own: u64 = cx
         .summary
@@ -1530,7 +1672,7 @@ fn site_count(
     let Some(fs) = cx.summary.fns.get(k) else {
         let r = (own, vec![k.clone()]);
         memo.insert(k.clone(), r.clone());
-        return Some(r);
+        return Ok(r);
     };
     stack.push(k.clone());
     let mut total: u64 = 0;
@@ -1542,22 +1684,25 @@ fn site_count(
     // whole count: dispatch may choose it.)
     let mut group_best: BTreeMap<u32, (u64, Vec<FnKey>)> =
         BTreeMap::new();
-    let mut unbounded = false;
+    let mut unbounded: Option<Unbounded> = None;
     for edge in &fs.calls {
         match &edge.callee {
             Callee::Resolved(next) => {
                 match site_count(next, cx, mask, stack, memo, steps)
                 {
-                    None => {
-                        unbounded = true;
+                    Err(u) => {
+                        unbounded = Some(u);
                         break;
                     }
-                    Some((w, p)) => {
+                    Ok((w, p)) => {
                         // A carrier reached inside a loop repeats
                         // per iteration — unbounded, like every
                         // per-call contributor in `@budget`.
                         if edge.loop_depth > 0 && w > 0 {
-                            unbounded = true;
+                            unbounded = Some(Unbounded::LoopCarrier {
+                                at: k.clone(),
+                                span: edge.span,
+                            });
                             break;
                         }
                         match edge.dispatch_group {
@@ -1588,13 +1733,16 @@ fn site_count(
                     // (unbounded).
                     || unresolved_opaque_receiver(edge)
                 {
-                    unbounded = true;
+                    unbounded = Some(Unbounded::Unfollowable {
+                        at: k.clone(),
+                        span: edge.span,
+                    });
                     break;
                 }
             }
         }
     }
-    if !unbounded {
+    if unbounded.is_none() {
         for (w, p) in group_best.into_values() {
             total = total.saturating_add(w);
             if w > best_child.0 {
@@ -1602,13 +1750,16 @@ fn site_count(
             }
         }
     }
-    if !unbounded {
+    if unbounded.is_none() {
         for site in &fs.effect_sites {
             let EffectSiteKind::Publish(subj) = &site.kind else {
                 continue;
             };
             let Some(subj) = subj else {
-                unbounded = true;
+                unbounded = Some(Unbounded::ComputedSubject {
+                    at: k.clone(),
+                    span: site.span,
+                });
                 break;
             };
             for (sub_locus, sub_handler, _sub_span) in
@@ -1617,13 +1768,16 @@ fn site_count(
                 let next = FnKey::method(sub_locus, sub_handler);
                 match site_count(&next, cx, mask, stack, memo, steps)
                 {
-                    None => {
-                        unbounded = true;
+                    Err(u) => {
+                        unbounded = Some(u);
                         break;
                     }
-                    Some((w, p)) => {
+                    Ok((w, p)) => {
                         if site.loop_depth > 0 && w > 0 {
-                            unbounded = true;
+                            unbounded = Some(Unbounded::LoopCarrier {
+                                at: k.clone(),
+                                span: site.span,
+                            });
                             break;
                         }
                         total = total.saturating_add(w);
@@ -1633,20 +1787,20 @@ fn site_count(
                     }
                 }
             }
-            if unbounded {
+            if unbounded.is_some() {
                 break;
             }
         }
     }
     stack.pop();
-    if unbounded {
-        return None;
+    if let Some(u) = unbounded {
+        return Err(u);
     }
     let mut path = vec![k.clone()];
     path.extend(best_child.1);
     let r = (own + total, path);
     memo.insert(k.clone(), r.clone());
-    Some(r)
+    Ok(r)
 }
 
 // ===================== require / cover / count ====================

--- a/crates/hale-types/tests/claims_edges.rs
+++ b/crates/hale-types/tests/claims_edges.rs
@@ -1069,3 +1069,170 @@ fn main() { App { }; }
     );
     assert!(witness.contains(" -> "), "plain call arrow:\n{}", witness);
 }
+
+// =====================================================================
+// Provenance for `only edges` and `bound` (downstream review, item 4)
+// =====================================================================
+//
+// `forbid` says WHERE to edit: the crossing call, or the publish and
+// the receiving subscription. `only edges` and `bound` anchored only
+// at the claim line — and `only edges` is explicitly a reviewable
+// boundary inventory, so making the reviewer hand-find the crossing
+// defeats the point of it.
+
+const BOUNDARY: &str = r#"
+type Cmd { v: Int; }
+topic Allowed { payload: Cmd; subject: "app.allowed"; }
+topic Sneaky  { payload: Cmd; subject: "app.sneaky"; }
+
+locus Ops {
+    params { n: Int = 0; }
+    bus { publish Allowed; publish Sneaky; }
+    fn act() {
+        let c = Cmd { v: 1 };
+        Allowed <- c;
+        Sneaky <- c;
+        let k = Core { };
+        k.poked();
+    }
+}
+locus Core {
+    params { n: Int = 0; }
+    bus { subscribe Allowed as on_allowed; subscribe Sneaky as on_sneaky; }
+    fn on_allowed(c: Cmd) { self.n = c.v; }
+    fn on_sneaky(c: Cmd) { self.n = c.v; }
+    fn poked() { self.n = 99; }
+}
+group ops = { Ops };
+group core = { Core };
+main locus App {
+    params { o: Ops = Ops { }; c: Core = Core { }; }
+    claims { boundary: only edges ops -> core { publish Allowed; }; }
+}
+fn main() { App { }; }
+"#;
+
+#[test]
+fn only_edges_points_at_the_ungranted_publish_and_subscription() {
+    let ds = diags(BOUNDARY);
+    assert!(
+        ds.iter().any(|m| m.contains("the un-granted publish happens here")),
+        "the publish site must be named: {:#?}",
+        ds
+    );
+    let recv = ds
+        .iter()
+        .find(|m| m.contains("received here"))
+        .unwrap_or_else(|| panic!("the subscription must be named: {:#?}", ds));
+    assert!(
+        recv.contains("publish Sneaky;"),
+        "and the repair must be the exact grant line to add: {}",
+        recv
+    );
+}
+
+#[test]
+fn only_edges_points_at_the_ungrantable_call() {
+    let ds = diags(BOUNDARY);
+    let call = ds
+        .iter()
+        .find(|m| m.contains("this call crosses the boundary"))
+        .unwrap_or_else(|| panic!("the call site must be named: {:#?}", ds));
+    assert!(
+        call.contains("cannot be granted"),
+        "and say why a grant is not the fix here: {}",
+        call
+    );
+}
+
+/// `bound` knew which of four conditions made a count unbounded and
+/// printed all four, at the claim line, nowhere near the construct.
+fn bound_src(body: &str, extra: &str) -> String {
+    format!(
+        r#"
+effect llm;
+@effects(is: {{llm}})
+fn model_call(p: Int) -> Int {{ return p; }}
+{extra}
+locus Planner {{
+    params {{ n: Int = 0; }}
+    fn go() {{ {body} }}
+}}
+group planners = {{ Planner }};
+main locus App {{
+    params {{ p: Planner = Planner {{ }}; }}
+    claims {{ one: bound llm <= 1 on paths from planners; }}
+}}
+fn main() {{ App {{ }}; }}
+"#
+    )
+}
+
+#[test]
+fn an_unbounded_bound_names_the_loop_and_points_at_the_carrier() {
+    let src = bound_src(
+        "let mut i = 0; while i < 10 { self.n = model_call(i); i = i + 1; }",
+        "",
+    );
+    let ds = diags(&src);
+    let primary = ds
+        .iter()
+        .find(|m| m.contains("claim `one` violated"))
+        .unwrap_or_else(|| panic!("expected a violation: {:#?}", ds));
+    assert!(
+        primary.contains("inside a loop") && primary.contains("Planner::go"),
+        "the primary must name THIS condition, not list four: {}",
+        primary
+    );
+    assert!(
+        !primary.contains("recursion cycle, loop-nested carrier"),
+        "the four-way disjunction must be gone: {}",
+        primary
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("this is the loop-nested carrier")),
+        "and point at the carrier site: {:#?}",
+        ds
+    );
+}
+
+#[test]
+fn an_unbounded_bound_names_recursion() {
+    let src = bound_src(
+        "self.n = recur(3);",
+        "fn recur(n: Int) -> Int { if n <= 0 { return model_call(n); } return recur(n - 1); }",
+    );
+    let primary = diags(&src)
+        .into_iter()
+        .find(|m| m.contains("claim `one` violated"))
+        .expect("expected a violation");
+    assert!(
+        primary.contains("reachable from itself")
+            && primary.contains("`recur`"),
+        "recursion must be named, with the fn: {}",
+        primary
+    );
+}
+
+#[test]
+fn an_unbounded_bound_points_at_an_unfollowable_call() {
+    let src = bound_src(
+        "self.n = thru(model_call, 1);",
+        "fn thru(f: fn(Int) -> Int, n: Int) -> Int { return f(n); }",
+    );
+    let ds = diags(&src);
+    let primary = ds
+        .iter()
+        .find(|m| m.contains("claim `one` violated"))
+        .unwrap_or_else(|| panic!("expected a violation: {:#?}", ds));
+    assert!(
+        primary.contains("cannot follow"),
+        "the unfollowable call must be named: {}",
+        primary
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("this is the call the walk cannot follow")),
+        "and pointed at: {:#?}",
+        ds
+    );
+}


### PR DESCRIPTION
Item 4 from the claims developer-experience review. **Stacked on #411** — both touch `claims.rs`, so this targets that branch and will retarget to `main` once #411 merges.

### `only edges`

The review's phrasing: it "correctly reported every ungranted crossing in one invocation" but "both errors were anchored only at the claim declaration. Since `only edges` is explicitly a reviewable boundary inventory, it should have at least the same provenance quality as `forbid`."

Now:

```
onlyedges.hl:29:9: claim `boundary` violated: un-granted edge `Ops::act`
  -(publishes "Sneaky")-> `Core::on_sneaky`. Granted: `Allowed`. …

onlyedges.hl:11:9: claim `boundary`: the un-granted publish happens here
            Sneaky <- c;
            ^^^^^^^^^^^^
onlyedges.hl:17:44: claim `boundary`: received here. Grant this edge with
                    `publish Sneaky;` if it is intended
        bus { … subscribe Sneaky as on_sneaky; }
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

The receiving diagnostic carries **the exact grant line to add**, since "name it in the grant list" is only actionable if you know the spelling. An un-grantable call gets its own site plus why a grant isn't the fix there.

### `bound`

The review: "The checker knows enough to classify the condition. It should attach the carrier site and the construct that made it unbounded."

It did know — and printed all four possibilities:

> a recursion cycle, loop-nested carrier, indirect call, or computed publish subject makes the count unbounded

Now:

```
claim `one` violated: paths from `planners` carry an unbounded number of
`llm` sites (limit 1) — a carrier is reached from inside a loop in
`Planner::go`, so it repeats per iteration

bnd.hl:10:22: claim `one`: this is the loop-nested carrier
                self.n = model_call(i);
                         ^^^^^^^^^^^^^
```

Verified for all four conditions:

| condition | names | points at |
|---|---|---|
| loop-nested carrier | the fn holding the loop | the carrier call |
| recursion | the fn reachable from itself | — |
| unfollowable call | the fn making it | the call |
| computed publish subject | the publishing fn | the publish |
| step ceiling | — | — |

Recursion and the step ceiling are properties of a *walk* rather than of one expression, so they name what they can and omit the caret rather than pointing somewhere arbitrary.

### Implementation

The classification was always computed — reaching the verdict requires it — and then discarded. `Heaviest` becomes `Result<(u64, Vec<FnKey>), Unbounded>` instead of an `Option`, and the `Unbounded` variants carry the fn and span. That's the whole change; no new analysis.

Secondary spans follow the same bundle-only rule as the `forbid` witness — a stdlib body parses in its own offset space, so a span from there attributed to a bundle file would name the wrong source.

Six tests in `claims_edges`, including a guard that the four-way disjunction string is gone. Ran `claims_edges` (36), `claims` (16), `claims_phases` (27), `library_claims` (2), `budget_contract` (9), `xseed_claims_verbs` (5), `claims_artifact_unknowns` (4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)