### PR TITLE
feat(fleet): check every declared deployment (GH #408 Phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,34 @@ everything they assert. It surfaced only because the real slice's
 publisher sat outside the selected instances — and adding that
 instance makes the claim hold again, which is the round trip that
 confirms the check is not simply always-failing.
+### `[fleets]`: check every declared deployment (GH #408 Phase 5)
+
+```toml
+[fleets]
+production = "ops/fleet/prod.plan.json"
+staging    = "ops/fleet/staging.plan.json"
+```
+
+`hale fleet check` with no plan now checks every deployment the
+workspace declares. A repository usually has more than one, and
+checking whichever one somebody remembered to name is the same
+partial-coverage problem `--matrix` solves for entrypoints. Every
+fleet runs even when an earlier one fails; the exit status is the
+worst of them, so a missing plan is not masked by an ordinary claim
+failure elsewhere. A workspace declaring no `[fleets]` is a usage
+error rather than a vacuous success.
+
+`[fleets]` and `[environments]` are **separate axes**. An environment
+binds law to an entrypoint at the application tier; a fleet is an
+arrangement of deployed instances. A workspace may declare both, and
+`production` in one need not mean `production` in the other —
+collapsing them would force every entrypoint's law to be a function of
+some deployment it may not even appear in.
+
+There is deliberately no coverage check over plans: unlike
+entrypoints, which are discoverable seeds, a plan is an arbitrary file
+path, so "every plan in the repository is declared" cannot be asked
+without guessing.
 
 ### Fleet claims over the composed model (GH #408 Phase 2)
 

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2509,6 +2509,98 @@ fn file_of_span(
 /// following token would make `hale check --dump-topology app.hl`
 /// ambiguous — is `app.hl` the artifact destination or the target? —
 /// and flags are supposed to be positionable on either side.
+/// Check every deployment declared in `[fleets]`.
+///
+/// Separate from `--matrix`, which is the ENTRYPOINT x ENVIRONMENT
+/// axis. A fleet is an arrangement of deployed instances; an
+/// environment is law bound to an entrypoint. A workspace declares
+/// both, and `production` in one need not mean `production` in the
+/// other.
+fn run_fleet_all() -> ExitCode {
+    let cwd =
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let mut dir = cwd.canonicalize().unwrap_or(cwd);
+    let manifest = loop {
+        let m = dir.join("hale.toml");
+        if m.exists() {
+            break Some(m);
+        }
+        match dir.parent() {
+            Some(p) => dir = p.to_path_buf(),
+            None => break None,
+        }
+    };
+    let Some(manifest) = manifest else {
+        eprintln!(
+            "`hale fleet check` with no plan checks every fleet in \
+             `[fleets]`, and no `hale.toml` was found at or above the \
+             current directory. Name a plan explicitly, or add one."
+        );
+        return ExitCode::from(2);
+    };
+    let fleets = match crate::pkg::read_fleets(&manifest) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("{}", e);
+            return ExitCode::from(2);
+        }
+    };
+    if fleets.is_empty() {
+        eprintln!(
+            "{} declares no `[fleets]`. Add `<name> = \"<plan path>\"` \
+             entries, or name a plan explicitly — reporting success for \
+             zero deployments would say nothing.",
+            manifest.display()
+        );
+        return ExitCode::from(2);
+    }
+    let base = manifest.parent().unwrap_or(Path::new(".")).to_path_buf();
+
+    let mut failed: Vec<(String, u8)> = Vec::new();
+    for (name, rel) in &fleets {
+        let path = base.join(rel);
+        println!("=== fleet `{}` ({}) ===", name, path.display());
+        if !path.exists() {
+            eprintln!("  plan not found: {}", path.display());
+            failed.push((name.clone(), 2));
+            continue;
+        }
+        // Every fleet runs. Stopping at the first failure would report
+        // a subset of the deployments as if it were all of them.
+        match fleet::compose(&path) {
+            Ok(artifact) => {
+                let v: serde_json::Value =
+                    serde_json::from_str(&artifact).unwrap_or_default();
+                println!(
+                    "  ok — {} instance(s), {} route(s), fleet_shape_hash {}",
+                    v["instances"].as_array().map(|a| a.len()).unwrap_or(0),
+                    v["routes"].as_array().map(|a| a.len()).unwrap_or(0),
+                    v["fleet_shape_hash"].as_str().unwrap_or("?")
+                );
+            }
+            Err(errs) => {
+                for e in &errs {
+                    eprintln!("  {}", e);
+                }
+                failed.push((name.clone(), 1));
+            }
+        }
+    }
+
+    println!();
+    if failed.is_empty() {
+        println!("ok: {} fleet(s) checked", fleets.len());
+        return ExitCode::SUCCESS;
+    }
+    eprintln!("{} of {} fleet(s) failed:", failed.len(), fleets.len());
+    for (n, _) in &failed {
+        eprintln!("  {}", n);
+    }
+    // Worst code wins, so a missing plan is not masked by an ordinary
+    // claim failure elsewhere.
+    ExitCode::from(failed.iter().map(|(_, c)| *c).max().unwrap_or(1))
+}
+
 /// `hale fleet check <plan>` / `hale fleet dump <plan>`.
 ///
 /// `check` composes and reports; `dump` writes the fleet artifact.
