### PR TITLE
fix(cli): structured related spans + pre-pass diags through normal reporting (downstream handoff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ behavior.
 
 ## Unreleased
 
+### `hale lsp`: go-to-definition on `std::` paths
+
+Downstream handoff. `textDocument/definition` on a `std::` path
+(`std::http::Server`, `std::bytes::BytesBuilder`, …) now jumps into
+the stdlib's own source. The rename table maps the user-facing path
+to the mangled declaration in the embedded `AP_SOURCE`; the
+declaration's owning per-domain file (the stdlib is a concatenation
+of `core.hl`, `http.hl`, … — now exported per-file as `AP_FILES`,
+with a test pinning the concatenation layout the span math depends
+on) is materialized into a versioned read-only cache
+(`~/.cache/hale/stdlib-<version>/`), and the location is a plain
+`file://` URI. That answers the handoff's install-story concern —
+an `install.sh` binary has no stdlib checkout — without the
+synthetic-URI schemes rust-analyzer-style setups need client
+support for: a materialized real file works in every editor.
+C-backed path-call primitives (`std::str::*` and friends) have no
+Hale definition and still return nothing.
+
 ### Diagnostics carry secondary locations, and the pre-pass stops eating them
 
 Two defects from a downstream editor-tooling handoff, both worst on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ behavior.
 
 ## Unreleased
 
