### PR TITLE
feat(cli): check --workspace, every seed independently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,34 @@ construction sites.
 `check` now runs its analysis once and shares it between the artifact
 gate and the diagnostic report, so this costs nothing on a
 `--dump-topology` run.
+### `hale check --workspace` (downstream review)
+
+`check` operates on one seed and does not recurse — correctly, since
+a directory is one compilation unit. The consequence was that a
+repository with several seeds needed a shell loop each project wrote
+itself, and a library or main-locus claim was enforced only where
+somebody remembered to point `check`.
+
+```sh
+hale check --workspace .        # every seed under `.`, each on its own
+hale verify --workspace .       # same, with advisories gated too
+```
+
+Every seed runs even when an earlier one fails: a runner that stopped
+at the first failure would report a subset of the truth, which is the
+shape of thing this exists to remove. The summary names the failing
+seeds, and the exit status is the worst of them so a usage error is
+not masked by an ordinary failure elsewhere. `vendor/`, `target/` and
+dot-directories are skipped — a seed you do not own is not yours to
+gate.
+
+It does **not** connect seeds. Each stays its own closed world; two
+binaries publishing and subscribing one topic are not linked by this,
+because nothing about a deployment is visible from source and
+inventing those edges would certify a system nobody deploys.
+Per-seed artifact flags are rejected in combination with
+`--workspace`: N seeds are N models, so there is no single artifact
+to emit or gate against.
 
 ### Topology artifact schema 1.3: an integrity digest
 

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -158,7 +158,8 @@ fn usage() {
     eprintln!("    hale parse <file.hl>          parse and print the AST");
     eprintln!("    hale check <file.hl | dir>    parse + typecheck");
     eprintln!("        [--dump-topology[=<path>]] [--check-topology[-shape] <path>]");
-    eprintln!("        [--dump-effects-manifest] [--json]   (`--help` for all)");
+    eprintln!("        [--dump-effects-manifest] [--json] [--workspace]");
+    eprintln!("        (`hale check --help` for all)");
     eprintln!("    hale verify <file.hl | dir>   check + FAIL on any advisory (discipline gate)");
     eprintln!("    hale run   <file.hl | dir>    compile + run as a native binary");
     eprintln!("    hale build <file.hl | dir>    parse + typecheck + emit native binary");
@@ -2338,16 +2339,19 @@ fn collect_checkable(
         ImportRenames,
         std::collections::BTreeSet<PathBuf>,
     ),
-    ExitCode,
+    u8,
 > {
     let files = match collect_ap_files(target) {
         Ok(f) => f,
         Err(e) => {
             eprintln!("{}", e);
-            return Err(ExitCode::from(1));
+            return Err(1);
         }
     };
-    let (programs, sources, file_bases) = parse_files(&files)?;
+    // `parse_files` still reports an `ExitCode` (its other two
+    // callers hand one straight back); it only ever fails with 1.
+    let (programs, sources, file_bases) =
+        parse_files(&files).map_err(|_| 1u8)?;
 
     // The files the target itself owns — everything else reached
     // from here arrived through an `import`.
@@ -2368,7 +2372,7 @@ fn collect_checkable(
         Some(m) => m,
         None => {
             eprintln!("no .hl files in {}", target.display());
-            return Err(ExitCode::from(1));
+            return Err(1);
         }
     };
     let workspace_root = find_workspace_root(target);
@@ -2412,7 +2416,7 @@ fn collect_checkable(
             eprintln!("{}:", path.display());
             eprintln!("  {}", d.render(src));
         }
-        return Err(ExitCode::from(1));
+        return Err(1);
     }
 
     let mut program = Program {
@@ -2515,6 +2519,7 @@ const CHECK_FLAGS: &[(&str, bool)] = &[
     // rather than left to chance.
     ("--warn-unbounded-alloc", false),
     ("--warn-resource-leak", false),
+    ("--workspace", false),
 ];
 
 fn check_usage(verify: bool) {
@@ -2530,6 +2535,13 @@ fn check_usage(verify: bool) {
     println!("A directory is ONE seed: the `.hl` files directly inside");
     println!("it are checked together, without recursing. Flags may");
     println!("appear before or after the target.");
+    println!();
+    println!("  --workspace                    check EVERY seed under the");
+    println!("                                 target, each independently.");
+    println!("                                 Skips vendor/, target/ and");
+    println!("                                 dot-dirs. Every seed runs even");
+    println!("                                 if an earlier one fails. It does");
+    println!("                                 NOT connect seeds to each other.");
     println!();
     println!("Claims and topology (spec/verification.md):");
     println!("  --dump-topology[=<path>]        emit the topology artifact");
@@ -2557,6 +2569,89 @@ fn check_usage(verify: bool) {
     println!("  --no-warn-unbounded-alloc       silence the unbounded-alloc lint");
     println!("  --allow-unowned-subscriber      permit a subscriber with no owner");
     println!("  --json                          machine-readable diagnostics");
+}
+
+/// Every SEED under `root`: a directory holding one or more `.hl`
+/// files directly. `check` operates on one seed and does not recurse
+/// — correctly, since a directory is one compilation unit — so a
+/// repository with many seeds needs something to enumerate them.
+///
+/// Skips `vendor` and dot-directories, matching `hale fmt`'s walk,
+/// plus `target`. A seed you do not own is not yours to gate.
+fn collect_seeds(root: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(root) else { return };
+    let mut has_hl = false;
+    let mut subdirs: Vec<PathBuf> = Vec::new();
+    for entry in entries.flatten() {
+        let p = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if p.is_dir() {
+            if name == "vendor" || name == "target" || name.starts_with('.')
+            {
+                continue;
+            }
+            subdirs.push(p);
+        } else if name.ends_with(".hl") {
+            has_hl = true;
+        }
+    }
+    if has_hl {
+        out.push(root.to_path_buf());
+    }
+    subdirs.sort();
+    for d in subdirs {
+        collect_seeds(&d, out);
+    }
+}
+
+/// `--workspace`: check EVERY seed under the target, independently.
+///
+/// It does not connect them. Each seed is its own closed world and
+/// gets its own check; this exists so that no library or main-locus
+/// claim is silently skipped because nobody remembered to point
+/// `check` at that directory. Cross-binary composition is a separate
+/// thing entirely and is not what this does.
+fn run_workspace(root: &Path, verify: bool) -> ExitCode {
+    let mut seeds = Vec::new();
+    collect_seeds(root, &mut seeds);
+    if seeds.is_empty() {
+        eprintln!(
+            "no seeds under {} — a seed is a directory holding `.hl` \
+             files",
+            root.display()
+        );
+        return ExitCode::from(2);
+    }
+
+    let mut failed: Vec<(PathBuf, u8)> = Vec::new();
+    for seed in &seeds {
+        println!("=== {} ===", seed.display());
+        let code = run_check_impl(seed, verify);
+        // Every seed runs. Stopping at the first failure would make
+        // the command report a subset of the truth, and the whole
+        // point is that nothing is silently skipped.
+        if code != 0 {
+            failed.push((seed.clone(), code));
+        }
+    }
+
+    println!();
+    if failed.is_empty() {
+        println!("ok: {} seed(s) checked", seeds.len());
+        return ExitCode::SUCCESS;
+    }
+    eprintln!(
+        "{} of {} seed(s) failed:",
+        failed.len(),
+        seeds.len()
+    );
+    for (p, code) in &failed {
+        eprintln!("  {} (exit {})", p.display(), code);
+    }
+    // The worst code wins, so a usage error is not masked by an
+    // ordinary check failure in another seed.
+    ExitCode::from(failed.iter().map(|(_, c)| *c).max().unwrap_or(1))
 }
 
 /// Parse `check` / `verify` arguments: exactly one positional target,
@@ -2599,6 +2694,51 @@ fn run_check_cli(rest: &[String], verify: bool) -> ExitCode {
         i += 1;
     }
 
+    let workspace = rest.iter().any(|a| a == "--workspace");
+    if workspace {
+        // Per-seed artifacts and one shared baseline are
+        // incompatible by construction: N seeds produce N models, so
+        // a single `--dump-topology` would interleave them on stdout
+        // and a single `--check-topology` would compare N models to
+        // one file. Silently taking the last would be the fail-open
+        // shape this command exists to remove.
+        for f in [
+            "--dump-topology",
+            "--check-topology",
+            "--check-topology-shape",
+            "--dump-effects-manifest",
+            "--check-effects-manifest",
+            "--dump-resource-budget",
+            "--check-resource-budget",
+            "--dump-alloc-summary",
+        ] {
+            if rest.iter().any(|a| a == f || a.starts_with(&format!("{}=", f)))
+            {
+                eprintln!(
+                    "`{}` is per-seed and cannot be combined with \
+                     --workspace — every seed is its own model, so \
+                     there is no single artifact to emit or gate \
+                     against. Run it against one seed.",
+                    f
+                );
+                return ExitCode::from(2);
+            }
+        }
+        let root = match positionals.len() {
+            0 => std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from(".")),
+            1 => PathBuf::from(positionals[0]),
+            _ => {
+                eprintln!(
+                    "hale {} --workspace takes at most one root",
+                    cmd
+                );
+                return ExitCode::from(2);
+            }
+        };
+        return run_workspace(&root, verify);
+    }
+
     match positionals.len() {
         1 => {}
         0 => {
@@ -2628,14 +2768,18 @@ fn run_check_cli(rest: &[String], verify: bool) -> ExitCode {
         }
     }
 
-    run_check_impl(&PathBuf::from(positionals[0]), verify)
+    ExitCode::from(run_check_impl(&PathBuf::from(positionals[0]), verify))
 }
 
 
 /// Shared core of `hale check` (advisories print, only errors
 /// fail) and `hale verify` (every finding fails — the CI
 /// discipline gate; same ~10 ms analysis, no execution).
-fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
+/// Returns the process exit CODE rather than an `ExitCode`, because
+/// `--workspace` runs this once per seed and has to aggregate the
+/// results — and `ExitCode` is opaque, so a caller cannot ask whether
+/// one succeeded.
+fn run_check_impl(target: &Path, gate_warnings: bool) -> u8 {
     // `check` MUST resolve cross-seed imports the same way `build`
     // and `run` do. It used to bundle only the target's own `.hl`
     // files, so an imported seed's bodies were never in the program
@@ -2667,7 +2811,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
             for d in &pre_diags {
                 eprintln!("{}", d.render(any_source));
             }
-            return ExitCode::from(1);
+            return 1;
         }
     }
 
@@ -2682,7 +2826,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
     // bound-proving yet.
     if std::env::args().any(|a| a == "--dump-alloc-summary") {
         print!("{}", hale_types::dump_alloc_summary(&bundle));
-        return ExitCode::SUCCESS;
+        return 0;
     }
     // GH #18 item 5: dump the per-program resource budget (pinned threads,
     // cooperative pools, bus subjects) and exit.
@@ -2715,7 +2859,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
                          hale check <target> --dump-effects-manifest > {}",
                         path
                     );
-                    return ExitCode::from(1);
+                    return 1;
                 }
             }
             Err(_) => {
@@ -2724,13 +2868,13 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
                      hale check <target> --dump-effects-manifest > {}",
                     path, path
                 );
