### PR TITLE
fix: four defects — DI reset at fn entry, fallible-method scratch ordering, vacuous count claims, mislabelled multi-hop witnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,54 @@ behavior.
 
 ## Unreleased
 
+### A fallible method no longer frees the loci it is about to dissolve
+
+A free-fn factory allocates its locus out of the caller's published
+arena, and a method publishes its own per-call scratch subregion. So a
+factory result let-bound inside a method frame has its struct living
+in that scratch — and the binding owns it, so the frame's exit
+dissolves it by loading its `__arena` field and destroying that arena.
+
+The **fallible** method epilogue destroyed the scratch *before*
+running those dissolves, so the dissolve read a locus struct out of
+freed — and, via the subregion freelist, possibly recycled — memory
+and handed whatever it found to `lotus_arena_destroy`. Every other
+epilogue already flushed first; this one alone had the two reversed.
+
+The bug needed all three of: a locus method, declared `fallible`, that
+let-binds a factory result. A downstream handoff hit exactly that
+shape — a trainer whose `fit(...) -> () fallible(E)` preallocated two
+row buffers — and segfaulted at method exit *after* computing entirely
+correct results, which is the worst way for this to present. It is a
+latent use-after-free rather than a reliable crash: at small sizes the
+freed bytes still hold the old contents and the program exits 0, so
+the regression test asserts on the emitted order rather than waiting
+for a segfault.
+
+### Three levels of locus nesting compile again
+
+A function's prologue — entry-block allocas, deferred-dissolve slots,
+the method scratch arena, the caller-arena snapshot — is emitted
+before the body's first statement establishes a debug location, so it
+inherited whatever location the *previously emitted* function left
+live. LLVM rejects that module outright:
+
+```
+!dbg attachment points at wrong subprogram for function
+```
+
+Debug info is always on, so this was a hard build failure with no
+workaround but restructuring the program. It reproduced on three
+levels of locus nesting where the middle one calls a free-fn factory
+(`Demo.go` → `Trainer.fit` → `Model.train_step`); two levels survived
+only because nothing had left a location live across the boundary.
+
+The reset existed on the free-fn path and on none of the twelve other
+function-body entry points. It is now one helper called at every
+entry, and `di_entry_reset_is_universal` fails the build if a new
+entry point forgets it — the gap was invisible for months precisely
+because nothing enforced it.
+
 ### `require_subscribes` needs a route, not just an endpoint (GH #408)
 
 Found by running the fleet checker against a real downstream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ behavior.
 
 ## Unreleased
 
+### A cardinality claim must name a bound (GH #408)
+
+`count_publisher_instances` / `count_subscriber_instances` with no
+`eq`, `min` or `max` compared nothing: every bound defaults to true
+when absent, so the claim held against any fleet whatsoever while
+reading like real law in review. A claim naming no *verb* was already
+refused; a verb naming no *bound* is the same emptiness one level
+down and now gets the same answer.
+
+### A multi-hop fleet witness names the route of each hop (GH #408)
+
+Route labels in a witness were shifted the wrong way — each node
+carried its OUTGOING route rather than the one it was entered by. On
+a two-node witness the fallback happened to produce the right answer,
+which is why every existing witness test passed; a three-node witness
+labelled *both* hops with the last route, sending a reader to the
+wrong route entry and, in a real deployment, the wrong config file.
+
 ### A fallible method no longer frees the loci it is about to dissolve
 
 A free-fn factory allocates its locus out of the caller's published

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -536,8 +536,14 @@ fn evaluate_claims(
         } else if let Some(r) = &c.require_publishes {
             endpoint_claim(r, groups, comps, resolved_routes, true, &c.name, errs)
         } else if let Some(k) = &c.count_publisher_instances {
+            if !bounded(k, &c.name, errs) {
+                continue;
+            }
             count_claim(k, comps, true)
         } else if let Some(k) = &c.count_subscriber_instances {
+            if !bounded(k, &c.name, errs) {
+                continue;
+            }
             count_claim(k, comps, false)
         } else if let Some(oe) = &c.only_edges {
             let (Some(src), Some(dst)) = (
@@ -637,14 +643,26 @@ fn bfs(
                 at = prev.clone();
             }
             path.reverse();
-            // shift the route labels so each names the hop INTO the
-            // node that follows it
+            // Reconstruction pairs each node with the route on its
+            // OUTGOING edge (parent[at] carries the route INTO `at`,
+            // and it is pushed alongside the predecessor). The
+            // renderer wants the route INTO each node, so every label
+            // shifts one position forward: node i is entered by the
+            // edge leaving node i-1.
+            //
+            // This read `path[i].1` first — node i's OUTGOING route —
+            // and only fell back to `path[i - 1].1`. On a two-node
+            // path the fallback is always taken (the destination has
+            // no outgoing edge) and the answer came out right, which
+            // is why every single-hop witness looked correct. A
+            // three-node witness labelled BOTH hops with the second
+            // route, sending a reader to the wrong route entry.
             let mut out: Vec<(String, Option<String>)> = Vec::new();
             for (i, (n, _)) in path.iter().enumerate() {
                 let via = if i == 0 {
                     None
                 } else {
-                    path[i].1.clone().or_else(|| path[i - 1].1.clone())
+                    path[i - 1].1.clone()
                 };
                 out.push((n.clone(), via));
             }
@@ -781,6 +799,26 @@ fn endpoint_claim(
             ),
         )
     }
