### PR TITLE
fix(fleet): require_subscribes needs a route, not just an endpoint (GH #408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ behavior.
 
 ## Unreleased
 
+### `require_subscribes` needs a route, not just an endpoint (GH #408)
+
+Found by running the fleet checker against a real downstream
+deployment slice rather than a synthetic fixture.
+
+`require_subscribes` / `require_publishes` checked only that some
+instance in the group *exposes* the endpoint. So a plan where the
+ledger subscribes `exec.fill` and nothing in the plan publishes it
+reported `holds` — and the law "fills must reach the ledger" could not
+catch a missing route, which is the one thing it exists for.
+
+Both halves are now required: the endpoint exists **and** a route in
+the plan carries the subject to (or from) it. The diagnostic
+distinguishes the two failures, because "nobody subscribes" and
+"somebody subscribes and nothing connects them" have different fixes.
+
+A synthetic fixture hides this, because whoever writes one routes
+everything they assert. It surfaced only because the real slice's
+publisher sat outside the selected instances — and adding that
+instance makes the claim hold again, which is the round trip that
+confirms the check is not simply always-failing.
+
 ### Fleet claims over the composed model (GH #408 Phase 2)
 
 `forbid_reaches` (with `avoiding`), `only_edges`, `require_subscribes`

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -266,6 +266,11 @@ pub fn compose(plan_path: &Path) -> Result<String, Vec<String>> {
     // ---- steps 4-6: routes ----
     let mut routes_out: Vec<String> = Vec::new();
     let mut route_edges: Vec<(String, String, String)> = Vec::new();
+    // (id, wire subject, publisher instances, subscriber instances) —
+    // what a `require_*` claim needs to ask whether the plan actually
+    // DELIVERS a subject, not merely whether somebody could receive it.
+    let mut resolved_routes: Vec<(String, String, Vec<String>, Vec<String>)> =
+        Vec::new();
     for r in &plan.routes {
         if r.publishers.is_empty() || r.subscribers.is_empty() {
             errs.push(format!(
@@ -358,6 +363,12 @@ pub fn compose(plan_path: &Path) -> Result<String, Vec<String>> {
                 }
             }
         }
+        resolved_routes.push((
+            r.id.clone(),
+            w.subject.clone(),
+            r.publishers.iter().map(|e| e.instance.clone()).collect(),
+            r.subscribers.iter().map(|e| e.instance.clone()).collect(),
+        ));
         routes_out.push(format!(
             "    {{\"id\": {}, \"subject\": {}, \"payload_hash\": {}, \
              \"transport\": {}}}",
@@ -396,7 +407,7 @@ pub fn compose(plan_path: &Path) -> Result<String, Vec<String>> {
     }
     let claim_rows = evaluate_claims(
         &plan, &groups, &comps, &by_id, &call_edges, &local_bus,
-        &route_edges, &mut errs,
+        &route_edges, &resolved_routes, &mut errs,
     );
     if !errs.is_empty() {
         return Err(errs);
@@ -467,6 +478,7 @@ fn evaluate_claims(
     calls: &[(String, String)],
     local_bus: &[(String, String)],
     routed: &[(String, String, String)],
+    resolved_routes: &[(String, String, Vec<String>, Vec<String>)],
     errs: &mut Vec<String>,
 ) -> Vec<String> {
     let inst_of = |v: &str| -> String {
@@ -520,9 +532,9 @@ fn evaluate_claims(
                 }
             }
         } else if let Some(r) = &c.require_subscribes {
-            endpoint_claim(r, groups, comps, false, &c.name, errs)
+            endpoint_claim(r, groups, comps, resolved_routes, false, &c.name, errs)
         } else if let Some(r) = &c.require_publishes {
-            endpoint_claim(r, groups, comps, true, &c.name, errs)
+            endpoint_claim(r, groups, comps, resolved_routes, true, &c.name, errs)
         } else if let Some(k) = &c.count_publisher_instances {
             count_claim(k, comps, true)
         } else if let Some(k) = &c.count_subscriber_instances {
@@ -700,10 +712,21 @@ fn decl_location(a: &serde_json::Value, local: &str) -> Option<String> {
         .and_then(|s| s["path"].as_str().map(str::to_string))
 }
 
+/// `require subscribes/publishes` is a STRUCTURAL DEPLOYMENT
+/// statement: some instance in the group exposes the endpoint **and
+/// the plan connects it**.
+///
+/// Checking only that the endpoint exists was a fail-open, and a real
+/// deployment found it: a slice where the ledger subscribes
+/// `exec.fill` but nothing in the plan publishes it reported `holds`.
+/// The law "fills must reach the ledger" then cannot catch a missing
+/// route, which is the one thing it is for. A synthetic fixture hides
+/// this because whoever writes it routes everything they assert.
 fn endpoint_claim(
     r: &RequireEndpoint,
     groups: &BTreeMap<String, BTreeSet<String>>,
     comps: &[Component],
+    resolved_routes: &[(String, String, Vec<String>, Vec<String>)],
     publishing: bool,
     claim: &str,
     errs: &mut Vec<String>,
@@ -716,19 +739,45 @@ fn endpoint_claim(
         ));
         return ("invalid", String::new());
     };
-    let found = comps.iter().any(|c| {
-        g.contains(&c.id) && has_endpoint(&c.artifact, &r.subject, publishing)
+    let verb = if publishing { "publishes" } else { "subscribes" };
+    let exposing: Vec<&str> = comps
+        .iter()
+        .filter(|c| {
+            g.contains(&c.id)
+                && has_endpoint(&c.artifact, &r.subject, publishing)
+        })
+        .map(|c| c.id.as_str())
+        .collect();
+    if exposing.is_empty() {
+        return (
+            "violated",
+            format!("no instance in `{}` {} `{}`", r.group, verb, r.subject),
+        );
+    }
+    // …and a route must actually carry it to (or from) one of them.
+    let connected = resolved_routes.iter().any(|(_, subj, pubs, subs)| {
+        subj == &r.subject
+            && {
+                let side = if publishing { pubs } else { subs };
+                side.iter().any(|i| exposing.contains(&i.as_str()))
+            }
+            // a route with an empty other side delivers nothing
+            && !pubs.is_empty()
+            && !subs.is_empty()
     });
-    if found {
+    if connected {
         ("holds", String::new())
     } else {
         (
             "violated",
             format!(
-                "no instance in `{}` {} `{}`",
-                r.group,
-                if publishing { "publishes" } else { "subscribes" },
-                r.subject
+                "`{}` {} `{}`, but no route in this plan carries it {} \
+                 them — the endpoint exists and nothing connects it, so \
+                 the traffic this claim is about does not flow",
+                exposing.join(", "),
+                verb,
+                r.subject,
+                if publishing { "from" } else { "to" }
             ),
         )
     }

--- a/crates/hale-cli/tests/fleet_compose.rs
+++ b/crates/hale-cli/tests/fleet_compose.rs
@@ -678,3 +678,59 @@ fn an_empty_or_unknown_group_is_an_error() {
         out
     );
 }
+
+/// A downstream conformance run found this: `require_subscribes`
+/// checked only that the endpoint EXISTS, so a plan where the ledger
+/// subscribes `exec.fill` and nothing publishes it reported `holds`.
+///
+/// The law "fills must reach the ledger" then cannot catch a missing
+/// route, which is the one thing it is for. A synthetic fixture hides
+/// it because whoever writes one routes everything they assert — this
+/// only surfaced against a real deployment slice whose publisher
+/// happened to sit outside the selected instances.
+#[test]
+fn require_subscribes_needs_a_route_not_just_an_endpoint() {
+    let r = fleet("unrouted");
+    // The gateway subscribes `svc.order.request` and the OMS
+    // publishes it — but the plan carries only the intent route, so
+    // nothing delivers order requests.
+    let plan = with_claims(PLAN, "")
+        .replace(
+            r#",
+    {"id": "request", "transport": "unix",
+     "publishers":  [{"instance": "oms-0", "topic": "t::OrderRequest"}],
+     "subscribers": [{"instance": "gw-0",  "topic": "t::OrderRequest"}]}"#,
+            "",
+        );
+    write(&r, "unrouted.plan.json", &plan);
+    let (out, code) = hale(&[
+        "fleet",
+        "check",
+        r.join("unrouted.plan.json").to_str().expect("utf8"),
+    ]);
+
+    assert_ne!(
+        code, 0,
+        "the endpoint exists but nothing routes to it — the claim is \
+         about traffic, and no traffic flows: {}",
+        out
+    );
+    assert!(
+        out.contains("gw_receives_orders")
+            && out.contains("no route in this plan carries it"),
+        "and the failure must say the endpoint is unconnected rather \
+         than absent: {}",
+        out
+    );
+
+    // Control: with the route restored it holds, so the check is not
+    // simply rejecting every require_subscribes.
+    write(&r, "routed.plan.json", &with_claims(PLAN, ""));
+    let (out2, code2) = hale(&[
+        "fleet",
+        "check",
+        r.join("routed.plan.json").to_str().expect("utf8"),
+    ]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_eq!(code2, 0, "the routed plan still passes: {}", out2);
+}

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -605,8 +605,11 @@ set.
   address. There are no cross-process calls to grant.
 - **`require_subscribes` / `require_publishes`** are structural
   deployment statements: some instance in the group exposes the
-  endpoint. "Ledger listens for fills" is provable; "every fill is
-  durably booked" is not implied by it.
+  endpoint **and the plan connects it**. Both halves are load-bearing
+  — checking only that the endpoint exists lets a plan where nothing
+  publishes a subject satisfy "the ledger receives fills", which is
+  the one thing that claim is for. "Ledger listens for fills" is
+  provable; "every fill is durably booked" is not implied by it.
 - **`count_publisher_instances` / `count_subscriber_instances`**
   count instance-qualified **endpoints**, which is a different sort
   from the application tier's declaration count — hence the different


### PR DESCRIPTION
Found by the downstream conformance run (#408 Phase 3) — against a real deployment slice, not a fixture I wrote.

## The fail-open

`require_subscribes` / `require_publishes` checked only that some instance in the group **exposes** the endpoint. So this passed:

```
ledger-0 subscribes exec.fill        ✓ endpoint exists
nothing in the plan publishes it     ✗ no route carries it
→ ledger_receives_fills: holds
```

The law "fills must reach the ledger" therefore could not catch a missing route, which is the one thing it exists for. In an incident, that's the check that was supposed to notice the ledger stopped receiving fills.

The proposal specified both halves — "at least one selected instance exposes the required endpoint **and is connected by the plan**" — and I implemented one.

## Why a synthetic fixture could never find it

Whoever writes a fixture routes everything they assert. My Phase 2 tests all had the route present, so `require_subscribes` was never exercised against an unrouted endpoint.

The real slice surfaced it by accident of scope: `exec.fill` is published by a service that wasn't in the four instances I selected, so the subject had subscribers and no publisher. That is a completely ordinary situation in a real deployment and does not occur in a fixture.

## The round trip

```
4-instance slice, exec.fill unrouted   → violated, "no route in this plan carries it to them"
add the real publisher instance        → 18 routes, exec.fill routed, holds again
```

The second half matters: it confirms the check isn't simply always-failing.

## The fix

Endpoint existence **and** a route carrying that subject to (or from) it. The diagnostic separates the two failures, because "nobody subscribes" and "somebody subscribes and nothing connects them" have different fixes:

```
`ledger-0` subscribes `exec.fill`, but no route in this plan carries it to them —
the endpoint exists and nothing connects it, so the traffic this claim is about
does not flow
```

One regression test with both directions. Ran `fleet_compose` (15), and the composition still passes on the corrected real slice.

## Conformance harness

Lives downstream (not in this repo), and derives the plan from the bus configs that are already the source of truth for routes — so the hand-maintained topology document can be generated from, or checked against, a certified plan instead of mirrored by hand.

One caveat worth recording, because it cost me a wrong result first: the checker validates each artifact and the routes between them, but **cannot know that an artifact is the service whose routes live in a given config**. I initially paired the execution gateway's artifact with the market-data gateway's config and got a wrong-but-plausible model — 13 routes that composed fine and claims that all passed. Pairing is the plan generator's responsibility, and a surprising result is worth a second look at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)