+### Diagnostics carry secondary locations, and the pre-pass stops eating them
+
+Two defects from a downstream editor-tooling handoff, both worst on
+the duplicate-top-level-name error — the easiest error to hit under
+the per-directory seed model (a second file with its own `fn main()`).
+
+**Structured related spans.** The duplicate-name diagnostic rendered
+the previous declaration by `{:?}`-formatting a `Span` into the
+message (`… at Span { start: Pos(5), end: Pos(11) }`) — visible in
+every editor via the LSP. `Diag` now carries
+`related: Vec<(Span, String)>`; the site that raises the error has no
+source text, so the renderers — which have the sources and the
+file-base table — resolve each entry: the text renderer emits
+`note: previous declaration at path:line:col` (cross-file correct),
+`--json` adds a `related` array (absent when empty, so existing
+consumers see an unchanged shape), and `hale lsp` publishes
+`DiagnosticRelatedInformation`, which clients render as a clickable
+second location. The two other `{:?}`-span leaks found by the sweep
+(duplicate topic binding, duplicate capacity slot) got the same
+treatment, and the fn/const duplicate path — which had no previous
+location at all — now recovers it from the symbol table.
+
+**Pre-pass diagnostics route through normal reporting.** Resolver
+diagnostics raised inside the `apply_sync_inference` pre-pass were
+printed through a bare `render()` and an early bail: no filename,
+`--json` silently ignored (empty stdout with exit 1 — a CI gate saw a
+failed build with zero explaining diagnostics), the wrong stream, and
+multi-file positions resolved against the alphabetically-first file's
+text (coordinates in neither file). The pre-pass now discards its
+return value and lets `check_bundle` re-raise through the normal
+path — exactly what `hale lsp` always did, which is why the LSP
+attributed the same diagnostic correctly while the CLI did not. The
+`run`/`build` twins of the bail are gone too (they double-reported).
+
 ### An intra-subtree publish is no longer invisible to observation
 
 Downstream handoff (P23). `desugar_intra_locus_topics` rewrites a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ version = "0.16.0"
 name = "hale-lsp"
 version = "0.16.0"
 dependencies = [
+ "hale-stdlib",
  "hale-syntax",
  "hale-types",
  "serde_json",

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -2284,6 +2284,25 @@ fn parse_with_imports(
 /// `file_bases`, so the output reads `path:line:col` against that file's
 /// own source instead of an arbitrary file. Falls back to the entry
 /// source if the span isn't in any known file range.
+/// Resolve a merged-bundle span to `(path, line, col)` via the
+/// file-base table. Shared by the text and JSON renderers for both
+/// primary and related spans.
+fn locate_span(
+    span: hale_syntax::Span,
+    file_bases: &[(u32, PathBuf, u32)],
+    sources: &BTreeMap<PathBuf, String>,
+) -> Option<(String, usize, usize)> {
+    let off = span.start.as_usize() as u32;
+    for (base, path, len) in file_bases {
+        if off >= *base && off < base.saturating_add(*len) {
+            let src = sources.get(path)?;
+            let (l, c) = span.shifted(base.wrapping_neg()).line_col(src);
+            return Some((path.display().to_string(), l, c));
+        }
+    }
+    None
+}
+
 fn render_located(
     d: &hale_syntax::Diag,
     file_bases: &[(u32, PathBuf, u32)],
@@ -2293,7 +2312,22 @@ fn render_located(
     for (base, path, len) in file_bases {
         if off >= *base && off < base.saturating_add(*len) {
             if let Some(src) = sources.get(path) {
-                return d.render_located(&path.display().to_string(), src, *base);
+                let mut out =
+                    d.render_located(&path.display().to_string(), src, *base);
+                // Secondary locations, each resolved through the
+                // file table — a related span may live in a
+                // DIFFERENT file than the primary.
+                for (rspan, label) in &d.related {
+                    if let Some((rf, rl, rc)) =
+                        locate_span(*rspan, file_bases, sources)
+                    {
+                        out.push_str(&format!(
+                            "\n    note: {} at {}:{}:{}",
+                            label, rf, rl, rc
+                        ));
+                    }
+                }
+                return out;
             }
         }
     }
@@ -3696,14 +3730,16 @@ fn run_check_impl_labelled(
         // `T::from_json` before typecheck, so the generated parser is
         // checked and callers must address its `fallible(JsonError)`.
         hale_syntax::json_gen::generate_json_parsers(prog);
-        let pre_diags = hale_types::apply_sync_inference(prog);
-        if !pre_diags.is_empty() {
-            let any_source = sources.values().next().map(|s| s.as_str()).unwrap_or("");
-            for d in &pre_diags {
-                eprintln!("{}", d.render(any_source));
-            }
-            return 1;
-        }
+        // Downstream handoff (2026-08-11): the pre-pass's resolver
+        // diagnostics are DISCARDED, not printed-and-bailed. They
+        // are re-raised by `check_bundle` below through the normal
+        // reporting path — which honours `--json`, names the file,
+        // and resolves multi-file spans; the bare `render` bail here
+        // did none of those (empty NDJSON on a duplicate `main`, a
+        // position from the wrong file). `hale lsp` has always done
+        // exactly this — it is why the LSP attributed the same
+        // diagnostic correctly while the CLI did not.
+        let _ = hale_types::apply_sync_inference(prog);
     }
 
     let bundle_programs: BTreeMap<String, &Program> = programs
@@ -4300,14 +4336,41 @@ fn render_diag_json(
         }
     }
     let severity = if d.is_error() { "error" } else { "warning" };
+    // Secondary locations ride along as a `related` array (absent
+    // when empty, so existing consumers see an unchanged shape).
+    let related = if d.related.is_empty() {
+        String::new()
+    } else {
+        let entries: Vec<String> = d
+            .related
+            .iter()
+            .filter_map(|(rspan, label)| {
+                let (rf, rl, rc) =
+                    locate_span(*rspan, file_bases, sources)?;
+                Some(format!(
+                    "{{\"file\":\"{}\",\"line\":{},\"col\":{},\"note\":\"{}\"}}",
+                    esc(&rf),
+                    rl,
+                    rc,
+                    esc(label)
+                ))
+            })
+            .collect();
+        if entries.is_empty() {
+            String::new()
+        } else {
+            format!(",\"related\":[{}]", entries.join(","))
+        }
+    };
     format!(
-        "{{\"file\":\"{}\",\"line\":{},\"col\":{},\"severity\":\"{}\",\"kind\":\"{}\",\"message\":\"{}\"}}",
+        "{{\"file\":\"{}\",\"line\":{},\"col\":{},\"severity\":\"{}\",\"kind\":\"{}\",\"message\":\"{}\"{}}}",
         esc(&file),
         line,
         col,
         severity,
         esc(d.kind_str()),
-        esc(&d.message)
+        esc(&d.message),
+        related
     )
 }
 
@@ -4781,13 +4844,10 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
     // agree.
     hale_codegen::mangle::apply_qualified_path_renames(&mut program, &renames);
     hale_syntax::json_gen::generate_json_parsers(&mut program);
-    let pre_diags = hale_types::apply_sync_inference(&mut program);
-    if !pre_diags.is_empty() {
-        for d in &pre_diags {
-            eprintln!("{}", render_located(d, &file_bases, &path_sources));
-        }
-        return ExitCode::from(1);
-    }
+    // Pre-pass diags are re-raised by `check_bundle_opts` below
+    // through the normal rendering — bailing here double-reported
+    // (see the `check` site for the full story).
+    let _ = hale_types::apply_sync_inference(&mut program);
 
     let bundle_programs: BTreeMap<String, &Program> =
         std::iter::once((target.display().to_string(), &program)).collect();
@@ -4999,13 +5059,10 @@ fn run_build(target: &Path) -> ExitCode {
     }
 
     hale_syntax::json_gen::generate_json_parsers(&mut program);
-    let pre_diags = hale_types::apply_sync_inference(&mut program);
-    if !pre_diags.is_empty() {
-        for d in &pre_diags {
-            eprintln!("{}", render_located(d, &file_bases, &sources));
-        }
-        return ExitCode::from(1);
-    }
+    // Pre-pass diags are re-raised by `check_bundle_opts` below
+    // through the normal rendering — bailing here double-reported
+    // (see the `check` site for the full story).
+    let _ = hale_types::apply_sync_inference(&mut program);
 
     // Typecheck before lowering. Render diagnostics against the
     // entry-file's source — diagnostic spans currently point into

--- a/crates/hale-cli/tests/diag_reporting.rs
+++ b/crates/hale-cli/tests/diag_reporting.rs
@@ -1,0 +1,145 @@
+//! Downstream handoff (2026-08-11) — two CLI diagnostic-reporting
+//! defects, both worst on the duplicate-top-level-name error (the
+//! easiest error to hit under the per-directory seed model):
+//!
+//! 1. The previous declaration's location was `{:?}`-formatted into
+//!    the message (`... at Span { start: Pos(5), end: Pos(11) }`).
+//!    It now rides as a structured related span, rendered by the
+//!    text renderer as `note: previous declaration at path:line:col`
+//!    and by `--json` as a `related` array.
+//! 2. The `apply_sync_inference` pre-pass printed its resolver
+//!    diagnostics through a bare `render()` + early bail: no
+//!    filename, `--json` ignored (empty stdout, exit 1 — a CI gate
+//!    saw a failed build with zero explaining diagnostics), wrong
+//!    stream, and multi-file positions resolved against the wrong
+//!    file's text. The pre-pass diags are now discarded and
+//!    re-raised by `check_bundle` through the normal reporting path
+//!    — exactly what `hale lsp` always did, which is why the LSP
+//!    attributed the same diagnostic correctly while the CLI did
+//!    not.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn seed_dir(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir()
+        .join(format!("hale_diagrep_{}_{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).expect("mkdir seed");
+    d
+}
+
+/// (stdout, stderr, exit code)
+fn hale_check(args: &[&str], target: &Path) -> (String, String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .args(args)
+        .arg(target)
+        .output()
+        .expect("run hale check");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn duplicate_name_json_emits_ndjson_with_its_file() {
+    // Two files in one seed, each declaring `main`. `--json` must
+    // emit NDJSON on stdout naming the SECOND file at a position
+    // inside it — not plain text on stderr, and never an empty
+    // stdout with exit 1.
+    let d = seed_dir("json");
+    std::fs::write(d.join("a.hl"), "fn main() {\n    println(\"a\");\n}\n")
+        .unwrap();
+    std::fs::write(d.join("b.hl"), "fn main() {\n    println(\"b\");\n}\n")
+        .unwrap();
+
+    let (stdout, stderr, code) = hale_check(&["--json"], &d);
+    assert_eq!(code, 1, "duplicate main fails the check");
+    assert!(
+        !stdout.trim().is_empty(),
+        "--json must not produce an empty stdout on a failing check \
+         (stderr was: {})",
+        stderr
+    );
+    let line = stdout.lines().next().unwrap();
+    let v: serde_json::Value =
+        serde_json::from_str(line).expect("stdout is NDJSON");
+    assert!(
+        v["file"].as_str().unwrap().ends_with("b.hl"),
+        "the second declaration is the one to change: {}",
+        line
+    );
+    assert_eq!(v["line"], 1, "a position inside b.hl: {}", line);
+    assert!(
+        v["message"].as_str().unwrap().contains("duplicate top-level"),
+        "got: {}",
+        line
+    );
+    // The previous declaration rides as structured related info.
+    assert!(
+        v["related"][0]["file"].as_str().unwrap().ends_with("a.hl"),
+        "related names the first declaration's file: {}",
+        line
+    );
+    assert!(
+        !stderr.contains("duplicate top-level"),
+        "diagnostics belong on stdout under --json, not stderr: {}",
+        stderr
+    );
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+#[test]
+fn duplicate_name_plain_names_both_locations() {
+    let d = seed_dir("plain");
+    std::fs::write(
+        d.join("a.hl"),
+        "type Widget { n: Int; }\n\nfn main() {\n    println(\"a\");\n}\n",
+    )
+    .unwrap();
+    std::fs::write(d.join("b.hl"), "type Widget { m: Int; }\n").unwrap();
+
+    let (stdout, stderr, code) = hale_check(&[], &d);
+    let all = format!("{}{}", stdout, stderr);
+    assert_eq!(code, 1);
+    assert!(
+        all.contains("b.hl:1:6"),
+        "the duplicate resolves to ITS file's coordinates: {}",
+        all
+    );
+    assert!(
+        all.contains("note: previous declaration at")
+            && all.contains("a.hl:1:6"),
+        "the first declaration renders as path:line:col: {}",
+        all
+    );
+    assert!(
+        !all.contains("Span {"),
+        "no Debug-formatted span may reach a user: {}",
+        all
+    );
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+#[test]
+fn ordinary_json_shape_is_unchanged() {
+    // The control from the report: an ordinary error keeps its
+    // exact NDJSON shape, `related`-free.
+    let d = seed_dir("control");
+    std::fs::write(
+        d.join("a.hl"),
+        "fn main() {\n    let x: Int = \"nope\";\n    println(x);\n}\n",
+    )
+    .unwrap();
+
+    let (stdout, _, code) = hale_check(&["--json"], &d);
+    assert_eq!(code, 1);
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.lines().next().unwrap()).expect("NDJSON");
+    assert!(v.get("related").is_none(), "no related key when empty: {}", v);
+    assert!(v["file"].as_str().unwrap().ends_with("a.hl"));
+    let _ = std::fs::remove_dir_all(&d);
+}

--- a/crates/hale-cli/tests/lsp.rs
+++ b/crates/hale-cli/tests/lsp.rs
@@ -760,3 +760,75 @@ fn lsp_v5_formatting_symbols_enforcement() {
     let _ = lsp.child.wait();
     let _ = std::fs::remove_dir_all(&seed);
 }
+
+/// Downstream handoff (2026-08-11): a diagnostic with a secondary
+/// location — duplicate top-level name pointing at the previous
+/// declaration — publishes `relatedInformation`, which clients
+/// render as a clickable second location. Before, the previous
+/// declaration reached editors as a Debug-formatted `Span { .. }`
+/// inside the message text.
+#[test]
+fn lsp_duplicate_name_carries_related_information() {
+    let seed = std::env::temp_dir().join(format!(
+        "hale_lsp_related_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&seed);
+    std::fs::create_dir_all(&seed).expect("mkdir");
+    let file = seed.join("main.hl");
+    let uri = format!("file://{}", file.display());
+    let dup = "type Widget { n: Int; }\ntype Widget { m: Int; }\n\nfn main() { println(\"x\"); }\n";
+    std::fs::write(&file, dup).expect("write seed file");
+
+    let mut lsp = Lsp::start();
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": { "capabilities": {} }
+    }));
+    let _ = lsp.recv();
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    }));
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": { "textDocument": {
+            "uri": uri, "languageId": "hale", "version": 1, "text": dup
+        }}
+    }));
+    let open = lsp.recv();
+    let diags =
+        open.pointer("/params/diagnostics").unwrap().as_array().unwrap();
+    let dup_diag = diags
+        .iter()
+        .find(|d| {
+            d["message"]
+                .as_str()
+                .map_or(false, |m| m.contains("duplicate top-level"))
+        })
+        .unwrap_or_else(|| panic!("duplicate diagnostic published: {}", open));
+    assert!(
+        !dup_diag["message"].as_str().unwrap().contains("Span {"),
+        "no Debug span in the editor payload: {}",
+        dup_diag
+    );
+    // The primary points at line 2 (0-based 1); the related entry
+    // points at line 1 (0-based 0) with a clickable location.
+    assert_eq!(dup_diag["range"]["start"]["line"], 1, "{}", dup_diag);
+    let rel = &dup_diag["relatedInformation"][0];
+    assert_eq!(
+        rel["location"]["range"]["start"]["line"], 0,
+        "related points at the previous declaration: {}",
+        dup_diag
+    );
+    assert_eq!(rel["message"], "previous declaration", "{}", dup_diag);
+
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "id": 9, "method": "shutdown", "params": {}
+    }));
+    let _ = lsp.recv();
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "method": "exit", "params": {}
+    }));
+    let _ = lsp.child.wait();
+    let _ = std::fs::remove_dir_all(&seed);
+}

