### PR TITLE
docs: bring spec, book and styleguide up to the shipped fleet surface

### DIFF
--- a/docs/src/services/multi-binary.md
+++ b/docs/src/services/multi-binary.md
@@ -162,6 +162,93 @@ be *pure* — no hidden state — because it runs on transport
 threads. Different bindings on the same topic can carry different
 codecs; the publisher's send site doesn't know which.
 
+## Checking the whole deployment
+
+Each binary checks its own claims in its own closed world. That
+leaves one question none of them can answer: what happens once they
+are wired together? A component that is individually correct can
+still be deployed into an arrangement that isn't — two publishers
+where the law says one, or a path from a strategy to a gateway that
+was supposed to go through risk.
+
+`hale fleet` answers that by composing the **artifacts**, never the
+source:
+
+```sh
+hale check apps/prober --dump-topology=artifacts/prober.json
+hale check apps/oms    --dump-topology=artifacts/oms.json
+hale check apps/gw     --dump-topology=artifacts/gw.json
+hale fleet check prod.plan.json
+```
+
+A plan names deployed **instances** and the routes between them:
+
+```json
+{ "schema": "1.0", "name": "prod",
+  "instances": [
+    {"id": "prober-0", "artifact": "artifacts/prober.json", "labels": ["strategy"]},
+    {"id": "oms-0",    "artifact": "artifacts/oms.json",    "labels": ["oms"]},
+    {"id": "gw-0",     "artifact": "artifacts/gw.json",     "labels": ["gateway"]}],
+  "routes": [
+    {"id": "intent",
+     "publishers":  [{"instance": "prober-0", "topic": "OrderIntent"}],
+     "subscribers": [{"instance": "oms-0",    "topic": "OrderIntent"}]}],
+  "groups": {"strategy": {"labels": ["strategy"]},
+             "gateway":  {"labels": ["gateway"]}},
+  "claims": [
+    {"name": "orders_pass_oms",
+     "forbid_reaches": {"from": "strategy", "to": "gateway",
+                        "avoiding": "oms"}}] }
+```
+
+Why an *instance* rather than an application: `oms` is a program,
+`oms-0` is a process. Cardinality, witnesses, and running two copies
+of one binary all need the distinction.
+
+Why artifacts rather than source: merging the programs would invent
+edges that no deployed route creates (an unbound topic is in-process
+by default), erase routes that exist only in config, and turn
+messaging into ordinary call reachability. Matching wire identities
+establish *compatibility*; only an explicit route creates an edge.
+
+A violation names the path across binaries — each hop, the route
+carrying it, and the file each vertex lives in:
+
+```
+fleet claim `orders_pass_oms` violated — witness:
+  prober-0::Probe::submit  [prober/main.hl]
+  -(route `bypass`)->
+  gw-0::Gateway::on_order  [gw/main.hl]
+```
+
+Declare your deployments in `hale.toml` and check them all at once:
+
+```toml
+[fleets]
+production = "ops/fleet/prod.plan.json"
+staging    = "ops/fleet/staging.plan.json"
+```
+
+### What it does not tell you
+
+The honest boundary matters more here than at any other tier,
+because a green result is easy to over-read.
+
+It certifies **topology** — which routes exist, which instances they
+connect, what each carries. It does not prove a message will
+*arrive*: delivery is a property of the protocol and the peer, not of
+your code, and no amount of static analysis changes that. Runtime
+observation is what measures delivery.
+
+Nor is it a rolling-upgrade proof. A clean old plan and a clean new
+plan say nothing about the arrangement that exists midway between
+them.
+
+Where the model is uncertain it says so rather than guessing. If a
+component reaches a call the compiler cannot resolve, a prohibition
+past that point comes back `uncertified` — not `holds`. An absence
+nobody could see is not an absence.
+
 ## The shape this gives you
 
 A single source tree, decomposed into loci that coordinate over

--- a/spec/styleguide.md
+++ b/spec/styleguide.md
@@ -852,6 +852,37 @@ certify a path — plus one tier you get for free because your
 | **fmt** (CI gate) | `hale fmt --check` — canonical mechanical form (§2, "Canonical form"); exit 1 lists offenders | gate in CI; `hale fmt` fixes |
 | escape hatches | `@unbounded` (fn or lifecycle hook) acknowledges intentional accumulation; `--allow-unowned-subscriber`; `--no-warn-unbounded-alloc` | |
 
+### Where law lives
+
+The tiers above certify a *function*. Claims certify a *system*, and
+the only real style question is which closed world owns each
+sentence.
+
+- **In the `main locus`** — law about this application. A claim is
+  evaluated in a closed world, so it belongs where the world closes.
+  Name it for the requirement (`orders_pass_risk`), never for the
+  mechanism (`no_call_from_a_to_b`): the name is what a reviewer
+  reads in a diff when someone weakens it.
+- **In a `constitution`** — the same sentence needed by several
+  entrypoints. Authorship moves; evaluation does not. Each adopting
+  main still proves it in its own world, so `adopt Core;` is not a
+  shortcut around closure. Composition is union-only: a stricter rule
+  is a second clause, never a replacement, so a derived constitution
+  can only add law.
+- **In a library's `claims { }`** — obligations about the surface the
+  library exports, re-evaluated in every importer.
+- **In a fleet plan** — law no single binary can state, because it is
+  about the arrangement. `count publishers == 1` inside one program
+  is a different sentence from "one deployed publisher"; write the
+  second where instances exist.
+
+Two habits worth keeping. Declare the vocabulary a claim quantifies
+over — an undeclared group is an error, and a group that is
+legitimately empty says so with `may_be_empty` rather than being
+allowed to hold vacuously. And read `uncertified` as work to do, not
+as a pass: it means the model has a hole where the claim needed to
+look.
+
 Resource budgets (`--dump-resource-budget`,
 `--check-resource-budget <toml>`, `--warn-resource-leak`) gate
 thread / pool / subject / fd counts in CI — see

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -623,10 +623,18 @@ application group makes from a locus to its methods, one altitude up.
 An unknown name or an empty resolution is an error, never an empty
 set.
 
