### PR TITLE
feat(fleet): signed components and binary attestation (GH #408 Phase 7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,6 +400,46 @@ Beyond the effect assertions above, all opt-in:
 - `@form(lru_cache)` joins `vec` / `hashmap` / `ring_buffer` as a
   cap-bounded collection shape.
 
+## Architecture as law (claims, constitutions, fleets)
+
+A `main locus` may carry a `claims { }` block: named sentences over
+the assembled program graph, checked by `hale check` as ERRORS, zero
+runtime cost. Groups are checked vocabulary (misspelling = error;
+empty group = error unless `may_be_empty`).
+
+```hale
+group workers = { delta::* };
+main locus App {
+    claims {
+        isolated:    forbid reaches(workers, gamma_wing);
+        consumed:    require subscribes(some workers, topic t::Tasks);
+        one_writer:  count publishers(topic t::Tasks) == 1;
+    }
+}
+```
+
+When a claim fails, the compiler returns a WITNESS — the exact path,
+in your spelling. Treat it as the next task: remove the edge, route
+through a gate, or change the law (a categorically different edit).
+Unknown means violation: an unresolvable call on a forbidden path
+refuses certification rather than counting as nothing.
+
+Shared law goes in a `constitution NAME { … }` (top level), adopted
+per entrypoint with `adopt NAME;` inside `claims { }`. Composition
+is union only — a stricter rule is a second named claim; weakening
+is unexpressible. `[environments]` in `hale.toml` binds constitutions
+per deployment target; `hale check --matrix` proves every
+(entrypoint × environment) pair.
+
+Multi-binary law lives one tier up: `hale check <app>
+--dump-topology=<f.json>` emits a byte-reproducible artifact per
+application; a fleet plan (JSON) names deployed INSTANCES and
+explicit routes; `hale fleet check <plan>` composes the artifacts
+and proves cross-binary claims. Only an explicit route creates a
+fleet edge — matching topic declarations alone connect nothing.
+`hale fleet sign/keygen/attest` + `[fleet_trust]` pin the artifacts
+and binaries a deployment admits (strict when declared).
+
 ## Matching
 
 `match` is an expression as well as a statement, so it can produce a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,47 @@ behavior.
 
 ## Unreleased
 
+### Signed fleet components & binary attestation (GH #408 Phase 7)
+
+A composition proves a world against artifacts it can read; now a
+signature proves those artifacts are the ones a key-holder meant.
+`hale fleet keygen | sign` produce ES256 keypairs and detached
+sidecars (`<artifact>.sig`, `es256:<hex r‖s>`) over the artifact's
+**exact bytes** — sound because artifacts are byte-reproducible
+(schema 1.8), and necessary because the in-band `artifact_digest`
+is FNV-1a, a tripwire rather than a trust anchor. ES256 because the
+system already speaks it: it is `std::crypto`'s suite, so a Hale
+program — a supervisor, a deploy gate — verifies the same sidecar
+with the language's own stdlib. One algorithm end to end.
+
+Trust is **strict when declared**: `--trust <pub.pem>` on
+`check`/`dump`, or `[fleet_trust] keys = [...]` in the manifest,
+makes an unsigned or unverifiable component a composition error.
+There is no `require = true` knob, for the reason `no_base` exists:
+a trust set that quietly admits unsigned artifacts is law that
+looks bound and binds nothing. Verification runs before the
+integrity digest — provenance before integrity before meaning, each
+check covering the bytes the next one reads. The fleet artifact
+records the admission as unhashed provenance: `sha256` of the
+admitted bytes, `signed_by` the verifying key's identity or `null`
+— a fact, not an omission, so "unsigned admission" and "verified
+under this key" stay distinguishable downstream.
+
+`hale fleet attest <plan>` answers the remaining question — are the
+executables the plan deploys the ones the operator hashed? Plan
+schema 1.1 (1.0 still reads) adds optional `binary` /
+`binary_sha256` rows per instance, and attestation is
+all-or-nothing over them: a missing row is a refusal, not a skip,
+because a partial attestation would report coverage it does not
+have. Attest checks bytes at rest; whether a *running* process is
+still that binary is runtime observation territory (7b), and
+nothing here claims otherwise.
+
+The honest boundary, stated where it can be quoted: signing
+certifies provenance and integrity, never behavior. Out of scope by
+design: compromised builders, malicious compilers, runtime memory
+tampering.
+
 ### The application checker moves onto the shared engine (GH #408)
 
 `forbid reaches` had its own breadth-first walk, written before the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +32,12 @@ dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "either"
@@ -46,6 +58,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "hale-cli"
 version = "0.15.0"
 dependencies = [
@@ -53,6 +80,7 @@ dependencies = [
  "hale-lsp",
  "hale-syntax",
  "hale-types",
+ "openssl",
  "serde",
  "serde_json",
  "toml",
@@ -195,6 +223,49 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "proc-macro2"
@@ -410,6 +481,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "winnow"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ One primitive, the **locus**, scales from a single function to a fleet of
 services wired over a typed message bus. There's no translation layer
 between the sentence you'd say out loud and the code you write.
 
-**[hale-lang.org](https://hale-lang.org)** — docs, [playground](https://hale-lang.org/playground), packages, roadmap.
+**[hale-lang.org](https://hale-lang.org)** — docs, [playground](https://hale-lang.org/playground), packages, [features](https://hale-lang.org/features).
 
 [![Tests](https://github.com/hale-lang/hale/actions/workflows/tests.yml/badge.svg)](https://github.com/hale-lang/hale/actions/workflows/tests.yml)
 [![Docs](https://github.com/hale-lang/hale/actions/workflows/docs.yml/badge.svg)](https://hale-lang.org/docs)

--- a/crates/hale-cli/Cargo.toml
+++ b/crates/hale-cli/Cargo.toml
@@ -18,3 +18,9 @@ hale-lsp = { path = "../hale-lsp" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+# GH #408 Phase 7: ES256 fleet signatures. System OpenSSL on
+# purpose — it is already an inherent build/runtime dependency
+# (codegen links every native build against -lssl -lcrypto, and
+# lotus_tls.c implements std::crypto's ES256 with it), so this
+# adds no second crypto provider to the system.
+openssl = "0.10"

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -32,7 +32,15 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 /// The plan's own schema, independent of the topology artifact's.
-pub const FLEET_PLAN_SCHEMA: &str = "1.0";
+/// 1.1 (GH #408 Phase 7): `binary` / `binary_sha256` on an instance,
+/// for `hale fleet attest`. A 1.0 plan still reads; the artifact
+/// emits 1.1.
+pub const FLEET_PLAN_SCHEMA: &str = "1.1";
+
+/// Plan schemas this build reads. Equality was right when there was
+/// one; a set keeps "your plan is newer than your compiler" a real
+/// refusal without making every older plan one too.
+const READABLE_PLAN_SCHEMAS: [&str; 2] = ["1.0", "1.1"];
 
 /// An exact, finite deployment. Autoscaling ranges and wildcard
 /// discovery are elaborator INPUTS, not sealed-plan contents: a
@@ -141,6 +149,18 @@ pub struct InstanceSpec {
     pub artifact: String,
     #[serde(default)]
     pub labels: Vec<String>,
+    /// GH #408 Phase 7 (`attest`): path to this instance's built
+    /// executable, relative to the plan file. The artifact certifies
+    /// the model; this row is what lets a deployment answer for the
+    /// bytes it actually runs.
+    #[serde(default)]
+    pub binary: Option<String>,
+    /// Expected SHA-256 of `binary`, hex. Cryptographic where the
+    /// in-band `artifact_digest` (FNV, a tripwire) deliberately is
+    /// not: this hash is the thing an operator asserts across a
+    /// trust boundary.
+    #[serde(default)]
+    pub binary_sha256: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -169,6 +189,15 @@ struct Component {
     labels: Vec<String>,
     artifact: serde_json::Value,
     path: PathBuf,
+    /// SHA-256 of the artifact bytes that were ADMITTED — recorded
+    /// in the fleet artifact so an auditor can re-check exactly what
+    /// the composition read, independent of the in-band FNV digest.
+    sha256: String,
+    /// key_id that verified this component's sidecar signature, when
+    /// trust roots were declared. `None` means composition ran
+    /// without trust — recorded rather than omitted, so a reader can
+    /// tell "unsigned admission" from "signed and verified".
+    signed_by: Option<String>,
 }
 
 /// `(wire subject, payload hash)` — the cross-binary join key.
@@ -182,7 +211,10 @@ struct WireId {
     payload_hash: String,
 }
 
-pub fn compose(plan_path: &Path) -> Result<String, Vec<String>> {
+pub fn compose(
+    plan_path: &Path,
+    trust: &crate::sign::Trust,
+) -> Result<String, Vec<String>> {
     let plan = read_plan(plan_path)?;
     let base = plan_path.parent().unwrap_or(Path::new("."));
     let mut errs: Vec<String> = Vec::new();
@@ -200,12 +232,14 @@ pub fn compose(plan_path: &Path) -> Result<String, Vec<String>> {
             ));
             continue;
         }
-        match load_artifact(&base.join(&inst.artifact)) {
-            Ok(v) => comps.push(Component {
+        match load_artifact(&base.join(&inst.artifact), trust) {
+            Ok((v, sha256, signed_by)) => comps.push(Component {
                 id: inst.id.clone(),
                 labels: inst.labels.clone(),
                 artifact: v,
                 path: base.join(&inst.artifact),
+                sha256,
+                signed_by,
             }),
             Err(e) => errs.push(format!("instance `{}`: {}", inst.id, e)),
         }
@@ -1090,10 +1124,21 @@ fn render(
         &comps
             .iter()
             .map(|c| {
+                // Unhashed provenance, like everything else in this
+                // section. `sha256` is what was ADMITTED; `signed_by`
+                // distinguishes "verified under this key" from
+                // "composed without trust roots" — null is a fact
+                // here, not an omission.
                 format!(
-                    "    {{\"id\": {}, \"artifact\": {}}}",
+                    "    {{\"id\": {}, \"artifact\": {}, \"sha256\": {}, \
+                     \"signed_by\": {}}}",
                     q(&c.id),
-                    q(&c.path.display().to_string())
+                    q(&c.path.display().to_string()),
+                    q(&c.sha256),
+                    c.signed_by
+                        .as_ref()
+                        .map(|k| q(k))
+                        .unwrap_or_else(|| "null".into())
                 )
             })
             .collect::<Vec<_>>()
@@ -1103,17 +1148,81 @@ fn render(
     out
 }
 
+/// `hale fleet attest <plan>` — the binary-digest half of Phase 7.
+///
+/// The composition certifies the model; attest answers a different
+/// question: are the executables this plan deploys the ones the
+/// operator hashed? All-or-nothing over the plan's instances — an
+/// attestation that skips an instance it cannot check is a partial
+/// answer wearing a full answer's exit code, so a missing `binary`
+/// or `binary_sha256` row is a refusal, not a skip.
+///
+/// Out of scope, on purpose: whether a RUNNING process still is
+/// that binary. This checks bytes at rest at deploy time; runtime
+/// self-attestation is obs territory (7b).
+pub fn attest(plan_path: &Path) -> Result<String, Vec<String>> {
+    let plan = read_plan(plan_path)?;
+    let base = plan_path.parent().unwrap_or(Path::new("."));
+    let mut errs: Vec<String> = Vec::new();
+    let mut ok: usize = 0;
+    for inst in &plan.instances {
+        let (Some(bin), Some(expect)) =
+            (&inst.binary, &inst.binary_sha256)
+        else {
+            errs.push(format!(
+                "instance `{}` declares no {} — every instance must \
+                 carry `binary` and `binary_sha256` for the plan to be \
+                 attestable; a partial attestation would report \
+                 coverage it does not have",
+                inst.id,
+                match (&inst.binary, &inst.binary_sha256) {
+                    (None, None) => "`binary` / `binary_sha256`",
+                    (None, _) => "`binary`",
+                    _ => "`binary_sha256`",
+                }
+            ));
+            continue;
+        };
+        let path = base.join(bin);
+        match crate::sign::sha256_file(&path) {
+            Err(e) => errs.push(format!("instance `{}`: {}", inst.id, e)),
+            Ok(actual) => {
+                if actual.eq_ignore_ascii_case(expect) {
+                    ok += 1;
+                } else {
+                    errs.push(format!(
+                        "instance `{}`: {} is not the binary the plan \
+                         names — sha256 {} where the plan says {}",
+                        inst.id,
+                        path.display(),
+                        actual,
+                        expect
+                    ));
+                }
+            }
+        }
+    }
+    if errs.is_empty() {
+        Ok(format!(
+            "ok: fleet `{}` attested — {} binary(ies) match the plan",
+            plan.name, ok
+        ))
+    } else {
+        Err(errs)
+    }
+}
+
 fn read_plan(p: &Path) -> Result<FleetPlan, Vec<String>> {
     let src = std::fs::read_to_string(p)
         .map_err(|e| vec![format!("read {}: {}", p.display(), e)])?;
     let plan: FleetPlan = serde_json::from_str(&src)
         .map_err(|e| vec![format!("parse {}: {}", p.display(), e)])?;
-    if plan.schema != FLEET_PLAN_SCHEMA {
+    if !READABLE_PLAN_SCHEMAS.contains(&plan.schema.as_str()) {
         return Err(vec![format!(
             "{}: plan schema `{}`, this build understands `{}`",
             p.display(),
             plan.schema,
-            FLEET_PLAN_SCHEMA
+            READABLE_PLAN_SCHEMAS.join("`, `")
         )]);
     }
     if plan.instances.is_empty() {
@@ -1126,10 +1235,39 @@ fn read_plan(p: &Path) -> Result<FleetPlan, Vec<String>> {
 }
 
 /// Load one component artifact and refuse anything a composition
-/// cannot honestly build on.
-fn load_artifact(p: &Path) -> Result<serde_json::Value, String> {
+/// cannot honestly build on. Returns the parsed artifact, the
+/// SHA-256 of the admitted bytes, and the key_id that signed them
+/// (when trust roots are declared).
+fn load_artifact(
+    p: &Path,
+    trust: &crate::sign::Trust,
+) -> Result<(serde_json::Value, String, Option<String>), String> {
     let src = std::fs::read_to_string(p)
         .map_err(|e| format!("read {}: {}", p.display(), e))?;
+    // Provenance BEFORE integrity BEFORE meaning. The signature is
+    // checked first because it covers the exact bytes everything
+    // after it reads — and because trust roots, once declared, make
+    // an unsigned component inadmissible outright (GH #408 Phase 7):
+    // declaring a trust set and then quietly composing unsigned
+    // artifacts would be the vacuity this system exists to refuse.
+    let signed_by = if trust.is_empty() {
+        None
+    } else {
+        Some(
+            trust
+                .verify(src.as_bytes(), &crate::sign::sidecar(p))
+                .map_err(|e| e.to_string())?,
+        )
+    };
+    let sha256 = {
+        use std::fmt::Write as _;
+        let d = openssl::sha::sha256(src.as_bytes());
+        let mut s = String::with_capacity(64);
+        for b in d {
+            let _ = write!(s, "{:02x}", b);
+        }
+        s
+    };
     // Integrity BEFORE meaning. `shape_hash` is an identity covering
     // the model half only, so it cannot vouch for the `topics` rows a
     // composition joins on; the whole-body digest can.
@@ -1182,7 +1320,7 @@ fn load_artifact(p: &Path) -> Result<serde_json::Value, String> {
             ))
         }
     }
-    Ok(v)
+    Ok((v, sha256, signed_by))
 }
 
 fn wire_id(a: &serde_json::Value, local: &str) -> Option<WireId> {

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -30,6 +30,7 @@ use hale_lsp as lsp;
 mod fleet;
 mod mcp;
 mod pkg;
+mod sign;
 
 fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
@@ -2545,6 +2546,23 @@ fn run_fleet_all() -> ExitCode {
             return ExitCode::from(2);
         }
     };
+    // GH #408 Phase 7: `[fleet_trust]` binds every declared fleet.
+    // A key that fails to load is a configuration error for the
+    // whole run — skipping it would narrow the trust set silently.
+    let trust_paths = match crate::pkg::read_fleet_trust(&manifest) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("{}", e);
+            return ExitCode::from(2);
+        }
+    };
+    let trust = match sign::Trust::load(&trust_paths) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("{}", e);
+            return ExitCode::from(2);
+        }
+    };
     if fleets.is_empty() {
         eprintln!(
             "{} declares no `[fleets]`. Add `<name> = \"<plan path>\"` \
@@ -2567,7 +2585,7 @@ fn run_fleet_all() -> ExitCode {
         }
         // Every fleet runs. Stopping at the first failure would report
         // a subset of the deployments as if it were all of them.
-        match fleet::compose(&path) {
+        match fleet::compose(&path, &trust) {
             Ok(artifact) => {
                 let v: serde_json::Value =
                     serde_json::from_str(&artifact).unwrap_or_default();
@@ -2609,7 +2627,94 @@ fn run_fleet_all() -> ExitCode {
 /// own law fails, or endpoints that disagree about a wire contract.
 fn run_fleet(rest: &[String]) -> ExitCode {
     let sub = rest.first().map(String::as_str);
-    let plan = rest.get(1);
+
+    // GH #408 Phase 7: key handling and attestation live under the
+    // same verb as composition — the fleet is where certificates
+    // change hands.
+    match sub {
+        Some("keygen") => {
+            let Some(prefix) = rest.get(1) else {
+                eprintln!("hale fleet keygen <prefix>   write <prefix>.pem + <prefix>.pub.pem");
+                return ExitCode::from(2);
+            };
+            return match sign::keygen(Path::new(prefix)) {
+                Ok(key_id) => {
+                    println!(
+                        "ok: {prefix}.pem (private, 0600) and \
+                         {prefix}.pub.pem — key_id {key_id}"
+                    );
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("{}", e);
+                    ExitCode::from(1)
+                }
+            };
+        }
+        Some("sign") => {
+            let (file, key) = match (rest.get(1), rest.get(2), rest.get(3)) {
+                (Some(f), Some(flag), Some(k)) if flag == "--key" => (f, k),
+                _ => {
+                    eprintln!("hale fleet sign <file> --key <priv.pem>   write <file>.sig (ES256 over exact bytes)");
+                    return ExitCode::from(2);
+                }
+            };
+            return match sign::sign(Path::new(file), Path::new(key)) {
+                Ok((sig_path, key_id)) => {
+                    println!(
+                        "ok: {} — key_id {}",
+                        sig_path.display(),
+                        key_id
+                    );
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("{}", e);
+                    ExitCode::from(1)
+                }
+            };
+        }
+        Some("attest") => {
+            let Some(plan) = rest.get(1) else {
+                eprintln!("hale fleet attest <plan.json>   compare each instance's binary to its binary_sha256");
+                return ExitCode::from(2);
+            };
+            return match fleet::attest(Path::new(plan)) {
+                Ok(msg) => {
+                    println!("{}", msg);
+                    ExitCode::SUCCESS
+                }
+                Err(errs) => {
+                    for e in &errs {
+                        eprintln!("{}", e);
+                    }
+                    ExitCode::from(1)
+                }
+            };
+        }
+        _ => {}
+    }
+
+    // `--trust <pub.pem>` (repeatable) on check/dump: strict when
+    // given, exactly like `[fleet_trust]` in the manifest.
+    let mut args: Vec<&String> = Vec::new();
+    let mut trust_paths: Vec<PathBuf> = Vec::new();
+    let mut it = rest.iter();
+    while let Some(a) = it.next() {
+        if a == "--trust" {
+            match it.next() {
+                Some(k) => trust_paths.push(PathBuf::from(k)),
+                None => {
+                    eprintln!("--trust needs a public key path");
+                    return ExitCode::from(2);
+                }
+            }
+        } else {
+            args.push(a);
+        }
+    }
+    let sub = args.first().map(|s| s.as_str());
+    let plan = args.get(1);
     // GH #408 Phase 5: `hale fleet check` with no plan checks EVERY
     // deployment the workspace declares. A repository usually has
     // more than one — production, staging, a reconciliation
@@ -2617,6 +2722,14 @@ fn run_fleet(rest: &[String]) -> ExitCode {
     // is the same partial-coverage problem `--matrix` solves for
     // entrypoints.
     if sub == Some("check") && plan.is_none() {
+        if !trust_paths.is_empty() {
+            eprintln!(
+                "--trust with no plan: the all-fleets form takes its \
+                 trust roots from `[fleet_trust]` in hale.toml, so one \
+                 flag cannot quietly rebind every deployment"
+            );
+            return ExitCode::from(2);
+        }
         return run_fleet_all();
     }
     let (sub, plan) = match (sub, plan) {
@@ -2627,6 +2740,13 @@ fn run_fleet(rest: &[String]) -> ExitCode {
             eprintln!("hale fleet check [plan.json]   compose and check");
             eprintln!("                                (no plan: every fleet in [fleets])");
             eprintln!("hale fleet dump  <plan.json>    write the fleet artifact");
+            eprintln!("hale fleet attest <plan.json>   binaries match the plan's sha256 rows");
+            eprintln!("hale fleet keygen <prefix>      ES256 keypair for signing");
+            eprintln!("hale fleet sign <file> --key K  detached .sig over exact bytes");
+            eprintln!();
+            eprintln!("check/dump take --trust <pub.pem> (repeatable):");
+            eprintln!("with trust roots declared, every component must");
+            eprintln!("verify under one of them.");
             eprintln!();
             eprintln!("A plan names exact application INSTANCES and the");
             eprintln!("routes between them. It composes artifacts, never");
@@ -2636,7 +2756,14 @@ fn run_fleet(rest: &[String]) -> ExitCode {
             return ExitCode::from(2);
         }
     };
-    match fleet::compose(Path::new(plan)) {
+    let trust = match sign::Trust::load(&trust_paths) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("{}", e);
+            return ExitCode::from(2);
+        }
+    };
+    match fleet::compose(Path::new(plan), &trust) {
         Ok(artifact) => {
             if sub == "dump" {
                 print!("{}", artifact);

--- a/crates/hale-cli/src/pkg.rs
+++ b/crates/hale-cli/src/pkg.rs
@@ -86,6 +86,27 @@ pub struct Manifest {
     /// some deployment it might not even appear in.
     #[serde(default)]
     pub fleets: BTreeMap<String, String>,
+    /// GH #408 Phase 7: `[fleet_trust] keys = ["keys/ops.pub.pem"]`
+    /// — public keys (SPKI PEM, paths relative to this manifest)
+    /// that fleet components must be signed under.
+    ///
+    /// Strict when declared: listing trust roots makes an unsigned
+    /// or unverifiable component a composition ERROR. There is no
+    /// `require = true` knob for the same reason `no_base` exists
+    /// in `[claims]` — declaring a trust set and then quietly
+    /// admitting unsigned artifacts would be law that looks bound
+    /// and binds nothing. Absent section = signatures not checked,
+    /// which is the pre-Phase-7 meaning of a composition, unchanged.
+    #[serde(default)]
+    pub fleet_trust: FleetTrust,
+}
+
+/// The `[fleet_trust]` section.
+#[derive(Deserialize, Default, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct FleetTrust {
+    #[serde(default)]
+    pub keys: Vec<String>,
 }
 
 /// The `[claims]` section.
@@ -560,4 +581,21 @@ pub fn read_fleets(
     let m: Manifest = toml::from_str(&src)
         .map_err(|e| format!("parse {}: {}", manifest.display(), e))?;
     Ok(m.fleets)
+}
+
+/// GH #408 Phase 7: the `[fleet_trust]` key paths, resolved
+/// relative to the manifest. Empty when the section is absent —
+/// which means "signatures not checked", not "signatures optional".
+pub fn read_fleet_trust(
+    manifest: &Path,
+) -> Result<Vec<PathBuf>, String> {
+    if !manifest.exists() {
+        return Ok(Vec::new());
+    }
+    let src = fs::read_to_string(manifest)
+        .map_err(|e| format!("read {}: {}", manifest.display(), e))?;
+    let m: Manifest = toml::from_str(&src)
+        .map_err(|e| format!("parse {}: {}", manifest.display(), e))?;
+    let base = manifest.parent().unwrap_or(Path::new("."));
+    Ok(m.fleet_trust.keys.iter().map(|k| base.join(k)).collect())
 }

--- a/crates/hale-cli/src/sign.rs
+++ b/crates/hale-cli/src/sign.rs
@@ -1,0 +1,260 @@
+//! GH #408 Phase 7 — signed fleet components.
+//!
+//! A signature makes the certificate portable: `hale fleet check`
+//! proves a composed world against artifacts it can read, and the
+//! signature proves those artifacts are the ones some key-holder
+//! meant. It certifies PROVENANCE AND INTEGRITY, never behavior —
+//! the artifact never claims a message will arrive, and the
+//! signature never claims the code is good.
+//!
+//! The scheme is ES256 (ECDSA P-256 over SHA-256), because the
+//! system already speaks it: `std::crypto::ecdsa_p256_sign/verify`
+//! (spec/stdlib.md), OpenSSL-backed in the runtime, PEM keys, raw
+//! `r‖s` 64-byte signatures. One signature algorithm end to end
+//! means a Hale program — a supervisor, a deploy gate — can verify
+//! the same sidecar with the language's own stdlib.
+//!
+//! Signatures cover the artifact's EXACT BYTES. That is sound
+//! because artifacts are byte-reproducible (schema 1.8: workspace-
+//! relative paths, canonicalized sources), and it is necessary
+//! because the in-band `artifact_digest` is FNV-1a — an integrity
+//! tripwire, not a trust anchor. Nothing here signs a digest.
+//!
+//! Sidecar format: `<artifact>.sig`, one line, `es256:<128 hex>`.
+//! The prefix is the format's version; an unknown prefix is a
+//! refusal, not a skip.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use openssl::bn::BigNum;
+use openssl::ec::{EcGroup, EcKey};
+use openssl::ecdsa::EcdsaSig;
+use openssl::nid::Nid;
+use openssl::pkey::{PKey, Public};
+use openssl::sha::sha256;
+
+const SIG_PREFIX: &str = "es256:";
+
+/// The trust roots one composition verifies against. Loaded once,
+/// up front, so a bad key file is its own error at the boundary
+/// rather than surfacing as a spurious per-component refusal.
+pub struct Trust {
+    /// `(key_id, key)` — key_id is the first 8 bytes of
+    /// SHA-256(SPKI DER), hex. Identity of the KEY, so a rotated
+    /// key changes the id even when the file path stays put.
+    pub keys: Vec<(String, EcKey<Public>)>,
+}
+
+impl Trust {
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+
+    /// Load trusted public keys (SPKI PEM). Every path must load —
+    /// a trust root that fails to parse is a configuration error,
+    /// and skipping it would silently narrow the trusted set.
+    pub fn load(paths: &[PathBuf]) -> Result<Trust, String> {
+        let mut keys = Vec::new();
+        for p in paths {
+            let pem = std::fs::read(p)
+                .map_err(|e| format!("trust key {}: {}", p.display(), e))?;
+            let pkey = PKey::public_key_from_pem(&pem).map_err(|e| {
+                format!("trust key {}: not a public key PEM: {}", p.display(), e)
+            })?;
+            let ec = pkey.ec_key().map_err(|_| {
+                format!(
+                    "trust key {}: not an EC key — fleet signatures are \
+                     ES256 (P-256), matching std::crypto",
+                    p.display()
+                )
+            })?;
+            keys.push((key_id(&pkey)?, ec));
+        }
+        Ok(Trust { keys })
+    }
+
+    /// Verify `bytes` against the sidecar signature at `sig_path`.
+    /// Returns the key_id that verified. Every failure names what
+    /// was checked — absence, format, and mismatch are three
+    /// different repairs.
+    pub fn verify(
+        &self,
+        bytes: &[u8],
+        sig_path: &Path,
+    ) -> Result<String, String> {
+        let raw = std::fs::read_to_string(sig_path).map_err(|_| {
+            format!(
+                "no signature at {} — trust roots are declared, so an \
+                 unsigned component is not admissible",
+                sig_path.display()
+            )
+        })?;
+        let hex = raw
+            .trim()
+            .strip_prefix(SIG_PREFIX)
+            .ok_or_else(|| {
+                format!(
+                    "{}: unrecognized signature format (expected \
+                     `{}<hex>`)",
+                    sig_path.display(),
+                    SIG_PREFIX
+                )
+            })?;
+        let sig = decode_hex(hex).ok_or_else(|| {
+            format!("{}: signature is not valid hex", sig_path.display())
+        })?;
+        if sig.len() != 64 {
+            return Err(format!(
+                "{}: signature is {} bytes, ES256 raw r‖s is 64",
+                sig_path.display(),
+                sig.len()
+            ));
+        }
+        let digest = sha256(bytes);
+        let r = BigNum::from_slice(&sig[..32]).map_err(es)?;
+        let s = BigNum::from_slice(&sig[32..]).map_err(es)?;
+        let esig = EcdsaSig::from_private_components(r, s).map_err(es)?;
+        for (id, key) in &self.keys {
+            if esig.verify(&digest, key).unwrap_or(false) {
+                return Ok(id.clone());
+            }
+        }
+        Err(format!(
+            "{}: signature does not verify under any of the {} trusted \
+             key(s) — either the artifact changed after signing or the \
+             signer is not in the trust set",
+            sig_path.display(),
+            self.keys.len()
+        ))
+    }
+}
+
+/// `hale fleet keygen <prefix>` — write `<prefix>.pem` (PKCS#8
+/// private) and `<prefix>.pub.pem` (SPKI public). Returns the
+/// key_id for the operator to record.
+pub fn keygen(prefix: &Path) -> Result<String, String> {
+    let group =
+        EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).map_err(es)?;
+    let ec = EcKey::generate(&group).map_err(es)?;
+    let pkey = PKey::from_ec_key(ec).map_err(es)?;
+
+    let priv_path = with_ext(prefix, "pem");
+    let pub_path = with_ext(prefix, "pub.pem");
+    write_private(&priv_path, &pkey.private_key_to_pem_pkcs8().map_err(es)?)?;
+    std::fs::write(&pub_path, pkey.public_key_to_pem().map_err(es)?)
+        .map_err(|e| format!("write {}: {}", pub_path.display(), e))?;
+    key_id(&pkey)
+}
+
+/// `hale fleet sign <file> --key <priv.pem>` — detached sidecar
+/// over the file's exact bytes. Works on any file: a component
+/// artifact and a fleet artifact are both just bytes here.
+pub fn sign(file: &Path, key_path: &Path) -> Result<(PathBuf, String), String> {
+    let bytes = std::fs::read(file)
+        .map_err(|e| format!("read {}: {}", file.display(), e))?;
+    let pem = std::fs::read(key_path)
+        .map_err(|e| format!("read key {}: {}", key_path.display(), e))?;
+    // PKCS#8 first (what keygen writes), SEC1 as the fallback —
+    // both spellings are in spec/stdlib.md for std::crypto.
+    let pkey = PKey::private_key_from_pem(&pem).map_err(|e| {
+        format!("{}: not a private key PEM: {}", key_path.display(), e)
+    })?;
+    let ec = pkey.ec_key().map_err(|_| {
+        format!(
+            "{}: not an EC key — fleet signatures are ES256 (P-256)",
+            key_path.display()
+        )
+    })?;
+
+    let digest = sha256(&bytes);
+    let esig = EcdsaSig::sign(&digest, &ec).map_err(es)?;
+    let mut raw = [0u8; 64];
+    let (r, s) = (esig.r().to_vec(), esig.s().to_vec());
+    raw[32 - r.len()..32].copy_from_slice(&r);
+    raw[64 - s.len()..].copy_from_slice(&s);
+
+    let sig_path = sidecar(file);
+    let mut line = String::with_capacity(6 + 128 + 1);
+    line.push_str(SIG_PREFIX);
+    for b in raw {
+        let _ = write!(line, "{:02x}", b);
+    }
+    line.push('\n');
+    std::fs::write(&sig_path, line)
+        .map_err(|e| format!("write {}: {}", sig_path.display(), e))?;
+    Ok((sig_path, key_id(&pkey)?))
+}
+
+/// SHA-256 of a file's bytes, hex — `hale fleet attest` compares
+/// this against the plan's `binary_sha256`.
+pub fn sha256_file(p: &Path) -> Result<String, String> {
+    let bytes = std::fs::read(p)
+        .map_err(|e| format!("read {}: {}", p.display(), e))?;
+    Ok(hex(&sha256(&bytes)))
+}
+
+pub fn sidecar(artifact: &Path) -> PathBuf {
+    let mut s = artifact.as_os_str().to_os_string();
+    s.push(".sig");
+    PathBuf::from(s)
+}
+
+/// First 8 bytes of SHA-256 over the SPKI DER, hex. Key identity,
+/// not file identity: rotating the key changes the id even if the
+/// path stays put.
+fn key_id<T: openssl::pkey::HasPublic>(
+    pkey: &PKey<T>,
+) -> Result<String, String> {
+    let der = pkey.public_key_to_der().map_err(es)?;
+    Ok(hex(&sha256(&der)[..8]))
+}
+
+fn with_ext(prefix: &Path, ext: &str) -> PathBuf {
+    let mut s = prefix.as_os_str().to_os_string();
+    s.push(".");
+    s.push(ext);
+    PathBuf::from(s)
+}
+
+#[cfg(unix)]
+fn write_private(path: &Path, pem: &[u8]) -> Result<(), String> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|e| format!("write {}: {}", path.display(), e))?;
+    f.write_all(pem)
+        .map_err(|e| format!("write {}: {}", path.display(), e))
+}
+
+#[cfg(not(unix))]
+fn write_private(path: &Path, pem: &[u8]) -> Result<(), String> {
+    std::fs::write(path, pem)
+        .map_err(|e| format!("write {}: {}", path.display(), e))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{:02x}", b);
+    }
+    s
+}
+
+fn decode_hex(s: &str) -> Option<Vec<u8>> {
+    if s.len() % 2 != 0 {
+        return None;
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).ok())
+        .collect()
+}
+
+fn es(e: openssl::error::ErrorStack) -> String {
+    format!("openssl: {}", e)
+}

--- a/crates/hale-cli/tests/fleet_sign.rs
+++ b/crates/hale-cli/tests/fleet_sign.rs
@@ -1,0 +1,426 @@
+//! GH #408 Phase 7: signed fleet components and binary attestation.
+//!
+//! A signature makes the certificate portable — it proves the
+//! artifacts a composition read are the ones a key-holder meant,
+//! never that the code behaves. The covered thing is the artifact's
+//! EXACT BYTES (sound because artifacts are byte-reproducible),
+//! never the in-band FNV digest, which is a tripwire rather than a
+//! trust anchor.
+//!
+//! Trust is strict when declared: passing `--trust` (or listing
+//! `[fleet_trust]` keys) makes an unsigned or unverifiable
+//! component a refusal. Declaring a trust set and then quietly
+//! admitting unsigned artifacts would be law that looks bound and
+//! binds nothing — so these tests care as much about what is
+//! REFUSED as what verifies.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn root(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir()
+        .join(format!("hale_fleet_sign_{}_{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&d);
+    d
+}
+
+fn write(root: &Path, rel: &str, src: &str) {
+    let p = root.join(rel);
+    std::fs::create_dir_all(p.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&p, src).expect("write");
+}
+
+fn hale(args: &[&str]) -> (String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(args)
+        .output()
+        .expect("run hale");
+    (
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// `hale` with a working directory — the `[fleet_trust]` form reads
+/// the manifest at and above the cwd.
+fn hale_in(dir: &Path, args: &[&str]) -> (String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("run hale");
+    (
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+const APP: &str = r#"
+type Ping { n: Int; }
+topic Pings { payload: Ping; subject: "svc.ping"; }
+locus Send {
+    bus { publish Pings; }
+    birth() { Pings <- Ping { n: 1 }; }
+}
+locus Recv {
+    bus { subscribe Pings as on_ping; }
+    fn on_ping(p: Ping) { println(p.n); }
+}
+main locus M {
+    params { s: Send = Send { }; r: Recv = Recv { }; }
+}
+fn main() { M { }; }
+"#;
+
+const PLAN: &str = r#"{
+  "schema": "1.1",
+  "name": "signed",
+  "instances": [
+    {"id": "app-0", "artifact": "artifacts/app.json"}
+  ]
+}"#;
+
+/// One seed, one artifact, one plan, one keypair.
+fn fleet(tag: &str) -> PathBuf {
+    let r = root(tag);
+    write(&r, "app/main.hl", APP);
+    write(&r, "hale.toml", "[deps]\n");
+    let dst = r.join("artifacts/app.json");
+    std::fs::create_dir_all(dst.parent().expect("parent")).expect("mkdir");
+    let (out, code) = hale(&[
+        "check",
+        r.join("app").to_str().expect("utf8"),
+        &format!("--dump-topology={}", dst.display()),
+    ]);
+    assert_eq!(code, 0, "component must check clean: {}", out);
+    write(&r, "signed.plan.json", PLAN);
+    let (out, code) = hale(&[
+        "fleet",
+        "keygen",
+        r.join("ops").to_str().expect("utf8"),
+    ]);
+    assert_eq!(code, 0, "keygen: {}", out);
+    r
+}
+
+fn p(r: &Path, rel: &str) -> String {
+    r.join(rel).to_str().expect("utf8").to_string()
+}
+
+/// keygen → sign → check --trust verifies, and the fleet artifact
+/// records which key admitted each component — `signed_by` is the
+/// key's identity, not the key file's path.
+#[test]
+fn a_signed_component_verifies_and_the_artifact_records_the_key() {
+    let r = fleet("verify");
+    let (out, code) = hale(&[
+        "fleet",
+        "sign",
+        &p(&r, "artifacts/app.json"),
+        "--key",
+        &p(&r, "ops.pem"),
+    ]);
+    assert_eq!(code, 0, "sign: {}", out);
+    let key_id = out
+        .split("key_id ")
+        .nth(1)
+        .expect("sign prints key_id")
+        .trim()
+        .to_string();
+
+    let (out, code) = hale(&[
+        "fleet",
+        "dump",
+        &p(&r, "signed.plan.json"),
+        "--trust",
+        &p(&r, "ops.pub.pem"),
+    ]);
+    assert_eq!(code, 0, "check with trust: {}", out);
+    let v: serde_json::Value =
+        serde_json::from_str(&out).expect("fleet artifact parses");
+    assert_eq!(
+        v["components"][0]["signed_by"].as_str(),
+        Some(key_id.as_str()),
+        "artifact records the admitting key: {}",
+        out
+    );
+    assert_eq!(
+        v["components"][0]["sha256"].as_str().map(str::len),
+        Some(64),
+        "artifact records the admitted bytes' sha256"
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// The signature covers exact bytes: appending one byte of
+/// whitespace — invisible to JSON, invisible to the FNV digest's
+/// prefix — is a refusal that names the sidecar.
+#[test]
+fn a_tampered_artifact_is_refused_even_when_json_still_parses() {
+    let r = fleet("tamper");
+    let art = r.join("artifacts/app.json");
+    let (_, code) = hale(&[
+        "fleet",
+        "sign",
+        art.to_str().expect("utf8"),
+        "--key",
+        &p(&r, "ops.pem"),
+    ]);
+    assert_eq!(code, 0);
+
+    let mut bytes = std::fs::read(&art).expect("read artifact");
+    bytes.push(b' ');
+    std::fs::write(&art, bytes).expect("append");
+
+    let (out, code) = hale(&[
+        "fleet",
+        "check",
+        &p(&r, "signed.plan.json"),
+        "--trust",
+        &p(&r, "ops.pub.pem"),
+    ]);
+    assert_eq!(code, 1, "tampered component must refuse: {}", out);
+    assert!(
+        out.contains("does not verify"),
+        "refusal names the signature failure: {}",
+        out
+    );
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// Trust declared + no sidecar = refusal. Absence is not admission.
+#[test]
+fn an_unsigned_component_is_refused_when_trust_is_declared() {
+    let r = fleet("unsigned");
+    let (out, code) = hale(&[
+        "fleet",
+        "check",
+        &p(&r, "signed.plan.json"),
+        "--trust",
+        &p(&r, "ops.pub.pem"),
+    ]);
+    assert_eq!(code, 1, "unsigned must refuse under trust: {}", out);
+    assert!(
+        out.contains("no signature at"),
+        "refusal says the sidecar is missing, not that bytes differ: {}",
+        out
+    );
+    // And WITHOUT trust the same plan composes — the pre-Phase-7
+    // meaning of a composition is unchanged.
+    let (out, code) = hale(&["fleet", "check", &p(&r, "signed.plan.json")]);
+    assert_eq!(code, 0, "no trust declared, no signature required: {}", out);
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// A valid signature under a key OUTSIDE the trust set is exactly as
+/// inadmissible as a broken one.
+#[test]
+fn a_signature_from_an_untrusted_key_is_refused() {
+    let r = fleet("untrusted");
+    let (_, code) =
+        hale(&["fleet", "keygen", r.join("rogue").to_str().expect("utf8")]);
+    assert_eq!(code, 0);
+    let (_, code) = hale(&[
+        "fleet",
+        "sign",
+        &p(&r, "artifacts/app.json"),
+        "--key",
+        &p(&r, "rogue.pem"),
+    ]);
+    assert_eq!(code, 0);
+
+    let (out, code) = hale(&[
+        "fleet",
+        "check",
+        &p(&r, "signed.plan.json"),
+        "--trust",
+        &p(&r, "ops.pub.pem"),
+    ]);
+    assert_eq!(code, 1, "untrusted signer must refuse: {}", out);
+    assert!(out.contains("not in the trust set"), "{}", out);
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// `[fleet_trust]` in the manifest binds the all-fleets form the
+/// same way `--trust` binds a named plan.
+#[test]
+fn fleet_trust_in_the_manifest_binds_every_declared_fleet() {
+    let r = fleet("manifest");
+    write(
+        &r,
+        "hale.toml",
+        "[deps]\n\n[fleets]\nsigned = \"signed.plan.json\"\n\n\
+         [fleet_trust]\nkeys = [\"ops.pub.pem\"]\n",
+    );
+    // Unsigned: the manifest's trust refuses it.
+    let (out, code) = hale_in(&r, &["fleet", "check"]);
+    assert_eq!(code, 1, "manifest trust must refuse unsigned: {}", out);
+    assert!(out.contains("no signature at"), "{}", out);
+    // Signed: the same form passes.
+    let (_, code) = hale(&[
+        "fleet",
+        "sign",
+        &p(&r, "artifacts/app.json"),
+        "--key",
+        &p(&r, "ops.pem"),
+    ]);
+    assert_eq!(code, 0);
+    let (out, code) = hale_in(&r, &["fleet", "check"]);
+    assert_eq!(code, 0, "signed fleet passes under manifest trust: {}", out);
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// attest: every instance carries `binary` + `binary_sha256`, and
+/// the bytes on disk match — or the plan is not attested. A missing
+/// row is a refusal, not a skip: partial coverage must not wear a
+/// full answer's exit code.
+#[test]
+fn attest_matches_binaries_and_refuses_partial_coverage() {
+    let r = fleet("attest");
+    // A stand-in "binary": attest hashes bytes; it does not run them.
+    write(&r, "bin/app", "not really an ELF but definitely bytes\n");
+    let bytes = std::fs::read(r.join("bin/app")).expect("read");
+    let digest = {
+        use std::fmt::Write as _;
+        // sha256 via the hale CLI would be circular; openssl's CLI may
+        // be absent. Small and standard beats clever here.
+        let d = sha256_ref(&bytes);
+        let mut s = String::new();
+        for b in d {
+            let _ = write!(s, "{:02x}", b);
+        }
+        s
+    };
+    write(
+        &r,
+        "attest.plan.json",
+        &format!(
+            r#"{{"schema": "1.1", "name": "signed",
+  "instances": [{{"id": "app-0", "artifact": "artifacts/app.json",
+                  "binary": "bin/app", "binary_sha256": "{}"}}]}}"#,
+            digest
+        ),
+    );
+    let (out, code) = hale(&["fleet", "attest", &p(&r, "attest.plan.json")]);
+    assert_eq!(code, 0, "matching binary attests: {}", out);
+
+    // Flip the bytes: same path, different binary.
+    write(&r, "bin/app", "different bytes\n");
+    let (out, code) = hale(&["fleet", "attest", &p(&r, "attest.plan.json")]);
+    assert_eq!(code, 1, "changed binary must refuse: {}", out);
+    assert!(out.contains("is not the binary the plan names"), "{}", out);
+
+    // An instance with no digest rows poisons the whole attestation.
+    let (out, code) = hale(&["fleet", "attest", &p(&r, "signed.plan.json")]);
+    assert_eq!(code, 1, "undeclared binary must refuse: {}", out);
+    assert!(out.contains("attestable"), "{}", out);
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// A 1.0 plan still reads — Phase 7's fields are additive, and a
+/// plan that predates them keeps its meaning.
+#[test]
+fn a_schema_1_0_plan_still_composes() {
+    let r = fleet("compat");
+    write(
+        &r,
+        "old.plan.json",
+        &PLAN.replace("\"schema\": \"1.1\"", "\"schema\": \"1.0\""),
+    );
+    let (out, code) = hale(&["fleet", "check", &p(&r, "old.plan.json")]);
+    assert_eq!(code, 0, "1.0 plan composes: {}", out);
+    let _ = std::fs::remove_dir_all(&r);
+}
+
+/// Minimal SHA-256, test-local, so the expected digest does not
+/// depend on the code under test. (FIPS 180-4; block-at-a-time.)
+fn sha256_ref(msg: &[u8]) -> [u8; 32] {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b,
+        0x59f111f1, 0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01,
+        0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7,
+        0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152,
+        0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+        0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819,
+        0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116, 0x1e376c08,
+        0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f,
+        0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+    ];
+    let mut h: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f,
+        0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    ];
+    let mut data = msg.to_vec();
+    let bitlen = (msg.len() as u64) * 8;
+    data.push(0x80);
+    while data.len() % 64 != 56 {
+        data.push(0);
+    }
+    data.extend_from_slice(&bitlen.to_be_bytes());
+    for block in data.chunks(64) {
+        let mut w = [0u32; 64];
+        for (i, c) in block.chunks(4).enumerate() {
+            w[i] = u32::from_be_bytes([c[0], c[1], c[2], c[3]]);
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7)
+                ^ w[i - 15].rotate_right(18)
+                ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17)
+                ^ w[i - 2].rotate_right(19)
+                ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let (mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh) = (
+            h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7],
+        );
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ (!e & g);
+            let t1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+        h[0] = h[0].wrapping_add(a);
+        h[1] = h[1].wrapping_add(b);
+        h[2] = h[2].wrapping_add(c);
+        h[3] = h[3].wrapping_add(d);
+        h[4] = h[4].wrapping_add(e);
+        h[5] = h[5].wrapping_add(f);
+        h[6] = h[6].wrapping_add(g);
+        h[7] = h[7].wrapping_add(hh);
+    }
+    let mut out = [0u8; 32];
+    for (i, x) in h.iter().enumerate() {
+        out[i * 4..i * 4 + 4].copy_from_slice(&x.to_be_bytes());
+    }
+    out
+}

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -49,3 +49,9 @@ diagnostic's meaning, go there.
 | `hale test` | run `*_test.hl` |
 | `hale fetch` | clone & pin git dependencies |
 | `hale fmt` | canonical formatter |
+| `hale verify` | `check`, but any advisory fails too (the CI gate) |
+| `hale bench` | run `*_bench.hl` (ns/op, allocs/op) |
+| `hale doc` | API reference from `///` comments |
+| `hale fleet` | compose topology artifacts across binaries: `check` / `dump` / `sign` / `attest` / `keygen` |
+| `hale lsp` | the language server, in the compiler binary |
+| `hale mcp` | the MCP server, in the compiler binary |

--- a/docs/src/services/multi-binary.md
+++ b/docs/src/services/multi-binary.md
@@ -229,6 +229,30 @@ production = "ops/fleet/prod.plan.json"
 staging    = "ops/fleet/staging.plan.json"
 ```
 
+### Signing the certificate
+
+A composition proves a world against the artifacts it reads. When
+the artifacts travel — a deploy box that didn't build them, a CI
+stage that didn't run the checks — a signature proves they are the
+ones you meant:
+
+```sh
+hale fleet keygen ops                        # ops.pem + ops.pub.pem
+hale fleet sign artifacts/oms.json --key ops.pem
+hale fleet check prod.plan.json --trust ops.pub.pem
+```
+
+Trust is **strict when declared**: with `--trust` given (or
+`[fleet_trust] keys = [...]` in `hale.toml`), an unsigned component
+is refused, not skipped. The signature is ES256 over the artifact's
+exact bytes — the same suite as `std::crypto`, so a Hale program
+can verify the sidecar itself.
+
+To pin the executables too, give each instance a `binary` and
+`binary_sha256` row and run `hale fleet attest prod.plan.json` —
+all-or-nothing: an instance without the rows fails the attestation
+rather than thinning it.
+
 ### What it does not tell you
 
 The honest boundary matters more here than at any other tier,

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -530,7 +530,7 @@ claim.
 
 ```json
 {
-  "schema": "1.0", "name": "prod",
+  "schema": "1.1", "name": "prod",
   "instances": [{"id": "oms-0", "artifact": "artifacts/oms.json", "labels": ["oms"]}],
   "routes": [{"id": "request", "transport": "unix",
               "publishers":  [{"instance": "oms-0", "topic": "t::OrderRequest"}],
@@ -694,6 +694,87 @@ fleet claim `orders_pass_oms` violated — witness:
   -(route `bypass`)->
   gw-0::Gateway::on_order  [gw/main.hl]
 ```
+
+### Signed components & attestation (GH #408 Phase 7)
+
+A composition proves a world against artifacts it can read; a
+signature proves those artifacts are the ones a key-holder meant.
+It certifies **provenance and integrity, never behavior** — the
+artifact never claims a message will arrive, and a signature never
+claims the code is good. Out of scope, deliberately: a compromised
+builder, a malicious compiler, runtime memory tampering.
+
+The scheme is **ES256** (ECDSA P-256 over SHA-256), because the
+system already speaks it: it is `std::crypto`'s signature suite,
+OpenSSL-backed in the runtime, PEM keys, raw `r‖s` 64-byte
+signatures. One algorithm end to end means a Hale program — a
+supervisor, a deploy gate — verifies the same sidecar with the
+language's own stdlib.
+
+Signatures cover the artifact's **exact bytes**. That is sound
+because artifacts are byte-reproducible (schema 1.8), and it is
+necessary because the in-band `artifact_digest` is FNV-1a — an
+integrity tripwire, not a trust anchor. Nothing signs a digest.
+The sidecar is `<artifact>.sig`, one line, `es256:<128 hex>`; an
+unknown prefix is a refusal, not a skip.
+
+```sh
+hale fleet keygen ops                      # ops.pem (0600) + ops.pub.pem
+hale fleet sign app.topo.json --key ops.pem
+hale fleet check prod.plan.json --trust ops.pub.pem
+```
+
+**Trust is strict when declared.** Passing `--trust` (repeatable),
+or declaring keys in the manifest, makes an unsigned or
+unverifiable component a composition **error**:
+
+```toml
+[fleet_trust]
+keys = ["keys/ops.pub.pem"]    # SPKI PEM, manifest-relative
+```
+
+There is no `require = true` knob, for the reason `no_base` exists
+in `[claims]`: a trust set that quietly admits unsigned artifacts
+is law that looks bound and binds nothing. An absent section means
+signatures are not checked — the pre-Phase-7 meaning of a
+composition, unchanged. Signature verification runs **before** the
+integrity digest: provenance before integrity before meaning, each
+check covering the bytes the next one reads. The all-fleets form
+(`hale fleet check` with no plan) takes trust from the manifest
+only; `--trust` there is an error, so one flag cannot quietly
+rebind every declared deployment.
+
+The fleet artifact records what admitted each component — unhashed
+provenance, like the rest of the `components` section:
+
+```json
+{"id": "app-0", "artifact": "artifacts/app.json",
+ "sha256": "59ad65d4…", "signed_by": "a88ca61a96ffa055"}
+```
+
+`sha256` is the admitted bytes; `signed_by` is the key's identity
+(first 8 bytes of SHA-256 over the SPKI DER) or `null` when trust
+was not declared — a fact, not an omission, so a reader can tell
+"unsigned admission" from "verified under this key".
+
+**Attestation** answers the remaining question: are the executables
+this plan deploys the ones the operator hashed? Plan schema 1.1
+adds two optional rows per instance, and `hale fleet attest` is
+all-or-nothing over them:
+
+```json
+{"id": "app-0", "artifact": "artifacts/app.json",
+ "binary": "bin/app", "binary_sha256": "de55ee70…"}
+```
+
+A missing row is a refusal, not a skip — a partial attestation
+would report coverage it does not have. `binary_sha256` is
+cryptographic where `artifact_digest` deliberately is not: this
+hash is the thing an operator asserts across a trust boundary.
+Attestation checks bytes at rest at deploy time; whether a
+*running* process is still that binary is runtime territory
+(sent/delivered observation, 7b), and the artifact never claims
+otherwise.
 
 ## Structural & design rules
 


### PR DESCRIPTION
The certificate travels: ES256 signatures over exact artifact bytes, strict-when-declared trust (`--trust` / `[fleet_trust]`), `hale fleet keygen|sign|attest`, plan schema 1.1 with `binary`/`binary_sha256`, admission provenance in the fleet artifact. Signing certifies provenance and integrity, never behavior.

Also: AGENTS.md architecture-as-law section, reference.md toolchain rows, README `/features` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)