--- a/crates/hale-cli/tests/lsp.rs
+++ b/crates/hale-cli/tests/lsp.rs
@@ -832,3 +832,96 @@ fn lsp_duplicate_name_carries_related_information() {
     let _ = lsp.child.wait();
     let _ = std::fs::remove_dir_all(&seed);
 }
+
+/// Downstream handoff (2026-08-11): `textDocument/definition` on a
+/// `std::` path jumps INTO the embedded stdlib source. The rename
+/// table maps the path to the mangled declaration in AP_SOURCE, and
+/// the owning per-domain file is materialized to a versioned
+/// read-only cache — so the location is a plain `file://` URI that
+/// works in every editor, even when the binary was installed with
+/// no stdlib checkout on disk.
+#[test]
+fn lsp_definition_resolves_std_paths_into_materialized_stdlib() {
+    let seed = std::env::temp_dir().join(format!(
+        "hale_lsp_stddef_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&seed);
+    std::fs::create_dir_all(&seed).expect("mkdir");
+    let file = seed.join("main.hl");
+    let uri = format!("file://{}", file.display());
+    let text = "fn main() {\n    let b = std::bytes::BytesBuilder { };\n    b.append_str(\"x\");\n}\n";
+    std::fs::write(&file, text).expect("write seed file");
+
+    let mut lsp = Lsp::start();
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": { "capabilities": {} }
+    }));
+    let _ = lsp.recv();
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    }));
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": { "textDocument": {
+            "uri": uri, "languageId": "hale", "version": 1, "text": text
+        }}
+    }));
+    let _ = lsp.recv(); // publishDiagnostics
+
+    // Cursor on `BytesBuilder` (line 1, inside the last segment).
+    let character = text.lines().nth(1).unwrap().find("BytesBuilder").unwrap() + 3;
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/definition",
+        "params": {
+            "textDocument": { "uri": uri },
+            "position": { "line": 1, "character": character }
+        }
+    }));
+    let d = lsp.recv();
+    let def_uri = d
+        .pointer("/result/uri")
+        .and_then(|u| u.as_str())
+        .unwrap_or_else(|| panic!("std:: definition resolves: {}", d));
+    assert!(
+        def_uri.ends_with("bytes_builder.hl"),
+        "lands in the owning per-domain file: {}",
+        def_uri
+    );
+    assert!(
+        def_uri.contains("stdlib-"),
+        "materialized under the versioned cache: {}",
+        def_uri
+    );
+
+    // The materialized file exists, is read-only, and the returned
+    // range points at the mangled declaration's name.
+    let def_path = std::path::PathBuf::from(
+        def_uri.strip_prefix("file://").unwrap(),
+    );
+    let content =
+        std::fs::read_to_string(&def_path).expect("materialized file");
+    assert!(
+        std::fs::metadata(&def_path).unwrap().permissions().readonly(),
+        "cache file is read-only"
+    );
+    let line = d.pointer("/result/range/start/line").unwrap().as_u64().unwrap()
+        as usize;
+    assert!(
+        content.lines().nth(line).unwrap().contains("__StdBytesBytesBuilder"),
+        "range points at the declaration: line {} = {:?}",
+        line,
+        content.lines().nth(line)
+    );
+
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "id": 9, "method": "shutdown", "params": {}
+    }));
+    let _ = lsp.recv();
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "method": "exit", "params": {}
+    }));
+    let _ = lsp.child.wait();
+    let _ = std::fs::remove_dir_all(&seed);
+}