+}
+
+/// A cardinality claim must actually bound something.
+///
+/// With `eq`/`min`/`max` all absent every comparison defaults to
+/// true, so the claim held against any fleet whatsoever — a
+/// `count_publisher_instances` naming only a subject read like a
+/// real law and asserted nothing. A claim naming NO verb was already
+/// refused; a verb naming no bound is the same emptiness one level
+/// down, and gets the same answer rather than a silent pass.
+fn bounded(k: &CountSpec, name: &str, errs: &mut Vec<String>) -> bool {
+    if k.eq.is_none() && k.min.is_none() && k.max.is_none() {
+        errs.push(format!(
+            "claim `{}` counts `{}` but names no bound — give it \
+             one of eq, min, max",
+            name, k.subject
+        ));
+        return false;
+    }
+    true
 }
 
 fn count_claim(

--- a/crates/hale-cli/tests/fleet_claim_shapes.rs
+++ b/crates/hale-cli/tests/fleet_claim_shapes.rs
@@ -1,0 +1,392 @@
+//! Fleet claim shapes: the ways a claim can be well-formed and still
+//! assert nothing, and the ways a plan can disagree with the
+//! artifacts it names.
+//!
+//! `fleet_compose.rs` covers each verb doing its job. This file
+//! covers the adversarial complement — a claim that parses, names a
+//! real verb, and quietly holds against every possible fleet is worse
+//! than no claim at all, because it reads like law in review.
+//!
+//! Two defects were found writing it, and both had the same shape:
+//! the check existed and the degenerate case slipped past it.
+//!
+//!  - a `count_*_instances` naming no `eq`/`min`/`max` held against
+//!    anything (every comparison defaults to true when its bound is
+//!    absent), even though a claim naming no VERB was already an
+//!    error;
+//!  - a witness of three or more nodes labelled every hop with the
+//!    LAST route, because the route labels were shifted the wrong
+//!    way. Two-node witnesses came out right by accident, and every
+//!    existing witness test was two-node.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn root(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir()
+        .join(format!("hale_fcs_{}_{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&d);
+    d
+}
+
+fn write(root: &Path, rel: &str, src: &str) {
+    let p = root.join(rel);
+    std::fs::create_dir_all(p.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&p, src).expect("write");
+}
+
+fn hale(args: &[&str]) -> (String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(args)
+        .output()
+        .expect("run hale");
+    (
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+const TOPICS: &str = r#"
+type Intent { id: Int; }
+type Order  { id: Int; }
+topic OrderIntent  { payload: Intent; subject: "svc.order.intent"; }
+topic OrderRequest { payload: Order;  subject: "svc.order.request"; }
+"#;
+
+const PROBER: &str = r#"
+import "../lib" as t;
+locus Probe {
+    params { n: Int = 0; }
+    bus { publish t::OrderIntent; }
+    fn submit() { let i = t::Intent { id: 1 }; t::OrderIntent <- i; }
+}
+main locus Prober { params { p: Probe = Probe { }; } }
+fn main() { Prober { }; }
+"#;
+
+const OMS: &str = r#"
+import "../lib" as t;
+locus Oms {
+    params { n: Int = 0; }
+    bus { subscribe t::OrderIntent as on_intent; publish t::OrderRequest; }
+    fn on_intent(i: t::Intent) {
+        self.n = i.id;
+        let o = t::Order { id: i.id };
+        t::OrderRequest <- o;
+    }
+}
+main locus OmsApp { params { o: Oms = Oms { }; } }
+fn main() { OmsApp { }; }
+"#;
+
+const GW: &str = r#"
+import "../lib" as t;
+locus Gateway {
+    params { n: Int = 0; }
+    bus { subscribe t::OrderRequest as on_order; }
+    fn on_order(o: t::Order) { self.n = o.id; }
+}
+main locus GwApp { params { g: Gateway = Gateway { }; } }
+fn main() { GwApp { }; }
+"#;
+
+/// The two real routes: prober -[intent]-> oms -[request]-> gw.
+const ROUTES: &str = r#"[
+    {"id": "intent", "transport": "unix",
+     "publishers":  [{"instance": "prober-0", "topic": "t::OrderIntent"}],
+     "subscribers": [{"instance": "oms-0",    "topic": "t::OrderIntent"}]},
+    {"id": "request", "transport": "unix",
+     "publishers":  [{"instance": "oms-0", "topic": "t::OrderRequest"}],
+     "subscribers": [{"instance": "gw-0",  "topic": "t::OrderRequest"}]}]"#;
+
+const INSTANCES: &str = r#"[
+    {"id": "prober-0", "artifact": "artifacts/prober.json", "labels": ["strategy"]},
+    {"id": "oms-0",    "artifact": "artifacts/oms.json",    "labels": ["oms"]},
+    {"id": "gw-0",     "artifact": "artifacts/gw.json",     "labels": ["gateway"]}]"#;
+
+const GROUPS: &str = r#"{
+    "strategy": {"labels": ["strategy"]},
+    "oms":      {"labels": ["oms"]},
+    "gateway":  {"labels": ["gateway"]}}"#;
+
+/// Three artifacts built once per test.
+fn fixture(tag: &str) -> PathBuf {
+    let r = root(tag);
+    write(&r, "lib/topics.hl", TOPICS);
+    write(&r, "prober/main.hl", PROBER);
+    write(&r, "oms/main.hl", OMS);
+    write(&r, "gw/main.hl", GW);
+    write(&r, "hale.toml", "[deps]\n");
+    for app in ["prober", "oms", "gw"] {
+        let dst = r.join(format!("artifacts/{}.json", app));
+        std::fs::create_dir_all(dst.parent().expect("parent")).expect("mkdir");
+        let (out, code) = hale(&[
+            "check",
+            r.join(app).to_str().expect("utf8"),
+            &format!("--dump-topology={}", dst.display()),
+        ]);
+        assert_eq!(code, 0, "component `{}` must check clean: {}", app, out);
+    }
+    r
+}
+
+/// Write a plan with the standard instances/groups and the given
+/// routes + claims, then check it.
+fn check_with(
+    r: &Path,
+    routes: &str,
+    claims: &str,
+) -> (String, i32) {
+    let plan = format!(
+        r#"{{"schema": "1.0", "name": "prod",
+            "instances": {INSTANCES},
+            "routes": {routes},
+            "groups": {GROUPS},
+            "claims": {claims}}}"#
+    );
+    write(r, "plan.json", &plan);
+    hale(&["fleet", "check", r.join("plan.json").to_str().expect("utf8")])
+}
+
+// ---------------------------------------------------------------
+// Degenerate claim shapes
+// ---------------------------------------------------------------
+
+/// A cardinality claim with no bound compared nothing and held
+/// against every fleet. It now gets the same answer as a claim naming
+/// no verb: an error, not a pass.
+#[test]
+fn a_count_claim_with_no_bound_is_refused() {
+    let r = fixture("nobound");
+    for verb in ["count_publisher_instances", "count_subscriber_instances"] {
+        let (out, code) = check_with(
+            &r,
+            ROUTES,
+            &format!(
+                r#"[{{"name": "vacuous",
+                      "{verb}": {{"subject": "svc.order.request"}}}}]"#
+            ),
+        );
+        assert_eq!(
+            code, 1,
+            "`{verb}` with no eq/min/max asserts nothing and must not \
+             pass: {out}"
+        );
+        assert!(
+            out.contains("names no bound"),
+            "the diagnostic should say what is missing: {out}"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// The bounded forms still work — the guard rejects emptiness, not
+/// cardinality claims in general.
+#[test]
+fn every_bound_form_still_evaluates() {
+    let r = fixture("bounds");
+    // exactly one instance publishes svc.order.request (oms-0).
+    for (bound, want_code) in [
+        (r#""eq": 1"#, 0),
+        (r#""eq": 2"#, 1),
+        (r#""min": 1"#, 0),
+        (r#""min": 2"#, 1),
+        (r#""max": 1"#, 0),
+        (r#""max": 0"#, 1),
+        (r#""min": 1, "max": 1"#, 0),
+    ] {
+        let (out, code) = check_with(
+            &r,
+            ROUTES,
+            &format!(
+                r#"[{{"name": "card",
+                      "count_publisher_instances":
+                        {{"subject": "svc.order.request", {bound}}}}}]"#
+            ),
+        );
+        assert_eq!(code, want_code, "bound `{bound}`: {out}");
+    }
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// A claim may name several verbs, and each is evaluated. Order must
+/// not matter — if only the first were checked, a violating second
+/// verb would be silently dropped.
+#[test]
+fn every_verb_in_a_claim_is_evaluated_whatever_the_order() {
+    let r = fixture("multiverb");
+    let holds = r#""count_publisher_instances":
+        {"subject": "svc.order.request", "eq": 1}"#;
+    // gateway subscribes svc.order.request, never svc.order.intent.
+    let violates = r#""require_subscribes":
+        {"group": "gateway", "subject": "svc.order.intent"}"#;
+
+    for (a, b) in [(holds, violates), (violates, holds)] {
+        let (out, code) = check_with(
+            &r,
+            ROUTES,
+            &format!(r#"[{{"name": "both", {a}, {b}}}]"#),
+        );
+        assert_eq!(
+            code, 1,
+            "a violating verb must be caught in either position: {out}"
+        );
+        assert!(
+            out.contains("subscribes `svc.order.intent`"),
+            "the violated verb should be the one reported: {out}"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// `min` above `max` can never be satisfied. It fails rather than
+/// passing, which is the safe direction for a contradiction.
+#[test]
+fn a_contradictory_bound_fails_closed() {
+    let r = fixture("contradiction");
+    let (out, code) = check_with(
+        &r,
+        ROUTES,
+        r#"[{"name": "impossible", "count_publisher_instances":
+             {"subject": "svc.order.request", "min": 5, "max": 2}}]"#,
+    );
+    assert_eq!(code, 1, "an unsatisfiable bound must not hold: {out}");
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// `only_edges` granting nothing seals the boundary completely. An
+/// empty grant list must mean "nothing may cross", not "no grants
+/// configured, so allow everything".
+#[test]
+fn only_edges_with_no_grants_seals_the_boundary() {
+    let r = fixture("sealed");
+    let (out, code) = check_with(
+        &r,
+        ROUTES,
+        r#"[{"name": "sealed",
+             "only_edges": {"from": "strategy", "to": "oms",
+                            "grant_subjects": []}}]"#,
+    );
+    assert_eq!(code, 1, "an empty grant list must forbid every edge: {out}");
+    assert!(out.contains("svc.order.intent"), "{out}");
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+// ---------------------------------------------------------------
+// Witnesses
+// ---------------------------------------------------------------
+
+/// A witness crossing three artifacts must name the route that
+/// carries EACH hop.
+///
+/// The labels used to be shifted the wrong way, so both hops were
+/// reported as `request` — pointing a reader at the wrong route
+/// entry, which for a real deployment means the wrong config file.
+/// Two-node witnesses were right by accident, so this needs the
+/// three-node path to catch it.
+#[test]
+fn a_multi_hop_witness_names_the_route_of_each_hop() {
+    let r = fixture("witness");
+    let (out, code) = check_with(
+        &r,
+        ROUTES,
+        r#"[{"name": "no_reach",
+             "forbid_reaches": {"from": "strategy", "to": "gateway"}}]"#,
+    );
+    assert_eq!(code, 1, "strategy does reach gateway: {out}");
+
+    let intent_at = out.find("route `intent`");
+    let request_at = out.find("route `request`");
+    assert!(
+        intent_at.is_some(),
+        "the prober -> oms hop rides route `intent`, and the witness \
+         never mentions it:\n{out}"
+    );
+    assert!(
+        request_at.is_some(),
+        "the oms -> gw hop rides route `request`:\n{out}"
+    );
+    assert!(
+        intent_at < request_at,
+        "the hops must be labelled in path order:\n{out}"
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+// ---------------------------------------------------------------
+// Plan vs. artifact disagreement
+// ---------------------------------------------------------------
+
+/// A route naming a topic the instance's artifact does not declare is
+/// a plan error. Otherwise a typo silently drops the edge, and a
+/// `forbid_reaches` law then "holds" because the path it was written
+/// to catch was never modelled.
+#[test]
+fn a_route_naming_an_undeclared_topic_is_refused() {
+    let r = fixture("typo");
+    let routes = r#"[
+        {"id": "intent", "transport": "unix",
+         "publishers":  [{"instance": "prober-0", "topic": "t::OrderIntnet"}],
+         "subscribers": [{"instance": "oms-0",    "topic": "t::OrderIntnet"}]}]"#;
+    let (out, code) = check_with(
+        &r,
+        routes,
+        r#"[{"name": "no_reach",
+             "forbid_reaches": {"from": "strategy", "to": "gateway"}}]"#,
+    );
+    assert_eq!(code, 1, "a misspelled topic must not pass silently: {out}");
+    assert!(
+        out.contains("declares no topic"),
+        "the error should name the undeclared topic, not report the \
+         claim as holding: {out}"
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// The plan may not vouch for behavior the code does not have.
+///
+/// `prober` imports the topic module, so `t::OrderRequest` IS in its
+/// artifact's topic table and a route may name it — but prober never
+/// publishes it. A positive claim must consult the artifact's actual
+/// endpoints rather than taking the plan's word, or a plan could
+/// satisfy any law by asserting the routes it wishes existed.
+#[test]
+fn a_positive_claim_trusts_the_artifact_over_the_plan() {
+    let r = fixture("planlies");
+    let routes = r#"[
+        {"id": "bogus", "transport": "unix",
+         "publishers":  [{"instance": "prober-0", "topic": "t::OrderRequest"}],
+         "subscribers": [{"instance": "gw-0",     "topic": "t::OrderRequest"}]}]"#;
+    let (out, code) = check_with(
+        &r,
+        routes,
+        r#"[{"name": "strategy_publishes",
+             "require_publishes": {"group": "strategy",
+                                   "subject": "svc.order.request"}}]"#,
+    );
+    assert_eq!(
+        code, 1,
+        "no code in `prober` publishes svc.order.request, so the claim \
+         must fail however the plan routes it: {out}"
+    );
+    assert!(out.contains("publishes `svc.order.request`"), "{out}");
+
+    // Control: the group that really does publish it satisfies the
+    // same claim, so the check is not simply always-failing.
+    let (out, code) = check_with(
+        &r,
+        r#"[
+        {"id": "request", "transport": "unix",
+         "publishers":  [{"instance": "oms-0", "topic": "t::OrderRequest"}],
+         "subscribers": [{"instance": "gw-0",  "topic": "t::OrderRequest"}]}]"#,
+        r#"[{"name": "oms_publishes",
+             "require_publishes": {"group": "oms",
+                                   "subject": "svc.order.request"}}]"#,
+    );
+    assert_eq!(code, 0, "oms does publish it: {out}");
+    let _ = std::fs::remove_dir_all(&r);
+}

--- a/crates/hale-cli/tests/fleet_cross_tier.rs
+++ b/crates/hale-cli/tests/fleet_cross_tier.rs
@@ -1,0 +1,366 @@
+//! Where the three tiers meet: constitutions and effects on
+//! components that are then composed into a fleet.
+//!
+//! Each tier has its own tests. This file covers what happens when
+//! law authored at one altitude rides into another — the questions
+//! nobody asks until a deployment answers them wrong.
+//!
+//! The load-bearing result here is a NEGATIVE one, recorded
+//! deliberately: two components can adopt constitutions that share a
+//! name and differ in content, and the fleet composes clean without
+//! recording either. See
+//! `a_shared_constitution_name_across_components_is_not_checked`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn root(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir()
+        .join(format!("hale_fct_{}_{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&d);
+    d
+}
+
+fn write(root: &Path, rel: &str, src: &str) {
+    let p = root.join(rel);
+    std::fs::create_dir_all(p.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&p, src).expect("write");
+}
+
+fn hale(args: &[&str]) -> (String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(args)
+        .output()
+        .expect("run hale");
+    (
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+const TOPICS: &str = r#"
+type Intent { id: Int; }
+topic OrderIntent { payload: Intent; subject: "svc.order.intent"; }
+"#;
+
+/// Emitter adopting a constitution named `Core`.
+fn emitter(clause: &str) -> String {
+    format!(
+        r#"
+import "../lib" as t;
+constitution Core {{
+    {clause}
+}}
+locus Emit {{
+    params {{ n: Int = 0; }}
+    bus {{ publish t::OrderIntent; }}
+    fn go() {{ let i = t::Intent {{ id: 1 }}; t::OrderIntent <- i; }}
+}}
+main locus AApp {{
+    params {{ e: Emit = Emit {{ }}; }}
+    claims {{ adopt Core; }}
+}}
+fn main() {{ AApp {{ }}; }}
+"#
+    )
+}
+
+/// Receiver adopting a constitution ALSO named `Core`.
+fn receiver(clause: &str) -> String {
+    format!(
+        r#"
+import "../lib" as t;
+constitution Core {{
+    {clause}
+}}
+locus Recv {{
+    params {{ n: Int = 0; }}
+    bus {{ subscribe t::OrderIntent as on_i; }}
+    fn on_i(i: t::Intent) {{ self.n = i.id; }}
+}}
+main locus BApp {{
+    params {{ r: Recv = Recv {{ }}; }}
+    claims {{ adopt Core; }}
+}}
+fn main() {{ BApp {{ }}; }}
+"#
+    )
+}
+
+const PLAN: &str = r#"{
+  "schema": "1.0", "name": "prod",
+  "instances": [
+    {"id": "a-0", "artifact": "artifacts/a.json", "labels": ["emit"]},
+    {"id": "b-0", "artifact": "artifacts/b.json", "labels": ["recv"]}],
+  "routes": [
+    {"id": "r", "transport": "unix",
+     "publishers":  [{"instance": "a-0", "topic": "t::OrderIntent"}],
+     "subscribers": [{"instance": "b-0", "topic": "t::OrderIntent"}]}]
+}"#;
+
+/// Build both components and return (root, per-component artifact).
+fn two_components(
+    tag: &str,
+    a_clause: &str,
+    b_clause: &str,
+) -> (PathBuf, serde_json::Value, serde_json::Value) {
+    let r = root(tag);
+    write(&r, "lib/topics.hl", TOPICS);
+    write(&r, "a/main.hl", &emitter(a_clause));
+    write(&r, "b/main.hl", &receiver(b_clause));
+    write(&r, "hale.toml", "[deps]\n");
+    write(&r, "plan.json", PLAN);
+    for app in ["a", "b"] {
+        let dst = r.join(format!("artifacts/{}.json", app));
+        std::fs::create_dir_all(dst.parent().expect("parent")).expect("mkdir");
+        let (out, code) = hale(&[
+            "check",
+            r.join(app).to_str().expect("utf8"),
+            &format!("--dump-topology={}", dst.display()),
+        ]);
+        assert_eq!(code, 0, "component `{}` must check clean: {}", app, out);
+    }
+    let read = |n: &str| -> serde_json::Value {
+        serde_json::from_str(
+            &std::fs::read_to_string(r.join(format!("artifacts/{}.json", n)))
+                .expect("artifact"),
+        )
+        .expect("artifact parses")
+    };
+    let (a, b) = (read("a"), read("b"));
+    (r, a, b)
+}
+
+/// Two constitutions with the same NAME and different clauses get
+/// different digests. This is the property the whole design rests on
+/// — within a seed it is enforced; the next test shows the fleet does
+/// not look at it.
+#[test]
+fn same_named_constitutions_with_different_clauses_differ_in_digest() {
+    let (r, a, b) = two_components(
+        "digests",
+        "one_pub: count publishers(topic t::OrderIntent) == 1;",
+        "any_subs: count subscribers(topic t::OrderIntent) >= 0;",
+    );
+    let dig = |v: &serde_json::Value| -> String {
+        v["evaluation"]["closure"][0]["digest"]
+            .as_str()
+            .unwrap_or("")
+            .to_string()
+    };
+    let name = |v: &serde_json::Value| -> String {
+        v["evaluation"]["closure"][0]["name"]
+            .as_str()
+            .unwrap_or("")
+            .to_string()
+    };
+    assert_eq!(name(&a), "Core", "both adopt a constitution called Core");
+    assert_eq!(name(&b), "Core");
+    assert_ne!(
+        dig(&a),
+        dig(&b),
+        "different clauses under one name must not share an identity"
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// **Known gap, pinned deliberately.**
+///
+/// Two components each record adopting `Core`, with different
+/// closures. The fleet composes clean, and its artifact records only
+/// `{id, artifact}` per component — so nothing anywhere says which
+/// law each component was actually held to, and a reader of the
+/// fleet artifact would reasonably conclude they share one.
+///
+/// This is NOT obviously a bug to fix by erroring: independently
+/// built artifacts may legitimately each define a local `Core`, and
+/// refusing that would be wrong. The gap is that the fleet artifact
+/// does not carry the closures forward, so the arrangement cannot be
+/// audited after the fact. The analogous check DOES exist one tier
+/// down — `env_matrix::one_environment_may_not_mean_two_different_claimsets`.
+///
+/// This test asserts today's behavior. If composition later grows to
+/// record or reconcile closures, this is the test to change, and the
+/// change is deliberate rather than accidental.
+#[test]
+fn a_shared_constitution_name_across_components_is_not_checked() {
+    let (r, _, _) = two_components(
+        "namecollision",
+        "one_pub: count publishers(topic t::OrderIntent) == 1;",
+        "any_subs: count subscribers(topic t::OrderIntent) >= 0;",
+    );
+    let plan = r.join("plan.json");
+    let (out, code) = hale(&["fleet", "check", plan.to_str().expect("utf8")]);
+    assert_eq!(
+        code, 0,
+        "today two different `Core`s compose without complaint: {out}"
+    );
+
+    let dump = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(["fleet", "dump", plan.to_str().expect("utf8")])
+        .output()
+        .expect("run hale");
+    let v: serde_json::Value =
+        serde_json::from_slice(&dump.stdout).expect("fleet artifact parses");
+    let components = v["components"].to_string();
+    assert!(
+        !components.contains("digest"),
+        "if the fleet artifact starts carrying component constitution \
+         digests, this gap is closed — update this test: {components}"
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// A component whose own adopted clause FAILS must never enter a
+/// fleet. The constitution is the component's law; the fleet is
+/// entitled to assume every component was certified under its own.
+#[test]
+fn a_component_failing_its_adopted_clause_cannot_enter_a_fleet() {
+    let r = root("failedclause");
+    write(&r, "lib/topics.hl", TOPICS);
+    // `a` publishes OrderIntent, so demanding zero publishers fails.
+    write(
+        &r,
+        "a/main.hl",
+        &emitter("none: count publishers(topic t::OrderIntent) == 0;"),
+    );
+    write(
+        &r,
+        "b/main.hl",
+        &receiver("any_subs: count subscribers(topic t::OrderIntent) >= 0;"),
+    );
+    write(&r, "hale.toml", "[deps]\n");
+    write(&r, "plan.json", PLAN);
+
+    for app in ["a", "b"] {
+        let dst = r.join(format!("artifacts/{}.json", app));
+        std::fs::create_dir_all(dst.parent().expect("parent")).expect("mkdir");
+        let _ = hale(&[
+            "check",
+            r.join(app).to_str().expect("utf8"),
+            &format!("--dump-topology={}", dst.display()),
+        ]);
+    }
+    let (out, code) = hale(&[
+        "fleet",
+        "check",
+        r.join("plan.json").to_str().expect("utf8"),
+    ]);
+    assert_eq!(
+        code, 1,
+        "a component whose constitution clause is violated must be \
+         refused by the fleet, not silently composed: {out}"
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// An effect class named by a constitution clause but never declared
+/// is an error in the adopting seed, and the diagnostic says how to
+/// fix it. Silence here would mean the clause quietly quantifies over
+/// nothing and always holds.
+#[test]
+fn a_constitution_naming_an_undeclared_effect_class_is_refused() {
+    let r = root("undeclared_effect");
+    write(&r, "hale.toml", "[deps]\n");
+    write(
+        &r,
+        "app/main.hl",
+        r#"
+locus Billing { params { n: Int = 0; } fn go() -> Int { return self.n; } }
+group billing = { Billing };
+constitution Core {
+    no_llm: forbid reaches(billing, effects(llm));
+}
+main locus App {
+    params { b: Billing = Billing { }; }
+    claims { adopt Core; }
+}
+fn main() { App { }; }
+"#,
+    );
+    let (out, code) =
+        hale(&["check", r.join("app").to_str().expect("utf8")]);
+    assert_eq!(code, 1, "an undeclared effect class must fail: {out}");
+    assert!(
+        out.contains("never declared"),
+        "the diagnostic should name the missing declaration: {out}"
+    );
+
+    // Declaring the class makes the same clause evaluable — and it
+    // holds, because nothing reaches it. The check is not merely
+    // rejecting the word `effects`.
+    write(
+        &r,
+        "app/main.hl",
+        r#"
+effect llm;
+locus Billing { params { n: Int = 0; } fn go() -> Int { return self.n; } }
+group billing = { Billing };
+constitution Core {
+    no_llm: forbid reaches(billing, effects(llm));
+}
+main locus App {
+    params { b: Billing = Billing { }; }
+    claims { adopt Core; }
+}
+fn main() { App { }; }
+"#,
+    );
+    let (out, code) =
+        hale(&["check", r.join("app").to_str().expect("utf8")]);
+    assert_eq!(code, 0, "declared class, nothing reaches it: {out}");
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// The fleet claim vocabulary has no `effects(...)` target, and the
+/// carve-out is structural rather than a runtime check: effect class
+/// names are seed-local, so they have no meaning across artifacts.
+/// `deny_unknown_fields` makes an attempt to smuggle one in a hard
+/// error instead of an ignored field.
+#[test]
+fn a_fleet_claim_cannot_name_an_effect_class() {
+    let (r, _, _) = two_components(
+        "noeffects",
+        "one_pub: count publishers(topic t::OrderIntent) == 1;",
+        "any_subs: count subscribers(topic t::OrderIntent) >= 0;",
+    );
+    let plan = r#"{
+      "schema": "1.0", "name": "prod",
+      "instances": [
+        {"id": "a-0", "artifact": "artifacts/a.json", "labels": ["emit"]},
+        {"id": "b-0", "artifact": "artifacts/b.json", "labels": ["recv"]}],
+      "groups": {"emit": {"labels": ["emit"]}},
+      "claims": [
+        {"name": "no_llm",
+         "forbid_reaches": {"from": "emit", "to": "effects(llm)"},
+         "effects": ["llm"]}]
+    }"#;
+    write(&r, "bad.plan.json", plan);
+    let (out, code) = hale(&[
+        "fleet",
+        "check",
+        r.join("bad.plan.json").to_str().expect("utf8"),
+    ]);
+    assert_eq!(code, 1, "an unknown claim field must be refused: {out}");
+
+    // And with the stray field removed, `effects(llm)` as a group
+    // name is an unknown group — not a silently-empty one that makes
+    // the claim hold.
+    let plan = plan.replace(",\n         \"effects\": [\"llm\"]", "");
+    write(&r, "bad2.plan.json", &plan);
+    let (out, code) = hale(&[
+        "fleet",
+        "check",
+        r.join("bad2.plan.json").to_str().expect("utf8"),
+    ]);
+    assert_eq!(
+        code, 1,
+        "`effects(llm)` is not a declared fleet group and must not \
+         resolve to the empty set: {out}"
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}

--- a/crates/hale-codegen/src/channels/mod.rs
+++ b/crates/hale-codegen/src/channels/mod.rs
@@ -114,6 +114,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             .expect("fallible locus fn declared in pass A2");
         let entry = self.context.append_basic_block(func, "entry");
         self.builder.position_at_end(entry);
+        self.di_begin_function();
         let self_ptr = func
             .get_nth_param(0)
             .expect("self_ptr param")
@@ -343,13 +344,31 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             .build_unconditional_branch(cleanup_bb)
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
 
-        // CLEANUP: shared scratch-destroy + flush + `ret i1
-        // path`. Order matters: deep-copy already happened
-        // above, so destroying the scratch here only frees
-        // bytes the caller is no longer reading.
+        // CLEANUP: shared flush + scratch-destroy + `ret i1 path`.
+        //
+        // Order matters twice over. Deep-copy already happened
+        // above, so destroying the scratch frees only bytes the
+        // caller is no longer reading. And the flush MUST precede
+        // the destroy: a fresh-factory locus let-bound in this
+        // method's frame is allocated out of the method scratch
+        // (the factory allocates in the caller's published arena,
+        // and a method publishes its own scratch), so its struct
+        // LIVES in the region the destroy reclaims. Dissolving
+        // after the destroy loads the locus's `__arena` field out
+        // of freed — and, via the subregion freelist, recycled —
+        // memory and hands the garbage to `lotus_arena_destroy`.
+        //
+        // This epilogue had the two the wrong way round while every
+        // other one (the non-fallible method epilogues, the second
+        // cleanup below) flushed first, so the bug was reachable
+        // only from a FALLIBLE locus method that let-binds a
+        // factory result: a downstream trainer whose
+        // `fit(...) -> () fallible(E)` preallocated two row buffers
+        // segfaulted in `lotus_arena_destroy` at method exit after
+        // computing entirely correct results.
         self.builder.position_at_end(cleanup_bb);
-        self.close_method_scratch()?;
         self.flush_dissolve_frame()?;
+        self.close_method_scratch()?;
         self.builder
             .build_return(Some(&path_v))
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -6793,6 +6793,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             let do_bb = self.context.append_basic_block(reclaim, "reclaim.do");
             let ret_bb = self.context.append_basic_block(reclaim, "reclaim.ret");
             self.builder.position_at_end(entry);
+            self.di_begin_function();
             let self_arg = reclaim
                 .get_nth_param(0)
                 .expect("reclaim self_ptr param")
@@ -7000,6 +7001,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 let wrap = self.module.add_function(&wname, wty, None);
                 let entry = self.context.append_basic_block(wrap, "entry");
                 self.builder.position_at_end(entry);
+                self.di_begin_function();
                 let self_arg = wrap
                     .get_nth_param(0)
                     .expect("hwrap self")
@@ -7469,6 +7471,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             let entry =
                 self.context.append_basic_block(wrapper, "entry");
             self.builder.position_at_end(entry);
+            self.di_begin_function();
             let self_arg = wrapper
                 .get_nth_param(0)
                 .expect("wrapper self_ptr param")
@@ -8344,6 +8347,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         let main_fn = self.module.add_function("main", main_ty, None);
         let entry = self.context.append_basic_block(main_fn, "entry");
         self.builder.position_at_end(entry);
+        self.di_begin_function();
         self.current_fn = Some(main_fn);
         self.current_user_fn_ret = None;
         self.current_self = None;
@@ -9627,6 +9631,11 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             None,
         );
         let saved_block = self.builder.get_insert_block();
+        // Emitted MID-STATEMENT while lowering the prelude: the
+        // caller's live location must not land on this fn's
+        // instructions. Restored with the block below.
+        let saved_di_loc = self.di_current_loc;
+        let saved_di_pos = self.di_current_pos;
 
         let entry_bb = self.context.append_basic_block(f, "entry");
         let have_main_bb = self.context.append_basic_block(f, "have_main");
@@ -9635,6 +9644,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         let done_bb = self.context.append_basic_block(f, "done");
 
         self.builder.position_at_end(entry_bb);
+        self.di_begin_function();
         let h = f.get_nth_param(0).expect("handle param").into_int_value();
         let locus_self_fn = self
             .module
@@ -9807,6 +9817,12 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // Back to the prelude position; register the dispatcher.
         if let Some(bb) = saved_block {
             self.builder.position_at_end(bb);
+        }
+        self.di_current_loc = saved_di_loc;
+        self.di_current_pos = saved_di_pos;
+        match saved_di_loc {
+            Some(loc) => self.builder.set_current_debug_location(loc),
+            None => self.builder.unset_current_debug_location(),
         }
         let set_fn = self
             .module
@@ -12439,6 +12455,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 .add_function("_hale_start", void_t.fn_type(&[], false), None);
         let entry = self.context.append_basic_block(start_fn, "entry");
         self.builder.position_at_end(entry);
+        self.di_begin_function();
         let arena_create = self
             .module
             .get_function("lotus_arena_create_labeled")
@@ -12971,15 +12988,10 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         self.current_self = None;
         self.loops.clear();
         // Entering a new subprogram: drop the previous function's
-        // debug location. Entry-block allocas emitted before the
-        // body's first statement sets a location would otherwise
-        // inherit it, and LLVM rejects the module — "!dbg attachment
-        // points at wrong subprogram", seen concretely as `%j` in
-        // `matrix_add` carrying `matrix_matmul`'s location. Latent
-        // until something emits an entry alloca that early; the
-        // reset belongs here regardless of what triggers it.
-        self.di_current_loc = None;
-        self.builder.unset_current_debug_location();
+        // debug location (see `di_begin_function`). Seen concretely
+        // as `%j` in `matrix_add` carrying `matrix_matmul`'s
+        // location.
+        self.di_begin_function();
         // Fn-call protocol shave: non-allocating bodies can't publish,
         // so their (empty-frame) scope-exit flushes skip the bus drain.
         let prev_skip_drain = self.current_fn_skip_exit_drain;
@@ -15261,6 +15273,32 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     }
 
     /// DI verifier fix (2026-07-03): synthesized epilogue code
+    /// Begin lowering a new function body: drop the debug location
+    /// left behind by whichever function was emitted before this one.
+    ///
+    /// A function's *prologue* — entry-block allocas for locals,
+    /// deferred-dissolve slots, the method scratch arena, the
+    /// caller-arena snapshot — is emitted before the body's first
+    /// statement calls `di_enter_stmt`, so it inherits whatever
+    /// location is still current. If that location belongs to the
+    /// previously emitted function, LLVM rejects the whole module:
+    /// "!dbg attachment points at wrong subprogram for function".
+    ///
+    /// The reset must run at EVERY function-body entry. It lived
+    /// inline in `lower_user_fn_body` (free fns) while all five
+    /// locus-method entry points went without, so three loci where
+    /// the middle one calls a free-fn factory — `Demo.go` ->
+    /// `Trainer.fit` -> `Model.train_step` — failed to build at all:
+    /// `Demo.go`'s prologue carried `Trainer.fit`'s location. Two
+    /// levels happened to survive because nothing had left a
+    /// location live. `di_entry_reset_is_universal` fails the build
+    /// if a new entry point forgets this call.
+    pub(crate) fn di_begin_function(&mut self) {
+        self.di_current_loc = None;
+        self.di_current_pos = None;
+        self.builder.unset_current_debug_location();
+    }
+
     /// (fn-exit local-locus dissolve cascades) can emit calls with
     /// no !dbg while the enclosing fn carries a DISubprogram — the
     /// verifier rejects the module ("inlinable function call in a
@@ -26427,8 +26465,13 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             false,
         );
         let tramp_fn = self.module.add_function(&tramp_name, tramp_ty, None);
+        // Emitted MID-STATEMENT while lowering the caller: the
+        // caller's live location must not land on this fn's
+        // instructions, and must come back with the block.
+        let saved_di = (self.di_current_loc, self.di_current_pos);
         let entry = self.context.append_basic_block(tramp_fn, "entry");
         self.builder.position_at_end(entry);
+        self.di_begin_function();
 
         let a_ptr = tramp_fn.get_nth_param(0).unwrap().into_pointer_value();
         let b_ptr = tramp_fn.get_nth_param(1).unwrap().into_pointer_value();
@@ -26580,6 +26623,12 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // Restore the caller's builder position.
         if let Some(bb) = saved_bb {
             self.builder.position_at_end(bb);
+        }
+        self.di_current_loc = saved_di.0;
+        self.di_current_pos = saved_di.1;
+        match saved_di.0 {
+            Some(loc) => self.builder.set_current_debug_location(loc),
+            None => self.builder.unset_current_debug_location(),
         }
 
         Ok(tramp_fn)

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -3245,10 +3245,14 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
             let thread_main = self
                 .module
                 .add_function(&thread_main_name, thread_main_ty, None);
+            // Emitted MID-STATEMENT while lowering the caller;
+            // restored with the block below.
+            let saved_di = (self.di_current_loc, self.di_current_pos);
             let entry_bb = self
                 .context
                 .append_basic_block(thread_main, "entry");
             self.builder.position_at_end(entry_bb);
+            self.di_begin_function();
             let thread_self =
                 thread_main.get_nth_param(0).unwrap().into_pointer_value();
             // 2026-05-23: stash this locus's mailbox in
@@ -3419,6 +3423,12 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
             // Restore builder to the calling fn so the rest of
             // the instantiation (pthread_create) emits there.
             self.builder.position_at_end(saved_block);
+            self.di_current_loc = saved_di.0;
+            self.di_current_pos = saved_di.1;
+            match saved_di.0 {
+                Some(loc) => self.builder.set_current_debug_location(loc),
+                None => self.builder.unset_current_debug_location(),
+            }
 
             // pthread_t alloca in the enclosing fn frame — hoisted
             // to entry so a locus-instantiation-in-loop pattern
@@ -4539,8 +4549,11 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         let saved_block = self.builder.get_insert_block();
         let prev_fn = self.current_fn.take();
         self.current_fn = Some(dispatch);
+        // Emitted MID-STATEMENT; restored with the block below.
+        let saved_di = (self.di_current_loc, self.di_current_pos);
 
         let entry = self.context.append_basic_block(dispatch, "entry");
+        self.di_begin_function();
         // Deserialize bound-check failure (corrupt payload) → drop the
         // cell (return void). Trusted same-process payload never trips
         // this; it exists only to satisfy the wire deserializer ABI.
@@ -4753,6 +4766,12 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         self.current_fn = prev_fn;
         if let Some(bb) = saved_block {
             self.builder.position_at_end(bb);
+        }
+        self.di_current_loc = saved_di.0;
+        self.di_current_pos = saved_di.1;
+        match saved_di.0 {
+            Some(loc) => self.builder.set_current_debug_location(loc),
+            None => self.builder.unset_current_debug_location(),
         }
         Ok(dispatch)
     }

--- a/crates/hale-codegen/src/locus/method.rs
+++ b/crates/hale-codegen/src/locus/method.rs
@@ -54,6 +54,7 @@ impl<'ctx, 'p> LocusMethodBodies<'ctx> for Cx<'ctx, 'p> {
                     .expect("method declared in pass A2");
                 let entry = self.context.append_basic_block(func, "entry");
                 self.builder.position_at_end(entry);
+                self.di_begin_function();
                 let self_ptr = func
                     .get_nth_param(0)
                     .expect("self_ptr param")
@@ -176,6 +177,7 @@ impl<'ctx, 'p> LocusMethodBodies<'ctx> for Cx<'ctx, 'p> {
             let ff = *ff;
             let entry = self.context.append_basic_block(ff, "entry");
             self.builder.position_at_end(entry);
+            self.di_begin_function();
             let parent_self = ff
                 .get_nth_param(0)
                 .expect("parent_self param")
@@ -281,6 +283,7 @@ impl<'ctx, 'p> LocusMethodBodies<'ctx> for Cx<'ctx, 'p> {
             };
             let entry = self.context.append_basic_block(func, "entry");
             self.builder.position_at_end(entry);
+            self.di_begin_function();
             let self_ptr = func
                 .get_nth_param(0)
                 .expect("self_ptr param")
@@ -354,6 +357,7 @@ impl<'ctx, 'p> LocusMethodBodies<'ctx> for Cx<'ctx, 'p> {
             let entry =
                 self.context.append_basic_block(duration_fn, "entry");
             self.builder.position_at_end(entry);
+            self.di_begin_function();
             let self_ptr = duration_fn
                 .get_nth_param(0)
                 .expect("self_ptr param")
@@ -579,6 +583,7 @@ impl<'ctx, 'p> LocusMethodBodies<'ctx> for Cx<'ctx, 'p> {
             };
             let entry = self.context.append_basic_block(wrapper_fn, "entry");
             self.builder.position_at_end(entry);
+            self.di_begin_function();
             let self_ptr = wrapper_fn
                 .get_nth_param(0)
                 .expect("self_ptr param")
@@ -655,6 +660,7 @@ impl<'ctx, 'p> LocusMethodBodies<'ctx> for Cx<'ctx, 'p> {
                     .expect("locus fn declared in pass A2");
                 let entry = self.context.append_basic_block(func, "entry");
                 self.builder.position_at_end(entry);
+                self.di_begin_function();
                 let self_ptr = func
                     .get_nth_param(0)
                     .expect("self_ptr param")
@@ -942,6 +948,7 @@ impl<'ctx, 'p> LocusMethodBodies<'ctx> for Cx<'ctx, 'p> {
                     .expect("mode declared in pass A2");
                 let entry = self.context.append_basic_block(func, "entry");
                 self.builder.position_at_end(entry);
+                self.di_begin_function();
                 let self_ptr = func
                     .get_nth_param(0)
                     .expect("self_ptr param")

--- a/crates/hale-codegen/tests/di_entry_reset_is_universal.rs
+++ b/crates/hale-codegen/tests/di_entry_reset_is_universal.rs
@@ -1,0 +1,120 @@
+//! Every function-body entry point must call `di_begin_function`.
+//!
+//! A function's prologue — entry-block allocas, deferred-dissolve
+//! slots, the method scratch arena, the caller-arena snapshot — is
+//! emitted before the body's first statement establishes a debug
+//! location, so it inherits whatever location the PREVIOUS function
+//! left live. When that happens LLVM rejects the entire module:
+//!
+//!     !dbg attachment points at wrong subprogram for function
+//!
+//! That is a hard build failure with no user-side workaround, since
+//! debug info is always on. It is also invisible until some
+//! arrangement of loci happens to leave a location live across the
+//! boundary — the free-fn path carried the reset for months while
+//! all five locus-method entry points went without, and the gap only
+//! surfaced at three levels of nesting.
+//!
+//! So this is enforced structurally rather than by review: a new
+//! `append_basic_block(f, "entry")` that positions the builder there
+//! and forgets the reset fails the build here, not in someone's
+//! program.
+
+use std::path::Path;
+
+/// Source sites that create a function's entry block and position
+/// the builder at it. Anything matching must reset the location
+/// within a few lines.
+fn scan(src: &str, path: &str, out: &mut Vec<String>) {
+    let lines: Vec<&str> = src.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        if !line.contains("append_basic_block(") || !line.contains("\"entry\"") {
+            continue;
+        }
+        // The builder must actually be positioned at this block for
+        // the prologue to land in it; a declared-but-unused entry
+        // block cannot inherit anything.
+        let window_end = (i + 12).min(lines.len());
+        let window = lines[i..window_end].join("\n");
+        if !window.contains("position_at_end(entry") {
+            continue;
+        }
+        if window.contains("di_begin_function()") {
+            continue;
+        }
+        out.push(format!(
+            "{}:{}: entry block positioned without \
+             `self.di_begin_function();`\n    {}",
+            path,
+            i + 1,
+            line.trim()
+        ));
+    }
+}
+
+#[test]
+fn di_entry_reset_is_universal() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+    let mut scanned = 0usize;
+
+    let mut stack = vec![root.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("read_dir src") {
+            let entry = entry.expect("dir entry");
+            let p = entry.path();
+            if p.is_dir() {
+                stack.push(p);
+                continue;
+            }
+            if p.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            let src = std::fs::read_to_string(&p).expect("read source");
+            let rel = p
+                .strip_prefix(&root)
+                .unwrap_or(&p)
+                .to_string_lossy()
+                .into_owned();
+            scan(&src, &rel, &mut offenders);
+            scanned += 1;
+        }
+    }
+
+    assert!(scanned > 0, "scanned no sources — path wrong?");
+    assert!(
+        offenders.is_empty(),
+        "function-body entry points missing the debug-location \
+         reset.\n\nEach of these emits a prologue that can inherit \
+         the previously emitted function's !dbg location, which \
+         makes LLVM reject the whole module. Add \
+         `self.di_begin_function();` right after the \
+         `position_at_end(entry)`.\n\n{}\n",
+        offenders.join("\n")
+    );
+}
+
+/// The scanner has to actually be able to see a violation — a lint
+/// that cannot fail is worse than no lint, because it reads as
+/// coverage.
+#[test]
+fn the_scanner_catches_a_missing_reset() {
+    let bad = r#"
+        let entry = self.context.append_basic_block(func, "entry");
+        self.builder.position_at_end(entry);
+        let self_ptr = func.get_nth_param(0);
+    "#;
+    let mut out = Vec::new();
+    scan(bad, "synthetic.rs", &mut out);
+    assert_eq!(out.len(), 1, "scanner missed an unguarded entry site");
+
+    let good = r#"
+        let entry = self.context.append_basic_block(func, "entry");
+        self.builder.position_at_end(entry);
+        self.di_begin_function();
+        let self_ptr = func.get_nth_param(0);
+    "#;
+    let mut out = Vec::new();
+    scan(good, "synthetic.rs", &mut out);
+    assert!(out.is_empty(), "scanner flagged a guarded entry site");
+}

--- a/crates/hale-codegen/tests/fallible_method_scratch_order.rs
+++ b/crates/hale-codegen/tests/fallible_method_scratch_order.rs
@@ -1,0 +1,307 @@
+//! A fallible locus method must dissolve its deferred loci BEFORE it
+//! destroys its method scratch — not after.
+//!
+//! A free-fn factory allocates its locus out of the caller's
+//! published arena, and a method publishes its own per-call scratch
+//! subregion. So a factory result let-bound inside a method frame
+//! has its *struct* living in that scratch. The binding also owns it
+//! (GH #383), so the frame's exit dissolves it — which loads the
+//! locus's `__arena` field and destroys that arena.
+//!
+//! Do those in the wrong order and the dissolve reads a struct out
+//! of a region that was just reclaimed and, via the subregion
+//! freelist, may already be handed back out. The garbage it finds in
+//! the `__arena` slot goes straight to `lotus_arena_destroy`.
+//!
+//! Every other method epilogue flushed before destroying. The
+//! FALLIBLE epilogue alone had them reversed, so the bug needed all
+//! three of: a locus method, declared `fallible`, that let-binds a
+//! factory result. A downstream trainer hit exactly that shape — its
+//! `fit(...) -> () fallible(E)` preallocated two row buffers — and
+//! segfaulted in `lotus_arena_destroy` at method exit having already
+//! computed entirely correct results, which is the worst way for
+//! this to present: the numbers look right up to the crash.
+//!
+//! The non-fallible twin is here too. It always worked, and it is
+//! what made the bug look like it was about factories or nesting
+//! rather than about `fallible`.
+
+use std::process::Command;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+use hale_codegen::build_executable;
+
+fn run(name: &str, src: &str) -> (String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(name);
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (String::from_utf8_lossy(&out.stdout).to_string(), out.status)
+}
+
+/// Build and return the emitted LLVM IR alongside the run result.
+///
+/// The ordering this file pins is a use-after-free, and a UAF only
+/// *crashes* when the freed bytes have actually been reused — at
+/// this program's size the old contents usually survive, so the
+/// broken order still exits 0 with correct output. (That is exactly
+/// how it stayed hidden: the downstream report needed 5000 epochs of
+/// churn to turn it into a segfault.) Asserting on the emitted order
+/// is deterministic where asserting on a crash is not.
+fn ir_and_run(
+    name: &str,
+    src: &str,
+) -> (String, String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(name);
+    // Set-only, never unset: every test in this binary wants it, so
+    // parallel execution cannot observe a half-applied value. The
+    // dump path derives from `bin`, which is already unique per test.
+    unsafe { std::env::set_var("LOTUS_DUMP_IR", "1") };
+    build_executable(&program, &bin).expect("build");
+    let ir = std::fs::read_to_string(bin.with_extension("ll"))
+        .expect("LOTUS_DUMP_IR should have written a .ll");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    let _ = std::fs::remove_file(bin.with_extension("ll"));
+    (
+        ir,
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        out.status,
+    )
+}
+
+/// The body of `define ... @<name>(`, up to its closing brace.
+fn function_body<'a>(ir: &'a str, name: &str) -> &'a str {
+    let needle = format!("@{}(", name);
+    let start = ir
+        .find(&needle)
+        .unwrap_or_else(|| panic!("no definition of {} in IR", name));
+    let rest = &ir[start..];
+    let end = rest.find("\n}").unwrap_or(rest.len());
+    &rest[..end]
+}
+
+/// `fit` is fallible and let-binds two factory results, then keeps
+/// using them across a loop — the downstream trainer's shape.
+const FALLIBLE: &str = r#"
+@form(vec)
+locus Row {
+    params { n: Int = 0; }
+    capacity { heap data of Float; }
+}
+
+fn make_row(v: Float) -> Row {
+    let r = Row { n: 1 };
+    r.push(v);
+    return r;
+}
+
+type StepError { detail: String = ""; }
+
+locus Model {
+    params { total: Float = 0.0; }
+    fn step(a: Row, b: Row) -> Float fallible(StepError) {
+        if (a.get(0) or 0.0) < 0.0 {
+            fail StepError { detail: "negative" };
+        }
+        self.total = self.total + (a.get(0) or 0.0) + (b.get(0) or 0.0);
+        return (a.get(0) or 0.0) + (b.get(0) or 0.0);
+    }
+}
+
+locus Trainer {
+    params { rounds: Int = 500; }
+    fn fit(m: Model) -> () fallible(StepError) {
+        let x = make_row(1.0);
+        let y = make_row(2.0);
+        let mut i = 0;
+        while i < self.rounds {
+            let s = m.step(x, y) or raise;
+            i = i + 1;
+        }
+    }
+}
+
+fn report(e: StepError) {
+    println("fit failed: ", e.detail);
+}
+
+fn main() {
+    let m = Model { };
+    let t = Trainer { };
+    t.fit(m) or report(err);
+    println("total=", to_string(m.total));
+    let z = make_row(9.0);
+    println("post=", to_string(z.get(0) or 0.0));
+}
+"#;
+
+#[test]
+fn a_fallible_method_dissolves_before_destroying_its_scratch() {
+    let (ir, out, status) =
+        ir_and_run("fallible_scratch_order", FALLIBLE);
+    let body = function_body(&ir, "Trainer.fit");
+
+    let scratch_destroy = body
+        .find("lotus_arena_destroy(ptr %method.scratch.load)")
+        .expect("fit should destroy its method scratch");
+    let first_dissolve_read = body
+        .find("dissolve.arena.gep")
+        .expect("fit should dissolve its two factory-bound loci");
+
+    assert!(
+        first_dissolve_read < scratch_destroy,
+        "the deferred dissolve reads a locus struct at offset {} but \
+         the method scratch holding that struct is destroyed at \
+         offset {} — the dissolve is loading `__arena` out of freed \
+         memory.\n\nA factory allocates in the caller's published \
+         arena, and a method publishes its scratch, so these structs \
+         LIVE in the region being destroyed.",
+        first_dissolve_read,
+        scratch_destroy
+    );
+
+    assert!(
+        status.success(),
+        "fallible method exited {:?} — a crash here is the scratch \
+         being destroyed before the deferred dissolves read the \
+         locus structs living in it.\nstdout:\n{}",
+        status.code(),
+        out
+    );
+    // Values, not just survival: an ordering fix that quietly
+    // dissolved the wrong thing would still exit 0 while handing
+    // back zeros, and that failure mode has burned this area before.
+    assert!(
+        out.contains("total=1500"),
+        "expected total=1500 (500 rounds x 3.0); got:\n{}",
+        out
+    );
+    assert!(
+        out.contains("post=9"),
+        "allocation after the fallible method must still work; got:\n{}",
+        out
+    );
+}
+
+/// The same program with `fallible` removed. This path always
+/// flushed before destroying, and pinning it keeps the two epilogues
+/// from drifting apart again.
+const NON_FALLIBLE: &str = r#"
+@form(vec)
+locus Row {
+    params { n: Int = 0; }
+    capacity { heap data of Float; }
+}
+
+fn make_row(v: Float) -> Row {
+    let r = Row { n: 1 };
+    r.push(v);
+    return r;
+}
+
+locus Model {
+    params { total: Float = 0.0; }
+    fn step(a: Row, b: Row) {
+        self.total = self.total + (a.get(0) or 0.0) + (b.get(0) or 0.0);
+    }
+}
+
+locus Trainer {
+    params { rounds: Int = 500; }
+    fn fit(m: Model) {
+        let x = make_row(1.0);
+        let y = make_row(2.0);
+        let mut i = 0;
+        while i < self.rounds {
+            m.step(x, y);
+            i = i + 1;
+        }
+    }
+}
+
+fn main() {
+    let m = Model { };
+    let t = Trainer { };
+    t.fit(m);
+    println("total=", to_string(m.total));
+    let z = make_row(9.0);
+    println("post=", to_string(z.get(0) or 0.0));
+}
+"#;
+
+#[test]
+fn the_non_fallible_twin_behaves_identically() {
+    let (out, status) = run("nonfallible_scratch_order", NON_FALLIBLE);
+    assert!(
+        status.success(),
+        "non-fallible method exited {:?}\nstdout:\n{}",
+        status.code(),
+        out
+    );
+    assert!(
+        out.contains("total=1500"),
+        "expected total=1500; got:\n{}",
+        out
+    );
+    assert!(out.contains("post=9"), "got:\n{}", out);
+}
+
+/// Three levels of locus nesting where the middle one calls a
+/// free-fn factory. This failed to BUILD at all — LLVM rejected the
+/// module ("!dbg attachment points at wrong subprogram") because the
+/// prologue of the outer method inherited the debug location left
+/// live by the previously emitted method. Debug info is always on,
+/// so there was no way to compile it.
+const THREE_LEVELS: &str = r#"
+locus Sample {
+    params { a: Float = 0.0; }
+}
+
+fn make(a: Float) -> Sample {
+    return Sample { a: a };
+}
+
+locus Model {
+    params { total: Float = 0.0; }
+    fn train_step(s: Sample) { self.total = self.total + s.a; }
+}
+
+locus Trainer {
+    params { rounds: Int = 100; }
+    fn fit(model: Model) {
+        let mut i = 0;
+        while i < self.rounds {
+            let x = make(1.0);
+            model.train_step(x);
+            i = i + 1;
+        }
+    }
+}
+
+locus Demo {
+    params {}
+    fn go() {
+        let m = Model { };
+        let t = Trainer { };
+        t.fit(m);
+        println("total=", to_string(m.total));
+    }
+}
+
+fn main() {
+    let d = Demo { };
+    d.go();
+}
+"#;
+
+#[test]
+fn three_levels_of_locus_nesting_compile_and_run() {
+    let (out, status) = run("three_level_nesting", THREE_LEVELS);
+    assert!(status.success(), "exited {:?}\n{}", status.code(), out);
+    assert!(out.contains("total=100"), "got:\n{}", out);
+}


