### PR TITLE
release: v0.16.0 — the law composes, the certificate travels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.16.0 — the law composes, the certificate travels (2026-08-06)
 
 ### Signed fleet components & binary attestation (GH #408 Phase 7)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "hale-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "hale-corpus",
  "hale-stdlib",
@@ -99,11 +99,11 @@ dependencies = [
 
 [[package]]
 name = "hale-corpus"
-version = "0.15.0"
+version = "0.16.0"
 
 [[package]]
 name = "hale-lsp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "hale-syntax",
  "hale-types",
@@ -112,18 +112,18 @@ dependencies = [
 
 [[package]]
 name = "hale-stdlib"
-version = "0.15.0"
+version = "0.16.0"
 
 [[package]]
 name = "hale-syntax"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "hale-corpus",
 ]
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "hale-corpus",
  "hale-stdlib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump + CHANGELOG header for v0.16.0. Contents: constitutions (GH #409), fleet composition and claims (GH #408 phases 0–3/5), signed components and binary attestation (GH #408 Phase 7), one shared reachability engine for both tiers, artifact schema 1.8, and the accumulated fixes since v0.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)