### PR TITLE
diag: an element chain over an unsupported source names itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ behavior.
 
 ## Unreleased
 
+### An element chain over an unsupported source names itself
+
+A chain (`.filter(…).count()` and the like) desugars to a loop that
+fetches each element through the source's `get`. A fixed array `[T; N]`
+or a `bounded[T; N]` has no such accessor, so the chain failed with a
+bare `no field \`get\` on \`[Int; 4]\`` — no mention of chains, and no
+pointer to the source forms a chain does support. `hale check` now
+adds, for exactly that shape, that the form is not a supported chain
+source yet and that chains anchor on a `@form(vec)` directly or a
+`@form(hashmap)` via `.entries`. Ordinary field typos keep their
+did-you-mean hint. (Supporting arrays and `bounded` as chain sources,
+and a `Decimal`/`Float` `sum`, is a larger change — chains desugar
+before type-checking, so the source form and element type aren't yet
+known where the accessor and accumulator are chosen.)
+
 ### An intra-locus publish no longer accrues its payload per delivery
 
 The fifth item from the downstream handoff (the four below shipped

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -11404,12 +11404,39 @@ impl<'a> Checker<'a> {
                                     _ => {}
                                 }
                             }
-                            let hint = crate::stdlib_surface::nearest_name(
-                                &name.name,
-                                candidates.iter().map(|s| s.as_str()),
-                            )
-                            .map(|s| format!(" — did you mean `{}`?", s))
-                            .unwrap_or_default();
+                            // Element chains desugar (pre-typecheck) to a
+                            // loop that fetches each element through the
+                            // source's `get` / `entry_at`. On a source form
+                            // that has neither — a fixed array or a
+                            // `bounded[T; N]` — the failure surfaces here as
+                            // a bare "no field `get`", with no hint that a
+                            // chain was even involved or which forms a chain
+                            // supports. Name it, so the reader doesn't have
+                            // to bisect the desugar (downstream handoff).
+                            let is_chain_accessor =
+                                name.name == "get" || name.name == "entry_at";
+                            let unsupported_chain_source = is_chain_accessor
+                                && matches!(
+                                    rt,
+                                    Ty::Array(..) | Ty::Bounded(..)
+                                );
+                            let hint = if unsupported_chain_source {
+                                format!(
+                                    " — if this is an element chain \
+                                     (`.filter(…).count()` and the like), \
+                                     `{}` is not a supported source form yet; \
+                                     chains anchor on a `@form(vec)` directly \
+                                     or a `@form(hashmap)` via `.entries`",
+                                    rt.display()
+                                )
+                            } else {
+                                crate::stdlib_surface::nearest_name(
+                                    &name.name,
+                                    candidates.iter().map(|s| s.as_str()),
+                                )
+                                .map(|s| format!(" — did you mean `{}`?", s))
+                                .unwrap_or_default()
+                            };
                             self.diags.push(Diag::ty(
                                 *span,
                                 format!(

--- a/crates/hale-types/tests/diag_quality.rs
+++ b/crates/hale-types/tests/diag_quality.rs
@@ -100,3 +100,60 @@ fn field_typo_gets_did_you_mean() {
         ds
     );
 }
+
+#[test]
+fn chain_over_unsupported_source_names_the_chain() {
+    // An element chain desugars to a loop fetching each element through
+    // the source's `get`. A fixed array / `bounded[T; N]` has no such
+    // accessor, so it failed with a bare "no field `get`" that never
+    // mentioned chains or the supported source forms (downstream
+    // handoff). Both the array and the bounded case now say so.
+    for src in [
+        r#"
+            locus L {
+                params { arr: [Int; 4] = [1, 2, 3, 4]; }
+                fn c() -> Int { return self.arr.filter(it > 2).count(); }
+            }
+            fn main() { }
+        "#,
+        r#"
+            fn take(b: bounded[Int; 8]) -> Int {
+                return b.filter(it > 2).count();
+            }
+            fn main() { }
+        "#,
+    ] {
+        let ds = diags(src);
+        assert!(
+            ds.iter().any(|m| {
+                m.contains("element chain")
+                    && m.contains("@form(vec)")
+                    && m.contains("`.entries`")
+            }),
+            "expected a chain-source diagnostic naming the supported \
+             forms; got: {:?}",
+            ds
+        );
+    }
+}
+
+#[test]
+fn a_real_field_typo_still_gets_did_you_mean_not_the_chain_hint() {
+    // The chain hint must not swallow the ordinary did-you-mean path:
+    // `.get` is the chain accessor, but a plain field typo on a struct
+    // is not a chain and keeps its own hint.
+    let src = r#"
+        type Order { quantity: Int = 0; }
+        fn main() {
+            let o = Order { quantity: 2 };
+            println(o.quantty);
+        }
+    "#;
+    let ds = diags(src);
+    assert!(
+        ds.iter().any(|m| m.contains("did you mean `quantity`")
+            && !m.contains("element chain")),
+        "did-you-mean must be unaffected by the chain hint; got: {:?}",
+        ds
+    );
+}


### PR DESCRIPTION
The residual from the P1 element-chains item in the downstream friction log. #450 landed the headline (chains over `@form(hashmap)` via `.entries`); the log's carryover ask was a diagnostic — a chain over a fixed array or `bounded[T; N]` fails with a bare `no field `get`` that "never mention[s] chains or that the source form is unsupported."

## Change

A chain (`.filter(…).count()` and the like) lowers — **before type-checking** — to a loop that fetches each element through the source's `get`. A fixed array (`arr[i]`) and a `bounded[T; N]` (free-fn `at(b, i)`) have no such accessor, so the chain surfaced as an unhelpful `no field `get` on `[Int; 4]``.

`hale check` now recognizes exactly that shape — the chain accessor `get`/`entry_at` missing on an `Ty::Array` / `Ty::Bounded` — and names it:

```
no field `get` on `[Int; 4]` — if this is an element chain
(`.filter(…).count()` and the like), `[Int; 4]` is not a supported
source form yet; chains anchor on a `@form(vec)` directly or a
`@form(hashmap)` via `.entries`
```

An ordinary field typo is not a chain and keeps its did-you-mean hint — a test pins both directions.

## Why not the full feature here

Actually supporting arrays and `bounded` as chain sources, and a `Decimal`/`Float` `sum`, is a larger change and is deliberately **not** in this PR. Chains desugar before typecheck, so the two things that decide how to lower — the **source form** (which accessor: a method `get`, a hashmap `entry_at`, an array index, a bounded `at`) and the **element type** (which zero seeds a `sum`) — aren't known where the desugar runs. The clean paths, for a follow-up with its own review:

- a fallible `get(Int) -> T fallible(IndexError)` surface on `[T; N]` and `bounded[T; N]` (bounded's `at` already *is* this), so the existing chain accessor resolves with no chains.rs change and no counted loop — the fallible get past the end terminates the loop; and
- a type-aware `sum` seed (the current `int(0)` can't type against `Decimal`), which needs the element type — i.e. a post-typecheck hook or a polymorphic zero.

## Verification

- Full workspace suite: **2500 passed** (2498 + two new `diag_quality` tests: the array/bounded chain hint, and did-you-mean staying intact)
- `hale fmt --check .` gate: clean
- Vec and hashmap chains unaffected (no false hint); a plain field typo still gets did-you-mean

🤖 Generated with [Claude Code](https://claude.com/claude-code)