### PR TITLE
docs: the Book's subtitle follows the site's line

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -4,7 +4,7 @@
 runtime — typed message-bus concurrency, data-race-free by
 design.**
 
-*One language. Four altitudes.*
+*Say less. Spell more.*
 
 Most languages pick a level and live there. Python and
 JavaScript sit high — fast to write, far from the metal. Go


### PR DESCRIPTION
`hale-lang.org`'s hero is now **Say less. Spell more.**, under the eyebrow "a new semantic compression for software" ([hale-lang.org](https://hale-lang.org), deployed). The Book's introduction carried *One language. Four altitudes.* — which says a similar thing in the register the site has just moved off, so the two now read as different pitches for the same language.

This file is the source the site renders at `/docs`: `scripts/sync-docs.mjs` copies `docs/src` into the site's content collection on every deploy. Changing it on the site side does nothing — CI regenerates the collection and the old line comes back. It has to change here.

One line, no other content touched.

**A note on the working tree, not on this diff.** My first attempt at this commit also reverted the bold intro from "A concurrent systems language with a model-checked, GC-free runtime…" back to an older "One structural construct — the locus…". That was not intentional: the local `docs/src/introduction.md` was stale relative to `origin/main`, so a diff against HEAD picked up the difference. Amended to the single line. Worth a look at whether `README.md` and `docs/src/verification.md` are stale in the same way locally, since they would carry the same kind of silent revert if committed from that tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)