### PR TITLE
fix(secrets): close confinement and claim fail-opens (GH #436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,17 @@ authentication bypass on any unconfigured deployment.
 `fingerprint` is no longer described as "safe to publish" and now
 carries `secret_use`.
 
+`require attributed` now attaches to the first **application-owned**
+fn crossing out, including `@ffi` declarations and Hale-source stdlib
+bodies. It previously ignored every resolved call, so a publish
+through `self.logger.info(m)` was invisible while the same operation
+as a path call was caught — coverage depending on how an API happens
+to be implemented. An ordinary application callee is still judged on
+its own row, which is what keeps attribution direct. `publish` also
+parses as a class name now; it is a built-in class and a reserved
+keyword, and `expect_ident` had rejected the one class most worth
+attributing.
+
 Also: `require attributed` accepted `ffi` / `spawn` / `recursion`,
 which its evaluator answered with unconditional success; it ignored
 direct allocation sites; the sealed/attributed collectors did not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,50 @@ claimed a constitution could already require sealing across a group,
 which was false — no claim form required an annotation. The same gap
 still applies to `@supervised`.
 
+### Confinement and claim fail-opens closed (GH #436 review)
+
+External review of the landed work found three release blockers. All
+reproduced; the negative controls in `secrets_fail_opens.rs` were
+written and verified failing first.
+
+**BREAKING: `secret_use` is now a compiler built-in.** `effect
+secret_use;` is an error. User effect classes intern per-`Program`, so
+the stdlib-declared class had no identity an application's claims
+could name: `forbid reaches(plugins, effects(secret_use))` silently
+missed `std::secret::Signer.sign` — the law over the recommended
+secrets path was unenforceable — and with an application declaring its
+own classes first, the stdlib's bit aliased onto whichever class sat
+at that index. A built-in has one identity by construction. `bound`
+accepts it, being the one counted built-in with no `@budget`
+spelling.
+
+**`@sealed` now stops writes.** It hooked only the expression
+field-access path, so `self.vault.key = 999` typechecked — for
+`std::secret`, outside code could CHOOSE the signing key.
+
+**`std::secret` fails closed.** `ready()` reported false and nothing
+consulted it, so `sign` returned a valid HMAC under the empty key and
+`verify` accepted the matching forgery. Sharpest case:
+`matches(b"")` against an unloaded credential returned **true** — an
+authentication bypass on any unconfigured deployment.
+`fingerprint` is no longer described as "safe to publish" and now
+carries `secret_use`.
+
+Also: `require attributed` accepted `ffi` / `spawn` / `recursion`,
+which its evaluator answered with unconditional success; it ignored
+direct allocation sites; the sealed/attributed collectors did not
+recurse into modules; `require sealed` held vacuously over a
+locus-free group; `--strict-secret` missed tuples, indexes, block
+tails, `or` substitutes, `fail` payloads, expression `match` arms and
+`LetTuple` (the expression walk is now exhaustive by construction —
+no catch-all arm, so a new `Expr` variant fails the build); and
+diagnostics rendered mangled stdlib names.
+
+**Schema 1.9:** `sealed` joins the hashed model, so sealing a locus
+moves `shape_hash`. `require sealed` replays from the artifact;
+`require attributed` is compiler-certified, since the artifact exports
+inferred rather than direct effect sites.
+
 ### `hale check --sealable` — the adoption survey (GH #436)
 
 `@sealed` is opt-in, so "would this collide with real code?" is a

--- a/crates/hale-cli/tests/xseed_claims_verbs.rs
+++ b/crates/hale-cli/tests/xseed_claims_verbs.rs
@@ -80,7 +80,7 @@ fn cover_catches_an_uncovered_topic_across_seeds() {
 fn the_topology_artifact_round_trips() {
     let dump = dump_artifact();
     assert!(
-        dump.contains("\"schema\": \"1.8\"")
+        dump.contains("\"schema\": \"1.9\"")
             && dump.contains("\"shape_hash\": \""),
         "the artifact must carry schema + shape_hash:\n{}",
         dump

--- a/crates/hale-codegen/tests/fixtures/examples/secrets-sealed-handler.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/secrets-sealed-handler.hl
@@ -17,7 +17,11 @@
 // public output. `sign`'s result is a signature and the signature is
 // published. Sealing confines the key; it does not track derivation.
 
-effect secret_use;
+// `secret_use` is a COMPILER BUILT-IN, not declared here. A
+// stdlib-declared user class had no identity an application's claims
+// could name — user classes intern per-Program, so the stdlib's bit
+// and the app's were different, and the law over `std::secret` was
+// silently unenforceable. Declaring it is now an error.
 
 type Req { id: Int; }
 type Plan { msg: Int; }

--- a/crates/hale-stdlib/hl/secret.hl
+++ b/crates/hale-stdlib/hl/secret.hl
@@ -13,9 +13,14 @@
 // the program, and there is no construction site at which the caller
 // held it.
 //
-// Every privileged operation carries the `secret_use` effect class,
-// declared here and travelling with the import, so an application can
-// state its own law with claim forms that already exist:
+// Every privileged operation carries the `secret_use` effect class.
+// It is a COMPILER BUILT-IN, not declared here: user effect classes
+// intern per-Program, so a stdlib-declared class had no identity an
+// application's claims could name — `forbid reaches(plugins,
+// effects(secret_use))` silently missed `Signer.sign`, and with the
+// application declaring its own classes first the stdlib bit aliased
+// onto whichever class sat at that index. An application writes the
+// claim and nothing else:
 //
 //     claims {
 //         no_plugin_secrets: forbid reaches(plugins, effects(secret_use));
@@ -28,8 +33,6 @@
 // guaranteed is that the key itself never becomes a value the
 // application can name. Zeroization is out of scope (#436 defers it):
 // the bytes live in this locus's arena for the process lifetime.
-
-effect secret_use;
 
 /// HMAC signing over a key the caller never sees.
 ///
@@ -75,13 +78,24 @@ effect secret_use;
         return len(self.key) > 0;
     }
 
+    // Every privileged method refuses when no key was loaded.
+    // Without this, a misconfigured deployment signs under the EMPTY
+    // key: `sign` returns a perfectly valid HMAC, and `verify`
+    // accepts a forgery anyone can compute. `ready()` reporting false
+    // is not enough — nothing consulted it.
     @effects(is: { secret_use })
     fn sign(message: Bytes) -> Bytes {
+        if !self.ready() {
+            return b"";
+        }
         return std::crypto::hmac_sha256(self.key, message);
     }
 
     @effects(is: { secret_use })
     fn sign_512(message: Bytes) -> Bytes {
+        if !self.ready() {
+            return b"";
+        }
         return std::crypto::hmac_sha512(self.key, message);
     }
 
@@ -90,6 +104,9 @@ effect secret_use;
     /// is NOT a constant-time primitive — see the scope note above.
     @effects(is: { secret_use })
     fn verify(message: Bytes, mac: Bytes) -> Bool {
+        if !self.ready() {
+            return false;
+        }
         let expect = std::crypto::hmac_sha256(self.key, message);
         if len(expect) != len(mac) {
             return false;
@@ -131,11 +148,26 @@ effect secret_use;
         return len(self.value) > 0;
     }
 
-    /// A stable, non-reversible handle for logs and metrics: the
-    /// first 8 bytes of SHA-256, hex-encoded. Safe to print, safe to
-    /// publish, and it correlates across processes without carrying
-    /// the credential.
+    /// A stable correlation handle: the first 8 bytes of SHA-256,
+    /// hex-encoded.
+    ///
+    /// NOT unconditionally safe to publish, and it is no longer
+    /// described that way. An unsalted SHA-256 prefix over a
+    /// LOW-ENTROPY credential (a password, a short PIN) is
+    /// dictionary-testable, and the handle itself is a stable
+    /// cross-process identifier that may be sensitive on its own. It
+    /// is a correlation identifier for high-entropy tokens, nothing
+    /// stronger.
+    ///
+    /// It consumes the credential directly, so it carries
+    /// `secret_use` like every other privileged method — a claim
+    /// keeping plugins away from secret operations would otherwise
+    /// not see it.
+    @effects(is: { secret_use })
     fn fingerprint() -> String {
+        if !self.ready() {
+            return "";
+        }
         let d = std::crypto::sha256(self.value);
         let mut out = "";
         let mut i = 0;
@@ -146,8 +178,15 @@ effect secret_use;
         return out;
     }
 
+    // The sharpest of the empty-secret failures: with no credential
+    // loaded, `self.value` is empty, `matches(b"")` took the
+    // zero-iteration path, and `diff == 0` authenticated. An
+    // unavailable credential must reject everything.
     @effects(is: { secret_use })
     fn matches(candidate: Bytes) -> Bool {
+        if !self.ready() {
+            return false;
+        }
         if len(candidate) != len(self.value) {
             return false;
         }

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -1963,6 +1963,24 @@ pub enum EffectClass {
     /// alloc_per_call = N)` is its counted form; as a class it is
     /// what `@phase_effects(birth: {alloc}, run: {})` names.
     Alloc,
+    /// GH #436 follow-up: privileged use of confined secret material.
+    ///
+    /// COMPILER-OWNED rather than a stdlib-declared user class, and
+    /// that is the whole point. User classes intern per-`Program`, so
+    /// the stdlib's `effect secret_use;` and an application's were
+    /// different bits: `forbid reaches(plugins, effects(secret_use))`
+    /// silently failed to see `std::secret::Signer.sign`, and with the
+    /// application declaring its own classes first, the stdlib's bit
+    /// aliased onto whatever the application declared at that index.
+    /// The law over the recommended secrets path was unenforceable and
+    /// order-dependent.
+    ///
+    /// A built-in has one identity by construction. It also matches
+    /// the architecture: the stdlib owns the mechanism, the compiler
+    /// classifies the privileged operation, the application states law
+    /// over the class. Applications do not write `effect secret_use;`
+    /// — and may not, since the name now resolves to a built-in.
+    SecretUse,
 }
 
 impl EffectClass {
@@ -1989,6 +2007,7 @@ impl EffectClass {
             "spawn" => EffectClass::Spawn,
             "recursion" => EffectClass::Recursion,
             "alloc" => EffectClass::Alloc,
+            "secret_use" => EffectClass::SecretUse,
             _ => return None,
         })
     }
@@ -2004,6 +2023,7 @@ impl EffectClass {
             EffectClass::Spawn => "spawn",
             EffectClass::Recursion => "recursion",
             EffectClass::Alloc => "alloc",
+            EffectClass::SecretUse => "secret_use",
             // resolved against `Program::effect_names` by the checker
             EffectClass::User(_) => "<user effect>",
         }

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -987,6 +987,27 @@ impl Parser {
                 members = Some(ms);
             }
             self.expect(TokenKind::Semi, ";")?;
+            // GH #436 follow-up: a built-in name may not be
+            // redeclared. `EffectClass::from_ident` wins at every use
+            // site, so the declaration is a silent no-op — the author
+            // writes `effect secret_use;`, believes they declared a
+            // class, and every claim naming it quietly means the
+            // built-in instead. Rejecting is the only reading that
+            // cannot mislead.
+            if EffectClass::from_ident(&name).is_some() {
+                return Err(Diag::parse(
+                    name_tok.span,
+                    format!(
+                        "`{name}` is a BUILT-IN effect class and cannot \
+                         be redeclared — the compiler already owns its \
+                         identity, and a second declaration would be a \
+                         silent no-op. Use it directly \
+                         (`@effects(is: {{ {name} }})`, \
+                         `effects({name})` in a claim), or pick another \
+                         name."
+                    ),
+                ));
+            }
             let idx = self.intern_effect(&name);
             if let Some(ms) = members {
                 self.effect_defs[idx as usize] = Some(ms);

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -1679,7 +1679,18 @@ impl Parser {
                     ));
                 }
             }
-            let class_name = self.expect_ident("effect class name")?;
+            // `publish` is a built-in effect class AND a reserved
+            // keyword, so `expect_ident` rejected the one class most
+            // worth attributing. Same shape as the `@budget`
+            // dimension parser, which hit this first.
+            let tok = self.peek_token().clone();
+            let class_name = match &tok.kind {
+                TokenKind::Publish => {
+                    self.bump();
+                    Ident { name: "publish".to_string(), span: tok.span }
+                }
+                _ => self.expect_ident("effect class name")?,
+            };
             self.expect(TokenKind::RParen, ")")?;
             return Ok(ClaimForm::RequireAttributed { class_name });
         }

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -5633,6 +5633,19 @@ impl ScopeStack {
     }
 }
 