-                return ExitCode::from(1);
+                return 1;
             }
         }
     }
     if std::env::args().any(|a| a == "--dump-resource-budget") {
         print!("{}", hale_types::dump_resource_budget(&bundle));
-        return ExitCode::SUCCESS;
+        return 0;
     }
     // GH #382 phase 2: the topology artifact — the serialized model
     // (sorts, relations) + every named claim's result, with a
@@ -2827,14 +2971,14 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
                 target.display(),
                 d.kind_str()
             );
-            return ExitCode::from(1);
+            return 1;
         }
         let artifact = hale_types::topology::dump_topology(&bundle);
         match &dump_topology_to {
             Some(path) => {
                 if let Err(e) = std::fs::write(path, &artifact) {
                     eprintln!("could not write {}: {}", path, e);
-                    return ExitCode::from(2);
+                    return 2;
                 }
             }
             None => print!("{}", artifact),
@@ -2856,7 +3000,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
         Ok(v) => v,
         Err(msg) => {
             eprintln!("{}", msg);
-            return ExitCode::from(2);
+            return 2;
         }
     };
     if let Some(path) = shape_gate {
@@ -2891,7 +3035,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
                      --dump-topology > {}",
                     path, path
                 );
-                return ExitCode::from(2);
+                return 2;
             }
             Ok(expected) => match (hash_of(&expected), hash_of(&current)) {
                 (Some(a), Some(b)) if a != b => {
@@ -2904,14 +3048,14 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
                          check <target> --dump-topology > {}",
                         path, a, b, path
                     );
-                    return ExitCode::from(1);
+                    return 1;
                 }
                 (None, _) | (_, None) => {
                     eprintln!(
                         "topology baseline {} has no shape_hash line",
                         path
                     );
-                    return ExitCode::from(2);
+                    return 2;
                 }
                 _ => {}
             },
