### PR TITLE
refactor(claims): the application checker walks the shared engine (GH #408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,23 @@ fleet tier walks past and refuses only if no path is found at all,
 since a concrete cross-binary counterexample is worth more than a
 refusal. `search` expresses both.
 
-`neither_claim_evaluator_rolls_its_own_search` fails the build if a
-third walk appears. Every fleet defect fixed this week — dropped
-through-stdlib edges, ignored unknowns, the zero-length overlap case,
-mislabelled witness hops — was a rule one walk had and the other
-lacked.
+Hole propagation moved INTO the engine: a caller reports that a
+vertex's edge set is incomplete and picks a policy, and the engine
+decides the verdict. Forgetting to consult a hole is no longer a
+mistake the API allows. Two fail-opens in the fleet wrapper closed
+with it — source/target overlap answered `None` instead of a
+zero-length path, and a tripped step ceiling answered `None` instead
+of refusing. Search *exhaustion* can prove an absence; search
+*abandonment* never can.
+
+Scope, stated precisely: this is BOOLEAN reachability, what `forbid
+reaches` and `only edges` ask. `bound` keeps its own weighted
+traversal (`site_count`), because a quantitative semiring is a
+different algorithm over the same edges — not a duplicate of this
+one. `no_prohibition_evaluator_defines_a_private_bfs` fails the build
+if a third frontier appears, its companions check that both
+evaluators still call the engine and that the engine holds exactly
+one queue.
 
 ### One reachability engine, shared by both tiers (GH #408)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ behavior.
 
 ## Unreleased
 
+### The application checker moves onto the shared engine (GH #408)
+
+`forbid reaches` had its own breadth-first walk, written before the
+fleet tier existed. Both are now `model_graph::search`, which owns the
+queue, the visited set, the parent tree, root seeding, masking and the
+step ceiling — the bookkeeping that is identical everywhere and easy
+to get subtly wrong. What stays with each tier is what genuinely
+differs: what a vertex is, which edges exist, what counts as the
+target, and the diagnostic for an edge the walk cannot follow.
+
+Behavior is unchanged, and that is checked rather than asserted:
+`hale check` output and topology artifacts — claim verdicts included —
+are byte-identical across all 88 corpus programs and three real
+downstream applications, before and after.
+
+The two tiers keep their opposite policies on an unfollowable edge,
+because both are deliberate. The application checker stops at it and
+names the edge, since the repair is to make that edge resolvable. The
+fleet tier walks past and refuses only if no path is found at all,
+since a concrete cross-binary counterexample is worth more than a
+refusal. `search` expresses both.
+
+`neither_claim_evaluator_rolls_its_own_search` fails the build if a
+third walk appears. Every fleet defect fixed this week — dropped
+through-stdlib edges, ignored unknowns, the zero-length overlap case,
+mislabelled witness hops — was a rule one walk had and the other
+lacked.
+
 ### One reachability engine, shared by both tiers (GH #408)
 
 The fleet tier read the topology artifact and rebuilt a smaller graph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,13 @@ zero-length path, and a tripped step ceiling answered `None` instead
 of refusing. Search *exhaustion* can prove an absence; search
 *abandonment* never can.
 
-Scope, stated precisely: this is BOOLEAN reachability, what `forbid
-reaches` and `only edges` ask. `bound` keeps its own weighted
-traversal (`site_count`), because a quantitative semiring is a
-different algorithm over the same edges — not a duplicate of this
-one. `no_prohibition_evaluator_defines_a_private_bfs` fails the build
+Scope, stated precisely: this centralizes unweighted TRANSITIVE
+reachability, which is what `forbid reaches` asks at both tiers.
+`only edges` stays direct crossing-edge enumeration — a cut-edge
+subset query with no transitive walk — and `bound` keeps
+`site_count`, a weighted traversal, because a quantitative semiring
+is a different algorithm over the same edges rather than a duplicate
+of this one. `no_prohibition_evaluator_defines_a_private_bfs` fails the build
 if a third frontier appears, its companions check that both
 evaluators still call the engine and that the engine holds exactly
 one queue.

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -676,10 +676,12 @@ fn evaluate_claims(
                 continue;
             }
             // An instance in BOTH groups already reaches the
-            // forbidden set by standing still. The BFS cannot see it
-            // (it refuses a destination that is also a source), so
-            // `forbid_reaches(g, g)` reported `holds` while every
-            // path in the fleet ran inside the prohibition.
+            // forbidden set by standing still. The shared engine
+            // tests roots, so it would now return a one-vertex path
+            // on its own — correctness no longer depends on this
+            // check. It stays because a plan-level message naming
+            // both group names is more useful here than a witness
+            // consisting of a single vertex.
             let both: Vec<&str> = src
                 .intersection(&dst)
                 .map(|s| s.as_str())

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -1385,7 +1385,6 @@ fn unresolved_opaque_receiver(
 /// the source decision that introduced the edge — the callsite, or
 /// the publish site + subscription decl — so a violation can say
 /// where to edit, not just which names are involved.
-#[derive(Clone)]
 enum Step {
     Call {
         span: hale_syntax::Span,
@@ -1515,7 +1514,7 @@ fn evaluate_forbid_reaches(
         roots.iter().cloned(),
         |k: &FnKey| {
             let Some(fs) = cx.summary.fns.get(k) else {
-                return model_graph::Visit::Edges(Vec::new());
+                return model_graph::Visit::edges(Vec::new());
             };
             let mut edges: Vec<(FnKey, Step)> = Vec::new();
             if *via_calls {
@@ -1555,7 +1554,7 @@ fn evaluate_forbid_reaches(
                                         src_name.name
                                     ),
                                 ));
-                                return model_graph::Visit::Halt;
+                                return model_graph::Visit::hole(());
                             }
                             // The backstop: an untyped-receiver call
                             // is a method of SOME locus, possibly a
@@ -1578,7 +1577,7 @@ fn evaluate_forbid_reaches(
                                         name
                                     ),
                                 ));
-                                return model_graph::Visit::Halt;
+                                return model_graph::Visit::hole(());
                             }
                         }
                     }
@@ -1606,7 +1605,7 @@ fn evaluate_forbid_reaches(
                                 src_name.name
                             ),
                         ));
-                        return model_graph::Visit::Halt;
+                        return model_graph::Visit::hole(());
                     };
                     for (sub_locus, sub_handler, sub_span) in
                         subscribers_of(cx.graph, subj)
@@ -1622,7 +1621,7 @@ fn evaluate_forbid_reaches(
                     }
                 }
             }
-            model_graph::Visit::Edges(edges)
+            model_graph::Visit::edges(edges)
         },
         // Roots are tested too: a decl in BOTH groups is a
         // zero-length path — a real boundary confusion `forbid`
@@ -1635,7 +1634,12 @@ fn evaluate_forbid_reaches(
             }
         },
         |k: &FnKey| mask_group.is_some_and(|m| m.contains_fn(k)),