--- a/crates/hale-lsp/Cargo.toml
+++ b/crates/hale-lsp/Cargo.toml
@@ -8,5 +8,6 @@ description = "Hale language server — compiled into the hale binary (`hale lsp
 
 [dependencies]
 hale-syntax = { path = "../hale-syntax" }
+hale-stdlib = { path = "../hale-stdlib" }
 hale-types = { path = "../hale-types" }
 serde_json = "1"

--- a/crates/hale-lsp/src/lib.rs
+++ b/crates/hale-lsp/src/lib.rs
@@ -1727,9 +1727,17 @@ fn definition(
     let offset = lsp_pos_to_offset(&src, line, character);
     let (tokens, idx, word, segs) = token_context(&src, offset)?;
 
-    // std:: paths have no in-seed definition.
+    // std:: paths resolve into the EMBEDDED stdlib source
+    // (downstream handoff, 2026-08-11): the rename table maps the
+    // user-facing path to the mangled name `AP_SOURCE` declares,
+    // and the declaration's file is materialized to a read-only
+    // cache so the location is a plain `file://` URI — no client-
+    // side virtual-document support needed, which matters for the
+    // editors that have none (an `install.sh` binary has no stdlib
+    // checkout on disk). C-backed path-call primitives have no
+    // Hale definition and still return None.
     if segs.first().map(String::as_str) == Some("std") {
-        return None;
+        return stdlib_definition(&segs);
     }
 
     let bundle = analysis.bundle();
@@ -1760,6 +1768,113 @@ fn definition(
 
     let sym = top.lookup(&word)?;
     merged_span_to_location(&analysis, sym.span())
+}
+
+/// The stdlib AST, parsed once per process from the embedded
+/// source. `None` if the embedded stdlib ever fails to parse
+/// (which the build would have caught long before an LSP ran).
+fn stdlib_ast() -> Option<&'static hale_syntax::ast::Program> {
+    use std::sync::OnceLock;
+    static AST: OnceLock<Option<hale_syntax::ast::Program>> =
+        OnceLock::new();
+    AST.get_or_init(|| {
+        hale_syntax::parse_source(hale_stdlib::AP_SOURCE).ok()
+    })
+    .as_ref()
+}
+
+/// The name ident of a top-level stdlib declaration, if it is a
+/// kind the rename table can point at.
+fn top_decl_name(
+    d: &hale_syntax::ast::TopDecl,
+) -> Option<&hale_syntax::ast::Ident> {
+    use hale_syntax::ast::TopDecl as TD;
+    match d {
+        TD::Locus(l) => Some(&l.name),
+        TD::Type(t) => Some(&t.name),
+        TD::Fn(f) => Some(&f.name),
+        TD::Interface(i) => Some(&i.name),
+        TD::Const(c) => Some(&c.name),
+        TD::Topic(t) => Some(&t.name),
+        _ => None,
+    }
+}
+
+/// Materialize one embedded stdlib file into the versioned
+/// read-only cache and return its path. Content-checked, so a
+/// version bump (or a dev build changing the stdlib) refreshes it.
+fn materialize_stdlib_file(
+    name: &str,
+    content: &str,
+) -> Option<PathBuf> {
+    let cache_root = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .map(|h| PathBuf::from(h).join(".cache"))
+        })?;
+    let dir = cache_root
+        .join("hale")
+        .join(format!("stdlib-{}", env!("CARGO_PKG_VERSION")));
+    std::fs::create_dir_all(&dir).ok()?;
+    let path = dir.join(name);
+    let fresh = std::fs::read_to_string(&path)
+        .map_or(true, |existing| existing != content);
+    if fresh {
+        // The file is left read-only as a "this is not yours to
+        // edit" signal, so a refresh must lift that first.
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(&path, content).ok()?;
+        let mut perm =
+            std::fs::metadata(&path).ok()?.permissions();
+        perm.set_readonly(true);
+        let _ = std::fs::set_permissions(&path, perm);
+    }
+    Some(path)
+}
+
+/// `textDocument/definition` for a `std::` path: rename-table
+/// lookup → declaration span in the embedded source → location in
+/// the materialized cache file.
+fn stdlib_definition(segs: &[String]) -> Option<Value> {
+    // Exact path match first; else the longest table entry that
+    // prefixes the cursor's path (`std::http::Server` inside a
+    // longer chain).
+    let matches_entry = |entry: &[&str], exact: bool| {
+        (entry.len() == segs.len()
+            || (!exact && entry.len() < segs.len()))
+            && entry.iter().zip(segs).all(|(a, b)| a == b)
+    };
+    let mangled = hale_stdlib::PATH_RENAMES
+        .iter()
+        .find(|(p, _)| matches_entry(p, true))
+        .or_else(|| {
+            hale_stdlib::PATH_RENAMES
+                .iter()
+                .filter(|(p, _)| matches_entry(p, false))
+                .max_by_key(|(p, _)| p.len())
+        })
+        .map(|(_, m)| *m)?;
+    let ast = stdlib_ast()?;
+    let name_span = ast.items.iter().find_map(|d| {
+        let n = top_decl_name(d)?;
+        (n.name == mangled).then_some(n.span)
+    })?;
+    let (file_name, content, local_start) =
+        hale_stdlib::ap_file_at(name_span.start.as_usize())?;
+    let local_end = (local_start
+        + (name_span.end.as_usize() - name_span.start.as_usize()))
+    .min(content.len());
+    let path = materialize_stdlib_file(file_name, content)?;
+    let (sl, sc) = offset_to_lsp_pos(content, local_start);
+    let (el, ec) = offset_to_lsp_pos(content, local_end);
+    Some(json!({
+        "uri": path_to_uri(&path),
+        "range": {
+            "start": { "line": sl, "character": sc },
+            "end":   { "line": el, "character": ec }
+        }
+    }))
 }
 
 fn references(

--- a/crates/hale-lsp/src/lib.rs
+++ b/crates/hale-lsp/src/lib.rs
@@ -408,10 +408,32 @@ fn check_and_publish(
                 if off >= *base && off < base.saturating_add(*len) {
                     if let Some(src) = sources.get(path) {
                         let local = d.clone().shifted(base.wrapping_neg());
+                        let mut v = diag_to_lsp(&local, src);
+                        // Related spans (downstream handoff,
+                        // 2026-08-11) resolve from the UN-shifted
+                        // diagnostic — each may live in a different
+                        // file than the primary — and publish as
+                        // `relatedInformation`, which clients render
+                        // as a clickable second location.
+                        let rel: Vec<Value> = d
+                            .related
+                            .iter()
+                            .filter_map(|(rspan, label)| {
+                                related_to_lsp(
+                                    *rspan,
+                                    label,
+                                    &file_bases,
+                                    &sources,
+                                )
+                            })
+                            .collect();
+                        if !rel.is_empty() {
+                            v["relatedInformation"] = json!(rel);
+                        }
                         per_file
                             .entry(path.clone())
                             .or_default()
-                            .push(diag_to_lsp(&local, src));
+                            .push(v);
                     }
                     break;
                 }
@@ -453,6 +475,35 @@ fn overlay_or_disk(
         }
     }
     std::fs::read_to_string(path).ok()
+}
+
+/// A merged-coordinate related span → LSP `DiagnosticRelatedInformation`,
+/// resolved to its own file through the file-base table.
+fn related_to_lsp(
+    rspan: hale_syntax::Span,
+    label: &str,
+    file_bases: &[(u32, PathBuf, u32)],
+    sources: &BTreeMap<PathBuf, String>,
+) -> Option<Value> {
+    let off = rspan.start.as_usize() as u32;
+    let (base, path, _) = file_bases
+        .iter()
+        .find(|(base, _, len)| off >= *base && off < base.saturating_add(*len))?;
+    let src = sources.get(path)?;
+    let local = rspan.shifted(base.wrapping_neg());
+    let (sl, sc) = offset_to_lsp_pos(src, local.start.as_usize());
+    let (el, ec) = offset_to_lsp_pos(src, local.end.as_usize());
+    let (el, ec) = if (el, ec) <= (sl, sc) { (sl, sc + 1) } else { (el, ec) };
+    Some(json!({
+        "location": {
+            "uri": path_to_uri(path),
+            "range": {
+                "start": { "line": sl, "character": sc },
+                "end":   { "line": el, "character": ec }
+            }
+        },
+        "message": label
+    }))
 }
 
 /// A file-local Diag → LSP diagnostic object with UTF-16 positions.

