### PR TITLE
fix(check): enforce the handler/payload rule the spec already states (soundness, downstream handoff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ behavior.
 
 ## Unreleased
 
+### A subscriber handler's parameter type is checked against the payload
+
+**Soundness fix**, from a downstream handoff. The spec has always
+said a subscriber's handler signature must match the topic's payload
+exactly (semantics § type-check rules, rule 1) — but nothing enforced
+it. Any parameter type was accepted, and the published value was
+reinterpreted field-by-field at the handler: a `String` field read
+through an `Int` parameter printed the string's **heap pointer** —
+a live, ASLR-moving address obtained from safe code, with `check`
+and `verify` both green. Sharper still, the string-subject `of type`
+conflict diagnostic already modelled this exact hazard and its
+advice steered users toward the unchecked `topic` construct.
+
+The subscribe-validation loop now compares the handler's parameter
+against the subject's payload for **both** subject forms (declared
+topics and string subjects with `of type` — the latter was only
+checked cross-site, not at the handler boundary), enforces
+one-parameter arity, accepts `Drain<T>` batch handlers by their
+element type, and leaves `Unknown` payloads (cross-seed topics,
+stdlib paths) permissive. The natural mistake that led to the report
+— annotating the parameter with the **topic** name
+(`fn on_hello(msg: Hello)`) — gets its own message naming the
+payload type to use; it previously survived to codegen and died as
+`unknown type name`, mangled and ungreppable across a seed boundary.
+Reported at the parameter's own span: the caret is on the thing to
+change. Verified against the full downstream corpus (pond, native
+suites) with zero false positives.
+
+### `hale lsp` follow-ups: stdlib-cache files stay diagnostic-free
+
+The materialized stdlib cache from the go-to-definition feature had
+a sharp edge (same handoff, reported live): jumping into
+`~/.cache/hale/stdlib-<version>/` and opening the file sprayed
+spurious errors over correct stdlib code — the per-domain files only
+resolve inside the merged program, not as standalone seeds. The LSP
+now recognizes stdlib-cache paths and publishes an empty diagnostic
+set for them (clearing, not skipping, so anything a client already
+showed is removed).
+
 ### `hale lsp`: go-to-definition on `std::` paths
 
 Downstream handoff. `textDocument/definition` on a `std::` path

--- a/crates/hale-cli/tests/diag_reporting.rs
+++ b/crates/hale-cli/tests/diag_reporting.rs
@@ -143,3 +143,51 @@ fn ordinary_json_shape_is_unchanged() {
     assert!(v["file"].as_str().unwrap().ends_with("a.hl"));
     let _ = std::fs::remove_dir_all(&d);
 }
+
+/// Downstream handoff (2026-08-11), soundness follow-through: the
+/// handler/payload mismatch must refuse to BUILD, not just fail
+/// `check` — before the fix it built and printed a live heap
+/// address from safe code.
+#[test]
+fn payload_mismatch_refuses_to_build() {
+    let d = seed_dir("buspay");
+    std::fs::write(
+        d.join("main.hl"),
+        r#"
+        type Greeting { text: String = "hello"; n: Int = 42; }
+        type Other { a: Int = 0; b: Int = 0; }
+        topic Hello { payload: Greeting; subject: "hello"; }
+        locus Pub {
+            bus { publish Hello; }
+            birth() { Hello <- Greeting { text: "P", n: 7 }; }
+        }
+        locus Sub {
+            bus { subscribe Hello as on_hello; }
+            fn on_hello(msg: Other) { println("a=", msg.a); }
+        }
+        fn main() { Sub { }; Pub { }; }
+        "#,
+    )
+    .unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("build")
+        .arg(&d)
+        .output()
+        .expect("run hale build");
+    let all = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "the reinterpreting program must not build: {}",
+        all
+    );
+    assert!(
+        all.contains("carries payload `Greeting`"),
+        "the refusal names the mismatch: {}",
+        all
+    );
+    let _ = std::fs::remove_dir_all(&d);
+}