-        callgraph::MAX_STEPS,
+        Some(callgraph::MAX_STEPS),
+        // Stop at the first unfollowable edge. The closure has
+        // already said which edge and why, and that diagnostic is
+        // the repair. (The fleet tier chooses `PathWins`; both are
+        // deliberate — see `model_graph::HolePolicy`.)
+        model_graph::HolePolicy::Halt,
     );
 
     match out {
@@ -1653,8 +1657,8 @@ fn evaluate_forbid_reaches(
         }
         // The closure has already said which edge it could not
         // follow and why.
-        model_graph::Search::Halted(_) => Verdict::Uncertified,
-        model_graph::Search::Saturated => {
+        model_graph::Search::Uncertified { .. } => Verdict::Uncertified,
+        model_graph::Search::Saturated { .. } => {
             diags.push(Diag::ty(
                 c.name.span,
                 format!(

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -1508,8 +1508,16 @@ fn evaluate_forbid_reaches(
     // which edge and why, because the repair is to make that edge
     // resolvable. The fleet tier walks past and only refuses if it
     // finds no path at all, because there a concrete cross-binary
-    // counterexample is worth more than a refusal. `search` expresses
-    // both: `Visit::Halt` versus recording the hole and continuing.
+    // counterexample is worth more than a refusal. That choice is
+    // `HolePolicy::Halt` versus `HolePolicy::PathWins`.
+    //
+    // NOTE for whoever changes that policy here: this closure reports
+    // `Visit::hole(())` and discards the successors it had already
+    // collected for the vertex, which is invisible under `Halt`
+    // because the engine stops anyway. Switching to `PathWins` needs
+    // the closure to scan the whole vertex and return
+    // `Visit::partial(edges, hole)` first, or every partial vertex
+    // would lose its known edges. The policy flag alone is not enough.
     let out = model_graph::search(
         roots.iter().cloned(),
         |k: &FnKey| {

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -41,13 +41,14 @@
 //! widen the grant list), which is the review event this surface
 //! exists to create.
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 
 use hale_syntax::ast::*;
 use hale_syntax::Diag;
 
 use crate::alloc_summary::{AllocSummary, Callee, EffectSiteKind, FnKey};
 use crate::bus_graph::BusGraph;
+use crate::model_graph;
 use crate::verdict::Verdict;
 use crate::callgraph;
 use crate::effects::{
@@ -1384,6 +1385,7 @@ fn unresolved_opaque_receiver(
 /// the source decision that introduced the edge — the callsite, or
 /// the publish site + subscription decl — so a violation can say
 /// where to edit, not just which names are involved.
+#[derive(Clone)]
 enum Step {
     Call {
         span: hale_syntax::Span,
@@ -1496,21 +1498,163 @@ fn evaluate_forbid_reaches(
         }
     }
 
-    let mut parent: BTreeMap<FnKey, (FnKey, Step)> = BTreeMap::new();
-    let mut queue: VecDeque<FnKey> = VecDeque::new();
-    let mut seen: BTreeSet<FnKey> = BTreeSet::new();
-    for r in &roots {
-        if mask_group.map_or(false, |m| m.contains_fn(r)) {
-            continue;
+    // The traversal is `model_graph::search`, shared with the fleet
+    // tier. What stays here is everything that is genuinely this
+    // tier's: what a vertex is, which edges exist, what counts as the
+    // target, and — the part that cannot move — the diagnostic for
+    // each kind of edge the walk cannot follow.
+    //
+    // The two tiers make OPPOSITE choices about an unfollowable edge,
+    // and both are deliberate. Here the walk stops at it and says
+    // which edge and why, because the repair is to make that edge
+    // resolvable. The fleet tier walks past and only refuses if it
+    // finds no path at all, because there a concrete cross-binary
+    // counterexample is worth more than a refusal. `search` expresses
+    // both: `Visit::Halt` versus recording the hole and continuing.
+    let out = model_graph::search(
+        roots.iter().cloned(),
+        |k: &FnKey| {
+            let Some(fs) = cx.summary.fns.get(k) else {
+                return model_graph::Visit::Edges(Vec::new());
+            };
+            let mut edges: Vec<(FnKey, Step)> = Vec::new();
+            if *via_calls {
+                for edge in &fs.calls {
+                    match &edge.callee {
+                        Callee::Resolved(next) => {
+                            edges.push((
+                                next.clone(),
+                                Step::Call {
+                                    span: edge.span,
+                                    via_interface: edge
+                                        .via_interface
+                                        .clone(),
+                                },
+                            ));
+                        }
+                        Callee::Unresolved(name) => {
+                            // #353: a call through a fn-typed param —
+                            // the target is unknowable from here, so
+                            // the claim cannot be certified. Unknown ⇒
+                            // violation, same as every shipped
+                            // certificate.
+                            if edge.indirect
+                                || fs.fn_params.iter().any(|p| p == name)
+                            {
+                                diags.push(Diag::ty(
+                                    c.name.span,
+                                    format!(
+                                        "claim `{}` cannot be certified: \
+                                         `{}` (reachable from `{}`) calls \
+                                         through a function-typed \
+                                         parameter, whose target is not \
+                                         knowable statically. An \
+                                         unresolvable edge fails closed",
+                                        c.name.name,
+                                        k.display(),
+                                        src_name.name
+                                    ),
+                                ));
+                                return model_graph::Visit::Halt;
+                            }
+                            // The backstop: an untyped-receiver call
+                            // is a method of SOME locus, possibly a
+                            // wrapper reaching the target. Fail closed.
+                            if unresolved_opaque_receiver(edge) {
+                                diags.push(Diag::ty(
+                                    c.name.span,
+                                    format!(
+                                        "claim `{}` cannot be certified: \
+                                         `{}` (reachable from `{}`) calls \
+                                         `{}` on a receiver the compiler \
+                                         cannot type, so the walk cannot \
+                                         follow the edge. An unresolvable \
+                                         edge fails closed — bind the \
+                                         receiver to a typed field or \
+                                         local so the call resolves",
+                                        c.name.name,
+                                        k.display(),
+                                        src_name.name,
+                                        name
+                                    ),
+                                ));
+                                return model_graph::Visit::Halt;
+                            }
+                        }
+                    }
+                }
+            }
+            if *via_bus {
+                for site in &fs.effect_sites {
+                    let EffectSiteKind::Publish(subj) = &site.kind
+                    else {
+                        continue;
+                    };
+                    let Some(subj) = subj else {
+                        // Computed subject: could route anywhere the
+                        // wire reaches. Fail closed.
+                        diags.push(Diag::ty(
+                            c.name.span,
+                            format!(
+                                "claim `{}` cannot be certified: `{}` \
+                                 (reachable from `{}`) publishes to a \
+                                 computed subject, which could route to \
+                                 any subscriber. An unresolvable edge \
+                                 fails closed",
+                                c.name.name,
+                                k.display(),
+                                src_name.name
+                            ),
+                        ));
+                        return model_graph::Visit::Halt;
+                    };
+                    for (sub_locus, sub_handler, sub_span) in
+                        subscribers_of(cx.graph, subj)
+                    {
+                        edges.push((
+                            FnKey::method(sub_locus, sub_handler),
+                            Step::Bus {
+                                subject: subj.clone(),
+                                publish_span: site.span,
+                                sub_span,
+                            },
+                        ));
+                    }
+                }
+            }
+            model_graph::Visit::Edges(edges)
+        },
+        // Roots are tested too: a decl in BOTH groups is a
+        // zero-length path — a real boundary confusion `forbid`
+        // should surface, not skip.
+        |k: &FnKey| match &dst_test {
+            DstTest::Group(g) => g.contains_fn(k),
+            DstTest::Effects(mask) => {
+                let direct = direct_effects(&cx.summary, k, &cx.ffi);
+                !direct.is_unclassified() && direct.0 & mask.0 != 0
+            }
+        },
+        |k: &FnKey| mask_group.is_some_and(|m| m.contains_fn(k)),
+        callgraph::MAX_STEPS,
+    );
+
+    match out {
+        model_graph::Search::Found { hit, parent } => {
+            render_violation(
+                c,
+                src_name,
+                &dst.display(),
+                &hit,
+                &parent,
+                cx,
+                diags,
+            );
+            Verdict::Violated
         }
-        if seen.insert(r.clone()) {
-            queue.push_back(r.clone());
-        }
-    }
-    let mut steps = 0u32;
-    while let Some(k) = queue.pop_front() {
-        steps += 1;
-        if steps > callgraph::MAX_STEPS {
+        // The closure has already said which edge it could not
+        // follow and why.
+        model_graph::Search::Halted(_) => Verdict::Uncertified,
+        model_graph::Search::Saturated => {
             diags.push(Diag::ty(
                 c.name.span,
                 format!(
@@ -1520,160 +1664,10 @@ fn evaluate_forbid_reaches(
                     callgraph::MAX_STEPS
                 ),
             ));
-            return Verdict::Violated;
+            Verdict::Violated
         }
-        // Membership hit? Roots included: a decl in BOTH groups is a
-        // zero-length path — a real boundary confusion `forbid`
-        // should surface, not skip.
-        let hit = match &dst_test {
-            DstTest::Group(g) => g.contains_fn(&k),
-            DstTest::Effects(mask) => {
-                let direct = direct_effects(&cx.summary, &k, &cx.ffi);
-                !direct.is_unclassified() && direct.0 & mask.0 != 0
-            }
-        };
-        if hit {
-            render_violation(
-                c,
-                src_name,
-                &dst.display(),
-                &k,
-                &parent,
-                cx,
-                diags,
-            );
-            return Verdict::Violated;
-        }
-        let Some(fs) = cx.summary.fns.get(&k) else { continue };
-        if *via_calls {
-            for edge in &fs.calls {
-                match &edge.callee {
-                    Callee::Resolved(next) => {
-                        if mask_group
-                            .map_or(false, |m| m.contains_fn(next))
-                        {
-                            continue;
-                        }
-                        if seen.insert(next.clone()) {
-                            parent.insert(
-                                next.clone(),
-                                (
-                                    k.clone(),
-                                    Step::Call {
-                                        span: edge.span,
-                                        via_interface: edge
-                                            .via_interface
-                                            .clone(),
-                                    },
-                                ),
-                            );
-                            queue.push_back(next.clone());
-                        }
-                    }
-                    Callee::Unresolved(name) => {
-                        // #353: a call through a fn-typed param —
-                        // the target is unknowable from here, so
-                        // the claim cannot be certified. Unknown ⇒
-                        // violation, same as every shipped
-                        // certificate.
-                        if edge.indirect
-                            || fs.fn_params.iter().any(|p| p == name)
-                        {
-                            diags.push(Diag::ty(
-                                c.name.span,
-                                format!(
-                                    "claim `{}` cannot be certified: \
-                                     `{}` (reachable from `{}`) calls \
-                                     through a function-typed \
-                                     parameter, whose target is not \
-                                     knowable statically. An \
-                                     unresolvable edge fails closed",
-                                    c.name.name,
-                                    k.display(),
-                                    src_name.name
-                                ),
-                            ));
-                            return Verdict::Uncertified;
-                        }
-                        // The backstop: an untyped-receiver call
-                        // is a method of SOME locus, possibly a
-                        // wrapper reaching the target. Fail closed.
-                        if unresolved_opaque_receiver(edge) {
-                            diags.push(Diag::ty(
-                                c.name.span,
-                                format!(
-                                    "claim `{}` cannot be certified: \
-                                     `{}` (reachable from `{}`) calls \
-                                     `{}` on a receiver the compiler \
-                                     cannot type, so the walk cannot \
-                                     follow the edge. An unresolvable \
-                                     edge fails closed — bind the \
-                                     receiver to a typed field or \
-                                     local so the call resolves",
-                                    c.name.name,
-                                    k.display(),
-                                    src_name.name,
-                                    name
-                                ),
-                            ));
-                            return Verdict::Uncertified;
-                        }
-                    }
-                }
-            }
-        }
-        if *via_bus {
-            for site in &fs.effect_sites {
-                let EffectSiteKind::Publish(subj) = &site.kind else {
-                    continue;
-                };
-                let Some(subj) = subj else {
-                    // Computed subject: could route anywhere the
-                    // wire reaches. Fail closed.
-                    diags.push(Diag::ty(
-                        c.name.span,
-                        format!(
-                            "claim `{}` cannot be certified: `{}` \
-                             (reachable from `{}`) publishes to a \
-                             computed subject, which could route to \
-                             any subscriber. An unresolvable edge \
-                             fails closed",
-                            c.name.name,
-                            k.display(),
-                            src_name.name
-                        ),
-                    ));
-                    return Verdict::Uncertified;
-                };
-                for (sub_locus, sub_handler, sub_span) in
-                    subscribers_of(cx.graph, subj)
-                {
-                    let next =
-                        FnKey::method(sub_locus, sub_handler);
-                    if mask_group
-                        .map_or(false, |m| m.contains_fn(&next))
-                    {
-                        continue;
-                    }
-                    if seen.insert(next.clone()) {
-                        parent.insert(
-                            next.clone(),
-                            (
-                                k.clone(),
-                                Step::Bus {
-                                    subject: subj.clone(),
-                                    publish_span: site.span,
-                                    sub_span,
-                                },
-                            ),
-                        );
-                        queue.push_back(next.clone());
-                    }
-                }
-            }
-        }
+        model_graph::Search::NotFound => Verdict::Holds,
     }
-    Verdict::Holds
 }
 
 // ===================== only edges =================================

--- a/crates/hale-types/src/model_graph.rs
+++ b/crates/hale-types/src/model_graph.rs
@@ -9,11 +9,17 @@
 //! path to a target and the prohibition reported `holds` — an
 //! absence certified by not looking.
 //!
-//! Both are the same bug: a second derivation of "what reaches what"
-//! that has to remember every rule the first one learned. This type
-//! is that derivation, once. A caller supplies edges and says which
-//! vertices have INCOMPLETE outgoing edge sets; it answers with a
-//! path, a certified absence, or a refusal to certify.
+//! Both are the same bug: a second traversal that has to remember
+//! every rule the first one learned.
+//!
+//! What lives here is that traversal, once — the BFS bookkeeping and
+//! the propagation of incomplete vertices. It is deliberately NOT the
+//! whole derivation: each caller still decides which relations exist,
+//! which contracted stdlib edges to include, which vertices are
+//! incomplete, and what counts as a target. Centralizing mechanism
+//! reduces drift; it does not make a caller's omission of a relation
+//! impossible, and this module should not be read as claiming
+//! otherwise.
 //!
 //! It deliberately knows nothing about instances, routes, claims or
 //! artifacts — a route id rides along as an opaque label on an edge

--- a/crates/hale-types/src/model_graph.rs
+++ b/crates/hale-types/src/model_graph.rs
@@ -23,6 +23,97 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
+/// What a caller knows about one vertex's outgoing edges.
+pub enum Visit<V, E> {
+    /// The successors, each with the label to record for the witness.
+    Edges(Vec<(V, E)>),
+    /// This vertex's edges cannot be enumerated, so the search must
+    /// not report an absence past it. The caller has already said why
+    /// (it owns the diagnostic); the search just stops.
+    Halt,
+}
+
+/// The outcome of one search.
+pub enum Search<V, E> {
+    /// The frontier was exhausted without reaching the target.
+    NotFound,
+    /// `hit` is in the target set; `parent` is the tree the caller's
+    /// own witness renderer walks back through. Returning the tree
+    /// rather than a path is what lets both tiers keep the witness
+    /// code they already have.
+    Found { hit: V, parent: BTreeMap<V, (V, E)> },
+    /// The caller refused to enumerate this vertex's edges.
+    Halted(V),
+    /// The step ceiling tripped.
+    Saturated,
+}
+
+/// The traversal both tiers share.
+///
+/// It owns exactly the bookkeeping that is easy to get subtly wrong
+/// and identical everywhere — the queue, the visited set, the parent
+/// tree, the root seeding, the mask, and the step ceiling. Everything
+/// that differs between an application and a fleet — what a vertex
+/// is, which edges exist, what counts as the target, when to refuse —
+/// stays with the caller as a closure.
+///
+/// Two rules are deliberately baked in because they are semantics
+/// rather than mechanism:
+///
+///  * **roots are tested.** A vertex in both the source and target
+///    sets is a zero-length path, which is a real boundary confusion
+///    a prohibition should surface rather than skip. The fleet tier
+///    lacked this rule and reported `forbid_reaches(g, g)` as holding.
+///  * **masked vertices are neither tested nor traversed**, so "no
+///    path avoids the gate" is the interposition proof.
+pub fn search<V, E>(
+    roots: impl IntoIterator<Item = V>,
+    mut successors: impl FnMut(&V) -> Visit<V, E>,
+    is_dst: impl Fn(&V) -> bool,
+    is_masked: impl Fn(&V) -> bool,
+    max_steps: u32,
+) -> Search<V, E>
+where
+    V: Ord + Clone,
+    E: Clone,
+{
+    let mut parent: BTreeMap<V, (V, E)> = BTreeMap::new();
+    let mut seen: BTreeSet<V> = BTreeSet::new();
+    let mut queue: VecDeque<V> = VecDeque::new();
+    for r in roots {
+        if is_masked(&r) {
+            continue;
+        }
+        if seen.insert(r.clone()) {
+            queue.push_back(r);
+        }
+    }
+    let mut steps: u32 = 0;
+    while let Some(k) = queue.pop_front() {
+        steps += 1;
+        if steps > max_steps {
+            return Search::Saturated;
+        }
+        if is_dst(&k) {
+            return Search::Found { hit: k, parent };
+        }
+        let edges = match successors(&k) {
+            Visit::Halt => return Search::Halted(k),
+            Visit::Edges(e) => e,
+        };
+        for (next, label) in edges {
+            if is_masked(&next) {
+                continue;
+            }
+            if seen.insert(next.clone()) {
+                parent.insert(next.clone(), (k.clone(), label));
+                queue.push_back(next);
+            }
+        }
+    }
+    Search::NotFound
+}
+
 /// An edge, with an optional label the witness renderer can name
 /// (the fleet tier puts a route id here; the application tier has
 /// nothing to say and passes `None`).
@@ -110,77 +201,66 @@ impl ModelGraph {
         dst: &BTreeSet<String>,
         masked: &BTreeSet<String>,
     ) -> Reach {
-        let mut parent: BTreeMap<&str, (&str, Option<String>)> =
-            BTreeMap::new();
-        let mut seen: BTreeSet<&str> = BTreeSet::new();
-        let mut queue: VecDeque<&str> = VecDeque::new();
-        // Holes seen while walking, kept in deterministic order so a
+        // Holes seen while walking, in deterministic order so a
         // refusal names the same vertex on every machine.
-        let mut hit: BTreeSet<&str> = BTreeSet::new();
-
-        for v in src {
-            if masked.contains(v) {
-                continue;
-            }
-            if seen.insert(v) {
-                queue.push_back(v);
+        //
+        // This tier walks PAST a hole rather than stopping at it: a
+        // concrete counterexample is more useful than "cannot tell",
+        // so the refusal is only reported if the search finds no path
+        // at all. The application tier makes the opposite choice —
+        // see `claims.rs`, where the diagnostic explains which edge
+        // could not be followed and the walk ends there.
+        let mut hit: BTreeSet<String> = BTreeSet::new();
+        let out = search(
+            src.iter().cloned(),
+            |v: &String| {
                 if self.holes.contains_key(v.as_str()) {
-                    hit.insert(v);
+                    hit.insert(v.clone());
                 }
-            }
-        }
+                Visit::Edges(
+                    self.edges
+                        .get(v)
+                        .into_iter()
+                        .flatten()
+                        .map(|e| (e.to.clone(), e.via.clone()))
+                        .collect(),
+                )
+            },
+            |v| dst.contains(v) && !src.contains(v),
+            |v| masked.contains(v),
+            u32::MAX,
+        );
 
-        while let Some(cur) = queue.pop_front() {
-            if dst.contains(cur) && !src.contains(cur) {
-                let mut path = vec![(cur.to_string(), None)];
-                let mut at = cur;
-                while let Some((prev, via)) = parent.get(at) {
-                    path.push((prev.to_string(), via.clone()));
-                    at = prev;
+        match out {
+            Search::Found { hit: h, parent } => {
+                // parent maps a node to (predecessor, label of the
+                // edge INTO it), so walking back already yields the
+                // label each hop was entered by.
+                let mut rev: Vec<(String, Option<String>)> =
+                    vec![(h.clone(), None)];
+                let mut cur = h;
+                while let Some((prev, via)) = parent.get(&cur) {
+                    rev.last_mut().expect("non-empty").1 = via.clone();
+                    rev.push((prev.clone(), None));
+                    cur = prev.clone();
                 }
-                path.reverse();
-                // Each node is paired with the label of its OUTGOING
-                // edge by the walk above; the renderer wants the one
-                // it was entered by, so shift every label forward.
-                let shifted: Vec<(String, Option<String>)> = path
-                    .iter()
-                    .enumerate()
-                    .map(|(i, (n, _))| {
-                        (
-                            n.clone(),
-                            if i == 0 {
-                                None
-                            } else {
-                                path[i - 1].1.clone()
-                            },
-                        )
-                    })
-                    .collect();
-                return Reach::Path(shifted);
+                rev.reverse();
+                Reach::Path(rev)
             }
-            for e in self.edges.get(cur).into_iter().flatten() {
-                if masked.contains(&e.to) {
-                    continue;
-                }
-                if seen.insert(&e.to) {
-                    parent.insert(&e.to, (cur, e.via.clone()));
-                    queue.push_back(&e.to);
-                    if self.holes.contains_key(e.to.as_str()) {
-                        hit.insert(&e.to);
-                    }
-                }
-            }
-        }
-
-        // No path. Only a hole the source could actually have walked
-        // to can conceal one — an unrelated unknown elsewhere in the
-        // fleet must not poison every claim.
-        match hit.first() {
-            Some(at) => Reach::Uncertified(Hole {
-                at: (*at).to_string(),
-                why: self.holes[*at].clone(),
+            // Only a hole the source could actually have walked to
+            // can conceal a path — an unrelated unknown elsewhere in
+            // the fleet must not poison every claim.
+            Search::NotFound | Search::Saturated => match hit.first() {
+                Some(at) => Reach::Uncertified(Hole {
+                    at: at.clone(),
+                    why: self.holes[at.as_str()].clone(),
+                }),
+                None => Reach::None,
+            },
+            Search::Halted(at) => Reach::Uncertified(Hole {
+                at: at.clone(),
+                why: self.holes.get(&at).cloned().unwrap_or_default(),
             }),
-            None => Reach::None,
         }
     }
 }

--- a/crates/hale-types/src/model_graph.rs
+++ b/crates/hale-types/src/model_graph.rs
@@ -24,62 +24,115 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 /// What a caller knows about one vertex's outgoing edges.
-pub enum Visit<V, E> {
-    /// The successors, each with the label to record for the witness.
-    Edges(Vec<(V, E)>),
-    /// This vertex's edges cannot be enumerated, so the search must
-    /// not report an absence past it. The caller has already said why
-    /// (it owns the diagnostic); the search just stops.
+///
+/// `edges` are the successors it CAN enumerate. `hole` is set when
+/// that list is incomplete — the honest shape, because an incomplete
+/// vertex usually has some known edges too. Reporting a hole is the
+/// caller's only obligation; what happens next is [`HolePolicy`], and
+/// the search guarantees the hole is never simply forgotten.
+pub struct Visit<V, E, H> {
+    pub edges: Vec<(V, E)>,
+    pub hole: Option<H>,
+}
+
+impl<V, E, H> Visit<V, E, H> {
+    /// A fully-known vertex.
+    pub fn edges(edges: Vec<(V, E)>) -> Self {
+        Self { edges, hole: None }
+    }
+    /// A vertex with known edges AND an incomplete edge set.
+    pub fn partial(edges: Vec<(V, E)>, hole: H) -> Self {
+        Self { edges, hole: Some(hole) }
+    }
+    /// A vertex whose edges cannot be enumerated at all.
+    pub fn hole(hole: H) -> Self {
+        Self { edges: Vec::new(), hole: Some(hole) }
+    }
+}
+
+/// What an incomplete vertex means to this caller.
+///
+/// Both tiers of this compiler want a different answer and both are
+/// right, so the choice belongs to the caller — but the consequence
+/// belongs to the engine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HolePolicy {
+    /// Stop at the first hole. The application checker wants this:
+    /// the repair is to make that edge resolvable, and the
+    /// diagnostic names the edge.
     Halt,
+    /// Keep walking known edges; a concrete counterexample beats a
+    /// refusal, and the hole only decides the answer if no path is
+    /// found. The fleet checker wants this: a cross-binary path is
+    /// worth more than "cannot tell".
+    PathWins,
 }
 
 /// The outcome of one search.
-pub enum Search<V, E> {
-    /// The frontier was exhausted without reaching the target.
+///
+/// Every variant except `NotFound` carries the parent tree, so a
+/// caller can render the path to wherever the walk stopped — "here is
+/// how the source reaches the edge I could not follow" is far more
+/// useful than naming the vertex alone.
+pub enum Search<V, E, H> {
+    /// The frontier was exhausted, over a graph with no relevant
+    /// holes. This is the ONLY variant that proves an absence.
     NotFound,
     /// `hit` is in the target set; `parent` is the tree the caller's
     /// own witness renderer walks back through. Returning the tree
     /// rather than a path is what lets both tiers keep the witness
     /// code they already have.
     Found { hit: V, parent: BTreeMap<V, (V, E)> },
-    /// The caller refused to enumerate this vertex's edges.
-    Halted(V),
-    /// The step ceiling tripped.
-    Saturated,
+    /// A reachable vertex had an incomplete edge set, so no absence
+    /// can be claimed past it.
+    Uncertified { at: V, hole: H, parent: BTreeMap<V, (V, E)> },
+    /// The step ceiling tripped. Distinct from `NotFound` on purpose:
+    /// search EXHAUSTION can prove an absence, search ABANDONMENT
+    /// never can, and collapsing the two is a fail-open.
+    Saturated { parent: BTreeMap<V, (V, E)> },
 }
 
 /// The traversal both tiers share.
 ///
 /// It owns exactly the bookkeeping that is easy to get subtly wrong
 /// and identical everywhere — the queue, the visited set, the parent
-/// tree, the root seeding, the mask, and the step ceiling. Everything
-/// that differs between an application and a fleet — what a vertex
-/// is, which edges exist, what counts as the target, when to refuse —
-/// stays with the caller as a closure.
+/// tree, root seeding, masking, the step ceiling, and the propagation
+/// of incomplete vertices. Everything that differs between an
+/// application and a fleet — what a vertex is, which edges exist,
+/// what counts as the target — stays with the caller.
 ///
-/// Two rules are deliberately baked in because they are semantics
-/// rather than mechanism:
+/// Three rules are baked in because they are semantics, not
+/// mechanism, and each one was a shipped bug before it lived here:
 ///
 ///  * **roots are tested.** A vertex in both the source and target
 ///    sets is a zero-length path, which is a real boundary confusion
-///    a prohibition should surface rather than skip. The fleet tier
-///    lacked this rule and reported `forbid_reaches(g, g)` as holding.
+///    a prohibition should surface rather than skip.
 ///  * **masked vertices are neither tested nor traversed**, so "no
 ///    path avoids the gate" is the interposition proof.
-pub fn search<V, E>(
+///  * **a reachable hole is never dropped.** A caller reports it; the
+///    engine decides the verdict. Forgetting to consult it is not a
+///    mistake this API allows.
+///
+/// `max_steps` is `None` for "walk until exhausted". It is not a
+/// large number: a ceiling that can be reached must be able to say
+/// so, and `u32::MAX` would overflow the counter before tripping.
+pub fn search<V, E, H>(
     roots: impl IntoIterator<Item = V>,
-    mut successors: impl FnMut(&V) -> Visit<V, E>,
+    mut successors: impl FnMut(&V) -> Visit<V, E, H>,
     is_dst: impl Fn(&V) -> bool,
     is_masked: impl Fn(&V) -> bool,
-    max_steps: u32,
-) -> Search<V, E>
+    max_steps: Option<u32>,
+    policy: HolePolicy,
+) -> Search<V, E, H>
 where
     V: Ord + Clone,
-    E: Clone,
 {
     let mut parent: BTreeMap<V, (V, E)> = BTreeMap::new();
     let mut seen: BTreeSet<V> = BTreeSet::new();
     let mut queue: VecDeque<V> = VecDeque::new();
+    // The first hole met under `PathWins`, kept so a fruitless search
+    // can still refuse rather than certify.
+    let mut pending: Option<(V, H)> = None;
     for r in roots {
         if is_masked(&r) {
             continue;
@@ -91,16 +144,25 @@ where
     let mut steps: u32 = 0;
     while let Some(k) = queue.pop_front() {
         steps += 1;
-        if steps > max_steps {
-            return Search::Saturated;
+        if max_steps.is_some_and(|m| steps > m) {
+            return Search::Saturated { parent };
         }
         if is_dst(&k) {
             return Search::Found { hit: k, parent };
         }
-        let edges = match successors(&k) {
-            Visit::Halt => return Search::Halted(k),
-            Visit::Edges(e) => e,
-        };
+        let Visit { edges, hole } = successors(&k);
+        if let Some(h) = hole {
+            match policy {
+                HolePolicy::Halt => {
+                    return Search::Uncertified { at: k, hole: h, parent }
+                }
+                HolePolicy::PathWins => {
+                    if pending.is_none() {
+                        pending = Some((k.clone(), h));
+                    }
+                }
+            }
+        }
         for (next, label) in edges {
             if is_masked(&next) {
                 continue;
@@ -111,7 +173,10 @@ where
             }
         }
     }
-    Search::NotFound
+    match pending {
+        Some((at, hole)) => Search::Uncertified { at, hole, parent },
+        None => Search::NotFound,
+    }
 }
 
 /// An edge, with an optional label the witness renderer can name
@@ -201,34 +266,31 @@ impl ModelGraph {
         dst: &BTreeSet<String>,
         masked: &BTreeSet<String>,
     ) -> Reach {
-        // Holes seen while walking, in deterministic order so a
-        // refusal names the same vertex on every machine.
-        //
-        // This tier walks PAST a hole rather than stopping at it: a
-        // concrete counterexample is more useful than "cannot tell",
-        // so the refusal is only reported if the search finds no path
-        // at all. The application tier makes the opposite choice —
-        // see `claims.rs`, where the diagnostic explains which edge
-        // could not be followed and the walk ends there.
-        let mut hit: BTreeSet<String> = BTreeSet::new();
+        // Hole propagation is the engine's job now: this tier just
+        // reports whether a vertex is incomplete and picks the
+        // policy. The application tier picks `Halt` instead — see
+        // `claims.rs`, where stopping at the edge is what makes the
+        // diagnostic actionable.
         let out = search(
             src.iter().cloned(),
-            |v: &String| {
-                if self.holes.contains_key(v.as_str()) {
-                    hit.insert(v.clone());
-                }
-                Visit::Edges(
-                    self.edges
-                        .get(v)
-                        .into_iter()
-                        .flatten()
-                        .map(|e| (e.to.clone(), e.via.clone()))
-                        .collect(),
-                )
+            |v: &String| Visit {
+                edges: self
+                    .edges
+                    .get(v)
+                    .into_iter()
+                    .flatten()
+                    .map(|e| (e.to.clone(), e.via.clone()))
+                    .collect(),
+                hole: self.holes.get(v.as_str()).cloned(),
             },
-            |v| dst.contains(v) && !src.contains(v),
+            // Roots are tested. A vertex in both sets is a
+            // zero-length path — the source already IS the forbidden
+            // destination — and suppressing that here is what made
+            // `forbid_reaches(g, g)` report a false absence.
+            |v| dst.contains(v),
             |v| masked.contains(v),
-            u32::MAX,
+            None,
+            HolePolicy::PathWins,
         );
 
         match out {
@@ -247,20 +309,19 @@ impl ModelGraph {
                 rev.reverse();
                 Reach::Path(rev)
             }
-            // Only a hole the source could actually have walked to
-            // can conceal a path — an unrelated unknown elsewhere in
-            // the fleet must not poison every claim.
-            Search::NotFound | Search::Saturated => match hit.first() {
-                Some(at) => Reach::Uncertified(Hole {
-                    at: at.clone(),
-                    why: self.holes[at.as_str()].clone(),
-                }),
-                None => Reach::None,
-            },
-            Search::Halted(at) => Reach::Uncertified(Hole {
-                at: at.clone(),
-                why: self.holes.get(&at).cloned().unwrap_or_default(),
-            }),
+            Search::Uncertified { at, hole, .. } => {
+                Reach::Uncertified(Hole { at, why: hole })
+            }
+            // Abandonment never proves an absence.
+            Search::Saturated { .. } => {
+                Reach::Uncertified(Hole {
+                    at: String::new(),
+                    why: "the reachability walk hit its step ceiling \
+                          before exhausting the graph"
+                        .to_string(),
+                })
+            }
+            Search::NotFound => Reach::None,
         }
     }
 }
@@ -382,6 +443,145 @@ mod tests {
             g.reaches(&set(&["a"]), &set(&["c"]), &set(&["b"])),
             Reach::None
         );
+    }
+
+    // ---- the wrapper's two fixed fail-opens -------------------
+
+    /// A vertex in both the source and target sets already sits in
+    /// the forbidden set without going anywhere. The wrapper used to
+    /// pass `dst.contains(v) && !src.contains(v)`, which disabled the
+    /// engine's root test and answered `None` — the exact false
+    /// absence the engine documents itself as preventing.
+    #[test]
+    fn source_target_overlap_is_a_zero_length_path() {
+        let g = ModelGraph::new();
+        assert_eq!(
+            g.reaches(&set(&["a"]), &set(&["a"]), &BTreeSet::new()),
+            Reach::Path(vec![("a".into(), None)])
+        );
+    }
+
+    /// Search EXHAUSTION can prove an absence. Search ABANDONMENT
+    /// cannot, and the wrapper used to map both to `Reach::None`.
+    #[test]
+    fn abandoning_the_walk_never_certifies_an_absence() {
+        let out: Search<&str, (), String> = search(
+            ["a"],
+            |_| Visit::edges(vec![("b", ()), ("c", ())]),
+            |_| false,
+            |_| false,
+            Some(1),
+            HolePolicy::PathWins,
+        );
+        assert!(
+            matches!(out, Search::Saturated { .. }),
+            "a tripped ceiling is not `NotFound`"
+        );
+    }
+
+    // ---- the generic engine's own contract ---------------------
+
+    #[test]
+    fn a_root_that_is_the_target_is_found_without_expanding() {
+        let mut expanded = false;
+        let out: Search<&str, (), ()> = search(
+            ["a"],
+            |_| {
+                expanded = true;
+                Visit::edges(vec![])
+            },
+            |v| *v == "a",
+            |_| false,
+            None,
+            HolePolicy::Halt,
+        );
+        assert!(matches!(out, Search::Found { .. }));
+        assert!(!expanded, "the target test precedes expansion");
+    }
+
+    #[test]
+    fn a_masked_root_is_neither_tested_nor_traversed() {
+        let out: Search<&str, (), ()> = search(
+            ["a"],
+            |_| Visit::edges(vec![]),
+            |v| *v == "a",
+            |v| *v == "a",
+            None,
+            HolePolicy::Halt,
+        );
+        assert!(matches!(out, Search::NotFound));
+    }
+
+    #[test]
+    fn halt_reports_the_vertex_and_the_reason() {
+        let out: Search<&str, (), &str> = search(
+            ["a"],
+            |_| Visit::hole("indirect"),
+            |_| false,
+            |_| false,
+            None,
+            HolePolicy::Halt,
+        );
+        match out {
+            Search::Uncertified { at, hole, .. } => {
+                assert_eq!(at, "a");
+                assert_eq!(hole, "indirect");
+            }
+            _ => panic!("expected uncertified"),
+        }
+    }
+
+    /// A vertex can have known edges AND an incomplete set. Under
+    /// `PathWins` the known edges are still walked, and the hole only
+    /// decides the answer if nothing is found.
+    #[test]
+    fn a_partial_vertex_still_contributes_its_known_edges() {
+        let out: Search<&str, (), &str> = search(
+            ["a"],
+            |v| match *v {
+                "a" => Visit::partial(vec![("b", ())], "indirect"),
+                _ => Visit::edges(vec![]),
+            },
+            |v| *v == "b",
+            |_| false,
+            None,
+            HolePolicy::PathWins,
+        );
+        assert!(
+            matches!(out, Search::Found { .. }),
+            "the known edge reaches the target, which beats the hole"
+        );
+    }
+
+    #[test]
+    fn several_roots_are_all_seeded() {
+        let out: Search<&str, (), ()> = search(
+            ["a", "b"],
+            |_| Visit::edges(vec![]),
+            |v| *v == "b",
+            |_| false,
+            None,
+            HolePolicy::Halt,
+        );
+        assert!(matches!(out, Search::Found { hit: "b", .. }));
+    }
+
+    /// Breadth-first: the parent tree records the SHORTEST route to
+    /// each vertex, so a witness is the shortest counterexample
+    /// rather than whichever one the walk stumbled into.
+    #[test]
+    fn the_parent_tree_records_the_shortest_route() {
+        let mut g = ModelGraph::new();
+        g.add_edge("a", "mid", Some("long1".into()));
+        g.add_edge("mid", "z", Some("long2".into()));
+        g.add_edge("a", "z", Some("short".into()));
+        match g.reaches(&set(&["a"]), &set(&["z"]), &BTreeSet::new()) {
+            Reach::Path(p) => {
+                assert_eq!(p.len(), 2, "a -> z directly: {p:?}");
+                assert_eq!(p[1].1, Some("short".into()));
+            }
+            other => panic!("expected a path, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/hale-types/tests/one_reachability_engine.rs
+++ b/crates/hale-types/tests/one_reachability_engine.rs
@@ -1,0 +1,70 @@
+//! Reachability is derived in exactly one place.
+//!
+//! GH #408. There used to be two walks: the application checker's,
+//! and a second one the fleet tier wrote against the topology
+//! artifact. The second had to remember every rule the first had
+//! learned, and it forgot several — through-stdlib edges, unknown
+//! propagation, the zero-length overlap case, and the label on each
+//! hop of a witness. Every one of those was a fail-open or a
+//! misleading diagnostic, and each was fixed separately before the
+//! shared engine existed.
+//!
+//! Both tiers now go through `model_graph::search`, which owns the
+//! queue, the visited set, the parent tree, root seeding, masking and
+//! the step ceiling. A third walk would reopen the same class, so it
+//! fails here rather than in someone's deployment.
+//!
+//! The check is deliberately narrow: `pop_front` is the tell for a
+//! hand-rolled breadth-first queue, and the engine is the only place
+//! that should have one.
+
+use std::path::Path;
+
+/// The two claim evaluators. Anything else in the tree may walk
+/// however it likes — this is about the two that must agree.
+const EVALUATORS: [&str; 2] =
+    ["src/claims.rs", "../hale-cli/src/fleet.rs"];
+
+#[test]
+fn neither_claim_evaluator_rolls_its_own_search() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut offenders = Vec::new();
+    for rel in EVALUATORS {
+        let p = root.join(rel);
+        let src = std::fs::read_to_string(&p)
+            .unwrap_or_else(|e| panic!("read {}: {e}", p.display()));
+        for (i, line) in src.lines().enumerate() {
+            if line.contains("pop_front()") {
+                offenders.push(format!(
+                    "{rel}:{}: {}",
+                    i + 1,
+                    line.trim()
+                ));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "a hand-rolled traversal in a claim evaluator.\n\nReachability \
+         belongs to `model_graph::search`, which both tiers share so \
+         that a rule learned in one cannot go missing in the other. \
+         If this genuinely is not a reachability walk, narrow the \
+         check rather than deleting it.\n\n{}\n",
+        offenders.join("\n")
+    );
+}
+
+/// The engine is where the queue lives, so the lint above would be
+/// vacuous if it also covered the engine — and vacuous if `pop_front`
+/// stopped being how the engine is written. Pin both facts.
+#[test]
+fn the_engine_is_the_one_place_that_has_a_queue() {
+    let p = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/model_graph.rs");
+    let src = std::fs::read_to_string(&p).expect("read model_graph.rs");
+    assert!(
+        src.contains("pop_front()"),
+        "the shared engine no longer contains the pattern the lint \
+         looks for, so that lint now proves nothing — update both"
+    );
+}

--- a/crates/hale-types/tests/one_reachability_engine.rs
+++ b/crates/hale-types/tests/one_reachability_engine.rs
@@ -1,70 +1,108 @@
-//! Reachability is derived in exactly one place.
+//! Boolean reachability is derived in one place.
 //!
-//! GH #408. There used to be two walks: the application checker's,
-//! and a second one the fleet tier wrote against the topology
-//! artifact. The second had to remember every rule the first had
-//! learned, and it forgot several — through-stdlib edges, unknown
-//! propagation, the zero-length overlap case, and the label on each
-//! hop of a witness. Every one of those was a fail-open or a
-//! misleading diagnostic, and each was fixed separately before the
-//! shared engine existed.
+//! GH #408. There used to be two unweighted reachability walks: the
+//! application checker's, and a second one the fleet tier wrote
+//! against the topology artifact. The second had to remember every
+//! rule the first had learned, and it forgot several — through-stdlib
+//! edges, unknown propagation, the zero-length overlap case, and the
+//! label on each hop of a witness. Every one was a fail-open or a
+//! misleading diagnostic.
 //!
-//! Both tiers now go through `model_graph::search`, which owns the
-//! queue, the visited set, the parent tree, root seeding, masking and
-//! the step ceiling. A third walk would reopen the same class, so it
-//! fails here rather than in someone's deployment.
+//! Both prohibition checks now go through `model_graph::search`.
 //!
-//! The check is deliberately narrow: `pop_front` is the tell for a
-//! hand-rolled breadth-first queue, and the engine is the only place
-//! that should have one.
+//! **Scope, stated precisely.** This is about BOOLEAN reachability,
+//! which is what `forbid reaches` and `only edges` ask. `claims.rs`
+//! still contains `site_count`, a recursive weighted traversal with
+//! its own memoization, cycle handling and step ceiling, because
+//! `bound` computes a quantitative semiring rather than a yes/no
+//! answer. That is a legitimately different algorithm over the same
+//! edges, not a duplicate of this one — but it does mean this file
+//! must not claim the evaluators contain no traversals at all.
+//!
+//! The checks below are textual and therefore heuristic. They are
+//! worth having anyway: the failure they guard against is someone
+//! writing a fresh queue rather than importing one, and that is
+//! exactly what a grep can see.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-/// The two claim evaluators. Anything else in the tree may walk
-/// however it likes — this is about the two that must agree.
-const EVALUATORS: [&str; 2] =
-    ["src/claims.rs", "../hale-cli/src/fleet.rs"];
+fn read(rel: &str) -> String {
+    let p: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    std::fs::read_to_string(&p)
+        .unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
 
+const CLAIMS: &str = "src/claims.rs";
+const FLEET: &str = "../hale-cli/src/fleet.rs";
+const ENGINE: &str = "src/model_graph.rs";
+
+/// Neither prohibition evaluator may stand up its own BFS queue.
 #[test]
-fn neither_claim_evaluator_rolls_its_own_search() {
-    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+fn no_prohibition_evaluator_defines_a_private_bfs() {
     let mut offenders = Vec::new();
-    for rel in EVALUATORS {
-        let p = root.join(rel);
-        let src = std::fs::read_to_string(&p)
-            .unwrap_or_else(|e| panic!("read {}: {e}", p.display()));
+    for rel in [CLAIMS, FLEET] {
+        let src = read(rel);
         for (i, line) in src.lines().enumerate() {
-            if line.contains("pop_front()") {
-                offenders.push(format!(
-                    "{rel}:{}: {}",
-                    i + 1,
-                    line.trim()
-                ));
+            let l = line.trim();
+            if l.starts_with("//") {
+                continue;
+            }
+            // The tells for a hand-rolled frontier.
+            if l.contains("pop_front()")
+                || l.contains("pop_back()")
+                || l.contains("VecDeque")
+            {
+                offenders.push(format!("{rel}:{}: {l}", i + 1));
             }
         }
     }
     assert!(
         offenders.is_empty(),
-        "a hand-rolled traversal in a claim evaluator.\n\nReachability \
-         belongs to `model_graph::search`, which both tiers share so \
-         that a rule learned in one cannot go missing in the other. \
-         If this genuinely is not a reachability walk, narrow the \
-         check rather than deleting it.\n\n{}\n",
+        "a hand-rolled frontier in a prohibition evaluator.\n\nBoolean \
+         reachability belongs to `model_graph::search`, which both \
+         tiers share so that a rule learned in one cannot go missing \
+         in the other.\n\n{}\n",
         offenders.join("\n")
     );
 }
 
-/// The engine is where the queue lives, so the lint above would be
-/// vacuous if it also covered the engine — and vacuous if `pop_front`
-/// stopped being how the engine is written. Pin both facts.
+/// ...and both must actually call the shared engine, or the check
+/// above is satisfied by an evaluator that simply stopped doing
+/// reachability the supported way.
 #[test]
-fn the_engine_is_the_one_place_that_has_a_queue() {
-    let p = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("src/model_graph.rs");
-    let src = std::fs::read_to_string(&p).expect("read model_graph.rs");
+fn both_prohibition_evaluators_call_the_shared_engine() {
     assert!(
-        src.contains("pop_front()"),
-        "the shared engine no longer contains the pattern the lint \
-         looks for, so that lint now proves nothing — update both"
+        read(CLAIMS).contains("model_graph::search("),
+        "`claims.rs` no longer calls the shared search"
+    );
+    assert!(
+        read(FLEET).contains("model_graph::ModelGraph")
+            || read(FLEET).contains("ModelGraph::new"),
+        "`fleet.rs` no longer uses the shared graph"
+    );
+    assert!(
+        read(ENGINE).contains("search("),
+        "`ModelGraph::reaches` no longer delegates to `search`"
+    );
+}
+
+/// The engine holds exactly one frontier.
+///
+/// "At least one" would be satisfied by an engine that had grown a
+/// second walk of its own, which is the same defect one level in.
+#[test]
+fn the_engine_holds_exactly_one_frontier() {
+    let src = read(ENGINE);
+    let n = src
+        .lines()
+        .filter(|l| !l.trim().starts_with("//"))
+        .filter(|l| l.contains("pop_front()"))
+        .count();
+    assert_eq!(
+        n, 1,
+        "expected exactly one queue in the shared engine, found {n} — \
+         either a second traversal appeared, or the first stopped \
+         being written the way the lint above looks for, and that \
+         lint is now vacuous"
     );
 }

--- a/crates/hale-types/tests/one_reachability_engine.rs
+++ b/crates/hale-types/tests/one_reachability_engine.rs
@@ -10,14 +10,20 @@
 //!
 //! Both prohibition checks now go through `model_graph::search`.
 //!
-//! **Scope, stated precisely.** This is about BOOLEAN reachability,
-//! which is what `forbid reaches` and `only edges` ask. `claims.rs`
-//! still contains `site_count`, a recursive weighted traversal with
-//! its own memoization, cycle handling and step ceiling, because
-//! `bound` computes a quantitative semiring rather than a yes/no
-//! answer. That is a legitimately different algorithm over the same
-//! edges, not a duplicate of this one — but it does mean this file
-//! must not claim the evaluators contain no traversals at all.
+//! **Scope, stated precisely.** This centralizes unweighted
+//! TRANSITIVE reachability, which is what `forbid reaches` asks at
+//! both tiers. Two neighbours are deliberately outside it:
+//!
+//!  * `only edges` enumerates DIRECT crossing edges — a cut-edge
+//!    subset query, with no transitive walk at either tier;
+//!  * `bound` keeps `site_count`, a recursive WEIGHTED traversal with
+//!    its own memoization, cycle handling and step ceiling, because a
+//!    quantitative semiring is a different algorithm over the same
+//!    edges rather than a duplicate of this one.
+//!
+//! So this file must not claim the evaluators contain no traversals
+//! at all. It claims something narrower and checkable: neither
+//! prohibition evaluator stands up its own frontier.
 //!
 //! The checks below are textual and therefore heuristic. They are
 //! worth having anyway: the failure they guard against is someone
@@ -75,34 +81,54 @@ fn both_prohibition_evaluators_call_the_shared_engine() {
         read(CLAIMS).contains("model_graph::search("),
         "`claims.rs` no longer calls the shared search"
     );
+    // Mentioning or constructing a graph is not using it: a private
+    // BFS could be restored while an unrelated `ModelGraph` reference
+    // stayed behind. Pin the CALL.
     assert!(
-        read(FLEET).contains("model_graph::ModelGraph")
-            || read(FLEET).contains("ModelGraph::new"),
-        "`fleet.rs` no longer uses the shared graph"
+        read(FLEET).contains("match graph.reaches("),
+        "`fleet.rs` no longer evaluates prohibitions through \
+         `ModelGraph::reaches`"
     );
+    // Likewise `search(` alone is vacuous here — this module's own
+    // tests call it, so the substring survives `reaches` ceasing to
+    // delegate. Pin the call site inside `reaches`.
     assert!(
-        read(ENGINE).contains("search("),
+        read(ENGINE).contains("let out = search("),
         "`ModelGraph::reaches` no longer delegates to `search`"
     );
 }
 
 /// The engine holds exactly one frontier.
 ///
-/// "At least one" would be satisfied by an engine that had grown a
-/// second walk of its own, which is the same defect one level in.
+/// "At least one queue" would be satisfied by an engine that had
+/// grown a second walk of its own — the same defect one level in. All
+/// three counts are pinned, because a second frontier could otherwise
+/// hide behind `pop_back` or a second `VecDeque` consumed by a
+/// helper.
 #[test]
 fn the_engine_holds_exactly_one_frontier() {
     let src = read(ENGINE);
-    let n = src
-        .lines()
-        .filter(|l| !l.trim().starts_with("//"))
-        .filter(|l| l.contains("pop_front()"))
-        .count();
+    let count = |needle: &str| {
+        src.lines()
+            .filter(|l| !l.trim().starts_with("//"))
+            .filter(|l| l.contains(needle))
+            .count()
+    };
     assert_eq!(
-        n, 1,
-        "expected exactly one queue in the shared engine, found {n} — \
-         either a second traversal appeared, or the first stopped \
-         being written the way the lint above looks for, and that \
-         lint is now vacuous"
+        count("VecDeque::new()"),
+        1,
+        "expected exactly one queue in the shared engine"
+    );
+    assert_eq!(
+        count("pop_front()"),
+        1,
+        "expected exactly one frontier pop — if the queue is now \
+         drained some other way, the sibling lint that greps for \
+         `pop_front` is vacuous and must change with this one"
+    );
+    assert_eq!(
+        count("pop_back()"),
+        0,
+        "a second frontier hiding behind `pop_back`"
     );
 }


### PR DESCRIPTION
`evaluate_forbid_reaches` had its own breadth-first walk, written before the fleet tier existed — and that second walk is where every fleet defect fixed this week came from. It had to remember each rule the first one had learned, and it forgot four: through-stdlib edges, unknown propagation, the zero-length overlap case, and the label on each hop of a witness.

Both prohibition checks now go through `model_graph::search`.

> **This description has been rewritten.** Its first version described an API that no longer exists and made two claims that were false — see *Corrections* at the end. Two rounds of external review are folded in.

## What the engine owns

`search` is generic over the vertex and edge-label types, and owns the parts that are identical everywhere and easy to get subtly wrong: the queue, the visited set, the parent tree, root seeding, masking, the step ceiling, and the propagation of incomplete vertices.

```rust
pub struct Visit<V, E, H> { pub edges: Vec<(V, E)>, pub hole: Option<H> }
pub enum HolePolicy { Halt, PathWins }
pub enum Search<V, E, H> { NotFound, Found {..}, Uncertified {..}, Saturated {..} }
```

A caller reports that a vertex's edge set is incomplete; the **engine** decides the verdict. Forgetting to consult a hole is not a mistake this API allows — the first version of this PR left that as a caller-side convention, and the review was right that it left one of the cited defect classes structurally open.

Three rules are baked in because they are semantics rather than mechanism, and each was a shipped bug before it lived here: roots are tested (source/target overlap is a zero-length path), masked vertices are neither tested nor traversed, and a reachable hole is never dropped.

Returning the parent **tree** rather than a path is what kept this small: `render_violation` walks that tree and is untouched, as is the fleet witness renderer.

## Two opposite policies, both deliberate

On an edge it cannot follow, the application checker **stops** and names the edge — the repair is to make that edge resolvable. The fleet tier **walks past** and refuses only if no path is found at all — a concrete cross-binary counterexample beats a refusal. Collapsing them during a mechanical refactor would have been the easy mistake.

## Scope, stated precisely

This centralizes unweighted **transitive** reachability, which is what `forbid reaches` asks at both tiers. Two neighbours are deliberately outside it:

- **`only edges`** enumerates direct crossing edges — a cut-edge subset query, with no transitive walk at either tier.
- **`bound`** keeps `site_count`, a recursive **weighted** traversal with its own memoization, cycle handling and step ceiling. A quantitative semiring is a different algorithm over the same edges, not a duplicate of this one.

The engine centralizes traversal and hole propagation. It is not the whole derivation: callers still decide which relations exist, which contracted stdlib edges are included, which vertices are incomplete, and what counts as a target.

## Behavior is unchanged — checked, not asserted

This is the highest-stakes evaluator in the checker, so the differential is the argument. Re-run after every revision:

| | result |
|---|---|
| `hale check` diagnostics + exit codes, 88 corpus programs | identical |
| topology artifacts (claim verdicts included), 88 corpus programs | **byte-identical** |
| topology artifacts, 3 real downstream applications | **byte-identical** |
| test suite | 1010 green |
| downstream fleet plan | composes at the same `fleet_shape_hash` |

Artifacts carry every claim's verdict, so byte-identity is a direct statement that no claim changed its answer.

## Fixed during review

- **zero-length paths were suppressed** in `ModelGraph::reaches` (`dst.contains(v) && !src.contains(v)` disabled the engine's root test) — a false absence reachable through the shared API regardless of the current caller
- **a tripped step ceiling was reported as a certified absence** — `max_steps` is now `Option<u32>`; search *exhaustion* can prove an absence, search *abandonment* cannot
- **hole propagation was a caller-side convention**, now structural
- **the enforcement guard asserted things it did not check** — `search(` was satisfied by the module's own tests; the fleet check proved only that a `ModelGraph` was mentioned; "exactly one queue" counted only `pop_front`

## Corrections to this PR's earlier description

Recorded rather than quietly edited away:

- it described `Visit::Halt`, which no longer exists
- it named the test `neither_claim_evaluator_rolls_its_own_search`, whose name was **false** — `site_count` is a traversal. Now `no_prohibition_evaluator_defines_a_private_bfs`
- it stated **"`bound` never walks the graph"**, which is simply wrong
- it reported 1001 tests; the current figure is 1010

## Deliberate follow-ups, not folded in

Each changes checker verdicts, and this PR's regression argument is byte-identical output:

1. **Application `PathWins`.** Today an unresolvable edge from one root can suppress a definitive violation reachable from another, so the result depends on traversal order. It fails closed, but the evidence is weaker. Prerequisite: the application closure must scan the whole vertex and return `Visit::partial(edges, hole)` — the policy flag alone is not enough, and a note in `claims.rs` says so where someone would act on it.
2. **Testing the target before the ceiling check.**
3. **`Verdict::Uncertified` rather than `Violated` on application saturation** — now the semantically accurate result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