--- a/crates/hale-stdlib/src/lib.rs
+++ b/crates/hale-stdlib/src/lib.rs
@@ -162,6 +162,74 @@ pub const AP_SOURCE: &str = concat!(
     include_str!("../hl/term.hl"),
 );
 
+/// The same sources as `AP_SOURCE`, per file. `AP_SOURCE` is the
+/// concatenation of these contents joined by `"\n"` — asserted by
+/// a test, since span math depends on it. Downstream handoff
+/// (2026-08-11): the LSP resolves a `std::` definition to a span
+/// inside `AP_SOURCE`, maps it to its owning file here, and
+/// materializes that file to a read-only cache so an editor can
+/// jump into stdlib source even when nothing exists on disk (an
+/// `install.sh` binary has no stdlib checkout).
+pub const AP_FILES: &[(&str, &str)] = &[
+    ("core.hl", include_str!("../hl/core.hl")),
+    ("io_tcp.hl", include_str!("../hl/io_tcp.hl")),
+    ("io_udp.hl", include_str!("../hl/io_udp.hl")),
+    ("http.hl", include_str!("../hl/http.hl")),
+    ("http_client.hl", include_str!("../hl/http_client.hl")),
+    ("metrics.hl", include_str!("../hl/metrics.hl")),
+    ("text.hl", include_str!("../hl/text.hl")),
+    ("secret.hl", include_str!("../hl/secret.hl")),
+    ("test.hl", include_str!("../hl/test.hl")),
+    ("log.hl", include_str!("../hl/log.hl")),
+    ("ts.hl", include_str!("../hl/ts.hl")),
+    ("lang.hl", include_str!("../hl/lang.hl")),
+    ("iter.hl", include_str!("../hl/iter.hl")),
+    ("tagged.hl", include_str!("../hl/tagged.hl")),
+    ("name.hl", include_str!("../hl/name.hl")),
+    ("json.hl", include_str!("../hl/json.hl")),
+    ("yaml.hl", include_str!("../hl/yaml.hl")),
+    ("cli.hl", include_str!("../hl/cli.hl")),
+    ("source.hl", include_str!("../hl/source.hl")),
+    ("process.hl", include_str!("../hl/process.hl")),
+    ("bus.hl", include_str!("../hl/bus.hl")),
+    ("file.hl", include_str!("../hl/file.hl")),
+    ("bytes_builder.hl", include_str!("../hl/bytes_builder.hl")),
+    ("mirror_ring.hl", include_str!("../hl/mirror_ring.hl")),
+    ("term.hl", include_str!("../hl/term.hl")),
+];
+
+/// Map an `AP_SOURCE` byte offset to `(file_name, file_content,
+/// local_offset)` via the concatenation layout (each file's content
+/// followed by one `"\n"` separator).
+pub fn ap_file_at(offset: usize) -> Option<(&'static str, &'static str, usize)> {
+    let mut base = 0usize;
+    for (name, content) in AP_FILES {
+        let end = base + content.len();
+        if offset < end {
+            return Some((name, content, offset - base));
+        }
+        base = end + 1; // the "\n" joiner
+    }
+    None
+}
+
+#[cfg(test)]
+mod ap_files_layout {
+    use super::*;
+
+    #[test]
+    fn ap_files_concat_is_ap_source() {
+        let joined: Vec<&str> =
+            AP_FILES.iter().map(|(_, c)| *c).collect();
+        assert_eq!(
+            joined.join("\n"),
+            AP_SOURCE,
+            "AP_FILES must mirror AP_SOURCE exactly — span math \
+             depends on the concatenation layout"
+        );
+    }
+}
+
 /// Maps each user-facing stdlib path (locus OR type) to the
 /// mangled name declared in `AP_SOURCE`. The mangled
 /// prefix (`__StdIo...`, `__StdHttp...`) makes collision with

