### PR TITLE
feat(model): one reachability engine for both tiers — fleet keeps every edge and propagates uncertainty (GH #408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ behavior.
 
 ## Unreleased
 
+### One reachability engine, shared by both tiers (GH #408)
+
+The fleet tier read the topology artifact and rebuilt a smaller graph
+of its own, and the omissions were not random.
+
+**It dropped `calls_via_stdlib`.** The artifact exports user→user
+paths whose interior is stdlib code, contracted to their user
+endpoints, and the application checker walks the union with `calls`.
+Fleet composition read `calls` alone, so a component whose routed
+handler reaches its routed publisher through `std::http::Router`
+contributed no edges at all — and a prohibition spanning it reported
+a false absence.
+
+**It ignored uncertainty.** Component `unknowns` were copied into the
+fleet artifact and never consulted, so an indirect call could remove
+the only modeled path to a target and `forbid_reaches` answered
+`holds` — an absence certified by not looking. Fleet claims can now
+answer `uncertified`, which fails like `violated` but says the repair
+is to resolve the unknown edge rather than to fix the program.
+
+Both are now one engine (`hale_types::model_graph`) that takes edges
+and holes and answers path / certified-absence / refusal, replacing
+the private graph walk. Uncertainty stays **reachability-sensitive**:
+only a hole the claim's source can actually walk to blocks
+certification, so an unrelated unknown elsewhere in the deployment
+does not poison every law.
+
+One nuance the engine encodes: `uninhabited_interface_call` is
+recorded as an unknown but is *not* fail-closed — in a closed world an
+interface with no conformers has no values, so the site is dead.
+Treating every unknown as a hole would make dead dispatch refuse to
+certify anything downstream of it.
+
 ### Publish provenance no longer mixes coordinate systems (GH #408)
 
 Schema 1.8 promises file-local spans. Calls, subscriptions and

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -230,14 +230,24 @@ pub fn compose(plan_path: &Path) -> Result<String, Vec<String>> {
                 vertices.push(format!("{}::{}", c.id, n));
             }
         }
