### PR TITLE
fix(claims): constitution identity at the boundary (GH #409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ behavior.
 
 ## Unreleased
 
+### Constitution identity, corrected at the boundary (GH #409)
+
+A second review found that the identity mechanism shipped in the
+previous entry had two holes of its own. Both were reproduced before
+fixing.
+
+- **Pure-composition constitutions vanished from identity.**
+  Identities were derived from the `source` of emitted claim rows, and
+  a constitution contributing no clause of its own emits none. So
+  `constitution Dev extends Left { }` — directly selected by the
+  manifest — appeared in no artifact and in no comparison. Two
+  entrypoints resolving the *same* `Dev` to different bases shared no
+  comparison key and the matrix passed. Pure composition is not
+  exotic: the corpus fixture added last release uses it. Identities
+  now come from the adoption **traversal**, which already visits every
+  constitution reached, and an evaluation reports its `roots` (named
+  directly) as well as its `closure`.
+- **`[claims] base` was compared per environment.** The key included
+  the environment name, so two environments with disjoint entrypoint
+  sets never shared one — a base resolving to different closures in
+  dev and prod went undetected. The mechanism proved consistency
+  *within* each environment and nothing about the base being shared.
+  The base now compares workspace-wide.
+
+Three smaller corrections:
+
+- **A workspace declaring environments must decide about a base**,
+  either `base = "…"` or `no_base = true`. An absent `[claims]`
+  section is indistinguishable from a misspelled one, and the intended
+  baseline would vanish while every environment still looked valid.
+- **`--env` requires an entrypoint** whether or not the environment
+  contributes a constitution. The check happened while injecting, so a
+  `source_only` environment with no base injected nothing, checked
+  nothing, and reported success for a library path.
+- **Duplicate bases normalize.** `extends Core, Core` and `extends
+  Core` evaluate identically, but the digest hashed the base twice and
+  reported a false mismatch — so a value called a *normalized* closure
+  was not normalized.
+
+Artifact schema **1.7**: `evaluation` splits into `roots` and
+`closure`, and gains the `environment` label. The prose promised this
+section says which deployment a run certified; only the label can.
+
 ### Constitution review fixes: three fail-opens, identity, and the spec (GH #409)
 
 An outside review of the constitutions PR found problems in shipped

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2812,7 +2812,9 @@ fn run_matrix(root: &Path, verify: bool) -> ExitCode {
                     adopt.push(c.clone());
                 }
             }
-            let code = run_check_impl_env(&target, verify, &adopt);
+            let code = run_check_impl_labelled(
+                &target, verify, &adopt, Some(env),
+            );
             if code != 0 {
                 failed.push(format!("{} @ {}", ep, env));
             }