--- a/crates/hale-syntax/src/error.rs
+++ b/crates/hale-syntax/src/error.rs
@@ -7,6 +7,15 @@ pub struct Diag {
     pub kind: DiagKind,
     pub span: Span,
     pub message: String,
+    /// Secondary locations (downstream handoff, 2026-08-11): a
+    /// diagnostic whose story spans two places — "duplicate name"
+    /// pointing at the PREVIOUS declaration — carries the other
+    /// span as data instead of `{:?}`-formatting it into the
+    /// message. The renderers (which have the sources and the
+    /// file-base table) turn each entry into `path:line:col`; the
+    /// LSP maps them to `DiagnosticRelatedInformation`, which
+    /// clients render as a clickable second location.
+    pub related: Vec<(Span, String)>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -47,6 +56,7 @@ impl Diag {
             kind: DiagKind::Lex,
             span,
             message: msg.into(),
+            related: Vec::new(),
         }
     }
 
@@ -55,6 +65,7 @@ impl Diag {
             kind: DiagKind::Parse,
             span,
             message: msg.into(),
+            related: Vec::new(),
         }
     }
 
@@ -63,6 +74,7 @@ impl Diag {
             kind: DiagKind::Codegen,
             span,
             message: msg.into(),
+            related: Vec::new(),
         }
     }
 
