### PR TITLE
feat(fleet): compose artifacts across applications (GH #408 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ behavior.
 
 ## Unreleased
 
+### `hale fleet`: compose artifacts across applications (GH #408 Phase 1)
+
+```sh
+hale fleet check prod.plan.json    # compose and validate
+hale fleet dump  prod.plan.json    # write the fleet artifact
+```
+
+A fleet is a named deployed system of application **instances**, and
+it composes *artifacts* — never source. A source-merged "super-main"
+would be unsound in both directions: an unbound topic is in-process by
+default, so merging two binaries makes matching publishers and
+subscribers look connected when no route joins them; deploy-time
+routes existing only in config would not appear; and calls, which
+cannot cross a process boundary, would become ordinary reachability.
+
+So **matching wire identities establish compatibility; only an
+explicit route creates a fleet edge.** Two instances that both declare
+a topic and are not routed stay unconnected, which has its own test.
+
+Validation refuses anything a certificate cannot rest on: integrity
+first (the whole-body digest, since `shape_hash` covers the model half
+and cannot vouch for the `topics` rows the join reads), then the
+`semantics` version, then the component's own verdict — local law is a
+precondition of admission. Routes join on `(subject, payload_hash)`,
+never the local topic name, so a shared name over a different payload
+is a plan that cannot be formed rather than a silent mismatch.
+
+`fleet_shape_hash` covers instance identities and cardinalities,
+routes and their wire identities, component shape hashes and the
+composed relations — and excludes provenance. Verified in both
+directions: a comment added to a component leaves it unchanged, while
+a changed transport or an added instance moves it.
+
 ### Artifact schema 1.8: source maps and model semantics (GH #408 Phase 0)
 
 The prerequisite for composing artifacts across separately compiled

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -1,0 +1,558 @@
+//! GH #408 Phase 1: compose topology artifacts into one fleet model.
+//!
+//! A fleet is a named deployed system of application **instances**,
+//! not "every main in a repository". It composes *artifacts*, never
+//! source — that distinction is the whole design, and it is worth
+//! restating because the tempting implementation is a super-main
+//! build that imports every application and runs ordinary claims over
+//! the merged source. That would be unsound in both directions:
+//!
+//!  - **it invents edges.** An unbound topic is in-process by
+//!    default, so merging two binaries makes matching publishers and
+//!    subscribers look locally connected when no deployed route joins
+//!    them;
+//!  - **it erases edges.** Real routes supplied by deployment config
+//!    do not appear merely because source was merged;
+//!  - **it changes what a call means.** Calls cannot cross a process
+//!    boundary; flattening makes ordinary method reachability look
+//!    possible where only serialized messaging exists.
+//!
+//! So the composition unit is the artifact instance. Matching wire
+//! identities establish *compatibility*; only an explicit route
+//! creates a fleet edge.
+//!
+//! This module is deliberately a CLIENT of the artifact rather than a
+//! second source analyzer. It reads exactly what a third party would
+//! read, which is the only way "an outside evaluator can replay this"
+//! stays true.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// The plan's own schema, independent of the topology artifact's.
+pub const FLEET_PLAN_SCHEMA: &str = "1.0";
+
+/// An exact, finite deployment. Autoscaling ranges and wildcard
+/// discovery are elaborator INPUTS, not sealed-plan contents: a
+/// bounded range is not one truth value for a cardinality claim.
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct FleetPlan {
+    pub schema: String,
+    pub name: String,
+    pub instances: Vec<InstanceSpec>,
+    #[serde(default)]
+    pub routes: Vec<RouteSpec>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct InstanceSpec {
+    /// `riskgw-prod-0`, not `riskgw`. An application TYPE is not a
+    /// deployed instance, and everything downstream — cardinality,
+    /// witnesses, several instances of one artifact — needs the
+    /// distinction.
+    pub id: String,
+    /// Path to a topology artifact, relative to the plan file.
+    pub artifact: String,
+    #[serde(default)]
+    pub labels: Vec<String>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct RouteSpec {
+    pub id: String,
+    pub publishers: Vec<Endpoint>,
+    pub subscribers: Vec<Endpoint>,
+    /// Free-form for now; transport POLICY is a later phase. Carried
+    /// so the fleet model records how a hop is realized.
+    #[serde(default)]
+    pub transport: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct Endpoint {
+    pub instance: String,
+    /// The topic's LOCAL name in that instance's artifact.
+    pub topic: String,
+}
+
+/// One loaded, validated component.
+struct Component {
+    id: String,
+    labels: Vec<String>,
+    artifact: serde_json::Value,
+    path: PathBuf,
+}
+
+/// `(wire subject, payload hash)` — the cross-binary join key.
+///
+/// Never the local topic identifier: the same identifier can mean
+/// different wire shapes in different applications, and different
+/// identifiers can deliberately denote one contract.
+#[derive(PartialEq, Eq, Clone, Debug)]
+struct WireId {
+    subject: String,
+    payload_hash: String,
+}
+
+pub fn compose(plan_path: &Path) -> Result<String, Vec<String>> {
+    let plan = read_plan(plan_path)?;
+    let base = plan_path.parent().unwrap_or(Path::new("."));
+    let mut errs: Vec<String> = Vec::new();
+
+    // ---- step 1: validate every component artifact ----
+    let mut comps: Vec<Component> = Vec::new();
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for inst in &plan.instances {
+        if !seen.insert(inst.id.as_str()) {
+            errs.push(format!(
+                "instance id `{}` is used twice — an instance id is \
+                 how every vertex, route endpoint and witness refers \
+                 to one deployed process",
+                inst.id
+            ));
+            continue;
+        }
+        match load_artifact(&base.join(&inst.artifact)) {
+            Ok(v) => comps.push(Component {
+                id: inst.id.clone(),
+                labels: inst.labels.clone(),
+                artifact: v,
+                path: base.join(&inst.artifact),
+            }),
+            Err(e) => errs.push(format!("instance `{}`: {}", inst.id, e)),
+        }
+    }
+    if !errs.is_empty() {
+        return Err(errs);
+    }
+    let by_id: BTreeMap<&str, &Component> =
+        comps.iter().map(|c| (c.id.as_str(), c)).collect();
+
+    // ---- steps 2-3: namespace, retaining interiors ----
+    //
+    // Calls stay strictly INSIDE one instance: there is no such thing
+    // as a cross-process call, and inventing one is exactly what
+    // source-merging would do.
+    let mut vertices: Vec<String> = Vec::new();
+    let mut call_edges: Vec<(String, String)> = Vec::new();
+    let mut local_bus: Vec<(String, String)> = Vec::new();
+    for c in &comps {
+        for f in arr(&c.artifact["sorts"]["fns"]) {
+            if let Some(n) = f.as_str() {
+                vertices.push(format!("{}::{}", c.id, n));
+            }
+        }
+        for e in arr(&c.artifact["relations"]["calls"]) {
+            if let (Some(f), Some(t)) =
+                (e["from"].as_str(), e["to"].as_str())
+            {
+                call_edges.push((
+                    format!("{}::{}", c.id, f),
+                    format!("{}::{}", c.id, t),
+                ));
+            }
+        }
+        // A local publish→subscribe pair inside one instance is a
+        // real in-process edge and stays one.
+        for p in arr(&c.artifact["relations"]["publishes"]) {
+            let (Some(pf), Some(subj)) =
+                (p["fn"].as_str(), p["subject"].as_str())
+            else {
+                continue;
+            };
+            for s in arr(&c.artifact["relations"]["subscribes"]) {
+                if s["subject"].as_str() == Some(subj) {
+                    if let (Some(l), Some(h)) =
+                        (s["locus"].as_str(), s["handler"].as_str())
+                    {
+                        local_bus.push((
+                            format!("{}::{}", c.id, pf),
+                            format!("{}::{}::{}", c.id, l, h),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- steps 4-6: routes ----
+    let mut routes_out: Vec<String> = Vec::new();
+    let mut route_edges: Vec<(String, String, String)> = Vec::new();
+    for r in &plan.routes {
+        if r.publishers.is_empty() || r.subscribers.is_empty() {
+            errs.push(format!(
+                "route `{}` has {} publisher(s) and {} subscriber(s) — \
+                 a route with an empty side connects nothing and is \
+                 almost certainly a mistake in the plan",
+                r.id,
+                r.publishers.len(),
+                r.subscribers.len()
+            ));
+            continue;
+        }
+        // step 5: every endpoint must agree on the wire identity.
+        let mut wire: Option<(WireId, String)> = None;
+        let mut bad = false;
+        for ep in r.publishers.iter().chain(r.subscribers.iter()) {
+            let Some(c) = by_id.get(ep.instance.as_str()) else {
+                errs.push(format!(
+                    "route `{}` names instance `{}`, which the plan \
+                     does not declare",
+                    r.id, ep.instance
+                ));
+                bad = true;
+                continue;
+            };
+            match wire_id(&c.artifact, &ep.topic) {
+                None => {
+                    errs.push(format!(
+                        "route `{}`: instance `{}` declares no topic \
+                         `{}`",
+                        r.id, ep.instance, ep.topic
+                    ));
+                    bad = true;
+                }
+                Some(w) => match &wire {
+                    None => wire = Some((w, ep.instance.clone())),
+                    Some((prev, prev_inst)) if *prev != w => {
+                        errs.push(format!(
+                            "route `{}` cannot be formed: `{}` sees \
+                             subject `{}` / payload {}, `{}` sees `{}` \
+                             / {}. Endpoints must agree on the WIRE \
+                             identity — a shared local name is not a \
+                             shared contract",
+                            r.id,
+                            prev_inst,
+                            prev.subject,
+                            prev.payload_hash,
+                            ep.instance,
+                            w.subject,
+                            w.payload_hash
+                        ));
+                        bad = true;
+                    }
+                    Some(_) => {}
+                },
+            }
+        }
+        if bad {
+            continue;
+        }
+        let Some((w, _)) = wire else { continue };
+        if w.subject.is_empty() {
+            errs.push(format!(
+                "route `{}` carries a topic with no declared \
+                 `subject:` — its wire name is a local, non-portable \
+                 fallback, so it cannot be joined across binaries",
+                r.id
+            ));
+            continue;
+        }
+
+        // step 6: the hop keeps its boundary as an explicit edge
+        // rather than collapsing into a direct call.
+        for p in &r.publishers {
+            let Some(pc) = by_id.get(p.instance.as_str()) else {
+                continue;
+            };
+            for pf in publishers_of(&pc.artifact, &p.topic) {
+                for s in &r.subscribers {
+                    let Some(sc) = by_id.get(s.instance.as_str()) else {
+                        continue;
+                    };
+                    for (l, h) in subscribers_of(&sc.artifact, &s.topic) {
+                        route_edges.push((
+                            format!("{}::{}", p.instance, pf),
+                            format!("{}::{}::{}", s.instance, l, h),
+                            r.id.clone(),
+                        ));
+                    }
+                }
+            }
+        }
+        routes_out.push(format!(
+            "    {{\"id\": {}, \"subject\": {}, \"payload_hash\": {}, \
+             \"transport\": {}}}",
+            q(&r.id),
+            q(&w.subject),
+            q(&w.payload_hash),
+            match &r.transport {
+                Some(t) => q(t),
+                None => "null".to_string(),
+            }
+        ));
+    }
+    if !errs.is_empty() {
+        return Err(errs);
+    }
+
+    // ---- step 8: unknowns propagate ----
+    //
+    // Uncertainty in a component stays uncertainty in the fleet. It
+    // may add paths; it may never delete one and certify an absence.
+    let mut unknowns: Vec<String> = Vec::new();
+    for c in &comps {
+        for u in arr(&c.artifact["unknowns"]) {
+            unknowns.push(format!(
+                "    {{\"instance\": {}, \"unknown\": {}}}",
+                q(&c.id),
+                serde_json::to_string(&u).unwrap_or_else(|_| "null".into())
+            ));
+        }
+    }
+
+    Ok(render(
+        &plan, &comps, &vertices, &call_edges, &local_bus, &route_edges,
+        &routes_out, &unknowns,
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render(
+    plan: &FleetPlan,
+    comps: &[Component],
+    vertices: &[String],
+    calls: &[(String, String)],
+    local_bus: &[(String, String)],
+    route_edges: &[(String, String, String)],
+    routes: &[String],
+    unknowns: &[String],
+) -> String {
+    // The MODEL half — hashed. Instance identities and cardinalities,
+    // route hyperedges, wire identities, component shape hashes.
+    // Claim results and provenance stay out of it, mirroring the
+    // application artifact's split.
+    let mut model = String::new();
+    model.push_str("  \"instances\": [\n");
+    for (i, c) in comps.iter().enumerate() {
+        model.push_str(&format!(
+            "    {{\"id\": {}, \"app_shape_hash\": {}, \"labels\": [{}]}}{}\n",
+            q(&c.id),
+            q(c.artifact["shape_hash"].as_str().unwrap_or("")),
+            c.labels
+                .iter()
+                .map(|l| q(l))
+                .collect::<Vec<_>>()
+                .join(", "),
+            if i + 1 == comps.len() { "" } else { "," }
+        ));
+    }
+    model.push_str("  ],\n  \"routes\": [\n");
+    model.push_str(&routes.join(",\n"));
+    model.push_str("\n  ],\n  \"vertices\": [");
+    model.push_str(
+        &vertices.iter().map(|v| q(v)).collect::<Vec<_>>().join(", "),
+    );
+    model.push_str("],\n  \"relations\": {\n    \"calls\": [\n");
+    model.push_str(
+        &calls
+            .iter()
+            .map(|(f, t)| {
+                format!("      {{\"from\": {}, \"to\": {}}}", q(f), q(t))
+            })
+            .collect::<Vec<_>>()
+            .join(",\n"),
+    );
+    model.push_str("\n    ],\n    \"local_bus\": [\n");
+    model.push_str(
+        &local_bus
+            .iter()
+            .map(|(f, t)| {
+                format!("      {{\"from\": {}, \"to\": {}}}", q(f), q(t))
+            })
+            .collect::<Vec<_>>()
+            .join(",\n"),
+    );
+    model.push_str("\n    ],\n    \"routed\": [\n");
+    model.push_str(
+        &route_edges
+            .iter()
+            .map(|(f, t, r)| {
+                format!(
+                    "      {{\"from\": {}, \"to\": {}, \"route\": {}}}",
+                    q(f),
+                    q(t),
+                    q(r)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",\n"),
+    );
+    model.push_str("\n    ]\n  }");
+
+    let fleet_shape_hash = fnv(&model);
+    let mut out = String::new();
+    out.push_str("{\n");
+    out.push_str(&format!("  \"schema\": {},\n", q(FLEET_PLAN_SCHEMA)));
+    out.push_str(&format!("  \"name\": {},\n", q(&plan.name)));
+    out.push_str(&format!(
+        "  \"fleet_shape_hash\": {},\n",
+        q(&fleet_shape_hash)
+    ));
+    out.push_str(&model);
+    // Unhashed: provenance and uncertainty, like the application
+    // artifact's results half.
+    out.push_str(",\n  \"unknowns\": [\n");
+    out.push_str(&unknowns.join(",\n"));
+    out.push_str("\n  ],\n  \"components\": [\n");
+    out.push_str(
+        &comps
+            .iter()
+            .map(|c| {
+                format!(
+                    "    {{\"id\": {}, \"artifact\": {}}}",
+                    q(&c.id),
+                    q(&c.path.display().to_string())
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",\n"),
+    );
+    out.push_str("\n  ]\n}\n");
+    out
+}
+
+fn read_plan(p: &Path) -> Result<FleetPlan, Vec<String>> {
+    let src = std::fs::read_to_string(p)
+        .map_err(|e| vec![format!("read {}: {}", p.display(), e)])?;
+    let plan: FleetPlan = serde_json::from_str(&src)
+        .map_err(|e| vec![format!("parse {}: {}", p.display(), e)])?;
+    if plan.schema != FLEET_PLAN_SCHEMA {
+        return Err(vec![format!(
+            "{}: plan schema `{}`, this build understands `{}`",
+            p.display(),
+            plan.schema,
+            FLEET_PLAN_SCHEMA
+        )]);
+    }
+    if plan.instances.is_empty() {
+        return Err(vec![format!(
+            "{}: a fleet with no instances composes nothing",
+            p.display()
+        )]);
+    }
+    Ok(plan)
+}
+
+/// Load one component artifact and refuse anything a composition
+/// cannot honestly build on.
+fn load_artifact(p: &Path) -> Result<serde_json::Value, String> {
+    let src = std::fs::read_to_string(p)
+        .map_err(|e| format!("read {}: {}", p.display(), e))?;
+    // Integrity BEFORE meaning. `shape_hash` is an identity covering
+    // the model half only, so it cannot vouch for the `topics` rows a
+    // composition joins on; the whole-body digest can.
+    match hale_types::topology::verify_artifact_digest(&src) {
+        Some(true) => {}
+        Some(false) => {
+            return Err(format!(
+                "{}: artifact_digest does not match its contents",
+                p.display()
+            ))
+        }
+        None => {
+            return Err(format!(
+                "{}: no artifact_digest — this predates schema 1.3 and \
+                 cannot be verified, and an unverifiable component is \
+                 not a foundation for a certificate",
+                p.display()
+            ))
+        }
+    }
+    let v: serde_json::Value = serde_json::from_str(&src)
+        .map_err(|e| format!("parse {}: {}", p.display(), e))?;
+
+    let sem = v["semantics"].as_u64();
+    if sem != Some(hale_types::topology::MODEL_SEMANTICS as u64) {
+        return Err(format!(
+            "{}: model semantics {} — this build speaks {}. The rows \
+             may share a shape and mean different things, so composing \
+             them would build a model neither compiler would certify",
+            p.display(),
+            sem.map(|s| s.to_string())
+                .unwrap_or_else(|| "absent".into()),
+            hale_types::topology::MODEL_SEMANTICS
+        ));
+    }
+    match v["verdict"].as_str() {
+        Some("clean") => {}
+        Some(other) => {
+            return Err(format!(
+                "{}: component verdict `{}` — a component whose own law \
+                 fails is not admissible; fix it before composing",
+                p.display(),
+                other
+            ))
+        }
+        None => {
+            return Err(format!(
+                "{}: no verdict field (pre-1.4 artifact)",
+                p.display()
+            ))
+        }
+    }
+    Ok(v)
+}
+
+fn wire_id(a: &serde_json::Value, local: &str) -> Option<WireId> {
+    arr(&a["topics"]).iter().find_map(|t| {
+        if t["name"].as_str() == Some(local) {
+            Some(WireId {
+                subject: t["subject"].as_str().unwrap_or("").to_string(),
+                payload_hash: t["payload_hash"]
+                    .as_str()
+                    .unwrap_or("")
+                    .to_string(),
+            })
+        } else {
+            None
+        }
+    })
+}
+
+fn publishers_of(a: &serde_json::Value, local: &str) -> Vec<String> {
+    arr(&a["relations"]["publishes"])
+        .iter()
+        .filter(|p| p["subject"].as_str() == Some(local))
+        .filter_map(|p| p["fn"].as_str().map(str::to_string))
+        .collect()
+}
+
+fn subscribers_of(
+    a: &serde_json::Value,
+    local: &str,
+) -> Vec<(String, String)> {
+    arr(&a["relations"]["subscribes"])
+        .iter()
+        .filter(|s| s["subject"].as_str() == Some(local))
+        .filter_map(|s| {
+            Some((
+                s["locus"].as_str()?.to_string(),
+                s["handler"].as_str()?.to_string(),
+            ))
+        })
+        .collect()
+}
+
+fn arr(v: &serde_json::Value) -> Vec<serde_json::Value> {
+    v.as_array().cloned().unwrap_or_default()
+}
+
+fn q(s: &str) -> String {
+    serde_json::to_string(s).unwrap_or_else(|_| "\"\"".into())
+}
+
+fn fnv(s: &str) -> String {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{:016x}", h)
+}

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -27,6 +27,7 @@ use std::process::ExitCode;
 use hale_syntax::ast::Program;
 
 use hale_lsp as lsp;
+mod fleet;
 mod mcp;
 mod pkg;
 
@@ -101,6 +102,15 @@ fn main() -> ExitCode {
     if cmd == "doc" {
         let rest: Vec<String> = args.iter().skip(2).cloned().collect();
         return run_doc(&rest);
+    }
+
+    // GH #408: `hale fleet check|dump <plan.json>` — compose
+    // topology artifacts into one fleet model. A CLIENT of the
+    // artifact, never a second source analyzer: it reads exactly what
+    // a third party would read.
+    if cmd == "fleet" {
+        let rest: Vec<String> = args.iter().skip(2).cloned().collect();
+        return run_fleet(&rest);
     }
 
     // `bench` is discovery-driven like `test`: *_bench.hl files,
@@ -2499,6 +2509,58 @@ fn file_of_span(
 /// following token would make `hale check --dump-topology app.hl`
 /// ambiguous — is `app.hl` the artifact destination or the target? —
 /// and flags are supposed to be positionable on either side.
+/// `hale fleet check <plan>` / `hale fleet dump <plan>`.
+///
+/// `check` composes and reports; `dump` writes the fleet artifact.
+/// Both fail on anything a composition cannot honestly build on — an
+/// unverifiable component, a semantics mismatch, a component whose
+/// own law fails, or endpoints that disagree about a wire contract.
+fn run_fleet(rest: &[String]) -> ExitCode {
+    let sub = rest.first().map(String::as_str);
+    let plan = rest.get(1);
+    let (sub, plan) = match (sub, plan) {
+        (Some("check"), Some(p)) | (Some("dump"), Some(p)) => {
+            (sub.unwrap(), p)
+        }
+        _ => {
+            eprintln!("hale fleet check <plan.json>    compose and check");
+            eprintln!("hale fleet dump  <plan.json>    write the fleet artifact");
+            eprintln!();
+            eprintln!("A plan names exact application INSTANCES and the");
+            eprintln!("routes between them. It composes artifacts, never");
+            eprintln!("source: matching wire identities establish");
+            eprintln!("compatibility, but only an explicit route creates");
+            eprintln!("a fleet edge.");
+            return ExitCode::from(2);
+        }
+    };
+    match fleet::compose(Path::new(plan)) {
+        Ok(artifact) => {
+            if sub == "dump" {
+                print!("{}", artifact);
+            } else {
+                let v: serde_json::Value =
+                    serde_json::from_str(&artifact).unwrap_or_default();
+                println!(
+                    "ok: fleet `{}` composed — {} instance(s), {} \
+                     route(s), fleet_shape_hash {}",
+                    v["name"].as_str().unwrap_or("?"),
+                    v["instances"].as_array().map(|a| a.len()).unwrap_or(0),
+                    v["routes"].as_array().map(|a| a.len()).unwrap_or(0),
+                    v["fleet_shape_hash"].as_str().unwrap_or("?")
+                );
+            }
+            ExitCode::SUCCESS
+        }
+        Err(errs) => {
+            for e in &errs {
+                eprintln!("{}", e);
+            }
+            ExitCode::from(1)
+        }
+    }
+}
+
 /// Flags that describe ONE evaluation: an artifact to emit, or a
 /// baseline to gate against. Meaningless when the command runs many
 /// evaluations.

--- a/crates/hale-cli/tests/fleet_compose.rs
+++ b/crates/hale-cli/tests/fleet_compose.rs
@@ -1,0 +1,420 @@
+//! GH #408 Phase 1: composing topology artifacts into a fleet model.
+//!
+//! The composition unit is the artifact INSTANCE, never the source
+//! file. Matching wire identities establish compatibility; only an
+//! explicit route creates a fleet edge. A source-merged "super-main"
+//! would invent local bus edges between binaries no route connects,
+//! erase deploy-time routes that exist only in config, and turn
+//! cross-process messaging into ordinary call reachability — so these
+//! tests care as much about what is NOT connected as what is.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn root(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir()
+        .join(format!("hale_fleet_{}_{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&d);
+    d
+}
+
+fn write(root: &Path, rel: &str, src: &str) {
+    let p = root.join(rel);
+    std::fs::create_dir_all(p.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&p, src).expect("write");
+}
+
+fn hale(args: &[&str]) -> (String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(args)
+        .output()
+        .expect("run hale");
+    (
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+fn hale_stdout(args: &[&str]) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(args)
+        .output()
+        .expect("run hale");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+const TOPICS: &str = r#"
+type Intent { id: Int; }
+type Order  { id: Int; }
+topic OrderIntent  { payload: Intent; subject: "svc.order.intent"; }
+topic OrderRequest { payload: Order;  subject: "svc.order.request"; }
+"#;
+
+const PROBER: &str = r#"
+import "../lib" as t;
+locus Probe {
+    params { n: Int = 0; }
+    bus { publish t::OrderIntent; }
+    fn submit() { let i = t::Intent { id: 1 }; t::OrderIntent <- i; }
+}
+main locus Prober { params { p: Probe = Probe { }; } }
+fn main() { Prober { }; }
+"#;
+
+const OMS: &str = r#"
+import "../lib" as t;
+locus Oms {
+    params { n: Int = 0; }
+    bus { subscribe t::OrderIntent as on_intent; publish t::OrderRequest; }
+    fn on_intent(i: t::Intent) {
+        self.n = i.id;
+        let o = t::Order { id: i.id };
+        t::OrderRequest <- o;
+    }
+}
+main locus OmsApp { params { o: Oms = Oms { }; } }
+fn main() { OmsApp { }; }
+"#;
+
+const GW: &str = r#"
+import "../lib" as t;
+locus Gateway {
+    params { n: Int = 0; }
+    bus { subscribe t::OrderRequest as on_order; }
+    fn on_order(o: t::Order) { self.n = o.id; }
+}
+main locus GwApp { params { g: Gateway = Gateway { }; } }
+fn main() { GwApp { }; }
+"#;
+
+const PLAN: &str = r#"{
+  "schema": "1.0",
+  "name": "prod",
+  "instances": [
+    {"id": "prober-0", "artifact": "artifacts/prober.json", "labels": ["strategy"]},
+    {"id": "oms-0",    "artifact": "artifacts/oms.json",    "labels": ["oms"]},
+    {"id": "gw-0",     "artifact": "artifacts/gw.json",     "labels": ["gateway"]}
+  ],
+  "routes": [
+    {"id": "intent", "transport": "unix",
+     "publishers":  [{"instance": "prober-0", "topic": "t::OrderIntent"}],
+     "subscribers": [{"instance": "oms-0",    "topic": "t::OrderIntent"}]},
+    {"id": "request", "transport": "unix",
+     "publishers":  [{"instance": "oms-0", "topic": "t::OrderRequest"}],
+     "subscribers": [{"instance": "gw-0",  "topic": "t::OrderRequest"}]}
+  ]
+}"#;
+
+/// Three seeds, three artifacts, one plan.
+fn fleet(tag: &str) -> PathBuf {
+    let r = root(tag);
+    write(&r, "lib/topics.hl", TOPICS);
+    write(&r, "prober/main.hl", PROBER);
+    write(&r, "oms/main.hl", OMS);
+    write(&r, "gw/main.hl", GW);
+    write(&r, "hale.toml", "[deps]\n");
+    for app in ["prober", "oms", "gw"] {
+        let dst = r.join(format!("artifacts/{}.json", app));
+        std::fs::create_dir_all(dst.parent().expect("parent")).expect("mkdir");
+        let (out, code) = hale(&[
+            "check",
+            r.join(app).to_str().expect("utf8"),
+            &format!("--dump-topology={}", dst.display()),
+        ]);
+        assert_eq!(code, 0, "component `{}` must check clean: {}", app, out);
+    }
+    write(&r, "prod.plan.json", PLAN);
+    r
+}
+
+fn plan_of(r: &Path) -> String {
+    r.join("prod.plan.json").to_str().expect("utf8").to_string()
+}
+
+/// Criteria 1-3: three independently compiled artifacts load, get
+/// instance-qualified, and an explicit route file connects a
+/// publisher in one to a subscriber in another — twice, so the graph
+/// carries A → route → B → route → C.
+#[test]
+fn three_artifacts_compose_into_a_routed_chain() {
+    let r = fleet("chain");
+    let out = hale_stdout(&["fleet", "dump", &plan_of(&r)]);
+    let v: serde_json::Value =
+        serde_json::from_str(&out).expect("fleet artifact parses");
+    let _ = std::fs::remove_dir_all(&r);
+
+    let routed: Vec<(String, String, String)> = v["relations"]["routed"]
+        .as_array()
+        .expect("routed")
+        .iter()
+        .map(|e| {
+            (
+                e["from"].as_str().unwrap_or("").to_string(),
+                e["to"].as_str().unwrap_or("").to_string(),
+                e["route"].as_str().unwrap_or("").to_string(),
+            )
+        })
+        .collect();
+    assert!(
+        routed.contains(&(
+            "prober-0::Probe::submit".into(),
+            "oms-0::Oms::on_intent".into(),
+            "intent".into()
+        )),
+        "A → route → B: {:?}",
+        routed
+    );
+    assert!(
+        routed.contains(&(
+            "oms-0::Oms::on_intent".into(),
+            "gw-0::Gateway::on_order".into(),
+            "request".into()
+        )),
+        "B → route → C: {:?}",
+        routed
+    );
+    // Every vertex is instance-qualified: an application TYPE is not
+    // a deployed instance.
+    for vtx in v["vertices"].as_array().expect("vertices") {
+        let s = vtx.as_str().unwrap_or("");
+        assert!(
+            s.starts_with("prober-0::")
+                || s.starts_with("oms-0::")
+                || s.starts_with("gw-0::"),
+            "unqualified vertex `{}`",
+            s
+        );
+    }
+}
+
+/// The property that separates composition from source-merging:
+/// matching wire identities are COMPATIBILITY, not connection. Two
+/// binaries that both know a topic are not joined unless the plan
+/// routes them.
+#[test]
+fn matching_topics_alone_do_not_create_an_edge() {
+    let r = fleet("noroute");
+    // Same three instances, no routes at all.
+    let plan = PLAN.replace(
+        &PLAN[PLAN.find("\"routes\"").expect("routes")..PLAN.rfind('}').expect("brace")],
+        "\"routes\": []\n",
+    );
+    write(&r, "noroute.plan.json", &plan);
+    let out = hale_stdout(&[
+        "fleet",
+        "dump",
+        r.join("noroute.plan.json").to_str().expect("utf8"),
+    ]);
+    let v: serde_json::Value =
+        serde_json::from_str(&out).expect("parses");
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert!(
+        v["relations"]["routed"].as_array().expect("routed").is_empty(),
+        "every instance declares the same topics, and a source merge \
+         would have joined them — only a route may: {}",
+        out
+    );
+}
+
+/// Criterion 5. The join key is the WIRE identity, so a shared local
+/// name over a different payload shape is not a route.
+#[test]
+fn a_same_subject_different_payload_route_is_rejected() {
+    let r = fleet("wire");
+    // A second gateway whose `Order` carries an extra field: same
+    // subject, different payload hash.
+    write(&r, "lib2/topics.hl", &TOPICS.replace(
+        "type Order  { id: Int; }",
+        "type Order  { id: Int; extra: Int; }",
+    ));
+    write(&r, "gw2/main.hl", &GW.replace("\"../lib\"", "\"../lib2\""));
+    let dst = r.join("artifacts/gw2.json");
+    let (_, code) = hale(&[
+        "check",
+        r.join("gw2").to_str().expect("utf8"),
+        &format!("--dump-topology={}", dst.display()),
+    ]);
+    assert_eq!(code, 0, "gw2 must check clean");
+
+    let plan = PLAN
+        .replace(
+            r#"{"id": "gw-0",     "artifact": "artifacts/gw.json",     "labels": ["gateway"]}"#,
+            r#"{"id": "gw-0", "artifact": "artifacts/gw.json", "labels": []},
+    {"id": "gw2-0", "artifact": "artifacts/gw2.json", "labels": []}"#,
+        )
+        .replace(
+            r#"[{"instance": "gw-0",  "topic": "t::OrderRequest"}]"#,
+            r#"[{"instance": "gw-0", "topic": "t::OrderRequest"},
+                     {"instance": "gw2-0", "topic": "t::OrderRequest"}]"#,
+        );
+    write(&r, "wire.plan.json", &plan);
+    let (out, code) = hale(&[
+        "fleet",
+        "check",
+        r.join("wire.plan.json").to_str().expect("utf8"),
+    ]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert_ne!(code, 0, "incompatible payloads must fail: {}", out);
+    assert!(
+        out.contains("cannot be formed") && out.contains("WIRE identity"),
+        "and say the contracts disagree, naming both hashes: {}",
+        out
+    );
+}
+
+/// A component is a foundation for a certificate, so anything that
+/// cannot be verified is refused rather than trusted.
+#[test]
+fn an_unverifiable_component_is_refused() {
+    let r = fleet("tamper");
+    let p = r.join("artifacts/prober.json");
+    let good = std::fs::read_to_string(&p).expect("read");
+    // Rewrite a wire subject — a `topics` row, which `shape_hash`
+    // does not cover but `artifact_digest` does.
+    std::fs::write(&p, good.replacen("svc.order.intent", "svc.order.EVIL", 1))
+        .expect("write");
+    let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    assert!(out.contains("artifact_digest"), "{}", out);
+}
+
+/// A component whose own law fails is not admissible: local claims
+/// are a precondition of fleet admission.
+#[test]
+fn a_component_whose_own_claims_fail_is_refused() {
+    let r = fleet("verdict");
+    let p = r.join("artifacts/prober.json");
+    let good = std::fs::read_to_string(&p).expect("read");
+    // Simulate a failing component by asking the composer to trust a
+    // verdict it should reject. (Rewriting the file breaks the
+    // digest, so assert the ordering instead: integrity first, then
+    // meaning.)
+    std::fs::write(&p, good.replacen("\"verdict\": \"clean\"", "\"verdict\": \"law_failed\"", 1))
+        .expect("write");
+    let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    // Integrity is checked before meaning, so this reports as a
+    // digest failure — which is correct: an edited artifact is not
+    // evidence of anything, whatever it now says.
+    assert!(
+        out.contains("artifact_digest") || out.contains("verdict"),
+        "{}",
+        out
+    );
+}
+
+#[test]
+fn a_route_naming_an_undeclared_instance_is_rejected() {
+    let r = fleet("ghost");
+    let plan = PLAN.replace(
+        r#"[{"instance": "oms-0",    "topic": "t::OrderIntent"}]"#,
+        r#"[{"instance": "ghost", "topic": "t::OrderIntent"}]"#,
+    );
+    write(&r, "ghost.plan.json", &plan);
+    let (out, code) = hale(&[
+        "fleet",
+        "check",
+        r.join("ghost.plan.json").to_str().expect("utf8"),
+    ]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    assert!(out.contains("does not declare"), "{}", out);
+}
+
+/// Criteria 9 and 10. The fleet identity must move when the deployed
+/// arrangement moves, and stay put when only source locations do.
+#[test]
+fn the_fleet_shape_hash_tracks_the_arrangement_not_provenance() {
+    let r = fleet("hash");
+    let hash_of = |plan: &str| -> String {
+        let out = hale_stdout(&["fleet", "dump", plan]);
+        let v: serde_json::Value =
+            serde_json::from_str(&out).expect("parses");
+        v["fleet_shape_hash"].as_str().unwrap_or("").to_string()
+    };
+    let base = hash_of(&plan_of(&r));
+    assert!(!base.is_empty());
+
+    // (a) provenance-only: a leading comment shifts every span in a
+    // component, and its artifact changes — but the MODEL does not.
+    write(&r, "prober/main.hl", &format!("// shift every span\n{}", PROBER));
+    let dst = r.join("artifacts/prober.json");
+    let (_, code) = hale(&[
+        "check",
+        r.join("prober").to_str().expect("utf8"),
+        &format!("--dump-topology={}", dst.display()),
+    ]);
+    assert_eq!(code, 0);
+    assert_eq!(
+        hash_of(&plan_of(&r)),
+        base,
+        "moving source must not change the deployed arrangement"
+    );
+
+    // (b) a transport change IS the arrangement.
+    write(&r, "t2.plan.json", &PLAN.replacen("\"unix\"", "\"udp\"", 1));
+    assert_ne!(
+        hash_of(r.join("t2.plan.json").to_str().expect("utf8")),
+        base,
+        "a changed transport is a changed fleet"
+    );
+
+    // (c) …and so is instance cardinality.
+    write(
+        &r,
+        "t3.plan.json",
+        &PLAN.replace(
+            r#"{"id": "gw-0",     "artifact": "artifacts/gw.json",     "labels": ["gateway"]}"#,
+            r#"{"id": "gw-0", "artifact": "artifacts/gw.json", "labels": []},
+    {"id": "gw-1", "artifact": "artifacts/gw.json", "labels": []}"#,
+        ),
+    );
+    assert_ne!(
+        hash_of(r.join("t3.plan.json").to_str().expect("utf8")),
+        base,
+        "a second instance of one artifact is a different deployment"
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+#[test]
+fn a_duplicate_instance_id_is_rejected() {
+    let r = fleet("dupid");
+    let plan = PLAN.replace(r#""id": "oms-0""#, r#""id": "prober-0""#);
+    write(&r, "dup.plan.json", &plan);
+    let (out, code) = hale(&[
+        "fleet",
+        "check",
+        r.join("dup.plan.json").to_str().expect("utf8"),
+    ]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    assert!(out.contains("used twice"), "{}", out);
+}
+
+/// An unknown key in a plan is a mistake, not something to ignore —
+/// the same rule the environment manifest follows.
+#[test]
+fn an_unknown_plan_field_is_rejected() {
+    let r = fleet("unknownfield");
+    write(
+        &r,
+        "bad.plan.json",
+        &PLAN.replace("\"name\": \"prod\"", "\"name\": \"prod\", \"transprot\": \"unix\""),
+    );
+    let (out, code) = hale(&[
+        "fleet",
+        "check",
+        r.join("bad.plan.json").to_str().expect("utf8"),
+    ]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "a misspelled plan key must not be ignored: {}", out);
+}

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -508,6 +508,70 @@ a model neither would certify, with nothing in the document revealing
 it. A consumer that does not recognise the value must refuse rather
 than assume equivalence.
 
+## Fleet composition (GH #408 Phase 1)
+
+A **fleet** is a named deployed system of application *instances* —
+not "every main in a repository". `hale fleet check|dump <plan.json>`
+composes **artifacts**, never source.
+
+That distinction is the design. A source-merged "super-main" would be
+unsound in both directions: an unbound topic is in-process by
+default, so merging two binaries makes matching publishers and
+subscribers look locally connected when no deployed route joins them;
+deploy-time routes that exist only in configuration would not appear
+at all; and calls, which cannot cross a process boundary, would
+become ordinary reachability. So **matching wire identities establish
+compatibility; only an explicit route creates a fleet edge.**
+
+A plan names exact, finite instances and routes. Autoscaling ranges
+and wildcard discovery are elaborator inputs, not sealed-plan
+contents: a bounded range is not one truth value for a cardinality
+claim.
+
+```json
+{
+  "schema": "1.0", "name": "prod",
+  "instances": [{"id": "oms-0", "artifact": "artifacts/oms.json", "labels": ["oms"]}],
+  "routes": [{"id": "request", "transport": "unix",
+              "publishers":  [{"instance": "oms-0", "topic": "t::OrderRequest"}],
+              "subscribers": [{"instance": "gw-0",  "topic": "t::OrderRequest"}]}]
+}
+```
+
+Composition:
+
+1. **Validate every component.** Integrity before meaning: the
+   whole-body `artifact_digest` is checked first, because
+   `shape_hash` covers the model half only and cannot vouch for the
+   `topics` rows the join reads. Then the `semantics` version, then
+   the component's own `verdict` — local law is a precondition of
+   fleet admission, and an artifact that fails it is not admissible.
+2. **Namespace under the instance id.** `oms-0::Oms::on_intent`. An
+   application type is not a deployed instance, and cardinality,
+   witnesses and multiple instances of one artifact all need that.
+3. **Retain interiors.** Calls stay strictly within one instance;
+   there is no cross-process call to invent.
+4. **Join on the wire identity** — `(subject, payload_hash)`, never
+   the local topic name, which can mean different shapes in different
+   applications. Endpoints that disagree are a plan that cannot be
+   formed. A topic with no declared `subject:` is not portable and is
+   rejected on a route.
+5. **Insert route edges explicitly**, so a cross-process hop keeps
+   its boundary rather than collapsing into a direct call.
+6. **Propagate unknowns.** Uncertainty in a component stays
+   uncertainty in the fleet: it may add paths, never delete one.
+
+`fleet_shape_hash` covers the model half — instance identities and
+cardinalities, routes and their wire identities, component shape
+hashes, the composed relations. Provenance and unknowns stay outside
+it, mirroring the application artifact's split: moving source must not
+change the identity of a deployment, but a changed transport or a
+second instance must.
+
+Unknown keys in a plan are rejected, for the reason they are rejected
+in the environment manifest: a misspelled field and an omitted one
+look identical to a verifier.
+
 ## Structural & design rules
 
 | Check | Catches | Severity | Enforced by |


### PR DESCRIPTION
Phase 1 of the fleet-claims issue: the FleetPlan IR and composition. No new source grammar — the plan is a JSON IR, so an external generator can produce one without Hale grammar committing to any deployment format.

```sh
hale fleet check prod.plan.json    # compose and validate
hale fleet dump  prod.plan.json    # write the fleet artifact
```

## Composition, not source-merging

The tempting implementation is a super-main that imports every application and runs ordinary claims over the merged source. It is unsound in **both** directions:

- an unbound topic is in-process by default, so merging two binaries makes matching publishers and subscribers look locally connected when **no deployed route joins them**;
- deploy-time routes that exist only in configuration would not appear at all;
- calls cannot cross a process boundary, so flattening turns serialized messaging into ordinary reachability.

So: **matching wire identities establish compatibility; only an explicit route creates a fleet edge.** `matching_topics_alone_do_not_create_an_edge` pins it — three instances all declaring the same topics, no routes, zero edges. That is the property a source merge destroys silently, so it gets a test of its own.

## Working end to end

Three independently compiled artifacts, two routes:

```
prober-0::Probe::submit  -(intent)->   oms-0::Oms::on_intent
oms-0::Oms::on_intent    -(request)->  gw-0::Gateway::on_order
```

Every vertex instance-qualified, since an application *type* is not a deployed instance.

## Validation order is deliberate

**Integrity, then meaning, then law.** The digest is checked first because `shape_hash` covers the model half and *cannot vouch for the `topics` rows the join actually reads* — the gap #407 was written for, now load-bearing. Then `semantics`, since rows can share a shape and mean different things. Then the component's own `verdict`, because local law is a precondition of admission.

Routes join on `(subject, payload_hash)`, never the local topic name:

```
route `request` cannot be formed: `oms-0` sees subject `svc.order.request` /
payload 548ec823…, `gw2-0` sees `svc.order.request` / a349ef14…. Endpoints must
agree on the WIRE identity — a shared local name is not a shared contract
```

A topic with no declared `subject:` is rejected on a route: its wire name is a local, non-portable fallback.

## `fleet_shape_hash`

Covers instance identities and cardinalities, routes and their wire identities, component shape hashes, and the composed relations. Provenance and unknowns sit outside it, mirroring the application artifact's split. Verified in **both** directions:

| change | hash |
|---|---|
| baseline | `f8cac19e73e9c6f4` |
| a comment added to a component | `f8cac19e73e9c6f4` (unchanged) |
| transport `unix` → `udp` | `f1b0b50204c53283` |
| a second gateway instance | `a1bbd42bc4714898` |

## Acceptance criteria

Of #408's fourteen, this covers **1, 2, 5, 8, 9, 10, 12** and the graph half of **3** — the routed chain exists; rendering it as a *witness* is Phase 2. Nine tests in `fleet_compose.rs`, each of the negative controls included: duplicate instance id, undeclared instance in a route, tampered artifact, unknown plan key, incompatible payloads.

## Design note

The module lives in `hale-cli` and is deliberately a **client of the artifact**, not a second source analyzer — it reads exactly what a third party would read, which is the only way "an outside evaluator can replay this" stays true. The issue's §23 suggestion of extracting a shared `hale-model` crate is still open and would be the natural home if a second consumer appears.

## Next

Phase 2: the fleet claim verbs (`forbid reaches`, `avoiding`, `only edges`, `require subscribes/publishes`, endpoint cardinality) over this composed model, with cross-artifact witnesses — which is what Phase 0's source maps exist to make renderable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)