### PR DESCRIPTION
Four defects, two in codegen and two in the fleet checker, found by two separate sweeps: re-measuring #402 against a downstream handoff's reference workload, and an adversarial combination pass over the effects / constitutions / fleets surface.

Every fix is verified against a pristine baseline build — each new test fails without its change and passes with it.

## Codegen

**Three levels of locus nesting failed to build.** A function's prologue — entry-block allocas, deferred-dissolve slots, the method scratch arena, the caller-arena snapshot — is emitted before the body's first statement establishes a debug location, so it inherited whatever location the *previously emitted* function left live. LLVM then rejects the whole module with `!dbg attachment points at wrong subprogram for function`. Debug info is always on, so there was no workaround short of restructuring the program.

The reset existed on the free-fn path and on **none of the other twelve** function-body entry points. It is now one `di_begin_function()` helper called at every entry, plus `di_entry_reset_is_universal`, a source lint that fails the build if a new entry point forgets — it found five sites that reading the code had missed. Two levels of nesting survived only because nothing had left a location live across the boundary, which is why this stayed invisible for so long.

**A fallible method freed the loci it was about to dissolve.** A free-fn factory allocates its locus out of the caller's published arena, and a method publishes its own per-call scratch subregion — so a factory result let-bound in a method frame has its struct living in that scratch. The binding owns it (#383), so the frame's exit dissolves it by loading `__arena` and destroying that arena.