@@ -71,6 +83,7 @@ impl Diag {
             kind: DiagKind::Type,
             span,
             message: msg.into(),
+            related: Vec::new(),
         }
     }
 
@@ -81,13 +94,30 @@ impl Diag {
             kind: DiagKind::Warn,
             span,
             message: msg.into(),
+            related: Vec::new(),
         }
     }
 
-    /// Offset this diagnostic's span by `delta` bytes (see
-    /// `Span::shifted` / `parse_source_at`).
+    /// Attach a secondary location (see the `related` field doc).
+    pub fn with_related(
+        mut self,
+        span: Span,
+        label: impl Into<String>,
+    ) -> Self {
+        self.related.push((span, label.into()));
+        self
+    }
+
+    /// Offset this diagnostic's spans by `delta` bytes (see
+    /// `Span::shifted` / `parse_source_at`). Related spans move
+    /// with the primary — a diagnostic shifts between coordinate
+    /// spaces whole. (Cross-FILE related spans should be resolved
+    /// from the un-shifted diagnostic instead; see the LSP.)
     pub fn shifted(mut self, delta: u32) -> Self {
         self.span = self.span.shifted(delta);
+        for (rspan, _) in &mut self.related {
+            *rspan = rspan.shifted(delta);
+        }
         self
     }
 