@@ -2518,12 +2610,22 @@ fn file_of_span(
 fn run_fleet(rest: &[String]) -> ExitCode {
     let sub = rest.first().map(String::as_str);
     let plan = rest.get(1);
+    // GH #408 Phase 5: `hale fleet check` with no plan checks EVERY
+    // deployment the workspace declares. A repository usually has
+    // more than one — production, staging, a reconciliation
+    // arrangement — and checking whichever one you remembered to name
+    // is the same partial-coverage problem `--matrix` solves for
+    // entrypoints.
+    if sub == Some("check") && plan.is_none() {
+        return run_fleet_all();
+    }
     let (sub, plan) = match (sub, plan) {
         (Some("check"), Some(p)) | (Some("dump"), Some(p)) => {
             (sub.unwrap(), p)
         }
         _ => {
-            eprintln!("hale fleet check <plan.json>    compose and check");
+            eprintln!("hale fleet check [plan.json]   compose and check");
+            eprintln!("                                (no plan: every fleet in [fleets])");
             eprintln!("hale fleet dump  <plan.json>    write the fleet artifact");
             eprintln!();
             eprintln!("A plan names exact application INSTANCES and the");

--- a/crates/hale-cli/src/pkg.rs
+++ b/crates/hale-cli/src/pkg.rs
@@ -74,6 +74,18 @@ pub struct Manifest {
     /// violation after the fact.
     #[serde(default)]
     pub claims: ClaimsManifest,
+    /// GH #408 Phase 5: `[fleets] <name> = "<plan path>"` — the
+    /// deployments this workspace declares.
+    ///
+    /// Deliberately a SEPARATE axis from `[environments]`. An
+    /// environment binds law to an entrypoint at the application
+    /// tier; a fleet is an arrangement of deployed instances. A
+    /// workspace can have a `production` environment and a
+    /// `production` fleet that mean different things, and collapsing
+    /// them would force every entrypoint's law to be a function of
+    /// some deployment it might not even appear in.
+    #[serde(default)]
+    pub fleets: BTreeMap<String, String>,
 }
 
 /// The `[claims]` section.
@@ -533,4 +545,19 @@ pub fn read_claims_config(
         }
     }
     Ok((m.environments, m.claims.base))
+}
+
+/// GH #408 Phase 5: the `[fleets]` table — name → plan path,
+/// relative to the manifest.
+pub fn read_fleets(
+    manifest: &Path,
+) -> Result<BTreeMap<String, String>, String> {
+    if !manifest.exists() {
+        return Ok(BTreeMap::new());
+    }
+    let src = fs::read_to_string(manifest)
+        .map_err(|e| format!("read {}: {}", manifest.display(), e))?;
+    let m: Manifest = toml::from_str(&src)
+        .map_err(|e| format!("parse {}: {}", manifest.display(), e))?;
+    Ok(m.fleets)
 }

--- a/crates/hale-cli/tests/fleet_compose.rs
+++ b/crates/hale-cli/tests/fleet_compose.rs
@@ -734,3 +734,115 @@ fn require_subscribes_needs_a_route_not_just_an_endpoint() {
     let _ = std::fs::remove_dir_all(&r);
     assert_eq!(code2, 0, "the routed plan still passes: {}", out2);
 }
+
+// =====================================================================
+// Phase 5: the workspace's declared deployments
+// =====================================================================
+
+/// A repository usually has more than one deployment — production,
+/// staging, a reconciliation arrangement. Checking whichever one you
+/// remembered to name is the same partial-coverage problem `--matrix`
+/// solves for entrypoints, so `hale fleet check` with no plan checks
+/// every fleet the workspace declares.
+fn hale_in(cwd: &Path, args: &[&str]) -> (String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .expect("run hale");
+    (
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn fleet_check_with_no_plan_checks_every_declared_deployment() {
+    let r = fleet("allfleets");
+    write(&r, "staging.plan.json", &PLAN.replace("\"prod\"", "\"staging\""));
+    write(
+        &r,
+        "hale.toml",
+        "[deps]\n\n[fleets]\nproduction = \"prod.plan.json\"\nstaging = \"staging.plan.json\"\n",
+    );
+    let (out, code) = hale_in(&r, &["fleet", "check"]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert_eq!(code, 0, "{}", out);
+    assert!(out.contains("2 fleet(s) checked"), "{}", out);
+    assert!(
+        out.contains("fleet `production`") && out.contains("fleet `staging`"),
+        "each deployment must be named as it is checked: {}",
+        out
+    );
+}
+
+/// One broken deployment must not hide the others, and the worst exit
+/// code wins so a missing plan is not masked by an ordinary claim
+/// failure elsewhere.
+#[test]
+fn a_missing_plan_fails_without_hiding_the_rest() {
+    let r = fleet("missingplan");
+    write(
+        &r,
+        "hale.toml",
+        "[deps]\n\n[fleets]\nproduction = \"prod.plan.json\"\nghost = \"nope.plan.json\"\n",
+    );
+    let (out, code) = hale_in(&r, &["fleet", "check"]);
+    let _ = std::fs::remove_dir_all(&r);
+
+    assert_eq!(code, 2, "a missing plan is a usage error: {}", out);
+    assert!(out.contains("plan not found"), "{}", out);
+    assert!(
+        out.contains("fleet `production`"),
+        "the healthy deployment must still have been checked: {}",
+        out
+    );
+}
+
+/// Reporting success for zero deployments would say nothing.
+#[test]
+fn a_workspace_with_no_declared_fleets_is_a_usage_error() {
+    let r = fleet("nofleets");
+    write(&r, "hale.toml", "[deps]\n");
+    let (out, code) = hale_in(&r, &["fleet", "check"]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_eq!(code, 2, "{}", out);
+    assert!(out.contains("declares no `[fleets]`"), "{}", out);
+}
+
+/// Fleets and environments are separate axes: a fleet is an
+/// arrangement of deployed instances, an environment is law bound to
+/// an entrypoint. Declaring both must not make either ambiguous, and
+/// a name may appear in both meaning different things.
+#[test]
+fn fleets_and_environments_are_independent_axes() {
+    let r = fleet("axes");
+    write(
+        &r,
+        "hale.toml",
+        "[claims]\nno_base = true\n\n\
+         [environments.production]\nsource_only = true\n\
+         entrypoints = [\"prober\", \"oms\", \"gw\"]\n\n\
+         [fleets]\nproduction = \"prod.plan.json\"\n",
+    );
+    // The fleet axis works…
+    let (out, code) = hale_in(&r, &["fleet", "check"]);
+    assert_eq!(code, 0, "fleet axis: {}", out);
+    assert!(out.contains("1 fleet(s) checked"), "{}", out);
+
+    // …and the entrypoint x environment axis works over the same
+    // manifest, with `production` meaning something different.
+    let (out2, code2) = hale_in(&r, &["check", "--matrix"]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_eq!(
+        code2, 0,
+        "the environment axis is unaffected by the fleets table: {}",
+        out2
+    );
+    assert!(out2.contains("pair(s) checked"), "{}", out2);
+}

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -572,6 +572,32 @@ Unknown keys in a plan are rejected, for the reason they are rejected
 in the environment manifest: a misspelled field and an omitted one
 look identical to a verifier.
 
+### The workspace's deployments
+
+```toml
+[fleets]
+production = "ops/fleet/prod.plan.json"
+staging    = "ops/fleet/staging.plan.json"
+```
+
+`hale fleet check` with no plan checks every declared deployment.
+A repository usually has more than one, and checking whichever one
+somebody remembered to name is the same partial-coverage problem
+`--matrix` solves for entrypoints. Every fleet runs even when an
+earlier one fails, and the exit status is the worst of them.
+
+`[fleets]` and `[environments]` are **separate axes** and a workspace
+may declare both. An environment binds law to an ENTRYPOINT at the
+application tier; a fleet is an ARRANGEMENT of deployed instances.
+`production` in one need not mean `production` in the other, and
+collapsing them would force every entrypoint's law to be a function
+of some deployment it may not even appear in.
+
+There is deliberately no coverage check over plans — unlike
+entrypoints, which are discoverable seeds, a plan is an arbitrary
+file path, so "every plan in the repository is declared" is not a
+question that can be asked without guessing.
+
 ### Fleet claims (GH #408 Phase 2)
 
 Claims over the composed model, carried in the plan as normalized


### PR DESCRIPTION
Phase 5 — the workspace's deployment matrix. Small and mechanical, now that you've confirmed the axes are orthogonal.

```toml
[fleets]
production = "ops/fleet/prod.plan.json"
staging    = "ops/fleet/staging.plan.json"
```

```sh
hale fleet check              # every declared deployment
hale fleet check prod.json    # one, as before
```

## Why it exists

A repository usually has more than one deployment, and checking whichever one somebody remembered to name is the same partial-coverage problem `--matrix` solves for entrypoints.

Same discipline as everywhere else in this area: every fleet runs even when an earlier one fails, and the exit status is the **worst** of them, so a missing plan (exit 2) is not masked by an ordinary claim failure (exit 1) elsewhere. A workspace declaring no `[fleets]` is a usage error — reporting success for zero deployments would say nothing.

## The axes stay separate

`[fleets]` and `[environments]` are independent, per your call:

- an **environment** binds law to an *entrypoint*, at the application tier
- a **fleet** is an *arrangement of deployed instances*

A workspace declares both, and `production` in one need not mean `production` in the other. `fleets_and_environments_are_independent_axes` pins that with a manifest declaring both under the same name, checking each axis works over it.

Collapsing them would force every entrypoint's law to be a function of some deployment it may not even appear in — the library that ships in three fleets and belongs to none of them being the obvious case.

## One deliberate omission

**No coverage check over plans.** Unlike entrypoints, which are discoverable seeds, a plan is an arbitrary file path — so "every plan in the repository is declared" cannot be asked without guessing, and a guess here produces noise rather than a gate.

That's a real asymmetry with `--matrix`, where the unbound-entrypoint error is one of the more valuable things it does. Worth stating explicitly rather than leaving someone to wonder why the analogous check is missing.

## Verified against real plans

Exercised on the downstream deployment slice from the conformance run — two declared fleets over five real instances and 18 routes derived from actual bus configs, plus the missing-plan and no-fleets paths.

Four new tests (19 in the file). Also ran `env_matrix` (28), `workspace_check` (7), `check_arg_parsing` (6), `source_map` (6).

## Rebase note

Rebasing onto #423 produced a conflict in the test file that my resolution mis-merged — it swallowed a closing brace, and the file no longer compiled. Caught by the build, fixed, and the suite re-run. Flagging it because a keep-both-sides resolution on two adjacent test additions is exactly the kind of thing that can also produce something that compiles and is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)