The fallible epilogue destroyed the scratch *first*. Every other epilogue already flushed first; this one alone had the two reversed, so the bug needed all three of: a locus method, declared `fallible`, that let-binds a factory result. A downstream handoff hit exactly that shape and segfaulted at method exit **after computing entirely correct results** — the worst way for this to present.

It is a *latent* use-after-free rather than a reliable crash: at small sizes the freed bytes still hold the old struct and the program exits 0 with correct output. The regression test therefore asserts on the emitted order rather than waiting for a segfault — a crash-based test passed on the broken compiler.

## Fleet claims (#408)

Both of these are the same shape: the check existed, and the degenerate case slipped past it.

**A cardinality claim with no bound held against every fleet.** `count_publisher_instances` / `count_subscriber_instances` compare against `eq`, `min` and `max`, each defaulting to true when absent — so a claim naming only a subject asserted nothing while reading like real law in review. A claim naming no *verb* was already refused; a verb naming no *bound* now gets the same answer.

**A multi-hop witness named the wrong route on every hop but the last.** Path reconstruction pairs each node with its *outgoing* route, but the shift loop read `path[i]` first and only fell back to `path[i - 1]`. On a two-node path the destination has no outgoing edge, so the fallback always fired and the label came out right — which is why every existing witness test passed. A three-node witness labelled both hops with the last route:

```
prober-0::Probe::submit
-(route `request`)->     ← wrong; this hop rides route `intent`
oms-0::Oms::on_intent
-(route `request`)->
gw-0::Gateway::on_order
```

The model was correct throughout; only the rendering lied, and it points a reader at the wrong route entry — for a real deployment, the wrong config file.

An off-by-one that self-corrects at the minimum size needs a test one size above the minimum.

## Coverage

Thirteen new tests over the combinations. Beyond the two defects they pin behavior that proved correct under probing but had no coverage:

- a positive claim consults the **artifact**, not the plan, so a route asserting an endpoint the code lacks is inert and cannot satisfy `require_publishes`
- a route naming an undeclared topic is refused, so a typo cannot silently drop an edge and leave `forbid_reaches` "holding"
- every verb in a claim is evaluated whatever the field order
- `only_edges` with no grants seals the boundary instead of allowing everything
- `min > max` fails closed
- a constitution naming an undeclared effect class errors with a fix-it, and declaring the class makes the same clause evaluable
- `effects(...)` is structurally unexpressible in a fleet claim, since effect class names are seed-local

## One gap pinned rather than fixed

Two components may adopt constitutions sharing a **name** with different closure digests; the fleet composes clean and its artifact records only `{id, artifact}` per component, so nothing says which law each was held to.

Erroring would be wrong — independently built artifacts may each legitimately define a local constitution of that name. The real gap is that closures are not carried into the fleet artifact, so the arrangement cannot be audited afterward. The analogous check does exist one tier down (`one_environment_may_not_mean_two_different_claimsets`). `a_shared_constitution_name_across_components_is_not_checked` asserts today's behavior and says what to change when it closes — that decision is deliberately left open.

## Verification

- `hale-codegen` 1240, `hale-cli` + `hale-types` 985, plus the in-language suite — all green
- the real downstream deployment plan still composes clean at 5 instances / 18 routes, unchanged `fleet_shape_hash`
- reverting the two fleet fixes fails exactly the two new tests and nothing else

## Not fixed here

A downstream reference workload now runs to completion instead of segfaulting, but its numerical checks return zeros. Confirmed pre-existing by reverting only the ordering fix in-tree — identical failures. That is #381 (matrices allocated after a receiver's `@form(vec)` growth reading as zeros), a separate live bug. This PR converts a crash into a completed run that exposes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
