### PR TITLE
ci: classify a new branch's first push against the default branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,19 @@ jobs:
           elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
             base="${{ github.event.before }}"
           fi
+          # The first push of a NEW branch has no `before` sha — it is all
+          # zeros — so the classifier had nothing to diff against and every
+          # new branch paid the full substrate suite on its first push, even
+          # for one line of prose. That is not genuinely unclassifiable: the
+          # branch's diff against the default branch is exactly what its own
+          # pull_request run computes a moment later, and the two disagreeing
+          # is how this was noticed (one run skipped the three jobs, the
+          # other ran them, same commit).
+          if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            default="origin/${{ github.event.repository.default_branch }}"
+            base="$(git merge-base "$default" HEAD 2>/dev/null || true)"
+            [ -n "$base" ] && echo "no before-sha; using merge-base with $default: $base"
+          fi
           if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
             echo "no usable base — running everything"
             echo "substrate=true" >> "$GITHUB_OUTPUT"; exit 0


### PR DESCRIPTION
The `scope` job takes its base from `github.event.before`, which is all zeros on the **first push of a new branch**. With no base it cannot diff, and it fails safe by running everything — so every new branch pays the ~20 CI-minutes of sanitizers, tsan and GenMC on its first push, even for one line of prose. The step's own comment names this case; it just treats it as unclassifiable.

It isn't. A new branch's diff against the default branch is exactly what its own `pull_request` run computes moments later — which is how this surfaced. #446 changes one line of `docs/src/introduction.md`, and its two runs disagreed on the same commit:

```
SKIPPED  tests/genmc, tests/sanitizers, tests/tsan   ← pull_request run
SUCCESS  tests/genmc, tests/sanitizers, tests/tsan   ← branch push run
```

Falls back to `git merge-base origin/<default> HEAD`, and still fails safe if even that is unavailable. Force-pushes, whose `before` is unreachable, now classify too rather than taking the same escape hatch.

Checked against the branch that exposed it, replaying the classifier locally:

| branch | changed | non-prose | substrate |
|---|---|---|---|
| `docs/say-less-spell-more` | `docs/src/introduction.md` | 0 | `false` — skips |
| this branch | `.github/workflows/tests.yml` | 1 | `true` — runs everything, correctly |

This PR is itself a CI change, so it runs the full suite, as it should.

**Not addressed here, but worth a look.** Every PR runs the suite twice — once for the branch push, once for the `pull_request` — because the concurrency group is `tests-${{ github.ref }}` and those refs differ (`refs/heads/…` vs `refs/pull/N/merge`). The header comment says pushing a feature branch is deliberately enough to get a full run without a PR, so the duplication looks like a known trade rather than an accident; flagging it since it is the larger share of the waste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)