### PR TITLE
fix(obs): intra-locus publish desugar probes like every other flavor (downstream handoff P23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ behavior.
 
 ## Unreleased
 
+### An intra-subtree publish is no longer invisible to observation
+
+Downstream handoff (P23). `desugar_intra_locus_topics` rewrites a
+`Topic <- payload` whose only subscriber lives inside the publisher's
+own locus subtree into a direct call to the subscriber's bus handler
+— before lowering, so the handoff-5 fix that gave the *codegen*
+direct-dispatch flavors their probes never reached it. Delivery
+worked; observation saw nothing: no `BUS_PUBLISH`, no `BUS_DELIVER`,
+no counters, and no manifest row at all — "declared but never
+published" and "compiled to a direct call" were the same absence,
+which poisons any source-topology-to-manifest join.
+
+The desugared call site (already identified in codegen by the
+payload-reclaim work — a bus handler is not callable from Hale
+source) now emits both probes, branch-gated on `lotus_obs_live` like
+every other flavor: `BUS_PUBLISH` attributing the publisher,
+`BUS_DELIVER` attributing the subscriber, enqueue-time-equivalent
+(the direct call is the delivery). The first probe creates the
+topic's manifest row, so a trafficked intra-tree topic registers and
+counts exactly like its bus-dispatched sibling; a zero-traffic topic
+stays absent on every flavor uniformly, so absence once again means
+"never mentioned at runtime". Pinned by the reporter's controlled
+pair (child-subscriber topic vs sibling-control topic in one binary),
+A/B'd against the pre-fix compiler.
+
+(The report's secondary observation — the sibling subscriber showing
+zero deliveries — is the documented birth-order trap, not this
+defect: the publisher was declared first with a long-running `run()`,
+so the sibling was never born during the burst.)
+
 ### Element chains: the second vocabulary tranche
 
 The remainder of the chain vocabulary recorded open when #380

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -15039,18 +15039,32 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         callee: &Expr,
         args: &[Expr],
     ) -> bool {
+        self.intra_locus_publish_target(callee, args).is_some()
+    }
+
+    /// The matched subscription behind an intra-locus-publish direct
+    /// call: `(wire_subject, payload_type_name)`. `None` when the call
+    /// is not that desugar. The subject is the same registration-side
+    /// string every other dispatch flavor probes with, so the fused
+    /// manifest row is shared.
+    fn intra_locus_publish_target(
+        &self,
+        callee: &Expr,
+        args: &[Expr],
+    ) -> Option<(String, String)> {
         let Expr::Field { receiver, name, .. } = callee else {
-            return false;
+            return None;
         };
-        let Some(recv_locus) = self.receiver_locus_name(receiver) else {
-            return false;
-        };
-        let Some(info) = self.user_loci.get(&recv_locus) else {
-            return false;
-        };
-        let is_handler =
-            info.subscriptions.iter().any(|(_, h, _, _)| h == &name.name);
-        is_handler && args.iter().any(|a| matches!(a, Expr::Struct { .. }))
+        let recv_locus = self.receiver_locus_name(receiver)?;
+        let info = self.user_loci.get(&recv_locus)?;
+        let (subject, _, payload_ty, _) = info
+            .subscriptions
+            .iter()
+            .find(|(_, h, _, _)| h == &name.name)?;
+        if !args.iter().any(|a| matches!(a, Expr::Struct { .. })) {
+            return None;
+        }
+        Some((subject.clone(), payload_ty.clone()))
     }
 
     /// Lower an intra-locus-publish direct handler call with its payload