@@ -111,14 +141,22 @@ impl Diag {
 
     pub fn render(&self, source: &str) -> String {
         let (line, col) = self.span.line_col(source);
-        format!(
+        let mut out = format!(
             "{}:{}: {}: {}{}",
             line,
             col,
             self.kind_str(),
             self.message,
             Self::context_snippet(self.span, source, line, col)
-        )
+        );
+        // Related notes, resolved against the same single source.
+        // Multi-file callers use the CLI's file-base-aware helper,
+        // which renders these with a path instead.
+        for (rspan, label) in &self.related {
+            let (rl, rc) = rspan.line_col(source);
+            out.push_str(&format!("\n    note: {} at {}:{}", label, rl, rc));
+        }
+        out
     }
 
     /// Render as `path:line:col: kind: message`, un-shifting the span by

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -4217,14 +4217,16 @@ fn check_main_and_bindings(
                             }
                             // Duplicate topic across all bindings
                             if let Some(prev) = bound.get(&entry.topic.name) {
-                                diags.push(Diag::ty(
-                                    entry.topic.span,
-                                    format!(
-                                        "topic `{}` already bound (previous \
-                                         binding at {:?})",
-                                        entry.topic.name, prev
-                                    ),
-                                ));
+                                diags.push(
+                                    Diag::ty(
+                                        entry.topic.span,
+                                        format!(
+                                            "topic `{}` already bound",
+                                            entry.topic.name
+                                        ),
+                                    )
+                                    .with_related(*prev, "previous binding"),
+                                );
                             } else {
                                 bound.insert(entry.topic.name.clone(), entry.topic.span);
                             }
@@ -8551,14 +8553,16 @@ impl<'a> Checker<'a> {
                         slot.name.name.clone(),
                         slot.name.span,
                     ) {
-                        self.diags.push(Diag::ty(
-                            slot.name.span,
-                            format!(
-                                "duplicate capacity slot name `{}` \
-                                 (first declared at {:?})",
-                                slot.name.name, prev
-                            ),
-                        ));
+                        self.diags.push(
+                            Diag::ty(
+                                slot.name.span,
+                                format!(
+                                    "duplicate capacity slot name `{}`",
+                                    slot.name.name
+                                ),
+                            )
+                            .with_related(prev, "first declared here"),
+                        );
                     }
                     let elem_ty = resolve_type_expr(&slot.elem_ty, self.known);
                     let kind_word = match slot.kind {

--- a/crates/hale-types/src/resolve.rs
+++ b/crates/hale-types/src/resolve.rs
@@ -296,13 +296,20 @@ fn insert_name(
     diags: &mut Vec<Diag>,
 ) {
     if let Some(prev) = known.get(&ident.name) {
-        diags.push(Diag::ty(
-            ident.span,
-            format!(
-                "duplicate top-level name `{}` (previous declaration at {:?})",
-                ident.name, prev
-            ),
-        ));
+        // Downstream handoff (2026-08-11): the previous declaration
+        // rides as a RELATED span, not a `{:?}`-formatted Span in
+        // the message — this fn has no source text, but the
+        // renderers (and the LSP's relatedInformation) do.
+        diags.push(
+            Diag::ty(
+                ident.span,
+                format!(
+                    "duplicate top-level name `{}`",
+                    ident.name
+                ),
+            )
+            .with_related(*prev, "previous declaration"),
+        );
         return;
     }
     known.insert(ident.name.clone(), ident.span);
@@ -1252,14 +1259,17 @@ fn register_symbol(
     span: Span,
     diags: &mut Vec<Diag>,
 ) {
-    if scope.symbols.contains_key(name) {
+    if let Some(prev) = scope.symbols.get(name) {
         // Duplicate already reported by collect_type_names for
         // type-like names; fns/consts get caught here.
         if let TopSymbol::Fn(_) | TopSymbol::Const(_) = &sym {
-            diags.push(Diag::ty(
-                span,
-                format!("duplicate top-level name `{}`", name),
-            ));
+            diags.push(
+                Diag::ty(
+                    span,
+                    format!("duplicate top-level name `{}`", name),
+                )
+                .with_related(prev.span(), "previous declaration"),
+            );
         }
         return;
     }

--- a/docs/src/getting-started/first-run.md
+++ b/docs/src/getting-started/first-run.md
@@ -96,7 +96,10 @@ A few switches worth knowing from day one:
   signatures with their contracts (fallibility, `@hot`/`@budget`
   status, a topic's routing key), completion covers `self.`
   members, the `std::` surface, and your seed's symbols,
-  go-to-definition and references work across the seed, and the custom requests `hale/busGraph`,
+  go-to-definition and references work across the seed —
+  go-to-definition on a `std::` path jumps into the stdlib's own
+  source (materialized read-only from the compiler's embedded copy,
+  so it works even when nothing is installed on disk) — and the custom requests `hale/busGraph`,
   `hale/placement`, and `hale/allocSummary` return the pub/sub
   topology, the thread/pool map, and the allocation survey's leak
   sites. No configuration. Prefer plain JSON?

--- a/spec/projects.md
+++ b/spec/projects.md
@@ -450,7 +450,7 @@ End-to-end coverage lives in
 | Surface | Effect |
 |---|---|
 | `hale build --dev` / `HALE_DEV=1` | Latency mode: LLVM O1 pipeline + Less machine codegen instead of the O3/`target-cpu=native` release default. For edit-build-run loops. |
-| `hale check --json` | NDJSON diagnostics on stdout, one object per line (`file`/`line`/`col`/`severity`/`kind`/`message`) — editor/LSP consumption. `hale check` runs in ~10 ms on the largest apps. |
+| `hale check --json` | NDJSON diagnostics on stdout, one object per line (`file`/`line`/`col`/`severity`/`kind`/`message`, plus `related`: an array of `{file, line, col, note}` secondary locations, present only when a diagnostic has them — e.g. a duplicate name's previous declaration; 2026-08-11) — editor/LSP consumption. `hale check` runs in ~10 ms on the largest apps. |
 | `HALE_TIME=1` | Per-phase build wall times on stderr (front-end+codegen, llvm-passes, obj-emit, emit+link). |
 | `--no-warn-unbounded-alloc` | Opts a run out of the default-on memory-bound survey (see verification.md). |
 | `hale check --sealable` | Reports which loci could take `@sealed` and what it would cost: per locus, the sites outside it that read or write its `params`. Empty means sealing is a no-op. The survey reruns the real check against an all-sealed clone rather than approximating the rule, so it cannot disagree with the checker. |


### PR DESCRIPTION
An editor-tooling handoff reported two CLI diagnostic defects, both worst on the duplicate-top-level-name error — the easiest error to hit under the per-directory seed model (second file with its own `fn main()`), and the one that reported worst.

## 1. Debug formatting leaked into user-facing diagnostics

``duplicate top-level name `Widget` (previous declaration at Span { start: Pos(5), end: Pos(11) })`` — the raising site has no source text, so it `{:?}`-formatted the previous span into the message, which reached every editor via the LSP payload.

`Diag` now carries `related: Vec<(Span, String)>` (the reporter's suggested design, mirroring LSP `relatedInformation`), and the renderers — which do have the sources and file-base table — resolve each entry:

- text: `note: previous declaration at path:line:col`, correct across files
- `--json`: a `related` array of `{file, line, col, note}` — **absent when empty**, so existing consumers see an unchanged shape
- `hale lsp`: `DiagnosticRelatedInformation`, a clickable second location in clients (resolved from the un-shifted diagnostic, since a related span may live in a different file than the primary)

The sweep found two more `{:?}`-span leaks (duplicate topic binding, duplicate capacity slot) — same treatment — and the fn/const duplicate path, which had *no* previous location at all, now recovers it from the symbol table via `TopSymbol::span()`.

## 2. Pre-pass diagnostics bypassed the reporting path

Resolver diags raised inside `apply_sync_inference` were printed through a bare `render()` + early bail: no filename, `--json` silently ignored (**empty stdout with exit 1** — a CI gate saw a failed build with zero explaining diagnostics), wrong stream, and multi-file positions resolved against the alphabetically-first file's text (coordinates in neither file).

The reporter proved the fix in-tree: `hale lsp` already discards the pre-pass return and lets `check_bundle` re-raise through the properly-routed path — which is why the LSP attributed the same diagnostic correctly while the CLI did not. All three CLI bail sites (`check`/`run`/`build`) now match the LSP; `run` and `build` had additionally been double-reporting.

## Tests

`diag_reporting.rs`: `--json` on a duplicate-`main` seed emits NDJSON on stdout naming the *second* file with a position inside it plus the `related` array, nothing on stderr; plain mode renders `b.hl:1:6` + a cross-file note at `a.hl:1:6`; `"Span {"` never reaches a user; the ordinary-error NDJSON shape is unchanged (no `related` key when empty). `lsp.rs` gains a case asserting `relatedInformation` with the clickable previous-declaration location. Spec's `--json` row documents the `related` array.

Validation: full workspace suite 2528/2528; fmt gate clean; the report's own repro script re-run end to end against the fixed binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)