### PR TITLE
feat(chains): second tranche — take/skip/enumerate, seeded sum, sort_into/reverse_into/group_count_into

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,59 @@ behavior.
 
 ## Unreleased
 
+### Element chains: the second vocabulary tranche
+
+The remainder of the chain vocabulary recorded open when #380
+shipped, minus stream sources (still future work). Everything fuses
+into the same single loop — or, for the whole-set terminals,
+materializes into caller storage — so the zero-allocation contract is
+unchanged.
+
+New **stages**:
+
+- `take(n)` / `skip(n)` — positional selection. Both count elements
+  arriving at their own position in the chain, so
+  `filter(p).skip(2)` skips the first two *matches*; the two orders
+  of `skip`/`take` are different chains and both are pinned by
+  tests. Limits are evaluated once, before the loop.
+- `enumerate()` — binds `idx`, the 0-based count of elements
+  reaching the stage, in every later stage and the terminal. An
+  explicit opt-in stage rather than an always-bound name, so a
+  chain never captures a user's own `idx` local; a second
+  `enumerate` shadows the first for everything after it. A
+  `min`/`max` key mentioning `idx` is rejected rather than silently
+  miscompared (the best element's count is not recoverable from the
+  element at compare time).
+
+New **terminals**:
+
+- `sum(seed)` — the seed is the accumulator's starting value *and*
+  its typed zero, so `sum(0.0)` sums Float elements and `sum(100)`
+  starts an Int sum at 100. Closes the "Int elements only" gap
+  without literal suffixes, and stays pre-typecheck-safe.
+- `sort_into(target, cmp?)` / `reverse_into(target)` — push the
+  survivors into a caller-owned `@form(vec)`, then reorder it in
+  place (the vec's own `sort()`/`sort_by(cmp)`, or an end-swap
+  loop). The spec's boundary paragraph already said whole-set
+  operations are "terminals that materialize into caller storage";
+  now they exist.
+- `group_count_into(target, key?)` — one hashmap `bump(key)` per
+  survivor (increment-or-init tallying); the bare form keys on the
+  element itself. Accumulates across chains, since `bump` does.
+
+The whole-set terminals are recognized even stage-less
+(`xs.sort_into(sorted)`) — their compound names belong to the
+vocabulary, unlike bare `into`. The recognition gate's it-mention
+walker also learned to see through if/match/block expressions, so a
+conditional key (`group_count_into(t, if it % 2 == 0 { "even" }
+else { "odd" })`) counts as the it-mention it is.
+
+Coverage is pairwise over the interaction classes — every new stage
+against every terminal family, both orders of the order-sensitive
+pairs, `idx` reach into each-blocks and keys, hashmap `.entries`
+sources, counter re-init on re-execution, and the facade-safety
+negatives.
+
 ### Free-fn locus rebinding no longer reclaims live memory
 
 **Critical regression, shipped in v0.16.0** (the GH #402

--- a/crates/hale-codegen/tests/element_chains.rs
+++ b/crates/hale-codegen/tests/element_chains.rs
@@ -384,3 +384,422 @@ fn find_miss_or_raise_diverges() {
         out
     );
 }
