### PR TITLE
fix(effects): close secret_use universes and attribution holes (GH #436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,8 +182,16 @@ External review of the landed work found three release blockers. All
 reproduced; the negative controls in `secrets_fail_opens.rs` were
 written and verified failing first.
 
-**BREAKING: `secret_use` is now a compiler built-in.** `effect
-secret_use;` is an error. User effect classes intern per-`Program`, so
+**BREAKING: every built-in effect name is now reserved.** `effect
+secret_use;` is an error — and so are `effect syscall;`, `effect
+block;`, `effect entropy;` and the rest. Those declarations were
+always silent no-ops (`EffectClass::from_ident` wins at every use
+site), so a program that wrote one believed it had declared a class
+while every claim naming it quietly meant the built-in. The break is
+narrow in practice and broader than "`secret_use` is new", which is
+why it is stated as the general rule.
+
+`secret_use` itself is now a compiler built-in. User effect classes intern per-`Program`, so
 the stdlib-declared class had no identity an application's claims
 could name: `forbid reaches(plugins, effects(secret_use))` silently
 missed `std::secret::Signer.sign` — the law over the recommended
@@ -199,7 +207,11 @@ field-access path, so `self.vault.key = 999` typechecked — for
 
 **`std::secret` fails closed.** `ready()` reported false and nothing
 consulted it, so `sign` returned a valid HMAC under the empty key and
-`verify` accepted the matching forgery. Sharpest case:
+`verify` accepted the matching forgery. Precisely: when the source is
+unavailable, signing returns an **empty result** and verification
+rejects — refusal by sentinel, not a startup failure. Gate startup on
+`ready()`; a structural birth failure may be better later and is not
+needed for the security property. Sharpest case:
 `matches(b"")` against an unloaded credential returned **true** — an
 authentication bypass on any unconfigured deployment.
 `fingerprint` is no longer described as "safe to publish" and now
@@ -230,6 +242,41 @@ diagnostics rendered mangled stdlib names.
 moves `shape_hash`. `require sealed` replays from the artifact;
 `require attributed` is compiler-certified, since the artifact exports
 inferred rather than direct effect sites.
+
+### Effect-system completeness (GH #436 review 2)
+
+Adding a compiler-owned class had two integration seams the first
+test matrix did not cover: the **closed universes**.
+
+`@effects(only: {…})` is the complement of a hardcoded class list and
+`@phase_effects` iterates another, so a class absent from either is
+one those contracts can never forbid. **`only: {}` certified a fn
+reaching `secret_use`**, and `@phase_effects(run: {})` admitted it
+during run — contracts whose entire purpose is rejecting unlisted
+effects were weaker than they read. Both universes now include it.
+
+Three attribution holes closed:
+
+* An **`@ffi` declaration** is now the direct boundary site rather
+  than its caller. The caller-side branch was unreachable (an `@ffi`
+  fn is a bundle decl, so the bundle test short-circuited first) and
+  the wrong shape besides — it returned true for every mask, so one
+  foreign call would have read as `publish`, `entropy` and
+  `secret_use` at once.
+* A fn's **own `@effects(is: {C})`** counts as a direct site. Without
+  it, `@effects(is: { secret_use }) fn sign(…)` — the shape the whole
+  secrets architecture rests on — was invisible, because it calls
+  nothing classified and allocates nothing.
+* An **indirect or opaque call** now leaves the claim `uncertified`
+  unless the caller already names a purpose. Attribution had asked
+  only whether a textual name sat in the stdlib registry, so a
+  callback parameter contributed nothing and the law reported `holds`
+  over a boundary it could not see.
+
+`--strict-secret` also missed **block tails** (`fn f(@secret t) { t }`
+— an implicit return; `block_mentions` promised the tail in its doc
+comment and checked only statements) and `fail` / `violate` payloads
+and `ShmWrite` bodies.
 
 ### `hale check --sealable` — the adoption survey (GH #436)
 

--- a/crates/hale-stdlib/hl/secret.hl
+++ b/crates/hale-stdlib/hl/secret.hl
@@ -72,8 +72,15 @@
         }
     }
 
