### PR TITLE
fix(claims): constitution review — fail-opens, identity, spec (GH #409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,60 @@ behavior.
 
 ## Unreleased
 
+### Constitution review fixes: three fail-opens, identity, and the spec (GH #409)
+
+An outside review of the constitutions PR found problems in shipped
+code. Three were fail-opens — which matters especially here, since the
+feature exists to stop law going missing quietly.
+
+- **A duplicate clause inside one constitution was silently dropped.**
+  Two clauses named `rule`, the second of which would have failed, and
+  the build *passed*. Diamond duplication is resolved at constitution
+  level, so a repeated `(origin, name)` can only be a duplicate
+  declaration; it is now an error.
+- **A misspelled manifest field silently removed all environment
+  law.** `constituton = "Prod"` parsed, left `constitution` as `None`,
+  and the entrypoint still counted as bound. `EnvSpec` now denies
+  unknown fields, and an environment that adds no law must say
+  `source_only = true` — an omission is indistinguishable from a typo.
+- **A malformed seed vanished from matrix coverage.** A seed with a
+  syntax error, listed in no environment, reported `ok: 1 pair(s)
+  checked`, exit 0 — while the same seed made valid was correctly
+  flagged. Breaking a file was a way out of the gate. Parse failure is
+  now an unknown entrypoint, never a non-entrypoint.
+
+**Constitution identity.** Names are flat and unmangled so diagnostics
+cite them as written — right for display, useless for identity. Two
+seeds can each declare `Core` with different clauses, so binding a
+bare name proved only that each entrypoint had *some* `Core`. A
+constitution's identity is now the digest of its normalized closure
+(its own clauses, sorted, plus its bases' digests), and `--matrix`
+rejects one environment resolving a name to two different claimsets.
+
+**`[claims] base`** makes "an environment may add law, never drop it"
+true of the mechanism rather than only of `extends`: every matrix
+evaluation carries the base by construction, so an environment can
+only add.
+
+**Artifact schema 1.6** gains an `evaluation` section naming the
+adopted constitutions and their closure digests. Per-claim `source`
+says where a clause came from; it cannot say which deployment the run
+certified, and two environments over one base can produce identical
+claim rows.
+
+**Documentation correction.** The previous docs said an entrypoint not
+importing a seed "gets an empty group, with `may_be_empty` as the
+opt-out". It does not: an undeclared group is an unknown-name error,
+and `may_be_empty` applies only to a group that IS declared and
+resolves to zero members. An entrypoint lacking a component writes
+`group thing = { } may_be_empty;` explicitly — a line a reviewer can
+see rather than an absence they must infer.
+
+The formal grammar gains `constitution_decl` and the `adopt` form, and
+`spec/verification.md` a normative account of placement, composition,
+collisions, diamonds, cycles, identity, environments and matrix
+completeness.
+
 ### `--env` and the entrypoint x environment matrix (GH #409)
 
 The tooling half of constitutions. `adopt Core;` in source means

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2651,7 +2651,7 @@ fn flag_value_in(
 fn resolve_env_constitution(
     target: &Path,
     env: &str,
-) -> Result<Option<String>, String> {
+) -> Result<Vec<String>, String> {
     let start = if target.is_dir() {
         target.to_path_buf()
     } else {
@@ -2661,9 +2661,20 @@ fn resolve_env_constitution(
     loop {
         let m = dir.join("hale.toml");
         if m.exists() {
-            let envs = crate::pkg::read_environments(&m)?;
+            let (envs, base) = crate::pkg::read_claims_config(&m)?;
             return match envs.get(env) {
-                Some(spec) => Ok(spec.constitution.clone()),
+                Some(spec) => {
+                    let mut v: Vec<String> = Vec::new();
+                    if let Some(b) = base {
+                        v.push(b);
+                    }
+                    if let Some(c) = &spec.constitution {
+                        if Some(c) != v.first() {
+                            v.push(c.clone());
+                        }
+                    }
+                    Ok(v)
+                }
                 None => Err(format!(
                     "no environment `{}` in {} (declared: {})",
                     env,
@@ -2701,13 +2712,14 @@ fn resolve_env_constitution(
 /// constitution bound per pair.
 fn run_matrix(root: &Path, verify: bool) -> ExitCode {
     let manifest_path = root.join("hale.toml");
-    let envs = match crate::pkg::read_environments(&manifest_path) {
-        Ok(e) => e,
-        Err(e) => {
-            eprintln!("{}", e);
-            return ExitCode::from(2);
-        }
-    };
+    let (envs, base) =
+        match crate::pkg::read_claims_config(&manifest_path) {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("{}", e);
+                return ExitCode::from(2);
+            }
+        };
     if envs.is_empty() {
         eprintln!(
             "no `[environments.<name>]` sections in {} — `--matrix` \
@@ -2724,8 +2736,15 @@ fn run_matrix(root: &Path, verify: bool) -> ExitCode {
     // feature exists to remove — so it is an error, not a skip.
     let mut seeds = Vec::new();
     collect_seeds(root, &mut seeds);
-    let entrypoints: Vec<PathBuf> =
-        seeds.into_iter().filter(|s| seed_has_main(s)).collect();
+    let mut entrypoints: Vec<PathBuf> = Vec::new();
+    let mut unparseable: Vec<PathBuf> = Vec::new();
+    for s in seeds {
+        match seed_entry_kind(&s) {
+            EntryKind::Yes => entrypoints.push(s),
+            EntryKind::No => {}
+            EntryKind::Unparseable(f) => unparseable.push(f),
+        }
+    }
 
     let mut bound: BTreeMap<PathBuf, Vec<String>> = BTreeMap::new();
     for (env, spec) in &envs {
@@ -2736,6 +2755,17 @@ fn run_matrix(root: &Path, verify: bool) -> ExitCode {
     }
 
     let mut failed: Vec<String> = Vec::new();
+    let mut seen_identity: BTreeMap<String, (String, String)> =
+        BTreeMap::new();
+    for f in &unparseable {
+        eprintln!(
+            "{} does not parse, so whether it is an entrypoint is \
+             unknown — and an unknown entrypoint cannot be shown to \
+             be covered by any environment. Fix the syntax first",
+            f.display()
+        );
+        failed.push(format!("{} (unparseable)", f.display()));
+    }
     for e in &entrypoints {
         let canon = e.canonicalize().unwrap_or_else(|_| e.clone());
         let listed: Vec<&String> = bound
@@ -2769,13 +2799,56 @@ fn run_matrix(root: &Path, verify: bool) -> ExitCode {
                 continue;
             }
             println!("=== {} @ {} ===", target.display(), env);
-            let code = run_check_impl_env(
-                &target,
-                verify,
-                spec.constitution.as_deref(),
-            );
+            // The base first, then the environment's own addition.
+            // Every pair carries the base, so an environment can only
+            // ADD law — monotonicity by construction rather than a
+            // rule the manifest is trusted to respect.
+            let mut adopt: Vec<String> = Vec::new();
+            if let Some(b) = &base {
+                adopt.push(b.clone());
+            }
+            if let Some(c) = &spec.constitution {
+                if Some(c) != base.as_ref() {
+                    adopt.push(c.clone());
+                }
+            }
+            let code = run_check_impl_env(&target, verify, &adopt);
             if code != 0 {
                 failed.push(format!("{} @ {}", ep, env));
+            }
+            // Review finding 3: prove the entrypoints in ONE
+            // environment resolved the SAME claimset, not merely the
+            // same NAME. Constitution names are flat and unmangled,
+            // so two seeds can each declare `Core` with different
+            // clauses and both would satisfy the binding. The digest
+            // covers the normalized closure, so agreement is real.
+            for (name, digest) in
+                constitution_identities(&target, &adopt)
+            {
+                let key = format!("{}::{}", env, name);
+                match seen_identity.get(&key) {
+                    Some((prev_digest, prev_ep))
+                        if *prev_digest != digest =>
+                    {
+                        eprintln!(
+                            "environment `{}` resolves `{}` to two \
+                             different claimsets: {} sees {}, {} sees \
+                             {}. One environment must mean one law — \
+                             the entrypoints are importing different \
+                             declarations that happen to share a name",
+                            env, name, prev_ep, prev_digest, ep, digest
+                        );
+                        failed.push(format!(
+                            "{} @ {} (constitution identity)",
+                            ep, env
+                        ));
+                    }
+                    Some(_) => {}
+                    None => {
+                        seen_identity
+                            .insert(key, (digest, ep.clone()));
+                    }
+                }
             }
         }
     }
@@ -2797,26 +2870,85 @@ fn run_matrix(root: &Path, verify: bool) -> ExitCode {
     ExitCode::from(1)
 }
 
-/// Does this seed declare a `main locus`? Parse-only — an entrypoint
-/// is a structural fact, and a seed that fails to typecheck is still
-/// an entrypoint whose absence from the matrix should be reported.
-fn seed_has_main(dir: &Path) -> bool {
-    let Ok(entries) = fs::read_dir(dir) else { return false };
-    for entry in entries.flatten() {
-        let p = entry.path();
-        if p.extension().and_then(|s| s.to_str()) != Some("hl") {
-            continue;
-        }
-        let Ok(src) = fs::read_to_string(&p) else { continue };
-        if let Ok(prog) = hale_syntax::parse_source(&src) {
-            if prog.items.iter().any(|i| {
-                matches!(i, hale_syntax::ast::TopDecl::Locus(l) if l.is_main)
-            }) {
-                return true;
-            }
+/// The `(name, digest)` of each constitution adopted when `target`
+/// is checked with `adopt`. Reads the same artifact section a
+/// third party would, rather than a private side channel.
+fn constitution_identities(
+    target: &Path,
+    adopt: &[String],
+) -> Vec<(String, String)> {
+    let (programs, _s, _fb, renames, _own) = match collect_checkable(target)
+    {
+        Ok(x) => x,
+        Err(_) => return Vec::new(),
+    };
+    let mut programs = programs;
+    for c in adopt {
+        for prog in programs.values_mut() {
+            inject_adopt(prog, c);
         }
     }
-    false
+    let bundle_programs: BTreeMap<String, &Program> = programs
+        .iter()
+        .map(|(p, prog)| (p.display().to_string(), prog))
+        .collect();
+    let mut bundle = hale_types::Bundle::new(bundle_programs);
+    bundle.import_renames = renames;
+    let (top, _d) = hale_types::resolve::build_top_scope(&bundle);
+    let graph = hale_types::bus_graph::build_bus_graph(&bundle, &top);
+    let progs: Vec<&Program> =
+        bundle.programs.values().copied().collect();
+    let (_d, _o, ids) = hale_types::claims::claims_report_with_identities(
+        &progs,
+        &graph,
+        &bundle.import_renames,
+    );
+    ids.into_iter().map(|i| (i.name, i.digest)).collect()
+}
+
+/// Is this seed an entrypoint? Parse-only — an entrypoint is a
+/// structural fact, and a seed that fails to TYPECHECK is still an
+/// entrypoint whose absence from the matrix must be reported.
+///
+/// A seed that fails to PARSE is `Unknown`, never `No`. Treating an
+/// unparseable file as "not a main" made a syntax error erase an
+/// entrypoint from coverage entirely: a broken seed listed in no
+/// environment reported `ok: 1 pair(s) checked`, exit 0, while the
+/// same seed made valid was correctly flagged. Breaking your file
+/// became a way out of the gate — in the mechanism built to stop law
+/// going missing quietly.
+enum EntryKind {
+    Yes,
+    No,
+    Unparseable(PathBuf),
+}
+
+fn seed_entry_kind(dir: &Path) -> EntryKind {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return EntryKind::No;
+    };
+    let mut files: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("hl"))
+        .collect();
+    files.sort();
+    for p in files {
+        let Ok(src) = fs::read_to_string(&p) else {
+            return EntryKind::Unparseable(p);
+        };
+        match hale_syntax::parse_source(&src) {
+            Ok(prog) => {
+                if prog.items.iter().any(|i| {
+                    matches!(i, hale_syntax::ast::TopDecl::Locus(l) if l.is_main)
+                }) {
+                    return EntryKind::Yes;
+                }
+            }
+            Err(_) => return EntryKind::Unparseable(p),
+        }
+    }
+    EntryKind::No
 }
 
 /// `--workspace`: check EVERY seed under the target, independently.
@@ -3008,7 +3140,7 @@ fn run_check_cli(rest: &[String], verify: bool) -> ExitCode {
     // `--env X` binds the constitution `[environments.X]` requires,
     // resolved from the nearest `hale.toml` at or above the target.
     let adopt = match &env_name {
-        None => None,
+        None => Vec::new(),
         Some(e) => match resolve_env_constitution(
             &PathBuf::from(positionals[0]),
             e,
@@ -3023,7 +3155,7 @@ fn run_check_cli(rest: &[String], verify: bool) -> ExitCode {
     ExitCode::from(run_check_impl_env(
         &PathBuf::from(positionals[0]),
         verify,
-        adopt.as_deref(),
+        &adopt,
     ))
 }
 
@@ -3073,7 +3205,7 @@ fn inject_adopt(prog: &mut hale_syntax::ast::Program, name: &str) -> bool {
 }
 
 fn run_check_impl(target: &Path, gate_warnings: bool) -> u8 {
-    run_check_impl_env(target, gate_warnings, None)
+    run_check_impl_env(target, gate_warnings, &[])
 }
 
 /// GH #409: `adopt_env` names a constitution the *deployment target*
@@ -3088,7 +3220,7 @@ fn run_check_impl(target: &Path, gate_warnings: bool) -> u8 {
 fn run_check_impl_env(
     target: &Path,
     gate_warnings: bool,
-    adopt_env: Option<&str>,
+    adopt_env: &[String],
 ) -> u8 {
     // `check` MUST resolve cross-seed imports the same way `build`
     // and `run` do. It used to bundle only the target's own `.hl`
@@ -3110,7 +3242,7 @@ fn run_check_impl_env(
     // path will see. Without this, `check` warns on
     // auto-inferable cross-pool calls while `build` silently
     // applies — same source, divergent answers.
-    if let Some(cname) = adopt_env {
+    for cname in adopt_env {
         let mut injected = false;
         for prog in programs.values_mut() {
             if inject_adopt(prog, cname) {

--- a/crates/hale-cli/src/pkg.rs
+++ b/crates/hale-cli/src/pkg.rs
@@ -61,15 +61,52 @@ pub struct Manifest {
     /// this system.
     #[serde(default)]
     pub environments: BTreeMap<String, EnvSpec>,
+    /// GH #409: `[claims] base = "Core"` — a constitution every
+    /// environment carries.
+    ///
+    /// This is what makes "an environment may add law, never drop
+    /// it" true of the MECHANISM rather than only of `extends`.
+    /// Without it the manifest can bind unrelated constitutions to
+    /// dev and prod, and monotonicity is a documentation promise
+    /// nothing enforces. With it, every matrix evaluation adopts the
+    /// base plus whatever the environment adds — monotone by
+    /// construction, which beats a check that has to notice a
+    /// violation after the fact.
+    #[serde(default)]
+    pub claims: ClaimsManifest,
+}
+
+/// The `[claims]` section.
+#[derive(Deserialize, Default, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct ClaimsManifest {
+    pub base: Option<String>,
 }
 
 /// One `[environments.<name>]` section.
+///
+/// `deny_unknown_fields` is load-bearing: without it a misspelled
+/// `constituton = "Prod"` parses fine, leaves `constitution` as
+/// `None`, and the entrypoint still counts as environment-bound —
+/// a typo silently removing all environment law from a deployment
+/// that reports success.
 #[derive(Deserialize, Default, Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct EnvSpec {
     /// The constitution every listed entrypoint must satisfy when
-    /// deployed here. Absent = this environment imposes no extra
-    /// law beyond what the entrypoints already adopt.
+    /// deployed here.
+    ///
+    /// Absent is an ERROR unless `source_only` says so explicitly.
+    /// "No environment law" is a real configuration, but it must be
+    /// stated rather than inferred from an omission — an omission is
+    /// indistinguishable from a mistake, and this feature exists to
+    /// stop law going missing quietly.
     pub constitution: Option<String>,
+    /// `source_only = true` — this environment adds no law of its
+    /// own; the entrypoints' source-level `adopt` lines (and the
+    /// workspace base, if declared) are the whole of it.
+    #[serde(default)]
+    pub source_only: bool,
     /// Seed directories, relative to the manifest. An entrypoint
     /// listed in NO environment is an error rather than a skip:
     /// silently unconstrained is the failure mode this whole
@@ -429,12 +466,44 @@ fn _phantom_pathbuf_use() -> PathBuf {
 pub fn read_environments(
     manifest: &Path,
 ) -> Result<BTreeMap<String, EnvSpec>, String> {
+    Ok(read_claims_config(manifest)?.0)
+}
+
+/// The `[environments.*]` table and the `[claims] base`, validated.
+pub fn read_claims_config(
+    manifest: &Path,
+) -> Result<(BTreeMap<String, EnvSpec>, Option<String>), String> {
     if !manifest.exists() {
-        return Ok(BTreeMap::new());
+        return Ok((BTreeMap::new(), None));
     }
     let src = fs::read_to_string(manifest)
         .map_err(|e| format!("read {}: {}", manifest.display(), e))?;
     let m: Manifest = toml::from_str(&src)
         .map_err(|e| format!("parse {}: {}", manifest.display(), e))?;
-    Ok(m.environments)
+    for (name, spec) in &m.environments {
+        match (&spec.constitution, spec.source_only) {
+            (Some(_), true) => {
+                return Err(format!(
+                    "{}: environment `{}` sets both `constitution` \
+                     and `source_only` — say one or the other",
+                    manifest.display(),
+                    name
+                ))
+            }
+            (None, false) => {
+                return Err(format!(
+                    "{}: environment `{}` names no `constitution`. \
+                     If it deliberately adds no law of its own, say \
+                     `source_only = true` — an omission is \
+                     indistinguishable from a typo, and a silently \
+                     law-free deployment is what this is here to \
+                     prevent",
+                    manifest.display(),
+                    name
+                ))
+            }
+            _ => {}
+        }
+    }
+    Ok((m.environments, m.claims.base))
 }

--- a/crates/hale-cli/tests/env_matrix.rs
+++ b/crates/hale-cli/tests/env_matrix.rs
@@ -277,3 +277,270 @@ fn a_manifest_with_no_environments_is_a_usage_error() {
     assert_eq!(code, 2, "{}", out);
     assert!(out.contains("[environments."), "{}", out);
 }
+
+// =====================================================================
+// PR #415 review findings
+// =====================================================================
+
+/// Finding 2. `constituton = "Prod"` parsed fine, left `constitution`
+/// as `None`, and the entrypoint still counted as bound — a typo
+/// silently removing all environment law from a deployment that
+/// reported success.
+#[test]
+fn a_misspelled_manifest_field_is_rejected() {
+    let r = workspace(
+        "typo",
+        "[environments.dev]\nconstituton = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    let (out, code) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "a typo must not be silently ignored: {}", out);
+}
+
+/// "This environment adds no law" is a real configuration, but it has
+/// to be stated. An omission is indistinguishable from a mistake.
+#[test]
+fn an_omitted_constitution_must_be_explicit() {
+    let r = workspace(
+        "omitted",
+        "[environments.dev]\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    let (out, code) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    assert_eq!(code, 2, "{}", out);
+    assert!(out.contains("source_only = true"), "name the fix: {}", out);
+    let _ = std::fs::remove_dir_all(&r);
+
+    // …and saying so explicitly works.
+    let r2 = workspace(
+        "sourceonly",
+        "[environments.dev]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    let (out2, code2) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r2.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r2);
+    assert_eq!(code2, 0, "{}", out2);
+}
+
+#[test]
+fn constitution_and_source_only_are_mutually_exclusive() {
+    let r = workspace(
+        "both",
+        "[environments.dev]\nconstitution = \"Core\"\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    let (out, code) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_eq!(code, 2, "{}", out);
+    assert!(out.contains("one or the other"), "{}", out);
+}
+
+/// Finding 4. Without a base, the manifest can bind unrelated
+/// constitutions to dev and prod, and "environments may add law,
+/// never drop it" is a documentation promise nothing enforces.
+/// `[claims] base` makes it true by construction.
+#[test]
+fn the_workspace_base_rides_along_with_every_environment() {
+    let r = workspace(
+        "base",
+        "[claims]\nbase = \"Core\"\n\n\
+         [environments.dev]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n\n\
+         [environments.prod]\nconstitution = \"Prod\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    let app = r.join("app-a");
+
+    let dev = hale_stdout(&[
+        "check".as_ref(), app.as_os_str(),
+        "--env".as_ref(), "dev".as_ref(),
+        "--dump-topology".as_ref(),
+    ]);
+    let prod = hale_stdout(&[
+        "check".as_ref(), app.as_os_str(),
+        "--env".as_ref(), "prod".as_ref(),
+        "--dump-topology".as_ref(),
+    ]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    let names = |s: &str| -> Vec<String> {
+        let v: serde_json::Value =
+            serde_json::from_str(s).expect("artifact parses");
+        v["evaluation"]["constitutions"]
+            .as_array()
+            .expect("constitutions")
+            .iter()
+            .map(|c| c["name"].as_str().unwrap_or("").to_string())
+            .collect()
+    };
+    assert!(
+        names(&dev).contains(&"Core".to_string()),
+        "an environment adding nothing still carries the base: {:?}",
+        names(&dev)
+    );
+    let p = names(&prod);
+    assert!(
+        p.contains(&"Core".to_string()) && p.contains(&"Prod".to_string()),
+        "prod ADDS to the base rather than replacing it: {:?}",
+        p
+    );
+}
+
+/// Finding 5. Per-claim `source` says where a clause came from; it
+/// cannot say which deployment the run certified. Two environments
+/// over one base can produce identical claim rows.
+#[test]
+fn the_artifact_names_the_constitutions_it_evaluated() {
+    let r = workspace(
+        "eval",
+        "[environments.prod]\nconstitution = \"Prod\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    let app = r.join("app-a");
+    let out = hale_stdout(&[
+        "check".as_ref(), app.as_os_str(),
+        "--env".as_ref(), "prod".as_ref(),
+        "--dump-topology".as_ref(),
+    ]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    let v: serde_json::Value =
+        serde_json::from_str(&out).expect("artifact parses");
+    let cs = v["evaluation"]["constitutions"]
+        .as_array()
+        .expect("evaluation.constitutions");
+    assert!(
+        cs.iter().any(|c| c["name"] == "Prod")
+            && cs.iter().any(|c| c["name"] == "Core"),
+        "the adopted closure, not just the directly-named one: {}",
+        out
+    );
+    assert!(
+        cs.iter().all(|c| c["digest"].as_str().is_some_and(|d| d.len() == 16)),
+        "each carries a closure digest: {}",
+        out
+    );
+}
+
+/// Finding 6. Treating an unparseable seed as "not a main" let a
+/// syntax error erase an entrypoint from coverage: the matrix
+/// reported `ok`, exit 0, while the same seed made valid was
+/// correctly flagged as unbound. Breaking a file became a way out of
+/// the gate.
+#[test]
+fn a_malformed_seed_cannot_vanish_from_coverage() {
+    let r = workspace(
+        "malformed",
+        "[environments.dev]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    // A main locus missing its closing brace.
+    write(&r, "broken/main.hl", "main locus C { params { n: Int = 0; }\nfn main() { C { }; }\n");
+
+    let (out, code) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert_ne!(code, 0, "an unparseable seed must fail the run: {}", out);
+    assert!(
+        out.contains("does not parse"),
+        "and say why it cannot be shown to be covered: {}",
+        out
+    );
+}
+
+/// Finding 3, at the level it matters: two entrypoints in ONE
+/// environment resolving `Core` to different declarations. Binding a
+/// bare name proves only that each had *some* constitution called
+/// `Core` — the digest is what proves they had the same one.
+#[test]
+fn one_environment_may_not_mean_two_different_claimsets() {
+    let r = root("identity");
+    write(&r, "p1/p.hl", LIB);
+    // Same display name, one extra clause: a different claimset.
+    write(
+        &r,
+        "p2/p.hl",
+        &LIB.replace(
+            "constitution Core { tenant_iso: forbid reaches(billing, research); }",
+            "constitution Core { tenant_iso: forbid reaches(billing, research); \
+             extra: count subscribers(topic Settled) == 0; }",
+        ),
+    );
+    write(&r, "app-a/main.hl", &APP.replace("../lib", "../p1"));
+    write(&r, "app-b/main.hl", &APP.replace("../lib", "../p2"));
+    write(
+        &r,
+        "hale.toml",
+        "[environments.prod]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+
+    let (out, code) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    assert_ne!(code, 0, "two different `Core`s must not pass: {}", out);
+    assert!(
+        out.contains("two different claimsets"),
+        "and the failure must say so: {}",
+        out
+    );
+
+    // Control: both importing the SAME policy seed passes, so the
+    // check is not simply rejecting every multi-entrypoint matrix.
+    write(&r, "app-b/main.hl", &APP.replace("../lib", "../p1"));
+    let (out2, code2) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_eq!(code2, 0, "one shared declaration is fine: {}", out2);
+}
+
+/// Review acceptance 12: an entrypoint that genuinely lacks a
+/// component declares the vocabulary explicitly. An undeclared group
+/// is an unknown-name error, not an empty set — the PR's original
+/// documentation had this backwards.
+#[test]
+fn an_entrypoint_without_a_component_declares_an_empty_group() {
+    let r = root("emptygroup");
+    write(
+        &r,
+        "lib/lib.hl",
+        "type Msg { v: Int; }\n\
+         topic Settled { payload: Msg; subject: \"app.settled\"; }\n\
+         locus Research { params { n: Int = 0; } fn look() -> Int { return self.n; } }\n\
+         group research = { Research };\n\
+         constitution Core { iso: forbid reaches(billing, research); }\n",
+    );
+    // This entrypoint has no Billing at all. The group must still be
+    // DECLARED — empty and explicitly so.
+    write(
+        &r,
+        "app-a/main.hl",
+        "import \"../lib\" as lb;\n\
+         group billing = { } may_be_empty;\n\
+         main locus A { params { r: lb::Research = lb::Research { }; } }\n\
+         fn main() { A { }; }\n",
+    );
+    write(
+        &r,
+        "hale.toml",
+        "[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\"]\n",
+    );
+    let (out, code) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+
+    // …and omitting the declaration is an error, not an empty set.
+    write(
+        &r,
+        "app-a/main.hl",
+        "import \"../lib\" as lb;\n\
+         main locus A { params { r: lb::Research = lb::Research { }; } }\n\
+         fn main() { A { }; }\n",
+    );
+    let (out2, code2) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert_eq!(code, 0, "an explicit empty group satisfies it: {}", out);
+    assert_ne!(code2, 0, "omitting the declaration must NOT: {}", out2);
+    assert!(
+        out2.contains("never declared"),
+        "with the unknown-name error, not a silent empty set: {}",
+        out2
+    );
+}

--- a/crates/hale-cli/tests/xseed_claims_verbs.rs
+++ b/crates/hale-cli/tests/xseed_claims_verbs.rs
@@ -80,7 +80,7 @@ fn cover_catches_an_uncovered_topic_across_seeds() {
 fn the_topology_artifact_round_trips() {
     let dump = dump_artifact();
     assert!(
-        dump.contains("\"schema\": \"1.5\"")
+        dump.contains("\"schema\": \"1.6\"")
             && dump.contains("\"shape_hash\": \""),
         "the artifact must carry schema + shape_hash:\n{}",
         dump

--- a/crates/hale-codegen/tests/fixtures/examples/constitutions.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/constitutions.hl
@@ -1,0 +1,48 @@
+// GH #409: the constitution surface, for the parse corpus.
+//
+// A named claimset declared outside any main, composed with
+// `extends` (union only — a derived constitution may add clauses and
+// may not replace one), and adopted by an entrypoint whose closed
+// world every clause is evaluated against.
+
+type Msg { v: Int; }
+topic Settled { payload: Msg; subject: "app.settled"; }
+
+locus Billing {
+    params { n: Int = 0; }
+    bus { publish Settled; }
+    fn go() { let m = Msg { v: 1 }; Settled <- m; }
+}
+locus Research {
+    params { n: Int = 0; }
+    fn look() -> Int { return self.n; }
+}
+
+group billing = { Billing };
+group research = { Research };
+
+constitution Core {
+    tenant_iso: forbid reaches(billing, research);
+    one_writer: count publishers(topic Settled) == 1;
+}
+
+constitution Dev extends Core {
+    quiet: count subscribers(topic Settled) == 0;
+}
+
+// Multiple bases, and a diamond: both extend `Core`, which
+// contributes its clauses exactly once.
+constitution Both extends Core, Dev { }
+
+main locus App {
+    params {
+        b: Billing = Billing { };
+        r: Research = Research { };
+    }
+    claims {
+        adopt Both;
+        local_rule: require publishes(some billing, topic Settled);
+    }
+}
+
+fn main() { App { }; }

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -86,6 +86,103 @@ pub fn claims_diags(
 /// Diagnostics plus per-claim outcomes (the artifact's rows).
 /// Demangles cross-seed symbols in the diagnostics so witnesses name
 /// what the author wrote.
+/// GH #409 (review finding 3): a constitution's identity is its
+/// NORMALIZED CLOSURE, not its display name.
+///
+/// Constitution names are flat and unmangled so diagnostics can cite
+/// them as written. That is right for display and useless for
+/// identity: two seeds can each declare `Core` with different
+/// clauses, and an environment binding a bare name would accept
+/// either. The matrix would then have proved "each entrypoint had
+/// SOME constitution called Core" — not "every entrypoint was
+/// evaluated against one shared claimset".
+///
+/// The digest covers the constitution's own clauses (name + rendered
+/// form, sorted) and, recursively, its bases' digests. Two
+/// declarations agree iff their whole closure agrees.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConstitutionIdentity {
+    pub name: String,
+    pub digest: String,
+}
+
+/// Diagnostics, outcomes, and the identities of the constitutions
+/// actually adopted.
+pub fn claims_report_with_identities(
+    programs: &[&Program],
+    graph: &BusGraph,
+    import_renames: &[(Vec<String>, String)],
+) -> (Vec<Diag>, Vec<ClaimOutcome>, Vec<ConstitutionIdentity>) {
+    let (d, o) = claims_report(programs, graph, import_renames);
+    let mut consts: Vec<&ConstitutionDecl> = Vec::new();
+    fn walk<'a>(items: &'a [TopDecl], out: &mut Vec<&'a ConstitutionDecl>) {
+        for i in items {
+            match i {
+                TopDecl::Constitution(c) => out.push(c),
+                TopDecl::Module(m) => walk(&m.items, out),
+                _ => {}
+            }
+        }
+    }
+    for p in programs {
+        walk(&p.items, &mut consts);
+    }
+    let by_name: BTreeMap<&str, &ConstitutionDecl> =
+        consts.iter().map(|c| (c.name.name.as_str(), *c)).collect();
+    // Only the constitutions whose clauses actually landed — the
+    // adopted closure, which is what an environment's identity is
+    // about.
+    let adopted: BTreeSet<String> =
+        o.iter().filter_map(|r| r.source.clone()).collect();
+    adopted
+        .iter()
+        .map(|n| ConstitutionIdentity {
+            name: n.clone(),
+            digest: constitution_digest(n, &by_name, &mut Vec::new()),
+        })
+        .fold((d, o, Vec::new()), |(d, o, mut v), id| {
+            v.push(id);
+            (d, o, v)
+        })
+}
+
+/// FNV-1a/64 over the normalized closure. Same family as the
+/// artifact's other identities, and dependency-free.
+fn constitution_digest(
+    name: &str,
+    by_name: &BTreeMap<&str, &ConstitutionDecl>,
+    stack: &mut Vec<String>,
+) -> String {
+    if stack.iter().any(|s| s == name) {
+        return "cycle".to_string();
+    }
+    let Some(cd) = by_name.get(name) else {
+        return "unresolved".to_string();
+    };
+    stack.push(name.to_string());
+    let mut parts: Vec<String> = cd
+        .extends
+        .iter()
+        .map(|b| constitution_digest(&b.name, by_name, stack))
+        .collect();
+    parts.sort();
+    let mut own: Vec<String> = cd
+        .entries
+        .iter()
+        .map(|e| format!("{}={}", e.name.name, render_form(&e.form)))
+        .collect();
+    own.sort();
+    parts.extend(own);
+    stack.pop();
+    let joined = parts.join(";");
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in joined.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{:016x}", h)
+}
+
 pub fn claims_report(
     programs: &[&Program],
     graph: &BusGraph,
@@ -362,7 +459,26 @@ fn expand_adoptions(
                     ),
                 ));
             }
-            Some(_) => {}
+            // Same origin, same name. Diamond duplication is already
+            // handled by the constitution-level `done` set, so a
+            // constitution's entries are collected exactly once —
+            // which means reaching here can only be TWO clauses
+            // declared with one name inside a single constitution.
+            // Skipping it silently dropped the second clause and let
+            // the build pass while a law the author wrote went
+            // unchecked.
+            Some(_) => {
+                diags.push(Diag::ty(
+                    decl.name.span,
+                    format!(
+                        "constitution `{}` declares claim `{}` twice. \
+                         The second would silently replace nothing and \
+                         go unchecked — claim names are the contract \
+                         of record, so one name means one clause",
+                        origin, decl.name.name
+                    ),
+                ));
+            }
             None => {
                 origins.insert(
                     decl.name.name.clone(),

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -93,7 +93,11 @@ use crate::symbol::Bundle;
 /// [`crate::verdict::Verdict`], which adds `uncertified` as a state
 /// distinct from `violated`. 1.5 (#409): a claim row gains an
 /// optional `source` — the constitution an adopted clause came from.
-pub const TOPOLOGY_SCHEMA: &str = "1.5";
+/// 1.6 (#409 review): an `evaluation` section naming the adopted
+/// constitutions and the digest of each one's normalized closure, so
+/// two entrypoints can be shown to have resolved the SAME claimset
+/// rather than merely the same name.
+pub const TOPOLOGY_SCHEMA: &str = "1.6";
 
 /// Serialize the bundle's model + claim results as the topology
 /// artifact (JSON).
@@ -459,7 +463,8 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
     }
 
     // ---- claims ----
-    let (_diags, outcomes) = crate::claims::claims_report(
+    let (_diags, outcomes, identities) =
+        crate::claims::claims_report_with_identities(
         &programs,
         &graph,
         &bundle.import_renames,
@@ -818,6 +823,27 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
     }
     trim_trailing_comma(&mut out);
     out.push_str("  ]");
+
+    // GH #409 (review finding 5): WHICH evaluation this artifact
+    // certifies. Per-claim `source` answers "where did this clause
+    // come from"; it cannot answer "which deployment was this run
+    // for". Two environments extending one base can produce
+    // identical claim rows, so without this the artifacts of a dev
+    // check and a prod check are indistinguishable while certifying
+    // different things.
+    //
+    // Inside the digest-covered body: an evaluation context that
+    // could be edited after the fact would certify nothing.
+    out.push_str(",\n  \"evaluation\": {\n    \"constitutions\": [\n");
+    for (i, id) in identities.iter().enumerate() {
+        out.push_str(&format!(
+            "      {{\"name\": {}, \"digest\": {}}}{}\n",
+            quote(&id.name),
+            quote(&id.digest),
+            if i + 1 == identities.len() { "" } else { "," }
+        ));
+    }
+    out.push_str("    ]\n  }");
 
     // The document's own verdict (schema 1.4). Every law in this
     // artifact — bundle claims and fn-grained certificates alike —

--- a/crates/hale-types/tests/artifact_integrity.rs
+++ b/crates/hale-types/tests/artifact_integrity.rs
@@ -169,7 +169,7 @@ fn only_holds_passes() {
 fn the_document_verdict_reflects_its_rows() {
     let a = artifact();
     let v: serde_json::Value = serde_json::from_str(&a).expect("valid JSON");
-    assert_eq!(v["schema"], "1.5");
+    assert_eq!(v["schema"], "1.6");
     assert_eq!(
         v["verdict"], "clean",
         "every claim in the fixture holds: {}",

--- a/crates/hale-types/tests/constitutions.rs
+++ b/crates/hale-types/tests/constitutions.rs
@@ -263,3 +263,156 @@ main locus App {
         err
     );
 }
+
+// =====================================================================
+// PR #415 review findings
+// =====================================================================
+
+/// Review finding 1. Diamond duplication is resolved by
+/// constitution-level traversal, so a repeated (origin, claim name)
+/// can only be two clauses declared under one name. The expansion
+/// took a `Some(_) => {}` branch and dropped the second — the build
+/// passed while a law the author wrote went unchecked, which is the
+/// exact failure mode this feature exists to prevent.
+#[test]
+fn a_constitution_may_not_declare_one_claim_name_twice() {
+    let src = program(
+        r#"
+constitution A {
+    rule: count publishers(topic Settled) == 1;
+    rule: count publishers(topic Settled) == 9;
+}
+main locus App {
+    params { b: Billing = Billing { }; r: Research = Research { }; }
+    claims { adopt A; }
+}
+"#,
+    );
+    let ds = diags(&src);
+    let hit = ds
+        .iter()
+        .find(|m| m.contains("declares claim `rule` twice"))
+        .unwrap_or_else(|| panic!("expected a duplicate error: {:#?}", ds));
+    assert!(hit.contains("`A`"), "name the constitution: {}", hit);
+}
+
+/// The second clause would have FAILED, so keeping only the first was
+/// not merely lossy — it changed the verdict.
+#[test]
+fn the_dropped_duplicate_would_have_changed_the_verdict() {
+    let src = program(
+        r#"
+constitution A {
+    rule: count publishers(topic Settled) == 1;
+    rule: count publishers(topic Settled) == 9;
+}
+main locus App {
+    params { b: Billing = Billing { }; r: Research = Research { }; }
+    claims { adopt A; }
+}
+"#,
+    );
+    assert!(
+        !diags(&src).is_empty(),
+        "a program whose second clause cannot hold must not pass"
+    );
+}
+
+/// Review finding 3: identity is the normalized closure, not the
+/// display name. Two constitutions with the same NAME and different
+/// clauses must not share a digest; the same closure reached two ways
+/// must.
+#[test]
+fn constitution_identity_follows_the_closure_not_the_name() {
+    use hale_types::bus_graph::build_bus_graph;
+    use hale_types::claims::claims_report_with_identities;
+
+    fn identities(src: &str) -> Vec<(String, String)> {
+        let prog = parse_source(src).expect("parse");
+        let mut programs = std::collections::BTreeMap::new();
+        programs.insert("app.hl".to_string(), &prog);
+        let bundle = hale_types::Bundle::new(programs);
+        let (top, _) = hale_types::resolve::build_top_scope(&bundle);
+        let graph = build_bus_graph(&bundle, &top);
+        let progs: Vec<&hale_syntax::ast::Program> =
+            bundle.programs.values().copied().collect();
+        let (_, _, ids) =
+            claims_report_with_identities(&progs, &graph, &[]);
+        ids.into_iter().map(|i| (i.name, i.digest)).collect()
+    }
+
+    let base = program(
+        r#"
+constitution Core { r: count publishers(topic Settled) == 1; }
+main locus App {
+    params { b: Billing = Billing { }; r: Research = Research { }; }
+    claims { adopt Core; }
+}
+"#,
+    );
+    // Same name, one extra clause: a different claimset entirely.
+    let wider = base.replace(
+        "constitution Core { r: count publishers(topic Settled) == 1; }",
+        "constitution Core { r: count publishers(topic Settled) == 1; \
+         s: count subscribers(topic Settled) == 0; }",
+    );
+
+    let a = identities(&base);
+    let b = identities(&wider);
+    assert_eq!(a.len(), 1);
+    assert_eq!(a[0].0, "Core");
+    assert_eq!(b[0].0, "Core", "the display name is unchanged");
+    assert_ne!(
+        a[0].1, b[0].1,
+        "…but two different claimsets must not share an identity, or a \
+         deployment binding the bare name proves nothing"
+    );
+
+    // Identity is stable for the same closure.
+    assert_eq!(identities(&base)[0].1, a[0].1);
+}
+
+/// An inherited clause changing must change the derived digest —
+/// otherwise a base edit would slip past an identity comparison.
+#[test]
+fn a_changed_base_clause_changes_the_derived_digest() {
+    use hale_types::bus_graph::build_bus_graph;
+    use hale_types::claims::claims_report_with_identities;
+
+    fn digest_of(src: &str, want: &str) -> String {
+        let prog = parse_source(src).expect("parse");
+        let mut programs = std::collections::BTreeMap::new();
+        programs.insert("app.hl".to_string(), &prog);
+        let bundle = hale_types::Bundle::new(programs);
+        let (top, _) = hale_types::resolve::build_top_scope(&bundle);
+        let graph = build_bus_graph(&bundle, &top);
+        let progs: Vec<&hale_syntax::ast::Program> =
+            bundle.programs.values().copied().collect();
+        let (_, _, ids) =
+            claims_report_with_identities(&progs, &graph, &[]);
+        ids.into_iter()
+            .find(|i| i.name == want)
+            .unwrap_or_else(|| panic!("no identity for {}", want))
+            .digest
+    }
+
+    let src = program(
+        r#"
+constitution Core { r: count publishers(topic Settled) == 1; }
+constitution Dev extends Core { d: count subscribers(topic Settled) == 0; }
+main locus App {
+    params { b: Billing = Billing { }; r: Research = Research { }; }
+    claims { adopt Dev; }
+}
+"#,
+    );
+    let changed = src.replace(
+        "r: count publishers(topic Settled) == 1;",
+        "r: count publishers(topic Settled) == 2;",
+    );
+    assert_ne!(
+        digest_of(&src, "Dev"),
+        digest_of(&changed, "Dev"),
+        "`Dev`'s own clauses did not change, but its CLOSURE did"
+    );
+}

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -711,13 +711,31 @@ close by construction, since no single compilation can see that a
 sibling was left out. A seed with no `main locus` is not an entrypoint
 and is not demanded of the manifest.
 
-### Groups resolve over shared vocabulary
+### Groups must be declared by every adopting entrypoint
 
 A constitution applied to every entrypoint cannot name any one
-application's internals. It doesn't need to: it names **shared library
-vocabulary**, which every entrypoint either imports or doesn't. An
-entrypoint that doesn't import a seed gets an empty group, and
-`may_be_empty` is the existing opt-out for exactly that.
+application's internals. It names **shared vocabulary** — but that
+vocabulary has to exist in each adopting entrypoint, and an
+*undeclared* name is an error, not an empty set:
+
+```
+type error: claim `iso` names group `payment_provider`, which is never
+declared. Add `group payment_provider = { … };` at the top level.
+```
+
+`may_be_empty` applies only to a group that IS declared and resolves
+to zero members. So an entrypoint that genuinely lacks a component
+declares the vocabulary and says so:
+
+```hale
+group payment_provider = { } may_be_empty;
+```
+
+The usual way to satisfy this is for the entrypoints to import the
+same seed that declares both the constitution and its groups — then
+the vocabulary arrives with the law. An entrypoint that deliberately
+lacks a component writes the empty group explicitly, which is a line
+a reviewer can see rather than an absence they must infer.
 
 ### Provenance, not annotation
 
@@ -848,11 +866,11 @@ reports as *unverifiable* rather than as valid — a consumer may
 choose to accept it, but must never read "nothing to check" as
 "checked and intact".
 
-The artifact shape (schema `1.5`):
+The artifact shape (schema `1.6`):
 
 ```text
 {
-  "schema": "1.5",
+  "schema": "1.6",
   "shape_hash": "<fnv1a-64 over the model half>",
   "sorts":     { "loci": […], "fns": […], "topics": […] },
   "relations": {

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -41,6 +41,7 @@ top_decl          = locus_decl
                   | target_decl
                   | group_decl
                   | claims_block          (* #392: library tier *)
+                  | constitution_decl     (* #409 *)
                   ;
 
 (* #392 thread 2 — a TOP-LEVEL claims_block is the LIBRARY tier: a
@@ -69,6 +70,22 @@ group_decl        = "group" , IDENTIFIER , "=" , "{" ,
 group_member      = IDENTIFIER , { "::" , IDENTIFIER } , [ "::" , "*" ] ;
 
 module_decl       = "module" , IDENTIFIER , "{" , { top_decl } , "}" ;
+
+(* GH #409 — a named, composable claimset, declared outside any main
+   and adopted by entrypoints. `extends` composes by UNION: a derived
+   constitution may ADD clauses and may not replace one, so a name
+   declared by two constitutions in one adopted set is an error. That
+   is what makes weakening unexpressible rather than merely
+   discouraged — deciding whether a replacement strengthens or weakens
+   would mean proving implication between claims, which fails open
+   when it is wrong.
+
+   `adopt` is deliberately NOT a constitution member: claimsets
+   compose with `extends`, and two composition mechanisms with
+   different rules is one too many. *)
+constitution_decl = "constitution" , IDENTIFIER ,
+                    [ "extends" , IDENTIFIER , { "," , IDENTIFIER } ] ,
+                    "{" , { IDENTIFIER , ":" , claim_form , ";" } , "}" ;
 
 (* F.20 — structural interface. Declares a named set of method
    signatures; any locus whose method set is a superset
@@ -308,7 +325,11 @@ locus_member      = params_block
    introducers are contextual keywords except `bus` / `publish` /
    `subscribe` / `on` / `in`, which are existing hard keywords. *)
 claims_block      = "claims" , "{" , { claim_entry } , "}" ;
-claim_entry       = IDENTIFIER , ":" , claim_form , ";" ;
+(* GH #409: `adopt` pulls in a named constitution. It is legal only
+   in a MAIN-LOCUS claims block — adoption fixes which world the
+   clauses are evaluated against, and a library seed closes none. *)
+claim_entry       = ( IDENTIFIER , ":" , claim_form , ";" )
+                  | ( "adopt" , IDENTIFIER , ";" ) ;
 claim_form        = forbid_form | only_edges_form | bound_form
                   | require_form | cover_form | count_form ;
 forbid_form       = "forbid" , "reaches" , "(" , claim_set , "," ,

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -235,7 +235,7 @@ earlier in the same file as the family. Companion:
 class along any path, with the same loop/indirect unboundedness
 rules as every per-call dimension.
 
-**The topology artifact** (#382 phase 2; schema 1.5):
+**The topology artifact** (#382 phase 2; schema 1.6):
 `hale check <t> --dump-topology` emits the serialized model —
 sorts (loci, fns, topics), relations (calls with **weights**: loop
 nesting, unbounded-loop membership, interface-dispatch tags;
@@ -323,6 +323,104 @@ traveling block is marked at the mangle stage, which only ever
 touches imported seeds. Group and topic references inside a
 traveling block canonicalize to mangled decls exactly as group
 decls do (#334); claim names are never mangled.
+
+## Constitutions — one authored claimset, many closed worlds (GH #409)
+
+A **constitution** is a named claimset declared outside any main and
+adopted by entrypoints with `adopt NAME;` inside a main-locus
+`claims { }` block. It is not a new quantification horizon: every
+clause is evaluated in the adopting main's own closed world, exactly
+as if written there. Authoring is shared, evaluation is not.
+
+- **Placement.** `constitution` is top-level only. `adopt` is legal
+  only in a MAIN-LOCUS `claims { }` block — adoption is what fixes
+  which world the clauses are evaluated against, and a library seed
+  closes none. `adopt` inside a `constitution` is a parse error;
+  claimsets compose with `extends`.
+- **Composition is union.** `extends A, B` contributes A's and B's
+  clauses. A derived constitution may ADD and may not REPLACE: a
+  claim name declared by two constitutions in one adopted set is an
+  error naming both origins, as is a local main clause shadowing an
+  adopted one. This is what makes weakening *unexpressible* — a
+  stricter bound is a second named claim that coexists with the
+  inherited one, and both are checked. Deciding whether a replacement
+  strengthens or weakens would require proving implication between
+  claims, which fails open when it is wrong.
+- **Duplicates within one constitution are an error.** Diamond
+  duplication is resolved by constitution-level traversal, so a
+  repeated `(origin, claim name)` can only be two clauses declared
+  under one name — silently keeping the first would leave law the
+  author wrote unchecked.
+- **Diamonds dedup by ORIGIN.** Two constitutions extending a common
+  base contribute the base once. Dedup is by originating
+  constitution, never by claim name: deduping by name would swallow
+  the genuine two-origin collision the union rule depends on.
+- **Cycles** in `extends`, unknown constitution names (with a
+  did-you-mean), and duplicate constitution declarations are errors.
+- **Groups are not implied.** A constitution names group vocabulary,
+  and every adopting entrypoint must DECLARE those groups. An
+  undeclared name is an unknown-name error, not an empty set;
+  `may_be_empty` applies only to a group that is declared and
+  resolves to zero members. An entrypoint lacking a component
+  therefore writes `group thing = { } may_be_empty;` rather than
+  omitting the declaration.
+
+### Identity
+
+A constitution's **display name** is flat and unmangled so
+diagnostics cite it as written. Its **identity** is the digest of its
+normalized closure — its own `(name, rendered form)` pairs, sorted,
+plus its bases' digests, recursively. Two declarations are the same
+constitution iff their closures agree.
+
+The distinction is load-bearing across entrypoints: two seeds may
+each declare `Core` with different clauses, so a binding by bare name
+proves only that each entrypoint had *some* constitution called
+`Core`, not that all were evaluated against one claimset.
+
+### Deployment environments
+
+`hale.toml` binds constitutions to deployment targets:
+
+```toml
+[claims]
+base = "Core"                # every environment carries this
+
+[environments.prod]
+constitution = "Prod"        # …and prod adds this
+entrypoints  = ["apps/riskgw"]
+
+[environments.dev]
+source_only  = true          # explicit: this environment adds none
+entrypoints  = ["apps/riskgw"]
+```
+
+`--env <name>` injects the base and the environment's constitution as
+if the source had written `adopt`. Binding here rather than in source
+is what lets one entrypoint satisfy different claimsets in different
+environments: it cannot write two conflicting `adopt` lines, but it
+can be checked twice.
+
+`[claims] base` is what makes "an environment may add law, never drop
+it" true of the mechanism rather than only of `extends` — every
+evaluation carries the base by construction. An environment naming no
+constitution must say `source_only = true`; an omission is
+indistinguishable from a typo, and unknown keys in an environment
+section are rejected for the same reason.
+
+`--matrix` checks every declared (entrypoint, environment) pair. It
+does not short-circuit; the exit status reflects every pair. An
+entrypoint in no environment is an error, and a seed that fails to
+PARSE is an unknown entrypoint rather than a non-entrypoint —
+otherwise a syntax error would erase a seed from coverage. Within one
+environment, all entrypoints must resolve each constitution to the
+same closure digest.
+
+The artifact records both: per-claim `source` (where this clause came
+from) and an `evaluation` section naming the adopted constitutions
+with their digests (which claimset this run certified). The second is
+inside the integrity-covered body — an evaluation context editable
+after the fact would certify nothing.
 
 ## Structural & design rules
 


### PR DESCRIPTION
Addresses all eight items from the #415 review. Three were fail-opens in already-merged code, which is why this is one PR rather than a queue.

Each finding was reproduced against the merged binary before being fixed.

## The three fail-opens

**1 — a duplicate clause inside one constitution was silently dropped.**

```hale
constitution A {
    rule: count publishers(topic T) == 0;
    rule: count publishers(topic T) == 9;   // ← discarded
}
```

Only one row reached the artifact and the build **passed**, even though the discarded clause would have failed it. The review's analysis was exact: diamond duplication is resolved by constitution-level traversal, so a repeated `(origin, claim name)` at expansion time can only be a duplicate declaration — the `Some(_) => {}` arm had nothing legitimate to absorb. Now an error naming the constitution and the claim.

**2 — a misspelled manifest field silently removed all environment law.**

```toml
[environments.prod]
constituton = "Prod"   # parsed fine; constitution stayed None
entrypoints = ["apps/riskgw"]
```

The entrypoint still counted as environment-bound, with no law. `EnvSpec` now has `deny_unknown_fields`, and an environment that genuinely adds nothing must say so:

```toml
[environments.dev]
source_only = true
```

Setting both is an error, and so is setting neither — an omission is indistinguishable from a typo.

**3 — a malformed seed vanished from matrix coverage.** The sharpest one:

```
broken/ has a syntax error, listed in no environment
  → "ok: 1 (entrypoint, environment) pair(s) checked", exit 0

same tree, broken/ made valid
  → "entrypoint badmain/broken is in no environment", exit 1
```

Breaking a file was a way *out* of the gate built to stop silent omission. `seed_has_main` returning `bool` conflated "no main" with "couldn't tell"; entrypoint discovery is now three-valued and an unparseable seed fails the run.

## Constitution identity (finding 3)

Names are flat and unmangled so diagnostics cite them as written — correct for display, useless for identity. Two seeds can each declare `Core` with different clauses, so binding a bare name proved only that each entrypoint had *some* constitution called `Core`.

A constitution's identity is now the digest of its **normalized closure**: its own `(name, rendered form)` pairs sorted, plus its bases' digests, recursively. `--matrix` compares them per environment:

```
environment `prod` resolves `Core` to two different claimsets: app-a sees
7ad5ad8479578cf7, app-b sees 605d31425128c2a0. One environment must mean one
law — the entrypoints are importing different declarations that happen to
share a name
```

with a control proving the check isn't simply rejecting every multi-entrypoint matrix: both apps importing the same policy seed passes. A changed *base* clause changes the *derived* digest, so a base edit can't slip past.

## Monotonicity, enforced (finding 4)

`[claims] base = "Core"` — every matrix evaluation carries it, so an environment can only add:

```
dev  adopts: ['Core']            # source_only
prod adopts: ['Core', 'Weak']    # base + its own
```

Monotone by construction rather than a documented promise nothing checks — the same "prefer constructed over verified" move as union-only composition itself.

## Schema 1.6 (finding 5)

```json
"evaluation": { "constitutions": [
  {"name": "Core", "digest": "24248e1f…"},
  {"name": "Dev",  "digest": "ba90a243…"}
]}
```

Per-claim `source` says where a clause came from; it cannot say which deployment the run certified, and two environments over one base can produce identical claim rows. Inside the digest-covered body — an evaluation context editable after the fact would certify nothing.

## Documentation correction

This one is mine, and I stated it confidently in the design discussion, the docs, and the PR body. I claimed an entrypoint not importing a seed "gets an empty group, with `may_be_empty` as the opt-out". It does not:

```
type error: claim `iso` names group `payment_provider`, which is never declared.
```

An undeclared name is an unknown-name error; `may_be_empty` applies only to a group that *is* declared and resolves to zero members. An entrypoint lacking a component writes `group payment_provider = { } may_be_empty;` — a line a reviewer can see rather than an absence they must infer. It also weakens the "no binding machinery needed" claim: each entrypoint must still declare the vocabulary, usually by importing the seed that declares law and groups together.

## Grammar and spec (finding 7)

`spec/grammar.ebnf` gains `constitution_decl` and the `adopt` form of `claim_entry`. `spec/verification.md` gains a normative section: placement, union-only composition, duplicate and collision rules, diamond dedup by origin, cycles, identity, environments, and matrix completeness. A corpus fixture covers the surface so the parse sweep exercises it.

## Tests

`constitutions.rs` 10 → 14, `env_matrix.rs` 9 → 17. New coverage per the review's acceptance list: duplicate clause fails; the dropped duplicate would have changed the verdict; identity follows closure not name; a changed base clause changes the derived digest; misspelled field rejected; omitted constitution must be explicit; `constitution`/`source_only` mutually exclusive; base rides along; artifact names its evaluation; malformed seed cannot vanish; one environment cannot mean two claimsets (with control); explicit empty group required (with negative control).

Also ran `claims` (16), `claims_edges` (36), `artifact_integrity` (9), `workspace_check` (7), `topology_artifact_contract` (9), `topology_v2` (5), `xseed_claims_verbs` (5), `claims_artifact_unknowns` (4), `keyword_sync` (3), `cross_seed_imports` (7), and the parse corpus.

## Not addressed

The review's secondary note that constitutions should be symbols in a law namespace with mangled semantic identity. The closure digest gives the invariant that mattered — every entrypoint in one environment resolves the same claimset — without moving names into the mangler, where `adopt` in source and `constitution =` in the manifest would both need rewriting. Worth revisiting if constitutions ever need to be referenced across seeds by qualified path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)