### PR TITLE
fix(codegen): reclaim the payload of an intra-locus direct-call publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ behavior.
 
 ## Unreleased
 
+### An intra-locus publish no longer accrues its payload per delivery
+
+The fifth item from the downstream handoff (the four below shipped
+first). A `Topic <- payload` for a topic used only within a locus tree,
+with no transport binding, is rewritten by `desugar_intra_locus_topics`
+into a direct call to the subscriber's bus handler — sidestepping the
+bus queue for speed, and with it the queue's per-delivery cell reclaim.
+The payload then built as an ordinary call argument in the publisher's
+method-scratch subregion and was not freed until `run()` returned, so a
+long-running publish loop accrued one payload per delivery (~31 B/cell
+on a string payload; unbounded over a daemon's lifetime).
+
+Codegen now confines each such payload to its own arena subregion,
+destroyed once the synchronous handler returns — the same lifetime the
+bus queue's cell reclaim gives a delivered payload, and safe for the
+same reason (the handler has returned, and Hale copies on every field
+store, so nothing it kept still points into the freed region). A bus
+subscription handler is not callable from Hale source, so a
+statement-position call to one is unambiguously this desugar; the
+reclaim applies to nothing else. Measured: the publish-payload accrual
+goes to zero (a residual reflects only transient `let`s the user's own
+code leaves in scratch, not the delivery). String and Int payloads
+verified intact across the reclaim boundary under ASan.
+
 ### Four fixes from a downstream handoff
 
 A substrate friction report surfaced four defects, fixed here as one

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -14830,6 +14830,104 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// so a location never attaches to a foreign function's
     /// instructions (LLVM verifier: "!dbg attachment points at
     /// wrong subprogram"). No-op end to end when `di` is None.
+    /// Resolve a self-relative field chain (`self`, `self.child`,
+    /// `self.a.b`) to the locus type at its tip, without emitting IR.
+    /// `None` for any receiver that isn't such a chain of LocusRef
+    /// fields. Used only to recognize the intra-locus-publish desugar's
+    /// direct call to a subscriber handler.
+    fn receiver_locus_name(&self, e: &Expr) -> Option<String> {
+        match e {
+            Expr::KwSelf(_) => {
+                self.current_self.as_ref().map(|cs| cs.locus_name.clone())
+            }
+            Expr::Field { receiver, name, .. } => {
+                let base = self.receiver_locus_name(receiver)?;
+                let info = self.user_loci.get(&base)?;
+                match info.fields.get(&name.name) {
+                    Some((_, CodegenTy::LocusRef(l))) => Some(l.clone()),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// Is this statement-position call the intra-locus-publish desugar's
+    /// direct handler call (`self.<child>.<handler>(payload)`)? A bus
+    /// subscription handler is not callable from Hale source, so a call
+    /// to one can only be that desugar. The payload is the struct-literal
+    /// argument. Recognizing this lets the caller reclaim the payload the
+    /// bus queue would have — see the call site.
+    fn is_intra_locus_publish_call(
+        &self,
+        callee: &Expr,
+        args: &[Expr],
+    ) -> bool {
+        let Expr::Field { receiver, name, .. } = callee else {
+            return false;
+        };
+        let Some(recv_locus) = self.receiver_locus_name(receiver) else {
+            return false;
+        };
+        let Some(info) = self.user_loci.get(&recv_locus) else {
+            return false;
+        };
+        let is_handler =
+            info.subscriptions.iter().any(|(_, h, _, _)| h == &name.name);
+        is_handler && args.iter().any(|a| matches!(a, Expr::Struct { .. }))
+    }
+
+    /// Lower an intra-locus-publish direct handler call with its payload
+    /// confined to a per-delivery arena subregion. The payload (and any
+    /// interior allocations, e.g. a `String` slice field) build into the
+    /// subregion; the synchronous handler runs; the subregion is then
+    /// destroyed. Safe because the handler has returned and Hale copies
+    /// on every field store, so nothing the handler kept still points
+    /// into the freed region — the same lifetime the bus queue's cell
+    /// reclaim gives a delivered payload.
+    fn lower_reclaimed_publish_call(
+        &mut self,
+        callee: &Expr,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<BlockEnd, CodegenError> {
+        let parent = self.current_arena_ptr()?;
+        let create = self
+            .module
+            .get_function("lotus_arena_create_subregion")
+            .expect("lotus_arena_create_subregion declared");
+        let subregion = self
+            .builder
+            .build_call(create, &[parent.into()], "publish.scratch.create")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .expect("subregion_create returns ptr")
+            .into_pointer_value();
+
+        let saved_override = self.current_arena_override;
+        self.current_arena_override = Some(subregion);
+        let Expr::Field { receiver, name, .. } = callee else {
+            unreachable!("is_intra_locus_publish_call gated on a Field callee");
+        };
+        let call_result = if matches!(receiver.as_ref(), Expr::KwSelf(_)) {
+            self.lower_self_method_call(&name.name, args, scope)
+        } else {
+            self.lower_external_method_call(receiver, &name.name, args, scope)
+        };
+        self.current_arena_override = saved_override;
+        call_result?;
+
+        let destroy = self
+            .module
+            .get_function("lotus_arena_destroy")
+            .expect("lotus_arena_destroy declared");
+        self.builder
+            .build_call(destroy, &[subregion.into()], "publish.scratch.destroy")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        Ok(BlockEnd::Open)
+    }
+
     pub(crate) fn lower_stmt(
         &mut self,
         stmt: &Stmt,
@@ -15612,6 +15710,26 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     }
                     Expr::Path(qn) => {
                         self.lower_path_call(qn, args, scope)?;
+                    }
+                    // An intra-locus publish, direct-called. `desugar_
+                    // intra_locus_topics` rewrites `Topic <- payload`
+                    // for a topic used only within a locus tree into a
+                    // direct call to the subscriber's bus handler,
+                    // sidestepping the bus queue — and with it the
+                    // queue's per-delivery reclaim. The payload then
+                    // builds as an ordinary call argument in the
+                    // method's scratch subregion and is not freed until
+                    // `run()` returns, so a long-running publish loop
+                    // accrues one payload per delivery. Reclaim it: a
+                    // bus handler is not callable from Hale source, so a
+                    // statement-position call to one is unambiguously
+                    // this desugar, and the payload is dead the moment
+                    // the synchronous handler returns.
+                    Expr::Field { .. }
+                        if self.is_intra_locus_publish_call(callee, args) =>
+                    {
+                        return self
+                            .lower_reclaimed_publish_call(callee, args, scope);
                     }
                     Expr::Field { receiver, name, .. }
                         if matches!(receiver.as_ref(), Expr::KwSelf(_)) =>

--- a/tests/hale/intra_locus_publish_reclaim_test.hl
+++ b/tests/hale/intra_locus_publish_reclaim_test.hl
@@ -1,0 +1,69 @@
+// An intra-locus publish delivered by the direct-call desugar must not
+// accrue its payload, and must deliver it intact.
+//
+// `desugar_intra_locus_topics` rewrites `Topic <- payload` (for a topic
+// used only within a locus tree, no binding) into a direct call to the
+// subscriber's bus handler, sidestepping the bus queue — and with it
+// the queue's per-delivery reclaim. The payload then built into the
+// publisher's method-scratch subregion and was not freed until the
+// publisher's run() returned, so a long-running publish loop accrued one
+// payload per delivery (GH: downstream handoff — ~31 B/cell on a string
+// payload). Codegen now confines each such payload to its own subregion,
+// destroyed once the synchronous handler returns.
+//
+// This test can't measure bytes/cell in-harness, so it pins the two
+// properties a reclaim must not break: delivery still happens, and the
+// payload the handler reads (and STORES, which deep-copies) is intact
+// across the reclaim boundary. The compiled-corpus oracle runs it under
+// ASan, where freeing a still-referenced payload would surface.
+
+type Ping { seq: Int = 0; sym: String = ""; }
+
+topic Tick { payload: Ping; subject: "reclaim.test"; }
+
+locus Sub {
+    params { sum: Int = 0; joined: String = ""; hits: Int = 0; }
+    bus { subscribe Tick as on_tick; }
+    fn on_tick(p: Ping) {
+        self.sum = self.sum + p.seq; // reads an Int field
+        self.joined = self.joined + p.sym; // reads AND stores a String (deep-copy)
+        self.hits = self.hits + 1;
+    }
+    fn hits() -> Int { return self.hits; }
+    fn sum() -> Int { return self.sum; }
+    fn joined() -> String { return self.joined; }
+}
+
+// A locus publisher, so the topic is intra-locus (Pub publishes, its
+// child Sub subscribes) and the direct-call reclaim path is exercised.
+locus Pub {
+    params { sub: Sub = Sub { }; }
+    bus { publish Tick; }
+    fn go() {
+        let mut i = 0;
+        while i < 5 {
+            // Inline slice so the payload's interior String is built
+            // inside the publish — the case that must reclaim fully.
+            Tick <- Ping { seq: i, sym: "ab" };
+            i = i + 1;
+        }
+    }
+    fn hits() -> Int { return self.sub.hits(); }
+    fn sum() -> Int { return self.sub.sum(); }
+    fn joined() -> String { return self.sub.joined(); }
+}
+
+main locus App {
+    params { pub: Pub = Pub { }; }
+}
+
+fn main() {
+    let app = App { };
+    app.pub.go();
+
+    std::test::assert_eq_int(app.pub.hits(), 5, "every intra-locus publish is delivered");
+    std::test::assert_eq_int(app.pub.sum(), 10, "Int payload fields survive the reclaim (0+1+2+3+4)");
+    std::test::assert(
+        app.pub.joined() == "ababababab",
+        "String payload fields survive the reclaim and store correctly");
+}


### PR DESCRIPTION
The fifth and final item from the downstream substrate handoff. The other four shipped in #450; this closes P2, the same-thread dispatch memory accrual.

## The bug, and why the reported mechanism didn't exist

The report described a ~31 B/delivery accrual on same-thread bus dispatch, with the proposed fix "reclaim the delivery cell on handler return, as the queued path does." Investigation (in #450's writeup) showed **that cell doesn't exist** — the direct-call path allocates none. The real mechanism, traced here:

`desugar_intra_locus_topics` rewrites `Topic <- payload` — for a topic used only within a locus tree, with no transport binding — into a direct call to the subscriber's bus handler (`self.child.on_topic(payload)`), sidestepping the bus queue entirely. That's a genuine dispatch win, but it also sidesteps the queue's **per-delivery cell reclaim**. The payload then builds as an ordinary call argument in the publisher's method-scratch subregion, which is only destroyed when `run()` returns — so a long-running publish loop accrues one payload per delivery.

This is why a **string-subject** publish (`"s" <- P{}`) measured 0 B/cell while the equivalent **declared-topic** publish (`Tick <- P{}`) accrued: only the latter references a declared topic and hits the intra-locus desugar. The string form stays a `Stmt::Send` and gets `lower_send`'s stack-alloca fast path.

## The fix

Give the payload the lifetime the queue's cell would have. Codegen builds each intra-locus-publish payload into its **own arena subregion** and destroys it once the synchronous handler returns:

```
subregion = create_subregion(current_arena)
[arena override = subregion]  build payload, call handler  [restore]
destroy(subregion)
```

Safe because the handler has completed and Hale **deep-copies on every field store**, so nothing it retained still points into the freed region. Verified under ASan with a payload the handler both reads (`p.seq`) and stores (`self.joined = self.joined + p.sym`).

**Gated precisely.** A bus subscription handler is not callable from Hale source, so a statement-position call to one (`self.<child>.<handler>(struct-literal)`) is unambiguously this desugar. `is_intra_locus_publish_call` resolves the receiver's locus statically and checks the callee is a subscription handler on it — nothing a user can write matches, so no other call pays the subregion cost.

## Measured

| payload shape | before | after |
|---|---|---|
| flat (Int fields) | 15 B/cell | **0** |
| string, built inline in the publish | 31 B/cell | **0** |
| string, via a prior `let sym = slice` | 31 B/cell | 3 B/cell |

The 3 B/cell residual is the reproducer's own transient `let sym = slice` in method scratch — a separate user-`let`, not the delivery (the general run()-activation-flush the report set aside). The **publish-payload accrual itself goes to zero**.

## Verification

- Full workspace suite: **2498 passed**
- Native `.hl` suite: **6 passed**, incl. a new delivery-and-integrity test (`intra_locus_publish_reclaim_test.hl`) — payloads delivered intact (`sum`/`joined` correct), run under ASan by the corpus oracle
- Downstream fleet: **112/112** binaries check clean
- Bench: the string-subject dispatch path is **byte-identical IR** between base and this branch (confirmed by normalized IR diff), so no dispatch regression — no bench exercises the intra-locus path, so all raw deltas are noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)