@@ -15067,6 +15081,94 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         args: &[Expr],
         scope: &Scope<'ctx>,
     ) -> Result<BlockEnd, CodegenError> {
+        // P23 (iris handoff-11): this rewrite was the last probe-less
+        // dispatch flavor — no BUS_PUBLISH, no BUS_DELIVER, no topic
+        // registration; a subject on this path was invisible to
+        // observation, so "declared but never published" and
+        // "compiled to a direct call" were the same absence. Emit
+        // both probes here, branch-gated on `lotus_obs_live` (same
+        // dormant-cost discipline as every other flavor: an
+        // unobserved publish pays one predictable load+branch). Same
+        // principle handoff-5 P17 settled for the devirtualized
+        // direct flavors, one rewrite earlier in the pipeline. The
+        // deliver probe is enqueue-time-equivalent — the direct call
+        // IS the delivery — and passes the subscriber's self for
+        // attribution; the publish probe passes the publisher's.
+        // The first probe call also creates the topic's manifest row.
+        {
+            let (subject, payload_ty) = self
+                .intra_locus_publish_target(callee, args)
+                .expect("caller gated on is_intra_locus_publish_call");
+            let func = self
+                .builder
+                .get_insert_block()
+                .and_then(|bb| bb.get_parent())
+                .expect("inside a function");
+            let ptr_t = self.context.ptr_type(AddressSpace::default());
+            let i64_t = self.context.i64_type();
+            let obs_live = self.obs_live_check()?;
+            let subj_val = self.global_string(&subject);
+            let payload_size_iv = self
+                .user_types
+                .get(&payload_ty)
+                .and_then(|ti| ti.struct_ty.size_of())
+                .unwrap_or_else(|| i64_t.const_zero());
+            let pub_self: BasicValueEnum = self
+                .current_self
+                .as_ref()
+                .map(|cs| cs.self_ptr.into())
+                .unwrap_or_else(|| ptr_t.const_null().into());
+            // The subscriber's self: `self` for the same-locus case,
+            // the field chain's tip otherwise. Re-lowering the
+            // receiver chain is pure loads.
+            let Expr::Field { receiver, .. } = callee else {
+                unreachable!("gated on a Field callee");
+            };
+            let sub_self: BasicValueEnum =
+                if matches!(receiver.as_ref(), Expr::KwSelf(_)) {
+                    pub_self
+                } else {
+                    let (v, _) = self.lower_expr(receiver, scope)?;
+                    v
+                };
+            let probe_bb = self
+                .context
+                .append_basic_block(func, "publish.direct.obs");
+            let cont_bb = self
+                .context
+                .append_basic_block(func, "publish.direct.obs.cont");
+            self.builder
+                .build_conditional_branch(obs_live, probe_bb, cont_bb)
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder.position_at_end(probe_bb);
+            let obs_pub_fn = self
+                .module
+                .get_function("lotus_obs_bus_publish")
+                .expect("lotus_obs_bus_publish declared");
+            self.builder
+                .build_call(
+                    obs_pub_fn,
+                    &[subj_val.into(), pub_self.into(), payload_size_iv.into()],
+                    "publish.direct.obs.pub",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let obs_dlv_fn = self
+                .module
+                .get_function("lotus_obs_bus_deliver")
+                .expect("lotus_obs_bus_deliver declared");
+            self.builder
+                .build_call(
+                    obs_dlv_fn,
+                    &[subj_val.into(), sub_self.into(), payload_size_iv.into()],
+                    "publish.direct.obs.dlv",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder
+                .build_unconditional_branch(cont_bb)
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder.position_at_end(cont_bb);
+        }
+
         let parent = self.current_arena_ptr()?;
         let create = self
             .module

--- a/crates/hale-codegen/tests/obs_intra_tree_publish.rs
+++ b/crates/hale-codegen/tests/obs_intra_tree_publish.rs
@@ -1,0 +1,171 @@
+//! P23 (iris handoff-11) — an intra-subtree publish must not vanish
+//! from observation.
+//!
+//! `desugar_intra_locus_topics` rewrites a `Topic <- payload` whose
+//! only subscriber lives inside the publisher's own locus subtree
+//! into a direct call to the subscriber's bus handler. Delivery
+//! worked; observation did not: no BUS_PUBLISH, no BUS_DELIVER, no
+//! counters — and no manifest row at all, so "declared but never
+//! published" and "compiled to a direct call" were the same
+//! observation (absence). Handoff-5 P17 already ruled on this
+//! principle for the devirtualized direct dispatch flavors ("publish
+//! once + deliver per matched target with full attribution"); this
+//! test pins the same sentence for the AST-level rewrite.
+//!
+//! The program is iris's controlled pair fused into one binary:
+//! `ToChild`'s one subscriber is the publisher's own child (the
+//! rewritten flavor), `ToSibling`'s subscriber is a sibling (the
+//! bus flavor, the in-program control). Both must register, count
+//! pub == dlv == N, and emit attributed ring records. If the
+//! desugar's eligibility rules ever change, `to_child` falls back
+//! to the bus path and these assertions still hold — the contract
+//! is flavor-independent by design.
+//!
+//! (iris's original repro also showed the sibling at dlv 0 — that
+//! is the documented birth-order trap, not P23: their `Sib` was
+//! declared AFTER the publisher whose `run()` never returns. `Sib`
+//! is declared first here.)
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+#[path = "support/obs.rs"]
+mod obs;
+use obs::{obs_bus_locus, records, topic_counters, topic_id_and_line};
+
+const EK_BUS_PUBLISH: u32 = 1;
+const EK_BUS_DELIVER: u32 = 2;
+
+const PAIR: &str = r#"
+    type P { v: Int = 0; }
+
+    topic ToChild { payload: P; }
+    topic ToSibling { payload: P; }
+
+    locus Kid {
+        params { got: Int = 0; }
+        bus { subscribe ToChild as on_p; }
+        fn on_p(p: P) { self.got = self.got + 1; }
+    }
+
+    locus Sib {
+        params { got: Int = 0; }
+        bus { subscribe ToSibling as on_p; }
+        fn on_p(p: P) { self.got = self.got + 1; }
+    }
+
+    locus Pub {
+        params { k: Kid = Kid { }; }
+        bus { publish ToChild; publish ToSibling; }
+        run() {
+            std::time::sleep(400ms);
+            let mut i = 0;
+            while i < 25 {
+                ToChild <- P { v: i };
+                ToSibling <- P { v: i };
+                i = i + 1;
+            }
+            println("kid_got=", to_string(self.k.got));
+        }
+    }
+
+    main locus App {
+        params { s: Sib = Sib { }; p: Pub = Pub { }; }
+        placement { p: pinned(core = 0); }
+        run() { std::time::sleep(1200ms); }
+    }
+
+    fn main() { App { }; }
+"#;
+
+#[test]
+fn intra_tree_publish_registers_counts_and_attributes() {
+    let program = hale_syntax::parse_source(PAIR).expect("parse");
+    let bin = harness::unique_bin("hale_test_obs_intra_tree");
+    build_executable(&program, &bin).expect("build");
+
+    let child = Command::new(&bin)
+        .env("LOTUS_OBS", "1")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn");
+    let pid = child.id();
+
+    // Attach as an observer before the publish burst (t+400ms) so
+    // ring records are emitted; hold a live mapping across exit so
+    // the final counters are readable after teardown unlinks.
+    let mut seg: Option<&'static [u8]> = None;
+    for _ in 0..40 {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        if std::fs::metadata(format!("/dev/shm/hale-obs-{}", pid)).is_ok() {
+            obs::attach_observer(pid);
+            seg = obs::map_shm(pid);
+            break;
+        }
+    }
+    let seg = seg.expect("obs segment never appeared");
+
+    let out = child.wait_with_output().expect("wait");
+    assert!(out.status.success(), "pair exited nonzero");
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(
+        stdout.contains("kid_got=25"),
+        "delivery itself must still work: {}",
+        stdout
+    );
+
+    // 1. The rewritten topic REGISTERS — the exact observation P23
+    // is about. Before the fix there was no `to_child` row at all.
+    let (child_id, _) = topic_id_and_line(seg, b"ToChild")
+        .expect("to_child has a manifest row (P23: it had none)");
+    let (sib_id, _) = topic_id_and_line(seg, b"ToSibling")
+        .expect("to_sibling has a manifest row (control)");
+
+    // 2. Counters match the control: pub == dlv == 25 on both.
+    let (c_pub, c_dlv, c_bytes) =
+        topic_counters(seg, b"ToChild").expect("to_child counters");
+    let (s_pub, s_dlv, _) =
+        topic_counters(seg, b"ToSibling").expect("to_sibling counters");
+    assert_eq!(c_pub, 25, "to_child published");
+    assert_eq!(c_dlv, 25, "to_child delivered (the direct call IS the delivery)");
+    assert!(c_bytes > 0, "to_child payload bytes counted");
+    assert_eq!(s_pub, 25, "control published");
+    assert_eq!(s_dlv, 25, "control delivered");
+
+    // 3. Ring records with locus attribution, same as every other
+    // flavor: publishes attribute the publisher, delivers the
+    // subscriber.
+    let pubs: Vec<u64> = records(seg, EK_BUS_PUBLISH)
+        .into_iter()
+        .filter(|(id, _)| *id == child_id)
+        .map(|(_, w1)| w1)
+        .collect();
+    let dlvs: Vec<u64> = records(seg, EK_BUS_DELIVER)
+        .into_iter()
+        .filter(|(id, _)| *id == child_id)
+        .map(|(_, w1)| w1)
+        .collect();
+    assert!(
+        !pubs.is_empty(),
+        "BUS_PUBLISH records exist for to_child"
+    );
+    assert!(
+        !dlvs.is_empty(),
+        "BUS_DELIVER records exist for to_child"
+    );
+    assert!(
+        pubs.iter().any(|w1| obs_bus_locus(*w1) != 0),
+        "publish records attribute the publisher locus"
+    );
+    assert!(
+        dlvs.iter().any(|w1| obs_bus_locus(*w1) != 0),
+        "deliver records attribute the subscriber locus"
+    );
+    let _ = sib_id;
+    let _ = std::fs::remove_file(&bin);
+}

--- a/crates/hale-codegen/tests/support/obs.rs
+++ b/crates/hale-codegen/tests/support/obs.rs
@@ -65,6 +65,22 @@ pub fn snapshot_shm(pid: u32) -> Option<Vec<u8>> {
         .to_vec())
 }
 
+/// Map a live process's obs segment and LEAK the mapping: the
+/// returned slice stays valid after the emitter exits and
+/// shm_unlinks (POSIX keeps the pages while a mapping holds them).
+/// For tests that must read final counters — map while the process
+/// runs, `wait()` it, then read.
+pub fn map_shm(pid: u32) -> Option<&'static [u8]> {
+    let f = std::fs::File::open(format!("/dev/shm/hale-obs-{}", pid))
+        .ok()?;
+    let len = f.metadata().ok()?.len() as usize;
+    let p = unsafe { mmap_raw(&f, len, 0x1) };
+    if p.is_null() {
+        return None;
+    }
+    Some(unsafe { std::slice::from_raw_parts(p as *const u8, len) })
+}
+
 /// Attach as an observer: bump `observer_count` on the control page
 /// so ring emission turns on (requires a writable map).
 pub fn attach_observer(pid: u32) {

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1470,7 +1470,17 @@ v0.11.18):
   first probe, always a locus birth), so LLVM hoists the branch
   and an unobserved publish loop is instruction-identical to the
   probe-free lowering. The same per-fn check now also gates the
