### PR TITLE
docs: bring spec, styleguide and AGENTS.md up to the secrets surface (GH #436)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ summary.)
    name; `params` from argv defaults; `run()` delegates to a
    free helper; `main()` reads argv and statement-instantiates
    the locus.
-2. **Namespace lotus** — empty (or config-only) `params { }`,
+2. **Namespace locus** — empty (or config-only) `params { }`,
    methods only. The language's substitute for "module of
    functions" / "static class". Instantiate once, dispatch
    through it.
@@ -391,8 +391,18 @@ Beyond the effect assertions above, all opt-in:
   lifecycle phase may do. `{}` forbids everything; a phase you don't
   mention is unconstrained. That one line is "no dynamic memory after
   initialization".
-- `@secret name: T` on a **parameter** — the value must not reach a
-  publish or a log/file sink.
+- `@sealed` on a **locus** — its `params` are readable and writable
+  only from inside its own methods. Others may still CALL it; they may
+  not touch its state. Loci are otherwise NOT field-encapsulated
+  (`self.child.key` typechecks), so this is the confinement primitive
+  secrets rest on. Opt-in, breaks nothing. `hale check --sealable`
+  reports which loci could take it today and what it would cost.
+- `@secret name: T` on a **parameter** — a LINT, not a certificate. It
+  flags a secret reaching a publish or log in the same body; it
+  follows no calls and tracks no aliases. `hale check --strict-secret`
+  widens the walk and reports `uncertified` where it cannot follow.
+  For a guarantee, confine with `@sealed` and claim over an effect
+  class instead.
 - `@supervised` on a **locus** — every locus in its subtree must have a
   failure policy in scope.
 - `@unbounded` on a fn or hook — acknowledges an intentional
@@ -423,6 +433,48 @@ in your spelling. Treat it as the next task: remove the edge, route
 through a gate, or change the law (a categorically different edit).
 Unknown means violation: an unresolvable call on a forbidden path
 refuses certification rather than counting as nothing.
+
+Two verbs quantify over the whole closed world rather than a path:
+
+```hale
+claims {
+    confined:   require sealed(all vaults);
+    attributed: require attributed(all syscall);
+}
+```
+
+`require sealed(all G)` — every locus in `G` is `@sealed`, so one
+member nobody sealed is a build error rather than a silent hole.
+`require attributed(all C)` — every fn that DIRECTLY performs
+built-in class `C` carries a user-declared class, so every boundary
+crossing names a purpose. That is orthogonal to
+`forbid reaches(app, effects(syscall)) avoiding gate`, which
+constrains WHERE the crossing happens and says nothing about what it
+is for. Neither implies the other.
+
+**Secrets** are the worked case, and they need no new analysis:
+confine the material to a `@sealed` locus that loads it in `birth`,
+classify the one privileged method, state the law.
+
+```hale
+@sealed locus Signer {
+    params { key: Bytes; }
+    @effects(is: { secret_use })
+    fn sign(m: Bytes) -> Signature { … }
+}
+
+claims {
+    no_plugin_secrets: forbid reaches(plugins, effects(secret_use));
+    one_op_per_request: bound secret_use <= 1 on paths from handlers;
+}
+```
+
+`secret_use` is a compiler built-in — every built-in effect name is
+reserved, so `effect secret_use;` is an error. `std::secret::Signer`
+and `Credential` ship this shape: they take the NAME of a source
+(`env_var:` / `key_file:`), never the bytes, so no line of your code
+ever holds the material. That is CONFINEMENT, not information flow —
+a value derived from the key is not tracked.
 
 Shared law goes in a `constitution NAME { … }` (top level), adopted
 per entrypoint with `adopt NAME;` inside `claims { }`. Composition

--- a/README.md
+++ b/README.md
@@ -258,6 +258,26 @@ inventory; and `bound llm <= N on paths from G` for cost. `bound`
 counts a **user-declared** effect class (`effect llm;`) — the
 counted built-ins keep their `@budget` spellings.
 
+Two more quantify over the whole closed world rather than a path, so
+code written next month is covered without editing the claim:
+`require sealed(all G)` — every locus in the group keeps its state to
+itself — and `require attributed(all syscall)` — every place the
+program touches the OS names a purpose. That second one is
+independent of routing all I/O through a vetted component
+(`forbid reaches(app, effects(syscall)) avoiding gate`): one
+constrains *where* a boundary is crossed, the other *what for*.
+
+**Secrets** are the worked example, and they need no new machinery.
+`@sealed` on a locus makes its `params` reachable only from inside it
+— loci are otherwise not field-encapsulated, so `self.signer.key`
+typechecks from anywhere holding one. `std::secret::Signer` ships
+that shape and takes the *name* of a source rather than the bytes, so
+no line of your code ever holds the key. Its one privileged method
+carries `secret_use`, and your claims say who may reach it. That is
+confinement, not information flow: a signature derived from the key
+is not tracked, and the docs say so rather than letting a green
+result imply otherwise.
+
 Three things make this hold up in practice:
 
 - **Groups are vocabulary, not patterns.** A misspelt member is an

--- a/docs/src/verification.md
+++ b/docs/src/verification.md
@@ -380,6 +380,25 @@ tracks no aliases. `hale check --strict-secret` widens the walk and
 reports `uncertified` wherever it can't follow, which is loud by
 design.
 
+**Adopting `@sealed` on an existing codebase** is a question you don't
+have to answer by reading. `hale check --sealable` tells you:
+
+```text
+sealability: 4 of 5 loci can be `@sealed` today
+
+  free to seal (nothing outside touches their params):
+    Already, App, Holder, Private
+
+  would break callers:
+    Exposed — 1 external access(es): Exposed.k
+```
+
+Empty means sealing that locus is a no-op. On this repo's own corpus,
+148 of 151 loci across 94 programs seal with no changes — and the
+three that don't are the same shape, a parent reading a child's result
+field instead of calling a method, which the no-locus-return rule
+already discourages.
+
 ## Invariants you declare, checked as it runs
 
 The checks above are the compiler's. You can add your own with a

--- a/spec/projects.md
+++ b/spec/projects.md
@@ -447,4 +447,6 @@ End-to-end coverage lives in
 | `hale check --json` | NDJSON diagnostics on stdout, one object per line (`file`/`line`/`col`/`severity`/`kind`/`message`) — editor/LSP consumption. `hale check` runs in ~10 ms on the largest apps. |
 | `HALE_TIME=1` | Per-phase build wall times on stderr (front-end+codegen, llvm-passes, obj-emit, emit+link). |
 | `--no-warn-unbounded-alloc` | Opts a run out of the default-on memory-bound survey (see verification.md). |
+| `hale check --sealable` | GH #436. Reports which loci could take `@sealed` today and what it would cost: per locus, the sites outside it that read or write its `params`. Empty means sealing is a no-op. The survey RERUNS the real check against an all-sealed clone rather than approximating the rule, so it cannot drift from the checker — a survey that disagrees would report a locus free to seal when it is not. |
+| `hale check --strict-secret` | GH #436. The fail-closed `@secret` walk: every branch, alias propagation through `let` and tuple destructuring, and `uncertified` for anything it cannot follow. Opt-in because it is loud; the default `@secret` pass is a lint (see verification.md § Secrets). |
 | `--target-cpu native\|baseline` | Backend CPU tuning (native = host, default; baseline = portable x86-64-v3). |

--- a/spec/styleguide.md
+++ b/spec/styleguide.md
@@ -913,15 +913,26 @@ certify a path — plus one tier you get for free because your
 | **@hot** (opt-in) | all of the above as errors within the fn; `snapshot()`/`finish()` in a loop; whole-struct self-field replace | errors in certified fns |
 | **@budget** (opt-in) | `alloc_per_call = N` counted transitively; `N=0` zero-alloc certificate | build fails on violation |
 | **@effects** (opt-in) | `@effects(none: {syscall, block, time, entropy, env, ffi, publish, spawn, recursion})` / `@effects(publish: {T})`, and the `@no_*` / `@deterministic` sugar — checked transitively; diagnostics carry the call chain to the offending leaf | build fails on violation |
+| **@sealed** (opt-in) | a sealed locus's `params` are reachable only from inside its own methods — reads and writes both. Loci are otherwise not field-encapsulated, so this is the only tier that makes state confinement structural rather than reviewed. `hale check --sealable` reports what taking it would cost | build fails on violation |
 | **placement-implied** (automatic) | a handler on a `cooperative(pool = X) where async_io` locus that reaches a blocking call — the placement *is* the assertion, so no annotation is needed; writing `@no_block` upgrades it to an enforced error | advisory |
 | **fmt** (CI gate) | `hale fmt --check` — canonical mechanical form (§2, "Canonical form"); exit 1 lists offenders | gate in CI; `hale fmt` fixes |
 | escape hatches | `@unbounded` (fn or lifecycle hook) acknowledges intentional accumulation; `--allow-unowned-subscriber`; `--no-warn-unbounded-alloc` | |
+| advisory tools | `hale check --sealable` (which loci could seal today); `hale check --strict-secret` (the fail-closed `@secret` walk — loud by design, because one body's reasoning is not a containment proof) | opt-in reports |
 
 ### Where law lives
 
 The tiers above certify a *function*. Claims certify a *system*, and
 the only real style question is which closed world owns each
 sentence.
+
+Two claim verbs quantify over the whole closed world rather than over
+a path, which makes them the right shape for a baseline a team adopts
+once: `require sealed(all G)` (every locus in the group keeps its
+state to itself) and `require attributed(all C)` (every fn that
+directly performs built-in class `C` names a user-declared purpose).
+Both cover code nobody has written yet, which a group-scoped claim
+does not — that is the reason to prefer them for policy, and to keep
+`forbid reaches` for the specific edges a design forbids.
 
 - **In the `main locus`** — law about this application. A claim is
   evaluated in a closed world, so it belongs where the world closes.

--- a/spec/styleguide.md
+++ b/spec/styleguide.md
@@ -299,6 +299,71 @@ Returnable by value; no lifecycle. Types may hold `fn(...)`
 fields. If methods accumulate on a concept, it has flow — it
 wanted to be a locus.
 
+### 2.6b Secret-owning locus — `@sealed`, one classified operation
+
+Key material, a token, anything the rest of the program must never
+hold. The shape is not an analysis; it is the ownership model doing
+its job with one word added.
+
+```hale,fragment
+@sealed locus Signer {
+    params { env_var: String = "SIGNING_KEY"; key: Bytes = b""; }
+
+    birth() { self.key = std::bytes::from_string(std::env::var(self.env_var)); }
+
+    fn ready() -> Bool { return len(self.key) > 0; }
+
+    @effects(is: { secret_use })
+    fn sign(m: Bytes) -> Bytes {
+        if !self.ready() { return b""; }
+        return std::crypto::hmac_sha256(self.key, m);
+    }
+}
+```
+
+Four rules, each carrying its weight:
+
+- **`@sealed`.** Loci are otherwise *not* field-encapsulated —
+  `self.signer.key` typechecks from anywhere holding the locus — so
+  without it "the key never leaves its owner" is something you check
+  rather than something that is true. Sealing covers reads *and*
+  writes; a locus that stops reads and permits writes lets a caller
+  choose the key, which is worse.
+- **Take the NAME of a source, not the bytes.** `env_var:` /
+  `key_file:`, loaded in `birth`. Param initialization is deliberately
+  not restricted — a parent writing `Signer { key: … }` already holds
+  what it passes — so if the material arrives through a constructor
+  argument, some line of the application held it. `birth` should be
+  the only writer, including the no-source case, or a caller can seed
+  it anyway.
+- **Refuse when unavailable.** `ready()` is not enough on its own:
+  every privileged method must consult it, or a misconfigured
+  deployment signs under the empty key and anyone can forge the
+  matching MAC.
+- **Classify the one privileged method** with `secret_use`, so the
+  law can find it.
+
+Then the application states its own rule with claim forms that
+already exist:
+
+```hale,fragment
+claims {
+    no_plugin_secrets: forbid reaches(plugins, effects(secret_use));
+    one_op_per_request: bound secret_use <= 1 on paths from handlers;
+    vault_confined: require sealed(all vaults);
+}
+```
+
+Prefer `std::secret::Signer` / `Credential` to writing your own —
+they are this shape, reviewed once. Write your own when the operation
+is not HMAC or credential comparison, and keep it small enough to
+read: **the sealed locus's own body is trusted**, and that is the
+residual assumption the whole shape rests on.
+
+What this is: confinement. What it is not: information flow. A
+signature *derived* from the key is not tracked, and a
+constant-time compare still lets the verdict be published.
+
 ### 2.7 Error-check fn — value error → structural failure
 
 A locus method that catches a `fallible` call's error and decides

--- a/spec/tokens.md
+++ b/spec/tokens.md
@@ -623,6 +623,14 @@ forbids every member, and a fn reaching a member carries it. Members
 may be built-ins or other declared classes; a definition cycle is
 rejected.
 
+The built-in classes are `syscall`, `block`, `time`, `entropy`,
+`env`, `ffi`, `publish`, `spawn`, `recursion`, `alloc`, and
+`secret_use` (GH #436 — a privileged operation over confined secret
+material, carried by `std::secret`'s methods). **Every built-in name
+is reserved**: `effect secret_use;` — or `effect syscall;` — is an
+error, because the built-in wins at every use site and the
+declaration would be a silent no-op.
+
 `effect NAME;` is a top-level **declaration**, not an annotation:
 it introduces a user effect class that `is:` / `none:` / `causes:`
 then name like a built-in. `effect` is a **contextual keyword** —
@@ -640,10 +648,15 @@ domain for effect families (`effect knowledge(wing);`), and
 `claims { … }` is a main-locus member holding named bundle-level
 claims (GH #382). The claim verbs are `forbid reaches` (with `via`
 / `during` / `avoiding` modifiers), `only edges` (grant
-enumeration), `bound` (path budgets over user classes), `require`,
-`cover`, and `count`. All introducers — `group`, `claims`,
+enumeration), `bound` (path budgets over user classes, plus the
+built-in `secret_use` — the one counted built-in with no `@budget`
+spelling), `require subscribes|publishes` (existence),
+`require sealed(all G)` and `require attributed(all C)` (GH #436 —
+universals over the closed world rather than over a path), `cover`,
+and `count`. All introducers — `group`, `claims`,
 `domain`, `forbid`, `reaches`, `via`, `may_be_empty`, `edges`,
-`bound`, `require`, `cover`, `count`, `during`, `avoiding`, `seed`
+`bound`, `require`, `sealed`, `attributed`, `all`, `cover`, `count`,
+`during`, `avoiding`, `seed`
 — are **contextual keywords**, recognized in their positions only,
 so existing identifiers with those names are unaffected.
 `@budget(<user class> = N)` bounds calls to declared carriers of


### PR DESCRIPTION
The secrets mechanism shipped across four PRs (#437, #438, #439, #440). The prose lagged, and one entry was actively wrong.

## The correction

`AGENTS.md` described `@secret` as *"the value must not reach a publish or a log/file sink"* — a certificate, which it stopped being when it was demoted to a lint. An agent reading that would trust a check that follows no calls and tracks no aliases. It now says what it is, points at `--strict-secret`, and names `@sealed` as the mechanism that carries the guarantee.

## Additions

**`AGENTS.md`** — `@sealed` in the contracts list, the two universal claim verbs, and the secrets shape end to end in the claims section. (Also fixes a `Namespace lotus` typo in the pattern catalog.)

**`spec/styleguide.md`** — shape 2.6b, the secret-owning locus. Four rules, each earned by something going wrong first:

- `@sealed`, because loci are otherwise not field-encapsulated — and sealing must cover writes as well as reads, since a locus that stops reads and permits writes lets a caller *choose* the key
- take the **name** of a source rather than the bytes, because param initialization is deliberately unrestricted, so a constructor argument means some line of the application held it
- refuse when unavailable, because `ready()` is not enough unless every privileged method consults it
- classify the one operation so the law can find it

It ends where the guarantee ends: confinement, not information flow.

**`spec/tokens.md`** — `secret_use` joins the built-in class list, with the reservation rule stated **generally**: every built-in name is reserved, not just the new one. The claim-verb sentence gains `require sealed` / `require attributed`, and the contextual-keyword list gains `sealed`, `attributed`, `all`.

**`spec/projects.md` + the book** — `--sealable` and `--strict-secret` were reachable only from CLI help. The survey entry says *why* it reruns the real checker rather than approximating the rule (a survey that disagreed would report a locus free to seal when it is not) and carries the corpus measurement: 148 of 151 loci seal with no changes.

**`README.md`** — the claim inventory said six forms; there are eight.

## Site

`hale-lang.org` gets **Secrets** as part 5 of *Hale as a general model checker*, plus a proof card. The synced spec and book carry the rest automatically — they are generated from this repo at build time, not authored there.

The article is the record of the design shrinking: four rounds converging from information-flow analysis with a semantic-event IR down to one annotation and claim forms that already existed. It is honest about the three review rounds, and about the pattern behind them — every finding was at an integration seam, never in the logic.

## Verification

`styleguide_snippets`, `docs_snippets`, `examples`, `codegen_fixtures_typecheck` green; site builds (79 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)