+
+// ==== 2026-08-11 tranche: take / skip / enumerate / seeded sum /
+// ==== sort_into / reverse_into / group_count_into.
+//
+// The vocabulary is combinatorial — 5 orderable stages x 6 terminal
+// families x 2 sources x 3 contexts — so coverage here is pairwise
+// over the interaction classes rather than cartesian: every NEW
+// stage meets every terminal FAMILY at least once, both orders of
+// every order-sensitive stage pair are pinned, and the dangerous
+// cells (early-break interactions, `idx` reach, counter re-init on
+// re-execution, uid separation) get their own probes.
+
+const F: &str =
+    "@form(vec)\nlocus Floats { capacity { heap items of Float; } }\n";
+
+const T: &str = "type Tally { tag: String; n: Int; }\n\
+    @form(hashmap)\n\
+    locus Tallies { capacity { pool entries of Tally indexed_by tag; } }\n";
+
+fn seed_ten() -> &'static str {
+    "let v = Nums { };\n\
+     let mut i = 1;\n\
+     while i <= 10 { v.push(i); i = i + 1; }\n"
+}
+
+/// take / skip count elements ARRIVING at their own stage position,
+/// and the two orders of skip x take are different chains: 1..10 has
+/// skip(1).take(3) = {2,3,4} while take(3).skip(1) = {2,3}.
+#[test]
+fn skip_take_both_orders_and_filter_position() {
+    let src = format!(
+        "{V}fn main() {{
+            {seed}
+            println(\"st=\", v.skip(1).take(3).sum());
+            println(\"ts=\", v.take(3).skip(1).sum());
+            println(\"ft=\", v.filter(it % 2 == 0).take(2).sum());
+            println(\"tf=\", v.take(2).filter(it % 2 == 0).sum());
+            println(\"fs=\", v.filter(it % 2 == 0).skip(3).sum());
+            println(\"sf=\", v.skip(3).filter(it % 2 == 0).sum());
+        }}",
+        seed = seed_ten()
+    );
+    let (out, st) = run("skip_take_orders", &src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("st=9"), "2+3+4: {:?}", out);
+    assert!(out.contains("ts=5"), "2+3: {:?}", out);
+    assert!(out.contains("ft=6"), "2+4 (first two matches): {:?}", out);
+    assert!(out.contains("tf=2"), "even of {{1,2}}: {:?}", out);
+    assert!(out.contains("fs=18"), "8+10 (skip 3 MATCHES): {:?}", out);
+    assert!(out.contains("sf=28"), "4+6+8+10: {:?}", out);
+}
+
+/// take(0) never admits an element; saturation and repeated
+/// positional stages compose; limits are ordinary expressions.
+#[test]
+fn take_zero_saturation_and_stacked_positionals() {
+    let src = format!(
+        "{V}fn main() {{
+            {seed}
+            println(\"t0=\", v.take(0).count());
+            println(\"big=\", v.take(99).count());
+            println(\"tt=\", v.take(5).take(2).sum());
+            println(\"ss=\", v.skip(4).skip(4).sum());
+            let n = 2;
+            println(\"expr=\", v.take(n + 1).sum());
+        }}",
+        seed = seed_ten()
+    );
+    let (out, st) = run("take_zero", &src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("t0=0"), "got: {:?}", out);
+    assert!(out.contains("big=10"), "limit past the end: {:?}", out);
+    assert!(out.contains("tt=3"), "1+2 (inner take wins): {:?}", out);
+    assert!(out.contains("ss=19"), "9+10: {:?}", out);
+    assert!(out.contains("expr=6"), "1+2+3: {:?}", out);
+}
+
+/// `idx` counts the stream reaching the enumerate STAGE: before a
+/// filter it is the source index, after it is the match ordinal. A
+/// second enumerate shadows the first for everything after it.
+#[test]
+fn enumerate_position_and_shadowing() {
+    let src = format!(
+        "{V}fn main() {{
+            {seed}
+            println(\"pre=\", v.enumerate().filter(idx % 2 == 0).sum());
+            println(\"post=\", v.filter(it > 5).enumerate().map(idx).sum());
+            println(\"both=\", v.enumerate().map(it + idx).sum());
+            println(\"shadow=\", v.enumerate().filter(idx >= 2).enumerate().map(idx).sum());
+        }}",
+        seed = seed_ten()
+    );
+    let (out, st) = run("enumerate_pos", &src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("pre=25"), "1+3+5+7+9 (source idx): {:?}", out);
+    assert!(out.contains("post=10"), "0+1+2+3+4 (match ordinal): {:?}", out);
+    assert!(out.contains("both=100"), "55 + 45: {:?}", out);
+    // outer idx filters to elements 3..10 (8 of them); inner idx
+    // renumbers them 0..7 -> sum 28.
+    assert!(out.contains("shadow=28"), "inner enumerate renumbers: {:?}", out);
+}
+
+/// Every new stage against the indexed-fallible family — the stage
+/// counters live in `lower_indexed`'s init path, and the take break
+/// must leave the best-so-far index intact.
+#[test]
+fn positional_stages_with_indexed_terminals() {
+    let src = format!(
+        "{V}fn main() {{
+            {seed}
+            println(\"sf=\", v.filter(it % 2 == 0).skip(2).first() or -1);
+            println(\"tm=\", v.take(4).max() or -1);
+            println(\"ef=\", v.enumerate().filter(idx == it - 1).first() or -1);
+            println(\"miss=\", v.skip(10).first() or -1);
+            println(\"t0m=\", v.take(0).min() or -1);
+            println(\"sfind=\", v.skip(2).find(it % 3 == 0) or -1);
+        }}",
+        seed = seed_ten()
+    );
+    let (out, st) = run("positional_indexed", &src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("sf=6"), "third even: {:?}", out);
+    assert!(out.contains("tm=4"), "max of first four: {:?}", out);
+    assert!(out.contains("ef=1"), "idx==it-1 holds from the start: {:?}", out);
+    assert!(out.contains("miss=-1"), "skip past the end is empty: {:?}", out);
+    assert!(out.contains("t0m=-1"), "take(0) min is empty: {:?}", out);
+    assert!(out.contains("sfind=3"), "find after skip sees 3 first: {:?}", out);
+}
+
+/// Early-break interactions: any's break vs take's break, all's
+/// vacuous truth over a take(0) selection, and a `continue` inside
+/// an each block advancing PAST an already-counted element.
+#[test]
+fn early_break_interactions() {
+    let src = format!(
+        "{V}fn main() {{
+            {seed}
+            println(\"a=\", v.take(3).any(it > 2));
+            println(\"a2=\", v.take(2).any(it > 5));
+            println(\"vac=\", v.take(0).all(it > 100));
+            let mut seen = 0;
+            v.take(4).each {{
+                if it % 2 == 0 {{ continue; }}
+                seen = seen + it;
+            }}
+            println(\"seen=\", seen);
+            let mut idxsum = 0;
+            v.filter(it > 6).enumerate().each {{ idxsum = idxsum + idx; }}
+            println(\"idxsum=\", idxsum);
+        }}",
+        seed = seed_ten()
+    );
+    let (out, st) = run("early_break", &src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("a=true"), "3 > 2 within take: {:?}", out);
+    assert!(out.contains("a2=false"), "take caps before a hit: {:?}", out);
+    assert!(out.contains("vac=true"), "empty all is true: {:?}", out);
+    assert!(out.contains("seen=4"), "1+3, continue skips evens: {:?}", out);
+    assert!(out.contains("idxsum=6"), "0+1+2+3 over four matches: {:?}", out);
+}
+
+/// sum(seed): the seed is the accumulator's typed zero (Float) and
+/// its starting value (Int offset); a map stage composes.
+#[test]
+fn seeded_sum_float_and_offset() {
+    let src = format!(
+        "{V}{F}fn main() {{
+            let f = Floats {{ }};
+            f.push(1.5); f.push(2.25); f.push(3.25);
+            println(\"f=\", f.filter(it > 1.6).sum(0.0));
+            println(\"fm=\", f.map(it + 0.5).sum(0.0));
+            {seed}
+            println(\"off=\", v.take(2).sum(100));
+            println(\"empty=\", v.take(0).sum(7));
+        }}",
+        seed = seed_ten()
+    );
+    let (out, st) = run("seeded_sum", &src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("f=5.5"), "2.25+3.25: {:?}", out);
+    assert!(out.contains("fm=8.5"), "2.0+2.75+3.75: {:?}", out);
+    assert!(out.contains("off=103"), "100+1+2: {:?}", out);
+    assert!(out.contains("empty=7"), "empty selection = seed: {:?}", out);
+}
+
+/// The whole-set terminals materialize into caller storage and then
+/// reorder it: sort_into (primitive + comparator), reverse_into, and
+/// take saturation must still run the post-loop reorder.
+#[test]
+fn sort_and_reverse_into() {
+    let src = format!(
+        "{V}fn desc(a: Int, b: Int) -> Bool {{ return a > b; }}
+        fn main() {{
+            let v = Nums {{ }};
+            v.push(3); v.push(9); v.push(1); v.push(7); v.push(5);
+            let s = Nums {{ }};
+            v.filter(it > 1).sort_into(s);
+            println(\"s=\", s.get(0) or -1, \",\", s.get(3) or -1, \",\", s.len());
+            let d = Nums {{ }};
+            v.sort_into(d, desc);
+            println(\"d=\", d.get(0) or -1, \",\", d.get(4) or -1);
+            let r = Nums {{ }};
+            v.take(3).reverse_into(r);
+            println(\"r=\", r.get(0) or -1, \",\", r.get(1) or -1, \",\", r.get(2) or -1);
+            let ts = Nums {{ }};
+            v.take(2).sort_into(ts);
+            println(\"ts=\", ts.get(0) or -1, \",\", ts.get(1) or -1);
+        }}"
+    );
+    let (out, st) = run("sort_reverse", &src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("s=3,9,4"), "sorted survivors: {:?}", out);
+    assert!(out.contains("d=9,1"), "comparator descends: {:?}", out);
+    assert!(out.contains("r=1,9,3"), "first three reversed: {:?}", out);
+    assert!(out.contains("ts=3,9"), "post-break reorder still runs: {:?}", out);
+}
+
+/// group_count_into rides the hashmap's bump: keyed by an
+/// it-expression, by the element itself (bare), by `idx` through an
+/// enumerate, and ACCUMULATING across two chains (increment-or-init).
+#[test]
+fn group_count_into_tallies() {
+    let src = format!(
+        "{V}{T}fn main() {{
+            {seed}
+            let t = Tallies {{ }};
+            v.group_count_into(t, if it % 2 == 0 {{ \"even\" }} else {{ \"odd\" }});
+            let e = t.get(\"even\") or Tally {{ tag: \"?\", n: -1 }};
+            let o = t.get(\"odd\") or Tally {{ tag: \"?\", n: -1 }};
+            println(\"eo=\", e.n, \",\", o.n);
+            v.take(4).group_count_into(t, \"even\");
+            let e2 = t.get(\"even\") or Tally {{ tag: \"?\", n: -1 }};
+            println(\"acc=\", e2.n);
+            let b = Tallies {{ }};
+            v.map(if it > 5 {{ \"hi\" }} else {{ \"lo\" }}).group_count_into(b, it);
+            let hi = b.get(\"hi\") or Tally {{ tag: \"?\", n: -1 }};
+            println(\"bare=\", hi.n);
+            let g = Tallies {{ }};
+            v.enumerate().group_count_into(g, if idx < 3 {{ \"head\" }} else {{ \"tail\" }});
+            let tl = g.get(\"tail\") or Tally {{ tag: \"?\", n: -1 }};
+            println(\"idxkey=\", tl.n);
+        }}",
+        seed = seed_ten()
+    );
+    let (out, st) = run("group_count", &src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("eo=5,5"), "five even, five odd: {:?}", out);
+    assert!(out.contains("acc=9"), "5 + 4 more bumps accumulate: {:?}", out);
+    assert!(out.contains("bare=5"), "mapped element as key: {:?}", out);
+    assert!(out.contains("idxkey=7"), "idx reaches the key: {:?}", out);
+}
+
+/// The hashmap `.entries` source drives the same counter machinery
+/// through `entry_at`, including regrouping one map into another.
+#[test]
+fn hashmap_source_with_new_stages() {
+    let src = format!(
+        "{T}fn main() {{
+            let t = Tallies {{ }};
+            t.set(Tally {{ tag: \"a\", n: 3 }});
+            t.set(Tally {{ tag: \"b\", n: 5 }});
+            t.set(Tally {{ tag: \"c\", n: 7 }});
+            t.set(Tally {{ tag: \"d\", n: 9 }});
+            println(\"take=\", t.entries.take(2).count());
+            println(\"skip=\", t.entries.skip(3).count());
+            println(\"sum=\", t.entries.map(it.n).sum());
+            println(\"enum=\", t.entries.enumerate().map(idx).sum());
+            let g = Tallies {{ }};
+            t.entries.filter(it.n > 4).group_count_into(g, \"big\");
+            let big = g.get(\"big\") or Tally {{ tag: \"?\", n: -1 }};
+            println(\"regroup=\", big.n);
+        }}"
+    );
+    let (out, st) = run("hashmap_stages", &src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("take=2"), "got: {:?}", out);
+    assert!(out.contains("skip=1"), "got: {:?}", out);
+    assert!(out.contains("sum=24"), "3+5+7+9: {:?}", out);
+    assert!(out.contains("enum=6"), "0+1+2+3: {:?}", out);
+    assert!(out.contains("regroup=3"), "5, 7 and 9 pass n>4: {:?}", out);
+}
+
+/// Context axes: a chain re-executed in a loop re-inits its
+/// counters; two chains with the same stages in one block keep
+/// their uids apart; a chain nested in a stage argument carries its
+/// own counters; statement-position sort_into splices with its
+/// post statements intact.
+#[test]
+fn counter_reinit_uid_separation_and_nesting() {
+    let src = format!(
+        "{V}fn main() {{
+            {seed}
+            let mut round = 0;
+            let mut total = 0;
+            while round < 3 {{
+                total = total + v.skip(8).take(1).sum();
+                round = round + 1;
+            }}
+            println(\"reinit=\", total);
+            let a = v.take(2).sum();
+            let b = v.take(3).sum();
+            println(\"uids=\", a, \",\", b);
+            println(\"nested=\", v.filter(it > v.take(4).sum() - 7).count());
+            let s = Nums {{ }};
+            v.skip(7).sort_into(s);
+            println(\"stmt=\", s.get(0) or -1, \",\", s.len());
+        }}",
+        seed = seed_ten()
+    );
+    let (out, st) = run("reinit_uid", &src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("reinit=27"), "9 three times, fresh counters: {:?}", out);
+    assert!(out.contains("uids=3,6"), "1+2 and 1+2+3: {:?}", out);
+    // take(4).sum() = 10; filter(it > 3) -> 7 elements.
+    assert!(out.contains("nested=7"), "inner chain in a predicate: {:?}", out);
+    assert!(out.contains("stmt=8,3"), "statement-position post ran: {:?}", out);
+}
+
+/// Method context: the desugar walks locus fn bodies; a self-field
+/// source and a self-field target work with the new stages.
+#[test]
+fn method_context_new_stages() {
+    let src = format!(
+        "{V}locus Holder {{
+            params {{ xs: Nums = Nums {{ }}; out: Nums = Nums {{ }}; }}
+            fn fill() {{
+                let mut i = 1;
+                while i <= 6 {{ self.xs.push(i); i = i + 1; }}
+            }}
+            fn head_sum(n: Int) -> Int {{
+                return self.xs.take(n).sum();
+            }}
+            fn tail_sorted_desc() {{
+                self.xs.skip(4).sort_into(self.out, __desc);
+            }}
+        }}
+        fn __desc(a: Int, b: Int) -> Bool {{ return a > b; }}
+        fn main() {{
+            let h = Holder {{ }};
+            h.fill();
+            println(\"hs=\", h.head_sum(3));
+            h.tail_sorted_desc();
+            println(\"ts=\", h.out.get(0) or -1, \",\", h.out.get(1) or -1);
+        }}"
+    );
+    let (out, st) = run("method_ctx", &src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("hs=6"), "1+2+3: {:?}", out);
+    assert!(out.contains("ts=6,5"), "5,6 sorted descending: {:?}", out);
+}
+
+/// Negative space. A min/max key that mentions `idx` is NOT lowered
+/// (the best's enumerate count is unrecoverable at compare time) —
+/// it must fail to build, never miscompare.
+#[test]
+fn min_key_mentioning_idx_is_rejected() {
+    let src = format!(
+        "{V}fn main() {{
+            let v = Nums {{ }};
+            v.push(3);
+            let m = v.enumerate().min(it + idx) or -1;
+            println(\"m=\", m);
+        }}"
+    );
+    let program = hale_syntax::parse_source(&src).expect("parse");
+    let bin = harness::unique_bin(&format!(
+        "hale_chain_minidx_{}",
+        std::process::id()
+    ));
+    let res = build_executable(&program, &bin);
+    let _ = std::fs::remove_file(&bin);
+    assert!(res.is_err(), "an idx-keyed min must not lower");
+}
+
+/// Negative space, facade half: user methods named like the new
+/// stages resolve as ordinary calls when no chain terminal follows,
+/// and a stage-less seeded sum / bare-keyed group_count_into stay
+/// ordinary calls (conservative recognition, unchanged).
+#[test]
+fn new_stage_names_do_not_hijack_facades() {
+    let src = r#"
+        locus Pager {
+            params { width: Int = 10; }
+            fn take(n: Int) -> Int { return n * self.width; }
+            fn skip(n: Int) -> Int { return n + self.width; }
+        }
+        fn main() {
+            let p = Pager { };
+            println("t=", p.take(3));
+            println("s=", p.skip(3));
+        }
+    "#;
+    let (out, st) = run("facade_take", src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("t=30"), "user take resolves: {:?}", out);
+    assert!(out.contains("s=13"), "user skip resolves: {:?}", out);
+}
+
+/// Name threading: `map` rebinds the element to a fresh local, and
+/// take/skip/enumerate pass the CURRENT name through — a map on each
+/// side of a positional stage must see its own element.
+#[test]
+fn map_sandwich_around_positional_stages() {
+    let src = format!(
+        "{V}fn main() {{
+            {seed}
+            let t = Nums {{ }};
+            v.map(it * 2).take(3).map(it + 1).into(t);
+            println(\"t=\", t.get(0) or -1, \",\", t.get(2) or -1, \",\", t.len());
+            println(\"s=\", v.map(it * 10).skip(8).enumerate().map(it + idx).sum());
+        }}",
+        seed = seed_ten()
+    );
+    let (out, st) = run("map_sandwich", &src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(out.contains("t=3,7,3"), "(1,2,3)*2+1 = 3,5,7: {:?}", out);
+    // 90+0 and 100+1 -> 191.
+    assert!(out.contains("s=191"), "maps on both sides of skip/enumerate: {:?}", out);
+}

--- a/crates/hale-syntax/src/chains.rs
+++ b/crates/hale-syntax/src/chains.rs
@@ -31,18 +31,25 @@
 //! machinery in either, and a chain over a non-form receiver fails
 //! with the ordinary "no method `len`" diagnostic.
 //!
-//! ## Vocabulary (2026-08-04 tranche; v1 was filter/count/into)
+//! ## Vocabulary (2026-08-04 tranche + 2026-08-11 tranche;
+//! v1 was filter/count/into)
 //!
 //! Elementwise stages — fuse into the one loop:
 //!   - `filter(pred)`  — `it`-predicate, drops non-matching elements
 //!   - `map(expr)`     — `it`-expression, rebinds the element
+//!   - `take(n)`       — stop the chain after n elements pass here
+//!   - `skip(n)`       — drop the first n elements reaching here
+//!   - `enumerate()`   — binds `idx` (0-based count of elements
+//!                       reaching this stage) in later stages and
+//!                       the terminal; explicit opt-in so a user's
+//!                       own `idx` local is never captured silently
 //!
 //! Terminals:
 //!   - `count()`            → Int
 //!   - `into(target)`       → pushes surviving (mapped) elements
-//!   - `sum()`              → Int (v1: Int elements only — the
-//!                            accumulator's typed zero needs literal
-//!                            suffixes for Float/Decimal/Duration)
+//!   - `sum()` / `sum(seed)` → `sum()` is Int; `sum(seed)` seeds the
+//!                            accumulator, and the seed IS its typed
+//!                            zero — `sum(0.0)` for Float elements
 //!   - `any(pred?)`         → Bool; empty ⇒ false (vacuous)
 //!   - `all(pred)`          → Bool; empty ⇒ true  (vacuous)
 //!   - `first()`            → element, FALLIBLE on empty (IndexError,
@@ -54,6 +61,22 @@
 //!                            on empty like `first`
 //!   - `each { ... }`       → side-effectful visitation; the block is
 //!                            the fused loop body with `it` bound
+//!   - `sort_into(target, cmp?)` → push survivors, then reorder the
+//!                            caller storage in place (`sort()` /
+//!                            `sort_by(cmp)`) — the whole-set ops
+//!                            materialize into CALLER storage, so
+//!                            the chain itself still allocates
+//!                            nothing
+//!   - `reverse_into(target)` → push survivors, then swap ends
+//!                            inward on the caller storage
+//!   - `group_count_into(target, key?)` → one hashmap `bump(key)`
+//!                            per survivor (increment-or-init); the
+//!                            bare form keys on the element itself
+//!
+//! A min/max KEY mentioning `idx` is left unrecognized: the best
+//! element's key is re-derived from `src.get(idx)` at compare time,
+//! and its enumerate count is not recoverable from the element —
+//! rejecting beats silently comparing with the wrong counter.
 //!
 //! Recognition is deliberately conservative so user-declared facade
 //! methods never get hijacked:
@@ -65,7 +88,11 @@
 //!     this — or when it is `each` with a block argument (no user
 //!     surface takes a block).
 //!   Bare `xs.sum()` / `xs.first()` therefore stay ordinary method
-//!   calls (`first` stage-less is just `xs.get(0) or …`).
+//!   calls (`first` stage-less is just `xs.get(0) or …`). The
+//!   whole-set terminals (`sort_into` / `reverse_into` /
+//!   `group_count_into`) are the exception: recognized stage-less
+//!   too — their compound names are this vocabulary's own, so
+//!   `xs.sort_into(sorted)` works as written.
 //!
 //! The element-valued fallible terminals (`first`/`find`/`min`/`max`)
 //! reuse the source's OWN fallible `get`: the loop finds an index,
@@ -152,6 +179,20 @@ fn if_stmt(i: &mut IfStmt, n: &mut usize) {
 enum Stage {
     Filter(Expr),
     Map(Expr),
+    /// 2026-08-11 tranche. `take(n)`: stop the whole chain once n
+    /// elements have passed this point; `skip(n)`: drop the first n
+    /// that reach it. Both count elements ARRIVING at their own
+    /// stage position, so `filter(p).skip(2)` skips the first two
+    /// matches, not the first two source elements. Their counters
+    /// are pre-loop inits (see `apply_stages`).
+    Take(Expr),
+    Skip(Expr),
+    /// `enumerate()`: binds `idx` — the 0-based count of elements
+    /// reaching this stage — in every LATER stage expression and in
+    /// the terminal. An explicit opt-in stage (not an always-bound
+    /// name) so a user's own `idx` local is never captured by a
+    /// chain that didn't ask.
+    Enumerate,
 }
 
 /// A chain's shape: the source receiver, the accumulated stages, and
@@ -174,31 +215,97 @@ struct Chain {
 
 const TERMINALS: &[&str] = &[
     "count", "into", "sum", "any", "all", "first", "find", "min", "max",
-    "each",
+    "each", "sort_into", "reverse_into", "group_count_into",
 ];
 
-/// Does this expression tree mention the identifier `it`? Used for
+/// Does this expression tree mention the identifier `name`? Used for
 /// the stage-less recognition gate: `it` is unbound outside a chain,
 /// so an argument that mentions it cannot be a valid ordinary call.
 /// Conservative direction: an unrecognized Expr variant returns
 /// false, which merely leaves the call as an ordinary method call —
 /// and if it truly used `it`, typecheck rejects the unbound name.
-fn mentions_it(e: &Expr) -> bool {
+fn mentions_ident(e: &Expr, name: &str) -> bool {
+    fn block_mentions(b: &Block, name: &str) -> bool {
+        b.stmts.iter().any(|s| match s {
+            Stmt::Let { value, .. }
+            | Stmt::Assign { value, .. }
+            | Stmt::Fail { value, .. } => mentions_ident(value, name),
+            Stmt::Expr(e) | Stmt::Return(Some(e), _) => {
+                mentions_ident(e, name)
+            }
+            Stmt::If(i) => if_mentions(i, name),
+            Stmt::While { cond, body, .. } => {
+                mentions_ident(cond, name) || block_mentions(body, name)
+            }
+            _ => false,
+        }) || b.tail.as_ref().map_or(false, |t| mentions_ident(t, name))
+    }
+    fn if_mentions(i: &IfStmt, name: &str) -> bool {
+        mentions_ident(&i.cond, name)
+            || block_mentions(&i.then_block, name)
+            || i.else_block.as_ref().map_or(false, |e| match e.as_ref() {
+                ElseBranch::Else(b) => block_mentions(b, name),
+                ElseBranch::ElseIf(ei) => if_mentions(ei, name),
+            })
+    }
     match e {
-        Expr::Ident(i) => i.name == "it",
-        Expr::Field { receiver, .. } => mentions_it(receiver),
+        Expr::Ident(i) => i.name == name,
+        Expr::Field { receiver, .. } => mentions_ident(receiver, name),
         Expr::Call { callee, args, .. } => {
-            mentions_it(callee) || args.iter().any(mentions_it)
+            mentions_ident(callee, name)
+                || args.iter().any(|a| mentions_ident(a, name))
         }
         Expr::Binary { left, right, .. } => {
-            mentions_it(left) || mentions_it(right)
+            mentions_ident(left, name) || mentions_ident(right, name)
         }
-        Expr::Unary { operand, .. } => mentions_it(operand),
+        Expr::Unary { operand, .. } => mentions_ident(operand, name),
         Expr::Index { receiver, index, .. } => {
-            mentions_it(receiver) || mentions_it(index)
+            mentions_ident(receiver, name) || mentions_ident(index, name)
+        }
+        // A conditional key — `group_count_into(t, if it % 2 == 0 {
+        // "even" } else { "odd" })` — must count as an it-mention for
+        // the stage-less recognition gate, same reach as the subst
+        // walker (which already descends these).
+        Expr::If(i) => if_mentions(i, name),
+        Expr::Match(m) => {
+            mentions_ident(&m.scrutinee, name)
+                || m.arms.iter().any(|arm| {
+                    arm.guard
+                        .as_ref()
+                        .map_or(false, |g| mentions_ident(g, name))
+                        || match &arm.body {
+                            MatchArmBody::Expr(e) => {
+                                mentions_ident(e, name)
+                            }
+                            MatchArmBody::Block(b) => {
+                                block_mentions(b, name)
+                            }
+                        }
+                })
+        }
+        Expr::Block(b) => block_mentions(b, name),
+        Expr::Struct { inits, .. } => {
+            inits.iter().any(|i| mentions_ident(&i.value, name))
+        }
+        Expr::Tuple(parts, _) | Expr::Array(parts, _) => {
+            parts.iter().any(|p| mentions_ident(p, name))
+        }
+        Expr::Or { inner, disposition, .. } => {
+            mentions_ident(inner, name)
+                || match disposition {
+                    OrDisposition::Substitute(e)
+                    | OrDisposition::Fail(e, _) => {
+                        mentions_ident(e, name)
+                    }
+                    _ => false,
+                }
         }
         _ => false,
     }
+}
+
+fn mentions_it(e: &Expr) -> bool {
+    mentions_ident(e, "it")
 }
 
 /// Peel `src.filter(p).map(f).<terminal>(…)` into its parts. `None`
@@ -227,6 +334,9 @@ fn peel(e: &Expr) -> Option<Chain> {
         let stage = match name.name.as_str() {
             "filter" if args.len() == 1 => Stage::Filter(args[0].clone()),
             "map" if args.len() == 1 => Stage::Map(args[0].clone()),
+            "take" if args.len() == 1 => Stage::Take(args[0].clone()),
+            "skip" if args.len() == 1 => Stage::Skip(args[0].clone()),
+            "enumerate" if args.is_empty() => Stage::Enumerate,
             _ => break,
         };
         stages.push(stage);
@@ -241,11 +351,20 @@ fn peel(e: &Expr) -> Option<Chain> {
     // methods keep resolving; a genuine mistake gets the ordinary
     // no-method / arity diagnostic).
     let shape_ok = match terminal.as_str() {
-        "count" | "sum" | "first" => term_args.is_empty(),
-        "into" => term_args.len() == 1,
+        "count" | "first" => term_args.is_empty(),
+        // `sum()` = Int accumulator; `sum(seed)` = the seed IS the
+        // accumulator's typed zero (`sum(0.0)` for Float elements).
+        "sum" => term_args.len() <= 1,
+        "into" | "reverse_into" => term_args.len() == 1,
         "any" | "find" => term_args.len() <= 1,
         "all" => term_args.len() == 1,
         "min" | "max" => term_args.len() <= 1,
+        // `sort_into(target)` rides the vec's own `sort()`;
+        // `sort_into(target, cmp)` rides `sort_by(cmp)`.
+        "sort_into" => (1..=2).contains(&term_args.len()),
+        // `group_count_into(target, key?)` rides the hashmap's
+        // `bump`; bare form uses the element itself as the key.
+        "group_count_into" => (1..=2).contains(&term_args.len()),
         "each" => {
             term_args.len() == 1
                 && matches!(term_args[0], Expr::Block(_))
@@ -262,6 +381,19 @@ fn peel(e: &Expr) -> Option<Chain> {
     {
         return None;
     }
+    // A min/max KEY that mentions `idx` cannot lower: the best
+    // element's key is re-derived from `src.get(idx)` at compare
+    // time, and its enumerate count is not recoverable from the
+    // element. Left unrecognized (ordinary diagnostics), never
+    // silently miscompared.
+    if matches!(terminal.as_str(), "min" | "max")
+        && stages.iter().any(|s| matches!(s, Stage::Enumerate))
+        && term_args
+            .first()
+            .map_or(false, |a| mentions_ident(a, "idx"))
+    {
+        return None;
+    }
 
     // Recognition gate.
     let recognized = if !stages.is_empty() {
@@ -273,6 +405,12 @@ fn peel(e: &Expr) -> Option<Chain> {
             "any" | "all" | "find" | "min" | "max" => {
                 term_args.first().map_or(false, mentions_it)
             }
+            // The whole-set terminals are recognized even stage-less:
+            // `xs.sort_into(sorted)` is their natural spelling, and
+            // the compound `*_into` names are this vocabulary's own —
+            // unlike bare `into`, no plausible user facade carries
+            // them. Same reasoning as `each`'s block argument.
+            "sort_into" | "reverse_into" | "group_count_into" => true,
             // No user surface takes a block argument.
             "each" => true,
             _ => false,
@@ -312,94 +450,115 @@ fn peel(e: &Expr) -> Option<Chain> {
 // untouched, which fails CLOSED: the unbound name is a typecheck
 // error at the chain's site, never a silently wrong binding.
 
-fn subst_expr(e: &mut Expr, to: &str) {
+fn subst_expr(e: &mut Expr, from: &str, to: &str) {
     match e {
-        Expr::Ident(i) if i.name == "it" => {
+        Expr::Ident(i) if i.name == from => {
             i.name = to.to_string();
         }
-        Expr::Field { receiver, .. } => subst_expr(receiver, to),
+        Expr::Field { receiver, .. } => subst_expr(receiver, from, to),
         Expr::Call { callee, args, .. } => {
-            subst_expr(callee, to);
+            subst_expr(callee, from, to);
             for a in args {
-                subst_expr(a, to);
+                subst_expr(a, from, to);
             }
         }
         Expr::Binary { left, right, .. } => {
-            subst_expr(left, to);
-            subst_expr(right, to);
+            subst_expr(left, from, to);
+            subst_expr(right, from, to);
         }
-        Expr::Unary { operand, .. } => subst_expr(operand, to),
+        Expr::Unary { operand, .. } => subst_expr(operand, from, to),
         Expr::Index { receiver, index, .. } => {
-            subst_expr(receiver, to);
-            subst_expr(index, to);
+            subst_expr(receiver, from, to);
+            subst_expr(index, from, to);
         }
-        Expr::Path2 { receiver, .. } => subst_expr(receiver, to),
-        Expr::Block(b) => subst_block(b, to),
+        Expr::Path2 { receiver, .. } => subst_expr(receiver, from, to),
+        Expr::Block(b) => subst_block(b, from, to),
+        // A conditional projection — `map(if it > 0 { "pos" } else
+        // { "neg" })` — is an if-EXPRESSION; descend so its arms see
+        // the element.
+        Expr::If(i) => subst_if(i, from, to),
+        Expr::Match(m) => {
+            subst_expr(&mut m.scrutinee, from, to);
+            for arm in &mut m.arms {
+                if let Some(g) = &mut arm.guard {
+                    subst_expr(g, from, to);
+                }
+                match &mut arm.body {
+                    MatchArmBody::Expr(e) => subst_expr(e, from, to),
+                    MatchArmBody::Block(b) => subst_block(b, from, to),
+                }
+            }
+        }
+        Expr::Tuple(parts, _) => {
+            for p in parts {
+                subst_expr(p, from, to);
+            }
+        }
         Expr::Or { inner, disposition, .. } => {
-            subst_expr(inner, to);
+            subst_expr(inner, from, to);
             match disposition {
-                OrDisposition::Substitute(e) => subst_expr(e, to),
-                OrDisposition::Fail(e, _) => subst_expr(e, to),
+                OrDisposition::Substitute(e) => subst_expr(e, from, to),
+                OrDisposition::Fail(e, _) => subst_expr(e, from, to),
                 _ => {}
             }
         }
         Expr::Struct { inits, .. } => {
             for init in inits {
-                subst_expr(&mut init.value, to);
+                subst_expr(&mut init.value, from, to);
             }
         }
         Expr::Array(parts, _) => {
             for p in parts {
-                subst_expr(p, to);
+                subst_expr(p, from, to);
             }
         }
         _ => {}
     }
 }
 
-fn subst_block(b: &mut Block, to: &str) {
+fn subst_block(b: &mut Block, from: &str, to: &str) {
     for s in &mut b.stmts {
-        subst_stmt(s, to);
+        subst_stmt(s, from, to);
     }
     if let Some(t) = &mut b.tail {
-        subst_expr(t, to);
+        subst_expr(t, from, to);
     }
 }
 
-fn subst_stmt(s: &mut Stmt, to: &str) {
+fn subst_stmt(s: &mut Stmt, from: &str, to: &str) {
     match s {
-        Stmt::Let { value, .. } => subst_expr(value, to),
+        Stmt::Let { value, .. } => subst_expr(value, from, to),
         Stmt::Assign { value, target, .. } => {
-            subst_expr(value, to);
+            subst_expr(value, from, to);
             // `it` cannot be assigned (it names an element copy the
             // loop rebinds) — but an index expression in the lvalue
             // tail may mention it. Leave the head; heads named `it`
             // become the unbound-name error, fail closed.
             let _ = target;
         }
-        Stmt::Expr(e) => subst_expr(e, to),
+        Stmt::Expr(e) => subst_expr(e, from, to),
         Stmt::While { cond, body, .. } => {
-            subst_expr(cond, to);
-            subst_block(body, to);
+            subst_expr(cond, from, to);
+            subst_block(body, from, to);
         }
-        Stmt::If(i) => subst_if(i, to),
-        Stmt::Return(Some(e), _) => subst_expr(e, to),
-        Stmt::Fail { value, .. } => subst_expr(value, to),
+        Stmt::If(i) => subst_if(i, from, to),
+        Stmt::Return(Some(e), _) => subst_expr(e, from, to),
+        Stmt::Fail { value, .. } => subst_expr(value, from, to),
         Stmt::Send { subject, value, .. } => {
-            subst_expr(subject, to);
-            subst_expr(value, to);
+            subst_expr(subject, from, to);
+            subst_expr(value, from, to);
         }
         _ => {}
     }
 }
 
-fn subst_if(i: &mut IfStmt, to: &str) {
-    subst_expr(&mut i.cond, to);
-    subst_block(&mut i.then_block, to);
+fn subst_if(i: &mut IfStmt, from: &str, to: &str) {
+    subst_expr(&mut i.cond, from, to);
+    subst_block(&mut i.then_block, from, to);
     if let Some(e) = &mut i.else_block {
         match e.as_mut() {
-            ElseBranch::Else(b) => subst_block(b, to),
-            ElseBranch::ElseIf(e) => subst_if(e, to),
+            ElseBranch::Else(b) => subst_block(b, from, to),
+            ElseBranch::ElseIf(e) => subst_if(e, from, to),
         }
     }
 }
@@ -569,6 +728,8 @@ fn get_or_break(
 }
 
 /// Wrap `action` in the chain's stages, innermost-out. Returns the
+/// pre-loop init statements the stages need (take/skip/enumerate
+/// counters — their state lives across iterations) and the
 /// statements forming the per-element body, and binds the running
 /// element name: stage k's expressions see the element as `elem`,
 /// and a `map` rebinds it to a fresh local for the stages after it.
@@ -578,41 +739,108 @@ fn apply_stages(
     uid: usize,
     mut action: Vec<Stmt>,
     sp: Span,
-) -> Vec<Stmt> {
+) -> (Vec<Stmt>, Vec<Stmt>) {
     // Compute the element name seen AFTER each stage prefix.
     let mut names: Vec<String> = vec![elem0.to_string()];
     let mut mapn = 0usize;
     for s in stages {
         match s {
-            Stage::Filter(_) => {
-                names.push(names.last().unwrap().clone());
-            }
             Stage::Map(_) => {
                 mapn += 1;
                 names.push(format!("__hale_m{}_{}", uid, mapn));
             }
+            // The positional stages read and pass on the same element.
+            Stage::Filter(_)
+            | Stage::Take(_)
+            | Stage::Skip(_)
+            | Stage::Enumerate => {
+                names.push(names.last().unwrap().clone());
+            }
         }
     }
     // Innermost-out: wrap the action with each stage, last first.
+    let mut inits: Vec<Stmt> = Vec::new();
     for (k, s) in stages.iter().enumerate().rev() {
         let seen = names[k].clone(); // element name THIS stage reads
         match s {
             Stage::Filter(p) => {
                 let mut p = p.clone();
-                subst_expr(&mut p, &seen);
+                subst_expr(&mut p, "it", &seen);
                 action = vec![if_then(p, action, sp)];
             }
             Stage::Map(f) => {
                 let mut f = f.clone();
-                subst_expr(&mut f, &seen);
+                subst_expr(&mut f, "it", &seen);
                 let bound = names[k + 1].clone();
                 let mut stmts = vec![let_val(&bound, f, sp)];
                 stmts.extend(action);
                 action = stmts;
             }
+            // `take(n)`: break the whole loop once n elements have
+            // passed this point. Saturation ends the chain — no
+            // later element could contribute anything. The limit is
+            // evaluated ONCE, before the loop.
+            Stage::Take(nexpr) => {
+                let lim = format!("__hale_tk{}_{}", uid, k);
+                let ctr = format!("__hale_tkc{}_{}", uid, k);
+                inits.push(let_val(&lim, nexpr.clone(), sp));
+                inits.push(let_mut(&ctr, int(0, sp), sp));
+                let mut stmts = vec![
+                    if_then(
+                        bin(BinOp::GtEq, var(&ctr, sp), var(&lim, sp), sp),
+                        vec![Stmt::Break(sp)],
+                        sp,
+                    ),
+                    assign(
+                        &ctr,
+                        bin(BinOp::Add, var(&ctr, sp), int(1, sp), sp),
+                        sp,
+                    ),
+                ];
+                stmts.extend(action);
+                action = stmts;
+            }
+            // `skip(n)`: count every element reaching this point and
+            // run the rest only from the (n+1)-th on.
+            Stage::Skip(nexpr) => {
+                let lim = format!("__hale_sk{}_{}", uid, k);
+                let ctr = format!("__hale_skc{}_{}", uid, k);
+                inits.push(let_val(&lim, nexpr.clone(), sp));
+                inits.push(let_mut(&ctr, int(0, sp), sp));
+                let mut stmts = vec![assign(
+                    &ctr,
+                    bin(BinOp::Add, var(&ctr, sp), int(1, sp), sp),
+                    sp,
+                )];
+                stmts.push(if_then(
+                    bin(BinOp::Gt, var(&ctr, sp), var(&lim, sp), sp),
+                    action,
+                    sp,
+                ));
+                action = stmts;
+            }
+            // `enumerate()`: bind `idx` in everything AFTER this
+            // stage. Wrapping runs innermost-out, so a later
+            // enumerate has already substituted its own scope's
+            // `idx` by the time an earlier one wraps — shadowing
+            // falls out of the ordering.
+            Stage::Enumerate => {
+                let ctr = format!("__hale_en{}_{}", uid, k);
+                inits.push(let_mut(&ctr, int(-1, sp), sp));
+                for a in &mut action {
+                    subst_stmt(a, "idx", &ctr);
+                }
+                let mut stmts = vec![assign(
+                    &ctr,
+                    bin(BinOp::Add, var(&ctr, sp), int(1, sp), sp),
+                    sp,
+                )];
+                stmts.extend(action);
+                action = stmts;
+            }
         }
     }
-    action
+    (inits, action)
 }
 
 /// The element name the TERMINAL sees (after all stages).
@@ -678,8 +906,16 @@ fn lower(mut c: Chain, sp: Span, uid: usize) -> Expr {
 
     let fin = final_elem(&c.stages, &elem0, uid);
 
-    // The innermost per-element action + (init, tail) for the block.
-    let (action, init, tail): (Vec<Stmt>, Option<Stmt>, Option<Expr>) =
+    // The innermost per-element action + (init, tail, post) for the
+    // block. `post` runs after the loop — the whole-set terminals
+    // (sort_into / reverse_into) do their reordering there, on the
+    // caller storage the loop filled.
+    let (action, init, tail, post): (
+        Vec<Stmt>,
+        Option<Stmt>,
+        Option<Expr>,
+        Vec<Stmt>,
+    ) =
         match c.terminal.as_str() {
             "count" => (
                 vec![assign(
@@ -689,25 +925,38 @@ fn lower(mut c: Chain, sp: Span, uid: usize) -> Expr {
                 )],
                 Some(let_mut(acc, int(0, sp), sp)),
                 Some(var(acc, sp)),
+                Vec::new(),
             ),
-            // v1: Int elements only — see module docs.
+            // `sum()` = Int accumulator zero; `sum(seed)` = the seed
+            // is the accumulator's initial value AND its typed zero
+            // (`sum(0.0)` for Float elements) — evaluated once,
+            // before the loop, so chains stay pre-typecheck-safe.
             "sum" => (
                 vec![assign(
                     acc,
                     bin(BinOp::Add, var(acc, sp), var(&fin, sp), sp),
                     sp,
                 )],
-                Some(let_mut(acc, int(0, sp), sp)),
+                Some(let_mut(
+                    acc,
+                    c.term_args
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| int(0, sp)),
+                    sp,
+                )),
                 Some(var(acc, sp)),
+                Vec::new(),
             ),
             "any" => (
                 vec![assign(acc, boolean(true, sp), sp), Stmt::Break(sp)],
                 Some(let_mut(acc, boolean(false, sp), sp)),
                 Some(var(acc, sp)),
+                Vec::new(),
             ),
             "all" => {
                 let mut p = c.term_args[0].clone();
-                subst_expr(&mut p, &fin);
+                subst_expr(&mut p, "it", &fin);
                 (
                     vec![if_then(
                         not(p, sp),
@@ -719,18 +968,153 @@ fn lower(mut c: Chain, sp: Span, uid: usize) -> Expr {
                     )],
                     Some(let_mut(acc, boolean(true, sp), sp)),
                     Some(var(acc, sp)),
+                    Vec::new(),
                 )
             }
             "each" => {
                 let Expr::Block(mut b) = c.term_args.remove(0) else {
                     unreachable!("peel gated each on a block arg");
                 };
-                subst_block(&mut b, &fin);
+                subst_block(&mut b, "it", &fin);
                 let mut stmts = b.stmts;
                 if let Some(t) = b.tail {
                     stmts.push(Stmt::Expr(*t));
                 }
-                (stmts, None, None)
+                (stmts, None, None, Vec::new())
+            }
+            // `sort_into(target, cmp?)`: push each surviving element,
+            // then reorder the caller storage in place — the vec's
+            // own `sort()` (primitive ordering) or `sort_by(cmp)`.
+            "sort_into" => {
+                let target = c.term_args[0].clone();
+                let post = match c.term_args.get(1) {
+                    Some(cmp) => vec![Stmt::Expr(method(
+                        target.clone(),
+                        "sort_by",
+                        vec![cmp.clone()],
+                        sp,
+                    ))],
+                    None => vec![Stmt::Expr(method(
+                        target.clone(),
+                        "sort",
+                        Vec::new(),
+                        sp,
+                    ))],
+                };
+                (
+                    vec![Stmt::Expr(method(
+                        target,
+                        "push",
+                        vec![var(&fin, sp)],
+                        sp,
+                    ))],
+                    None,
+                    None,
+                    post,
+                )
+            }
+            // `reverse_into(target)`: push, then swap ends inward.
+            // The `get` misses cannot fire (both indices are in
+            // bounds by construction) and `set`'s error channel is
+            // discarded for the same reason.
+            "reverse_into" => {
+                let target = c.term_args[0].clone();
+                let l = format!("__hale_rl{}", uid);
+                let r = format!("__hale_rr{}", uid);
+                let a = format!("__hale_ra{}", uid);
+                let b = format!("__hale_rb{}", uid);
+                let or_discard = |inner: Expr| {
+                    Stmt::Expr(Expr::Or {
+                        inner: Box::new(inner),
+                        disposition: OrDisposition::Discard(sp),
+                        span: sp,
+                    })
+                };
+                let swap_body = vec![
+                    get_or_break(&target, &l, &a, "get", sp),
+                    get_or_break(&target, &r, &b, "get", sp),
+                    or_discard(method(
+                        target.clone(),
+                        "set",
+                        vec![var(&l, sp), var(&b, sp)],
+                        sp,
+                    )),
+                    or_discard(method(
+                        target.clone(),
+                        "set",
+                        vec![var(&r, sp), var(&a, sp)],
+                        sp,
+                    )),
+                    assign(
+                        &l,
+                        bin(BinOp::Add, var(&l, sp), int(1, sp), sp),
+                        sp,
+                    ),
+                    assign(
+                        &r,
+                        bin(BinOp::Sub, var(&r, sp), int(1, sp), sp),
+                        sp,
+                    ),
+                ];
+                let post = vec![
+                    let_mut(&l, int(0, sp), sp),
+                    let_mut(
+                        &r,
+                        bin(
+                            BinOp::Sub,
+                            method(target.clone(), "len", Vec::new(), sp),
+                            int(1, sp),
+                            sp,
+                        ),
+                        sp,
+                    ),
+                    Stmt::While {
+                        cond: bin(BinOp::Lt, var(&l, sp), var(&r, sp), sp),
+                        body: Block {
+                            stmts: swap_body,
+                            tail: None,
+                            span: sp,
+                        },
+                        span: sp,
+                    },
+                ];
+                (
+                    vec![Stmt::Expr(method(
+                        target,
+                        "push",
+                        vec![var(&fin, sp)],
+                        sp,
+                    ))],
+                    None,
+                    None,
+                    post,
+                )
+            }
+            // `group_count_into(target, key?)`: one `bump` per
+            // surviving element — the hashmap's increment-or-init
+            // counter primitive. Bare form keys on the element
+            // itself.
+            "group_count_into" => {
+                let target = c.term_args[0].clone();
+                let key = match c.term_args.get(1) {
+                    Some(k) => {
+                        let mut k = k.clone();
+                        subst_expr(&mut k, "it", &fin);
+                        k
+                    }
+                    None => var(&fin, sp),
+                };
+                (
+                    vec![Stmt::Expr(method(
+                        target,
+                        "bump",
+                        vec![key],
+                        sp,
+                    ))],
+                    None,
+                    None,
+                    Vec::new(),
+                )
             }
             // `into(target)` pushes the (mapped) element.
             _ => (
@@ -745,15 +1129,19 @@ fn lower(mut c: Chain, sp: Span, uid: usize) -> Expr {
                 ))],
                 None,
                 None,
+                Vec::new(),
             ),
         };
 
-    let body = apply_stages(&c.stages, &elem0, uid, action, sp);
+    let (stage_inits, body) =
+        apply_stages(&c.stages, &elem0, uid, action, sp);
     let mut stmts = Vec::new();
     if let Some(i) = init {
         stmts.push(i);
     }
+    stmts.extend(stage_inits);
     stmts.extend(build_loop(&c.src, uid, body, c.accessor, sp));
+    stmts.extend(post);
     Expr::Block(Block {
         stmts,
         tail: tail.map(Box::new),
@@ -801,7 +1189,7 @@ fn lower_indexed(
                         // Key expression over the candidate.
                         let kname = format!("__hale_k{}", uid);
                         let mut ke = k.clone();
-                        subst_expr(&mut ke, &kname);
+                        subst_expr(&mut ke, "it", &kname);
                         Expr::Block(Block {
                             stmts: vec![let_val(&kname, e, sp)],
                             tail: Some(Box::new(ke)),
@@ -844,8 +1232,10 @@ fn lower_indexed(
     // idx stays) — one redundant compare per seed keeps the shape to
     // two ifs with no else machinery.
 
-    let body = apply_stages(&c.stages, &elem0, uid, action, sp);
+    let (stage_inits, body) =
+        apply_stages(&c.stages, &elem0, uid, action, sp);
     let mut stmts = vec![let_mut(idx, int(-1, sp), sp)];
+    stmts.extend(stage_inits);
     stmts.extend(build_loop(&c.src, uid, body, c.accessor, sp));
 
     // The element-valued result rides the same accessor the loop did —

--- a/docs/src/everyday/collections.md
+++ b/docs/src/everyday/collections.md
@@ -200,8 +200,31 @@ let n = readings.filter(it > 10).filter(it < 100).count();
 let total = users.filter(it.active).map(it.age).sum();
 ```
 
-`map` rebinds the element; `sum` adds it up (Int elements — project
-with `map` first). Yes-or-no questions have their own terminals:
+`map` rebinds the element; `sum` adds it up. Bare `sum()` is for Int
+elements; give it a seed and the seed's type drives the accumulator —
+`sum(0.0)` sums Floats, `sum(100)` starts an Int sum at 100.
+
+Position matters too, and there are stages for it:
+
+```hale,fragment
+let podium = scores.take(3).sum();          // stop after three
+let rest = scores.skip(3).sum();            // drop the first three
+let page = items.skip(20).take(10).count(); // pagination in one pass
+```
+
+`take` and `skip` count elements arriving *at their own spot in the
+chain*, so `filter(p).skip(2)` skips the first two matches, not the
+first two elements. When you need the position itself, `enumerate()`
+binds `idx` for everything after it:
+
+```hale,fragment
+let evens = xs.enumerate().filter(idx % 2 == 0).sum();
+xs.filter(it.active).enumerate().each {
+    println(idx, ": ", it.name);   // idx counts the matches
+}
+```
+
+Yes-or-no questions have their own terminals:
 
 ```hale,fragment
 if users.any(it.age < 18) { restrict(); }
@@ -236,6 +259,24 @@ users.filter(it.age >= 18).each {
 The block *is* the loop body — `it` is in scope, `break` and
 `continue` do what they do in any loop, and nothing is captured
 because there is no closure.
+
+The whole-set operations — the ones that need every element before
+they can produce anything — write into a collection *you* own:
+
+```hale,fragment
+let ranked = Scores { };
+scores.filter(it > 0).sort_into(ranked);        // ascending
+scores.sort_into(ranked, harder_first);         // your comparator fn
+recent.take(10).reverse_into(latest_first);
+let by_desk = DeskCounts { };
+orders.group_count_into(by_desk, it.desk);      // tally per key
+```
+
+`sort_into` and `reverse_into` fill a `@form(vec)` and reorder it in
+place; `group_count_into` bumps a per-key Int counter in a
+`@form(hashmap)` (its cell type is the key plus one Int field). The
+chain itself still allocates nothing — the storage is yours, declared
+where you can see it.
 
 This looks like an iterator chain from another language, and it is
 deliberately not one. There is no intermediate collection between the

--- a/spec/projects.md
+++ b/spec/projects.md
@@ -370,7 +370,13 @@ files *without* threading the path-rename table, so cross-seed
 `alias::Name` references — and a topic decl referenced from a
 sibling file — failed under `run` though they worked under
 `build`. That gap is closed; the two commands no longer diverge on
-imports.)
+imports. `hale check` had the last surviving divergence: a
+multi-file seed with no imports was kept as per-file programs, and
+a pre-pass resolved each file alone — so a `topic` declared in one
+file and subscribed from a sibling reported "unknown topic" under
+`check` while `build` and `run` resolved it. Closed 2026-08-11: a
+multi-file seed merges before checking, exactly like the
+import-bearing path.)
 
 ## Git-based dependency fetching (`hale fetch`)
 

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -2245,11 +2245,14 @@ Three properties follow, and they are the contract:
    question.
 
 **Boundary.** Elementwise operations fuse. Whole-set operations
-(`sort`, `reverse`, `group`) cannot — they need every element before
-producing any — so they are terminals that materialize into caller
-storage. Over a stream source (a bus subscription, where the driver is
-delivery rather than a loop) they are rejected outright: "needs an
-end" is a property the compiler can decide.
+(`sort_into`, `reverse_into`, `group_count_into`) cannot — they need
+every element before producing any — so they are terminals that
+materialize into caller storage: the loop fills (or bumps) a target
+the caller owns, and any reordering runs on that target after the
+loop. The chain itself still allocates nothing. Over a stream source
+(a bus subscription, where the driver is delivery rather than a
+loop) they are rejected outright: "needs an end" is a property the
+compiler can decide.
 
 A bare method call with no stage (`v.count()`) is an ordinary form
 method, not a chain, and is left alone. A chain over a non-form
@@ -2263,13 +2266,27 @@ Elementwise **stages** (fuse into the one loop):
 |---|---|
 | `filter(pred)` | drop elements where the `it`-predicate is false |
 | `map(expr)` | rebind the element to the `it`-expression's value |
+| `take(n)` | stop the whole chain once n elements have passed this point (2026-08-11) |
+| `skip(n)` | drop the first n elements that reach this point (2026-08-11) |
+| `enumerate()` | bind `idx` — the 0-based count of elements reaching this stage — in every later stage and the terminal (2026-08-11) |
+
+`take` and `skip` count elements **arriving at their own position**,
+so `filter(p).skip(2)` skips the first two matches, not the first
+two source elements; their limits are evaluated once, before the
+loop. `enumerate` is an explicit opt-in stage rather than an
+always-bound name so a chain never captures a user's own `idx`
+local; written after a `filter`, `idx` counts the filtered stream.
+A `min`/`max` key mentioning `idx` is left unrecognized (the best
+element's key is re-derived from the element at compare time, and
+its enumerate count is not recoverable from it — rejecting beats a
+silently wrong comparison).
 
 **Terminals**:
 
 | terminal | result |
 |---|---|
 | `count()` | Int |
-| `sum()` | Int — v1 requires Int elements (`map` first); the accumulator's typed zero for Float/Decimal/Duration needs literal suffixes that do not exist yet |
+| `sum()` / `sum(seed)` | `sum()` is Int; `sum(seed)` seeds the accumulator and the seed **is** its typed zero — `sum(0.0)` sums Float elements, `sum(100)` starts an Int sum at 100 (2026-08-11) |
 | `into(target)` | pushes each surviving (mapped) element |
 | `any(pred?)` | Bool; **empty selection ⇒ `false`** (vacuous) |
 | `all(pred)` | Bool; **empty selection ⇒ `true`** (vacuous) |
@@ -2277,6 +2294,9 @@ Elementwise **stages** (fuse into the one loop):
 | `find(pred?)` | `find(p)` ≡ `filter(p).first()` |
 | `min(key?)` / `max(key?)` | the **element** with the least/greatest key (`min_by_key` shape; bare form compares elements) — fallible on empty |
 | `each { … }` | run the block per surviving element |
+| `sort_into(target, cmp?)` | push survivors into the caller's vec, then reorder it in place — `sort()` (primitive ordering) or `sort_by(cmp)` with a named comparator (2026-08-11) |
+| `reverse_into(target)` | push survivors, then swap ends inward on the caller's vec (2026-08-11) |
+| `group_count_into(target, key?)` | one hashmap `bump(key)` per survivor — increment-or-init tallying into the caller's `@form(hashmap)`; the bare form keys on the element itself (2026-08-11) |
 
 **Fallible terminals ride the source's own `get`.** `first` / `find`
 / `min` / `max` lower to an index search whose value is
@@ -2313,7 +2333,11 @@ is unbound outside a chain, so no valid ordinary call can look like
 that — or when it is `each` with a block. Bare `xs.sum()` /
 `xs.first()` therefore stay ordinary method calls (stage-less first
 is just `xs.get(0) or …`; a stage-less sum can be written
-`xs.map(it).sum()`).
+`xs.map(it).sum()`). The whole-set terminals (`sort_into` /
+`reverse_into` / `group_count_into`) are recognized stage-less too:
+`xs.sort_into(sorted)` is their natural spelling, and the compound
+`*_into` names belong to this vocabulary — unlike bare `into`, no
+plausible user facade carries them (2026-08-11).
 
 ## Bus subscription dispatch
 

--- a/spec/styleguide.md
+++ b/spec/styleguide.md
@@ -867,6 +867,9 @@ self.users.filter(it.active).into(self.actives);
 let total = self.users.map(it.age).sum();
 let oldest = self.users.max(it.age) or raise;
 self.users.filter(it.active).each { self.greet(it); }
+let page = self.users.skip(20).take(10).count();
+self.users.filter(it.active).sort_into(self.ranked, older_first);
+self.orders.group_count_into(self.by_desk, it.desk);
 
 // not this
 let mut i = 0;
@@ -902,10 +905,14 @@ knowing rather than assuming:
 - **No lambdas.** `it` is bound by the rewrite; the predicate is
   syntax, not a value. Nothing captures, so nothing escapes.
 
-Whole-set operations (`sort`, and later `reverse` / `group`) cannot
-fuse — they need every element before producing any — so they
-materialize into caller storage. That cost is visible in the budget,
-which is the point.
+Whole-set operations (`sort_into`, `reverse_into`,
+`group_count_into`) cannot fuse — they need every element before
+producing any — so they materialize into caller storage: the chain
+fills (or bumps) a collection you declared, then reorders it in
+place. That cost is visible in the budget, which is the point.
+Positional selection (`take(n)` / `skip(n)`) and the element's
+ordinal (`enumerate()`, binding `idx`) DO fuse — they are counters
+on the one loop, not materializations.
 
 ---
 
@@ -1094,10 +1101,10 @@ One is soundness-adjacent and worth knowing cold.
 - **`@form` cell types can't be loci or qualified paths** — keep
   cell structs in-seed (C7).
 - **Lifecycle bodies reject `return`** — factor short-circuit
-  logic into a free helper. Related paper cuts: `-> ()` on a
-  non-fallible method fails codegen (omit the return type);
-  empty `if` bodies parse-fail (add a comment or invert the
-  condition).
+  logic into a free helper. Related paper cut: empty `if`
+  bodies parse-fail (add a comment or invert the condition).
+  (`-> ()` on a non-fallible method was a paper cut here until
+  2026-08-11; it is now a no-op unit annotation everywhere.)
 - **No char-level `s[i]`** — use `s[i..i+1]` slices,
   `std::str::index_of`, or the UTF-8 accessors
   `std::str::cp_at` / `cp_size` / `cp_count` when you need code

--- a/tests/hale/chains_tranche2_test.hl
+++ b/tests/hale/chains_tranche2_test.hl
@@ -1,0 +1,63 @@
+// The 2026-08-11 chain tranche: take / skip / enumerate stages,
+// seeded sum, and the whole-set terminals (sort_into / reverse_into
+// / group_count_into). The Rust suite (element_chains.rs) covers the
+// pairwise stage-x-terminal matrix; this file keeps the typechecked
+// end-to-end shapes a program actually writes.
+
+@form(vec)
+locus Nums { capacity { heap items of Int; } }
+
+@form(vec)
+locus Floats { capacity { heap items of Float; } }
+
+type Tally { tag: String; n: Int; }
+
+@form(hashmap)
+locus Tallies { capacity { pool entries of Tally indexed_by tag; } }
+
+fn desc(a: Int, b: Int) -> Bool { return a > b; }
+
+fn main() {
+    let v = Nums { };
+    let mut i = 1;
+    while i <= 10 { v.push(i); i = i + 1; }
+
+    // Positional stages count arrivals at their own position, and
+    // skip/take order matters: skip-then-take is {2,3,4}, the other
+    // order is {2,3}.
+    std::test::assert_eq_int(v.skip(1).take(3).sum(), 9, "skip then take");
+    std::test::assert_eq_int(v.take(3).skip(1).sum(), 5, "take then skip");
+    std::test::assert_eq_int(
+        v.filter(it % 2 == 0).skip(1).take(2).sum(), 10,
+        "skip/take count matches, not source elements");
+
+    // enumerate binds idx to the stream reaching its stage.
+    std::test::assert_eq_int(
+        v.enumerate().filter(idx % 2 == 0).sum(), 25,
+        "idx before a filter is the source index");
+    std::test::assert_eq_int(
+        v.filter(it > 5).enumerate().map(idx).sum(), 10,
+        "idx after a filter is the match ordinal");
+
+    // Seeded sum: the seed is the accumulator's typed zero.
+    let f = Floats { };
+    f.push(1.5); f.push(2.25); f.push(3.25);
+    std::test::assert((f.map(it).sum(0.0) - 7.0) < 0.000001, "float sum via seed");
+    std::test::assert_eq_int(v.take(2).sum(100), 103, "seed as offset");
+
+    // Whole-set terminals materialize into caller storage.
+    let s = Nums { };
+    v.skip(6).sort_into(s, desc);
+    std::test::assert_eq_int(s.get(0) or - 1, 10, "sort_into with comparator");
+    std::test::assert_eq_int(s.len(), 4, "sort_into pushed the survivors");
+
+    let r = Nums { };
+    v.take(3).reverse_into(r);
+    std::test::assert_eq_int(r.get(0) or - 1, 3, "reverse_into head");
+    std::test::assert_eq_int(r.get(2) or - 1, 1, "reverse_into tail");
+
+    let t = Tallies { };
+    v.group_count_into(t, if it % 2 == 0 { "even" } else { "odd" });
+    let e = t.get("even") or Tally { tag: "?", n: -1 };
+    std::test::assert_eq_int(e.n, 5, "group_count_into tallies by key");
+}


### PR DESCRIPTION
Supersedes #454 (auto-closed when its stacked base branch was deleted on #453's merge; same branch, now against `main`). Full description there — summary:

The remainder of the chain vocabulary recorded open when #380 shipped, minus stream sources. Zero-allocation contract unchanged: elementwise stages fuse into the one loop; whole-set terminals materialize into **caller storage**, the boundary `spec/semantics.md` already promised.

- **Stages**: `take(n)` / `skip(n)` (count arrivals at their own position; both skip/take orders pinned — they're different chains), `enumerate()` (opt-in `idx`; double-enumerate shadows innermost-out; `idx`-keyed `min`/`max` rejected rather than miscompared).
- **Terminals**: `sum(seed)` (seed = typed zero; `sum(0.0)` sums Floats), `sort_into(target, cmp?)` / `reverse_into(target)` (push + in-place reorder of a caller vec), `group_count_into(target, key?)` (hashmap `bump` per survivor). Whole-set `*_into` terminals recognized stage-less.
- Recognition/subst walkers now descend if/match/tuple expressions (a conditional key is the it-mention it is).

Tests are pairwise over the combinatorial surface (stage×stage orders, stage×terminal families, `idx` reach, early-break cells, hashmap `.entries`, counter re-init, uid separation, map sandwich, facade negatives — pond's zero-arg `take()` facades verified unaffected): 13 new tests in `element_chains.rs`, plus `tests/hale/chains_tranche2_test.hl`. Workspace 2522/2522; fmt gate clean. Spec, module docs, and the collections chapter updated together.

Still open by design: stream sources, general group-into-collections (needs vec-valued hashmap cells), `map` × element-valued fallible terminals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)