-  publisher-attribution TLS note.
+  publisher-attribution TLS note. **The AST-level rewrite got the
+  same sentence on 2026-08-11 (downstream handoff P23):** the
+  closed-world intra-locus/tower desugar — one rewrite earlier
+  than these codegen flavors, so the earlier fix never reached it
+  — now emits `BUS_PUBLISH` (publisher-attributed) +
+  `BUS_DELIVER` (subscriber-attributed) at the direct handler
+  call, behind the same per-fn gate. Its first probe registers
+  the topic's manifest row, so an intra-tree subject with traffic
+  is indistinguishable from its bus-dispatched sibling, and
+  manifest absence uniformly means "never mentioned at runtime"
+  on every flavor.
 - **Observer attach no longer needs probe traffic.** The 0→1
   birth replay was driven from inside probes, so a probe-quiet
   process (a main parked in a read loop with pinned raw-fd


### PR DESCRIPTION
A downstream observability handoff (P23) found the last probe-less dispatch flavor: `desugar_intra_locus_topics` rewrites a publish whose only subscriber lives inside the publisher's own subtree into a direct handler call **before lowering** — so the earlier fix that gave the codegen direct-dispatch flavors their probes never reached it. Delivery worked; observation saw nothing: no `BUS_PUBLISH`/`BUS_DELIVER`, no counters, and no manifest row at all. "Declared but never published" and "compiled to a direct call" were the same observation (absence), which poisons any source-topology-to-manifest join.

**Fix**: the payload-reclaim work (`ab44ecd`) already identifies the desugared call site in codegen (a bus handler is not callable from Hale source, so a statement-position call to one is unambiguously this rewrite). The established probe pattern drops in there:

- `BUS_PUBLISH` attributing the publisher's self, `BUS_DELIVER` attributing the subscriber's — enqueue-time-equivalent, since the direct call *is* the delivery
- both branch-gated on the per-fn `lotus_obs_live` check (dormant cost: one hoisted load+branch, same as every other flavor)
- the first probe creates the topic's manifest row, so a trafficked intra-tree topic registers and counts exactly like its bus-dispatched sibling; zero-traffic topics stay absent **uniformly across flavors**, restoring "absence = never mentioned at runtime"

**Test**: `obs_intra_tree_publish.rs` — the reporter's controlled pair fused into one binary (child-subscriber topic + sibling-control topic): both topics register, `pub == dlv == 25` with bytes counted on both, and BUS_PUBLISH/BUS_DELIVER ring records attribute publisher and subscriber loci. A/B'd against the pre-fix compiler: fails there on the missing manifest row, exactly the reported observation. The shared obs test reader gains `map_shm` (leaked live mapping readable after emitter teardown).

The report's secondary observation (sibling subscriber at dlv 0, absent from the locus list) is the documented **birth-order trap**, not this defect — their publisher is declared before the sibling and its `run()` blocks for 60s, so the sibling is never born during the burst. Diagnosed in the handoff response (with a note that the blocking lint only catches provably-forever shapes, not bounded-but-long loops).

Validation: full workspace suite 2524/2524; obs suites (emission/fleet-contract/net-seq) and the intra-locus reclaim/topic tests green; fmt gate clean. `spec/runtime.md`'s flavor-completeness bullet extended; CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)