-    /// Was a key actually loaded? A misconfigured deployment should
-    /// fail at startup, not produce signatures under an empty key.
+    /// Was a key actually loaded?
+    ///
+    /// Gate startup on this. When the source is unavailable the
+    /// privileged methods REFUSE — `sign` returns an empty result,
+    /// `verify` and `matches` return false — rather than computing
+    /// under the empty key, which anyone could forge against. That is
+    /// refusal by sentinel, not a startup failure: nothing stops a
+    /// misconfigured program from running, only from producing a
+    /// privileged result.
     fn ready() -> Bool {
         return len(self.key) > 0;
     }

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -2478,7 +2478,33 @@ fn evaluate_require_attributed(
         if !cx.model.is_bundle_fn(key) {
             continue;
         }
-        let performs_directly = fs.calls.iter().any(|e| match &e.callee {
+        // GH #436 review 2: the `@ffi` DECLARATION is the boundary,
+        // not its caller. Attributing the caller was unreachable
+        // anyway — an `@ffi` fn is a bundle decl, so `is_bundle_fn`
+        // short-circuited before the FFI test — and it was the wrong
+        // shape besides: the old branch returned true for EVERY mask,
+        // so one foreign call would have read as publish, entropy and
+        // secret_use at once. The declaration is application-owned
+        // and can carry the purpose itself, which keeps ordinary
+        // callers ordinary and attribution direct.
+        let direct_ffi = mask == EffectSet::SYSCALL
+            && key.locus.is_none()
+            && cx.ffi.contains(&key.fn_name);
+        // A fn that DECLARES it carries the class is a direct site by
+        // definition. Without this, `@effects(is: { secret_use }) fn
+        // sign(…)` — the whole shape the secrets architecture rests
+        // on — was invisible to `require attributed(all secret_use)`,
+        // because it calls nothing classified and allocates nothing.
+        // A built-in in `is:` establishes that the operation exists;
+        // it still is not its purpose, so a user class is required.
+        let directly_classified = cx
+            .summary
+            .carries
+            .get(key)
+            .map_or(false, |eff| eff.contains(mask));
+        let performs_directly = direct_ffi
+            || directly_classified
+            || fs.calls.iter().any(|e| match &e.callee {
             Callee::Unresolved(name) => {
                 let segs: Vec<&str> = name.split("::").collect();
                 crate::stdlib_surface::effects_for(&segs)
@@ -2503,10 +2529,6 @@ fn evaluate_require_attributed(
                 if cx.model.is_bundle_fn(callee) {
                     return false;
                 }
-                if callee.locus.is_none() && cx.ffi.contains(&callee.fn_name)
-                {
-                    return true;
-                }
                 crate::frontier::infer_effects(
                     &cx.summary,
                     callee,
@@ -2529,7 +2551,63 @@ fn evaluate_require_attributed(
             });
         }
     }
+    // GH #436 review 2: an unresolved call the callgraph knows is
+    // INDIRECT or opaque may do anything — the general effect engine
+    // already treats it as unclassified for exactly this reason.
+    // Attribution asked only whether the textual name sat in the
+    // stdlib registry, so a callback parameter contributed nothing
+    // and the law reported `holds` over a boundary it could not see.
+    // Same refusal-to-certify posture as the rest of the stack: a fn
+    // that already names a purpose has attributed the potential
+    // crossing; one that does not leaves the claim uncertified.
     if unattributed.is_empty() {
+        let opaque: Vec<String> = cx
+            .summary
+            .fns
+            .iter()
+            .filter(|(key, _)| cx.model.is_bundle_fn(key))
+            .filter(|(key, fs)| {
+                !fn_carries_a_user_class(key, cx)
+                    && fs.calls.iter().any(|e| match &e.callee {
+                        Callee::Unresolved(n) => {
+                            // A frontier path is classified, so it is
+                            // not a hole; anything else unresolved is.
+                            let segs: Vec<&str> = n.split("::").collect();
+                            crate::stdlib_surface::effects_for(&segs)
+                                .is_none()
+                        }
+                        Callee::Resolved(_) => false,
+                    })
+            })
+            .map(|(key, _)| match &key.locus {
+                Some(l) => format!("{}::{}", l, key.fn_name),
+                None => key.fn_name.clone(),
+            })
+            .collect();
+        if !opaque.is_empty() {
+            let mut names = opaque;
+            names.sort();
+            diags.push(Diag::ty(
+                c.name.span,
+                format!(
+                    "claim `{}` uncertified: {} an indirect or opaque \
+                     call whose target this check cannot resolve, and \
+                     names no purpose of its own — so whether a `{}` \
+                     boundary is crossed there is unknown. Classify \
+                     the caller (`@effects(is: {{...}})`) or bind the \
+                     callee so it resolves: {}",
+                    c.name.name,
+                    if names.len() == 1 {
+                        "a fn makes"
+                    } else {
+                        "fns make"
+                    },
+                    class_name.name,
+                    names.join(", ")
+                ),
+            ));
+            return Verdict::Uncertified;
+        }
         return Verdict::Holds;
     }
     unattributed.sort();

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -236,6 +236,14 @@ fn class_universe(declared: &std::collections::BTreeSet<u16>) -> Vec<EffectClass
         EffectClass::Spawn,
         EffectClass::Recursion,
         EffectClass::Alloc,
+        // GH #436 review 2: a compiler-owned class MUST appear in
+        // every closed universe. `@effects(only: {…})` is the
+        // complement of this list, so an omitted class is one the
+        // contract can never forbid: `only: {}` certified a fn
+        // reaching `secret_use`, making a closed contract weaker than
+        // it reads. Adding a built-in without adding it here is the
+        // integration seam to check.
+        EffectClass::SecretUse,
     ];
     out.extend(declared.iter().map(|i| EffectClass::User(*i)));
     out
@@ -395,6 +403,11 @@ fn phase_effects_diags(
                     EffectClass::Ffi,
                     EffectClass::Publish,
                     EffectClass::Spawn,
+                    // Same reason as `class_universe`: an exact
+                    // phase contract that cannot name a class cannot
+                    // reject it. `@phase_effects(run: {})` admitted
+                    // `secret_use` during run.
+                    EffectClass::SecretUse,
                 ];
                 classes.extend(declared.iter().filter_map(|i| {
                     match defs.get(*i as usize) {
@@ -1106,6 +1119,15 @@ fn check_class(
         EffectClass::Time => (EffectSet::TIME, "a clock read"),
         EffectClass::Entropy => (EffectSet::ENTROPY, "an entropy read"),
         EffectClass::Env => (EffectSet::ENV, "an environment read"),
+        // GH #436 review 2: queries the frontier like any other
+        // masked class. Reaching this arm at all is the point — the
+        // class was absent from `class_universe`, so `only: {}` never
+        // asked about it and this code was unreachable BECAUSE the
+        // contract was blind, not because the class was special.
+        EffectClass::SecretUse => (
+            EffectSet::SECRET_USE,
+            "a privileged operation over confined secret material",
+        ),
         // #345: a user class queries the frontier exactly like a
         // built-in — the bit differs, the machinery does not.
         EffectClass::User(_) => (

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -825,8 +825,44 @@ fn strict_block(
                 strict_block(body, tainted, diags)
             }
             Stmt::Block(blk) => strict_block(blk, tainted, diags),
+            // Payload-bearing escapes: a secret in a failure value or
+            // a closure violation leaves the fn as surely as a return
+            // does. `stmt_mentions` learned these; the emitting walk
+            // had no arm for them, so they were seen and not reported.
+            Stmt::Fail { value, span } => {
+                strict_escape(value, tainted, "a failure payload", *span, diags)
+            }
+            Stmt::Violate { payload: Some(p), span, .. } => strict_escape(
+                p,
+                tainted,
+                "a closure-violation payload",
+                *span,
+                diags,
+            ),
+            Stmt::ShmWrite { body, .. } => {
+                strict_block(body, tainted, diags)
+            }
             _ => {}
         }
+    }
+    strict_tail(b, tainted, diags);
+}
+
+/// A tainted trailing expression leaves the fn exactly like a
+/// `return` does, so it is the same escape.
+fn strict_tail(
+    b: &Block,
+    tainted: &BTreeSet<String>,
+    diags: &mut Vec<Diag>,
+) {
+    if let Some(tail) = &b.tail {
+        strict_escape(
+            tail,
+            tainted,
+            "this fn's trailing return value",
+            b.span,
+            diags,
+        );
     }
 }
 
@@ -899,6 +935,10 @@ fn expr_mentions(e: &Expr, names: &BTreeSet<String>) -> bool {
 /// A block mentions a name if any statement or its tail does.
 fn block_mentions(b: &Block, names: &BTreeSet<String>) -> bool {
     b.stmts.iter().any(|st| stmt_mentions(st, names))
+        // The doc comment promised the tail and the body did not
+        // check it, so an implicit return — `fn f(@secret t) { t }` —
+        // escaped both walks.
+        || b.tail.as_ref().map_or(false, |e| expr_mentions(e, names))
 }
 
 fn stmt_mentions(st: &Stmt, names: &BTreeSet<String>) -> bool {
@@ -928,6 +968,11 @@ fn stmt_mentions(st: &Stmt, names: &BTreeSet<String>) -> bool {
             block_mentions(body, names)
         }
         Stmt::Block(b) => block_mentions(b, names),
+        Stmt::Fail { value, .. } => expr_mentions(value, names),
+        Stmt::Violate { payload, .. } => {
+            payload.as_ref().map_or(false, |e| expr_mentions(e, names))
+        }
+        Stmt::ShmWrite { body, .. } => block_mentions(body, names),
         _ => false,
     }
 }

--- a/crates/hale-types/tests/secrets_fail_opens.rs
+++ b/crates/hale-types/tests/secrets_fail_opens.rs
@@ -469,3 +469,179 @@ fn a_keyword_named_class_parses() {
     ";
     assert!(parse_source(src).is_ok(), "`all publish` must parse");
 }
+
+// ---------------------------------------------------------------
+// Review 2: a compiler-owned class must join every CLOSED universe.
+// ---------------------------------------------------------------
+
+#[test]
+fn only_closed_contract_rejects_a_reachable_secret_use() {
+    // `@effects(only: {…})` is the COMPLEMENT of a hardcoded class
+    // list, so a class missing from that list is one the contract can
+    // never forbid — `only: {}` certified a fn reaching `secret_use`,
+    // making a closed contract weaker than it reads. Adding a
+    // built-in without adding it to both universes is the seam.
+    let src = "
+        locus L {
+            params { key: Int = 7; }
+            @effects(is: { secret_use })
+            fn privileged() -> Int { return self.key; }
+            @effects(only: { })
+            fn supposedly_closed() -> Int { return self.privileged(); }
+        }
+        main locus App { params { l: L = L { }; } }
+        fn main() { App { }; }
+    ";
+    let es = errors(src);
+    assert!(
+        es.iter().any(|m| m.contains("secret_use")),
+        "a closed contract must forbid the class it never listed: {es:?}"
+    );
+}
+
+#[test]
+fn an_exact_phase_contract_rejects_secret_use_during_run() {
+    let src = "
+        @phase_effects(run: { })
+        locus Worker {
+            params { key: Int = 7; }
+            run() { let x = self.vault_op(); }
+            @effects(is: { secret_use })
+            fn vault_op() -> Int { return self.key; }
+        }
+        main locus App { params { w: Worker = Worker { }; } }
+        fn main() { App { }; }
+    ";
+    let es = errors(src);
+    assert!(
+        es.iter().any(|m| m.contains("secret_use")),
+        "an exact phase contract must reject it: {es:?}"
+    );
+}
+
+// ---------------------------------------------------------------
+// Review 2: attribution holes.
+// ---------------------------------------------------------------
+
+#[test]
+fn an_unattributed_ffi_declaration_violates() {
+    // The `@ffi` DECLARATION is the boundary, not its caller. The
+    // caller-side branch was unreachable anyway — an `@ffi` fn is a
+    // bundle decl, so the bundle test short-circuited first — and it
+    // was the wrong shape besides: it returned true for every mask,
+    // so one foreign call would have read as publish, entropy and
+    // secret_use at once.
+    let src = "
+        @ffi(\"c\")
+        fn foreign_write(p: String);
+        locus L {
+            params { n: Int = 0; }
+            fn use_ffi(p: String) { foreign_write(p); }
+        }
+        main locus App {
+            params { l: L = L { }; }
+            claims { io: require attributed(all syscall); }
+        }
+        fn main() { App { }; }
+    ";
+    let es = errors(src);
+    assert!(
+        es.iter().any(|m| m.contains("foreign_write")),
+        "the ffi declaration must be the site blamed: {es:?}"
+    );
+}
+
+#[test]
+fn a_directly_classified_operation_still_needs_a_purpose() {
+    // The shape the whole secrets architecture rests on: a method
+    // that DECLARES `@effects(is: { secret_use })` calls nothing
+    // classified and allocates nothing, so it was invisible to the
+    // attribution evaluator. A built-in in `is:` establishes that the
+    // operation exists; it is not its purpose.
+    let src = "
+        effect signing;
+        @sealed locus CustomSigner {
+            params { key: Int = 7; }
+            @effects(is: { secret_use })
+            fn sign(n: Int) -> Int { return n + self.key; }
+        }
+        main locus App {
+            params { c: CustomSigner = CustomSigner { }; }
+            claims { every_op: require attributed(all secret_use); }
+        }
+        fn main() { App { }; }
+    ";
+    let es = errors(src);
+    assert!(
+        es.iter().any(|m| m.contains("CustomSigner::sign")),
+        "a self-declared secret operation must name a purpose: {es:?}"
+    );
+}
+
+#[test]
+fn an_indirect_call_leaves_attribution_uncertified() {
+    // The general effect engine treats a call through a fn-typed
+    // parameter as may-do-anything. Attribution asked only whether
+    // the textual name sat in the stdlib registry, so a callback
+    // contributed nothing and the law reported `holds` over a
+    // boundary it could not see.
+    let src = "
+        fn invoke(f: fn(Int) -> Int, n: Int) -> Int { return f(n); }
+        fn double(x: Int) -> Int { return x + x; }
+        locus L {
+            params { n: Int = 0; }
+            fn go(k: Int) -> Int { return invoke(double, k); }
+        }
+        main locus App {
+            params { l: L = L { }; }
+            claims { io: require attributed(all syscall); }
+        }
+        fn main() { App { }; }
+    ";
+    let es = errors(src);
+    assert!(
+        es.iter().any(|m| m.contains("uncertified")),
+        "an opaque callee must not be certified past: {es:?}"
+    );
+}
+
+// ---------------------------------------------------------------
+// Review 2: strict-secret block tails and payload statements.
+// ---------------------------------------------------------------
+
+#[test]
+fn strict_sees_a_trailing_return_expression() {
+    // `block_mentions` promised the tail in its doc comment and
+    // checked only statements, so an implicit return escaped both
+    // walks.
+    let src = "
+        locus L {
+            params { n: Int = 0; }
+            fn leak(@secret token: String) -> String { token }
+        }
+        main locus App { params { l: L = L { }; } }
+        fn main() { App { }; }
+    ";
+    let ms = strict(src);
+    assert!(
+        ms.iter().any(|m| m.contains("trailing return")),
+        "an implicit return must not escape: {ms:?}"
+    );
+}
+
+#[test]
+fn strict_sees_a_fail_payload() {
+    let src = "
+        type E { m: String; }
+        locus L {
+            params { n: Int = 0; }
+            fn f(@secret token: String) -> Int fallible(E) {
+                fail E { m: token };
+            }
+        }
+        main locus App { params { l: L = L { }; } }
+        fn main() { App { }; }
+    ";
+    let ms = strict(src);
+    assert!(!ms.is_empty(), "a `fail` payload must be walked: {ms:?}");
+}

--- a/docs/src/effects.md
+++ b/docs/src/effects.md
@@ -44,7 +44,8 @@ enforces it across everything reachable from it:
 ```
 
 `none: {…}` forbids effect classes — `syscall`, `block`, `time`,
-`entropy`, `env`, `ffi`, `publish`, `spawn`, `recursion`.
+`entropy`, `env`, `ffi`, `publish`, `spawn`, `recursion`,
+`secret_use`.
 `publish: {…}` declares which topics a fn may publish to (exact,
 because Hale's topic set is closed).
 
@@ -222,6 +223,14 @@ upgrades the check to an enforced error.
 | `spawn` | instantiating a locus | `Worker { }` |
 | `recursion` | a cycle in the call graph | a fn that reaches itself |
 | `alloc` | arena allocation — a phase-only class, see `@phase_effects` | `Buf { n: 1 }` |
+| `secret_use` | a privileged operation over confined secret material | `std::secret::Signer.sign` |
+
+`secret_use` is **compiler-owned**: `std::secret`'s privileged methods
+carry it, and you use it without declaring it — in `none:`, `only:`,
+`@phase_effects`, `forbid reaches(G, effects(secret_use))`, and
+`bound secret_use <= N`. Every built-in name is reserved, so
+`effect secret_use;` (or `effect syscall;`) is an error rather than a
+silent no-op. See [Verification](./verification.md#secrets-confine-classify-claim).
 
 Two of those are worth dwelling on, because they are the ones people
 guess wrong.

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -216,6 +216,23 @@ The remaining verbs (#382 phases 2–5):
   and one written next month is uncovered until someone edits the
   group. This is a universal over the whole closed world.
 
+  A **direct site** is: a classified frontier path call, an `@ffi`
+  declaration (the declaration itself, not its caller — it is the
+  application-owned boundary and can carry the purpose), a resolved
+  callee the author does not own whose effects include the class, a
+  syntactic site (publish, allocation), or the fn's own
+  `@effects(is: {C})`. That last one matters most to the secrets
+  architecture: a method declaring itself a `secret_use` operation
+  calls nothing classified and allocates nothing, so without it the
+  central shape was invisible to the claim. A built-in in `is:`
+  establishes that the operation exists; it is still not its purpose,
+  so a user class is required.
+
+  An **indirect or opaque call** the checker cannot resolve leaves
+  the claim `uncertified` unless the enclosing fn already names a
+  purpose — the same refusal-to-certify posture as the rest of the
+  stack, rather than reporting `holds` over a boundary it cannot see.
+
   **DIRECT, not transitive**, and that is load-bearing: transitively,
   every caller downstream of one attributed fn inherits the label and
   passes, which would make the claim nearly vacuous. The attribution


### PR DESCRIPTION
Second review round. No new language surface, no architectural reopening — an effect-system completeness patch, as the reviewer framed it.

Every finding reproduced against `db3f093` first; the seven requested canaries are in `secrets_fail_opens.rs` (now 23 controls).

## P0 — `secret_use` was missing from both closed universes

This is the one that matters. `@effects(only: {…})` is computed as the **complement** of a hardcoded class list, and `@phase_effects` iterates another. A class absent from either is one those contracts can never forbid:

```hale
@effects(is: { secret_use }) fn privileged() { … }
@effects(only: { })          fn closed() { privileged(); }   // certified
```

`@phase_effects(run: {})` likewise admitted `secret_use` during run. **Contracts whose entire purpose is rejecting future unlisted effects were weaker than they read** — exactly what the `class_universe` comment says must not happen when a class is added later.

Both universes now include it. Worth noting: adding it made an `unreachable!("handled above")` arm panic, which was the tell — that code was unreachable *because* the contract was blind, not because the class was special.

## P1 — three attribution holes

**`@ffi` declarations.** Now the direct boundary site rather than the caller. Your diagnosis was exactly right that the caller-side branch was unreachable — `is_bundle_fn` short-circuits first — and the shape was wrong besides: it returned `true` for **every** mask, so one foreign call would have read as `publish`, `entropy` and `secret_use` at once. Removed rather than reordered.

**Directly classified operations.** A fn's own `@effects(is: {C})` now counts as a direct site. Without it, `@effects(is: { secret_use }) fn sign(…)` — the shape the whole secrets architecture rests on — was invisible, because it calls nothing classified and allocates nothing. The distinction holds: a built-in in `is:` establishes the operation exists, and is still not its purpose.

**Indirect and opaque calls.** Now `uncertified` unless the caller already names a purpose, rather than `holds` over a boundary the checker cannot see. Same refusal-to-certify posture as the rest of the stack.

## P1 — `--strict-secret` block tails and payloads

`fn f(@secret t) { t }` escaped. Doubly bad: `block_mentions` promised the tail in its doc comment and checked only statements.

`fail` / `violate` payloads and `ShmWrite` bodies were also missed — and in a way worth recording, because `stmt_mentions` had *learned* them in the last PR while the emitting walk had no arm, so they were seen and not reported.

## Documentation

`secret_use` joins the effects reference (prose, class table, and a note that it is compiler-owned and usable in `none:` / `only:` / `@phase_effects` / `effects(…)` / `bound`).

**The CHANGELOG now states the real break.** You were right that naming only `secret_use` understated it: *every* built-in effect name is reserved, so `effect syscall;` and `effect entropy;` are errors too. I kept the generic rejection — those were always silent no-ops, and a program that wrote one believed it had declared a class while every claim naming it quietly meant the built-in — but the note says so plainly rather than implying the break is new-class-only.

The stdlib comment no longer claims a misconfigured deployment "fails at startup". It refuses by sentinel — empty signature, false verdict — and callers gate on `ready()`. Stated precisely rather than aspirationally.

## Canaries

All seven you asked for, verified failing on `db3f093`:

```
only:{} does not admit secret_use
phase_effects(run:{}) does not admit secret_use
unattributed @ffi declaration violates attributed(syscall)
direct @effects(is:{secret_use}) needs a user-purpose class
unknown callback prevents attributed(syscall) from holding
strict-secret catches function tail
strict-secret catches fail payload
```

Plus `a_bundle_callee_is_still_judged_on_its_own_row` as the counterweight, so attribution cannot quietly become transitive.

`hale-types`, `hale-syntax`, `hale-cli`, corpus oracle, effects conformance, stdlib parity, native suite, docs snippets — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)