--- a/crates/hale-cli/tests/lsp.rs
+++ b/crates/hale-cli/tests/lsp.rs
@@ -925,3 +925,67 @@ fn lsp_definition_resolves_std_paths_into_materialized_stdlib() {
     let _ = lsp.child.wait();
     let _ = std::fs::remove_dir_all(&seed);
 }
+
+/// A file inside the materialized stdlib cache
+/// (`…/hale/stdlib-<version>/…`) is a definition-jump target, not
+/// a seed: analyzed standalone it would spray spurious errors over
+/// correct stdlib code (mangled declarations and path-call
+/// primitives only resolve in the merged program). The LSP
+/// publishes an EMPTY diagnostic set for such files.
+#[test]
+fn lsp_stdlib_cache_files_get_no_diagnostics() {
+    let dir = std::env::temp_dir()
+        .join(format!("hale_lsp_cachedq_{}", std::process::id()))
+        .join("hale")
+        .join("stdlib-0.0.0-test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let file = dir.join("core.hl");
+    // Standalone-invalid content of the kind real stdlib files
+    // carry (path-call primitive references, mangled names).
+    let text = "fn __StdProbe(n: Int) -> Int {\n    return std::__nonexistent::path(n);\n}\n";
+    std::fs::write(&file, text).expect("write");
+    let uri = format!("file://{}", file.display());
+
+    let mut lsp = Lsp::start();
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": { "capabilities": {} }
+    }));
+    let _ = lsp.recv();
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "method": "initialized", "params": {}
+    }));
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": { "textDocument": {
+            "uri": uri, "languageId": "hale", "version": 1, "text": text
+        }}
+    }));
+    let open = lsp.recv();
+    assert_eq!(
+        open.get("method").and_then(|m| m.as_str()),
+        Some("textDocument/publishDiagnostics"),
+        "{}",
+        open
+    );
+    assert_eq!(
+        open.pointer("/params/diagnostics")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .len(),
+        0,
+        "stdlib cache files publish empty diagnostics: {}",
+        open
+    );
+
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "id": 9, "method": "shutdown", "params": {}
+    }));
+    let _ = lsp.recv();
+    lsp.send(serde_json::json!({
+        "jsonrpc": "2.0", "method": "exit", "params": {}
+    }));
+    let _ = lsp.child.wait();
+}

--- a/crates/hale-lsp/src/lib.rs
+++ b/crates/hale-lsp/src/lib.rs
@@ -313,11 +313,47 @@ fn path_to_uri(path: &Path) -> String {
 
 /// Re-parse and re-check the SEED containing `changed`, then publish
 /// diagnostics for every .hl file in it (empties clear stale ones).
+/// Is this path inside the materialized stdlib cache
+/// (`<cache>/hale/stdlib-<version>/`)? Those files are read-only
+/// jump targets, not user seeds: analyzed standalone they spray
+/// spurious errors over correct stdlib code (mangled declarations
+/// and path-call primitives only resolve in the merged program),
+/// so the LSP publishes no diagnostics for them.
+fn is_stdlib_cache_path(path: &Path) -> bool {
+    let canon = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let mut comps = canon.components().rev();
+    let _file = comps.next();
+    let (Some(ver_dir), Some(hale_dir)) = (comps.next(), comps.next())
+    else {
+        return false;
+    };
+    hale_dir.as_os_str() == "hale"
+        && ver_dir
+            .as_os_str()
+            .to_string_lossy()
+            .starts_with("stdlib-")
+}
+
 fn check_and_publish(
     writer: &mut impl Write,
     changed: &Path,
     overlays: &BTreeMap<PathBuf, String>,
 ) {
+    // A file inside the stdlib cache gets an EMPTY publish — it is
+    // a definition-jump target, not a seed member, and clearing
+    // (rather than skipping) removes anything a client already
+    // showed for it.
+    if is_stdlib_cache_path(changed) {
+        notify(
+            writer,
+            "textDocument/publishDiagnostics",
+            json!({
+                "uri": path_to_uri(changed),
+                "diagnostics": []
+            }),
+        );
+        return;
+    }
     let seed_dir = changed
         .parent()
         .map(Path::to_path_buf)

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -6584,6 +6584,118 @@ impl<'a> Checker<'a> {
                         ),
                     ));
                 }
