### PR TITLE
fix(fleet): one verb per claim, real endpoint roles, no vacuous prohibitions (GH #408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ behavior.
 
 ## Unreleased
 
+### Fleet claims: one verb per claim, real endpoint roles, and no vacuous prohibitions (GH #408)
+
+Three fail-opens, found by an external review of the effects / claims
+/ constitutions / fleet stack and confirmed by reproduction.
+
+**A claim naming several verbs judged only one of them.** Every verb
+on a claim row is an `Option`, and the evaluator is an `if/else`
+chain emitting one row, so a claim pairing a holding
+`require_subscribes` with an impossible `count ... eq: 999` passed —
+and the artifact recorded the whole claim's name as holding. A claim
+is one sentence, as it is in source: naming more than one verb is now
+refused, with the fix being to split it so each half has its own name
+and verdict.
+
+**A route endpoint did not have to hold the role the plan gave it.**
+Admission checked only that the instance *declared* the topic — which
+any component importing the topic module does, published or not. A
+route could therefore name a phantom producer, and a law about the
+consumer side would hold with nothing feeding it. The artifact is now
+the authority: a publisher endpoint must publish, a subscriber
+endpoint must subscribe, and a plan that misdescribes its components
+is refused before any claim is evaluated.
+
+**Overlapping prohibitions held vacuously.** `forbid_reaches(g, g)`
+reported `holds` while every path in the fleet ran inside the
+prohibition, because the search refuses a destination that is also a
+source. An instance in both groups is now a zero-length violation,
+matching the application tier. Likewise `avoiding` may no longer name
+an endpoint of its own claim — masking one deletes the domain being
+quantified over, which makes any prohibition hold.
+
 ### A cardinality claim must name a bound (GH #408)
 
 `count_publisher_instances` / `count_subscriber_instances` with no

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -283,10 +283,25 @@ pub fn compose(plan_path: &Path) -> Result<String, Vec<String>> {
             ));
             continue;
         }
-        // step 5: every endpoint must agree on the wire identity.
+        // step 5: every endpoint must agree on the wire identity AND
+        // actually hold the role the plan gives it.
+        //
+        // Declaring a topic is not the same as using it: a component
+        // that imports the topic module has every topic in its table
+        // whether or not any of its code publishes or subscribes one.
+        // Checking only the table admits a route with a phantom
+        // producer, and a `require_subscribes` law then holds with
+        // nothing on the other end — the plan vouching for behavior
+        // the code does not have. The artifact is the authority here,
+        // never the plan.
         let mut wire: Option<(WireId, String)> = None;
         let mut bad = false;