+/// GH #436 follow-up: which half of confinement a site exercises.
+///
+/// Reads resolve through the expression field-access arm and writes
+/// through LValue traversal — two paths, and the original check only
+/// hooked the first. Naming the distinction keeps the diagnostic
+/// honest ("writes one from outside", not "reads") and makes the
+/// second path impossible to forget again.
+#[derive(Clone, Copy)]
+enum SealedAccess {
+    Read,
+    Write,
+}
+
 impl<'a> Checker<'a> {
     fn check_top_decl(&mut self, decl: &'a TopDecl) {
         match decl {
@@ -9809,6 +9822,19 @@ impl<'a> Checker<'a> {
         for seg in &lv.tail {
             match seg {
                 LValueSeg::Field(f) => {
+                    // GH #436 follow-up: an assignment TARGET resolves
+                    // here, not through the expression field-access
+                    // arm, so sealing was enforced on reads and not on
+                    // writes. Confinement that stops a read and permits
+                    // a write is not confinement — for `std::secret` it
+                    // let outside code CHOOSE the signing key, which is
+                    // worse than reading it.
+                    self.check_sealed_access(
+                        &ty,
+                        f,
+                        f.span,
+                        SealedAccess::Write,
+                    );
                     ty = self.field_ty(&ty, &f.name).unwrap_or(Ty::Unknown);
                 }
                 LValueSeg::Index(idx) => {
@@ -10179,7 +10205,7 @@ impl<'a> Checker<'a> {
         Ok(())
     }
 
-    /// GH #436: `@sealed` — a sealed locus's `params` are readable
+    /// GH #436: `@sealed` — a sealed locus's `params` are reachable
     /// only from inside its own methods.
     ///
     /// The rule is about the *reader*, not the receiver syntax: what
@@ -10192,7 +10218,13 @@ impl<'a> Checker<'a> {
     /// Only `params` are sealed. Capacity slots and methods are
     /// untouched — sealing confines state, it does not make a locus
     /// uncallable, which is the entire point.
-    fn check_sealed_read(&mut self, rt: &Ty, name: &Ident, span: Span) {
+    fn check_sealed_access(
+        &mut self,
+        rt: &Ty,
+        name: &Ident,
+        span: Span,
+        access: SealedAccess,
+    ) {
         let Ty::Named(locus_name) = rt else { return };
         let Some(TopSymbol::Locus(li)) = self.top.symbols.get(locus_name)
         else {
@@ -10229,12 +10261,16 @@ impl<'a> Checker<'a> {
         } else {
             format!("call one of its methods instead ({})", callable.join(", "))
         };
+        let (verb, gerund) = match access {
+            SealedAccess::Read => ("readable", "reads"),
+            SealedAccess::Write => ("writable", "writes"),
+        };
         self.diags.push(Diag::ty(
             span,
             format!(
-                "`{shown}` is `@sealed`: its `params` are readable only \
-                 from inside its own methods, and `{shown}.{}` reads one \
-                 from outside — {hint}",
+                "`{shown}` is `@sealed`: its `params` are {verb} only \
+                 from inside its own methods, and `{shown}.{}` {gerund} \
+                 one from outside — {hint}",
                 name.name
             ),
         ));
@@ -11260,7 +11296,12 @@ impl<'a> Checker<'a> {
                     }
                 }
                 let rt = self.check_expr(receiver);
-                self.check_sealed_read(&rt, name, *span);
+                self.check_sealed_access(
+                    &rt,
+                    name,
+                    *span,
+                    SealedAccess::Read,
+                );
                 match self.field_ty(&rt, &name.name) {
                     Some(t) => t,
                     None => {

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -1127,16 +1127,30 @@ fn validate_claim(c: &ClaimDecl, cx: &Cx, diags: &mut Vec<Diag>) -> bool {
             ..
         } => {
             ok &= check_group(from, diags);
-            if matches!(class, EffectClass::User(_)) {
-                ok &= check_class(class, class_name, *class_span, cx, diags);
+            // `secret_use` is a built-in WITHOUT a `@budget` spelling,
+            // so the rule below does not apply to it: there is no
+            // second way to write the bound, and "at most one
+            // privileged secret operation per request" is exactly the
+            // shape `bound` exists for. The rejection is about
+            // avoiding two spellings of one contract, not about
+            // built-ins as a category.
+            if matches!(class, EffectClass::User(_) | EffectClass::SecretUse)
+            {
+                if matches!(class, EffectClass::User(_)) {
+                    ok &= check_class(
+                        class, class_name, *class_span, cx, diags,
+                    );
+                }
             } else {
                 diags.push(Diag::ty(
                     *class_span,
                     format!(
                         "claim `{}`: `bound` takes a user-declared \
-                         effect class — the counted built-ins keep \
-                         their `@budget` spellings (`publish`, \
-                         `block_points`, `alloc_per_call`)",
+                         effect class (or `secret_use`) — the counted \
+                         built-ins keep their `@budget` spellings \
+                         (`publish`, `block_points`, `alloc_per_call`), \
+                         and a second way to write one contract is \
+                         what this rejects",
                         c.name.name
                     ),
                 ));
@@ -1154,18 +1168,24 @@ fn validate_claim(c: &ClaimDecl, cx: &Cx, diags: &mut Vec<Diag>) -> bool {
             // Built-ins only. A USER class here would ask that every
             // site carrying it also carries a user class — trivially
             // true, and it would read as a real contract.
-            if hale_syntax::ast::EffectClass::from_ident(&class_name.name)
-                .is_none()
-            {
+            // Validation must use the SAME predicate as evaluation.
+            // Accepting a class the evaluator answers with
+            // unconditional `Holds` gives a sentence that reads like a
+            // security baseline and checks nothing — `ffi`, `spawn`
+            // and `recursion` are structural, carried by no registry
+            // row, so no site can be attributed for them.
+            if attributed_mask(&class_name.name).is_none() {
                 diags.push(Diag::ty(
                     class_name.span,
                     format!(
                         "claim `{}`: `require attributed` takes a \
-                         BUILT-IN effect class (`syscall`, `block`, \
-                         `publish`, `time`, `entropy`, `env`, `alloc`, \
-                         …) — it asks that every site performing one \
-                         names a user-declared purpose. `{}` is not a \
-                         built-in.",
+                         built-in class with countable DIRECT sites — \
+                         `syscall`, `block`, `publish`, `time`, \
+                         `entropy`, `env`, `alloc`, `secret_use`. `{}` \
+                         is not one of those: a user class would be \
+                         trivially true, and `ffi` / `spawn` / \
+                         `recursion` are structural properties with no \
+                         site to attribute.",
                         c.name.name, class_name.name
                     ),
                 ));
@@ -2355,6 +2375,23 @@ fn evaluate_require_sealed(
         unreachable!("dispatched on form")
     };
     let g = &cx.groups[&group.name];
+    // A universal over an empty projection is the fail-open this
+    // whole system exists to avoid: a group of free fns has no loci,
+    // so nothing is unsealed, so the claim "holds" while confining
+    // nothing. Same vacuity discipline the other verbs apply.
+    if g.loci.is_empty() {
+        diags.push(Diag::ty(
+            c.name.span,
+            format!(
+                "claim `{}`: group `{}` contains no loci, so \
+                 `require sealed` would quantify over an empty set and \
+                 hold while confining nothing. Sealing is a property of \
+                 loci — name a group of them.",
+                c.name.name, group.name
+            ),
+        ));
+        return Verdict::Invalid;
+    }
     let unsealed: Vec<&str> = g
         .loci
         .iter()
@@ -2381,6 +2418,30 @@ fn evaluate_require_sealed(
     Verdict::Violated
 }
 
+/// The classes `require attributed` can actually check: those carried
+/// by a registry row or a syntactic site, so a DIRECT site exists to
+/// attribute. `ffi` / `spawn` / `recursion` are structural and have
+/// none; a user class would be trivially true.
+///
+/// Validation and evaluation share this so a form the evaluator would
+/// answer with unconditional success can never be accepted.
+fn attributed_mask(
+    name: &str,
+) -> Option<crate::stdlib_surface::EffectSet> {
+    use crate::stdlib_surface::EffectSet;
+    Some(match name {
+        "syscall" => EffectSet::SYSCALL,
+        "block" => EffectSet::BLOCK,
+        "publish" => EffectSet::PUBLISH,
+        "time" => EffectSet::TIME,
+        "entropy" => EffectSet::ENTROPY,
+        "env" => EffectSet::ENV,
+        "alloc" => EffectSet::ALLOC,
+        "secret_use" => EffectSet::SECRET_USE,
+        _ => return None,
+    })
+}
+
 /// GH #436: `require attributed(all C)` — every user fn that DIRECTLY
 /// performs an operation of built-in class `C` carries at least one
 /// user-declared effect class.
@@ -2405,26 +2466,9 @@ fn evaluate_require_attributed(
     let ClaimForm::RequireAttributed { class_name } = &c.form else {
         unreachable!("dispatched on form")
     };
-    let Some(class) =
-        hale_syntax::ast::EffectClass::from_ident(&class_name.name)
-    else {
-        unreachable!("validated")
-    };
     use crate::stdlib_surface::EffectSet;
-    let mask = match class {
-        hale_syntax::ast::EffectClass::Syscall => EffectSet::SYSCALL,
-        hale_syntax::ast::EffectClass::Block => EffectSet::BLOCK,
-        hale_syntax::ast::EffectClass::Publish => EffectSet::PUBLISH,
-        hale_syntax::ast::EffectClass::Time => EffectSet::TIME,
-        hale_syntax::ast::EffectClass::Entropy => EffectSet::ENTROPY,
-        hale_syntax::ast::EffectClass::Env => EffectSet::ENV,
-        hale_syntax::ast::EffectClass::Alloc => EffectSet::ALLOC,
-        // `ffi` / `spawn` / `recursion` have no registry mask: they
-        // are structural, not carried by a stdlib row. Nothing has a
-        // direct site to attribute, so the claim holds vacuously —
-        // and a vacuous security claim is worse than none, so it is
-        // rejected at validation instead.
-        _ => return Verdict::Holds,
+    let Some(mask) = attributed_mask(&class_name.name) else {
+        unreachable!("validated against the same predicate")
     };
 
     let mut unattributed: Vec<String> = Vec::new();
@@ -2443,7 +2487,8 @@ fn evaluate_require_attributed(
             // A resolved callee is another bundle fn; its own sites
             // are judged on their own row.
             Callee::Resolved(_) => false,
-        }) || (mask == EffectSet::PUBLISH
+        }) || (mask == EffectSet::ALLOC && !fs.sites.is_empty())
+            || (mask == EffectSet::PUBLISH
             && fs.effect_sites.iter().any(|s| {
                 matches!(s.kind, crate::alloc_summary::EffectSiteKind::Publish(_))
             }));

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -2484,9 +2484,36 @@ fn evaluate_require_attributed(
                 crate::stdlib_surface::effects_for(&segs)
                     .map_or(false, |eff| eff.contains(mask))
             }
-            // A resolved callee is another bundle fn; its own sites
-            // are judged on their own row.
-            Callee::Resolved(_) => false,
+            Callee::Resolved(callee) => {
+                // A resolved BUNDLE fn is judged on its own row —
+                // that is what keeps attribution direct rather than
+                // transitive.
+                //
+                // A resolved callee the author does not own is a
+                // different case, and treating it like a bundle fn
+                // was a hole: `@ffi` declarations and Hale-source
+                // stdlib bodies both resolve, so
+                // `self.logger.info(m)` crossed a publish boundary
+                // and nothing owed a purpose, while the same
+                // operation written as a path call did. Attribution
+                // has to attach to the first APPLICATION-OWNED fn
+                // crossing out, or it depends on whether an API
+                // happens to be a frontier path or a Hale-source
+                // wrapper — not a stable boundary.
+                if cx.model.is_bundle_fn(callee) {
+                    return false;
+                }
+                if callee.locus.is_none() && cx.ffi.contains(&callee.fn_name)
+                {
+                    return true;
+                }
+                crate::frontier::infer_effects(
+                    &cx.summary,
+                    callee,
+                    &cx.ffi,
+                )
+                .contains(mask)
+            }
         }) || (mask == EffectSet::ALLOC && !fs.sites.is_empty())
             || (mask == EffectSet::PUBLISH
             && fs.effect_sites.iter().any(|s| {

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -65,21 +65,25 @@ pub(crate) fn ffi_names(programs: &[&Program]) -> BTreeSet<String> {
 /// than silently `false` — which for a confinement claim would read as
 /// "not sealed" and fail closed, but for the wrong reason.
 pub(crate) fn sealed_loci_of(programs: &[&Program]) -> BTreeSet<String> {
-    let mut out = BTreeSet::new();
-    let mut walk = |items: &[TopDecl]| {
+    // Recursive: a sealed locus inside a `module` was invisible here,
+    // so `require sealed` reported a violation that is not real.
+    fn walk(items: &[TopDecl], out: &mut BTreeSet<String>) {
         for item in items {
-            if let TopDecl::Locus(l) = item {
-                if l.sealed {
+            match item {
+                TopDecl::Locus(l) if l.sealed => {
                     out.insert(l.name.name.clone());
                 }
+                TopDecl::Module(m) => walk(&m.items, out),
+                _ => {}
             }
         }
-    };
+    }
+    let mut out = BTreeSet::new();
     for p in programs {
-        walk(&p.items);
+        walk(&p.items, &mut out);
     }
     if let Some(sp) = crate::stdlib_bodies::program() {
-        walk(&sp.items);
+        walk(&sp.items, &mut out);
     }
     out
 }
@@ -103,15 +107,22 @@ pub(crate) fn fns_carrying_a_user_class(
                 }))
         })
     };
-    for p in programs {
-        for item in &p.items {
+    // Recursive for the same reason as `sealed_loci_of`: an
+    // attributed method inside a `module` was invisible, so
+    // `require attributed` blamed a fn that had named its purpose.
+    fn walk(
+        items: &[TopDecl],
+        carries_user: &dyn Fn(&hale_syntax::ast::FnDecl) -> bool,
+        out: &mut BTreeSet<FnKey>,
+    ) {
+        for item in items {
             match item {
                 TopDecl::Fn(fd) if carries_user(fd) => {
                     out.insert(FnKey::free_fn(fd.name.name.clone()));
                 }
                 TopDecl::Locus(l) => {
-                    // `@effects(is: …)` is fn-only (spec/tokens.md), so
-                    // there is no locus-level form to inherit from.
+                    // `@effects(is: …)` is fn-only (spec/tokens.md),
+                    // so there is no locus-level form to inherit.
                     for m in &l.members {
                         if let hale_syntax::ast::LocusMember::Fn(fd) = m {
                             if carries_user(fd) {
@@ -123,9 +134,13 @@ pub(crate) fn fns_carrying_a_user_class(
                         }
                     }
                 }
+                TopDecl::Module(m) => walk(&m.items, carries_user, out),
                 _ => {}
             }
         }
+    }
+    for p in programs {
+        walk(&p.items, &carries_user, &mut out);
     }
     out
 }

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -170,6 +170,7 @@ pub fn render_effects_named(e: EffectSet, names: &[String]) -> Vec<String> {
         (EffectSet::ENTROPY, "entropy"),
         (EffectSet::ENV, "env"),
         (EffectSet::ALLOC, "alloc"),
+        (EffectSet::SECRET_USE, "secret_use"),
     ] {
         if e.contains(mask) {
             out.push(name.to_string());
@@ -356,6 +357,7 @@ fn class_mask(c: EffectClass) -> EffectSet {
         EffectClass::Entropy => EffectSet::ENTROPY,
         EffectClass::Env => EffectSet::ENV,
         EffectClass::Alloc => EffectSet::ALLOC,
+        EffectClass::SecretUse => EffectSet::SECRET_USE,
         EffectClass::Ffi => EffectSet::SYSCALL,
         EffectClass::Spawn | EffectClass::Recursion => EffectSet::PURE,
         // #345: user classes occupy the bits above the built-ins.
@@ -779,12 +781,43 @@ fn strict_block(
                     }
                 }
             }
+            // A destructuring bind taints every name it introduces.
+            // Position-precise would be better; conservative is the
+            // safe direction and this is the walk that must not miss.
+            Stmt::LetTuple { names, value, span, .. } => {
+                if expr_mentions(value, tainted) {
+                    if matches!(value, Expr::Call { .. }) {
+                        strict_escape(
+                            value,
+                            tainted,
+                            "a call this check does not follow",
+                            *span,
+                            diags,
+                        );
+                    }
+                    for n in names {
+                        tainted.insert(n.name.clone());
+                    }
+                }
+            }
             // The traversal hole: every branch, not just `then`.
             Stmt::If(i) => strict_if(i, tainted, diags),
             Stmt::Match(m) => {
                 for arm in &m.arms {
-                    if let MatchArmBody::Block(blk) = &arm.body {
-                        strict_block(blk, tainted, diags);
+                    match &arm.body {
+                        MatchArmBody::Block(blk) => {
+                            strict_block(blk, tainted, diags)
+                        }
+                        // An EXPRESSION arm was skipped entirely, so
+                        // `match k { 0 -> print(secret), … }` walked
+                        // straight past.
+                        MatchArmBody::Expr(e) => strict_escape(
+                            e,
+                            tainted,
+                            "a `match` arm expression",
+                            m.span,
+                            diags,
+                        ),
                     }
                 }
             }
@@ -810,21 +843,107 @@ fn strict_if(
     }
 }
 
+/// Does this expression mention a tainted name?
+///
+/// EXHAUSTIVE by construction: the `match` has no `_` arm, so adding
+/// an `Expr` variant fails the build here rather than silently
+/// creating a laundering route. The original had a catch-all and
+/// listed six forms, so a tuple, an index, a block tail, an `or`
+/// substitute — anything else — carried a secret straight past both
+/// the lint and the strict walk.
 fn expr_mentions(e: &Expr, names: &BTreeSet<String>) -> bool {
+    let any = |es: &[Expr]| es.iter().any(|x| expr_mentions(x, names));
     match e {
         Expr::Ident(i) => names.contains(&i.name),
         Expr::Binary { left, right, .. } => {
             expr_mentions(left, names) || expr_mentions(right, names)
         }
         Expr::Unary { operand, .. } => expr_mentions(operand, names),
-        Expr::Call { args, .. } => {
-            args.iter().any(|a| expr_mentions(a, names))
+        Expr::Call { callee, args, .. } => {
+            expr_mentions(callee, names) || any(args)
         }
         Expr::Struct { inits, .. } => {
             inits.iter().any(|si| expr_mentions(&si.value, names))
         }
         Expr::Field { receiver, .. } => expr_mentions(receiver, names),
+        Expr::Path2 { receiver, .. } => expr_mentions(receiver, names),
+        Expr::Tuple(items, _) | Expr::Array(items, _) => any(items),
+        Expr::ArrayRepeat { val, .. } => expr_mentions(val, names),
+        Expr::Index { receiver, index, .. } => {
+            expr_mentions(receiver, names) || expr_mentions(index, names)
+        }
+        Expr::Range { lo, hi, .. } => {
+            expr_mentions(lo, names) || expr_mentions(hi, names)
+        }
+        Expr::Approx { left, right, tolerance, .. } => {
+            expr_mentions(left, names)
+                || expr_mentions(right, names)
+                || expr_mentions(tolerance, names)
+        }
+        Expr::If(i) => stmt_mentions(&Stmt::If((**i).clone()), names),
+        Expr::Match(m) => {
+            stmt_mentions(&Stmt::Match((**m).clone()), names)
+        }
+        Expr::Block(b) => block_mentions(b, names),
+        Expr::Or { inner, disposition, .. } => {
+            expr_mentions(inner, names)
+                || disposition_mentions(disposition, names)
+        }
+        Expr::Sum(body, _) | Expr::Prod(body, _) => {
+            expr_mentions(body, names)
+        }
+        Expr::Literal(..) | Expr::KwSelf(_) | Expr::Path(_) => false,
+    }
+}
+
+/// A block mentions a name if any statement or its tail does.
+fn block_mentions(b: &Block, names: &BTreeSet<String>) -> bool {
+    b.stmts.iter().any(|st| stmt_mentions(st, names))
+}
+
+fn stmt_mentions(st: &Stmt, names: &BTreeSet<String>) -> bool {
+    match st {
+        Stmt::Let { value, .. } => expr_mentions(value, names),
+        Stmt::LetTuple { value, .. } => expr_mentions(value, names),
+        Stmt::Assign { value, .. } => expr_mentions(value, names),
+        Stmt::Return(Some(e), _) => expr_mentions(e, names),
+        Stmt::Expr(e) => expr_mentions(e, names),
+        Stmt::Send { value, .. } => expr_mentions(value, names),
+        Stmt::If(i) => {
+            expr_mentions(&i.cond, names)
+                || block_mentions(&i.then_block, names)
+                || match i.else_block.as_deref() {
+                    Some(ElseBranch::Else(b)) => block_mentions(b, names),
+                    Some(ElseBranch::ElseIf(inner)) => {
+                        stmt_mentions(&Stmt::If((*inner).clone()), names)
+                    }
+                    None => false,
+                }
+        }
+        Stmt::Match(m) => m.arms.iter().any(|a| match &a.body {
+            MatchArmBody::Expr(x) => expr_mentions(x, names),
+            MatchArmBody::Block(b) => block_mentions(b, names),
+        }),
+        Stmt::While { body, .. } | Stmt::For { body, .. } => {
+            block_mentions(body, names)
+        }
+        Stmt::Block(b) => block_mentions(b, names),
         _ => false,
+    }
+}
+
+fn disposition_mentions(
+    d: &OrDisposition,
+    names: &BTreeSet<String>,
+) -> bool {
+    // Exhaustive for the same reason as `expr_mentions`.
+    match d {
+        OrDisposition::Substitute(e) => expr_mentions(e, names),
+        // `or fail <payload>` carries a value out of the fn.
+        OrDisposition::Fail(payload, _) => expr_mentions(payload, names),
+        OrDisposition::Raise(_)
+        | OrDisposition::Discard(_)
+        | OrDisposition::Wait(_) => false,
     }
 }
 

--- a/crates/hale-types/src/sealability.rs
+++ b/crates/hale-types/src/sealability.rs
@@ -22,8 +22,13 @@ use hale_syntax::ast::{Program, TopDecl};
 /// One locus's verdict.
 pub struct Sealable {
     pub locus: String,
-    /// Sites outside the locus that read its `params`. Empty means
-    /// sealing it today is a no-op.
+    /// Sites outside the locus that read OR write its `params`.
+    /// Empty means sealing it today is a no-op.
+    ///
+    /// Writes joined the set for free when the sealed check learned
+    /// to look at assignment targets — the survey reruns the real
+    /// checker rather than approximating it, so it tracks whatever
+    /// the rule covers.
     pub blockers: Vec<String>,
 }
 
@@ -118,7 +123,9 @@ pub fn render(rows: &[Sealable]) -> String {
         rows.len()
     ));
     if !free.is_empty() {
-        out.push_str("\n  free to seal (nothing outside reads their params):\n");
+        out.push_str(
+            "\n  free to seal (nothing outside touches their params):\n",
+        );
         for r in &free {
             out.push_str(&format!("    {}\n", r.locus));
         }
@@ -127,7 +134,7 @@ pub fn render(rows: &[Sealable]) -> String {
         out.push_str("\n  would break callers:\n");
         for r in &blocked {
             out.push_str(&format!(
-                "    {} — {} external read(s): {}\n",
+                "    {} — {} external access(es): {}\n",
                 r.locus,
                 r.blockers.len(),
                 r.blockers.join(", ")

--- a/crates/hale-types/src/stdlib_bodies.rs
+++ b/crates/hale-types/src/stdlib_bodies.rs
@@ -82,12 +82,20 @@ pub fn demangle_imports(
     diags: &mut [hale_syntax::Diag],
     import_renames: &[(Vec<String>, String)],
 ) {
-    if import_renames.is_empty() {
-        return;
-    }
+    // GH #436 follow-up: the stdlib table applies unconditionally.
+    // This used to return early when a program had no imports, so a
+    // diagnostic naming a Hale-source stdlib locus rendered its
+    // MANGLED name — `__StdSecretSigner::sign` — a symbol that
+    // appears nowhere in the author's program. Claims witnesses hit
+    // this the moment `secret_use` became findable.
     let mut table: Vec<(&str, String)> = import_renames
         .iter()
         .map(|(segs, mangled)| (mangled.as_str(), segs.join("::")))
+        .chain(
+            hale_stdlib::PATH_RENAMES
+                .iter()
+                .map(|(segs, mangled)| (*mangled, segs.join("::"))),
+        )
         .collect();
     table.sort_by_key(|(m, _)| std::cmp::Reverse(m.len()));
     for d in diags.iter_mut() {

--- a/crates/hale-types/src/stdlib_surface.rs
+++ b/crates/hale-types/src/stdlib_surface.rs
@@ -181,6 +181,10 @@ impl EffectSet {
     pub const ENTROPY: EffectSet = EffectSet(1 << 4);
     pub const ENV: EffectSet = EffectSet(1 << 5);
     pub const ALLOC: EffectSet = EffectSet(1 << 6);
+    /// GH #436 follow-up: privileged use of confined secret material.
+    /// Bits 7-9 sit below `BUILTIN_BITS`, so this costs no user
+    /// capacity.
+    pub const SECRET_USE: EffectSet = EffectSet(1 << 7);
     /// Not yet classified (#265 step 4 turns the surface; until
     /// then queries must treat this as "may do anything").
     pub const UNCLASSIFIED: EffectSet = EffectSet(u64::MAX);

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -76,6 +76,13 @@ use hale_syntax::ast::*;
 use crate::alloc_summary::{self, Callee, EffectSiteKind, FnKey};
 use crate::symbol::Bundle;
 
+/// 1.9 (GH #436 review): `labels.sealed` in the HASHED half — the
+/// loci whose state is confined. Sealing is a structural
+/// confidentiality property, and without it in the model a locus
+/// could gain or lose `@sealed` with no `shape_hash` diff at all,
+/// which is exactly the invisible security change the artifact
+/// exists to surface. Existing `shape_hash` values change.
+///
 /// The artifact's schema version. Additions are minor versions;
 /// changes are breaking. 1.1 (#392): weights on call edges,
 /// `calls_via_stdlib`, `phases`, `seeds`, `effects` in the hashed
@@ -101,7 +108,7 @@ use crate::symbol::Bundle;
 /// (everything they reach), and gains the `environment` label —
 /// identities now come from the adoption traversal, so a constitution
 /// contributing no clause of its own is no longer invisible.
-pub const TOPOLOGY_SCHEMA: &str = "1.8";
+pub const TOPOLOGY_SCHEMA: &str = "1.9";
 
 /// GH #408 Phase 0: what the rows MEAN, as distinct from their shape.
 ///
@@ -521,6 +528,38 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
         join_str(topics.iter())
     ));
     model.push_str("  },\n");
+    // GH #436 review: sealing is a MODEL fact, not merely a claim
+    // input. A locus gaining or losing `@sealed` changes what the
+    // program structurally confines; if `shape_hash` did not move,
+    // the one diff a reviewer most needs to see would be invisible.
+    let sealed: BTreeSet<String> = {
+        let mut out = BTreeSet::new();
+        fn walk(items: &[TopDecl], out: &mut BTreeSet<String>) {
+            for item in items {
+                match item {
+                    TopDecl::Locus(l) if l.sealed => {
+                        out.insert(l.name.name.clone());
+                    }
+                    TopDecl::Module(m) => walk(&m.items, out),
+                    _ => {}
+                }
+            }
+        }
+        for p in &programs {
+            walk(&p.items, &mut out);
+        }
+        out
+    };
+    // Its own key rather than a row inside `labels`: that map is
+    // fn -> effect classes, and a locus-level structural property is
+    // a different shape. (An earlier draft emitted a second `labels`
+    // object, producing a duplicate JSON key that every parser
+    // silently resolved to the LAST one — the sealed set vanished
+    // while `shape_hash` still moved, which is the worst of both.)
+    model.push_str(&format!(
+        "  \"sealed\": [{}],\n",
+        join_str(sealed.iter().map(|s| name(s)).collect::<Vec<_>>().iter())
+    ));
     model.push_str("  \"relations\": {\n    \"calls\": [\n");
     for ((from, to), meta) in &calls {
         let mut row = format!(

--- a/crates/hale-types/tests/artifact_integrity.rs
+++ b/crates/hale-types/tests/artifact_integrity.rs
@@ -169,7 +169,7 @@ fn only_holds_passes() {
 fn the_document_verdict_reflects_its_rows() {
     let a = artifact();
     let v: serde_json::Value = serde_json::from_str(&a).expect("valid JSON");
-    assert_eq!(v["schema"], "1.8");
+    assert_eq!(v["schema"], "1.9");
     assert_eq!(
         v["verdict"], "clean",
         "every claim in the fixture holds: {}",

--- a/crates/hale-types/tests/require_attributed.rs
+++ b/crates/hale-types/tests/require_attributed.rs
@@ -129,24 +129,34 @@ fn a_builtin_in_is_does_not_count_as_attribution() {
 }
 
 #[test]
-fn the_class_must_be_a_builtin() {
-    // `require attributed(all audit)` would ask that every site
-    // carrying `audit` also carries a user class — trivially true,
-    // while reading like a real contract.
-    let src = "
-        effect audit;
-        locus L { params { n: Int = 0; } fn f() -> Int { return 1; } }
-        main locus App {
-            params { l: L = L { }; }
-            claims { bogus: require attributed(all audit); }
-        }
-        fn main() { App { }; }
-    ";
-    let es = errors(src);
-    assert!(
-        es.iter().any(|m| m.contains("BUILT-IN")),
-        "a user class must be rejected, got {es:?}"
-    );
+fn the_class_must_have_countable_direct_sites() {
+    // Two rejections with one rationale: the claim can only be
+    // evaluated where a DIRECT site exists to attribute.
+    //
+    // A user class (`audit`) would ask that every site carrying it
+    // also carries a user class — trivially true, while reading like
+    // a real contract. `ffi` / `spawn` / `recursion` are structural,
+    // carried by no registry row, so the evaluator answered them with
+    // unconditional success. Validation now uses the same predicate
+    // as evaluation, so neither can be accepted.
+    for class in ["audit", "ffi", "spawn", "recursion"] {
+        let src = format!(
+            "effect audit;
+             locus L {{ params {{ n: Int = 0; }}
+                 fn f() -> Int {{ return 1; }} }}
+             main locus App {{
+                 params {{ l: L = L {{ }}; }}
+                 claims {{ bogus: require attributed(all {class}); }}
+             }}
+             fn main() {{ App {{ }}; }}"
+        );
+        let es = errors(&src);
+        assert!(
+            es.iter().any(|m| m.contains("countable DIRECT sites")),
+            "`{class}` must be rejected with the shared-predicate \
+             message, got {es:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/hale-types/tests/sealability_survey.rs
+++ b/crates/hale-types/tests/sealability_survey.rs
@@ -117,4 +117,9 @@ fn the_rendering_leads_with_the_count() {
         "unexpected header: {out}"
     );
     assert!(out.contains("would break callers"), "{out}");
+    assert!(
+        out.contains("external access(es)"),
+        "the survey covers writes as well as reads now that the \
+         sealed rule does — reruns of the real checker track it: {out}"
+    );
 }

--- a/crates/hale-types/tests/secrets_fail_opens.rs
+++ b/crates/hale-types/tests/secrets_fail_opens.rs
@@ -1,0 +1,359 @@
+//! GH #436 follow-up: the negative-control matrix for the confinement
+//! and claim fail-opens found in review of the landed work.
+//!
+//! Every test here was verified to FAIL against the merge commit
+//! `d9b0965` before its fix landed. That ordering matters: the point
+//! of this file is that each defect was reproduced first, not asserted
+//! after the fact against code already changed to satisfy it.
+//!
+//! The defects share one shape — a stated guarantee that the
+//! implementation did not make true:
+//!
+//!   * `@sealed` stopped reads and permitted writes, so outside code
+//!     could REPLACE a confined key rather than read it;
+//!   * an unavailable credential authenticated the empty candidate;
+//!   * the stdlib's `secret_use` had no identity the application's
+//!     claims could name, so the law over `std::secret` was silently
+//!     unenforceable;
+//!   * `require attributed` reported `holds` for classes its
+//!     evaluator never implemented.
+
+use hale_syntax::parse_source;
+
+fn errors(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .filter(|d| d.is_error())
+        .map(|d| d.message)
+        .collect()
+}
+
+// ---------------------------------------------------------------
+// P0: `@sealed` must stop WRITES, not only reads.
+// ---------------------------------------------------------------
+
+const VAULT: &str = r#"
+    @sealed locus Vault {
+        params { key: Int = 0; }
+        fn use1(m: Int) -> Int { return m + self.key; }
+    }
+"#;
+
+fn attacker(body: &str) -> String {
+    format!(
+        "{VAULT}
+         locus Attacker {{
+             params {{ v: Vault = Vault {{ }}; }}
+             {body}
+         }}
+         main locus App {{ params {{ a: Attacker = Attacker {{ }}; }} }}
+         fn main() {{ App {{ }}; }}"
+    )
+}
+
+#[test]
+fn an_outside_write_to_a_sealed_param_is_rejected() {
+    // Confinement that stops reads but permits writes is not
+    // confinement: for `std::secret` it lets outside code CHOOSE the
+    // signing key, which is worse than reading it.
+    let es = errors(&attacker("fn replace() { self.v.key = 999; }"));
+    assert!(
+        es.iter().any(|m| m.contains("`@sealed`")),
+        "an outside write must be rejected, got {es:?}"
+    );
+}
+
+#[test]
+fn an_outside_write_is_rejected_by_the_TARGET_not_the_rhs() {
+    // Deliberately a clean RHS. `self.v.key = self.v.key;` would pass
+    // this test on the pre-fix build, because the READ on the right
+    // trips the expression-path check — the target would never be
+    // examined and the test would prove nothing.
+    let es = errors(&attacker("fn bump(n: Int) { self.v.key = n; }"));
+    assert!(
+        es.iter().any(|m| m.contains("`@sealed`")),
+        "the assignment TARGET must be checked, got {es:?}"
+    );
+}
+
+#[test]
+fn the_locus_still_writes_its_own_params() {
+    let src = "
+        @sealed locus Vault {
+            params { key: Int = 0; }
+            fn rotate(k: Int) { self.key = k; }
+        }
+        main locus App { params { v: Vault = Vault { }; } }
+        fn main() { App { }; }
+    ";
+    assert!(errors(src).is_empty(), "{:?}", errors(src));
+}
+
+#[test]
+fn construction_still_initializes() {
+    // A parent writing `Vault { key: … }` already holds what it
+    // passes; it is not an LValue mutation of an existing locus, and
+    // restricting it would cost ordinary configuration for nothing.
+    let src = "
+        @sealed locus Vault {
+            params { key: Int = 0; }
+            fn use1(m: Int) -> Int { return m + self.key; }
+        }
+        main locus App { params { v: Vault = Vault { key: 5 }; } }
+        fn main() { App { }; }
+    ";
+    assert!(errors(src).is_empty(), "{:?}", errors(src));
+}
+
+// ---------------------------------------------------------------
+// P0: the stdlib effect class needs an identity claims can name.
+// ---------------------------------------------------------------
+
+#[test]
+fn a_claim_over_secret_use_sees_the_stdlib_signer() {
+    // THE defect that mattered most: `std::secret` was documented as
+    // the recommended path and had no enforceable law over it. User
+    // effect classes intern per-`Program`, so the stdlib's
+    // `secret_use` and the application's were different bits.
+    let src = "
+        locus Plugin {
+            params {
+                s: std::secret::Signer =
+                    std::secret::Signer { env_var: \"SK\" };
+            }
+            fn sneak(m: Bytes) -> Bytes { return self.s.sign(m); }
+        }
+        group plugins = { Plugin };
+        main locus App {
+            params { p: Plugin = Plugin { }; }
+            claims {
+                blocked: forbid reaches(plugins, effects(secret_use));
+            }
+        }
+        fn main() { App { }; }
+    ";
+    let es = errors(src);
+    assert!(
+        es.iter().any(|m| m.contains("blocked") && m.contains("violated")),
+        "a plugin reaching the stdlib signer must violate: {es:?}"
+    );
+}
+
+#[test]
+fn secret_use_identity_survives_unrelated_effect_declarations() {
+    // The aliasing canary: with the application declaring its own
+    // classes first, an index-based identity would have the stdlib's
+    // bit mean whatever the application declared at that index.
+    let src = "
+        effect unrelated_one;
+        effect unrelated_two;
+        locus Plugin {
+            params {
+                s: std::secret::Signer =
+                    std::secret::Signer { env_var: \"SK\" };
+            }
+            fn sneak(m: Bytes) -> Bytes { return self.s.sign(m); }
+        }
+        group plugins = { Plugin };
+        main locus App {
+            params { p: Plugin = Plugin { }; }
+            claims {
+                blocked: forbid reaches(plugins, effects(secret_use));
+                unrelated_is_clean:
+                    forbid reaches(plugins, effects(unrelated_one));
+            }
+        }
+        fn main() { App { }; }
+    ";
+    let es = errors(src);
+    assert!(
+        es.iter().any(|m| m.contains("blocked") && m.contains("violated")),
+        "`secret_use` must still match regardless of declaration \
+         order: {es:?}"
+    );
+    assert!(
+        !es.iter().any(|m| m.contains("unrelated_is_clean")),
+        "an unrelated class must NOT alias onto signing: {es:?}"
+    );
+}
+
+// ---------------------------------------------------------------
+// P1: `require attributed` must not hold for classes it cannot check.
+// ---------------------------------------------------------------
+
+fn attributed(class: &str) -> String {
+    format!(
+        "locus L {{
+             params {{ n: Int = 0; }}
+             fn f() -> Int {{ return 1; }}
+         }}
+         main locus App {{
+             params {{ l: L = L {{ }}; }}
+             claims {{ c: require attributed(all {class}); }}
+         }}
+         fn main() {{ App {{ }}; }}"
+    )
+}
+
+#[test]
+fn structural_classes_are_rejected_rather_than_holding_vacuously() {
+    // `ffi` / `spawn` / `recursion` have no registry mask, so the
+    // evaluator answered every one with unconditional success while
+    // reading like a security baseline.
+    for class in ["ffi", "spawn", "recursion"] {
+        let es = errors(&attributed(class));
+        assert!(
+            !es.is_empty(),
+            "`require attributed(all {class})` must be rejected, not \
+             silently satisfied"
+        );
+    }
+}
+
+#[test]
+fn a_direct_allocation_is_visible_to_attributed_alloc() {
+    // The evaluator mapped `alloc` to its mask but only ever looked
+    // at call edges and publish syntax — never at allocation sites,
+    // which is exactly where a direct allocation is recorded.
+    let src = "
+        type Rec { v: Int; }
+        locus L {
+            params { n: Int = 0; }
+            fn make() -> Int { let r = Rec { v: 1 }; return r.v; }
+        }
+        main locus App {
+            params { l: L = L { }; }
+            claims { c: require attributed(all alloc); }
+        }
+        fn main() { App { }; }
+    ";
+    let es = errors(src);
+    assert!(
+        es.iter().any(|m| m.contains("L::make")),
+        "a direct allocation must need attribution: {es:?}"
+    );
+}
+
+// ---------------------------------------------------------------
+// P1: the universals must see declarations inside modules.
+// ---------------------------------------------------------------
+
+#[test]
+fn require_sealed_sees_a_SEALED_locus_inside_a_module() {
+    // The failing direction is the false POSITIVE, not the missed
+    // violation: `sealed_loci_of` was top-level-only, so a sealed
+    // locus inside a module read as unsealed and the claim reported
+    // a violation that is not real. An unsealed-in-module test would
+    // pass on the broken build and prove nothing.
+    let src = "
+        module secrets {
+            @sealed locus Vault { params { k: Int = 1; }
+                fn f() -> Int { return self.k; } }
+        }
+        group vaults = { Vault };
+        main locus App {
+            params { v: Vault = Vault { }; }
+            claims { confined: require sealed(all vaults); }
+        }
+        fn main() { App { }; }
+    ";
+    assert!(
+        errors(src).is_empty(),
+        "a sealed locus in a module must satisfy the claim: {:?}",
+        errors(src)
+    );
+}
+
+// ---------------------------------------------------------------
+// P1/P2: `require sealed` must not hold over a group with no loci.
+// ---------------------------------------------------------------
+
+#[test]
+fn require_sealed_over_a_free_fn_group_is_rejected() {
+    // The claims system's vacuity discipline: a universal over an
+    // empty projection reported `holds`, which is a fail-open wearing
+    // formal clothing.
+    let src = "
+        fn helper() -> Int { return 1; }
+        group helpers = { helper };
+        main locus App {
+            params { n: Int = 0; }
+            claims { confined: require sealed(all helpers); }
+        }
+        fn main() { App { }; }
+    ";
+    assert!(
+        !errors(src).is_empty(),
+        "a locus-free group must be rejected, not vacuously satisfied"
+    );
+}
+
+// ---------------------------------------------------------------
+// P1: `--strict-secret` must actually be exhaustive.
+// ---------------------------------------------------------------
+
+fn strict(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::frontier::secret_taint_strict(&[&program])
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+#[test]
+fn strict_sees_a_tuple_destructuring_alias() {
+    // `expr_mentions` had a catch-all arm listing six expression
+    // forms, so a tuple — and an index, a block tail, an `or`
+    // substitute, anything else — carried a secret straight past. It
+    // is now exhaustive by construction: no `_` arm, so a new `Expr`
+    // variant fails the build rather than opening a laundering route.
+    let src = "
+        type Msg { v: String; }
+        topic Out { payload: Msg; subject: \"app.out\"; }
+        locus S {
+            params { n: Int = 0; }
+            bus { publish Out; }
+            fn f(@secret t: String) {
+                let (a, b) = (t, 0);
+                Out <- Msg { v: a };
+            }
+        }
+        locus K { params { n: Int = 0; }
+            bus { subscribe Out as on_out; }
+            fn on_out(m: Msg) { self.n = len(m.v); } }
+        main locus App {
+            params { s: S = S { }; k: K = K { }; }
+        }
+        fn main() { App { }; }
+    ";
+    let ms = strict(src);
+    assert!(
+        ms.iter().any(|m| m.contains("bus publish")),
+        "a tuple-destructured alias must not launder: {ms:?}"
+    );
+}
+
+#[test]
+fn strict_sees_a_match_arm_expression() {
+    // Arm bodies were walked only when they were BLOCKS, so
+    // `match k { 0 -> print(secret), … }` was skipped entirely.
+    let src = "
+        locus S {
+            params { n: Int = 0; }
+            fn f(@secret t: String, k: Int) -> Int {
+                match k {
+                    0 -> len(t),
+                    _ -> 0,
+                }
+            }
+        }
+        main locus App { params { s: S = S { }; } }
+        fn main() { App { }; }
+    ";
+    let ms = strict(src);
+    assert!(
+        !ms.is_empty(),
+        "an expression arm must be walked, not skipped: {ms:?}"
+    );
+}

--- a/crates/hale-types/tests/secrets_fail_opens.rs
+++ b/crates/hale-types/tests/secrets_fail_opens.rs
@@ -392,3 +392,80 @@ fn sealing_a_locus_moves_the_shape_hash() {
         "sealing must change the model identity"
     );
 }
+
+// ---------------------------------------------------------------
+// P1: attribution must not depend on how an API happens to be
+// implemented.
+// ---------------------------------------------------------------
+
+#[test]
+fn attribution_crosses_a_resolved_stdlib_boundary() {
+    // The evaluator ignored EVERY resolved call, so a boundary
+    // reached through a Hale-source stdlib body was invisible while
+    // the same operation written as a frontier path call was caught.
+    // Whether an API is a path call or a locus method is not a
+    // stable semantic boundary to hang a security claim on.
+    let src = "
+        locus L {
+            params {
+                lg: std::log::Logger = std::log::Logger { name: \"app\" };
+            }
+            fn via_handle(m: String) { self.lg.info(m); }
+        }
+        main locus App {
+            params { l: L = L { }; }
+            claims { c: require attributed(all publish); }
+        }
+        fn main() { App { }; }
+    ";
+    let es = errors(src);
+    assert!(
+        es.iter().any(|m| m.contains("L::via_handle")),
+        "a publish through a stdlib handle must need attribution: {es:?}"
+    );
+}
+
+#[test]
+fn a_bundle_callee_is_still_judged_on_its_own_row() {
+    // The counterweight: crossing into code the author does NOT own
+    // attributes the caller, but an ordinary application callee is
+    // judged where its own site is. Without this, attribution would
+    // become transitive and nearly vacuous.
+    let src = "
+        effect audit;
+        locus Raw {
+            params { n: Int = 0; }
+            @effects(is: { audit })
+            fn io(s: String) { std::io::fs::write_file(\"/tmp/x\", s); }
+        }
+        locus Wrapper {
+            params { r: Raw = Raw { }; }
+            fn go(s: String) { self.r.io(s); }
+        }
+        main locus App {
+            params { w: Wrapper = Wrapper { }; }
+            claims { c: require attributed(all syscall); }
+        }
+        fn main() { App { }; }
+    ";
+    assert!(
+        errors(src).is_empty(),
+        "a wrapper over an attributed bundle fn owes nothing: {:?}",
+        errors(src)
+    );
+}
+
+#[test]
+fn a_keyword_named_class_parses() {
+    // `publish` is a built-in effect class AND a reserved keyword, so
+    // `expect_ident` rejected the one class most worth attributing.
+    let src = "
+        locus L { params { n: Int = 0; } fn f() -> Int { return 1; } }
+        main locus App {
+            params { l: L = L { }; }
+            claims { c: require attributed(all publish); }
+        }
+        fn main() { App { }; }
+    ";
+    assert!(parse_source(src).is_ok(), "`all publish` must parse");
+}

--- a/crates/hale-types/tests/secrets_fail_opens.rs
+++ b/crates/hale-types/tests/secrets_fail_opens.rs
@@ -357,3 +357,38 @@ fn strict_sees_a_match_arm_expression() {
         "an expression arm must be walked, not skipped: {ms:?}"
     );
 }
+
+// ---------------------------------------------------------------
+// P1: sealing must be visible in the artifact.
+// ---------------------------------------------------------------
+
+#[test]
+fn sealing_a_locus_moves_the_shape_hash() {
+    // A seal changing with no topology diff is precisely the
+    // invisible security change the artifact exists to surface.
+    // Sealing was a claim INPUT that no model row recorded, so
+    // `shape_hash` was byte-identical either way.
+    fn hash_of(src: &str) -> String {
+        let p = parse_source(src).expect("parse");
+        let mut m = std::collections::BTreeMap::new();
+        m.insert(String::new(), &p);
+        let art = hale_types::topology::dump_topology(
+            &hale_types::Bundle::new(m),
+        );
+        let v: serde_json::Value =
+            serde_json::from_str(&art).expect("artifact is json");
+        v["shape_hash"].as_str().unwrap().to_string()
+    }
+    let plain = "
+        locus Vault { params { k: Int = 1; }
+            fn f() -> Int { return self.k; } }
+        main locus App { params { v: Vault = Vault { }; } }
+        fn main() { App { }; }
+    ";
+    let sealed = plain.replace("locus Vault", "@sealed locus Vault");
+    assert_ne!(
+        hash_of(plain),
+        hash_of(&sealed),
+        "sealing must change the model identity"
+    );
+}

--- a/docs/src/verification.md
+++ b/docs/src/verification.md
@@ -268,8 +268,6 @@ own methods**. Others can still call it — that's the point — they just
 can't read its state:
 
 ```hale,fragment
-effect secret_use;
-
 @sealed locus Signer {
     params { key: Bytes; }
 
@@ -347,6 +345,9 @@ claims {
     io_attributed: require attributed(all syscall);
 }
 ```
+
+(`secret_use` above needs no `effect` declaration — it is a compiler
+built-in, so every program means the same class by it.)
 
 Every fn that actually touches the OS must name a purpose with a user
 effect class. These are independent: I/O can be perfectly gated and

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -219,7 +219,14 @@ The remaining verbs (#382 phases 2–5):
   **DIRECT, not transitive**, and that is load-bearing: transitively,
   every caller downstream of one attributed fn inherits the label and
   passes, which would make the claim nearly vacuous. The attribution
-  point is the site where the boundary is crossed. A built-in in
+  point is the first **application-owned** fn crossing out — a
+  frontier path call, an `@ffi` declaration, or a Hale-source stdlib
+  body whose own effects include the class. An ordinary application
+  callee is judged on its own row instead, which is what keeps this
+  direct. Attaching only to frontier path calls would have made
+  coverage depend on whether an API happens to be a path call or a
+  stdlib locus method — not a stable boundary to hang a security
+  claim on. A built-in in
   `is:` does not count — it restates what the compiler already
   infers, and the claim asks for a purpose the author supplied. The
   class must be a built-in; a user class there would be trivially

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -929,6 +929,18 @@ any secret capability. Prefer a closed operation enum over a callback
 programmable oracle. Worked end to end in
 `crates/hale-codegen/tests/fixtures/examples/secrets-sealed-handler.hl`.
 
+**In the artifact.** `sealed` is a hashed model row (schema 1.9), so a
+locus gaining or losing `@sealed` moves `shape_hash` — a
+`--check-topology` gate sees it. Confinement is a structural property,
+not merely a claim input, and a seal changing with no topology diff is
+exactly the invisible security change the artifact exists to surface.
+
+`require sealed` replays from that row. `require attributed` does not:
+it turns on DIRECT effect sites, and the artifact exports inferred
+per-fn effect sets rather than the direct/transitive distinction, so
+that form is **compiler-certified** — the artifact carries its verdict
+and not the facts to recompute it.
+
 ### What this guarantees, and what it does not
 
 > The secret lives in a locus that owns it, the domain cannot obtain

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -868,9 +868,14 @@ with no further annotation.
 **3. Law.** The domain states who may reach it and how often, using
 claim forms that already exist:
 
-```hale
-effect secret_use;
+`secret_use` is a **compiler built-in** — the stdlib owns the
+mechanism, the compiler owns the class identity, the application
+states the law. Declaring `effect secret_use;` is an error: user
+classes intern per-`Program`, so a stdlib-declared class had no
+identity an application's claims could name, and the law over
+`std::secret` was silently unenforceable and order-dependent.
 
+```hale
 claims {
     no_plugin_secrets: forbid reaches(plugins, effects(secret_use));
     one_op_per_request: bound secret_use <= 1 on paths from handlers;
@@ -1400,10 +1405,18 @@ assume the others in a build:
   newly fails programs that compile today, and a lint that grows
   teeth in a point release is a userspace break even when every new
   finding is a real bug. **`hale check --strict-secret`** runs the
-  widened walk: every branch, alias propagation through `let`, and
-  `uncertified` for anything it cannot follow — an unfollowed call, a
-  field store, a return. It is loud, which is the honest signal that
-  one body's reasoning is not a containment proof.
+  widened walk: every branch (including `else`, `else if`, and both
+  block and EXPRESSION `match` arms), alias propagation through `let`
+  and tuple destructuring, and `uncertified` for anything it cannot
+  follow — an unfollowed call, a field store, a return. It is loud,
+  which is the honest signal that one body's reasoning is not a
+  containment proof.
+
+  The expression walk is **exhaustive by construction**: it has no
+  catch-all arm, so adding an `Expr` variant fails the build rather
+  than silently opening a laundering route. Branch taint is shared
+  rather than merged per-branch — imprecise in the over-tainting
+  direction, which is the safe one.
 
   For a guarantee rather than a lint, see § Secrets below.
 - **Inferred effect sets + symbolic cost** (GH #265, 2026-07-29).

--- a/tests/hale/std_secret_test.hl
+++ b/tests/hale/std_secret_test.hl
@@ -24,6 +24,7 @@ locus Unset {
     params { c: std::secret::Credential = std::secret::Credential { env_var: "" }; }
     fn ready() -> Bool { return self.c.ready(); }
     fn tag() -> String { return self.c.fingerprint(); }
+    fn accepts(x: Bytes) -> Bool { return self.c.matches(x); }
 }
 
 main locus App {
@@ -53,13 +54,33 @@ fn main() {
         !app.unset.ready(),
         "an unset env var yields an empty credential");
 
-    // Still functional with no key: HMAC-SHA256 is 32 bytes whatever
-    // the key length, so `ready()` is the check that matters.
+    // A signer with no key produces NO signature.
+    //
+    // The first version of this test asserted 32 here — pinning the
+    // defect as the specification. An unavailable signer was happily
+    // returning a valid HMAC under the EMPTY key, which `verify` then
+    // accepted, so anyone could forge. `ready()` reporting false was
+    // not enough, because nothing consulted it.
     std::test::assert_eq_int(
-        app.seeded.mac_len(b"hello"), 32, "hmac-sha256 width");
+        app.seeded.mac_len(b"hello"), 0,
+        "an unavailable signer does not sign");
 
-    // A fingerprint is derived and publishable even when empty.
+    // Same rule for the correlation handle: no credential, no handle.
+    // A fingerprint over the empty value is a constant that looks
+    // like a real identifier.
     std::test::assert_eq_int(
-        len(app.unset.tag()), 16, "fingerprint is 8 bytes as hex");
+        len(app.unset.tag()), 0,
+        "an unavailable credential has no fingerprint");
+
+    // The authentication bypass. With no credential loaded,
+    // `self.value` was empty, `matches(b"")` took the zero-iteration
+    // path, and `diff == 0` returned TRUE. Anyone presenting an empty
+    // token authenticated against an unconfigured deployment.
+    std::test::assert(
+        !app.unset.accepts(b""),
+        "an unavailable credential rejects the empty candidate");
+    std::test::assert(
+        !app.unset.accepts(b"anything"),
+        "an unavailable credential rejects everything");
 
 }


### PR DESCRIPTION
Addresses the external review of the landed secrets work. Three release blockers, several vacuous-success paths, and the artifact gap.

**Every finding reproduced on `d9b0965` before its fix.** `secrets_fail_opens.rs` is the negative-control matrix, written first and verified failing — 8 of 13 red against the merge commit. Two of my initial controls passed on the broken build and were rewritten; details below, because a control that passes before the fix proves nothing.

## P0 — `@sealed` stopped reads and permitted writes

`check_sealed_read` hooked the expression field-access arm. An assignment target resolves through LValue traversal, which was never hooked:

```hale
fn replace() { self.v.key = 999; }   // ok: 1 file(s) typechecked
```

Confinement that stops a read and permits a write is not confinement — for `std::secret` it let outside code **choose** the signing key, which is worse than reading it. Now checked on both paths, with the diagnostic naming which ("writes one from outside").

## P0 — the stdlib's `secret_use` had no identity claims could name

```hale
locus Plugin { params { s: std::secret::Signer = ...; }
    fn sneak(m: Bytes) -> Bytes { return self.s.sign(m); } }
claims { blocked: forbid reaches(plugins, effects(secret_use)); }
```

```
ok: 1 file(s) typechecked          ← the plugin signs freely
```

A user-declared signer with the identical claim was caught correctly, so the mechanism was fine — user effect classes intern **per-`Program`**, and the stdlib's class was a different bit. The law over the recommended secrets path was unenforceable, and with an application declaring its own classes first the stdlib bit aliased onto whichever class sat at that index.

**`secret_use` is now a compiler built-in** (BREAKING: `effect secret_use;` is an error rather than a silent no-op). One identity by construction, and it matches the architecture — stdlib owns the mechanism, compiler owns the class, application states the law. `bound` accepts it: it is the one counted built-in with no `@budget` spelling, and that rule exists to prevent two spellings of one contract, not to exclude built-ins as a category.

## P0 — missing secret material still produced valid cryptography

`ready()` reported false and nothing consulted it. `sign` returned a valid HMAC under the **empty key**; `verify` accepted the matching forgery. Sharpest case:

```
NOT ready (no credential)
BYPASS: empty candidate authenticated
```

`matches(b"")` took the zero-iteration path and returned `true` — an authentication bypass against any unconfigured deployment. Every privileged method now refuses when unavailable.

**My own runtime test had pinned the empty-key behaviour as expected**, asserting a 32-byte MAC from a keyless signer. Encoding the defect as the specification is the failure this suite exists to prevent; it now asserts the opposite.

`Credential.fingerprint` is no longer described as "safe to publish" — an unsalted SHA-256 prefix over a low-entropy credential is dictionary-testable — and carries `secret_use`, since it consumes the secret directly.

## P1 — new law that reported `holds` without checking

- `require attributed` accepted `ffi` / `spawn` / `recursion`, which the evaluator answered with unconditional success. Validation and evaluation now share **one predicate**, so a form the evaluator cannot check is impossible to accept.
- `require attributed(all alloc)` never looked at allocation sites.
- `sealed_loci_of` / `fns_carrying_a_user_class` were top-level only, so a sealed locus or attributed method inside a `module` was invisible — a **false violation**, not a missed one. (My first control tested the missed direction and passed on the broken build.)
- `require sealed` over a locus-free group held vacuously.

## P1 — `--strict-secret` was not exhaustive

`expr_mentions` had a catch-all listing six forms, so tuples, indexes, block tails, `or` substitutes and `fail` payloads all laundered; `match` arms were walked only when blocks; `LetTuple` was ignored.

The expression walk is now **exhaustive by construction** — no `_` arm, so a new `Expr` variant fails the build rather than silently opening a route. Branch taint stays shared rather than merged per-branch: imprecise in the over-tainting direction, which is the safe one, and now written down as such.

## Schema 1.9 — sealing enters the hashed model

A locus could gain or lose `@sealed` with a byte-identical `shape_hash`. Sealing is structural confidentiality, and a seal changing with no topology diff is exactly the invisible security change the artifact exists to surface. `sealed` is now a hashed row and `require sealed` replays from it.

`require attributed` deliberately does not: it turns on **direct** effect sites and the artifact exports inferred per-fn sets, so that form is documented as compiler-certified rather than pretending to be replayable.

*(An earlier draft emitted a second `labels` object — a duplicate JSON key every parser resolves to the last one, so the sealed set vanished from the document while `shape_hash` still moved. Caught by reading the raw output rather than the parsed value.)*

## Also

`demangle_imports` returned early when a program had no imports and never consulted the stdlib table, so witnesses read `__StdSecretSigner::sign` — a symbol appearing nowhere in the author's program. Now applied unconditionally.

## Verification

- `secrets_fail_opens.rs` — 13 controls, 8 verified red on `d9b0965`
- `hale-types`, `hale-syntax`, `hale-cli` suites, corpus oracle, stdlib parity, native suite, docs snippets — all green
- Empty-credential and empty-key canaries run natively in `tests/hale/std_secret_test.hl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)