### PR TITLE
feat(topology): source maps and model semantics (GH #408 Phase 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ behavior.
 
 ## Unreleased
 
+### Artifact schema 1.8: source maps and model semantics (GH #408 Phase 0)
+
+The prerequisite for composing artifacts across separately compiled
+applications, and the reason #408's Phase 0 is where the risk is.
+
+**Spans resolve to files.** They were bundle-global byte offsets — an
+artifact of concatenating a seed's files, meaningful only inside the
+process that produced them. `[1204, 1231]` cannot be turned into a
+location by anyone else, so no cross-artifact witness could say where
+to look, which is most of what a witness is for. Provenance rows now
+carry `"source": <id>` alongside a file-local span, resolved through a
+new `sources` table.
+
+**Artifacts are reproducible.** Source paths are relative to the
+workspace — the nearest ancestor holding a `hale.toml`, else the
+deepest common ancestor of every source — and are canonicalized
+before being made relative. Both were needed: an absolute path makes
+the artifact machine-specific, and rooting at the target alone left
+imported seeds absolute, since they usually live outside it. The same
+sources now produce a byte-identical artifact from any working
+directory.
+
+Each source carries a content digest, so a consumer can tell whether
+two artifacts came from the same text — and catch a stale artifact
+paired with edited source — without the source being shipped. A span
+the map cannot place reports `"source": -1` rather than being
+attributed to the nearest file.
+
+**`semantics`**, a version distinct from `schema`. Schema says a row
+has these fields; it cannot say what they mean. Two compilers
+agreeing on the schema and disagreeing on the semantics would compose
+artifacts into a model neither would certify, with nothing in the
+document revealing it.
+
+*Breaking:* `provenance.decls` rows change from `[start, end]` to
+`{"source": id, "span": [start, end]}`, and every other provenance row
+gains a `source` field.
+
 ### Constitution edge cases: silent-ignore combinations and manifest provenance (GH #409)
 
 An edge-case sweep before starting the fleet tier. Four gaps, all of

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -3394,6 +3394,99 @@ fn run_check_impl_labelled(
         .collect();
     let mut bundle = hale_types::Bundle::new(bundle_programs);
     bundle.import_renames = import_renames.clone();
+    // GH #408 Phase 0: hand the source map to the artifact, so a span
+    // resolves to a file outside this process. Paths are relative to
+    // the checked target (an absolute path would make the artifact
+    // differ per machine, and it is meant to be comparable), with
+    // forward slashes so a Windows-built artifact matches a
+    // Linux-built one.
+    {
+        // Root at the WORKSPACE, not the target. An imported seed
+        // usually lives outside the target directory (`apps/api`
+        // importing `../../lib`), so relativizing to the target left
+        // those paths absolute — and an artifact carrying absolute
+        // paths differs per machine, which defeats the comparability
+        // it exists for.
+        //
+        // The nearest ancestor holding a `hale.toml` is the natural
+        // root: it is where a fleet plan's repo-relative paths are
+        // anchored too. Failing that, the deepest common ancestor of
+        // every source, which is always fully relativizing.
+        let start = if target.is_dir() {
+            target.to_path_buf()
+        } else {
+            target.parent().unwrap_or(Path::new(".")).to_path_buf()
+        };
+        let start = start.canonicalize().unwrap_or(start);
+        let manifest_root = {
+            let mut d = Some(start.as_path());
+            let mut found = None;
+            while let Some(cur) = d {
+                if cur.join("hale.toml").exists() {
+                    found = Some(cur.to_path_buf());
+                    break;
+                }
+                d = cur.parent();
+            }
+            found
+        };
+        let root = manifest_root.unwrap_or_else(|| {
+            let mut common: Option<PathBuf> = None;
+            for (_, p, _) in &file_bases {
+                let dir = p.parent().unwrap_or(Path::new("/")).to_path_buf();
+                common = Some(match common {
+                    None => dir,
+                    Some(c) => {
+                        let mut shared = PathBuf::new();
+                        for (a, b) in c.components().zip(dir.components()) {
+                            if a != b {
+                                break;
+                            }
+                            shared.push(a);
+                        }
+                        shared
+                    }
+                });
+            }
+            common.unwrap_or(start)
+        });
+        bundle.sources = file_bases
+            .iter()
+            .enumerate()
+            .map(|(i, (base, path, len))| {
+                // Canonicalize first: the target's own file arrives
+                // as written on the command line while imported seeds
+                // arrive absolute, so stripping without this left the
+                // target's path relative to the CWD — and the same
+                // sources checked from two directories produced two
+                // different artifacts.
+                let abs = path.canonicalize().unwrap_or_else(|_| path.clone());
+                let rel = abs
+                    .strip_prefix(&root)
+                    .unwrap_or(&abs)
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                let digest = sources
+                    .get(path)
+                    .map(|src| {
+                        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+                        for b in src.as_bytes() {
+                            h ^= *b as u64;
+                            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+                        }
+                        format!("{:016x}", h)
+                    })
+                    .unwrap_or_else(|| "unknown".to_string());
+                hale_types::symbol::SourceFile {
+                    id: i as u32,
+                    path: rel,
+                    digest,
+                    base: *base,
+                    len: *len,
+                }
+            })
+            .collect();
+    }
     // GH #18 item 1 (step 1): dump the per-method allocation summary +
     // call graph and exit. A diagnostic view of the scaffold; no
     // bound-proving yet.

--- a/crates/hale-cli/src/pkg.rs
+++ b/crates/hale-cli/src/pkg.rs
@@ -473,12 +473,6 @@ fn _phantom_pathbuf_use() -> PathBuf {
 /// GH #409: the `[environments.*]` table, or an empty map when the
 /// manifest is absent. A missing `hale.toml` is not an error here —
 /// most seeds have none — but a malformed one is.
-pub fn read_environments(
-    manifest: &Path,
-) -> Result<BTreeMap<String, EnvSpec>, String> {
-    Ok(read_claims_config(manifest)?.0)
-}
-
 /// The `[environments.*]` table and the `[claims] base`, validated.
 pub fn read_claims_config(
     manifest: &Path,

--- a/crates/hale-cli/tests/source_map.rs
+++ b/crates/hale-cli/tests/source_map.rs
@@ -1,0 +1,237 @@
+//! GH #408 Phase 0: the artifact's source map and semantics version.
+//!
+//! Spans were bundle-GLOBAL byte offsets — a concatenation artifact,
+//! meaningful only inside the process that produced them. A consumer
+//! composing artifacts from separately compiled applications cannot
+//! turn `[1204, 1231]` into a location, so no cross-artifact witness
+//! could say where to look, which is most of what a witness is for.
+//!
+//! Two properties matter and neither is obvious:
+//!
+//!  - a span must resolve to a FILE, via a source table;
+//!  - the artifact must be REPRODUCIBLE, or two machines checking one
+//!    commit disagree about a document that exists to be compared.
+//!    That is why paths are workspace-relative rather than absolute,
+//!    and why they are canonicalized before being made relative.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn root(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir()
+        .join(format!("hale_srcmap_{}_{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&d);
+    d
+}
+
+fn write(root: &Path, rel: &str, src: &str) {
+    let p = root.join(rel);
+    std::fs::create_dir_all(p.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&p, src).expect("write");
+}
+
+/// Run with an explicit working directory — the whole point is that
+/// the result must not depend on it.
+fn dump_from(cwd: &Path, target: &str) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .current_dir(cwd)
+        .args(["check", target, "--dump-topology"])
+        .output()
+        .expect("run hale");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+const LIB: &str = r#"
+type Msg { v: Int; }
+topic Settled { payload: Msg; subject: "app.settled"; }
+locus Billing {
+    params { n: Int = 0; }
+    bus { publish Settled; }
+    fn go() { let m = Msg { v: 1 }; Settled <- m; }
+}
+"#;
+
+const APP: &str = r#"
+import "../../lib" as lb;
+main locus App { params { b: lb::Billing = lb::Billing { }; } }
+fn main() { App { }; }
+"#;
+
+fn workspace(tag: &str) -> PathBuf {
+    let r = root(tag);
+    write(&r, "lib/lib.hl", LIB);
+    write(&r, "apps/api/main.hl", APP);
+    write(&r, "hale.toml", "[deps]\n");
+    r
+}
+
+#[test]
+fn every_provenance_span_names_a_source_file() {
+    let r = workspace("resolve");
+    let out = dump_from(&r, "apps/api");
+    let v: serde_json::Value =
+        serde_json::from_str(&out).expect("artifact parses");
+    let _ = std::fs::remove_dir_all(&r);
+
+    let sources = v["sources"].as_array().expect("sources table");
+    assert!(!sources.is_empty(), "a source table is required: {}", out);
+    let ids: Vec<i64> =
+        sources.iter().map(|s| s["id"].as_i64().unwrap_or(-1)).collect();
+
+    // Every decl row must point at a real entry — a span that cannot
+    // be placed is reported as -1 rather than attributed to the wrong
+    // file, and none of these should be unplaceable.
+    let decls = v["provenance"]["decls"].as_object().expect("decls");
+    assert!(!decls.is_empty(), "fixture must declare something");
+    for (name, row) in decls {
+        let sid = row["source"].as_i64().expect("source id");
+        assert!(
+            ids.contains(&sid),
+            "decl `{}` names source {}, which is not in the table",
+            name,
+            sid
+        );
+        let span = row["span"].as_array().expect("span");
+        assert_eq!(span.len(), 2, "decl `{}` span", name);
+    }
+}
+
+/// Spans are now file-LOCAL. A bundle-global offset would exceed the
+/// length of the file it claims to be in, which is exactly what made
+/// them useless to a consumer.
+#[test]
+fn spans_are_local_to_their_file() {
+    let r = workspace("local");
+    let out = dump_from(&r, "apps/api");
+    let v: serde_json::Value =
+        serde_json::from_str(&out).expect("artifact parses");
+
+    let lens: Vec<usize> = v["sources"]
+        .as_array()
+        .expect("sources")
+        .iter()
+        .map(|s| {
+            let p = r.join(s["path"].as_str().expect("path"));
+            std::fs::read_to_string(&p).map(|t| t.len()).unwrap_or(0)
+        })
+        .collect();
+    let _ = std::fs::remove_dir_all(&r);
+
+    for (name, row) in v["provenance"]["decls"].as_object().expect("decls") {
+        let sid = row["source"].as_i64().expect("id") as usize;
+        let end = row["span"][1].as_u64().expect("end") as usize;
+        assert!(
+            end <= lens[sid],
+            "decl `{}` ends at {} but source {} is only {} bytes — that \
+             is a bundle-global offset, not a file-local one",
+            name,
+            end,
+            sid,
+            lens[sid]
+        );
+    }
+}
+
+/// The artifact must not depend on where it was produced from. Paths
+/// are relative to the workspace (the nearest `hale.toml`), and are
+/// canonicalized first — without that the target's own file kept the
+/// path as typed on the command line while imported seeds arrived
+/// absolute, so the same sources produced two different documents.
+#[test]
+fn the_artifact_is_reproducible_across_working_directories() {
+    let r = workspace("repro");
+    let from_root = dump_from(&r, "apps/api");
+    let from_apps = dump_from(&r.join("apps"), "api");
+    let from_tmp =
+        dump_from(Path::new("/"), r.join("apps/api").to_str().expect("utf8"));
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert_eq!(
+        from_root, from_apps,
+        "checking from the workspace root and from `apps/` must produce \
+         one artifact"
+    );
+    assert_eq!(
+        from_apps, from_tmp,
+        "…and so must an absolute target from an unrelated directory"
+    );
+}
+
+/// Absolute paths would make the artifact machine-specific, which
+/// defeats comparing two of them.
+#[test]
+fn source_paths_are_workspace_relative() {
+    let r = workspace("relative");
+    let out = dump_from(&r, "apps/api");
+    let v: serde_json::Value =
+        serde_json::from_str(&out).expect("artifact parses");
+    let _ = std::fs::remove_dir_all(&r);
+
+    let paths: Vec<&str> = v["sources"]
+        .as_array()
+        .expect("sources")
+        .iter()
+        .map(|s| s["path"].as_str().unwrap_or(""))
+        .collect();
+    for p in &paths {
+        assert!(
+            !p.starts_with('/') && !p.contains(".."),
+            "`{}` is not workspace-relative — an absolute path makes the \
+             artifact differ per machine: {:?}",
+            p,
+            paths
+        );
+    }
+    // The imported seed lives OUTSIDE the target directory, which is
+    // the case that kept paths absolute before the workspace root.
+    assert!(
+        paths.iter().any(|p| p.starts_with("lib/")),
+        "the imported seed must be relativized too: {:?}",
+        paths
+    );
+}
+
+/// A content digest lets a consumer tell whether two artifacts were
+/// built from the same text, and catches a stale artifact paired with
+/// edited source — without shipping the source.
+#[test]
+fn a_source_digest_tracks_its_contents() {
+    let r = workspace("digest");
+    let before = dump_from(&r, "apps/api");
+    write(&r, "lib/lib.hl", &format!("{}\n// a comment\n", LIB));
+    let after = dump_from(&r, "apps/api");
+    let _ = std::fs::remove_dir_all(&r);
+
+    let dig = |s: &str| -> Vec<String> {
+        let v: serde_json::Value = serde_json::from_str(s).expect("parses");
+        v["sources"]
+            .as_array()
+            .expect("sources")
+            .iter()
+            .map(|x| x["digest"].as_str().unwrap_or("").to_string())
+            .collect()
+    };
+    assert_ne!(
+        dig(&before),
+        dig(&after),
+        "editing a source must change its digest"
+    );
+}
+
+/// `schema` says a row has these fields; it cannot say what they
+/// MEAN. Two compilers agreeing on the schema and disagreeing on the
+/// semantics would compose artifacts into a model neither would
+/// certify, with nothing in the document revealing it.
+#[test]
+fn the_artifact_declares_its_model_semantics() {
+    let r = workspace("semantics");
+    let out = dump_from(&r, "apps/api");
+    let v: serde_json::Value =
+        serde_json::from_str(&out).expect("artifact parses");
+    let _ = std::fs::remove_dir_all(&r);
+    assert!(
+        v["semantics"].as_u64().is_some(),
+        "a semantics version, distinct from `schema`: {}",
+        out
+    );
+}

--- a/crates/hale-cli/tests/topology_v2.rs
+++ b/crates/hale-cli/tests/topology_v2.rs
@@ -114,8 +114,11 @@ fn moving_code_changes_provenance_but_not_shape_hash() {
         "provenance spans must track the moved source"
     );
     assert!(
-        a.contains("\"decls\": {") && a.contains("\"A\": ["),
-        "decl spans are exported:\n{}",
+        a.contains("\"decls\": {")
+            && a.contains("\"A\": {\"source\":"),
+        "decl spans are exported, resolved to a source file (#408 \
+         Phase 0 — a bare offset means nothing outside the process \
+         that produced it):\n{}",
         a
     );
 }

--- a/crates/hale-cli/tests/xseed_claims_verbs.rs
+++ b/crates/hale-cli/tests/xseed_claims_verbs.rs
@@ -80,7 +80,7 @@ fn cover_catches_an_uncovered_topic_across_seeds() {
 fn the_topology_artifact_round_trips() {
     let dump = dump_artifact();
     assert!(
-        dump.contains("\"schema\": \"1.7\"")
+        dump.contains("\"schema\": \"1.8\"")
             && dump.contains("\"shape_hash\": \""),
         "the artifact must carry schema + shape_hash:\n{}",
         dump

--- a/crates/hale-types/src/symbol.rs
+++ b/crates/hale-types/src/symbol.rs
@@ -33,6 +33,37 @@ pub struct Bundle<'a> {
     ///
     /// Empty for a single-seed bundle, which is every in-repo test.
     pub import_renames: Vec<(Vec<String>, String)>,
+    /// GH #408 Phase 0: the source map.
+    ///
+    /// Spans in this bundle are bundle-GLOBAL byte offsets — a
+    /// concatenation artifact, meaningful only inside the process
+    /// that built it. A consumer composing artifacts from separately
+    /// compiled applications cannot turn `[1204, 1231]` into a
+    /// location, so no cross-artifact witness can say where to look.
+    ///
+    /// Each entry maps a slice of that global space back to a file,
+    /// so the artifact can emit `(source, [local_start, local_end])`.
+    /// Paths are RELATIVE to the checked target: an absolute path
+    /// would make the artifact differ per machine, and the artifact
+    /// is supposed to be comparable.
+    pub sources: Vec<SourceFile>,
+}
+
+/// One file's slice of the bundle-global offset space.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceFile {
+    /// Stable within one artifact; provenance rows reference it.
+    pub id: u32,
+    /// Relative to the checked target, forward slashes.
+    pub path: String,
+    /// FNV-1a/64 of the file's bytes. Lets a consumer tell whether
+    /// two artifacts were built from the same text without shipping
+    /// the text, and catches a stale artifact paired with edited
+    /// source.
+    pub digest: String,
+    /// The file's start in the bundle-global space, and its length.
+    pub base: u32,
+    pub len: u32,
 }
 
 impl<'a> Bundle<'a> {
@@ -40,7 +71,11 @@ impl<'a> Bundle<'a> {
     pub fn new(
         programs: BTreeMap<String, &'a hale_syntax::ast::Program>,
     ) -> Self {
-        Self { programs, import_renames: Vec::new() }
+        Self {
+            programs,
+            import_renames: Vec::new(),
+            sources: Vec::new(),
+        }
     }
 }
 

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -101,7 +101,21 @@ use crate::symbol::Bundle;
 /// (everything they reach), and gains the `environment` label —
 /// identities now come from the adoption traversal, so a constitution
 /// contributing no clause of its own is no longer invisible.
-pub const TOPOLOGY_SCHEMA: &str = "1.7";
+pub const TOPOLOGY_SCHEMA: &str = "1.8";
+
+/// GH #408 Phase 0: what the rows MEAN, as distinct from their shape.
+///
+/// `schema` says a row has these fields. It cannot say that "an
+/// interface dispatch fans out to every conformer" or "unknown
+/// implies violation" were the rules in force when the rows were
+/// produced. Two compilers agreeing on the schema and disagreeing on
+/// the semantics would compose artifacts into a model neither of them
+/// would certify — and nothing in the document would reveal it.
+///
+/// Bump whenever the interpretation of any row changes, even when its
+/// shape does not. A consumer that does not recognise the value must
+/// refuse rather than assume equivalence.
+pub const MODEL_SEMANTICS: u32 = 1;
 
 /// Serialize the bundle's model + claim results as the topology
 /// artifact (JSON).
@@ -640,36 +654,76 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
     let mut out = String::new();
     out.push_str("{\n");
     out.push_str(&format!(
-        "  \"schema\": {},\n",
-        quote(TOPOLOGY_SCHEMA)
+        "  \"schema\": {},\n  \"semantics\": {},\n",
+        quote(TOPOLOGY_SCHEMA),
+        MODEL_SEMANTICS
     ));
     out.push_str(&format!(
         "  \"shape_hash\": \"{:016x}\",\n",
         shape_hash
     ));
     out.push_str(&model);
-    // Provenance (#392): source spans as bundle-global byte offsets
-    // [start, end]. UNHASHED on purpose — moving code must not
-    // change the shape identity — so it sits in the results half
-    // beside the claim rows.
+    // GH #408 Phase 0: the source map, so a span means something
+    // outside the process that produced it.
+    //
+    // Bundle-global offsets are a concatenation artifact. A consumer
+    // composing artifacts from separately compiled applications
+    // cannot turn `[1204, 1231]` into a location, so no cross-artifact
+    // witness could say where to look — which is most of what a
+    // witness is for. Paths are relative to the checked target and
+    // carry a content digest, so an artifact stays comparable across
+    // machines and a consumer can tell a stale pairing from a fresh
+    // one.
+    out.push_str(",\n  \"sources\": [\n");
+    for (i, sf) in bundle.sources.iter().enumerate() {
+        out.push_str(&format!(
+            "    {{\"id\": {}, \"path\": {}, \"digest\": {}}}{}\n",
+            sf.id,
+            quote(&sf.path),
+            quote(&sf.digest),
+            if i + 1 == bundle.sources.len() { "" } else { "," }
+        ));
+    }
+    out.push_str("  ]");
+
+    // Provenance (#392): source spans, now resolved to
+    // `(source, [local_start, local_end])`. UNHASHED by `shape_hash`
+    // on purpose — moving code must not change the shape identity —
+    // so it sits in the results half beside the claim rows.
+    let loc = |pos: u32| -> (i64, u32) {
+        match bundle
+            .sources
+            .iter()
+            .filter(|f| pos >= f.base && pos < f.base.saturating_add(f.len + 1))
+            .max_by_key(|f| f.base)
+        {
+            Some(f) => (f.id as i64, pos - f.base),
+            // -1 rather than a guessed file: a span the map cannot
+            // place is better reported as unplaceable than attributed
+            // to the wrong source.
+            None => (-1, pos),
+        }
+    };
     out.push_str(",\n  \"provenance\": {\n    \"calls\": [\n");
     for (from, to, s, e) in &call_spans {
         out.push_str(&format!(
-            "      {{\"from\": {}, \"to\": {}, \"span\": [{}, {}]}},\n",
+            "      {{\"from\": {}, \"to\": {}, \"source\": {}, \"span\": [{}, {}]}},\n",
             quote(from),
             quote(to),
-            s,
-            e
+            loc(*s).0,
+            loc(*s).1,
+            loc(*e).1
         ));
     }
     trim_trailing_comma(&mut out);
     out.push_str("    ],\n    \"publishes\": [\n");
     for (f, subj, s, e) in &publish_spans {
         out.push_str(&format!(
-            "      {{\"fn\": {}, \"subject\": {}, \"span\": [{}, {}]}},\n",
+            "      {{\"fn\": {}, \"subject\": {}, \"source\": {}, \"span\": [{}, {}]}},\n",
             quote(f),
             quote(subj),
-            s,
+            loc(*s).0,
+            loc(*s).1,
             e
         ));
     }
@@ -678,22 +732,24 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
     for (subj, locus, handler, s, e) in &subscribe_spans {
         out.push_str(&format!(
             "      {{\"subject\": {}, \"locus\": {}, \"handler\": {}, \
-             \"span\": [{}, {}]}},\n",
+             \"source\": {}, \"span\": [{}, {}]}},\n",
             quote(subj),
             quote(locus),
             quote(handler),
-            s,
-            e
+            loc(*s).0,
+            loc(*s).1,
+            loc(*e).1
         ));
     }
     trim_trailing_comma(&mut out);
     out.push_str("    ],\n    \"decls\": {\n");
     for (decl, (s, e)) in &decl_spans {
         out.push_str(&format!(
-            "      {}: [{}, {}],\n",
+            "      {}: {{\"source\": {}, \"span\": [{}, {}]}},\n",
             quote(decl),
-            s,
-            e
+            loc(*s).0,
+            loc(*s).1,
+            loc(*e).1
         ));
     }
     trim_trailing_comma(&mut out);

--- a/crates/hale-types/tests/artifact_integrity.rs
+++ b/crates/hale-types/tests/artifact_integrity.rs
@@ -169,7 +169,7 @@ fn only_holds_passes() {
 fn the_document_verdict_reflects_its_rows() {
     let a = artifact();
     let v: serde_json::Value = serde_json::from_str(&a).expect("valid JSON");
-    assert_eq!(v["schema"], "1.7");
+    assert_eq!(v["schema"], "1.8");
     assert_eq!(
         v["verdict"], "clean",
         "every claim in the fixture holds: {}",

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -235,7 +235,7 @@ earlier in the same file as the family. Companion:
 class along any path, with the same loop/indirect unboundedness
 rules as every per-call dimension.
 
-**The topology artifact** (#382 phase 2; schema 1.7):
+**The topology artifact** (#382 phase 2; schema 1.8):
 `hale check <t> --dump-topology` emits the serialized model —
 sorts (loci, fns, topics), relations (calls with **weights**: loop
 nesting, unbounded-loop membership, interface-dispatch tags;
@@ -465,6 +465,48 @@ clause came from), and an `evaluation` section carrying the
 (which deployment this run certified, and under what law). All are
 inside the integrity-covered body — an evaluation context editable
 after the fact would certify nothing.
+
+### Source maps and model semantics (GH #408 Phase 0)
+
+Spans in the artifact are **file-local**, resolved through a
+`sources` table:
+
+```json
+"sources": [{"id": 0, "path": "apps/api/main.hl", "digest": "…"}],
+"provenance": { "decls": { "App": {"source": 0, "span": [36, 39]} } }
+```
+
+They were bundle-global byte offsets — an artifact of concatenating
+the seed's files, meaningful only inside the process that produced
+them. A consumer composing artifacts from separately compiled
+applications cannot turn `[1204, 1231]` into a location, so no
+cross-artifact witness could say where to look.
+
+Paths are relative to the **workspace** (the nearest ancestor holding
+a `hale.toml`, else the deepest common ancestor of every source) and
+are canonicalized before being made relative. Both matter: an
+absolute path makes the artifact machine-specific, and rooting at the
+target alone leaves an imported seed — which usually lives outside it
+— absolute anyway. The artifact must be byte-identical for the same
+sources regardless of the working directory it was produced from,
+because comparing two of them is the point.
+
+Each source carries a content digest, so a consumer can tell whether
+two artifacts were built from the same text, and can catch a stale
+artifact paired with edited source, without the source being shipped.
+
+A span the map cannot place reports `"source": -1` rather than being
+attributed to the nearest file: an unplaceable location is more
+useful than a confidently wrong one.
+
+**`semantics`** is a version distinct from `schema`. Schema says a row
+has these fields; it cannot say that "an interface dispatch fans out
+to every conformer" or "unknown implies violation" were the rules in
+force when the rows were produced. Two compilers agreeing on the
+schema and disagreeing on the semantics would compose artifacts into
+a model neither would certify, with nothing in the document revealing
+it. A consumer that does not recognise the value must refuse rather
+than assume equivalence.
 
 ## Structural & design rules
 


### PR DESCRIPTION
Phase 0 of the fleet-claims issue — the prerequisite for composing artifacts across separately compiled applications, and the part I flagged as where the risk actually is.

## Spans now mean something outside the process that made them

Provenance was bundle-global byte offsets:

```json
"decls": { "App": [1204, 1231] }
```

That is an artifact of concatenating a seed's files. Nobody else can turn it into a location, so **no cross-artifact witness could say where to look** — which is most of what a witness is for. Now:

```json
"sources": [{"id": 0, "path": "apps/api/main.hl", "digest": "3894bed2056b0f22"}],
"provenance": { "decls": { "App": {"source": 0, "span": [36, 39]} } }
```

Every provenance row — calls, publishes, subscribes, decls — carries a `source`.

## Reproducibility took two fixes, and the second only appeared on test

An artifact that differs by machine or by working directory defeats the thing it exists for, so I tested it directly. Both attempts were wrong:

**Rooting at the target left imported seeds absolute.** `apps/api` importing `../../lib` puts the library *outside* the target, so `strip_prefix` failed and the path stayed `/tmp/…/lib/policy.hl`. Paths are now relative to the **workspace** — the nearest ancestor holding a `hale.toml`, else the deepest common ancestor of every source.

**The target's own file was still cwd-relative.** It arrives as typed on the command line while imported seeds arrive canonicalized, so stripping an absolute root off a relative path silently fell back to the original:

```
from scratchpad : "art/ws/apps/api/main.hl"     ← differs
from art/ws     : "apps/api/main.hl"
```

Canonicalizing before relativizing fixes it. Verified byte-identical from three different working directories, including an absolute target from `/`.

## Also

- **Content digest per source**, so a consumer can tell whether two artifacts came from the same text — and catch a stale artifact paired with edited source — without the source being shipped.
- **An unplaceable span reports `"source": -1`** rather than being attributed to the nearest file. A location that says "I don't know" beats a confidently wrong one.
- **`semantics`**, a version distinct from `schema`. Schema says a row has these fields; it cannot say that "an interface dispatch fans out to every conformer" or "unknown implies violation" were the rules in force. Two compilers agreeing on the schema and disagreeing on the semantics would compose artifacts into a model neither would certify, with nothing in the document revealing it.

## Breaking

`provenance.decls` rows change from `[start, end]` to `{"source": id, "span": [start, end]}`, and every other provenance row gains a `source` field. Schema 1.8.

## Tests

Six in `source_map.rs`: spans resolve to a real source id; spans are file-local (a bundle-global offset would exceed the length of the file it claims to be in — the property that made them useless); the artifact is byte-identical across three working directories; paths are workspace-relative with the imported seed included; a source digest tracks its contents; and the artifact declares its semantics.

Also ran `artifact_integrity` (10), `constitutions` (20), `claims` (16), `claims_edges` (36), `env_matrix` (28), `topology_artifact_contract` (9), `topology_v2` (5), `xseed_claims_verbs` (5), `claims_artifact_unknowns` (4), `workspace_check` (7).

## Next

Phase 1 is the FleetPlan IR and composition — artifact validation, instance namespacing, wire-topic compatibility, route edges, `fleet_shape_hash`. Phase 2 is the fleet claim verbs with cross-artifact witnesses, which is what this Phase 0 work exists to make possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)