-        for ep in r.publishers.iter().chain(r.subscribers.iter()) {
+        let endpoints = r
+            .publishers
+            .iter()
+            .map(|e| (e, true))
+            .chain(r.subscribers.iter().map(|e| (e, false)));
+        for (ep, publishing) in endpoints {
             let Some(c) = by_id.get(ep.instance.as_str()) else {
                 errs.push(format!(
                     "route `{}` names instance `{}`, which the plan \
@@ -302,6 +317,26 @@ pub fn compose(plan_path: &Path) -> Result<String, Vec<String>> {
                         "route `{}`: instance `{}` declares no topic \
                          `{}`",
                         r.id, ep.instance, ep.topic
+                    ));
+                    bad = true;
+                }
+                Some(w) if !has_endpoint(
+                    &c.artifact,
+                    &w.subject,
+                    publishing,
+                ) =>
+                {
+                    errs.push(format!(
+                        "route `{}`: instance `{}` is named as a {} of \
+                         `{}` (subject `{}`), but nothing in that \
+                         component {} it — declaring a topic is not \
+                         using it",
+                        r.id,
+                        ep.instance,
+                        if publishing { "publisher" } else { "subscriber" },
+                        ep.topic,
+                        w.subject,
+                        if publishing { "publishes" } else { "subscribes" },
                     ));
                     bad = true;
                 }
@@ -511,6 +546,49 @@ fn evaluate_claims(
 
     let mut rows: Vec<String> = Vec::new();
     for c in &plan.claims {
+        // A claim is ONE sentence, exactly as it is in source.
+        //
+        // Every verb is an `Option`, so a plan could set several and
+        // the evaluator — an if/else chain producing one row — would
+        // silently judge whichever came first in this file and ignore
+        // the rest. A claim pairing a holding `require_subscribes`
+        // with an impossible `count ... eq: 999` passed. Worse, the
+        // name that survived into the artifact was the whole claim's,
+        // so the record said a sentence held when half of it was
+        // never read.
+        //
+        // Refusing the shape is better than evaluating each verb: one
+        // name must mean one normalized form, or the claim name stops
+        // being the contract of record.
+        let named: Vec<&str> = [
+            ("forbid_reaches", c.forbid_reaches.is_some()),
+            ("require_subscribes", c.require_subscribes.is_some()),
+            ("require_publishes", c.require_publishes.is_some()),
+            (
+                "count_publisher_instances",
+                c.count_publisher_instances.is_some(),
+            ),
+            (
+                "count_subscriber_instances",
+                c.count_subscriber_instances.is_some(),
+            ),
+            ("only_edges", c.only_edges.is_some()),
+        ]
+        .iter()
+        .filter(|(_, set)| *set)
+        .map(|(n, _)| *n)
+        .collect();
+        if named.len() > 1 {
+            errs.push(format!(
+                "claim `{}` names {} verbs ({}) — a claim is one \
+                 sentence; split it into one claim per verb so each \
+                 has its own name and verdict",
+                c.name,
+                named.len(),
+                named.join(", ")
+            ));
+            continue;
+        }
         let (result, witness) = if let Some(fr) = &c.forbid_reaches {
             let (Some(src), Some(dst)) = (
                 group(&fr.from, &c.name, errs),
@@ -525,10 +603,56 @@ fn evaluate_claims(
                 },
                 None => BTreeSet::new(),
             };
-            match bfs(&adj, &src, &dst, &masked, &inst_of) {
-                None => ("holds", String::new()),
-                Some(path) => {
-                    ("violated", render_witness(&path, comps, by_id))
+            // Masking an endpoint deletes the quantification domain,
+            // and an empty domain makes a prohibition hold over
+            // nothing. The application tier rejects this rather than
+            // reporting a green vacuous law; so does this one.
+            let mask_hits: Vec<&str> = masked
+                .iter()
+                .filter(|i| src.contains(*i) || dst.contains(*i))
+                .map(|s| s.as_str())
+                .collect();
+            if !mask_hits.is_empty() {
+                errs.push(format!(
+                    "claim `{}`: `avoiding` group `{}` contains {}, \
+                     which is already an endpoint of this claim — \
+                     masking an endpoint removes what the claim \
+                     quantifies over and would make it hold over \
+                     nothing",
+                    c.name,
+                    fr.avoiding.as_deref().unwrap_or(""),
+                    mask_hits.join(", ")
+                ));
+                continue;
+            }
+            // An instance in BOTH groups already reaches the
+            // forbidden set by standing still. The BFS cannot see it
+            // (it refuses a destination that is also a source), so
+            // `forbid_reaches(g, g)` reported `holds` while every
+            // path in the fleet ran inside the prohibition.
+            let both: Vec<&str> = src
+                .intersection(&dst)
+                .map(|s| s.as_str())
+                .collect();
+            if !both.is_empty() {
+                (
+                    "violated",
+                    format!(
+                        "{} is in both `{}` and `{}` — a zero-length \
+                         path: the source already IS the forbidden \
+                         destination",
+                        both.join(", "),
+                        fr.from,
+                        fr.to
+                    ),
+                )
+            } else {
+                match bfs(&adj, &src, &dst, &masked, &inst_of) {
+                    None => ("holds", String::new()),
+                    Some(path) => (
+                        "violated",
+                        render_witness(&path, comps, by_id),
+                    ),
                 }
             }
         } else if let Some(r) = &c.require_subscribes {

--- a/crates/hale-cli/tests/fleet_claim_shapes.rs
+++ b/crates/hale-cli/tests/fleet_claim_shapes.rs
@@ -111,7 +111,8 @@ const INSTANCES: &str = r#"[
 const GROUPS: &str = r#"{
     "strategy": {"labels": ["strategy"]},
     "oms":      {"labels": ["oms"]},
-    "gateway":  {"labels": ["gateway"]}}"#;
+    "gateway":  {"labels": ["gateway"]},
+    "all":      {"labels": ["strategy", "oms", "gateway"]}}"#;
 
 /// Three artifacts built once per test.
 fn fixture(tag: &str) -> PathBuf {
@@ -213,33 +214,135 @@ fn every_bound_form_still_evaluates() {
     let _ = std::fs::remove_dir_all(&r);
 }
 
-/// A claim may name several verbs, and each is evaluated. Order must
-/// not matter — if only the first were checked, a violating second
-/// verb would be silently dropped.
+/// A claim naming several verbs is refused, because only one of them
+/// would ever be judged.
+///
+/// This test replaces one that asserted the opposite — that every
+/// verb is evaluated "whatever the order" — and passed while the bug
+/// was live. Two things were wrong with it. JSON field order cannot
+/// affect anything: serde fills a struct, and precedence is fixed by
+/// the `if/else` chain in the evaluator, so the two "orders" it tried
+/// were the same case twice. And it paired a violating
+/// `require_subscribes` with a holding `count`, where the violating
+/// verb happens to come FIRST in that chain — so the claim failed for
+/// a reason the test was not measuring, and a green result meant
+/// nothing.
+///
+/// The case that mattered is the reverse: an earlier verb that holds
+/// hiding a later one that cannot. Below, `require_subscribes` is
+/// satisfied and `count ... eq: 999` is impossible against a
+/// one-publisher fleet, and the whole claim used to pass.
 #[test]
-fn every_verb_in_a_claim_is_evaluated_whatever_the_order() {
+fn a_claim_naming_several_verbs_is_refused() {
     let r = fixture("multiverb");
-    let holds = r#""count_publisher_instances":
-        {"subject": "svc.order.request", "eq": 1}"#;
-    // gateway subscribes svc.order.request, never svc.order.intent.
-    let violates = r#""require_subscribes":
-        {"group": "gateway", "subject": "svc.order.intent"}"#;
+    let (out, code) = check_with(
+        &r,
+        ROUTES,
+        r#"[{"name": "both",
+             "require_subscribes": {"group": "gateway",
+                                    "subject": "svc.order.request"},
+             "count_publisher_instances": {"subject": "svc.order.request",
+                                           "eq": 999}}]"#,
+    );
+    assert_eq!(
+        code, 1,
+        "an impossible count must not be ignored because an earlier \
+         verb in the same claim holds: {out}"
+    );
+    assert!(
+        out.contains("names 2 verbs"),
+        "the diagnostic should say the claim is ambiguous rather than \
+         silently judging one verb: {out}"
+    );
 
-    for (a, b) in [(holds, violates), (violates, holds)] {
+    // Split into two claims, each with its own name, and the
+    // impossible one is now visible on its own terms.
+    let (out, code) = check_with(
+        &r,
+        ROUTES,
+        r#"[{"name": "fed", "require_subscribes":
+               {"group": "gateway", "subject": "svc.order.request"}},
+            {"name": "impossible", "count_publisher_instances":
+               {"subject": "svc.order.request", "eq": 999}}]"#,
+    );
+    assert_eq!(code, 1, "the impossible count must fail: {out}");
+    assert!(
+        out.contains("impossible"),
+        "the failing claim's own name should be reported: {out}"
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// A prohibition whose source and target overlap is violated by the
+/// overlap itself: an instance in both groups already sits in the
+/// forbidden set without going anywhere.
+///
+/// The BFS cannot see this — it refuses to accept a destination that
+/// is also a source — so `forbid_reaches(g, g)` reported `holds`
+/// while every path in the fleet ran inside the prohibition. The
+/// application tier calls this a zero-length violation; so does this.
+#[test]
+fn an_overlapping_prohibition_is_violated_not_vacuous() {
+    let r = fixture("overlap");
+    for (from, to) in [("all", "all"), ("all", "oms")] {
         let (out, code) = check_with(
             &r,
             ROUTES,
-            &format!(r#"[{{"name": "both", {a}, {b}}}]"#),
+            &format!(
+                r#"[{{"name": "ovl", "forbid_reaches":
+                     {{"from": "{from}", "to": "{to}"}}}}]"#
+            ),
         );
         assert_eq!(
             code, 1,
-            "a violating verb must be caught in either position: {out}"
+            "`forbid_reaches({from}, {to})` overlaps and must not \
+             hold: {out}"
         );
         assert!(
-            out.contains("subscribes `svc.order.intent`"),
-            "the violated verb should be the one reported: {out}"
+            out.contains("zero-length"),
+            "the witness should name the overlap as the violation: \
+             {out}"
         );
     }
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// `avoiding` may not name an endpoint of its own claim. Masking one
+/// deletes what the claim quantifies over, and an empty domain makes
+/// any prohibition hold.
+#[test]
+fn avoiding_may_not_mask_an_endpoint() {
+    let r = fixture("mask");
+    for group in ["strategy", "gateway"] {
+        let (out, code) = check_with(
+            &r,
+            ROUTES,
+            &format!(
+                r#"[{{"name": "av", "forbid_reaches":
+                     {{"from": "strategy", "to": "gateway",
+                       "avoiding": "{group}"}}}}]"#
+            ),
+        );
+        assert_eq!(
+            code, 1,
+            "masking the `{group}` endpoint must be refused: {out}"
+        );
+        assert!(out.contains("already an endpoint"), "{out}");
+    }
+
+    // The legitimate interposition form — masking the gate in the
+    // middle — still works, so this is not simply always-failing.
+    let (out, code) = check_with(
+        &r,
+        ROUTES,
+        r#"[{"name": "ok", "forbid_reaches":
+             {"from": "strategy", "to": "gateway",
+              "avoiding": "oms"}}]"#,
+    );
+    assert_eq!(
+        code, 0,
+        "every strategy->gateway path goes through oms: {out}"
+    );
     let _ = std::fs::remove_dir_all(&r);
 }
 