@@ -2825,18 +2827,35 @@ fn run_matrix(root: &Path, verify: bool) -> ExitCode {
             for (name, digest) in
                 constitution_identities(&target, &adopt)
             {
-                let key = format!("{}::{}", env, name);
+                // The `[claims] base` is ONE constitution carried by
+                // every environment, so it must agree workspace-wide.
+                // Keying it per-environment meant two environments
+                // with disjoint entrypoints never shared a key, and a
+                // base resolving to different closures in dev and
+                // prod went undetected — the mechanism proved
+                // consistency WITHIN each environment and nothing
+                // about the base being shared.
+                let key = if Some(&name) == base.as_ref() {
+                    format!("base::{}", name)
+                } else {
+                    format!("env::{}::{}", env, name)
+                };
+                let scope = if Some(&name) == base.as_ref() {
+                    "the workspace base".to_string()
+                } else {
+                    format!("environment `{}`", env)
+                };
                 match seen_identity.get(&key) {
                     Some((prev_digest, prev_ep))
                         if *prev_digest != digest =>
                     {
                         eprintln!(
-                            "environment `{}` resolves `{}` to two \
-                             different claimsets: {} sees {}, {} sees \
-                             {}. One environment must mean one law — \
-                             the entrypoints are importing different \
-                             declarations that happen to share a name",
-                            env, name, prev_ep, prev_digest, ep, digest
+                            "{} resolves `{}` to two different \
+                             claimsets: {} sees {}, {} sees {}. One \
+                             name must mean one law — the entrypoints \
+                             are importing different declarations \
+                             that happen to share it",
+                            scope, name, prev_ep, prev_digest, ep, digest
                         );
                         failed.push(format!(
                             "{} @ {} (constitution identity)",
@@ -2903,7 +2922,10 @@ fn constitution_identities(
         &graph,
         &bundle.import_renames,
     );
-    ids.into_iter().map(|i| (i.name, i.digest)).collect()
+    // ROOTS, not the whole closure: the manifest asked for these by
+    // name, so these are what must agree across entrypoints. The
+    // closure follows from them.
+    ids.roots.into_iter().map(|i| (i.name, i.digest)).collect()
 }
 
 /// Is this seed an entrypoint? Parse-only — an entrypoint is a
@@ -3152,10 +3174,11 @@ fn run_check_cli(rest: &[String], verify: bool) -> ExitCode {
             }
         },
     };
-    ExitCode::from(run_check_impl_env(
+    ExitCode::from(run_check_impl_labelled(
         &PathBuf::from(positionals[0]),
         verify,
         &adopt,
+        env_name.as_deref(),
     ))
 }
 
@@ -3222,6 +3245,16 @@ fn run_check_impl_env(
     gate_warnings: bool,
     adopt_env: &[String],
 ) -> u8 {
+    run_check_impl_labelled(target, gate_warnings, adopt_env, None)
+}
+
+fn run_check_impl_labelled(
+    target: &Path,
+    gate_warnings: bool,
+    adopt_env: &[String],
+    env_label: Option<&str>,
+) -> u8 {
+    hale_types::claims::set_environment(env_label.map(str::to_string));
     // `check` MUST resolve cross-seed imports the same way `build`
     // and `run` do. It used to bundle only the target's own `.hl`
     // files, so an imported seed's bodies were never in the program
@@ -3242,6 +3275,28 @@ fn run_check_impl_env(
     // path will see. Without this, `check` warns on
     // auto-inferable cross-pool calls while `build` silently
     // applies — same source, divergent answers.
+    // An environment binds law to an ENTRYPOINT, so the target must
+    // be one — whether or not that environment happens to contribute
+    // a constitution. Checking this only while injecting meant a
+    // `source_only` environment with no workspace base injected
+    // nothing, checked nothing, and reported success for a library
+    // path; a matrix could count that as a covered pair.
+    if env_label.is_some() {
+        let has_main = programs.values().any(|p| {
+            p.items.iter().any(|i| {
+                matches!(i, hale_syntax::ast::TopDecl::Locus(l) if l.is_main)
+            })
+        });
+        if !has_main {
+            eprintln!(
+                "{}: `--env` names a deployment target, and a \
+                 deployment target is an ENTRYPOINT — this seed \
+                 declares no `main locus`",
+                target.display()
+            );
+            return 2;
+        }
+    }
     for cname in adopt_env {
         let mut injected = false;
         for prog in programs.values_mut() {

--- a/crates/hale-cli/src/pkg.rs
+++ b/crates/hale-cli/src/pkg.rs
@@ -81,6 +81,16 @@ pub struct Manifest {
 #[serde(deny_unknown_fields)]
 pub struct ClaimsManifest {
     pub base: Option<String>,
+    /// `no_base = true` — this workspace deliberately has no shared
+    /// base, so environments may bind unrelated constitutions.
+    ///
+    /// Required rather than inferred, for the same reason
+    /// `source_only` is: an absent `[claims]` section is
+    /// indistinguishable from a misspelled one (`[claim]`), and the
+    /// intended workspace baseline would vanish while every
+    /// environment still looked explicit and valid.
+    #[serde(default)]
+    pub no_base: bool,
 }
 
 /// One `[environments.<name>]` section.
@@ -500,6 +510,29 @@ pub fn read_claims_config(
                      prevent",
                     manifest.display(),
                     name
+                ))
+            }
+            _ => {}
+        }
+    }
+    if !m.environments.is_empty() {
+        match (&m.claims.base, m.claims.no_base) {
+            (Some(_), true) => {
+                return Err(format!(
+                    "{}: `[claims]` sets both `base` and `no_base` — \
+                     say one or the other",
+                    manifest.display()
+                ))
+            }
+            (None, false) => {
+                return Err(format!(
+                    "{}: declares environments but no `[claims] base`. \
+                     Without one, environments may bind unrelated \
+                     constitutions and \"an environment may add law, \
+                     never drop it\" is not a property of the \
+                     mechanism. Say `[claims] base = \"…\"`, or \
+                     `[claims] no_base = true` if that is deliberate",
+                    manifest.display()
                 ))
             }
             _ => {}

--- a/crates/hale-cli/tests/env_matrix.rs
+++ b/crates/hale-cli/tests/env_matrix.rs
@@ -79,6 +79,12 @@ main locus A { params { r: lb::Research = lb::Research { }; } }
 fn main() { A { }; }
 "#;
 
+/// Like `workspace`, but the manifest is written verbatim — for
+/// tests about the manifest itself.
+fn workspace_raw(tag: &str, manifest: &str) -> PathBuf {
+    workspace(tag, manifest)
+}
+
 fn workspace(tag: &str, manifest: &str) -> PathBuf {
     let r = root(tag);
     write(&r, "lib/lib.hl", LIB);
@@ -94,7 +100,7 @@ fn workspace(tag: &str, manifest: &str) -> PathBuf {
 fn the_same_entrypoint_is_judged_by_where_it_deploys() {
     let r = workspace(
         "twoenv",
-        "[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\"]\n\
+        "[claims]\nno_base = true\n\n[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\"]\n\
          \n[environments.prod]\nconstitution = \"Prod\"\nentrypoints = [\"app-a\"]\n",
     );
     let app = r.join("app-a");
@@ -121,7 +127,7 @@ fn the_same_entrypoint_is_judged_by_where_it_deploys() {
 fn the_artifact_records_which_constitution_each_clause_came_from() {
     let r = workspace(
         "prov",
-        "[environments.prod]\nconstitution = \"Prod\"\nentrypoints = [\"app-a\"]\n",
+        "[claims]\nno_base = true\n\n[environments.prod]\nconstitution = \"Prod\"\nentrypoints = [\"app-a\"]\n",
     );
     let app = r.join("app-a");
     let out = hale_stdout(&[
@@ -163,7 +169,7 @@ fn the_artifact_records_which_constitution_each_clause_came_from() {
 fn the_matrix_checks_every_pair() {
     let r = workspace(
         "matrix",
-        "[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n\
+        "[claims]\nno_base = true\n\n[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n\
          \n[environments.prod]\nconstitution = \"Core\"\nentrypoints = [\"app-a\"]\n",
     );
     let (out, code) =
@@ -186,7 +192,7 @@ fn the_matrix_checks_every_pair() {
 fn an_entrypoint_in_no_environment_is_an_error() {
     let r = workspace(
         "unbound",
-        "[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\"]\n",
+        "[claims]\nno_base = true\n\n[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\"]\n",
     );
     let (out, code) =
         hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
@@ -207,7 +213,7 @@ fn an_entrypoint_in_no_environment_is_an_error() {
 fn a_library_seed_is_not_an_entrypoint() {
     let r = workspace(
         "libonly",
-        "[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+        "[claims]\nno_base = true\n\n[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
     );
     let (out, code) =
         hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
@@ -221,7 +227,7 @@ fn a_library_seed_is_not_an_entrypoint() {
 fn a_listed_entrypoint_that_does_not_exist_is_reported() {
     let r = workspace(
         "missing",
-        "[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\", \"ghost\"]\n",
+        "[claims]\nno_base = true\n\n[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\", \"ghost\"]\n",
     );
     let (out, code) =
         hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
@@ -234,7 +240,7 @@ fn a_listed_entrypoint_that_does_not_exist_is_reported() {
 fn an_unknown_environment_name_is_a_usage_error() {
     let r = workspace(
         "unknownenv",
-        "[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+        "[claims]\nno_base = true\n\n[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
     );
     let app = r.join("app-a");
     let (out, code) = hale(&[
@@ -256,7 +262,7 @@ fn an_unknown_environment_name_is_a_usage_error() {
 fn env_requires_a_value() {
     let r = workspace(
         "noval",
-        "[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+        "[claims]\nno_base = true\n\n[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
     );
     let app = r.join("app-a");
     let (out, code) =
@@ -290,7 +296,7 @@ fn a_manifest_with_no_environments_is_a_usage_error() {
 fn a_misspelled_manifest_field_is_rejected() {
     let r = workspace(
         "typo",
-        "[environments.dev]\nconstituton = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+        "[claims]\nno_base = true\n\n[environments.dev]\nconstituton = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
     );
     let (out, code) =
         hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
@@ -304,7 +310,7 @@ fn a_misspelled_manifest_field_is_rejected() {
 fn an_omitted_constitution_must_be_explicit() {
     let r = workspace(
         "omitted",
-        "[environments.dev]\nentrypoints = [\"app-a\", \"app-b\"]\n",
+        "[claims]\nno_base = true\n\n[environments.dev]\nentrypoints = [\"app-a\", \"app-b\"]\n",
     );
     let (out, code) =
         hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
@@ -315,7 +321,7 @@ fn an_omitted_constitution_must_be_explicit() {
     // …and saying so explicitly works.
     let r2 = workspace(
         "sourceonly",
-        "[environments.dev]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
+        "[claims]\nno_base = true\n\n[environments.dev]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
     );
     let (out2, code2) =
         hale(&["check".as_ref(), "--matrix".as_ref(), r2.as_os_str()]);
@@ -327,7 +333,7 @@ fn an_omitted_constitution_must_be_explicit() {
 fn constitution_and_source_only_are_mutually_exclusive() {
     let r = workspace(
         "both",
-        "[environments.dev]\nconstitution = \"Core\"\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
+        "[claims]\nno_base = true\n\n[environments.dev]\nconstitution = \"Core\"\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
     );
     let (out, code) =
         hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
@@ -365,9 +371,9 @@ fn the_workspace_base_rides_along_with_every_environment() {
     let names = |s: &str| -> Vec<String> {
         let v: serde_json::Value =
             serde_json::from_str(s).expect("artifact parses");
-        v["evaluation"]["constitutions"]
+        v["evaluation"]["closure"]
             .as_array()
-            .expect("constitutions")
+            .expect("evaluation.closure")
             .iter()
             .map(|c| c["name"].as_str().unwrap_or("").to_string())
             .collect()
@@ -392,7 +398,7 @@ fn the_workspace_base_rides_along_with_every_environment() {
 fn the_artifact_names_the_constitutions_it_evaluated() {
     let r = workspace(
         "eval",
-        "[environments.prod]\nconstitution = \"Prod\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+        "[claims]\nno_base = true\n\n[environments.prod]\nconstitution = \"Prod\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
     );
     let app = r.join("app-a");
     let out = hale_stdout(&[
@@ -404,9 +410,9 @@ fn the_artifact_names_the_constitutions_it_evaluated() {
 
     let v: serde_json::Value =
         serde_json::from_str(&out).expect("artifact parses");
-    let cs = v["evaluation"]["constitutions"]
+    let cs = v["evaluation"]["closure"]
         .as_array()
-        .expect("evaluation.constitutions");
+        .expect("evaluation.closure");
     assert!(
         cs.iter().any(|c| c["name"] == "Prod")
             && cs.iter().any(|c| c["name"] == "Core"),
@@ -429,7 +435,7 @@ fn the_artifact_names_the_constitutions_it_evaluated() {
 fn a_malformed_seed_cannot_vanish_from_coverage() {
     let r = workspace(
         "malformed",
-        "[environments.dev]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
+        "[claims]\nno_base = true\n\n[environments.dev]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
     );
     // A main locus missing its closing brace.
     write(&r, "broken/main.hl", "main locus C { params { n: Int = 0; }\nfn main() { C { }; }\n");
@@ -469,7 +475,7 @@ fn one_environment_may_not_mean_two_different_claimsets() {
     write(
         &r,
         "hale.toml",
-        "[environments.prod]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+        "[claims]\nno_base = true\n\n[environments.prod]\nconstitution = \"Core\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
     );
 
     let (out, code) =
@@ -519,7 +525,7 @@ fn an_entrypoint_without_a_component_declares_an_empty_group() {
     write(
         &r,
         "hale.toml",
-        "[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\"]\n",
+        "[claims]\nno_base = true\n\n[environments.dev]\nconstitution = \"Core\"\nentrypoints = [\"app-a\"]\n",
     );
     let (out, code) =
         hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
@@ -542,5 +548,207 @@ fn an_entrypoint_without_a_component_declares_an_empty_group() {
         out2.contains("never declared"),
         "with the unknown-name error, not a silent empty set: {}",
         out2
+    );
+}
+
+// =====================================================================
+// Second review: identity boundary
+// =====================================================================
+
+/// Required canary. A constitution that contributes NO clause of its
+/// own — pure composition — emitted no claim row, so deriving
+/// identities from claim-row `source` dropped it entirely. Two
+/// entrypoints resolving the SAME directly-selected `Dev` to
+/// different bases then shared no comparison key and the matrix
+/// passed.
+///
+/// Pure composition is not exotic: #415's own corpus fixture uses
+/// `constitution Both extends Core, Dev { }`.
+#[test]
+fn a_pure_composition_constitution_is_still_compared() {
+    let r = root("purecomp");
+    let seed = |extra_rule: &str| {
+        format!(
+            "type Msg {{ v: Int; }}\n\
+             topic Settled {{ payload: Msg; subject: \"app.settled\"; }}\n\
+             locus S {{ params {{ n: Int = 0; }} bus {{ publish Settled; }} \
+             fn go() {{ let m = Msg {{ v: 1 }}; Settled <- m; }} }}\n\
+             group all = {{ S }};\n\
+             constitution Base {{ {} }}\n\
+             constitution Dev extends Base {{ }}\n",
+            extra_rule
+        )
+    };
+    write(&r, "p1/p.hl", &seed("r: count publishers(topic Settled) == 1;"));
+    // Same `Dev`, different base closure.
+    write(
+        &r,
+        "p2/p.hl",
+        &seed("r: count publishers(topic Settled) == 1; s: count subscribers(topic Settled) == 0;"),
+    );
+    let app = |alias: &str, n: &str| {
+        format!(
+            "import \"../{}\" as p;\nmain locus {} {{ params {{ s: p::S = p::S {{ }}; }} }}\nfn main() {{ {} {{ }}; }}\n",
+            alias, n, n
+        )
+    };
+    write(&r, "app-a/main.hl", &app("p1", "A"));
+    write(&r, "app-b/main.hl", &app("p2", "B"));
+    write(
+        &r,
+        "hale.toml",
+        "[claims]\nno_base = true\n\n[environments.prod]\nconstitution = \"Dev\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+
+    let (out, code) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert_ne!(code, 0, "two different `Dev` closures must fail: {}", out);
+    assert!(
+        out.contains("resolves `Dev`"),
+        "and must fail on Dev specifically — the directly selected \
+         constitution — not merely on whichever base emitted rows: {}",
+        out
+    );
+}
+
+/// Required canary. `[claims] base` means ONE constitution carried by
+/// every environment, so it must agree workspace-wide. Keying the
+/// comparison per-environment meant two environments with disjoint
+/// entrypoints never shared a key, and a base resolving differently
+/// in dev and prod went undetected.
+#[test]
+fn the_workspace_base_must_agree_across_environments() {
+    let r = root("basescope");
+    let seed = |rules: &str| {
+        format!(
+            "type Msg {{ v: Int; }}\n\
+             topic Settled {{ payload: Msg; subject: \"app.settled\"; }}\n\
+             locus S {{ params {{ n: Int = 0; }} bus {{ publish Settled; }} \
+             fn go() {{ let m = Msg {{ v: 1 }}; Settled <- m; }} }}\n\
+             group all = {{ S }};\n\
+             constitution Core {{ {} }}\n",
+            rules
+        )
+    };
+    write(&r, "p1/p.hl", &seed("r: count publishers(topic Settled) == 1;"));
+    write(
+        &r,
+        "p2/p.hl",
+        &seed("r: count publishers(topic Settled) == 1; s: count subscribers(topic Settled) == 0;"),
+    );
+    let app = |alias: &str, n: &str| {
+        format!(
+            "import \"../{}\" as p;\nmain locus {} {{ params {{ s: p::S = p::S {{ }}; }} }}\nfn main() {{ {} {{ }}; }}\n",
+            alias, n, n
+        )
+    };
+    write(&r, "app-a/main.hl", &app("p1", "A"));
+    write(&r, "app-b/main.hl", &app("p2", "B"));
+    // DISJOINT entrypoint sets: nothing forces the two to meet
+    // except the base being workspace-scoped.
+    write(
+        &r,
+        "hale.toml",
+        "[claims]\nbase = \"Core\"\n\n\
+         [environments.dev]\nsource_only = true\nentrypoints = [\"app-a\"]\n\n\
+         [environments.prod]\nsource_only = true\nentrypoints = [\"app-b\"]\n",
+    );
+
+    let (out, code) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert_ne!(code, 0, "the base resolves two ways: {}", out);
+    assert!(
+        out.contains("the workspace base"),
+        "and the failure must say the BASE is what disagrees, not one \
+         environment: {}",
+        out
+    );
+}
+
+/// A workspace declaring environments must decide about a base.
+/// Absence is indistinguishable from a misspelled `[claim]` section,
+/// and the intended baseline would vanish while every environment
+/// still looked explicit and valid.
+#[test]
+fn a_workspace_base_decision_is_required() {
+    let r = workspace_raw(
+        "nobase",
+        "[environments.dev]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    let (out, code) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_eq!(code, 2, "{}", out);
+    assert!(out.contains("no_base = true"), "name the opt-out: {}", out);
+}
+
+#[test]
+fn base_and_no_base_are_mutually_exclusive() {
+    let r = workspace_raw(
+        "bothbase",
+        "[claims]\nbase = \"Core\"\nno_base = true\n\n[environments.dev]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    let (out, code) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_eq!(code, 2, "{}", out);
+    assert!(out.contains("one or the other"), "{}", out);
+}
+
+/// An environment binds law to an ENTRYPOINT. Checking that only
+/// while injecting meant a `source_only` environment with no base
+/// injected nothing, and a library path passed as a checked pair.
+#[test]
+fn env_requires_the_target_to_be_an_entrypoint() {
+    let r = workspace(
+        "libtarget",
+        "[claims]\nno_base = true\n\n[environments.dev]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    let lib = r.join("lib");
+    let (out, code) = hale(&[
+        "check".as_ref(),
+        lib.as_os_str(),
+        "--env".as_ref(),
+        "dev".as_ref(),
+    ]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_eq!(code, 2, "a library is not a deployment target: {}", out);
+    assert!(out.contains("declares no `main locus`"), "{}", out);
+}
+
+/// The artifact must say WHICH deployment it certifies, not only
+/// which law applied — two environment labels can select identical
+/// law and would otherwise produce indistinguishable certificates.
+#[test]
+fn the_artifact_records_the_environment_and_its_roots() {
+    let r = workspace(
+        "envlabel",
+        "[claims]\nno_base = true\n\n[environments.prod]\nconstitution = \"Prod\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    let app = r.join("app-a");
+    let out = hale_stdout(&[
+        "check".as_ref(), app.as_os_str(),
+        "--env".as_ref(), "prod".as_ref(),
+        "--dump-topology".as_ref(),
+    ]);
+    let _ = std::fs::remove_dir_all(&r);
+    let v: serde_json::Value =
+        serde_json::from_str(&out).expect("artifact parses");
+    assert_eq!(v["evaluation"]["environment"], "prod", "{}", out);
+    let roots: Vec<String> = v["evaluation"]["roots"]
+        .as_array()
+        .expect("roots")
+        .iter()
+        .map(|c| c["name"].as_str().unwrap_or("").to_string())
+        .collect();
+    assert_eq!(
+        roots,
+        vec!["Prod".to_string()],
+        "roots is what was ASKED for; the closure is what applied: {}",
+        out
     );
 }

--- a/crates/hale-cli/tests/xseed_claims_verbs.rs
+++ b/crates/hale-cli/tests/xseed_claims_verbs.rs
@@ -80,7 +80,7 @@ fn cover_catches_an_uncovered_topic_across_seeds() {
 fn the_topology_artifact_round_trips() {
     let dump = dump_artifact();
     assert!(
-        dump.contains("\"schema\": \"1.6\"")
+        dump.contains("\"schema\": \"1.7\"")
             && dump.contains("\"shape_hash\": \""),
         "the artifact must carry schema + shape_hash:\n{}",
         dump

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -112,8 +112,10 @@ pub fn claims_report_with_identities(
     programs: &[&Program],
     graph: &BusGraph,
     import_renames: &[(Vec<String>, String)],
-) -> (Vec<Diag>, Vec<ClaimOutcome>, Vec<ConstitutionIdentity>) {
-    let (d, o) = claims_report(programs, graph, import_renames);
+) -> (Vec<Diag>, Vec<ClaimOutcome>, Adoption) {
+    let (mut d, o, adoption) =
+        claims_report_inner(programs, graph, import_renames);
+    crate::stdlib_bodies::demangle_imports(&mut d, import_renames);
     let mut consts: Vec<&ConstitutionDecl> = Vec::new();
     fn walk<'a>(items: &'a [TopDecl], out: &mut Vec<&'a ConstitutionDecl>) {
         for i in items {
@@ -129,21 +131,27 @@ pub fn claims_report_with_identities(
     }
     let by_name: BTreeMap<&str, &ConstitutionDecl> =
         consts.iter().map(|c| (c.name.name.as_str(), *c)).collect();
-    // Only the constitutions whose clauses actually landed — the
-    // adopted closure, which is what an environment's identity is
-    // about.
-    let adopted: BTreeSet<String> =
-        o.iter().filter_map(|r| r.source.clone()).collect();
-    adopted
-        .iter()
-        .map(|n| ConstitutionIdentity {
-            name: n.clone(),
-            digest: constitution_digest(n, &by_name, &mut Vec::new()),
-        })
-        .fold((d, o, Vec::new()), |(d, o, mut v), id| {
-            v.push(id);
-            (d, o, v)
-        })
+    let id_of = |n: &String| ConstitutionIdentity {
+        name: n.clone(),
+        digest: constitution_digest(n, &by_name, &mut Vec::new()),
+    };
+    let out = Adoption {
+        roots: adoption.roots.iter().map(&id_of).collect(),
+        closure: adoption.closure.iter().map(&id_of).collect(),
+    };
+    (d, o, out)
+}
+
+/// The identities an evaluation adopted: the roots it named directly,
+/// and the whole closure those roots reach.
+///
+/// A consumer needs both. `roots` is what the manifest asked for, so
+/// it is what a matrix must compare across entrypoints; `closure` is
+/// the law that actually applied.
+#[derive(Debug, Default, Clone)]
+pub struct Adoption {
+    pub roots: Vec<ConstitutionIdentity>,
+    pub closure: Vec<ConstitutionIdentity>,
 }
 
 /// FNV-1a/64 over the normalized closure. Same family as the
@@ -160,10 +168,19 @@ fn constitution_digest(
         return "unresolved".to_string();
     };
     stack.push(name.to_string());
-    let mut parts: Vec<String> = cd
-        .extends
+    // Dedup the bases. Expansion already visits each constitution
+    // once, so `extends Core, Core` and `extends Core` have identical
+    // evaluated clauses — hashing the base twice gave them different
+    // digests, which would report a false mismatch between two
+    // semantically identical closures. Fail-closed, but it means the
+    // value called a NORMALIZED closure was not normalized.
+    let mut bases: Vec<&str> =
+        cd.extends.iter().map(|b| b.name.as_str()).collect();
+    bases.sort_unstable();
+    bases.dedup();
+    let mut parts: Vec<String> = bases
         .iter()
-        .map(|b| constitution_digest(&b.name, by_name, stack))
+        .map(|b| constitution_digest(b, by_name, stack))
         .collect();
     parts.sort();
     let mut own: Vec<String> = cd
@@ -188,7 +205,7 @@ pub fn claims_report(
     graph: &BusGraph,
     import_renames: &[(Vec<String>, String)],
 ) -> (Vec<Diag>, Vec<ClaimOutcome>) {
-    let (mut out, outcomes) =
+    let (mut out, outcomes, _adoption) =
         claims_report_inner(programs, graph, import_renames);
     crate::stdlib_bodies::demangle_imports(&mut out, import_renames);
     // Mark the whole batch at the one place they all funnel through,
@@ -308,6 +325,37 @@ struct Cx<'a> {
     model: crate::model::Model,
 }
 
+thread_local! {
+    /// The environment name a `--env` / matrix run was for, so the
+    /// artifact can record WHICH deployment it certifies. A
+    /// thread-local because the artifact is serialized far from the
+    /// CLI that knows the label, and threading an `Option<String>`
+    /// through every intervening signature would buy nothing.
+    static ENVIRONMENT: std::cell::RefCell<Option<String>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Record the environment this evaluation is for.
+pub fn set_environment(name: Option<String>) {
+    ENVIRONMENT.with(|e| *e.borrow_mut() = name);
+}
+
+pub fn current_environment() -> Option<String> {
+    ENVIRONMENT.with(|e| e.borrow().clone())
+}
+
+/// GH #409: what an evaluation adopted.
+///
+/// `roots` are the constitutions named directly (by source `adopt`
+/// lines and by `--env` injection); `closure` is every constitution
+/// reached from them. Both come from the adoption traversal, never
+/// from inspecting which claims happened to be emitted.
+#[derive(Debug, Default, Clone)]
+pub struct AdoptionInfo {
+    pub roots: Vec<String>,
+    pub closure: Vec<String>,
+}
+
 /// GH #409: expand a main's `adopt` lines into its claim set,
 /// returning claim-name → originating constitution.
 ///
@@ -323,6 +371,7 @@ fn expand_adoptions(
     lib_adopts: &[Ident],
     claims: &mut Vec<ClaimDecl>,
     diags: &mut Vec<Diag>,
+    info: &mut AdoptionInfo,
 ) -> BTreeMap<String, String> {
     let mut origins: BTreeMap<String, String> = BTreeMap::new();
 
@@ -416,6 +465,9 @@ fn expand_adoptions(
     }
     let mut stack = Vec::new();
     for a in adopts {
+        if !info.roots.contains(&a.name) {
+            info.roots.push(a.name.clone());
+        }
         visit(
             a,
             &by_name,
@@ -425,6 +477,19 @@ fn expand_adoptions(
             diags,
         );
     }
+    // The EFFECTIVE closure comes from the traversal, which visits
+    // every constitution reached — directly adopted roots, empty
+    // composition constitutions, intermediates, bases, and
+    // diamond-deduplicated ancestors alike.
+    //
+    // Deriving it instead from the `source` of emitted claim rows
+    // silently dropped any constitution that contributes no clause of
+    // its own. `constitution Dev extends Left { }` was then absent
+    // from the artifact and from the matrix's identity comparison —
+    // so two entrypoints resolving the SAME `Dev` to different bases
+    // shared no comparison key and passed. Pure composition is not an
+    // edge case; #415's own corpus fixture uses it.
+    info.closure = done.iter().cloned().collect();
 
     // Collisions. Claim names are the contract of record — cited in
     // reviews, in diagnostics, in the artifact — and are deliberately
@@ -495,7 +560,7 @@ fn claims_report_inner(
     programs: &[&Program],
     graph: &BusGraph,
     import_renames: &[(Vec<String>, String)],
-) -> (Vec<Diag>, Vec<ClaimOutcome>) {
+) -> (Vec<Diag>, Vec<ClaimOutcome>, AdoptionInfo) {
     // ---- collect group decls + claims blocks (modules included) ----
     //
     // #392 thread 2 — two tiers. Main-locus blocks are the WORLD
@@ -579,12 +644,14 @@ fn claims_report_inner(
     // GH #409: expand adopted constitutions into this main's claim
     // set. Authoring is shared, evaluation is not — every clause is
     // checked HERE, against this entrypoint's closed world.
+    let mut adoption = AdoptionInfo::default();
     let origins = expand_adoptions(
         &consts,
         &adopts,
         &lib_adopts,
         &mut claims,
         &mut diags,
+        &mut adoption,
     );
     for cb in top_blocks {
         // The seed merge flattens imported items into the closing
@@ -633,7 +700,7 @@ fn claims_report_inner(
         }
     }
     if group_decls.is_empty() && claims.is_empty() {
-        return (diags, Vec::new());
+        return (diags, Vec::new(), adoption);
     }
 
     // ---- decl indexes for member / topic resolution ----
@@ -730,7 +797,7 @@ fn claims_report_inner(
     }
 
     if claims.is_empty() {
-        return (diags, Vec::new());
+        return (diags, Vec::new(), adoption);
     }
 
     // ---- claim names are the contract-of-record ----
@@ -804,7 +871,7 @@ fn claims_report_inner(
             source: origins.get(&c.name.name).cloned(),
         });
     }
-    (diags, outcomes)
+    (diags, outcomes, adoption)
 }
 
 // ===================== validation =================================

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -96,8 +96,12 @@ use crate::symbol::Bundle;
 /// 1.6 (#409 review): an `evaluation` section naming the adopted
 /// constitutions and the digest of each one's normalized closure, so
 /// two entrypoints can be shown to have resolved the SAME claimset
-/// rather than merely the same name.
-pub const TOPOLOGY_SCHEMA: &str = "1.6";
+/// rather than merely the same name. 1.7 (#415 review 2): that
+/// section splits into `roots` (named directly) and `closure`
+/// (everything they reach), and gains the `environment` label —
+/// identities now come from the adoption traversal, so a constitution
+/// contributing no clause of its own is no longer invisible.
+pub const TOPOLOGY_SCHEMA: &str = "1.7";
 
 /// Serialize the bundle's model + claim results as the topology
 /// artifact (JSON).
@@ -834,16 +838,39 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
     //
     // Inside the digest-covered body: an evaluation context that
     // could be edited after the fact would certify nothing.
-    out.push_str(",\n  \"evaluation\": {\n    \"constitutions\": [\n");
-    for (i, id) in identities.iter().enumerate() {
+    out.push_str(",\n  \"evaluation\": {\n");
+    // The environment this run was for, when one was named. Two
+    // environment labels selecting identical law produce equivalent
+    // certificates on the `closure` alone — but the prose promised
+    // this section says WHICH deployment was certified, and only the
+    // label can say that.
+    if let Some(env) = crate::claims::current_environment() {
         out.push_str(&format!(
-            "      {{\"name\": {}, \"digest\": {}}}{}\n",
-            quote(&id.name),
-            quote(&id.digest),
-            if i + 1 == identities.len() { "" } else { "," }
+            "    \"environment\": {},\n",
+            quote(&env)
         ));
     }
-    out.push_str("    ]\n  }");
+    // `roots` — what was asked for. `closure` — what applied.
+    //
+    // Both come from the adoption traversal. Deriving them from the
+    // `source` of emitted claim rows dropped every constitution that
+    // contributes no clause of its own, so a directly-selected
+    // `constitution Dev extends Left { }` never appeared at all.
+    let mut section = |label: &str, ids: &[crate::claims::ConstitutionIdentity], last: bool| {
+        out.push_str(&format!("    \"{}\": [\n", label));
+        for (i, id) in ids.iter().enumerate() {
+            out.push_str(&format!(
+                "      {{\"name\": {}, \"digest\": {}}}{}\n",
+                quote(&id.name),
+                quote(&id.digest),
+                if i + 1 == ids.len() { "" } else { "," }
+            ));
+        }
+        out.push_str(if last { "    ]\n" } else { "    ],\n" });
+    };
+    section("roots", &identities.roots, false);
+    section("closure", &identities.closure, true);
+    out.push_str("  }");
 
     // The document's own verdict (schema 1.4). Every law in this
     // artifact — bundle claims and fn-grained certificates alike —

--- a/crates/hale-types/tests/artifact_integrity.rs
+++ b/crates/hale-types/tests/artifact_integrity.rs
@@ -169,7 +169,7 @@ fn only_holds_passes() {
 fn the_document_verdict_reflects_its_rows() {
     let a = artifact();
     let v: serde_json::Value = serde_json::from_str(&a).expect("valid JSON");
-    assert_eq!(v["schema"], "1.6");
+    assert_eq!(v["schema"], "1.7");
     assert_eq!(
         v["verdict"], "clean",
         "every claim in the fixture holds: {}",

--- a/crates/hale-types/tests/constitutions.rs
+++ b/crates/hale-types/tests/constitutions.rs
@@ -338,7 +338,7 @@ fn constitution_identity_follows_the_closure_not_the_name() {
             bundle.programs.values().copied().collect();
         let (_, _, ids) =
             claims_report_with_identities(&progs, &graph, &[]);
-        ids.into_iter().map(|i| (i.name, i.digest)).collect()
+        ids.closure.into_iter().map(|i| (i.name, i.digest)).collect()
     }
 
     let base = program(
@@ -390,7 +390,8 @@ fn a_changed_base_clause_changes_the_derived_digest() {
             bundle.programs.values().copied().collect();
         let (_, _, ids) =
             claims_report_with_identities(&progs, &graph, &[]);
-        ids.into_iter()
+        ids.closure
+            .into_iter()
             .find(|i| i.name == want)
             .unwrap_or_else(|| panic!("no identity for {}", want))
             .digest
@@ -414,5 +415,148 @@ main locus App {
         digest_of(&src, "Dev"),
         digest_of(&changed, "Dev"),
         "`Dev`'s own clauses did not change, but its CLOSURE did"
+    );
+}
+
+/// Second review: a constitution that contributes no clause of its
+/// own must still have an identity. Deriving identities from the
+/// `source` of emitted claim rows dropped it, because it emitted
+/// none.
+#[test]
+fn a_pure_composition_constitution_has_an_identity() {
+    use hale_types::bus_graph::build_bus_graph;
+    use hale_types::claims::claims_report_with_identities;
+
+    fn adoption(src: &str) -> (Vec<String>, Vec<String>) {
+        let prog = parse_source(src).expect("parse");
+        let mut programs = std::collections::BTreeMap::new();
+        programs.insert("app.hl".to_string(), &prog);
+        let bundle = hale_types::Bundle::new(programs);
+        let (top, _) = hale_types::resolve::build_top_scope(&bundle);
+        let graph = build_bus_graph(&bundle, &top);
+        let progs: Vec<&hale_syntax::ast::Program> =
+            bundle.programs.values().copied().collect();
+        let (_, _, a) = claims_report_with_identities(&progs, &graph, &[]);
+        (
+            a.roots.iter().map(|i| i.name.clone()).collect(),
+            a.closure.iter().map(|i| i.name.clone()).collect(),
+        )
+    }
+
+    let src = program(
+        r#"
+constitution Base { r: count publishers(topic Settled) == 1; }
+constitution Dev extends Base { }
+main locus App {
+    params { b: Billing = Billing { }; r: Research = Research { }; }
+    claims { adopt Dev; }
+}
+"#,
+    );
+    let (roots, closure) = adoption(&src);
+    assert_eq!(
+        roots,
+        vec!["Dev".to_string()],
+        "the directly selected constitution is the root, even with no \
+         clauses of its own"
+    );
+    assert!(
+        closure.contains(&"Dev".to_string())
+            && closure.contains(&"Base".to_string()),
+        "and the closure holds both: {:?}",
+        closure
+    );
+}
+
+/// Two `Dev`s that differ only in their base must not share a digest
+/// — that is the whole point of comparing closures.
+#[test]
+fn pure_composition_digests_follow_the_base() {
+    use hale_types::bus_graph::build_bus_graph;
+    use hale_types::claims::claims_report_with_identities;
+
+    fn dev_digest(src: &str) -> String {
+        let prog = parse_source(src).expect("parse");
+        let mut programs = std::collections::BTreeMap::new();
+        programs.insert("app.hl".to_string(), &prog);
+        let bundle = hale_types::Bundle::new(programs);
+        let (top, _) = hale_types::resolve::build_top_scope(&bundle);
+        let graph = build_bus_graph(&bundle, &top);
+        let progs: Vec<&hale_syntax::ast::Program> =
+            bundle.programs.values().copied().collect();
+        let (_, _, a) = claims_report_with_identities(&progs, &graph, &[]);
+        a.roots
+            .iter()
+            .find(|i| i.name == "Dev")
+            .expect("Dev is a root")
+            .digest
+            .clone()
+    }
+
+    let base = program(
+        r#"
+constitution Base { r: count publishers(topic Settled) == 1; }
+constitution Dev extends Base { }
+main locus App {
+    params { b: Billing = Billing { }; r: Research = Research { }; }
+    claims { adopt Dev; }
+}
+"#,
+    );
+    let wider = base.replace(
+        "constitution Base { r: count publishers(topic Settled) == 1; }",
+        "constitution Base { r: count publishers(topic Settled) == 1; \
+         s: count subscribers(topic Settled) == 0; }",
+    );
+    assert_ne!(
+        dev_digest(&base),
+        dev_digest(&wider),
+        "`Dev`'s own body is empty and identical; its CLOSURE is not"
+    );
+}
+
+/// `extends Core, Core` and `extends Core` evaluate identically —
+/// expansion visits each constitution once — so they must digest
+/// identically. Hashing the base twice reported a false mismatch
+/// between semantically identical closures.
+#[test]
+fn duplicate_bases_normalize_to_one_digest() {
+    use hale_types::bus_graph::build_bus_graph;
+    use hale_types::claims::claims_report_with_identities;
+
+    fn digest(src: &str, want: &str) -> String {
+        let prog = parse_source(src).expect("parse");
+        let mut programs = std::collections::BTreeMap::new();
+        programs.insert("app.hl".to_string(), &prog);
+        let bundle = hale_types::Bundle::new(programs);
+        let (top, _) = hale_types::resolve::build_top_scope(&bundle);
+        let graph = build_bus_graph(&bundle, &top);
+        let progs: Vec<&hale_syntax::ast::Program> =
+            bundle.programs.values().copied().collect();
+        let (_, _, a) = claims_report_with_identities(&progs, &graph, &[]);
+        a.roots
+            .iter()
+            .find(|i| i.name == want)
+            .unwrap_or_else(|| panic!("no root {}", want))
+            .digest
+            .clone()
+    }
+
+    let one = program(
+        r#"
+constitution Core { r: count publishers(topic Settled) == 1; }
+constitution D extends Core { }
+main locus App {
+    params { b: Billing = Billing { }; r: Research = Research { }; }
+    claims { adopt D; }
+}
+"#,
+    );
+    let twice = one.replace("extends Core {", "extends Core, Core {");
+    assert_eq!(
+        digest(&one, "D"),
+        digest(&twice, "D"),
+        "a repeated base is deduplicated by expansion, so it must be \
+         deduplicated by the digest that claims to be normalized"
     );
 }

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -685,14 +685,24 @@ cannot write two conflicting `adopt` lines. So the environment binding
 lives in `hale.toml`, where the deployment facts already are:
 
 ```toml
+[claims]
+base = "Core"                 # carried by EVERY environment
+
 [environments.dev]
-constitution = "Dev"
+constitution = "Dev"          # …and dev adds this
 entrypoints  = ["apps/prober", "apps/dashboard"]
 
 [environments.prod]
 constitution = "Prod"
 entrypoints  = ["apps/prober"]
 ```
+
+The base is what makes "an environment may add law, never drop it"
+true of the mechanism rather than of convention — every evaluation
+carries it by construction. A workspace with environments must decide
+explicitly: `base = "…"` or `no_base = true`. An environment adding
+nothing of its own says `source_only = true`. In each case an omission
+would be indistinguishable from a typo.
 
 ```sh
 hale check apps/prober --env prod    # adopts Prod for this run
@@ -866,11 +876,11 @@ reports as *unverifiable* rather than as valid — a consumer may
 choose to accept it, but must never read "nothing to check" as
 "checked and intact".
 
-The artifact shape (schema `1.6`):
+The artifact shape (schema `1.7`):
 
 ```text
 {
-  "schema": "1.6",
+  "schema": "1.7",
   "shape_hash": "<fnv1a-64 over the model half>",
   "sorts":     { "loci": […], "fns": […], "topics": […] },
   "relations": {

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -235,7 +235,7 @@ earlier in the same file as the family. Companion:
 class along any path, with the same loop/indirect unboundedness
 rules as every per-call dimension.
 
-**The topology artifact** (#382 phase 2; schema 1.6):
+**The topology artifact** (#382 phase 2; schema 1.7):
 `hale check <t> --dump-topology` emits the serialized model —
 sorts (loci, fns, topics), relations (calls with **weights**: loop
 nesting, unbounded-loop membership, interface-dispatch tags;
@@ -370,8 +370,16 @@ as if written there. Authoring is shared, evaluation is not.
 A constitution's **display name** is flat and unmangled so
 diagnostics cite it as written. Its **identity** is the digest of its
 normalized closure — its own `(name, rendered form)` pairs, sorted,
-plus its bases' digests, recursively. Two declarations are the same
-constitution iff their closures agree.
+plus its **deduplicated** bases' digests, recursively. `extends A, A`
+and `extends A` evaluate identically, so they must digest identically.
+Two declarations are the same constitution iff their closures agree.
+
+Identities come from the adoption **traversal**, not from inspecting
+which claims were emitted: a constitution that contributes no clause
+of its own (`constitution Dev extends Base { }`) has a meaningful
+closure and must still be compared. An evaluation reports both its
+`roots` — the constitutions named directly, by source `adopt` or by
+environment binding — and the `closure` those roots reach.
 
 The distinction is load-bearing across entrypoints: two seeds may
 each declare `Core` with different clauses, so a binding by bare name
@@ -403,10 +411,28 @@ can be checked twice.
 
 `[claims] base` is what makes "an environment may add law, never drop
 it" true of the mechanism rather than only of `extends` — every
-evaluation carries the base by construction. An environment naming no
-constitution must say `source_only = true`; an omission is
-indistinguishable from a typo, and unknown keys in an environment
-section are rejected for the same reason.
+evaluation carries the base by construction. A workspace declaring
+environments must decide about a base explicitly: either `base = "…"`
+or `no_base = true`. An absent `[claims]` section is indistinguishable
+from a misspelled one, and the intended baseline would vanish while
+every environment still looked valid.
+
+An environment naming no constitution must say `source_only = true`
+for the same reason, and unknown keys in an environment section are
+rejected.
+
+The base is compared **workspace-wide** (`base::<name>`); an
+environment's own addition is compared within that environment
+(`env::<env>::<name>`). Keying the base per-environment meant two
+environments with disjoint entrypoint sets never shared a comparison
+key, so a base resolving to different closures in dev and prod went
+undetected — the mechanism proved consistency *within* each
+environment and nothing about the base being shared.
+
+`--env` requires its target to be an entrypoint, whether or not the
+environment contributes any constitution: an environment binds law to
+a deployment target, and a `source_only` environment with no base
+would otherwise check a library and report success.
 
 `--matrix` checks every declared (entrypoint, environment) pair. It
 does not short-circuit; the exit status reflects every pair. An
@@ -416,9 +442,10 @@ otherwise a syntax error would erase a seed from coverage. Within one
 environment, all entrypoints must resolve each constitution to the
 same closure digest.
 
-The artifact records both: per-claim `source` (where this clause came
-from) and an `evaluation` section naming the adopted constitutions
-with their digests (which claimset this run certified). The second is
+The artifact records three things: per-claim `source` (where this
+clause came from), and an `evaluation` section carrying the
+`environment` label plus `roots` and `closure` with their digests
+(which deployment this run certified, and under what law). All are
 inside the integrity-covered body — an evaluation context editable
 after the fact would certify nothing.
 


### PR DESCRIPTION
Second review of the constitution work. Both merge blockers were real and are fixed, along with the three smaller items. Each was reproduced against merged `main` before being touched.

## Blocker 1 — pure-composition constitutions vanished from identity

Identities were derived from the `source` of emitted claim rows. A constitution contributing no clause of its own emits none, so it was invisible:

```hale
constitution Left { left_rule: count publishers(topic T) == 1; }
constitution Dev extends Left { }        // ← directly selected, never reported
```

Reproduced, with the environment binding `constitution = "Dev"` for both entrypoints:

```
app-a evaluation: ['Left']
app-b evaluation: ['Right']
ok: 2 (entrypoint, environment) pair(s) checked     exit 0
```

No key collided, so no digest was ever compared — the two entrypoints resolved the *same* `Dev` to different closures and it passed. The review's point that this isn't exotic is well taken: the corpus fixture added in the last PR is `constitution Both extends Core, Dev { }`.

Identities now come from the **adoption traversal**, which already visits every constitution reached — roots, empty derived constitutions, intermediates, bases, diamond-deduplicated ancestors. An evaluation reports both:

```
roots:    [('Dev', '1a2a52fc')]
closure:  [('Dev', '1a2a52fc'), ('Left', '6f8b7ebd')]
```

`roots` is what the manifest asked for, so it is what the matrix compares; `closure` is what applied. After the fix the canary fails on `Dev` specifically.

## Blocker 2 — the workspace base was compared per environment

The key was `<env>::<name>`, so two environments with disjoint entrypoint sets never shared one:

```
dev::Core  → 7ad5ac84…     (app-a)
prod::Core → 605d3242…     (app-b)
ok: 2 pair(s) checked       exit 0
```

The mechanism proved `Core` was consistent *within* each environment and nothing about `[claims] base` being one shared constitution. Scopes are now split — `base::<name>` workspace-wide, `env::<env>::<name>` for an environment's own addition — and the diagnostic names which scope disagreed:

```
the workspace base resolves `Core` to two different claimsets: app-a sees
7ad5ac8479578b44, app-b sees 605d32425128c453
```

## The three smaller items

**A base decision is now required** when a workspace declares environments — `base = "…"` or `no_base = true`. This also catches the `[claim]` typo the review raised: a misspelled section leaves `base` unset, which is now an error rather than a silently vanished baseline. Same reasoning the PR already applied to `source_only`, applied one level up.

**`--env` requires an entrypoint** regardless of injection. The check lived inside the injection loop, so a `source_only` environment with no base injected nothing and never verified the target had a `main locus` — a library path passed as a checked pair.

**Duplicate bases normalize.** `extends Core, Core` and `extends Core` evaluate identically since expansion visits each constitution once, but the digest hashed the base twice. Fail-closed, but it meant the value called a *normalized* closure wasn't. Both now digest to `b2045d29d751c3b2`.

## Artifact (schema 1.7)

```json
"evaluation": {
  "environment": "prod",
  "roots":   [{"name": "Dev",  "digest": "…"}],
  "closure": [{"name": "Dev",  "digest": "…"}, {"name": "Left", "digest": "…"}]
}
```

The review was right that the section didn't do what the prose claimed. Two environment labels selecting identical law produce equivalent `closure`s — only the label can say which deployment was certified. Everything stays inside the integrity-covered body.

## Tests

`constitutions.rs` 14 → 17, `env_matrix.rs` 17 → 23, including both required canaries: two entrypoints with the same directly-selected empty `Dev` over different bases must fail on `Dev`; and two environments with disjoint entrypoints resolving the workspace base differently must fail on the base.

One note from doing it: updating the existing fixtures for the new manifest requirement, a blind regex also rewrote an *assertion string* in `a_manifest_with_no_environments_is_a_usage_error`. The suite caught it. Worth mentioning because a mechanical edit across test fixtures can silently weaken an assertion rather than break it.

Also ran `claims` (16), `claims_edges` (36), `artifact_integrity` (9), `workspace_check` (7), `topology_artifact_contract` (9), `topology_v2` (5), `xseed_claims_verbs` (5), `claims_artifact_unknowns` (4), `check_arg_parsing` (6) and the parse corpus.

## Not taken

Moving constitution names into the mangler. The traversal-derived closure gives the invariant — every entrypoint in one environment resolves the same claimset — without `adopt` in source and `constitution =` in the manifest both needing rewrite paths. Still worth revisiting if constitutions ever need qualified cross-seed references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)