### PR TITLE
fix(check): reject @sealed together with contract { expose … } (GH #436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,30 @@ Three attribution holes closed:
 comment and checked only statements) and `fail` / `violate` payloads
 and `ShmWrite` bodies.
 
+### `@sealed` and `contract { expose … }` are mutually exclusive (GH #436)
+
+Two contradictory claims about the same boundary, and sealing wins. The
+contract consistency check passes — a matching `consume` binds — and
+then every use of the exposed field is rejected, leaving a construct
+that reads as a permission and grants nothing. The pair is now a check
+error at the declaration.
+
+```text
+locus `Greeter` is `@sealed`, so `expose greeting` cannot grant anything:
+sealing denies every read from outside the locus, including one a
+coordinator `consume`s.
+```
+
+`expose` cannot serve as the sealed allowlist without redefining it:
+it is the coordinator/coordinatee surface, so honouring it would grant
+reads to an `accept`ing parent while still denying them to a parent
+holding the same child as a param — one field, public to one kind of
+holder and not the other.
+
+The `consume` side needs no check of its own: a sealed locus cannot
+declare an `expose`, so a coordinator consuming from one lands in the
+existing "does not expose it" arm.
+
 ### `hale check --sealable` — the adoption survey (GH #436)
 
 `@sealed` is opt-in, so "would this collide with real code?" is a

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -8053,6 +8053,35 @@ impl<'a> Checker<'a> {
     /// compiles, and a parent consuming `value: String` checks
     /// clean against fiction.
     fn check_contract_expose_validity(&mut self, locus: &LocusInfo) {
+        // GH #436: `@sealed` and `expose` are contradictory claims
+        // about the same boundary, and sealing wins — so an `expose`
+        // here reads as a permission it cannot grant. The contract
+        // consistency check passes (a matching `consume` binds fine),
+        // and then every use of the exposed field is rejected.
+        //
+        // `expose` cannot become the sealed allowlist without a
+        // redesign: it is the coordinator/coordinatee surface, so
+        // honouring it would grant reads to an `accept`ing parent and
+        // still deny them to a parent holding the same child as a
+        // param — one field, public to one kind of holder and not the
+        // other. Rejecting the pair is the honest reading until
+        // `expose` means "public param" independent of `accept`.
+        if locus.sealed {
+            if let Some(entry) = locus.contract_expose.first() {
+                self.diags.push(Diag::ty(
+                    entry.span,
+                    format!(
+                        "locus `{}` is `@sealed`, so `expose {}` cannot \
+                         grant anything: sealing denies every read from \
+                         outside the locus, including one a coordinator \
+                         `consume`s. Drop the `@sealed`, or drop the \
+                         contract and let callers use its methods.",
+                        locus.name, entry.name
+                    ),
+                ));
+                return;
+            }
+        }
         for entry in &locus.contract_expose {
             // 1. params field
             if let Some(p) =

--- a/crates/hale-types/tests/sealed_locus.rs
+++ b/crates/hale-types/tests/sealed_locus.rs
@@ -208,3 +208,91 @@ fn sealing_confines_a_secret_the_bus_would_otherwise_carry() {
         "sealed: publishing the key must be rejected, got {es:?}"
     );
 }
+
+// ---------------------------------------------------------------
+// `@sealed` and `contract { expose … }` are contradictory claims
+// about the same boundary.
+// ---------------------------------------------------------------
+
+#[test]
+fn sealed_plus_expose_is_rejected() {
+    // Sealing wins over an expose, so the pair leaves a contract that
+    // typechecks as coherent — a matching `consume` binds fine — and
+    // is then rejected at every use. A construct that reads as a
+    // permission and grants nothing.
+    let src = "
+        @sealed locus Greeter {
+            params { greeting: String = \"hi\"; }
+            contract { expose greeting: String; }
+            fn hello() -> String { return self.greeting; }
+        }
+        main locus App { params { g: Greeter = Greeter { }; } }
+        fn main() { App { }; }
+    ";
+    let es = errors(src);
+    assert!(
+        es.iter().any(|m| m.contains("cannot grant anything")),
+        "the pair must be rejected at the declaration, got {es:?}"
+    );
+}
+
+#[test]
+fn the_consume_side_needs_no_check_of_its_own() {
+    // Because a sealed locus cannot declare an `expose`, a
+    // coordinator consuming from one falls into the existing
+    // "does not expose it" arm. One check covers both directions.
+    let src = "
+        @sealed locus Greeter {
+            params { greeting: String = \"hi\"; }
+            fn hello() -> String { return self.greeting; }
+        }
+        locus Coord {
+            params { n: Int = 0; }
+            contract { consume greeting: String; }
+            accept(g: Greeter) { self.n = 1; }
+        }
+        main locus App { params { c: Coord = Coord { }; } }
+        fn main() { App { }; }
+    ";
+    let es = errors(src);
+    assert!(
+        es.iter().any(|m| m.contains("does not expose it")),
+        "expected the existing contract arm to catch it, got {es:?}"
+    );
+}
+
+#[test]
+fn a_contract_on_an_unsealed_locus_is_unaffected() {
+    let src = "
+        locus Greeter {
+            params { greeting: String = \"hi\"; }
+            contract { expose greeting: String; }
+            fn hello() -> String { return self.greeting; }
+        }
+        locus Coord {
+            params { n: Int = 0; }
+            contract { consume greeting: String; }
+            accept(g: Greeter) { self.n = len(g.greeting); }
+        }
+        main locus App { params { c: Coord = Coord { }; } }
+        fn main() { App { }; }
+    ";
+    assert!(errors(src).is_empty(), "{:?}", errors(src));
+}
+
+#[test]
+fn a_sealed_locus_without_a_contract_is_unaffected() {
+    let src = "
+        @sealed locus Greeter {
+            params { greeting: String = \"hi\"; }
+            fn hello() -> String { return self.greeting; }
+        }
+        locus Coord {
+            params { n: Int = 0; }
+            accept(g: Greeter) { self.n = len(g.hello()); }
+        }
+        main locus App { params { c: Coord = Coord { }; } }
+        fn main() { App { }; }
+    ";
+    assert!(errors(src).is_empty(), "{:?}", errors(src));
+}

--- a/spec/styleguide.md
+++ b/spec/styleguide.md
@@ -342,6 +342,11 @@ Four rules, each load-bearing:
 - **Classify the one privileged method** with `secret_use`, so the
   law can find it.
 
+A sealed locus may not also carry `contract { expose … }`: sealing
+denies every external read, so the expose grants nothing, and the pair
+is rejected rather than left to read as permission. Callers use the
+locus's methods.
+
 Then the application states its own rule with claim forms that
 already exist:
 

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -865,6 +865,18 @@ Only `params` are confined. Capacity slots and methods are untouched
 — sealing confines state, it does not make a locus uncallable, which
 is the entire point.
 
+**`@sealed` and `contract { expose … }` cannot be combined.** They are
+contradictory claims about the same boundary and sealing wins, so an
+`expose` on a sealed locus reads as a permission it cannot grant — the
+contract consistency check passes, a matching `consume` binds, and
+every use of the field is then rejected. The pair is a check error.
+
+`expose` cannot serve as the sealed allowlist without redefining it:
+it is the coordinator/coordinatee surface, so honouring it would grant
+reads to an `accept`ing parent while still denying them to a parent
+holding the same child as a param — one field, public to one kind of
+holder and not the other.
+
 Param **initialization** is deliberately not restricted. A parent
 writing `Signer { key: … }` already holds the value it passes, so
 sealing the initializer would cost ordinary configuration and buy


### PR DESCRIPTION
Two constructs describing the same boundary, and sealing wins.

```hale
@sealed locus Greeter {
    params { greeting: String = "hi"; }
    contract { expose greeting: String; }     // declares the surface
}
locus Coord {
    contract { consume greeting: String; }    // agrees with it
    accept(g: Greeter) { self.n = len(g.greeting); }
}
```

The contract consistency check **passes** — `expose greeting` matches `consume greeting`, so the compiler agrees the surface is coherent — and then rejects every use of it. The author has written an `expose`, agreed it with a `consume`, and been handed a permission that grants nothing.

Now an error at the declaration:

```
locus `Greeter` is `@sealed`, so `expose greeting` cannot grant anything:
sealing denies every read from outside the locus, including one a
coordinator `consume`s. Drop the `@sealed`, or drop the contract and let
callers use its methods.
```

## Why not make `expose` the allowlist

That is the fix that looks obvious and does not hold up. `expose` / `consume` is the **coordinator ↔ accept'd coordinatee** surface. `@sealed` applies to every reader. Honouring an expose would grant reads to an accepting parent while still denying them to a parent holding the same child as a param — one field, public to one kind of holder and not the other, which is a worse contract than either construct has alone.

Making it coherent means redefining `expose` as "public param" independent of `accept` — a redesign of a shipped construct, not a fix. If that ever happens, this rejection is exactly the site that becomes the allowlist.

## One check, both directions

A sealed locus cannot declare an `expose`, so a coordinator consuming from one already lands in the existing arm:

```
contract: locus `Coord` consumes `greeting` but child locus `Greeter`
does not expose it
```

Pinned by `the_consume_side_needs_no_check_of_its_own` rather than assumed.

## Blast radius

None today. 8 corpus programs use `contract {`; none use `@sealed`, which is new. Free now, and it would not have been once someone wrote both.

## Context

Found while answering a question about the article example — `self.signer.key` typechecking looked like it should have been gated by `expose` / `consume`. It is not: that contract checks the *agreement* between coordinator and coordinatee for coherence and never restricted reads, and a param-held child was never in its scope at all. `@sealed` is the first mechanism that gates field access, which is what exposed the overlap.

## Verification

`sealed_locus.rs` — 4 new tests: the pair rejected, the consume side falling out, and both halves unaffected on their own (unsealed locus with a contract; sealed locus without one). `hale-types`, `hale-syntax`, `hale-cli`, corpus oracle, stdlib parity, styleguide and docs snippets all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
