### PR TITLE
fix(topology): localize both ends of a publish span (GH #408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ behavior.
 
 ## Unreleased
 
+### Publish provenance no longer mixes coordinate systems (GH #408)
+
+Schema 1.8 promises file-local spans. Calls, subscriptions and
+declarations localized both endpoints; publishes localized only the
+start and emitted the raw bundle-global end. A publish in any source
+whose virtual base is nonzero therefore produced a row naming a file
+with a span reaching past the end of it — a file-local start with a
+bundle-global end, which is not a coordinate in any single system. A
+consumer resolving it lands outside the file it was told to open.
+
+Concretely, a publishing locus in an imported library serialized as
+`source 1, span [182, 328]` where that file is 319 bytes, while a
+subscription in the *same file* was correct.
+
+`shape_hash` is unaffected — provenance is excluded from it by design
+— and an application whose publishes all sit in its first source is
+byte-identical, which is why the cross-artifact conformance loop never
+surfaced this. The locality test now checks calls, publishes,
+subscribes and declarations rather than declarations alone, and
+asserts both endpoints.
+
 ### Fleet claims: one verb per claim, real endpoint roles, and no vacuous prohibitions (GH #408)
 
 Three fail-opens, found by an external review of the effects / claims

--- a/crates/hale-cli/tests/source_map.rs
+++ b/crates/hale-cli/tests/source_map.rs
@@ -100,6 +100,81 @@ fn every_provenance_span_names_a_source_file() {
 /// length of the file it claims to be in, which is exactly what made
 /// them useless to a consumer.
 #[test]
+fn every_provenance_span_is_local_at_both_ends() {
+    let r = workspace("local_all");
+    let out = dump_from(&r, "apps/api");
+    let v: serde_json::Value =
+        serde_json::from_str(&out).expect("artifact parses");
+
+    let lens: Vec<usize> = v["sources"]
+        .as_array()
+        .expect("sources")
+        .iter()
+        .map(|s| {
+            let p = r.join(s["path"].as_str().expect("path"));
+            std::fs::read_to_string(&p).map(|t| t.len()).unwrap_or(0)
+        })
+        .collect();
+    let _ = std::fs::remove_dir_all(&r);
+
+    // (label, source id, start, end) for every provenance row there
+    // is — not just declarations.
+    let mut rows: Vec<(String, usize, usize, usize)> = Vec::new();
+    let mut push = |label: String, row: &serde_json::Value| {
+        rows.push((
+            label,
+            row["source"].as_i64().expect("source id") as usize,
+            row["span"][0].as_u64().expect("start") as usize,
+            row["span"][1].as_u64().expect("end") as usize,
+        ));
+    };
+    for sect in ["calls", "publishes", "subscribes"] {
+        for (i, row) in v["provenance"][sect]
+            .as_array()
+            .unwrap_or(&Vec::new())
+            .iter()
+            .enumerate()
+        {
+            push(format!("{sect}[{i}]"), row);
+        }
+    }
+    for (name, row) in
+        v["provenance"]["decls"].as_object().expect("decls")
+    {
+        push(format!("decl `{name}`"), row);
+    }
+
+    assert!(
+        rows.iter().any(|(l, ..)| l.starts_with("publishes")),
+        "the fixture must contain a publish, or this test cannot see \
+         the section it was written for"
+    );
+    // The publishing locus lives in the LIBRARY, which is not the
+    // first source — so its virtual base is nonzero and a
+    // bundle-global offset is distinguishable from a file-local one.
+    // With the publish in source 0 the two coincide and the bug is
+    // invisible, which is how it survived.
+    assert!(
+        rows.iter()
+            .any(|(l, sid, ..)| l.starts_with("publishes") && *sid != 0),
+        "the publish must come from a source with a nonzero base"
+    );
+
+    for (label, sid, start, end) in &rows {
+        let len = lens[*sid];
+        assert!(
+            *start <= *end && *end <= len,
+            "{label}: span [{start}, {end}] in source {sid}, which is \
+             only {len} bytes. A row that names a file must resolve \
+             INSIDE it at BOTH ends — a file-local start with a \
+             bundle-global end is not a coordinate in any single \
+             system, and a consumer following it lands outside the \
+             file it was told to open"
+        );
+    }
+}
+
+#[test]
 fn spans_are_local_to_their_file() {
     let r = workspace("local");
     let out = dump_from(&r, "apps/api");

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -724,7 +724,15 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
             quote(subj),
             loc(*s).0,
             loc(*s).1,
-            e
+            // BOTH endpoints localize. This end was the raw
+            // bundle-global offset while every other provenance
+            // section localized both, so a publish in any source
+            // whose virtual base is nonzero produced a row naming a
+            // file and a span reaching past the end of it — a
+            // file-local start with a bundle-global end, which is not
+            // a coordinate in any single system. A consumer resolving
+            // it lands outside the file it was told to open.
+            loc(*e).1
         ));
     }
     trim_trailing_comma(&mut out);


### PR DESCRIPTION
Finding C-1 from the external review of the effects / claims / constitutions / fleet stack. Reproduced first, then fixed.

## The defect

Schema 1.8 promises file-local spans. Calls, subscriptions and declarations pass **both** endpoints through the source-map localization. Publishes localized only the start:

```rust
source = loc(start).source
span   = [loc(start).local, end]   // ← raw bundle-global end
```

A publish in any source whose virtual base is nonzero therefore produced a row naming a file together with a span reaching past the end of it — a file-local start with a bundle-global end, which is not a coordinate in any single system. A consumer resolving it lands outside the file it was told to open, and cross-artifact witnesses are precisely the consumers that were going to.

Reproduced with a publishing locus in an imported library:

```
publishes   src=1 span=[182,328] len=319   <== outside the named file
subscribes  src=1 span=[250,276] len=319   ok
```

Both rows come from the same file. The start looks plausible and `start <= end` holds, so nothing about the row looks wrong locally — it just points somewhere else.

## Blast radius

Narrower than it first appears, and worth stating precisely:

- **`shape_hash` is unaffected.** Provenance is excluded from it by design, and I verified two real downstream artifacts hash identically before and after.
- **An application whose publishes all sit in its first source is byte-identical**, including `artifact_digest`. The bug needs the publish to come from an *imported* source.

That second point is why the conformance loop against a real multi-binary deployment never surfaced it: those applications publish from their own main source.

## The test could not have caught it

`spans_are_local_to_their_file` iterated `provenance.decls` only, so a defect confined to the publish section was invisible to it.

The new test walks calls, publishes, subscribes and declarations, asserts `0 <= start <= end <= source_length` at both ends, and — before any of that — asserts the fixture actually contains a publish from a nonzero-base source. Without that guard the test would pass by testing nothing, which is the exact failure mode that let this survive.

Verified to fail against unfixed source:

```
publishes[0]: span [186, 314] in source 1, which is only 204 bytes.
```

988 tests green across `hale-cli` + `hale-types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
