### PR TITLE
fix(claims): reject silent-ignore combinations; name the manifest (GH #409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ behavior.
 
 ## Unreleased
 
+### Constitution edge cases: silent-ignore combinations and manifest provenance (GH #409)
+
+An edge-case sweep before starting the fleet tier. Four gaps, all of
+the same shape the two reviews found — a combination that behaves
+plausibly instead of refusing.
+
+- **`--matrix --dump-topology` emitted N concatenated artifacts** to
+  one stdout — not valid JSON as a whole — and exited 0. A matrix is
+  many evaluations, so there is no single artifact to emit; likewise
+  `--matrix --check-topology` compared one entrypoint's model against
+  another's baseline and reported a failure that meant nothing.
+  `--workspace` already rejected these flags; `--matrix` did not.
+- **`--workspace --env prod` silently ignored `--env`**, reporting
+  "N seed(s) checked" with no environment law applied — a green run
+  the user believes was gated. A workspace sweep includes libraries;
+  an environment binds law to an entrypoint. Now rejected.
+- **`--matrix --env` / `--matrix --workspace`** likewise selected
+  nothing the matrix did not already enumerate. Rejected.
+- **A manifest-required constitution had no provenance.** An injected
+  adoption has no source line, so `unknown constitution \`Prod\``
+  pointed at a main locus containing no `adopt` at all. The
+  diagnostic now names the environment and the manifest.
+
+Five behaviors that were already correct but unpinned now have tests:
+one policy seed imported under two different aliases is one identity
+(the review's required control — and the property that makes the
+feature usable at all); a `claims` block outside `main locus` is a
+parse error with `adopt` in it; a repeated `adopt` is idempotent
+rather than a collision; an unknown `extends` base is an error; an
+environment with an empty entrypoint list leaves the real entrypoints
+unbound; and tampering with the artifact's `evaluation` section — the
+constitution digests a consumer compares — fails the body hash.
+
 ### Constitution identity, corrected at the boundary (GH #409)
 
 A second review found that the identity mechanism shipped in the

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2499,6 +2499,20 @@ fn file_of_span(
 /// following token would make `hale check --dump-topology app.hl`
 /// ambiguous — is `app.hl` the artifact destination or the target? —
 /// and flags are supposed to be positionable on either side.
+/// Flags that describe ONE evaluation: an artifact to emit, or a
+/// baseline to gate against. Meaningless when the command runs many
+/// evaluations.
+const PER_SEED_FLAGS: &[&str] = &[
+    "--dump-topology",
+    "--check-topology",
+    "--check-topology-shape",
+    "--dump-effects-manifest",
+    "--check-effects-manifest",
+    "--dump-resource-budget",
+    "--check-resource-budget",
+    "--dump-alloc-summary",
+];
+
 const CHECK_FLAGS: &[(&str, bool)] = &[
     ("--allow-unowned-subscriber", false),
     ("--check-effects-manifest", true),
@@ -2552,7 +2566,9 @@ fn check_usage(verify: bool) {
     println!("  --matrix                       check every (entrypoint, environment)");
     println!("                                 pair the manifest declares. An");
     println!("                                 entrypoint listed in NO environment");
-    println!("                                 is an error, not a skip.");
+    println!("                                 is an error, not a skip. Cannot be");
+    println!("                                 combined with --env, --workspace, or");
+    println!("                                 any per-evaluation artifact flag.");
     println!();
     println!("Claims and topology (spec/verification.md):");
     println!("  --dump-topology[=<path>]        emit the topology artifact");
@@ -3062,9 +3078,50 @@ fn run_check_cli(rest: &[String], verify: bool) -> ExitCode {
         i += 1;
     }
 
+    let env_name = match flag_value_in(rest, "--env") {
+        Ok(v) => v,
+        Err(msg) => {
+            eprintln!("{}", msg);
+            return ExitCode::from(2);
+        }
+    };
+
     // GH #409: the (entrypoint x environment) matrix.
     let matrix = rest.iter().any(|a| a == "--matrix");
     if matrix {
+        // A matrix is N evaluations, so a single artifact on stdout
+        // or a single baseline to diff against is meaningless — two
+        // concatenated artifacts are not valid JSON, and one baseline
+        // compared to N models reports a failure that means nothing.
+        // `--workspace` already rejects these; `--matrix` silently
+        // did the wrong thing.
+        for f in PER_SEED_FLAGS {
+            if rest.iter().any(|a| a == f || a.starts_with(&format!("{}=", f)))
+            {
+                eprintln!(
+                    "`{}` is per-evaluation and cannot be combined \
+                     with --matrix — a matrix is many evaluations, so \
+                     there is no single artifact to emit or gate \
+                     against. Run it against one (entrypoint, \
+                     environment) pair with `--env`.",
+                    f
+                );
+                return ExitCode::from(2);
+            }
+        }
+        // …and the selectors that would silently do nothing.
+        for f in ["--workspace", "--env"] {
+            if rest.iter().any(|a| a == f || a.starts_with(&format!("{}=", f)))
+            {
+                eprintln!(
+                    "`{}` cannot be combined with --matrix: the matrix \
+                     already enumerates every (entrypoint, \
+                     environment) pair the manifest declares",
+                    f
+                );
+                return ExitCode::from(2);
+            }
+        }
         let root = match positionals.len() {
             0 => std::env::current_dir()
                 .unwrap_or_else(|_| PathBuf::from(".")),
@@ -3077,32 +3134,30 @@ fn run_check_cli(rest: &[String], verify: bool) -> ExitCode {
         return run_matrix(&root, verify);
     }
 
-    let env_name = match flag_value_in(rest, "--env") {
-        Ok(v) => v,
-        Err(msg) => {
-            eprintln!("{}", msg);
-            return ExitCode::from(2);
-        }
-    };
-
     let workspace = rest.iter().any(|a| a == "--workspace");
     if workspace {
+        // `--workspace` sweeps every seed, libraries included, and an
+        // environment binds law to an ENTRYPOINT. Accepting the
+        // combination and ignoring it reported "N seed(s) checked"
+        // with no environment law applied — a green run the user
+        // believes was gated.
+        if env_name.is_some() {
+            eprintln!(
+                "`--env` cannot be combined with --workspace: an \
+                 environment binds law to an entrypoint, and a \
+                 workspace sweep checks every seed including \
+                 libraries. Use `--matrix` for every (entrypoint, \
+                 environment) pair, or `--env` against one entrypoint."
+            );
+            return ExitCode::from(2);
+        }
         // Per-seed artifacts and one shared baseline are
         // incompatible by construction: N seeds produce N models, so
         // a single `--dump-topology` would interleave them on stdout
         // and a single `--check-topology` would compare N models to
         // one file. Silently taking the last would be the fail-open
         // shape this command exists to remove.
-        for f in [
-            "--dump-topology",
-            "--check-topology",
-            "--check-topology-shape",
-            "--dump-effects-manifest",
-            "--check-effects-manifest",
-            "--dump-resource-budget",
-            "--check-resource-budget",
-            "--dump-alloc-summary",
-        ] {
+        for f in PER_SEED_FLAGS {
             if rest.iter().any(|a| a == f || a.starts_with(&format!("{}=", f)))
             {
                 eprintln!(
@@ -3254,7 +3309,10 @@ fn run_check_impl_labelled(
     adopt_env: &[String],
     env_label: Option<&str>,
 ) -> u8 {
-    hale_types::claims::set_environment(env_label.map(str::to_string));
+    hale_types::claims::set_env_binding(hale_types::claims::EnvBinding {
+        name: env_label.map(str::to_string),
+        injected: adopt_env.to_vec(),
+    });
     // `check` MUST resolve cross-seed imports the same way `build`
     // and `run` do. It used to bundle only the target's own `.hl`
     // files, so an imported seed's bodies were never in the program

--- a/crates/hale-cli/tests/env_matrix.rs
+++ b/crates/hale-cli/tests/env_matrix.rs
@@ -752,3 +752,142 @@ fn the_artifact_records_the_environment_and_its_roots() {
         out
     );
 }
+
+// =====================================================================
+// Edge-case sweep before the fleet tier
+// =====================================================================
+
+/// Required control from the identity review, and the property that
+/// makes the feature usable at all: the SAME policy seed imported
+/// under DIFFERENT aliases must resolve to one identity. If it did
+/// not, a workspace whose apps happen to spell the import differently
+/// would be rejected for no reason — fail-closed, but unusable.
+#[test]
+fn one_policy_seed_under_two_aliases_is_one_identity() {
+    let r = root("aliases");
+    write(&r, "policy/p.hl", LIB);
+    let app = |alias: &str, n: &str| {
+        format!(
+            "import \"../policy\" as {a};\n\
+             main locus {n} {{ params {{ b: {a}::Billing = {a}::Billing {{ }}; \
+             r: {a}::Research = {a}::Research {{ }}; }} }}\n\
+             fn main() {{ {n} {{ }}; }}\n",
+            a = alias,
+            n = n
+        )
+    };
+    write(&r, "app-a/main.hl", &app("pol", "A"));
+    write(&r, "app-b/main.hl", &app("plc", "B"));
+    write(
+        &r,
+        "hale.toml",
+        "[claims]\nbase = \"Core\"\n\n[environments.prod]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    let (out, code) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_eq!(
+        code, 0,
+        "the alias is not part of a constitution's identity: {}",
+        out
+    );
+}
+
+/// A matrix is N evaluations, so one artifact on stdout or one
+/// baseline to diff against is meaningless. Before this, `--matrix
+/// --dump-topology` emitted two concatenated artifacts (not valid
+/// JSON) and exited 0, and `--matrix --check-topology` compared one
+/// entrypoint's model to another's baseline and reported a failure
+/// that meant nothing.
+#[test]
+fn matrix_rejects_per_evaluation_flags() {
+    let r = workspace(
+        "matrixflags",
+        "[claims]\nno_base = true\n\n[environments.dev]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    for f in ["--dump-topology", "--check-topology-shape=/tmp/x.json"] {
+        let (out, code) = hale(&[
+            "check".as_ref(),
+            "--matrix".as_ref(),
+            r.as_os_str(),
+            f.as_ref(),
+        ]);
+        assert_eq!(code, 2, "`{}` with --matrix: {}", f, out);
+        assert!(out.contains("per-evaluation"), "{}", out);
+    }
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// Selectors that would silently do nothing are rejected rather than
+/// ignored — the failure mode this whole feature exists to remove.
+#[test]
+fn conflicting_selectors_are_rejected_not_ignored() {
+    let r = workspace(
+        "selectors",
+        "[claims]\nno_base = true\n\n[environments.dev]\nsource_only = true\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    // --matrix already enumerates every pair.
+    for extra in ["--workspace", "--env"] {
+        let (out, code) = hale(&[
+            "check".as_ref(),
+            "--matrix".as_ref(),
+            r.as_os_str(),
+            extra.as_ref(),
+            "dev".as_ref(),
+        ]);
+        assert_eq!(code, 2, "`--matrix {}`: {}", extra, out);
+    }
+    // A workspace sweep includes libraries; an environment binds law
+    // to an entrypoint. Accepting and ignoring reported a green run
+    // the user believed was gated.
+    let (out, code) = hale(&[
+        "check".as_ref(),
+        "--workspace".as_ref(),
+        r.as_os_str(),
+        "--env".as_ref(),
+        "dev".as_ref(),
+    ]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_eq!(code, 2, "`--workspace --env`: {}", out);
+    assert!(out.contains("binds law to an entrypoint"), "{}", out);
+}
+
+/// An injected adoption has no source line, so the span lands on the
+/// main locus and the author sees no `adopt` to explain the error.
+#[test]
+fn an_unknown_environment_constitution_names_the_manifest() {
+    let r = workspace(
+        "provenance",
+        "[claims]\nno_base = true\n\n[environments.prod]\nconstitution = \"Nonexistent\"\nentrypoints = [\"app-a\", \"app-b\"]\n",
+    );
+    let app = r.join("app-a");
+    let (out, code) = hale(&[
+        "check".as_ref(),
+        app.as_os_str(),
+        "--env".as_ref(),
+        "prod".as_ref(),
+    ]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    assert!(
+        out.contains("[environments.prod]") && out.contains("hale.toml"),
+        "the error must say WHERE the constitution was required from, \
+         since the entrypoint has no `adopt` line to point at: {}",
+        out
+    );
+}
+
+/// An environment listing no entrypoints leaves the real ones bound
+/// to nothing, which the coverage check must catch.
+#[test]
+fn an_environment_with_no_entrypoints_leaves_them_unbound() {
+    let r = workspace(
+        "emptyenv",
+        "[claims]\nno_base = true\n\n[environments.dev]\nsource_only = true\nentrypoints = []\n",
+    );
+    let (out, code) =
+        hale(&["check".as_ref(), "--matrix".as_ref(), r.as_os_str()]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    assert!(out.contains("in no environment"), "{}", out);
+}

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -325,23 +325,58 @@ struct Cx<'a> {
     model: crate::model::Model,
 }
 
+/// What a deployment environment contributed to this evaluation: its
+/// label, and the constitutions it required.
+#[derive(Debug, Default, Clone)]
+pub struct EnvBinding {
+    pub name: Option<String>,
+    /// Constitutions injected by the manifest rather than written in
+    /// source. Kept so a diagnostic about one can say WHERE it was
+    /// required from — without this, "unknown constitution `Prod`"
+    /// points at a `main locus` containing no `adopt` line at all,
+    /// and the author has no way to know the manifest asked for it.
+    pub injected: Vec<String>,
+}
+
 thread_local! {
-    /// The environment name a `--env` / matrix run was for, so the
-    /// artifact can record WHICH deployment it certifies. A
-    /// thread-local because the artifact is serialized far from the
-    /// CLI that knows the label, and threading an `Option<String>`
-    /// through every intervening signature would buy nothing.
-    static ENVIRONMENT: std::cell::RefCell<Option<String>> =
-        const { std::cell::RefCell::new(None) };
+    /// A thread-local because the artifact is serialized, and claims
+    /// are evaluated, far from the CLI that knows the label —
+    /// threading an `EnvBinding` through every intervening signature
+    /// would buy nothing.
+    static ENV_BINDING: std::cell::RefCell<EnvBinding> =
+        const { std::cell::RefCell::new(EnvBinding {
+            name: None,
+            injected: Vec::new(),
+        }) };
 }
 
 /// Record the environment this evaluation is for.
-pub fn set_environment(name: Option<String>) {
-    ENVIRONMENT.with(|e| *e.borrow_mut() = name);
+pub fn set_env_binding(b: EnvBinding) {
+    ENV_BINDING.with(|e| *e.borrow_mut() = b);
 }
 
 pub fn current_environment() -> Option<String> {
-    ENVIRONMENT.with(|e| e.borrow().clone())
+    ENV_BINDING.with(|e| e.borrow().name.clone())
+}
+
+fn injected_from_manifest(name: &str) -> Option<String> {
+    ENV_BINDING.with(|e| {
+        let b = e.borrow();
+        if b.injected.iter().any(|i| i == name) {
+            Some(match &b.name {
+                Some(env) => format!(
+                    ". `[environments.{}]` in hale.toml requires it — \
+                     this entrypoint cannot see a declaration, so \
+                     either import the seed that declares it or fix \
+                     the manifest",
+                    env
+                ),
+                None => ". It was required by hale.toml".to_string(),
+            })
+        } else {
+            None
+        }
+    })
 }
 
 /// GH #409: what an evaluation adopted.
@@ -445,6 +480,12 @@ fn expand_adoptions(
                 "unknown constitution `{}` — nothing declares it",
                 name.name
             );
+            // Manifest provenance: an injected adoption has no source
+            // line, so the span points at the main locus and the
+            // author sees no `adopt` to explain the error.
+            if let Some(extra) = injected_from_manifest(&name.name) {
+                msg.push_str(&extra);
+            }
             if let Some(near) = by_name.keys().find(|k| {
                 k.len().abs_diff(name.name.len()) <= 2
                     && k.chars().next() == name.name.chars().next()

--- a/crates/hale-types/tests/artifact_integrity.rs
+++ b/crates/hale-types/tests/artifact_integrity.rs
@@ -228,3 +228,55 @@ fn an_unresolvable_edge_is_uncertified_not_violated() {
     );
     assert_ne!(v["verdict"], "clean", "and it still does not pass");
 }
+
+/// GH #409: the `evaluation` section says which deployment a run
+/// certified and under what law. It is inside the digest-covered body
+/// on purpose — an evaluation context editable after the fact would
+/// certify nothing, and it is exactly the section a fleet consumer
+/// would trust to decide that two entrypoints ran the same law.
+#[test]
+fn tampering_with_the_evaluation_section_is_caught() {
+    const ADOPTING: &str = r#"
+        type T { v: Int; }
+        topic Tk { payload: T; subject: "app.t"; }
+        locus Sub {
+            params { got: Int = 0; }
+            bus { subscribe Tk as on_t; }
+            fn on_t(t: T) { self.got = t.v; }
+        }
+        group subs = { Sub };
+        constitution Core {
+            wired: require subscribes(some subs, topic Tk);
+        }
+        main locus App {
+            params { s: Sub = Sub { }; }
+            claims { adopt Core; }
+        }
+        fn main() { App { }; }
+    "#;
+    let a = dump(ADOPTING);
+    assert!(
+        a.contains("\"roots\""),
+        "fixture must carry an evaluation section:\n{}",
+        a
+    );
+
+    // Rewriting a constitution's digest is the tamper that matters:
+    // it is what a consumer compares across entrypoints.
+    let at = a.find("\"digest\": \"").expect("a digest") + 11;
+    let forged = format!("{}dead0000beef0000{}", &a[..at], &a[at + 16..]);
+    assert_ne!(forged, a, "the forgery must change the text");
+    assert_eq!(
+        verify_artifact_digest(&forged),
+        Some(false),
+        "a rewritten constitution digest must fail the body hash — \
+         otherwise two entrypoints could be made to look like they ran \
+         the same law"
+    );
+
+    // …and so must the environment label.
+    if a.contains("\"environment\"") {
+        let t = a.replacen("\"environment\"", "\"environmenX\"", 1);
+        assert_eq!(verify_artifact_digest(&t), Some(false));
+    }
+}

--- a/crates/hale-types/tests/constitutions.rs
+++ b/crates/hale-types/tests/constitutions.rs
@@ -560,3 +560,95 @@ main locus App {
          deduplicated by the digest that claims to be normalized"
     );
 }
+
+/// A `claims` block outside `main locus` is rejected at parse — main
+/// is the closed-world gate, and `adopt` there would name a world
+/// that is not closed. Pinned because the `adopt` form is new and the
+/// check predates it.
+#[test]
+fn a_non_main_locus_may_not_hold_a_claims_block_with_adopt() {
+    let src = program(
+        r#"
+constitution Core { r: count publishers(topic Settled) == 1; }
+locus Q { params { n: Int = 0; } claims { adopt Core; } }
+main locus App {
+    params { b: Billing = Billing { }; r: Research = Research { }; q: Q = Q { }; }
+}
+"#,
+    );
+    let err = parse_source(&src).expect_err("must not parse");
+    assert!(
+        err.iter().any(|d| d.message.contains("only valid inside `main locus`")),
+        "{:?}",
+        err
+    );
+}
+
+/// Adopting the same constitution twice is idempotent, not a
+/// collision — the clauses arrive once, and the root is recorded
+/// once. (A second `adopt` is redundant, not contradictory.)
+#[test]
+fn adopting_the_same_constitution_twice_is_idempotent() {
+    use hale_types::bus_graph::build_bus_graph;
+    use hale_types::claims::claims_report_with_identities;
+
+    let src = program(
+        r#"
+constitution Core { r: count publishers(topic Settled) == 1; }
+main locus App {
+    params { b: Billing = Billing { }; r: Research = Research { }; }
+    claims { adopt Core; adopt Core; }
+}
+"#,
+    );
+    assert!(
+        diags(&src).is_empty(),
+        "a repeated adoption is redundant, not a collision: {:#?}",
+        diags(&src)
+    );
+
+    let prog = parse_source(&src).expect("parse");
+    let mut programs = std::collections::BTreeMap::new();
+    programs.insert("app.hl".to_string(), &prog);
+    let bundle = hale_types::Bundle::new(programs);
+    let (top, _) = hale_types::resolve::build_top_scope(&bundle);
+    let graph = build_bus_graph(&bundle, &top);
+    let progs: Vec<&hale_syntax::ast::Program> =
+        bundle.programs.values().copied().collect();
+    let (_, outcomes, a) =
+        claims_report_with_identities(&progs, &graph, &[]);
+    assert_eq!(
+        a.roots.len(),
+        1,
+        "one root, not two: {:?}",
+        a.roots.iter().map(|i| &i.name).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        outcomes.iter().filter(|o| o.name == "r").count(),
+        1,
+        "and the clause arrives once"
+    );
+}
+
+/// A base that no declaration provides is an error rather than a
+/// silently-empty closure — otherwise a constitution could appear to
+/// carry law it never got.
+#[test]
+fn an_unknown_base_is_an_error() {
+    let src = program(
+        r#"
+constitution Dev extends Missing { d: count publishers(topic Settled) == 1; }
+main locus App {
+    params { b: Billing = Billing { }; r: Research = Research { }; }
+    claims { adopt Dev; }
+}
+"#,
+    );
+    assert!(
+        diags(&src)
+            .iter()
+            .any(|m| m.contains("unknown constitution `Missing`")),
+        "{:#?}",
+        diags(&src)
+    );
+}

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -434,6 +434,23 @@ environment contributes any constitution: an environment binds law to
 a deployment target, and a `source_only` environment with no base
 would otherwise check a library and report success.
 
+Combinations that cannot be honoured are rejected rather than
+ignored. `--matrix` runs many evaluations, so a per-evaluation
+artifact flag (`--dump-topology`, the `--check-*` baselines) has no
+single artifact to emit or gate against; and `--env` / `--workspace`
+alongside it would select nothing the matrix does not already
+enumerate. `--env` with `--workspace` is likewise rejected: a
+workspace sweep includes libraries, and an environment binds law to
+an entrypoint.
+
+A constitution required by the manifest has no source `adopt` line,
+so a diagnostic about it names the environment and the manifest
+rather than pointing at a main locus that mentions it nowhere.
+
+A constitution's identity does not depend on the import alias
+through which its seed was reached: the same policy seed imported as
+`pol` in one entrypoint and `plc` in another is one identity.
+
 `--matrix` checks every declared (entrypoint, environment) pair. It
 does not short-circuit; the exit status reflects every pair. An
 entrypoint in no environment is an error, and a seed that fails to


### PR DESCRIPTION
An edge-case sweep of the constitution work before starting the fleet tier. Two review rounds found five fail-opens, and the pattern was consistent enough to search for deliberately: **I test each mechanism doing its job, not failing safely.** So I enumerated the surfaces and probed each one.

Four gaps found, all the same shape — a combination that behaves plausibly instead of refusing.

## Silent-ignore combinations

| input | before | now |
|---|---|---|
| `--matrix --dump-topology` | **2 concatenated artifacts** on stdout, exit 0 | exit 2 |
| `--matrix --check-topology base.json` | compared app-b to app-a's baseline, reported a meaningless failure | exit 2 |
| `--workspace --env prod` | `ok: 3 seed(s) checked` — **`--env` ignored** | exit 2 |
| `--matrix --env` / `--matrix --workspace` | second flag ignored | exit 2 |

The first is the worst: a CI job piping `--matrix --dump-topology` to a file gets a document no parser accepts, with a zero exit. `--workspace` already rejected per-seed artifact flags; `--matrix` inherited none of that. The `--workspace --env` case is the familiar shape — a green run the user believes was gated.

## Manifest provenance

A manifest-required constitution has no source `adopt` line, so the span landed on the main locus:

```
main.hl:2:12: unknown constitution `Nonexistent` — nothing declares it
    main locus A { params { s: pol::S = pol::S { }; } }
               ^
```

The author looks at their claims block, finds no `adopt Nonexistent`, and has nothing to go on. Now:

> …nothing declares it. `[environments.prod]` in hale.toml requires it — this entrypoint cannot see a declaration, so either import the seed that declares it or fix the manifest

## Five correct-but-unpinned behaviors, now tested

Probing turned these up as working. They had no tests, which for a feature that has already regressed twice under review is the more relevant fact:

- **One policy seed under two aliases is one identity.** This was a *required control* from the identity review that I never wrote. It passes — the digest doesn't depend on the import alias — and it is the property that makes the feature usable at all: without it, a workspace whose apps spell the import differently would be rejected for no reason.
- A `claims` block outside `main locus` is a parse error, including with `adopt` in it (the check predates `adopt`).
- A repeated `adopt Core; adopt Core;` is idempotent — one root, one clause — not a collision.
- An unknown `extends` base is an error, not a silently-empty closure.
- An environment with `entrypoints = []` leaves the real entrypoints unbound, and the coverage check catches it.
- Tampering with the artifact's `evaluation` section — specifically a constitution **digest**, the value a consumer compares across entrypoints — fails the body hash.

## Surfaces probed and found sound

Recording these so the next sweep doesn't redo them: self-`extends` cycles, diamond-plus-cycle, duplicate constitution names, a non-main locus holding claims, an environment naming a constitution the entrypoint cannot see (errors correctly, now with provenance), and `--env` resolving a manifest from a parent directory.

## Tests

`env_matrix.rs` 23 → 28, `constitutions.rs` 17 → 20, `artifact_integrity.rs` 9 → 10. Also ran `claims` (16), `claims_edges` (36), `workspace_check` (7), `check_arg_parsing` (6), `topology_artifact_contract` (9), `xseed_claims_verbs` (5) and the docs-snippet gate.

No schema change — this is behavior and diagnostics only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)