+                // Downstream handoff (2026-08-11), SOUNDNESS: the
+                // handler's parameter type was never compared
+                // against the subject's payload — any type was
+                // accepted, and the published value reinterpreted
+                // field-by-field at the handler (a String field
+                // read through an Int parameter surfaced its heap
+                // pointer, from safe code, with both gates green).
+                // The string-subject `of type` conflict check
+                // already models this hazard cross-site; this is
+                // the same comparison at the handler boundary,
+                // covering BOTH subject forms. `Ty::Unknown` on
+                // either side stays permissive — cross-seed topics,
+                // stdlib paths, and `Drain<T>` batch handlers all
+                // resolve Unknown here by design.
+                if !matches!(sub.payload, Ty::Unknown) {
+                    match handler_fn.params.as_slice() {
+                        [p] => {
+                            // A `Drain<T>` batch handler receives the
+                            // same payload per element — compare T.
+                            let (payload_te, is_drain) = match &p.ty {
+                                TypeExpr::Named {
+                                    path, generic_args, ..
+                                } if path.segments.len() == 1
+                                    && path.segments[0].name == "Drain"
+                                    && generic_args.len() == 1 =>
+                                {
+                                    (&generic_args[0], true)
+                                }
+                                other => (other, false),
+                            };
+                            let got = crate::resolve::resolve_type_expr(
+                                payload_te, self.known,
+                            );
+                            let got_display = if is_drain {
+                                format!("Drain<{}>", got.display())
+                            } else {
+                                got.display()
+                            };
+                            if matches!(got, Ty::Unknown) {
+                                // The mistake that led here: the
+                                // TOPIC name used as the parameter
+                                // type (`subscribe Hello as on_h` +
+                                // `fn on_h(msg: Hello)`). Un-checked
+                                // it survived to codegen as an
+                                // `unknown type name` — mangled and
+                                // ungreppable across a seed boundary.
+                                if let TypeExpr::Named {
+                                    path,
+                                    generic_args,
+                                    ..
+                                } = payload_te
+                                {
+                                    if generic_args.is_empty()
+                                        && path.segments.len() == 1
+                                        && matches!(
+                                            self.top.lookup(
+                                                &path.segments[0].name
+                                            ),
+                                            Some(TopSymbol::Topic(_))
+                                        )
+                                    {
+                                        self.diags.push(Diag::ty(
+                                            p.ty.span(),
+                                            format!(
+                                                "bus subscribe `{}` handler \
+                                                 `{}`: `{}` is the topic, \
+                                                 not a type — the handler \
+                                                 receives the topic's \
+                                                 payload; declare the \
+                                                 parameter as `{}`",
+                                                sub.subject,
+                                                sub.handler,
+                                                path.segments[0].name,
+                                                sub.payload.display(),
+                                            ),
+                                        ));
+                                    }
+                                }
+                            } else if got != sub.payload {
+                                self.diags.push(Diag::ty(
+                                    p.ty.span(),
+                                    format!(
+                                        "bus subscribe `{}` handler `{}` \
+                                         takes `{}`, but the subject \
+                                         carries payload `{}` — the \
+                                         mismatch would reinterpret the \
+                                         payload's bytes as the wrong \
+                                         type at runtime",
+                                        sub.subject,
+                                        sub.handler,
+                                        got_display,
+                                        sub.payload.display(),
+                                    ),
+                                ));
+                            }
+                        }
+                        params => {
+                            self.diags.push(Diag::ty(
+                                handler_fn.name.span,
+                                format!(
+                                    "bus subscribe `{}` handler `{}` must \
+                                     take exactly one parameter (the \
+                                     payload `{}`), but takes {}",
+                                    sub.subject,
+                                    sub.handler,
+                                    sub.payload.display(),
+                                    params.len(),
+                                ),
+                            ));
+                        }
+                    }
+                }
             }
         }
 