-        for e in arr(&c.artifact["relations"]["calls"]) {
-            if let (Some(f), Some(t)) =
-                (e["from"].as_str(), e["to"].as_str())
-            {
-                call_edges.push((
-                    format!("{}::{}", c.id, f),
-                    format!("{}::{}", c.id, t),
-                ));
+        // BOTH call relations. `calls_via_stdlib` holds user→user
+        // paths whose interior is stdlib code, contracted to their
+        // user endpoints — the application checker walks the union,
+        // so a fleet that read only `calls` would lose a path the
+        // component's own claims can see. An intermediate service
+        // whose routed handler reaches its routed publisher through
+        // `std::http::Router` is invisible in `calls` alone, and a
+        // prohibition spanning it would report a false absence.
+        for rel in ["calls", "calls_via_stdlib"] {
+            for e in arr(&c.artifact["relations"][rel]) {
+                if let (Some(f), Some(t)) =
+                    (e["from"].as_str(), e["to"].as_str())
+                {
+                    call_edges.push((
+                        format!("{}::{}", c.id, f),
+                        format!("{}::{}", c.id, t),
+                    ));
+                }
             }
         }
         // A local publish→subscribe pair inside one instance is a
@@ -425,6 +435,11 @@ pub fn compose(plan_path: &Path) -> Result<String, Vec<String>> {
     // Uncertainty in a component stays uncertainty in the fleet. It
     // may add paths; it may never delete one and certify an absence.
     let mut unknowns: Vec<String> = Vec::new();
+    // Instance-qualified vertex -> why its out-edges are incomplete.
+    // Serializing these and then evaluating without them is how an
+    // indirect call used to remove the only modeled path to a target
+    // and leave `forbid_reaches` reporting `holds`.
+    let mut holes: Vec<(String, String)> = Vec::new();
     for c in &comps {
         for u in arr(&c.artifact["unknowns"]) {
             unknowns.push(format!(
@@ -432,6 +447,16 @@ pub fn compose(plan_path: &Path) -> Result<String, Vec<String>> {
                 q(&c.id),
                 serde_json::to_string(&u).unwrap_or_else(|_| "null".into())
             ));
+            let Some(f) = u["fn"].as_str() else { continue };
+            for r in arr(&u["reasons"]) {
+                let Some(kind) = r.as_str() else { continue };
+                if hale_types::model_graph::kind_hides_edges(kind) {
+                    holes.push((
+                        format!("{}::{}", c.id, f),
+                        kind.to_string(),
+                    ));
+                }
+            }
         }
     }
 
@@ -442,7 +467,7 @@ pub fn compose(plan_path: &Path) -> Result<String, Vec<String>> {
     }
     let claim_rows = evaluate_claims(
         &plan, &groups, &comps, &by_id, &call_edges, &local_bus,
-        &route_edges, &resolved_routes, &mut errs,
+        &route_edges, &resolved_routes, &holes, &mut errs,
     );
     if !errs.is_empty() {
         return Err(errs);
@@ -514,6 +539,7 @@ fn evaluate_claims(
     local_bus: &[(String, String)],
     routed: &[(String, String, String)],
     resolved_routes: &[(String, String, Vec<String>, Vec<String>)],
+    holes: &[(String, String)],
     errs: &mut Vec<String>,
 ) -> Vec<String> {
     let inst_of = |v: &str| -> String {
@@ -535,14 +561,38 @@ fn evaluate_claims(
     // The composed edge set: interior calls, interior bus hops, and
     // the explicit routes. Nothing else — a route is the ONLY way a
     // vertex in one instance reaches one in another.
-    let mut adj: BTreeMap<&str, Vec<(&str, Option<&str>)>> =
-        BTreeMap::new();
+    let mut graph = hale_types::model_graph::ModelGraph::new();
     for (f, t) in calls.iter().chain(local_bus.iter()) {
-        adj.entry(f).or_default().push((t, None));
+        graph.add_edge(f.as_str(), t.as_str(), None);
     }
     for (f, t, r) in routed {
-        adj.entry(f).or_default().push((t, Some(r)));
+        graph.add_edge(f.as_str(), t.as_str(), Some(r.clone()));
     }
+    // Uncertainty is part of the model, not a footnote beside it.
+    for (v, why) in holes {
+        graph.add_hole(v.as_str(), why.as_str());
+    }
+
+    // Fleet groups name INSTANCES; the graph is over the vertices
+    // those instances contain, which is the same projection the
+    // application tier makes from a locus to its methods.
+    let all_vertices: Vec<String> = comps
+        .iter()
+        .flat_map(|c| {
+            arr(&c.artifact["sorts"]["fns"])
+                .iter()
+                .filter_map(|f| f.as_str())
+                .map(|n| format!("{}::{}", c.id, n))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let expand = |insts: &BTreeSet<String>| -> BTreeSet<String> {
+        all_vertices
+            .iter()
+            .filter(|v| insts.contains(&inst_of(v)))
+            .cloned()
+            .collect()
+    };
 
     let mut rows: Vec<String> = Vec::new();
     for c in &plan.claims {
@@ -647,11 +697,27 @@ fn evaluate_claims(
                     ),
                 )
             } else {
-                match bfs(&adj, &src, &dst, &masked, &inst_of) {
-                    None => ("holds", String::new()),
-                    Some(path) => (
+                use hale_types::model_graph::Reach;
+                match graph.reaches(
+                    &expand(&src),
+                    &expand(&dst),
+                    &expand(&masked),
+                ) {
+                    Reach::None => ("holds", String::new()),
+                    Reach::Path(path) => (
                         "violated",
                         render_witness(&path, comps, by_id),
+                    ),
+                    // An absence nobody could see is not an absence.
+                    Reach::Uncertified(h) => (
+                        "uncertified",
+                        format!(
+                            "cannot certify this absence: `{}` has \
+                             outgoing edges this model cannot see \
+                             ({}), and it is reachable from `{}` — \
+                             the missing edges could lead to `{}`",
+                            h.at, h.why, fr.from, fr.to
+                        ),
                     ),
                 }
             }
@@ -723,89 +789,22 @@ fn evaluate_claims(
             q(result),
             q(&witness)
         ));
-        if result == "violated" {
+        // `uncertified` fails too. A law that could not be checked
+        // has not been satisfied — the distinction from `violated`
+        // is recorded because the REPAIR differs (resolve the
+        // unknown edge vs. fix the program), not because one of them
+        // passes.
+        if result == "violated" || result == "uncertified" {
             errs.push(format!(
-                "fleet claim `{}` violated{}{}",
+                "fleet claim `{}` {}{}{}",
                 c.name,
+                result,
                 if witness.is_empty() { "" } else { " — witness:\n  " },
                 witness
             ));
         }
     }
     rows
-}
-
-/// Shortest path over the composed graph, masking a group out. The
-/// mask is what makes `forbid reaches … avoiding G` the interposition
-/// form: any surviving path is a bypass.
-fn bfs(
-    adj: &BTreeMap<&str, Vec<(&str, Option<&str>)>>,
-    src: &BTreeSet<String>,
-    dst: &BTreeSet<String>,
-    masked: &BTreeSet<String>,
-    inst_of: &dyn Fn(&str) -> String,
-) -> Option<Vec<(String, Option<String>)>> {
-    let mut parent: BTreeMap<String, (String, Option<String>)> =
-        BTreeMap::new();
-    let mut queue: std::collections::VecDeque<String> =
-        std::collections::VecDeque::new();
-    let mut seen: BTreeSet<String> = BTreeSet::new();
-    for (v, _) in adj.iter() {
-        if src.contains(&inst_of(v)) && !masked.contains(&inst_of(v)) {
-            seen.insert((*v).to_string());
-            queue.push_back((*v).to_string());
-        }
-    }
-    while let Some(cur) = queue.pop_front() {
-        if dst.contains(&inst_of(&cur))
-            && !src.contains(&inst_of(&cur))
-        {
-            let mut path = vec![(cur.clone(), None)];
-            let mut at = cur;
-            while let Some((prev, via)) = parent.get(&at) {
-                path.push((prev.clone(), via.clone()));
-                at = prev.clone();
-            }
-            path.reverse();
-            // Reconstruction pairs each node with the route on its
-            // OUTGOING edge (parent[at] carries the route INTO `at`,
-            // and it is pushed alongside the predecessor). The
-            // renderer wants the route INTO each node, so every label
-            // shifts one position forward: node i is entered by the
-            // edge leaving node i-1.
-            //
-            // This read `path[i].1` first — node i's OUTGOING route —
-            // and only fell back to `path[i - 1].1`. On a two-node
-            // path the fallback is always taken (the destination has
-            // no outgoing edge) and the answer came out right, which
-            // is why every single-hop witness looked correct. A
-            // three-node witness labelled BOTH hops with the second
-            // route, sending a reader to the wrong route entry.
-            let mut out: Vec<(String, Option<String>)> = Vec::new();
-            for (i, (n, _)) in path.iter().enumerate() {
-                let via = if i == 0 {
-                    None
-                } else {
-                    path[i - 1].1.clone()
-                };
-                out.push((n.clone(), via));
-            }
-            return Some(out);
-        }
-        for (next, via) in adj.get(cur.as_str()).into_iter().flatten() {
-            if masked.contains(&inst_of(next)) {
-                continue;
-            }
-            if seen.insert((*next).to_string()) {
-                parent.insert(
-                    (*next).to_string(),
-                    (cur.clone(), via.map(str::to_string)),
-                );
-                queue.push_back((*next).to_string());
-            }
-        }
-    }
-    None
 }
 
 /// A witness that crosses artifacts, naming the source file of each

--- a/crates/hale-cli/tests/fleet_model_soundness.rs
+++ b/crates/hale-cli/tests/fleet_model_soundness.rs
@@ -1,0 +1,274 @@
+//! The two rules a composed model must not break: keep every edge
+//! the components represent, and never certify an absence over a
+//! graph with holes in it.
+//!
+//! GH #408. The fleet tier used to read `relations.calls` and stop
+//! there, so a user→stdlib→user path — which the application checker
+//! walks, and which the artifact exports as `calls_via_stdlib` —
+//! vanished the moment those components were composed. It also
+//! copied every component's `unknowns` into its output and evaluated
+//! as though they were not there, so an indirect call could remove
+//! the only modeled path to a target and the prohibition reported
+//! `holds`: an absence certified by not looking.
+//!
+//! Both are now answered by one shared reachability engine
+//! (`hale_types::model_graph`) rather than a second graph walk that
+//! has to remember every rule the first one learned.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn root(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir()
+        .join(format!("hale_fms_{}_{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&d);
+    d
+}
+
+fn write(root: &Path, rel: &str, src: &str) {
+    let p = root.join(rel);
+    std::fs::create_dir_all(p.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&p, src).expect("write");
+}
+
+fn hale(args: &[&str]) -> (String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(args)
+        .output()
+        .expect("run hale");
+    (
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+const TOPICS: &str = r#"
+type Intent { id: Int; }
+type Order  { id: Int; }
+topic OrderIntent  { payload: Intent; subject: "svc.order.intent"; }
+topic OrderRequest { payload: Order;  subject: "svc.order.request"; }
+"#;
+
+const A: &str = r#"
+import "../lib" as t;
+locus Probe {
+    params { n: Int = 0; }
+    bus { publish t::OrderIntent; }
+    fn submit() { let i = t::Intent { id: 1 }; t::OrderIntent <- i; }
+}
+main locus Prober { params { p: Probe = Probe { }; } }
+fn main() { Prober { }; }
+"#;
+
+/// The middle component's handler reaches its publisher ONLY through
+/// `std::http::Router`. Its artifact has an empty `calls` relation
+/// and one `calls_via_stdlib` edge, so a composer reading `calls`
+/// alone sees an instance that connects nothing.
+const B_VIA_STDLIB: &str = r#"
+import "../lib" as t;
+locus Fwd {
+    params { n: Int = 0; }
+    bus { publish t::OrderRequest; }
+    fn handle(ctx: std::http::Context) -> std::http::Response {
+        let o = t::Order { id: 1 };
+        t::OrderRequest <- o;
+        return std::http::Response { status: 200, body: "ok" };
+    }
+}
+locus Oms {
+    params { n: Int = 0; }
+    bus { subscribe t::OrderIntent as on_intent; }
+    fn on_intent(i: t::Intent) {
+        self.n = i.id;
+        let r = std::http::Router { };
+        r.add("GET", "/fwd", Fwd { });
+        let resp = r.dispatch(std::http::Request {
+            method: "GET", path: "/fwd",
+            version: "HTTP/1.1", headers: "", body: ""
+        });
+        self.n = resp.status;
+    }
+}
+main locus OmsApp { params { o: Oms = Oms { }; } }
+fn main() { OmsApp { }; }
+"#;
+
+/// The middle component's handler calls through an index-result
+/// receiver, which stays untypeable — its outgoing edges are
+/// incomplete, so nothing downstream of it can be proved absent.
+const B_UNKNOWN: &str = r#"
+import "../lib" as t;
+locus Sink { params { n: Int = 0; } fn work(v: Int) -> Int { return v * 2; } }
+locus Oms {
+    params { n: Int = 0; }
+    bus { subscribe t::OrderIntent as on_intent; }
+    fn on_intent(i: t::Intent) {
+        let xs = [Sink { }];
+        self.n = xs[0].work(i.id);
+    }
+}
+main locus OmsApp { params { o: Oms = Oms { }; } }
+fn main() { OmsApp { }; }
+"#;
+
+const C: &str = r#"
+import "../lib" as t;
+locus Gateway {
+    params { n: Int = 0; }
+    bus { subscribe t::OrderRequest as on_order; }
+    fn on_order(o: t::Order) { self.n = o.id; }
+}
+main locus GwApp { params { g: Gateway = Gateway { }; } }
+fn main() { GwApp { }; }
+"#;
+
+const INSTANCES: &str = r#"[
+    {"id": "a-0", "artifact": "artifacts/a.json", "labels": ["strategy"]},
+    {"id": "b-0", "artifact": "artifacts/b.json", "labels": ["oms"]},
+    {"id": "c-0", "artifact": "artifacts/c.json", "labels": ["gateway"]}]"#;
+
+const GROUPS: &str = r#"{
+    "strategy": {"labels": ["strategy"]},
+    "gateway":  {"labels": ["gateway"]}}"#;
+
+const NO_REACH: &str = r#"[{"name": "no_reach",
+    "forbid_reaches": {"from": "strategy", "to": "gateway"}}]"#;
+
+/// Build the three components with the given middle one.
+fn fixture(tag: &str, middle: &str) -> PathBuf {
+    let r = root(tag);
+    write(&r, "lib/topics.hl", TOPICS);
+    write(&r, "a/main.hl", A);
+    write(&r, "b/main.hl", middle);
+    write(&r, "c/main.hl", C);
+    write(&r, "hale.toml", "[deps]\n");
+    for app in ["a", "b", "c"] {
+        let dst = r.join(format!("artifacts/{}.json", app));
+        std::fs::create_dir_all(dst.parent().expect("parent")).expect("mkdir");
+        let (out, code) = hale(&[
+            "check",
+            r.join(app).to_str().expect("utf8"),
+            &format!("--dump-topology={}", dst.display()),
+        ]);
+        assert_eq!(code, 0, "component `{}` must check clean: {}", app, out);
+    }
+    r
+}
+
+fn check(r: &Path, routes: &str) -> (String, i32) {
+    let plan = format!(
+        r#"{{"schema": "1.0", "name": "prod",
+            "instances": {INSTANCES}, "routes": {routes},
+            "groups": {GROUPS}, "claims": {NO_REACH}}}"#
+    );
+    write(r, "plan.json", &plan);
+    hale(&["fleet", "check", r.join("plan.json").to_str().expect("utf8")])
+}
+
+const BOTH_ROUTES: &str = r#"[
+    {"id": "intent", "transport": "unix",
+     "publishers":  [{"instance": "a-0", "topic": "t::OrderIntent"}],
+     "subscribers": [{"instance": "b-0", "topic": "t::OrderIntent"}]},
+    {"id": "request", "transport": "unix",
+     "publishers":  [{"instance": "b-0", "topic": "t::OrderRequest"}],
+     "subscribers": [{"instance": "c-0", "topic": "t::OrderRequest"}]}]"#;
+
+const INTENT_ONLY: &str = r#"[
+    {"id": "intent", "transport": "unix",
+     "publishers":  [{"instance": "a-0", "topic": "t::OrderIntent"}],
+     "subscribers": [{"instance": "b-0", "topic": "t::OrderIntent"}]}]"#;
+
+/// F-1: the hop through stdlib is part of the path.
+#[test]
+fn a_path_through_stdlib_survives_composition() {
+    let r = fixture("viastdlib", B_VIA_STDLIB);
+
+    // The premise: this component's user→user edge exists ONLY in
+    // `calls_via_stdlib`. If that ever stops being true the test
+    // still passes but stops testing anything, so assert it.
+    let art = std::fs::read_to_string(r.join("artifacts/b.json"))
+        .expect("artifact");
+    let v: serde_json::Value =
+        serde_json::from_str(&art).expect("parses");
+    assert!(
+        v["relations"]["calls"].as_array().expect("calls").is_empty(),
+        "the middle component must have NO direct call edges, or this \
+         test does not exercise the contracted relation"
+    );
+    assert!(
+        !v["relations"]["calls_via_stdlib"]
+            .as_array()
+            .expect("via")
+            .is_empty(),
+        "the middle component must have a through-stdlib edge"
+    );
+
+    let (out, code) = check(&r, BOTH_ROUTES);
+    assert_eq!(
+        code, 1,
+        "strategy reaches gateway through the middle component's \
+         stdlib-interior path: {out}"
+    );
+    assert!(
+        out.contains("Oms::on_intent") && out.contains("Fwd::handle"),
+        "the witness must include the hop the stdlib contracted: {out}"
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// F-3: a hole the source can walk to blocks certification.
+#[test]
+fn a_reachable_unknown_makes_an_absence_uncertified() {
+    let r = fixture("unknown", B_UNKNOWN);
+
+    let art = std::fs::read_to_string(r.join("artifacts/b.json"))
+        .expect("artifact");
+    assert!(
+        art.contains("untyped_receiver_call"),
+        "the middle component must carry an unknown, or this test \
+         does not exercise uncertainty:\n{art}"
+    );
+
+    // Nothing routes b -> c, so the modeled graph has no path. The
+    // old answer was `holds`.
+    let (out, code) = check(&r, INTENT_ONLY);
+    assert_eq!(
+        code, 1,
+        "an unknown reachable from the source could conceal the path, \
+         so this absence must not be certified: {out}"
+    );
+    assert!(
+        out.contains("uncertified"),
+        "the verdict must be `uncertified` — nothing was disproved, \
+         so it is not `violated` either: {out}"
+    );
+    assert!(
+        out.contains("Oms::on_intent"),
+        "the refusal must name the vertex whose edges are missing, or \
+         it is not actionable: {out}"
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// The rule that keeps `uncertified` usable: an unknown the claim's
+/// source cannot reach is not evidence about that claim.
+///
+/// Same artifacts and same claim as the test above — only the route
+/// differs. With nothing routed into the component that carries the
+/// unknown, the absence is real and certified.
+#[test]
+fn an_unreachable_unknown_does_not_poison_the_fleet() {
+    let r = fixture("unrelated", B_UNKNOWN);
+    let (out, code) = check(&r, "[]");
+    assert_eq!(
+        code, 0,
+        "with nothing routed from strategy, the unknown in the middle \
+         component is unreachable and must not block certification: \
+         {out}"
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -32,6 +32,7 @@ pub mod claims;
 pub mod model;
 pub mod topic_identity;
 pub mod topology;
+pub mod model_graph;
 pub mod verdict;
 pub mod stdlib_bodies;
 pub mod stdlib_surface;

--- a/crates/hale-types/src/model_graph.rs
+++ b/crates/hale-types/src/model_graph.rs
@@ -1,0 +1,317 @@
+//! One reachability engine over a normalized model.
+//!
+//! GH #408: the fleet tier read the topology artifact and rebuilt a
+//! smaller graph of its own, and the omissions were not random. It
+//! dropped `calls_via_stdlib`, so a user→stdlib→user path the
+//! application checker walks disappeared when the same components
+//! were composed. It collected `unknowns` into its output and never
+//! consulted them, so an indirect call could remove the only modeled
+//! path to a target and the prohibition reported `holds` — an
+//! absence certified by not looking.
+//!
+//! Both are the same bug: a second derivation of "what reaches what"
+//! that has to remember every rule the first one learned. This type
+//! is that derivation, once. A caller supplies edges and says which
+//! vertices have INCOMPLETE outgoing edge sets; it answers with a
+//! path, a certified absence, or a refusal to certify.
+//!
+//! It deliberately knows nothing about instances, routes, claims or
+//! artifacts — a route id rides along as an opaque label on an edge
+//! so a witness can name it. That keeps it usable from the
+//! application tier, whose edges are ordinary calls and bus hops,
+//! when that tier moves onto the shared model.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+/// An edge, with an optional label the witness renderer can name
+/// (the fleet tier puts a route id here; the application tier has
+/// nothing to say and passes `None`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Edge {
+    pub to: String,
+    pub via: Option<String>,
+}
+
+/// Why a vertex's outgoing edges are not fully known.
+///
+/// Recorded per vertex so the refusal can say which hole stopped it —
+/// "cannot certify" is only actionable if the reader learns where to
+/// look.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Hole {
+    pub at: String,
+    pub why: String,
+}
+
+/// The result of asking whether one set reaches another.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Reach {
+    /// No path, over a graph with no relevant holes: a real absence.
+    None,
+    /// A concrete path, as `(vertex, edge label used to enter it)`.
+    /// The first element's label is always `None`.
+    Path(Vec<(String, Option<String>)>),
+    /// No path was found, but a vertex reachable from the source has
+    /// incomplete outgoing edges, so the absence is not proved. This
+    /// is `uncertified`, not `holds` — and not `violated` either,
+    /// since nothing was disproved.
+    Uncertified(Hole),
+}
+
+/// A directed graph plus the set of vertices whose out-edges are
+/// incomplete.
+#[derive(Default, Debug)]
+pub struct ModelGraph {
+    edges: BTreeMap<String, Vec<Edge>>,
+    holes: BTreeMap<String, String>,
+}
+
+impl ModelGraph {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_edge(
+        &mut self,
+        from: impl Into<String>,
+        to: impl Into<String>,
+        via: Option<String>,
+    ) {
+        self.edges.entry(from.into()).or_default().push(Edge {
+            to: to.into(),
+            via,
+        });
+    }
+
+    /// Mark a vertex as having outgoing edges this model cannot see.
+    pub fn add_hole(
+        &mut self,
+        at: impl Into<String>,
+        why: impl Into<String>,
+    ) {
+        self.holes.insert(at.into(), why.into());
+    }
+
+    pub fn has_holes(&self) -> bool {
+        !self.holes.is_empty()
+    }
+
+    /// Does any vertex in `src` reach any vertex in `dst`?
+    ///
+    /// `masked` vertices are removed from the graph entirely, which
+    /// is how interposition is asked: "no path avoids the gate".
+    ///
+    /// A found path always wins over a hole. A counterexample is
+    /// definitive, and reporting `uncertified` when a real violation
+    /// exists would hide the more useful answer.
+    pub fn reaches(
+        &self,
+        src: &BTreeSet<String>,
+        dst: &BTreeSet<String>,
+        masked: &BTreeSet<String>,
+    ) -> Reach {
+        let mut parent: BTreeMap<&str, (&str, Option<String>)> =
+            BTreeMap::new();
+        let mut seen: BTreeSet<&str> = BTreeSet::new();
+        let mut queue: VecDeque<&str> = VecDeque::new();
+        // Holes seen while walking, kept in deterministic order so a
+        // refusal names the same vertex on every machine.
+        let mut hit: BTreeSet<&str> = BTreeSet::new();
+
+        for v in src {
+            if masked.contains(v) {
+                continue;
+            }
+            if seen.insert(v) {
+                queue.push_back(v);
+                if self.holes.contains_key(v.as_str()) {
+                    hit.insert(v);
+                }
+            }
+        }
+
+        while let Some(cur) = queue.pop_front() {
+            if dst.contains(cur) && !src.contains(cur) {
+                let mut path = vec![(cur.to_string(), None)];
+                let mut at = cur;
+                while let Some((prev, via)) = parent.get(at) {
+                    path.push((prev.to_string(), via.clone()));
+                    at = prev;
+                }
+                path.reverse();
+                // Each node is paired with the label of its OUTGOING
+                // edge by the walk above; the renderer wants the one
+                // it was entered by, so shift every label forward.
+                let shifted: Vec<(String, Option<String>)> = path
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (n, _))| {
+                        (
+                            n.clone(),
+                            if i == 0 {
+                                None
+                            } else {
+                                path[i - 1].1.clone()
+                            },
+                        )
+                    })
+                    .collect();
+                return Reach::Path(shifted);
+            }
+            for e in self.edges.get(cur).into_iter().flatten() {
+                if masked.contains(&e.to) {
+                    continue;
+                }
+                if seen.insert(&e.to) {
+                    parent.insert(&e.to, (cur, e.via.clone()));
+                    queue.push_back(&e.to);
+                    if self.holes.contains_key(e.to.as_str()) {
+                        hit.insert(&e.to);
+                    }
+                }
+            }
+        }
+
+        // No path. Only a hole the source could actually have walked
+        // to can conceal one — an unrelated unknown elsewhere in the
+        // fleet must not poison every claim.
+        match hit.first() {
+            Some(at) => Reach::Uncertified(Hole {
+                at: (*at).to_string(),
+                why: self.holes[*at].clone(),
+            }),
+            None => Reach::None,
+        }
+    }
+}
+
+/// Which artifact `unknowns` kinds actually mean "edges are missing".
+///
+/// `uninhabited_interface_call` is recorded as an unknown but is NOT
+/// fail-closed: in a closed world an interface with no conformers has
+/// no values, so the call site is dead and the walker treats it as
+/// such (see `topology.rs`). Reading every unknown as a hole would
+/// make a dead site refuse to certify anything downstream of it,
+/// which is both wrong and loud.
+pub fn kind_hides_edges(kind: &str) -> bool {
+    match kind {
+        "indirect_call" => true,
+        "computed_publish" => true,
+        k if k.starts_with("untyped_receiver_call") => true,
+        k if k.starts_with("uninhabited_interface_call") => false,
+        // Unrecognized kinds fail CLOSED. A newer compiler emitting a
+        // hole this build has never heard of must not be read as an
+        // absence of holes.
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set(xs: &[&str]) -> BTreeSet<String> {
+        xs.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn chain() -> ModelGraph {
+        let mut g = ModelGraph::new();
+        g.add_edge("a", "b", Some("r1".into()));
+        g.add_edge("b", "c", Some("r2".into()));
+        g
+    }
+
+    #[test]
+    fn a_path_names_the_label_of_each_hop() {
+        let g = chain();
+        match g.reaches(&set(&["a"]), &set(&["c"]), &BTreeSet::new()) {
+            Reach::Path(p) => {
+                assert_eq!(p[0], ("a".into(), None));
+                assert_eq!(p[1], ("b".into(), Some("r1".into())));
+                assert_eq!(p[2], ("c".into(), Some("r2".into())));
+            }
+            other => panic!("expected a path, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn absence_over_a_complete_graph_is_certified() {
+        let mut g = ModelGraph::new();
+        g.add_edge("a", "b", None);
+        assert_eq!(
+            g.reaches(&set(&["a"]), &set(&["z"]), &BTreeSet::new()),
+            Reach::None
+        );
+    }
+
+    #[test]
+    fn a_reachable_hole_refuses_to_certify_an_absence() {
+        let mut g = ModelGraph::new();
+        g.add_edge("a", "b", None);
+        g.add_hole("b", "indirect_call");
+        match g.reaches(&set(&["a"]), &set(&["z"]), &BTreeSet::new()) {
+            Reach::Uncertified(h) => {
+                assert_eq!(h.at, "b");
+                assert_eq!(h.why, "indirect_call");
+            }
+            other => panic!("expected uncertified, got {other:?}"),
+        }
+    }
+
+    /// The rule that keeps this usable: an unknown somewhere else in
+    /// the model is not evidence about THIS claim.
+    #[test]
+    fn an_unreachable_hole_does_not_poison_the_claim() {
+        let mut g = ModelGraph::new();
+        g.add_edge("a", "b", None);
+        g.add_hole("q", "indirect_call");
+        assert_eq!(
+            g.reaches(&set(&["a"]), &set(&["z"]), &BTreeSet::new()),
+            Reach::None
+        );
+    }
+
+    /// A counterexample is definitive; a hole elsewhere must not
+    /// downgrade it to "cannot tell".
+    #[test]
+    fn a_real_path_wins_over_a_hole() {
+        let mut g = chain();
+        g.add_hole("b", "indirect_call");
+        assert!(matches!(
+            g.reaches(&set(&["a"]), &set(&["c"]), &BTreeSet::new()),
+            Reach::Path(_)
+        ));
+    }
+
+    #[test]
+    fn masking_the_gate_removes_the_path() {
+        let g = chain();
+        assert_eq!(
+            g.reaches(&set(&["a"]), &set(&["c"]), &set(&["b"])),
+            Reach::None
+        );
+    }
+
+    /// A hole behind the mask is not reachable, so it cannot conceal
+    /// anything the claim is about.
+    #[test]
+    fn masking_also_hides_the_holes_behind_it() {
+        let mut g = chain();
+        g.add_hole("b", "indirect_call");
+        assert_eq!(
+            g.reaches(&set(&["a"]), &set(&["c"]), &set(&["b"])),
+            Reach::None
+        );
+    }
+
+    #[test]
+    fn unknown_kinds_are_classified_by_whether_they_hide_edges() {
+        assert!(kind_hides_edges("indirect_call"));
+        assert!(kind_hides_edges("computed_publish"));
+        assert!(kind_hides_edges("untyped_receiver_call:foo"));
+        // dead in a closed world, not a hole
+        assert!(!kind_hides_edges("uninhabited_interface_call:I.m"));
+        // a kind from a newer compiler fails closed
+        assert!(kind_hides_edges("some_future_hole"));
+    }
+}


### PR DESCRIPTION
Closes **F-1** and **F-3** from the external review — structurally, by giving both tiers one reachability engine, rather than by patching each finding where it surfaced.

## Why one engine

The fleet tier read the topology artifact and rebuilt a smaller graph by hand. That meant it had to remember every rule the application checker had already learned, and it forgot two. Fixing them individually would have re-earned the same debt the moment a third rule appeared.

`hale_types::model_graph` takes edges and holes and answers **path** / **certified absence** / **refusal to certify**. Fleet's private BFS is deleted rather than left beside it — a second graph walk in the same file is exactly what this change exists to stop.

## F-1 — the path through stdlib survives composition

The artifact exports `calls_via_stdlib`: user→user paths whose interior is stdlib code, contracted to their user endpoints. Application claims walk the union with `calls`. Fleet composition read `calls` alone.

So a component whose routed handler reaches its routed publisher only through `std::http::Router` contributed **no edges at all**, and a prohibition spanning it reported a false absence. The canary component has an empty `calls` relation and one `calls_via_stdlib` edge — and the test asserts that premise, so it cannot silently stop exercising the contracted relation if the compiler's classification changes.

The witness now shows the contracted hop:

```
a-0::Probe::submit  [a/main.hl]
-(route `intent`)->
b-0::Oms::on_intent  [b/main.hl]
->                              ← the stdlib-interior hop
b-0::Fwd::handle  [b/main.hl]
-(route `request`)->
c-0::Gateway::on_order  [c/main.hl]
```

## F-3 — uncertainty is consulted, not just serialized

Component `unknowns` were gathered, written into the fleet artifact, and never read — underneath a comment stating that uncertainty "may never delete a path and certify an absence". An indirect call could remove the only modeled path to a target and `forbid_reaches` answered `holds`.

Fleet claims now answer `uncertified`. It fails like `violated` but names a different repair — resolve the unknown edge, rather than fix the program:

```
fleet claim `no_reach` uncertified — witness:
  cannot certify this absence: `b-0::Oms::on_intent` has outgoing edges
  this model cannot see (untyped_receiver_call:work), and it is
  reachable from `strategy` — the missing edges could lead to `gateway`
```

**Reachability-sensitive on purpose.** Only a hole the claim's source can actually walk to blocks certification. A global poison would make `uncertified` useless on any real deployment, so there is a test for that direction too: same artifacts, same claim, no route in — and the absence is certified.

## A nuance the review didn't have

`uninhabited_interface_call` is recorded as an unknown but is **not** fail-closed: in a closed world an interface with no conformers has no values, so the site is dead and every walker treats it as such. Reading every unknown as a hole would make dead dispatch refuse to certify anything downstream of it.

This is not hypothetical. **Both** unknowns in the real downstream deployment are exactly that kind — so the literal reading would have started reporting `uncertified` against real production config on day one. The classifier is explicit about which kinds hide edges, and unrecognized kinds fail closed so a newer compiler's hole is never read as an absence of holes.

## Verification

- both canaries verified to **fail** against unfixed source and pass after
- the unreachable-unknown control passes either way — it guards against over-correction
- 8 unit tests on the engine itself (path labelling, certified absence, reachable vs unreachable hole, path-beats-hole, masking, kind classification)
- 999 tests green across `hale-cli` + `hale-types`
- the downstream conformance plan still composes clean at 5 instances / 18 routes, unchanged `fleet_shape_hash`

## Scope

The application tier still evaluates over AST + `BusGraph`. This establishes the shared engine and moves the fleet onto it; moving `claims.rs` across is the differential migration that follows, with the corpus as its oracle. The remaining review findings (F-2 wildcards, F-7…F-13 artifact identity) are untouched and independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