-- **`forbid_reaches`** walks the composed edge set: interior calls,
-  interior bus hops, and explicit routes. `avoiding` masks a group's
+- **`forbid_reaches`** walks the composed edge set: interior calls
+  **including the through-stdlib contracted edges**
+  (`calls_via_stdlib`), interior bus hops, and explicit routes.
+  Reading only `calls` loses a path the component's own claims can
+  see — a handler reaching its publisher through `std::http::Router`
+  contributes no direct edge at all. `avoiding` masks a group's
   vertices out, which makes it the interposition form — any surviving
-  path is a bypass.
+  path is a bypass, and `avoiding` may not name an endpoint of its
+  own claim, since masking one deletes the domain being quantified
+  over. An instance in **both** the source and target groups is a
+  zero-length violation: the source already is the forbidden
+  destination.
 - **`only_edges`** grants by wire **subject**, not by transport
   address. There are no cross-process calls to grant.
 - **`require_subscribes` / `require_publishes`** are structural
@@ -640,15 +648,45 @@ set.
   count instance-qualified **endpoints**, which is a different sort
   from the application tier's declaration count — hence the different
   spelling. Two components can each be individually legal while the
-  deployment has two publishers.
+  deployment has two publishers. A count must name at least one of
+  `eq`, `min`, `max`: with none of them a claim compares nothing and
+  holds against every fleet while reading like law.
+
+A claim names **exactly one** verb. Several verbs under one name
+would be judged one at a time and recorded under that name as though
+the whole sentence held, so the shape is refused: split it, and each
+half gets its own name and verdict.
+
+Route admission validates **roles**, not just topic identity. A
+publisher endpoint must publish the subject and a subscriber endpoint
+must subscribe it, as its own artifact records — declaring a topic is
+not using it, and any component importing a topic module declares
+every topic in it. Without this a plan could name a producer that
+does not exist and satisfy a law about the consumer side with nothing
+feeding it. A plan that misdescribes its components is an invalid
+model, refused before any claim is evaluated rather than reported as
+a law failure.
+
+**Uncertainty propagates.** A component's `unknowns` are part of the
+composed model, not a footnote beside it. A prohibition whose source
+can reach a vertex with an incomplete outgoing edge set answers
+`uncertified` — that vertex's missing edges could lead to the target,
+so the absence is not proved. `uncertified` fails like `violated`;
+the distinction is recorded because the repair differs (resolve the
+unknown edge, versus fix the program). Two rules keep it usable: a
+concrete counterexample wins over a hole, and only a hole the claim's
+source can actually reach counts, so an unrelated unknown elsewhere
+in the deployment does not poison every law. `uninhabited_interface_call`
+is not such a hole — in a closed world an interface with no
+conformers has no values, so the site is dead rather than unknown.
 
 Endpoints resolve through each component's `topics` table by wire
 subject, never by local name.
 
 A violation renders a **cross-artifact witness**: the instance-
-qualified vertices, the route carrying each hop, and the source file
-each vertex lives in — which is what Phase 0's source maps exist to
-make renderable.
+qualified vertices, the route carrying **each** hop, and the source
+file each vertex lives in — which is what Phase 0's source maps exist
+to make renderable.
 
 ```
 fleet claim `orders_pass_oms` violated — witness:


### PR DESCRIPTION
The spec is the canonical contract and is supposed to change in the same commit as the behavior. It did not for #426–#430, so it still described the fleet tier as it was a week ago. This catches spec, book and styleguide up, and adds the chapter the book was missing entirely.

No behavior change.

## spec/verification.md — six shipped rules were missing

The fleet-claims section now states what the checker actually does:

- `forbid_reaches` walks the through-stdlib contracted edges as well as direct calls
- source/target overlap is a zero-length violation, and `avoiding` may not mask an endpoint of its own claim
- a claim names exactly one verb
- a cardinality claim must name a bound
- route admission validates endpoint **roles**, not just topic identity, and does so before any claim runs
- uncertainty propagates: a prohibition whose source reaches an incomplete vertex answers `uncertified`

With the two rules that keep `uncertified` usable — a concrete counterexample wins, and only a *reachable* hole counts — and the carve-out that an uninhabited-interface call is a dead site rather than a hole.

## docs — the book had no mention of `hale fleet`

Not a thin section: none. The feature was undiscoverable to anyone not reading issues.

*Across binaries* now covers the workflow, why the unit is a deployed **instance** rather than an application, why composition takes artifacts rather than merged source, the cross-artifact witness, and `[fleets]` in `hale.toml`.

At equal length, what a green result does **not** mean: topology is certified, delivery is not — delivery is a property of the protocol and the peer, and no static analysis changes that. A clean old plan plus a clean new plan is also not a rolling-upgrade proof. And where the model is uncertain it says `uncertified` rather than guessing.

## styleguide — "Where law lives"

The enforcement ladder certified *functions* and said nothing about claims, so it never answered the question an author actually has: which closed world owns this sentence — the main locus, a constitution, a library's exported surface, or the fleet plan. Plus the two habits worth keeping: declare the vocabulary a claim quantifies over, and read `uncertified` as work to do rather than as a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