--- a/crates/hale-types/tests/bus_payload_handler.rs
+++ b/crates/hale-types/tests/bus_payload_handler.rs
@@ -1,0 +1,164 @@
+//! Downstream handoff (2026-08-11), SOUNDNESS — a subscriber
+//! handler's parameter type was never compared against the
+//! subject's payload. Any type was accepted; the published value
+//! was then reinterpreted field-by-field at the handler, and a
+//! String field read through an Int parameter surfaced its heap
+//! pointer from safe code, with `check` and `verify` both green.
+//! The string-subject `of type` path already rejected the same
+//! mismatch cross-site — and its message steered users toward the
+//! unchecked `topic` construct.
+
+use hale_types::check_program;
+
+fn errors(src: &str) -> Vec<String> {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    check_program(&program)
+        .into_iter()
+        .filter(|d| d.is_error())
+        .map(|d| d.message)
+        .collect()
+}
+
+const PRELUDE: &str = r#"
+    type Greeting { text: String = ""; n: Int = 0; }
+    type Other { a: Int = 0; b: Int = 0; }
+    topic Hello { payload: Greeting; subject: "hello"; }
+"#;
+
+#[test]
+fn subscribe_handler_payload_type_must_match_topic() {
+    let src = format!(
+        r#"{PRELUDE}
+        locus Sub {{
+            bus {{ subscribe Hello as on_hello; }}
+            fn on_hello(msg: Other) {{ println(msg.a); }}
+        }}
+        fn main() {{ Sub {{ }}; }}
+        "#
+    );
+    let errs = errors(&src);
+    assert!(
+        errs.iter().any(|e| e.contains("takes `Other`")
+            && e.contains("payload `Greeting`")),
+        "the reinterpretation is rejected at check time: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn subscribe_handler_annotated_with_topic_name_is_a_type_error() {
+    // The natural mistake (`subscribe Hello as on_hello` reads like
+    // the handler gets a Hello). Used to survive check and die at
+    // codegen as `unknown type name` — mangled and ungreppable
+    // across a seed boundary.
+    let src = format!(
+        r#"{PRELUDE}
+        locus Sub {{
+            bus {{ subscribe Hello as on_hello; }}
+            fn on_hello(msg: Hello) {{ println("x"); }}
+        }}
+        fn main() {{ Sub {{ }}; }}
+        "#
+    );
+    let errs = errors(&src);
+    assert!(
+        errs.iter().any(|e| e.contains("`Hello` is the topic")
+            && e.contains("declare the parameter as `Greeting`")),
+        "the topic-as-type mistake is named at check time: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn subscribe_handler_arity_must_be_one() {
+    let two = format!(
+        r#"{PRELUDE}
+        locus Sub {{
+            bus {{ subscribe Hello as on_hello; }}
+            fn on_hello(a: Greeting, b: Int) {{ println(b); }}
+        }}
+        fn main() {{ Sub {{ }}; }}
+        "#
+    );
+    let errs = errors(&two);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("exactly one parameter") && e.contains("takes 2")),
+        "two params rejected: {:?}",
+        errs
+    );
+
+    let zero = format!(
+        r#"{PRELUDE}
+        locus Sub {{
+            bus {{ subscribe Hello as on_hello; }}
+            fn on_hello() {{ println("x"); }}
+        }}
+        fn main() {{ Sub {{ }}; }}
+        "#
+    );
+    let errs = errors(&zero);
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("exactly one parameter") && e.contains("takes 0")),
+        "zero params rejected: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn string_subject_of_type_handler_mismatch_is_also_caught() {
+    // Same comparison, other subject form — the `of type` conflict
+    // check was cross-site only; the handler boundary is covered by
+    // the same new check.
+    let src = r#"
+        type Greeting { text: String = ""; n: Int = 0; }
+        type Other { a: Int = 0; b: Int = 0; }
+        locus Sub {
+            bus { subscribe "hello" as on_hello of type Greeting; }
+            fn on_hello(msg: Other) { println(msg.a); }
+        }
+        fn main() { Sub { }; }
+    "#;
+    let errs = errors(src);
+    assert!(
+        errs.iter().any(|e| e.contains("takes `Other`")
+            && e.contains("payload `Greeting`")),
+        "of-type handler mismatch rejected: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn matching_handler_and_unknown_payloads_stay_clean() {
+    // Control: the correct spelling is untouched...
+    let ok = format!(
+        r#"{PRELUDE}
+        locus Sub {{
+            params {{ seen: Int = 0; }}
+            bus {{ subscribe Hello as on_hello; }}
+            fn on_hello(msg: Greeting) {{ self.seen = self.seen + 1; }}
+        }}
+        fn main() {{ Sub {{ }}; }}
+        "#
+    );
+    assert!(errors(&ok).is_empty(), "control errs: {:?}", errors(&ok));
+
+    // ...and a `Drain<T>` batch handler (which resolves Unknown at
+    // this layer by design) is not flagged.
+    let drain = format!(
+        r#"{PRELUDE}
+        locus Sub {{
+            bus {{ subscribe Hello as on_batch; }}
+            fn on_batch(d: Drain<Greeting>) {{ println("x"); }}
+        }}
+        fn main() {{ Sub {{ }}; }}
+        "#
+    );
+    let errs = errors(&drain);
+    assert!(
+        !errs.iter().any(|e| e.contains("carries payload")),
+        "Drain batch handlers stay permissive: {:?}",
+        errs
+    );
+}

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -911,6 +911,17 @@ Type-check rules:
 
 1. Every subscriber's handler signature must match `Topic.payload`
    exactly — a static error cites both sites if they diverge.
