### PR TITLE
feat(secrets): @sealed confines locus state; @secret becomes a lint (GH #436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,89 @@ behavior.
 
 ---
 
+## Unreleased
+
+### Secrets: confine, classify, claim (GH #436)
+
+**`@sealed locus L`** — a locus's `params` become readable only from
+inside its own methods. Others may still CALL it; they may not read
+its state. This closes the gap the whole secrets story rested on:
+loci are otherwise **not** field-encapsulated, so `self.child.key`
+typechecks from anywhere holding the locus, and "the key never leaves
+its owner" was a property you checked rather than one that was true.
+
+Opt-in, one word, breaks no existing program — the `@supervised`
+shape. (No claim form requires an annotation yet, so a constitution
+cannot demand `@sealed` across a group; that is a follow-up, and the
+same gap applies to `@supervised`.)
+Only `params` are confined; capacity slots and methods are untouched,
+because sealing confines state rather than making a locus uncallable.
+Param **initialization** is deliberately not restricted: a parent
+writing `Signer { key: … }` already holds the value it passes, so
+sealing the initializer would cost ordinary configuration and buy
+nothing. Load real secret material inside `birth`.
+
+The guarantee then needs no new analysis — confine with `@sealed`,
+classify the one privileged method with a user effect class, and state
+the law with claim forms that already exist:
+
+```hale
+effect secret_use;
+
+@sealed locus Signer {
+    params { key: Bytes; }
+    @effects(is: { secret_use })
+    fn sign(m: Bytes) -> Signature { … }
+}
+
+claims {
+    no_plugin_secrets: forbid reaches(plugins, effects(secret_use));
+    one_op_per_request: bound secret_use <= 1 on paths from handlers;
+}
+```
+
+Stated exactly: *the secret lives in a locus that owns it, the domain
+cannot obtain it, the only operations on it are classified, and the
+domain's claims constrain who may reach them and how often.* That is
+confinement, **not** information flow — a value derived from the key
+is not tracked, a constant-time compare still lets the verdict be
+published, and the sealed locus's own body is trusted.
+
+**BEHAVIOR: `@secret` is now a lint (warning), not an error.** It was
+reported as a certificate while being a local identifier walker over a
+*fragment* of one fn body — it walked `then` branches but not `else`,
+and had no notion of aliasing, so moving a publish across a branch or
+renaming through one `let` made the finding disappear rather than
+surface as uncertified. Both of these checked clean:
+
+```hale
+fn leak(@secret token: String, flag: Bool) {
+    if flag { print("nothing"); } else { Out <- Msg { v: token }; }
+}
+fn leak2(@secret token: String) {
+    let alias = token;
+    Out <- Msg { v: alias };
+}
+```
+
+The true positives it *can* see are still reported, as warnings. The
+default traversal is deliberately left narrow: widening a lint in
+place newly fails programs that compile today, which is a userspace
+break even when every new finding is a real bug.
+
+**New: `hale check --strict-secret`** runs the widened, fail-closed
+walk — every branch including `else` / `else if` / `match`, alias
+propagation through `let`, and `uncertified` for anything it cannot
+follow (an unfollowed call, a field store, a return). Opt-in because
+it is loud, which is the honest signal that one body's reasoning is
+not a containment proof.
+
+Worked end to end in
+`crates/hale-codegen/tests/fixtures/examples/secrets-sealed-handler.hl`.
+Spec: `spec/verification.md` § Secrets.
+
+---
+
 ## v0.16.0 — the law composes, the certificate travels (2026-08-06)
 
 ### Signed fleet components & binary attestation (GH #408 Phase 7)

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2824,6 +2824,8 @@ const CHECK_FLAGS: &[(&str, bool)] = &[
     // rather than left to chance.
     ("--warn-unbounded-alloc", false),
     ("--warn-resource-leak", false),
+    // GH #436
+    ("--strict-secret", false),
     ("--workspace", false),
     // GH #409
     ("--env", true),
@@ -2884,6 +2886,7 @@ fn check_usage(verify: bool) {
     println!();
     println!("Advisories:");
     println!("  --warn-resource-leak            enable the resource-leak lint");
+    println!("  --strict-secret                 fail-closed `@secret` containment check");
     println!("  --no-warn-unbounded-alloc       silence the unbounded-alloc lint");
     println!("  --allow-unowned-subscriber      permit a subscriber with no owner");
     println!("  --json                          machine-readable diagnostics");
@@ -4158,6 +4161,17 @@ fn run_check_impl_labelled(
     // GH #18 item 5: opt-in fd-resource-leak warnings.
     if std::env::args().any(|a| a == "--warn-resource-leak") {
         diags.extend(hale_types::resource_leak_warnings(&bundle));
+    }
+    // GH #436: opt-in fail-closed `@secret` containment. The default
+    // `@secret` pass is a LINT (warnings, narrow traversal). This one
+    // walks every branch, propagates aliases, and reports
+    // `uncertified` for anything it cannot follow — it newly fails
+    // programs that compile today, which is why it is a flag and not
+    // the default. See spec/verification.md § "Secrets".
+    if std::env::args().any(|a| a == "--strict-secret") {
+        let progs: Vec<&hale_syntax::ast::Program> =
+            bundle.programs.values().copied().collect();
+        diags.extend(hale_types::frontier::secret_taint_strict(&progs));
     }
     // #8 LSP groundwork (2026-07-02): `hale check --json` emits
     // NDJSON diagnostics on STDOUT (one object per line: file,

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -11139,6 +11139,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             phase_effects: None,
             depends: None,
             supervised: false,
+            sealed: false,
             name: Ident {
                 name: mangled_name.to_string(),
                 span: template.name.span.clone(),

--- a/crates/hale-codegen/tests/fixtures/examples/secrets-sealed-handler.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/secrets-sealed-handler.hl
@@ -1,0 +1,81 @@
+// GH #436: the secrets shape, end to end.
+//
+// The guarantee is not an analysis. It is four ordinary pieces:
+//
+//   1. `@sealed` — the key is readable only from inside `Signer`.
+//      Without it `self.signer.key` typechecks from anywhere that
+//      holds the locus, and confinement is checked rather than true.
+//   2. one classified operation — `sign` carries `secret_use`, so
+//      every path that touches the key is visible on the call graph.
+//   3. an ordinary planner — public data in, closed plan out. It
+//      never receives the key, a handle, or any secret capability.
+//   4. claims — the domain states who may reach the operation and
+//      how often. That is the only part the domain writes at length,
+//      and it is the part nothing else could supply.
+//
+// What this does NOT prove: nothing derived from the key influences a
+// public output. `sign`'s result is a signature and the signature is
+// published. Sealing confines the key; it does not track derivation.
+
+effect secret_use;
+
+type Req { id: Int; }
+type Plan { msg: Int; }
+type Sig { v: Int; }
+
+topic Signed { payload: Sig; subject: "app.signed"; }
+
+// The privileged owner. Sealed, so nothing outside reads `key`.
+@sealed locus Signer {
+    params { key: Int = 7; }
+
+    @effects(is: { secret_use })
+    fn sign(p: Plan) -> Int { return p.msg + self.key; }
+}
+
+// An ordinary function. No secret, no capability, no annotation.
+fn prepare(r: Req) -> Plan { return Plan { msg: r.id }; }
+
+locus Gateway {
+    params { s: Signer = Signer { }; total: Int = 0; }
+    bus { publish Signed; }
+
+    fn handle(r: Req) {
+        let sig = self.s.sign(prepare(r));
+        self.total = self.total + sig;
+        Signed <- Sig { v: sig };
+    }
+}
+
+// A plugin host: allowed to run, never allowed near the key.
+locus PluginHost {
+    params { seen: Int = 0; }
+    fn observe(r: Req) -> Int { return r.id; }
+}
+
+locus Audit {
+    params { n: Int = 0; }
+    bus { subscribe Signed as on_signed; }
+    fn on_signed(s: Sig) { self.n = s.v; }
+}
+
+group plugins = { PluginHost };
+group handlers = { Gateway };
+
+main locus App {
+    params {
+        g: Gateway = Gateway { };
+        p: PluginHost = PluginHost { };
+        a: Audit = Audit { };
+    }
+    claims {
+        // Who may reach the secret at all.
+        no_plugin_secrets: forbid reaches(plugins, effects(secret_use));
+        // How often it may happen on a request path.
+        one_op_per_request: bound secret_use <= 1 on paths from handlers;
+    }
+}
+
+fn main() {
+    App { };
+}

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -664,6 +664,24 @@ pub struct LocusDecl {
     /// have a failure policy in scope. Supervision coverage as a
     /// checked property.
     pub supervised: bool,
+    /// GH #436: `@sealed locus L { ... }` — this locus's `params` are
+    /// readable only from inside its own methods. Others may still
+    /// CALL it; they may not read its state.
+    ///
+    /// The confinement primitive secrets rest on. Without it a parent
+    /// reads a child's params directly (`self.child.key` typechecks),
+    /// so "the key never leaves the locus that owns it" is a property
+    /// we check rather than one that is true. One word, opt-in, and
+    /// it breaks no existing program — the `@supervised` shape.
+    ///
+    /// Deliberately NOT restricted: param *initialization*. A parent
+    /// writing `Signer { key: … }` must hold what it passes, so a real
+    /// secret should arrive inside `birth` from a vault / env / file
+    /// rather than through a constructor argument. Sealing the
+    /// initializer too would make the annotation unusable for
+    /// ordinary configuration without buying a guarantee — the value
+    /// is already in the parent's hands either way.
+    pub sealed: bool,
     pub members: Vec<LocusMember>,
     pub span: Span,
 }

--- a/crates/hale-syntax/src/desugar.rs
+++ b/crates/hale-syntax/src/desugar.rs
@@ -124,6 +124,7 @@ pub fn wrap_main_as_wasm_export(program: &mut Program) -> bool {
         phase_effects: None,
         depends: None,
             supervised: false,
+            sealed: false,
         name: Ident { name: "__Main".to_string(), span: main_span },
         is_main: false,
         export: true,

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -423,6 +423,8 @@ impl Parser {
         // RFC #330
         let mut depends: Option<DependsSet> = None;
         let mut supervised_locus = false;
+        // GH #436: `@sealed locus` — params readable only from inside.
+        let mut sealed_locus = false;
         let mut leading_span: Option<Span> = None;
         loop {
             if !matches!(self.peek(), TokenKind::At) {
@@ -446,6 +448,9 @@ impl Parser {
             // GH #265: `@supervised locus` — supervision coverage.
             let is_supervised = matches!(&kind_tok,
                 TokenKind::Ident(s) if s == "supervised");
+            // GH #436: `@sealed locus` — state confinement.
+            let is_sealed = matches!(&kind_tok,
+                TokenKind::Ident(s) if s == "sealed");
             let is_unbounded =
                 matches!(&kind_tok, TokenKind::Ident(s) if s == "unbounded");
             let is_budget =
@@ -524,6 +529,16 @@ impl Parser {
                 let at = self.expect(TokenKind::At, "@")?;
                 self.bump();
                 supervised_locus = true;
+                leading_span = Some(match leading_span {
+                    Some(s) => s.merge(at.span),
+                    None => at.span,
+                });
+                continue;
+            }
+            if is_sealed {
+                let at = self.expect(TokenKind::At, "@")?;
+                self.bump();
+                sealed_locus = true;
                 leading_span = Some(match leading_span {
                     Some(s) => s.merge(at.span),
                     None => at.span,
@@ -766,11 +781,12 @@ impl Parser {
             return Err(Diag::parse(
                 self.peek_token().span,
                 "expected `form`, `locality`, `bounded`, `unbounded`, \
-                 `budget`, or `ffi` after `@`",
+                 `budget`, `sealed`, or `ffi` after `@`",
             ));
         }
         if form.is_some() || locality.is_some() || export_locus || bounded_locus
             || phase_effects.is_some() || supervised_locus || depends.is_some()
+            || sealed_locus
         {
             // Verify a `locus` (or contextual `main locus`)
             // follows.
@@ -797,6 +813,7 @@ impl Parser {
             locus.phase_effects = phase_effects;
             locus.depends = depends;
             locus.supervised = supervised_locus;
+            locus.sealed = sealed_locus;
             return Ok(TopDecl::Locus(locus));
         }
         // #382 phase 3: `domain wing = { delta, gamma };` — a
@@ -2953,6 +2970,7 @@ impl Parser {
             phase_effects: None,
             depends: None,
             supervised: false,
+            sealed: false,
             name,
             is_main,
             export: false,

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -10179,6 +10179,59 @@ impl<'a> Checker<'a> {
         Ok(())
     }
 
+    /// GH #436: `@sealed` — a sealed locus's `params` are readable
+    /// only from inside its own methods.
+    ///
+    /// The rule is about the *reader*, not the receiver syntax: what
+    /// matters is whether the enclosing locus IS the sealed one. A
+    /// parent holding `s: Signer` reads `self.s.key` with receiver
+    /// type `Signer` while `current_locus` is `Gateway`, and that is
+    /// the read this forbids. `self.key` inside `Signer` has the same
+    /// receiver type with `current_locus == Signer`, and is fine.
+    ///
+    /// Only `params` are sealed. Capacity slots and methods are
+    /// untouched — sealing confines state, it does not make a locus
+    /// uncallable, which is the entire point.
+    fn check_sealed_read(&mut self, rt: &Ty, name: &Ident, span: Span) {
+        let Ty::Named(locus_name) = rt else { return };
+        let Some(TopSymbol::Locus(li)) = self.top.symbols.get(locus_name)
+        else {
+            return;
+        };
+        if !li.sealed {
+            return;
+        }
+        // Inside the sealed locus itself: every read is legal.
+        if self.current_locus.map_or(false, |cur| cur.name == li.name) {
+            return;
+        }
+        // Only `params` are confined; a slot or method name reaching
+        // here is not a state read.
+        if !li.params.iter().any(|p| p.name == name.name) {
+            return;
+        }
+        let callable: Vec<&str> =
+            li.methods.iter().map(|m| m.name.as_str()).collect();
+        let hint = if callable.is_empty() {
+            format!(
+                "`{}` declares no methods, so its state is reachable \
+                 only from inside it",
+                li.name
+            )
+        } else {
+            format!("call one of its methods instead ({})", callable.join(", "))
+        };
+        self.diags.push(Diag::ty(
+            span,
+            format!(
+                "`{}` is `@sealed`: its `params` are readable only from \
+                 inside its own methods, and `{}.{}` reads one from \
+                 outside — {}",
+                li.name, li.name, name.name, hint
+            ),
+        ));
+    }
+
     fn field_ty(&self, ty: &Ty, name: &str) -> Option<Ty> {
         match ty {
             // Numeric tuple field access: `t.0`, `t.1`. Parser
@@ -11199,6 +11252,7 @@ impl<'a> Checker<'a> {
                     }
                 }
                 let rt = self.check_expr(receiver);
+                self.check_sealed_read(&rt, name, *span);
                 match self.field_ty(&rt, &name.name) {
                     Some(t) => t,
                     None => {

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -500,11 +500,32 @@ pub fn supervised_diags(programs: &[&Program]) -> Vec<Diag> {
 
 // ===================== @secret taint =============================
 
-/// Coarse secret taint: a param declared `@secret` must not flow to
-/// a publish or a log/stdout sink within the fn body. Parameter-
-/// granular (not full value-flow), which is the honest reach — but
-/// the choke-pointed sinks make even this catch the real mistake:
-/// a key or token landing in a log line or on the bus.
+/// The `@secret` **lint** (GH #436).
+///
+/// Emits WARNINGS for the leaks it can actually see: a `@secret`
+/// param mentioned in a publish or a log / file sink in the same fn
+/// body. Those are true positives worth reporting and it keeps
+/// reporting them.
+///
+/// It is deliberately NOT a certificate, and #436 stopped it claiming
+/// to be one. "Must not reach a sink" is a whole-world property, and
+/// this is a local walker over one body: it does not follow calls, it
+/// does not track aliases, and the fragment it walks is narrower
+/// still (`then` branches but not `else`, no `match`, no `let`, no
+/// assignment). Everything outside that fragment vanishes from the
+/// result rather than surfacing as `uncertified` — which is the
+/// fail-open shape the rest of the stack exists to avoid.
+///
+/// The traversal is deliberately left narrow here. Widening it would
+/// newly fail programs that compile today, and a lint that grows
+/// teeth in a point release is a userspace break even when every new
+/// finding is a real bug. The widened walk lives in
+/// [`secret_taint_strict`] behind `--strict-secret`.
+///
+/// For a guarantee rather than a lint, confine the secret to a
+/// `@sealed` locus, classify its one operation with an effect class,
+/// and state the law in `claims` — see `spec/verification.md`
+/// § "Secrets".
 pub fn secret_taint_diags(programs: &[&Program]) -> Vec<Diag> {
     let mut diags = Vec::new();
     for p in programs {
@@ -547,12 +568,15 @@ fn check_secret_block(
         match st {
             Stmt::Send { value, span, .. } => {
                 if expr_mentions(value, secrets) {
-                    diags.push(Diag::ty(
+                    diags.push(Diag::warn(
                         *span,
-                        "a `@secret` value reaches a bus publish — the \
-                         payload crosses a process boundary and may be \
-                         observed or logged downstream. Send a derived \
-                         non-secret (an id, a hash) instead."
+                        "lint: a `@secret` value reaches a bus publish — \
+                         the payload crosses a process boundary and may \
+                         be observed or logged downstream. Send a derived \
+                         non-secret (an id, a hash) instead. This lint \
+                         sees one fn body and follows no calls; for a \
+                         checked guarantee, confine the secret to a \
+                         `@sealed` locus and claim over its effect class."
                             .to_string(),
                     ));
                 }
@@ -577,11 +601,15 @@ fn check_secret_block(
                     if is_sink
                         && args.iter().any(|a| expr_mentions(a, secrets))
                     {
-                        diags.push(Diag::ty(
+                        diags.push(Diag::warn(
                             *span,
-                            "a `@secret` value reaches a log / file sink — \
-                             secrets must not be written where they can be \
-                             read back. Log an identifier instead."
+                            "lint: a `@secret` value reaches a log / file \
+                             sink — secrets must not be written where they \
+                             can be read back. Log an identifier instead. \
+                             This lint sees one fn body and follows no \
+                             calls; for a checked guarantee, confine the \
+                             secret to a `@sealed` locus and claim over \
+                             its effect class."
                                 .to_string(),
                         ));
                     }
@@ -593,6 +621,192 @@ fn check_secret_block(
             }
             _ => {}
         }
+    }
+}
+
+/// The `@secret` **strict** pass (GH #436) — `hale check --strict-secret`.
+///
+/// Opt-in, because it newly fails programs that compile today. It is
+/// the same idea as the lint with the two holes closed:
+///
+/// 1. **Every control-flow form is walked**, not just `then` branches
+///    — `else`, `else if`, `match` arms, loops, bare blocks. Moving a
+///    publish from `then` to `else` no longer hides it.
+/// 2. **Aliases propagate.** `let alias = token;` taints `alias`, so
+///    a one-line rename no longer launders.
+///
+/// And, unlike the lint, it **fails closed**. A tainted value that
+/// reaches anything this walker cannot model — a call to a fn whose
+/// body it does not follow, a field store, a return — is reported as
+/// `uncertified` rather than passing silently. That will be loud on
+/// real code, which is the honest signal: this is still one body's
+/// worth of reasoning, and the whole-world guarantee lives in
+/// `@sealed` + effect classes + `claims`, not here.
+pub fn secret_taint_strict(programs: &[&Program]) -> Vec<Diag> {
+    let mut diags = Vec::new();
+    for p in programs {
+        for item in &p.items {
+            let fns: Vec<&FnDecl> = match item {
+                TopDecl::Fn(fd) => vec![fd],
+                TopDecl::Locus(l) => l
+                    .members
+                    .iter()
+                    .filter_map(|m| match m {
+                        LocusMember::Fn(fd) => Some(fd),
+                        _ => None,
+                    })
+                    .collect(),
+                _ => continue,
+            };
+            for fd in fns {
+                let mut tainted: BTreeSet<String> = fd
+                    .params
+                    .iter()
+                    .filter(|pm| pm.secret)
+                    .map(|pm| pm.name.name.clone())
+                    .collect();
+                if tainted.is_empty() {
+                    continue;
+                }
+                strict_block(&fd.body, &mut tainted, &mut diags);
+            }
+        }
+    }
+    diags
+}
+
+fn strict_sink_name(callee: &Expr) -> bool {
+    match callee {
+        Expr::Ident(i) => i.name == "println" || i.name == "print",
+        Expr::Path(p) => p
+            .segments
+            .last()
+            .map(|s| {
+                s.name == "write_bytes"
+                    || s.name == "write_file"
+                    || s.name == "write_line"
+            })
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+/// Report every tainted expression that escapes into something this
+/// walker cannot follow. `what` names the shape for the diagnostic.
+fn strict_escape(
+    e: &Expr,
+    tainted: &BTreeSet<String>,
+    what: &str,
+    span: Span,
+    diags: &mut Vec<Diag>,
+) {
+    if !expr_mentions(e, tainted) {
+        return;
+    }
+    diags.push(Diag::ty(
+        span,
+        format!(
+            "uncertified: a `@secret` value reaches {what}, which this \
+             check does not follow — it cannot certify that the secret \
+             is contained. Confine it to a `@sealed` locus and let a \
+             claim over its effect class carry the guarantee."
+        ),
+    ));
+}
+
+fn strict_block(
+    b: &Block,
+    tainted: &mut BTreeSet<String>,
+    diags: &mut Vec<Diag>,
+) {
+    for st in &b.stmts {
+        match st {
+            Stmt::Send { value, span, .. } => {
+                if expr_mentions(value, tainted) {
+                    diags.push(Diag::ty(
+                        *span,
+                        "a `@secret` value reaches a bus publish — the \
+                         payload crosses a process boundary and may be \
+                         observed or logged downstream. Send a derived \
+                         non-secret (an id, a hash) instead."
+                            .to_string(),
+                    ));
+                }
+            }
+            // The alias hole: `let alias = token;` taints `alias`.
+            Stmt::Let { name, value, span, .. } => {
+                if expr_mentions(value, tainted) {
+                    // A call in the initializer is opaque to us; the
+                    // binding is tainted AND the call is unmodelled.
+                    if matches!(value, Expr::Call { .. }) {
+                        strict_escape(
+                            value, tainted, "a call this check does not \
+                            follow", *span, diags,
+                        );
+                    }
+                    tainted.insert(name.name.clone());
+                }
+            }
+            Stmt::Assign { value, span, .. } => {
+                strict_escape(value, tainted, "a stored location", *span, diags)
+            }
+            Stmt::Return(Some(e), span) => {
+                strict_escape(e, tainted, "this fn's return", *span, diags)
+            }
+            Stmt::Expr(e) => {
+                if let Expr::Call { callee, args, span, .. } = e {
+                    if strict_sink_name(callee) {
+                        if args.iter().any(|a| expr_mentions(a, tainted)) {
+                            diags.push(Diag::ty(
+                                *span,
+                                "a `@secret` value reaches a log / file \
+                                 sink — secrets must not be written where \
+                                 they can be read back. Log an identifier \
+                                 instead."
+                                    .to_string(),
+                            ));
+                        }
+                    } else {
+                        for a in args {
+                            strict_escape(
+                                a,
+                                tainted,
+                                "a call this check does not follow",
+                                *span,
+                                diags,
+                            );
+                        }
+                    }
+                }
+            }
+            // The traversal hole: every branch, not just `then`.
+            Stmt::If(i) => strict_if(i, tainted, diags),
+            Stmt::Match(m) => {
+                for arm in &m.arms {
+                    if let MatchArmBody::Block(blk) = &arm.body {
+                        strict_block(blk, tainted, diags);
+                    }
+                }
+            }
+            Stmt::While { body, .. } | Stmt::For { body, .. } => {
+                strict_block(body, tainted, diags)
+            }
+            Stmt::Block(blk) => strict_block(blk, tainted, diags),
+            _ => {}
+        }
+    }
+}
+
+fn strict_if(
+    i: &IfStmt,
+    tainted: &mut BTreeSet<String>,
+    diags: &mut Vec<Diag>,
+) {
+    strict_block(&i.then_block, tainted, diags);
+    match i.else_block.as_deref() {
+        Some(ElseBranch::Else(b)) => strict_block(b, tainted, diags),
+        Some(ElseBranch::ElseIf(inner)) => strict_if(inner, tainted, diags),
+        None => {}
     }
 }
 

--- a/crates/hale-types/src/resolve.rs
+++ b/crates/hale-types/src/resolve.rs
@@ -968,6 +968,7 @@ fn register_locus(
 
     let info = LocusInfo {
         name: decl.name.name.clone(),
+        sealed: decl.sealed,
         serves: decl.serves.iter().map(|s| s.name.clone()).collect(),
         params,
         bus_publishes,

--- a/crates/hale-types/src/symbol.rs
+++ b/crates/hale-types/src/symbol.rs
@@ -176,6 +176,9 @@ pub struct InterfaceMethodInfo {
 #[derive(Debug, Clone)]
 pub struct LocusInfo {
     pub name: String,
+    /// GH #436: declared `@sealed` — its `params` are readable only
+    /// from inside its own methods. Others may still call it.
+    pub sealed: bool,
     /// Phase 2a: perspective contracts this locus `serves` — the
     /// `locus L : serves P, Q` clause names. Empty for non-impl
     /// loci. Consulted by `reperspective` (Phase 2b) to verify the

--- a/crates/hale-types/tests/sealed_locus.rs
+++ b/crates/hale-types/tests/sealed_locus.rs
@@ -1,0 +1,210 @@
+//! GH #436: `@sealed locus` — state confinement.
+//!
+//! A sealed locus's `params` are readable only from inside its own
+//! methods. This is the primitive the secrets story rests on: without
+//! it a parent reads a child's params directly (`self.child.key`
+//! typechecks), so "the key never leaves the locus that owns it" is a
+//! property we check rather than one that is true.
+//!
+//! What sealing does NOT do is make a locus uncallable — that is the
+//! whole point, and `sealing_does_not_block_calls` pins it.
+
+use hale_syntax::parse_source;
+
+fn errors(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .filter(|d| d.is_error())
+        .map(|d| d.message)
+        .collect()
+}
+
+const SEALED_SIGNER: &str = r#"
+    @sealed locus Signer {
+        params { key: Int = 7; }
+        fn sign(m: Int) -> Int { return m + self.key; }
+    }
+"#;
+
+#[test]
+fn reading_a_sealed_param_from_outside_is_an_error() {
+    let src = format!(
+        "{SEALED_SIGNER}
+        locus Gateway {{
+            params {{ s: Signer = Signer {{ }}; }}
+            fn bad() -> Int {{ return self.s.key; }}
+        }}
+        main locus App {{ params {{ g: Gateway = Gateway {{ }}; }} }}
+        fn main() {{ App {{ }}; }}
+        "
+    );
+    let es = errors(&src);
+    assert!(
+        es.iter().any(|m| m.contains("`Signer` is `@sealed`")
+            && m.contains("readable only from inside")),
+        "expected a sealed-read error, got {es:?}"
+    );
+}
+
+#[test]
+fn the_diagnostic_names_a_method_to_call_instead() {
+    // The point of sealing is that the locus stays usable. The
+    // diagnostic has to say so, or it reads as "you cannot use this".
+    let src = format!(
+        "{SEALED_SIGNER}
+        locus Gateway {{
+            params {{ s: Signer = Signer {{ }}; }}
+            fn bad() -> Int {{ return self.s.key; }}
+        }}
+        main locus App {{ params {{ g: Gateway = Gateway {{ }}; }} }}
+        fn main() {{ App {{ }}; }}
+        "
+    );
+    let es = errors(&src);
+    assert!(
+        es.iter().any(|m| m.contains("call one of its methods")
+            && m.contains("sign")),
+        "diagnostic should name `sign` as the way in, got {es:?}"
+    );
+}
+
+#[test]
+fn the_sealed_locus_reads_its_own_params_freely() {
+    // `self.key` INSIDE `Signer` has receiver type `Signer` exactly
+    // like `self.s.key` outside it does. The rule is about the
+    // reader, not the receiver syntax, and this is the case that
+    // catches getting that backwards.
+    let src = format!(
+        "{SEALED_SIGNER}
+        main locus App {{ params {{ s: Signer = Signer {{ }}; }} }}
+        fn main() {{ App {{ }}; }}
+        "
+    );
+    assert!(errors(&src).is_empty(), "{:?}", errors(&src));
+}
+
+#[test]
+fn sealing_does_not_block_calls() {
+    let src = format!(
+        "{SEALED_SIGNER}
+        locus Gateway {{
+            params {{ s: Signer = Signer {{ }}; }}
+            fn ok(m: Int) -> Int {{ return self.s.sign(m); }}
+        }}
+        main locus App {{ params {{ g: Gateway = Gateway {{ }}; }} }}
+        fn main() {{ App {{ }}; }}
+        "
+    );
+    assert!(errors(&src).is_empty(), "{:?}", errors(&src));
+}
+
+#[test]
+fn sealing_does_not_block_construction() {
+    // Deliberate: a parent writing `Signer { key: … }` already holds
+    // the value it passes, so sealing the initializer would cost
+    // ordinary configuration and buy nothing. Real secret material
+    // should be loaded inside `birth` instead. Pinned because it is
+    // a design decision, not an oversight.
+    let src = "
+        @sealed locus Signer {
+            params { key: Int = 0; }
+            fn sign(m: Int) -> Int { return m + self.key; }
+        }
+        main locus App { params { s: Signer = Signer { key: 9 }; } }
+        fn main() { App { }; }
+    ";
+    assert!(errors(src).is_empty(), "{:?}", errors(src));
+}
+
+#[test]
+fn an_unsealed_locus_is_unaffected() {
+    // The annotation is opt-in and breaks no existing program.
+    let src = "
+        locus Signer {
+            params { key: Int = 7; }
+            fn sign(m: Int) -> Int { return m + self.key; }
+        }
+        locus Gateway {
+            params { s: Signer = Signer { }; }
+            fn reads() -> Int { return self.s.key; }
+        }
+        main locus App { params { g: Gateway = Gateway { }; } }
+        fn main() { App { }; }
+    ";
+    assert!(errors(src).is_empty(), "{:?}", errors(src));
+}
+
+#[test]
+fn a_free_fn_cannot_read_a_sealed_param_either() {
+    // The rule is "inside its own methods", and a free fn is not one.
+    // Without this the annotation has a hole a helper walks through.
+    let src = format!(
+        "{SEALED_SIGNER}
+        fn peek(s: Signer) -> Int {{ return s.key; }}
+        main locus App {{ params {{ s: Signer = Signer {{ }}; }} }}
+        fn main() {{ App {{ }}; }}
+        "
+    );
+    let es = errors(&src);
+    assert!(
+        es.iter().any(|m| m.contains("`@sealed`")),
+        "expected the free fn to be rejected, got {es:?}"
+    );
+}
+
+#[test]
+fn sealing_is_per_type_not_per_instance() {
+    // A `Signer` method may read another `Signer`'s params. Class-
+    // private rather than instance-private, matching the ordinary
+    // reading of "inside its own methods" — the two instances share
+    // a trust domain because they share a body. Pinned as a decision.
+    let src = "
+        @sealed locus Signer {
+            params { key: Int = 7; }
+            fn sign(m: Int) -> Int { return m + self.key; }
+            fn peer(o: Signer) -> Int { return o.key; }
+        }
+        main locus App { params { s: Signer = Signer { }; } }
+        fn main() { App { }; }
+    ";
+    assert!(errors(src).is_empty(), "{:?}", errors(src));
+}
+
+#[test]
+fn sealing_confines_a_secret_the_bus_would_otherwise_carry() {
+    // The end-to-end shape: without `@sealed` this program publishes
+    // the key and typechecks clean. That is the defect #436 opened on.
+    let leaky = "
+        type Msg { v: Int; }
+        topic Out { payload: Msg; subject: \"app.out\"; }
+        LOCUS_KW locus Signer {
+            params { key: Int = 7; }
+            fn sign(m: Int) -> Int { return m + self.key; }
+        }
+        locus Gateway {
+            params { s: Signer = Signer { }; }
+            bus { publish Out; }
+            fn go() { Out <- Msg { v: self.s.key }; }
+        }
+        locus Sink {
+            params { n: Int = 0; }
+            bus { subscribe Out as on_out; }
+            fn on_out(m: Msg) { self.n = m.v; }
+        }
+        main locus App {
+            params { g: Gateway = Gateway { }; k: Sink = Sink { }; }
+        }
+        fn main() { App { }; }
+    ";
+    assert!(
+        errors(&leaky.replace("LOCUS_KW", "")).is_empty(),
+        "unsealed: the key on the bus must still typecheck, or this \
+         test is measuring something else"
+    );
+    let es = errors(&leaky.replace("LOCUS_KW", "@sealed"));
+    assert!(
+        es.iter().any(|m| m.contains("`@sealed`")),
+        "sealed: publishing the key must be rejected, got {es:?}"
+    );
+}

--- a/crates/hale-types/tests/secret_lint_and_strict.rs
+++ b/crates/hale-types/tests/secret_lint_and_strict.rs
@@ -1,0 +1,152 @@
+//! GH #436: `@secret` is a lint by default and fails closed under
+//! `--strict-secret`.
+//!
+//! The defect: `@secret` was reported as a certificate while being a
+//! local identifier walker over a fragment of one fn body. It walked
+//! `then` branches but not `else`, and had no notion of aliasing, so
+//! moving a publish across a branch or renaming through one `let`
+//! made the finding *disappear* rather than surface as uncertified.
+//!
+//! Two things are pinned here, and the split between them is the
+//! whole point. The default pass keeps exactly the reach it always
+//! had — widening a lint in place newly fails programs that compile
+//! today, which is a userspace break even when every new finding is a
+//! real bug. The widened, fail-closed walk is opt-in.
+
+use hale_syntax::parse_source;
+
+fn diags(src: &str) -> Vec<hale_syntax::error::Diag> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+}
+
+fn strict(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::frontier::secret_taint_strict(&[&program])
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+/// One publish of a `@secret` param, in the shape named by `body`.
+fn program(body: &str) -> String {
+    format!(
+        "
+        type Msg {{ v: String; }}
+        topic Out {{ payload: Msg; subject: \"app.out\"; }}
+        locus Sender {{
+            params {{ n: Int = 0; }}
+            bus {{ publish Out; }}
+            fn f(@secret token: String, flag: Bool) {{ {body} }}
+        }}
+        locus Sink {{
+            params {{ n: Int = 0; }}
+            bus {{ subscribe Out as on_out; }}
+            fn on_out(m: Msg) {{ self.n = len(m.v); }}
+        }}
+        main locus App {{
+            params {{ s: Sender = Sender {{ }}; k: Sink = Sink {{ }}; }}
+        }}
+        fn main() {{ App {{ }}; }}
+        "
+    )
+}
+
+const DIRECT: &str = "Out <- Msg { v: token };";
+const IN_ELSE: &str =
+    "if flag { print(\"x\"); } else { Out <- Msg { v: token }; }";
+const VIA_ALIAS: &str = "let alias = token; Out <- Msg { v: alias };";
+
+#[test]
+fn the_default_pass_is_a_warning_not_an_error() {
+    let ds = diags(&program(DIRECT));
+    assert!(
+        ds.iter().any(|d| !d.is_error()
+            && d.message.contains("`@secret` value reaches a bus publish")),
+        "the direct leak must still be reported: {:?}",
+        ds.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert!(
+        !ds.iter().any(|d| d.is_error()),
+        "a lint must not fail the build: {:?}",
+        ds.iter().filter(|d| d.is_error()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn the_default_pass_keeps_its_old_reach_exactly() {
+    // Deliberate, not an oversight: widening the default would break
+    // programs that compile today. Both of these are real leaks and
+    // both stay silent until `--strict-secret`.
+    for body in [IN_ELSE, VIA_ALIAS] {
+        let ds = diags(&program(body));
+        assert!(
+            !ds.iter().any(|d| d.message.contains("`@secret`")),
+            "default pass unexpectedly widened on {body:?}: {:?}",
+            ds.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn strict_closes_the_else_hole() {
+    let ms = strict(&program(IN_ELSE));
+    assert!(
+        ms.iter().any(|m| m.contains("reaches a bus publish")),
+        "the else-branch publish must be caught: {ms:?}"
+    );
+}
+
+#[test]
+fn strict_closes_the_alias_hole() {
+    let ms = strict(&program(VIA_ALIAS));
+    assert!(
+        ms.iter().any(|m| m.contains("reaches a bus publish")),
+        "the aliased publish must be caught: {ms:?}"
+    );
+}
+
+#[test]
+fn strict_still_catches_the_direct_case() {
+    // A widened walker that lost the case the narrow one had would be
+    // a regression the other two tests cannot see.
+    let ms = strict(&program(DIRECT));
+    assert!(
+        ms.iter().any(|m| m.contains("reaches a bus publish")),
+        "{ms:?}"
+    );
+}
+
+#[test]
+fn strict_reports_uncertified_rather_than_passing_silently() {
+    // The property that separates this from the lint: a secret
+    // reaching something the walker cannot follow is uncertified, not
+    // absent. `helper` is a fn whose body this pass does not enter.
+    let src = "
+        fn helper(s: String) -> Int { return len(s); }
+        locus L {
+            params { n: Int = 0; }
+            fn f(@secret token: String) { self.n = helper(token); }
+        }
+        main locus App { params { l: L = L { }; } }
+        fn main() { App { }; }
+    ";
+    let ms = strict(src);
+    assert!(
+        ms.iter().any(|m| m.contains("uncertified")),
+        "an unfollowed call must be uncertified, got {ms:?}"
+    );
+}
+
+#[test]
+fn strict_is_silent_on_a_program_with_no_secret_params() {
+    let src = "
+        locus L {
+            params { n: Int = 0; }
+            fn f(x: String) { print(\"{x}\"); }
+        }
+        main locus App { params { l: L = L { }; } }
+        fn main() { App { }; }
+    ";
+    assert!(strict(src).is_empty(), "{:?}", strict(src));
+}

--- a/docs/src/verification.md
+++ b/docs/src/verification.md
@@ -258,6 +258,68 @@ claim's result under a `shape_hash`, and `--check-topology
 <baseline>` fails CI when the topology or the law changes without
 review.
 
+## Secrets: confine, classify, claim
+
+A signing key is not a problem for a taint checker to solve. It's a
+problem the ownership model already solves, once you close one gap.
+
+`@sealed` on a locus makes its `params` readable **only from inside its
+own methods**. Others can still call it — that's the point — they just
+can't read its state:
+
+```hale,fragment
+effect secret_use;
+
+@sealed locus Signer {
+    params { key: Bytes; }
+
+    @effects(is: { secret_use })
+    fn sign(m: Bytes) -> Signature { … }
+}
+```
+
+Without `@sealed`, `self.signer.key` typechecks from anywhere holding
+the locus, so "the key never leaves its owner" would be something you
+hope for rather than something the compiler knows. With it, the only
+way in is a method call — and that method carries an effect class, so
+every path that can touch the key is visible on the call graph.
+
+Now the law is two ordinary claims:
+
+```hale,fragment
+claims {
+    no_plugin_secrets: forbid reaches(plugins, effects(secret_use));
+    one_op_per_request: bound secret_use <= 1 on paths from handlers;
+}
+```
+
+Wire a `Signer` into a plugin and the build stops with the crossing
+call named:
+
+```text
+claim `no_plugin_secrets` violated: `plugins` reaches
+  `effects(secret_use)` — witness: `PluginHost::sneaky` -> `Signer::sign`
+```
+
+The shape that falls out: an ordinary function prepares a request from
+public data and hands back a plan; the sealed locus interprets the plan
+and performs the one privileged step. The planner never receives the
+key, a handle, or anything that could produce one — so there is nothing
+for it to leak, whatever it does.
+
+**What this is and isn't.** The secret lives in a locus that owns it,
+your code cannot obtain it, the operations on it are classified, and
+your claims constrain who reaches them. That is confinement, not
+information flow: a signature *derived* from the key is not tracked, a
+constant-time compare still lets the verdict be published, and the
+sealed locus's own body is trusted — keep it small enough to read.
+
+`@secret` on a parameter is a **lint**, not a proof. It flags a secret
+reaching a publish or log in the same body, follows no calls, and
+tracks no aliases. `hale check --strict-secret` widens the walk and
+reports `uncertified` wherever it can't follow, which is loud by
+design.
+
 ## Invariants you declare, checked as it runs
 
 The checks above are the compiler's. You can add your own with a

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -233,7 +233,18 @@ locus_decorator   = form_annotation
                   | locality_annotation
                   | export_annotation
                   | bounded_annotation
+                  | sealed_annotation
                   ;
+
+(* GH #436: `@sealed` confines a locus's state — its `params` are
+   readable only from inside its own methods. Others may still CALL
+   it; they may not read it. Opt-in. Only
+   `params` are confined (not capacity slots, not methods), and param
+   *initialization* is deliberately unrestricted: the parent already
+   holds what it passes. `sealed` is a contextual word recognized
+   only after `@` in decorator position.
+   See `spec/verification.md` § Secrets. *)
+sealed_annotation = "@" , "sealed" ;
 
 (* GH #18 item 1 (memory-bound proofs): `@bounded` opts a locus into
    the memory-bound proof — its bodies are checked for unbounded

--- a/spec/tokens.md
+++ b/spec/tokens.md
@@ -608,7 +608,8 @@ They attach to the declaration that follows.
 | `@phase_effects(phase: {…}, …)` | locus | per-lifecycle-phase effect contract |
 | `@effects(causes: {…})` | fn | effect classes this fn may cause via bus edges |
 | `@supervised` | locus | every locus in the subtree has a failure policy |
-| `@secret` | fn param | the value must not reach a publish or log/file sink |
+| `@sealed` | locus | this locus's `params` are readable only from inside it |
+| `@secret` | fn param | **lint**: flags a value reaching a publish or log/file sink in the same body |
 | `@effects(publish: {…})` | fn | the allowed publish set |
 | `@effects(depends: {…})` | locus | complete set of subjects that may transitively reach any handler |
 | `@effects(is: {…})` | fn | classify this fn as a source of the named effect classes |

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -776,6 +776,97 @@ Attestation checks bytes at rest at deploy time; whether a
 (sent/delivered observation, 7b), and the artifact never claims
 otherwise.
 
+## Secrets — confine, classify, claim (GH #436)
+
+Hale's answer to secrets is not an analysis. It is the ownership
+primitive doing its job, plus one classified operation, plus law.
+
+**1. `@sealed locus L` — confinement.** A sealed locus's `params` are
+readable only from inside its own methods. Others may still CALL it;
+they may not read its state:
+
+```hale
+@sealed locus Signer {
+    params { key: Bytes; }
+    @effects(is: { secret_use })
+    fn sign(m: Bytes) -> Signature { … }
+}
+```
+
+This exists because loci are otherwise **not** field-encapsulated —
+`self.child.key` typechecks from anywhere holding the locus, so
+without sealing "the key never leaves the locus that owns it" is a
+property you check rather than one that is true. The annotation is
+opt-in and breaks no existing program. There is currently **no**
+claim form for requiring an annotation, so a constitution cannot yet
+demand `@sealed` across a group — a `require sealed(all G)` form is
+the obvious follow-up, and the same gap applies to `@supervised`.
+
+Only `params` are confined. Capacity slots and methods are untouched
+— sealing confines state, it does not make a locus uncallable, which
+is the entire point.
+
+Param **initialization** is deliberately not restricted. A parent
+writing `Signer { key: … }` already holds the value it passes, so
+sealing the initializer would cost ordinary configuration and buy
+nothing. Real secret material should be loaded inside `birth` from a
+vault, environment, or file rather than passed in.
+
+**2. One classified operation.** The privileged method carries a user
+effect class, so every path that can touch the secret is visible on
+the call graph — `frontier::infer_effects` propagates it transitively
+with no further annotation.
+
+**3. Law.** The domain states who may reach it and how often, using
+claim forms that already exist:
+
+```hale
+effect secret_use;
+
+claims {
+    no_plugin_secrets: forbid reaches(plugins, effects(secret_use));
+    one_op_per_request: bound secret_use <= 1 on paths from handlers;
+}
+```
+
+A violation names the crossing call:
+
+```text
+claim `no_plugin_secrets` violated: `plugins` reaches
+  `effects(secret_use)` — witness: `PluginHost::sneaky` -> `Signer::sign`
+```
+
+**The recommended shape**, a pattern rather than an enforced contract:
+an ordinary function prepares a request from public data and returns a
+closed plan; the sealed locus interprets the plan and performs the one
+privileged step. The planner never receives the secret, a handle, or
+any secret capability. Prefer a closed operation enum over a callback
+— a finite vocabulary is reviewable, a function parameter is a
+programmable oracle. Worked end to end in
+`crates/hale-codegen/tests/fixtures/examples/secrets-sealed-handler.hl`.
+
+### What this guarantees, and what it does not
+
+> The secret lives in a locus that owns it, the domain cannot obtain
+> it, the only operations on it are classified, and the domain's
+> claims constrain who may reach those operations and how often.
+
+This is **not** information flow and **not** noninterference. Two
+residual assumptions, both deliberate:
+
+1. **The sealed locus's own body is trusted.** Sealing stops others
+   reading the field; it does not stop the owner returning it. Keep
+   that locus small enough to review.
+2. **Primitive classifications are compiler-asserted facts.** That
+   `crypto::hmac` behaves as claimed is a declaration in the stdlib
+   frontier, not a proof — the same trust every effect claim rests on.
+
+Deliberately out of scope, each a separate and stronger theorem:
+derivation tracking (nothing derived from the key influences a public
+output), control dependence (a constant-time compare still lets the
+*verdict* be published), resource uniqueness (nonce counters, DRBG
+state), and zeroization.
+
 ## Structural & design rules
 
 | Check | Catches | Severity | Enforced by |
@@ -1211,15 +1302,31 @@ assume the others in a build:
   by name: a failure there has nowhere to go. The declared ownership
   tree makes this a tree walk; it is the static supervision-coverage
   property the actor world has wanted for decades.
-- **Coarse secret taint — `@secret` params** (GH #265, 2026-07-29).
-  A parameter declared `@secret name: T` must not reach a bus publish
-  or a log / file sink. Deliberately **coarse** — parameter-granular,
-  not value-flow-complete — which the issue asked be assessed rather
-  than deferred to a "v2 horizon"; the choke-pointed sinks make even
-  this catch the mistake that matters (a key or token in a log line
-  or on the wire). Constant-time / full information flow remains out
-  of scope: value-dependent control flow and microarchitecture are a
-  different shape of analysis.
+- **`@secret` params — a LINT, not a certificate** (GH #265, revised
+  by GH #436 2026-08-08). A parameter declared `@secret name: T`
+  reaching a bus publish or a log / file sink in the same fn body is
+  reported as a **warning**. Those are true positives and it keeps
+  reporting them.
+
+  It is not a proof, and #436 stopped it claiming to be one. "Must
+  not reach a sink" is a whole-world property; this is a local walker
+  over one body that follows no calls and tracks no aliases, and the
+  fragment it walks is narrower still — `then` branches but not
+  `else`, no `match`, no `let`, no assignment. Everything outside
+  that fragment vanished from the result rather than surfacing as
+  `uncertified`, which is the fail-open shape the rest of this
+  document exists to avoid.
+
+  The default traversal is deliberately left narrow. Widening it
+  newly fails programs that compile today, and a lint that grows
+  teeth in a point release is a userspace break even when every new
+  finding is a real bug. **`hale check --strict-secret`** runs the
+  widened walk: every branch, alias propagation through `let`, and
+  `uncertified` for anything it cannot follow — an unfollowed call, a
+  field store, a return. It is loud, which is the honest signal that
+  one body's reasoning is not a containment proof.
+
+  For a guarantee rather than a lint, see § Secrets below.
 - **Inferred effect sets + symbolic cost** (GH #265, 2026-07-29).
   `frontier::infer_effects` computes the transitive effect set of ANY
   fn — no declaration required — which is what feeds the causality


### PR DESCRIPTION
Closes the `@secret` fail-open by moving the guarantee to where the language already had the pieces. Implements [#436](https://github.com/hale-lang/hale/issues/436).

## The defect

`@secret` was reported as a certificate while being a local identifier walker over a *fragment* of one fn body — `then` branches but not `else`, and no notion of aliasing. Both of these check clean on `main` today:

```hale
fn leak(@secret token: String, flag: Bool) {
    if flag { print("nothing"); } else { Out <- Msg { v: token }; }
}
fn leak2(@secret token: String) {
    let alias = token;
    Out <- Msg { v: alias };
}
```

Moving a publish across a branch, or renaming through one `let`, made the finding **vanish** rather than surface as `uncertified`.

The category error is bigger than the traversal gaps: "must not reach a sink" is a whole-world property written as a local parameter annotation and checked inside one body. A local walker cannot be made sound for a global property — making it exhaustive only makes it a more thorough local walker.

## `@sealed locus L`

A sealed locus's `params` are readable only from inside its own methods. Others may still **call** it; they may not read its state.

This closes the gap everything else rested on. Loci are **not** otherwise field-encapsulated — `self.child.key` typechecks from anywhere holding the locus — so "the key never leaves its owner" was a property you checked rather than one that was true.

```
`Signer` is `@sealed`: its `params` are readable only from inside its own
methods, and `Signer.key` reads one from outside — call one of its methods
instead (sign)
```

Opt-in, one word, breaks no existing program — the `@supervised` shape. Only `params` are confined; capacity slots and methods are untouched, because sealing confines state rather than making a locus uncallable, which is the entire point.

**Two semantics pinned as decisions, not accidents:**

- **Per-type, not per-instance.** A `Signer` method may read another `Signer`'s params — they share a body, so they share a trust domain. Class-private, as in Java/C++.
- **Param initialization is unrestricted.** A parent writing `Signer { key: … }` already holds what it passes, so sealing the initializer would cost ordinary configuration and buy nothing. Real material should load inside `birth`.

A free fn reading a sealed param is also rejected — otherwise the annotation has a hole a helper walks through.

## The guarantee needs no new analysis

Confine with `@sealed`, classify the one privileged method with a user effect class, state the law with claim forms that already exist:

```hale
effect secret_use;

@sealed locus Signer {
    params { key: Bytes; }
    @effects(is: { secret_use })
    fn sign(m: Bytes) -> Signature { … }
}

claims {
    no_plugin_secrets: forbid reaches(plugins, effects(secret_use));
    one_op_per_request: bound secret_use <= 1 on paths from handlers;
}
```

```
claim `no_plugin_secrets` violated: `plugins` reaches `effects(secret_use)`
  — witness: `PluginHost::sneaky` -> `Signer::sign`
```

**Stated exactly:** the secret lives in a locus that owns it, the domain cannot obtain it, the only operations on it are classified, and the domain's claims constrain who may reach them and how often.

That is confinement, **not information flow**. A value *derived* from the key is not tracked; a constant-time compare still lets the verdict be published; and the sealed locus's own body is trusted — keep it small enough to read. Both residual assumptions are stated in `spec/verification.md` § Secrets rather than left to be inferred from a green result.

## BEHAVIOR: `@secret` is now a warning

Its true positives are still reported. It is no longer documented as proof.

The default traversal is **deliberately left narrow**. Widening a lint in place newly fails programs that compile today, which is a userspace break even when every new finding is a real bug.

**`hale check --strict-secret`** runs the widened, fail-closed walk: every branch including `else` / `else if` / `match`, alias propagation through `let`, and `uncertified` for anything it cannot follow (an unfollowed call, a field store, a return). Opt-in because it is loud — which is the honest signal that one body's reasoning is not a containment proof.

## Not delivered here

A stdlib-owned secret handler (`std::crypto::Signer`). With `@sealed` the pattern is writable in Hale today, and a runtime-backed vault carries its own design surface — key loading, rotation, and zeroization, the last of which #436 defers on purpose.

Also corrected mid-review: an earlier draft of the spec claimed a constitution could *require* `@sealed` across a group. There is no claim form for requiring an annotation, so that was untrue; the text now names it as a follow-up and notes the same gap applies to `@supervised`.

## Verification

- `sealed_locus.rs` — 9 tests: outside-read rejected, inside-read fine, calls unaffected, construction unaffected, unsealed locus untouched, free fn rejected, per-type semantics, and an end-to-end case asserting the leak typechecks *unsealed* (so the test measures the seal, not something else)
- `secret_lint_and_strict.rs` — 7 tests: lint is a warning and does not fail the build, default reach unchanged on both holes, strict closes `else` and alias, strict still catches the direct case, strict reports `uncertified`
- New corpus fixture `secrets-sealed-handler.hl` — checks, `fmt --check` clean, runs
- `hale-types`, `hale-syntax`, `hale-cli` suites green; corpus typecheck / parse / fmt / docs-snippet gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)