@@ -350,12 +453,19 @@ fn a_route_naming_an_undeclared_topic_is_refused() {
 /// The plan may not vouch for behavior the code does not have.
 ///
 /// `prober` imports the topic module, so `t::OrderRequest` IS in its
-/// artifact's topic table and a route may name it — but prober never
-/// publishes it. A positive claim must consult the artifact's actual
-/// endpoints rather than taking the plan's word, or a plan could
-/// satisfy any law by asserting the routes it wishes existed.
+/// artifact's topic table and the old admission check — "does the
+/// instance declare this topic?" — accepted it as a publisher. But
+/// prober never publishes it, so the route had a phantom producer,
+/// and a `require_subscribes` law about the consumer side could hold
+/// with nothing feeding it.
+///
+/// Role validity is now an ADMISSION check: the plan is refused
+/// before any claim is evaluated. That is the right stage — a plan
+/// that misdescribes its components is not a law failure, it is an
+/// invalid model, and the two should not be reported as if a claim
+/// had been judged.
 #[test]
-fn a_positive_claim_trusts_the_artifact_over_the_plan() {
+fn a_route_endpoint_must_hold_the_role_the_plan_gives_it() {
     let r = fixture("planlies");
     let routes = r#"[
         {"id": "bogus", "transport": "unix",
@@ -364,19 +474,40 @@ fn a_positive_claim_trusts_the_artifact_over_the_plan() {
     let (out, code) = check_with(
         &r,
         routes,
-        r#"[{"name": "strategy_publishes",
-             "require_publishes": {"group": "strategy",
-                                   "subject": "svc.order.request"}}]"#,
+        r#"[{"name": "gateway_is_fed",
+             "require_subscribes": {"group": "gateway",
+                                    "subject": "svc.order.request"}}]"#,
     );
     assert_eq!(
         code, 1,
-        "no code in `prober` publishes svc.order.request, so the claim \
-         must fail however the plan routes it: {out}"
+        "nothing in `prober` publishes svc.order.request, so this \
+         route has no producer: {out}"
     );
-    assert!(out.contains("publishes `svc.order.request`"), "{out}");
+    assert!(
+        out.contains("named as a publisher")
+            && out.contains("prober-0"),
+        "the diagnostic should name the route, the instance and the \
+         missing role: {out}"
+    );
 
-    // Control: the group that really does publish it satisfies the
-    // same claim, so the check is not simply always-failing.
+    // The subscriber side is checked the same way: gw-0 does not
+    // subscribe `svc.order.intent`.
+    let (out, code) = check_with(
+        &r,
+        r#"[
+        {"id": "wrongsub", "transport": "unix",
+         "publishers":  [{"instance": "prober-0", "topic": "t::OrderIntent"}],
+         "subscribers": [{"instance": "gw-0",     "topic": "t::OrderIntent"}]}]"#,
+        "[]",
+    );
+    assert_eq!(code, 1, "gw-0 does not subscribe that subject: {out}");
+    assert!(
+        out.contains("named as a subscriber"),
+        "the missing role should be named: {out}"
+    );
+
+    // Control: a route whose both ends really hold their roles is
+    // admitted, so the check is not simply always-failing.
     let (out, code) = check_with(
         &r,
         r#"[


### PR DESCRIPTION
Three fleet-claim fail-opens, from an external review of the effects / claims / constitutions / fleet stack. I reproduced each one before fixing it, and verified each new test fails against unfixed source.

These are the bounded ones. The review's remaining criticals (`calls_via_stdlib` dropped, wildcard bus delivery lost, unknowns not consulted) are all symptoms of the fleet tier re-deriving a model rather than sharing one, and are deliberately **not** in this PR — see the spike results at the end.

## A claim naming several verbs judged only one

Every verb on `ClaimSpec` is an `Option`, and `evaluate_claims` is an `if/else` chain emitting a single row. Whichever verb comes first in the chain wins; the rest are never read.

```json
{ "name": "both",
  "require_subscribes": {"group": "gateway", "subject": "svc.order.request"},
  "count_publisher_instances": {"subject": "svc.order.request", "eq": 999} }
```

`require_subscribes` holds, the impossible count is ignored, and the artifact records the claim's name as holding. Naming more than one verb is now refused — one name must mean one normalized form, or the claim name stops being the contract of record.

**This also replaces a test of mine that asserted the opposite and passed while the bug was live.** It was wrong twice over: JSON field order cannot affect this (serde fills a struct; precedence is fixed in Rust source), so its two "orders" were the same case twice — and it paired a violating verb that happens to come *first* with a holding one, so the claim failed for a reason the test never measured. The case that mattered is the reverse, and it is now the test.

## A route endpoint did not have to hold its role

Admission checked only that the instance **declared** the topic. Any component importing the topic module declares every topic in it, published or not. So a route could name a phantom producer:

```
gateway really subscribes
plan names a publisher that knows the topic but never publishes it
require_subscribes(gateway, subject) => holds, with nothing feeding it
```

The artifact is now the authority on both sides. A plan that misdescribes its components is refused *before* claims run — a plan that lies about its model is an invalid model, not a law failure, and the two should not be reported as though a claim had been judged.

## Overlapping prohibitions held vacuously

`forbid_reaches(g, g)` reported `holds` while every path in the fleet ran inside the prohibition, because the search will not accept a destination that is also a source. An instance in both groups is now a zero-length violation, matching the application tier.

`avoiding` may no longer name an endpoint of its own claim either — masking one deletes the domain being quantified over, and an empty domain makes any prohibition true.

## Verification

- each new test verified to **fail** against unfixed source and pass after; the six existing claim-shape tests pass either way
- 987 tests green across `hale-cli` + `hale-types`
- the downstream conformance plan still composes clean at 5 instances / 18 routes, unchanged `fleet_shape_hash` — the check that matters most for role validation, since it runs against real deployment config

## Spike results, for the follow-up

I ran a scope spike on the reviewer's "unify the model" recommendation. Two findings worth recording:

**The claim evaluator touches no `Expr` or `Stmt`** — only declaration-level AST. All behavioral reasoning already comes from `AllocSummary` / `BusGraph` / `frontier`, whose outputs the artifact serializes. So the expensive half of a shared model already exists, and the real gaps are narrow: `claims[].form` is a rendered *string* rather than a normalized IR (which is why the fleet tier had to invent its own claim vocabulary, and why the multi-verb shape was expressible at all), and `claims_report` has no model-taking entry point.

**`payload_hash` fuses subject with shape.** `topic_shape_hash(subject, shape)` hashes the subject bytes in, confirmed empirically: two topics with identical payload shape get different hashes purely from differing subjects. Since the fleet join key is `(subject, payload_hash)`, a wildcard subscriber can never join a concrete publisher — so the lost-wildcard finding is **structurally unexpressible, not merely unimplemented**. Fixing it means separating contract identity from addressing, which changes `shape_hash` and every pinned artifact. That belongs in its own deliberate change, not a bugfix sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