+   (Enforced 2026-08-11 — downstream handoff; this rule was
+   written but never implemented, and the reinterpreted payload
+   surfaced a String field's heap pointer through an Int
+   parameter from safe code. The check covers both subject forms
+   — declared topics and string subjects with `of type` — plus
+   arity, accepts `Drain<T>` batch handlers by their element
+   type, and names the topic-as-parameter-type mistake
+   (`fn on_h(msg: Hello)` where `Hello` is the topic)
+   specifically. Payloads that resolve `Unknown` — cross-seed
+   topics, stdlib paths — stay permissive by the milestone-2
+   rule.)
 2. The send-expression's type at a topic-ref `<-` site must match
    `Topic.payload`.
 3. The `of type T` clause is forbidden on topic-ref subscribe /


### PR DESCRIPTION
A downstream handoff found a **soundness hole**: a subscriber handler's parameter type is never compared against the topic's payload. Any type substitutes cleanly — typechecks, verifies, builds, runs — and the published value is reinterpreted field-by-field at the handler. Their repro prints a `String` field's **heap pointer** through an `Int` parameter: a live, ASLR-moving address obtained from safe code with `check` and `verify` both green. Sharpest detail in the report: the string-subject `of type` conflict diagnostic already models this exact hazard, and its advice ("Declare a `topic` to fix the type in one place") steered users toward the unchecked construct. And `spec/semantics.md` type-check rule 1 **already states the rule** — it was written but never implemented, so this is a spec-conformance fix.

**The check** (in the subscribe-validation loop that already had the `FnDecl` and resolved payload in hand, exactly as the report's patch sketch proposed):
- payload comparison for **both** subject forms — declared topics *and* string subjects with `of type`, whose handler boundary was also unchecked (the existing conflict check was cross-site only)
- one-parameter arity, both directions
- `Drain<T>` batch handlers compared by their **element** type
- `Unknown` payloads (cross-seed topics, stdlib paths) stay permissive per the milestone-2 rule
- the natural mistake that led to the report — the **topic** name as the parameter type (`fn on_hello(msg: Hello)`) — gets its own message naming the payload type to declare; it previously survived to codegen and died as a mangled, ungreppable `unknown type name`
- diagnostics land at the parameter's own span (the caret is on the thing to change)

**Also fixed, same handoff (reported live)**: opening a materialized stdlib-cache file (`~/.cache/hale/stdlib-<version>/…`, the #457 go-to-definition targets) sprayed spurious diagnostics — the per-domain files only resolve inside the merged program. The LSP now recognizes cache paths and publishes an empty diagnostic set (clearing, not skipping).

**Tests**: the report's three suggested regressions plus controls (`bus_payload_handler.rs`), the build-refusal assertion they asked for (`payload_mismatch_refuses_to_build` — before this, the program built and printed a heap address), and the cache-silence LSP case. Verified against the whole downstream corpus (pond libs, native suites) with **zero false positives**; workspace suite 2537/2537; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)