### PR TITLE
fix(image): builder stage needs libssl-dev + pkg-config for the openssl crate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       curl ca-certificates build-essential \
       llvm-18-dev libpolly-18-dev libzstd-dev \
       clang-18 libclang-18-dev zlib1g-dev \
+      libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 # Stock Ubuntu rustc can lag the workspace; install the current stable


### PR DESCRIPTION
The v0.16.0 image build failed on openssl-sys (P7 dep) — builder stage lacked pkg-config/libssl-dev; release/Dockerfile already had both. Re-publish via the workflow_dispatch path once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)