@@ -2921,7 +3065,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
                      it:\n  hale check <target> --dump-topology > {}",
                     path, path
                 );
-                return ExitCode::from(1);
+                return 1;
             }
         }
     }
@@ -2929,7 +3073,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
         Ok(v) => v,
         Err(msg) => {
             eprintln!("{}", msg);
-            return ExitCode::from(2);
+            return 2;
         }
     };
     if let Some(path) = check_topology_path {
@@ -2953,7 +3097,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
                          hale check <target> --dump-topology > {}",
                         path
                     );
-                    return ExitCode::from(1);
+                    return 1;
                 }
             }
             Err(_) => {
@@ -2962,7 +3106,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
                      hale check <target> --dump-topology > {}",
                     path, path
                 );
-                return ExitCode::from(1);
+                return 1;
             }
         }
     }
@@ -2987,14 +3131,14 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
                 Ok(t) => t,
                 Err(e) => {
                     eprintln!("--check-resource-budget: cannot read `{}`: {}", path, e);
-                    return ExitCode::from(1);
+                    return 1;
                 }
             };
             let ct: CeilingToml = match toml::from_str(&text) {
                 Ok(c) => c,
                 Err(e) => {
                     eprintln!("--check-resource-budget: invalid budget file `{}`: {}", path, e);
-                    return ExitCode::from(1);
+                    return 1;
                 }
             };
             let ceiling = hale_types::resource_budget::ResourceCeiling {
@@ -3006,7 +3150,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
             let violations = hale_types::check_resource_ceiling(&bundle, &ceiling);
             if violations.is_empty() {
                 println!("resource budget OK (within `{}`)", path);
-                return ExitCode::SUCCESS;
+                return 0;
             }
             for v in &violations {
                 eprintln!(
@@ -3014,7 +3158,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
                     v, path
                 );
             }
-            return ExitCode::from(1);
+            return 1;
         }
     }
     let mut diags = checked;
