### PR TITLE
docs: the README advertised a claim form the checker rejects

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,9 @@ absence, optionally narrowed `via { calls }` or `via { bus }`;
 publishers(topic T) <= 1` for cardinality; `cover topic in seed(a):
 subscribed_by(some G)` so a new topic can't be quietly orphaned;
 `only edges A -> B { publish T; }` for a reviewable boundary
-inventory; and `bound alloc <= N on paths from G` for cost.
+inventory; and `bound llm <= N on paths from G` for cost. `bound`
+counts a **user-declared** effect class (`effect llm;`) — the
+counted built-ins keep their `@budget` spellings.
 
 Three things make this hold up in practice:
 
@@ -385,10 +387,16 @@ Platform-specific setup (Linux, macOS/Apple Silicon) is in
 
 ## Where the language stands
 
-The language surface has taken **no breaking changes since v0.10.0
-(2026-07-07)** — everything since has been additive (`@hot` / `@budget`
+The **language surface** has taken no breaking changes since v0.10.0
+(2026-07-07) — everything since has been additive (`@hot` / `@budget`
 enforcement, `match` expressions, String routing keys) plus runtime
-fixes. It's pre-1.0 because the frontier below is still moving.
+fixes. The **stdlib** is a narrower promise: v0.11.0 (2026-07-16)
+carried two breaking entries — `Stream.send` / `recv` and their
+`_bytes` forms became `fallible(IoError)`, so every call site must
+address the error, and TCP listeners stopped setting `SO_REUSEPORT`,
+so a second live bind on the same port now fails instead of
+silently splitting connections. It's pre-1.0 because the frontier
+below is still moving.
 
 The proven core is the typed topic bus, `placement` / `bindings` deployment,
 `@form` collections, structural `interface`s, `@ffi` C bindings, and the

--- a/crates/hale-codegen/tests/fixtures/examples/claim-forms.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/claim-forms.hl
@@ -1,0 +1,67 @@
+// The claim forms the README advertises, as a compiled artifact.
+//
+// The README's six-form inventory once listed `bound alloc <= N on
+// paths from G`, which the checker rejects: `bound` counts a
+// user-declared effect class, and the counted built-ins keep their
+// `@budget` spellings. Nothing caught it, because prose is not in a
+// harness — the mdBook gate parses snippets and `hale,fragment` opts
+// out of even that, while this was a *type* error. So the inventory
+// lives here too, where `on_disk_example_corpus_typechecks_clean`
+// fails the build if an advertised form stops holding.
+//
+// Five of the six are expressible in one file. `cover topic in
+// seed(a): subscribed_by(some G)` quantifies over an import alias's
+// declared topics, so it needs a second seed and is covered by the
+// multi-file corpus instead.
+
+effect llm;
+
+@effects(is: { llm })
+fn model_call(p: Int) -> Int { return p; }
+
+type Cmd { n: Int; }
+topic Plan { payload: Cmd; subject: "app.plan"; }
+
+locus Planner {
+    params { n: Int = 0; }
+    bus { publish Plan; }
+    fn kick(n: Int) { Plan <- Cmd { n: n }; }
+    fn budgeted(n: Int) -> Int { return model_call(n); }
+}
+
+locus Worker {
+    params { done: Int = 0; }
+    bus { subscribe Plan as on_plan; }
+    fn on_plan(c: Cmd) { self.done = c.n; }
+}
+
+locus Audit {
+    params { seen: Int = 0; }
+    fn note(n: Int) -> Int { return n; }
+}
+
+group planners = { Planner };
+group workers = { Worker };
+group audit = { Audit };
+
+main locus App {
+    params {
+        p: Planner = Planner { };
+        w: Worker = Worker { };
+        a: Audit = Audit { };
+    }
+    claims {
+        // Absence, narrowed to one relation.
+        isolated: forbid reaches(workers, audit) via { calls };
+        // Existence over the declared bus ends.
+        wired: require subscribes(some workers, topic Plan);
+        // Cardinality.
+        one_writer: count publishers(topic Plan) <= 1;
+        // A reviewable boundary inventory: every direct edge is granted.
+        boundary: only edges planners -> workers { publish Plan; };
+        // Cost, over a user-declared class.
+        one_call: bound llm <= 1 on paths from planners;
+    }
+}
+
+fn main() { App { }; }


### PR DESCRIPTION
The README's six-form claim inventory listed `bound alloc <= N on paths from G`. That does not compile — `bound` counts a **user-declared** effect class, and the counted built-ins keep their `@budget` spellings. The checker says exactly that:

```
claim `budget`: `bound` takes a user-declared effect class — the counted built-ins keep their `@budget` spellings (`publish`, `block_points`, `alloc_per_call`)
```

**Only the README was wrong.** `spec/verification.md` states the rule generically — `bound C <= N on paths from G`, "Built-ins keep their `@budget` spellings" — and `docs/src/claims.md` spells out that a built-in there is an error pointing at the `@budget` spellings. The two other occurrences of that exact string are describing the **lowered report row**: the form `@budget` is pointwise sugar for in an artifact's `lowered` array. That is a rendering of a certificate, not a sentence anyone may write. The README took a report row and put it in the list of forms you can type.

## Why nothing caught it

Prose is not in a harness. The mdBook gate (`docs_snippets.rs`) **parses** ```hale snippets, `hale,fragment` opts out of even that, and this was a *type* error — so a full parse gate would not have caught it either. The README is in no harness at all.

So the inventory becomes a compiled artifact. `crates/hale-codegen/tests/fixtures/examples/claim-forms.hl` carries the advertised forms and rides `on_disk_example_corpus_typechecks_clean`. Putting `alloc` back fails it:

```
test result: FAILED. 0 passed; 1 failed
  crates/hale-codegen/tests/fixtures/examples/claim-forms.hl
  "claim `one_call`: `bound` takes a user-declared effect class…"
```

Five of the six forms are expressible in one file. `cover topic in seed(a): subscribed_by(some G)` quantifies over an import alias's declared topics, so it needs a second seed and is left to the multi-file corpus — the fixture header says so rather than quietly listing five as six.

## Also: scoping the stability line

"The language surface has taken **no breaking changes since v0.10.0**" is true as written and narrower than it reads. v0.11.0, nine days later, carried two breaking stdlib entries: `Stream.send` / `recv` and their `_bytes` forms became `fallible(IoError)` (every call site must address the error), and TCP listeners stopped setting `SO_REUSEPORT` (a second live bind now fails instead of silently splitting connections). Both are now named, so the promise does not rest on the reader parsing "language surface" strictly.

## Verification

- `codegen_fixtures_typecheck` — green; **red** when the fixture reverts to `bound alloc`
- `hale-syntax::examples`, `hale-types::examples`, `fmt_corpus` — green
- `hale run claim-forms.hl` — exit 0

No compiler or spec change; `docs/src/claims.md` and `spec/verification.md` were already correct.

Reported in review of the language catalogue entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)