@@ -3091,10 +3235,10 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
                     diags.len()
                 );
             }
-            return ExitCode::from(1);
+            return 1;
         }
         if diags.iter().any(|d| d.is_error()) {
-            return ExitCode::from(1);
+            return 1;
         }
     }
     if !json_mode {
@@ -3104,7 +3248,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> ExitCode {
             eprintln!("ok: {} file(s) typechecked", programs.len());
         }
     }
-    ExitCode::SUCCESS
+    0
 }
 
 /// One NDJSON diagnostic line for `hale check --json`.

--- a/crates/hale-cli/tests/workspace_check.rs
+++ b/crates/hale-cli/tests/workspace_check.rs
@@ -1,0 +1,193 @@
+//! `hale check --workspace` / `hale verify --workspace`.
+//!
+//! `check` operates on ONE seed and does not recurse — correctly, a
+//! directory is one compilation unit. The consequence is that a
+//! repository with many seeds needs something to enumerate them, and
+//! until now that was a shell loop each project wrote itself. A
+//! library or main-locus claim was enforced only if somebody
+//! remembered to point `check` at that directory.
+//!
+//! This command does NOT connect seeds. Each stays its own closed
+//! world and gets its own check; composing models across binaries is
+//! a different feature with different semantics.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn root(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir()
+        .join(format!("hale_ws_{}_{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&d);
+    d
+}
+
+fn seed(root: &Path, name: &str, src: &str) {
+    let d = root.join(name);
+    std::fs::create_dir_all(&d).expect("mkdir seed");
+    std::fs::write(d.join("main.hl"), src).expect("write seed");
+}
+
+fn hale(args: &[&std::ffi::OsStr]) -> (String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(args)
+        .output()
+        .expect("run hale");
+    (
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+const OK_SRC: &str = r#"
+    locus Q { params { n: Int = 0; } fn go() -> Int { return self.n; } }
+    main locus App { params { q: Q = Q { }; } }
+    fn main() { App { }; }
+"#;
+
+const BAD_SRC: &str = r#"
+    locus Bad { params { n: Int = 0; } fn go() -> Int { return self.nope; } }
+    main locus App { params { b: Bad = Bad { }; } }
+    fn main() { App { }; }
+"#;
+
+/// The core property: EVERY seed runs, and one failure does not hide
+/// the others. A runner that stopped at the first failure would
+/// report a subset of the truth, which is the shape of thing this
+/// command exists to eliminate.
+#[test]
+fn every_seed_runs_and_a_failure_does_not_short_circuit() {
+    let r = root("all");
+    // Alphabetically first so a short-circuiting runner would never
+    // reach the two after it.
+    seed(&r, "a-bad", BAD_SRC);
+    seed(&r, "b-ok", OK_SRC);
+    seed(&r, "c-ok", OK_SRC);
+
+    let (out, code) =
+        hale(&["check".as_ref(), "--workspace".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert_ne!(code, 0, "a failing seed must fail the run:\n{}", out);
+    for s in ["a-bad", "b-ok", "c-ok"] {
+        assert!(
+            out.contains(s),
+            "seed `{}` must have been visited — a failure earlier in \
+             the walk must not skip it:\n{}",
+            s,
+            out
+        );
+    }
+    assert!(
+        out.contains("1 of 3 seed(s) failed"),
+        "the summary must say how many of how many:\n{}",
+        out
+    );
+}
+
+#[test]
+fn a_clean_workspace_passes_and_counts_its_seeds() {
+    let r = root("clean");
+    seed(&r, "one", OK_SRC);
+    seed(&r, "two", OK_SRC);
+
+    let (out, code) =
+        hale(&["check".as_ref(), "--workspace".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert_eq!(code, 0, "no seed fails:\n{}", out);
+    assert!(out.contains("2 seed(s) checked"), "got:\n{}", out);
+}
+
+/// A seed you do not own is not yours to gate. `vendor` and
+/// dot-directories match `hale fmt`'s walk; `target` is build output.
+#[test]
+fn vendored_and_build_directories_are_not_seeds() {
+    let r = root("skip");
+    seed(&r, "mine", OK_SRC);
+    seed(&r, "vendor/theirs", BAD_SRC);
+    seed(&r, "target/generated", BAD_SRC);
+    seed(&r, ".hidden/cache", BAD_SRC);
+
+    let (out, code) =
+        hale(&["check".as_ref(), "--workspace".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert_eq!(
+        code, 0,
+        "only `mine` is owned; the broken ones are skipped:\n{}",
+        out
+    );
+    assert!(out.contains("1 seed(s) checked"), "got:\n{}", out);
+}
+
+/// A nested seed is still a seed — `check` not recursing is exactly
+/// why this command exists.
+#[test]
+fn nested_seeds_are_all_found() {
+    let r = root("nested");
+    seed(&r, "top", OK_SRC);
+    seed(&r, "top/inner", OK_SRC);
+    seed(&r, "top/inner/deeper", OK_SRC);
+
+    let (out, code) =
+        hale(&["check".as_ref(), "--workspace".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert_eq!(code, 0, "{}", out);
+    assert!(out.contains("3 seed(s) checked"), "got:\n{}", out);
+}
+
+/// Per-seed artifacts and one shared baseline are incompatible by
+/// construction: N seeds are N models. Taking the last silently would
+/// be the same fail-open the artifact gates were fixed for.
+#[test]
+fn per_seed_artifact_flags_are_rejected_with_workspace() {
+    let r = root("artifact");
+    seed(&r, "one", OK_SRC);
+
+    for flag in ["--dump-topology", "--check-topology-shape=/tmp/x.json"] {
+        let (out, code) = hale(&[
+            "check".as_ref(),
+            "--workspace".as_ref(),
+            r.as_os_str(),
+            flag.as_ref(),
+        ]);
+        assert_eq!(
+            code, 2,
+            "`{}` with --workspace must be a usage error:\n{}",
+            flag, out
+        );
+        assert!(
+            out.contains("per-seed"),
+            "and say why:\n{}",
+            out
+        );
+    }
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+#[test]
+fn a_root_with_no_seeds_is_a_usage_error() {
+    let r = root("empty");
+    std::fs::create_dir_all(&r).expect("mkdir");
+    let (out, code) =
+        hale(&["check".as_ref(), "--workspace".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_eq!(code, 2, "nothing to check is a usage error:\n{}", out);
+}
+
+/// `verify` gates advisories too, and `--workspace` composes with it
+/// rather than being a `check`-only flag.
+#[test]
+fn verify_workspace_applies_the_stricter_gate() {
+    let r = root("verify");
+    seed(&r, "one", OK_SRC);
+    let (out, code) =
+        hale(&["verify".as_ref(), "--workspace".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_eq!(code, 0, "a clean seed passes verify too:\n{}", out);
+}

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -607,6 +607,36 @@ Violations (the claim's result is `violated`):
 | `count` | the actual count + the participating loci |
 | any call-traversing claim | "cannot be certified" for indirect calls, untypeable receivers, computed subjects — with the repair named |
 
+## Checking a repository with many seeds
+
+`hale check` operates on **one seed** and does not recurse — a
+directory is one compilation unit, and that is the right unit for a
+closed-world check. The consequence is that a repository with several
+seeds needs something to enumerate them, or a claim is enforced only
+where somebody remembered to point `check`.
+
+```sh
+hale check --workspace .        # every seed under `.`, each on its own
+hale verify --workspace .       # same, with advisories gated too
+```
+
+Every seed runs even if an earlier one fails — a runner that stopped
+at the first failure would report a subset of the truth. The summary
+names which seeds failed, and the exit status is the worst of them, so
+a usage error is not masked by an ordinary check failure elsewhere.
+
+`vendor/`, `target/` and dot-directories are skipped: a seed you do
+not own is not yours to gate.
+
+What this does **not** do is connect seeds to each other. Each stays
+its own closed world with its own model. Two binaries that publish and
+subscribe the same topic are not linked by this command — nothing
+about a deployment is visible from source alone, and inventing those
+edges would certify a system nobody deploys. Per-seed artifact flags
+(`--dump-topology`, `--check-topology*`, the effects and budget
+equivalents) are therefore rejected in combination with `--workspace`:
+N seeds are N models, and there is no single artifact to emit or gate.
+
 ## The topology artifact
 
 The checked model exports, diffs, and gates:


### PR DESCRIPTION
Item 8, the last of the claims developer-experience review. Branched off `main`, so it is independent of the #410 → #411 → #412 stack (it does touch `main.rs`, which #410 also edits, so it will want a rebase after that lands).

### The gap

`check` operates on **one seed** and does not recurse — correctly, since a directory is one compilation unit and that is the right unit for a closed-world check. The consequence was that a repository with several seeds needed a shell loop each project wrote itself, and a library or main-locus claim was enforced only where somebody remembered to point `check`.

```sh
hale check --workspace .        # every seed under `.`, each on its own
hale verify --workspace .       # same, with advisories gated too
```

```
=== ws/app-a ===
ok: 1 file(s) typechecked
=== ws/app-b ===
ws/app-b/main.hl:2:60: type error: no field `nope` on `Bad`
=== ws/lib ===
ok: 1 file(s) typechecked

1 of 3 seed(s) failed:
  ws/app-b (exit 1)
```

### Decisions worth naming

**Every seed runs.** Stopping at the first failure would report a subset of the truth — the shape of thing this command exists to remove. Pinned by a test whose failing seed sorts *first*, so a short-circuiting runner would never reach the other two.

**The exit status is the worst code, not the first.** A usage error (2) must not be masked by an ordinary check failure (1) in another seed.

**It does not connect seeds.** Each stays its own closed world. Two binaries publishing and subscribing one topic are *not* linked by this, because nothing about a deployment is visible from source alone, and inventing those edges would certify a system nobody deploys. That is cross-binary composition, a separate thing with separate semantics.

**Per-seed artifact flags are rejected with `--workspace`.** N seeds are N models, so `--dump-topology` would interleave N artifacts on stdout and `--check-topology` would compare N models to one file. Silently taking the last would be exactly the fail-open the artifact gates were fixed for, so it is a usage error naming why.

**`vendor/`, `target/` and dot-directories are skipped**, matching `hale fmt`'s existing walk. A seed you do not own is not yours to gate.

### One refactor

`run_check_impl` returns the exit **code** (`u8`) rather than an `ExitCode`. Aggregating results requires asking whether a run succeeded, and `ExitCode` is opaque — there is no way to read one back. `collect_checkable`'s error type follows for the same reason. Single caller, mechanical.

### Scope

This is deliberately the dumb version: enumerate, check, aggregate. It is also the natural home for a future entrypoint × environment matrix (#409) and for fleet-tier checks over dumped artifacts (#408), but building either seam before those designs settle would mean building it twice.

Seven tests in `workspace_check`. Also ran `check_arg_parsing` (6), `topology_artifact_contract` (6), `xseed_claims_verbs` (5) and `doc` (3) for the return-type refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)