### PR TITLE
feat(cli): hale init — bootstrap a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,20 @@ resolve inside the merged program, not as standalone seeds. The LSP
 now recognizes stdlib-cache paths and publishes an empty diagnostic
 set for them (clearing, not skipping, so anything a client already
 showed is removed).
+### `hale init` bootstraps a project
+
+There was no way to scaffold a project — `hale.toml` was hand-written
+from the spec. `hale init [dir]` (default: the current directory) now
+writes the canonical minimal shape: a `[deps]`-only `hale.toml`
+skeleton with the entry syntax in a comment, a hello-world `main.hl`,
+a first `tests/main_test.hl` (in a subdirectory, per the seed model —
+a test file carries its own `fn main`, so beside `main.hl` it would
+collide; it imports the parent seed, the established convention), and
+a `.gitignore` covering the build artifact and `vendor/`. The
+scaffold is fmt-canonical from birth and passes `run`, `test`, and
+`verify` out of the box — all asserted by test. Strictly
+non-destructive: existing files are kept and reported, so `init` is
+also safe for filling gaps in a partially-scaffolded directory.
 
 ### `hale lsp`: go-to-definition on `std::` paths
 

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -83,6 +83,20 @@ fn main() -> ExitCode {
         };
     }
 
+    // `init` bootstraps a project: a `hale.toml` skeleton, a
+    // hello-world `main.hl` seed, a first native test, and a
+    // `.gitignore` for the build artifact + vendor/. Defaults to
+    // the current directory; strictly non-destructive (every file
+    // that already exists is left untouched and reported).
+    if cmd == "init" {
+        let root = if args.len() >= 3 {
+            PathBuf::from(&args[2])
+        } else {
+            env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+        };
+        return run_init(&root);
+    }
+
     // `test` is a discovery-driven subcommand: like `fetch` it
     // defaults its target to the current working directory, so
     // `hale test` (no path) is valid. An explicit file/dir and any
@@ -183,6 +197,7 @@ fn usage() {
     eprintln!("Usage:");
     eprintln!("    hale lex   <file.hl>          tokenize and print tokens");
     eprintln!("    hale parse <file.hl>          parse and print the AST");
+    eprintln!("    hale init  [dir]              bootstrap a project (hale.toml, main.hl, first test)");
     eprintln!("    hale check <file.hl | dir>    parse + typecheck");
     eprintln!("        [--dump-topology[=<path>]] [--check-topology[-shape] <path>]");
     eprintln!("        [--dump-effects-manifest] [--json] [--workspace]");
@@ -2948,6 +2963,108 @@ fn check_usage(verify: bool) {
     println!("  --no-warn-unbounded-alloc       silence the unbounded-alloc lint");
     println!("  --allow-unowned-subscriber      permit a subscriber with no owner");
     println!("  --json                          machine-readable diagnostics");
+}
+
+/// `hale init [dir]` — bootstrap a project. Writes the canonical
+/// minimal scaffold: a `hale.toml` skeleton (the manifest is
+/// `[deps]`-only by design — a project is identified by its
+/// directory name and its source, per spec/packages.md), a
+/// hello-world `main.hl`, a first `tests/*_test.hl` so `hale test` works
+/// from minute one, and a `.gitignore` covering the build artifact
+/// and `vendor/`. Strictly non-destructive: an existing file is
+/// never touched, only reported — so `init` is also safe to run in
+/// a partially-scaffolded directory to fill in what's missing.
+fn run_init(root: &Path) -> ExitCode {
+    if let Err(e) = fs::create_dir_all(root) {
+        eprintln!("hale init: cannot create {}: {}", root.display(), e);
+        return ExitCode::from(1);
+    }
+    let name = root
+        .canonicalize()
+        .ok()
+        .and_then(|p| {
+            p.file_name().map(|n| n.to_string_lossy().into_owned())
+        })
+        .unwrap_or_else(|| "app".to_string());
+
+    let manifest = "\
+# hale.toml — the project manifest. The only section is [deps]:\n\
+# a project is identified by its directory name and its source\n\
+# (no [package] metadata table exists). `hale fetch` clones each\n\
+# dep into vendor/<name>/ and pins the resolved SHA in hale.lock.\n\
+#\n\
+# [deps]\n\
+# helpers = { git = \"https://github.com/me/helpers\", tag = \"v0.1.0\" }\n\
+\n\
+[deps]\n";
+
+    let main_hl = r#"/// Entry seed. Every `.hl` file in this directory shares one
+/// scope — decompose by concern, not by visibility.
+fn greeting() -> String {
+    return "Hello from Hale.";
+}
+
+fn main() {
+    println(greeting());
+}
+"#;
+
+    // Tests live in a SUBDIRECTORY: a seed is the `.hl` files
+    // directly in one directory, and a test file carries its own
+    // `fn main` — beside main.hl it would collide. `tests/` is its
+    // own seed importing the parent, the pond/stdlib convention.
+    let test_hl = r#"// `hale test` discovers *_test.hl recursively. Each test file is
+// its own program: it imports the seed under test and asserts —
+// typechecked, next to the code.
+
+import ".." as app;
+
+fn main() {
+    std::test::assert_eq_str(app::greeting(), "Hello from Hale.", "greeting");
+}
+"#;
+
+    let gitignore = format!(
+        "# the build artifact (`hale build .` names it after the directory)\n\
+         /{}\n\
+         # toolchain-managed dependency clones (`hale fetch`)\n\
+         /vendor/\n",
+        name
+    );
+
+    let files: &[(&str, &str)] = &[
+        ("hale.toml", manifest),
+        ("main.hl", main_hl),
+        ("tests/main_test.hl", test_hl),
+        (".gitignore", &gitignore),
+    ];
+    let mut wrote = 0usize;
+    for (fname, content) in files {
+        let path = root.join(fname);
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        if path.exists() {
+            println!("kept    {} (already exists)", path.display());
+            continue;
+        }
+        if let Err(e) = fs::write(&path, content) {
+            eprintln!("hale init: cannot write {}: {}", path.display(), e);
+            return ExitCode::from(1);
+        }
+        println!("created {}", path.display());
+        wrote += 1;
+    }
+    if wrote == 0 {
+        println!("nothing to do — every scaffold file already exists");
+    } else {
+        println!();
+        println!("next steps:");
+        println!("    hale run {}      # compile + run", root.display());
+        println!("    hale test {}     # run tests/", root.display());
+        println!("    hale check {}    # typecheck + analyze", root.display());
+    }
+    ExitCode::SUCCESS
 }
 
 /// Every SEED under `root`: a directory holding one or more `.hl`

--- a/crates/hale-cli/tests/init.rs
+++ b/crates/hale-cli/tests/init.rs
@@ -1,0 +1,90 @@
+//! `hale init` — project bootstrap. The scaffold must be the
+//! canonical minimal project: fmt-clean, runnable, testable, and
+//! verifiable out of the box; the command must be strictly
+//! non-destructive on re-run and in partially-scaffolded
+//! directories.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn hale(args: &[&str], cwd: Option<&Path>) -> (String, i32) {
+    let mut c = Command::new(env!("CARGO_BIN_EXE_hale"));
+    c.args(args);
+    if let Some(d) = cwd {
+        c.current_dir(d);
+    }
+    let out = c.output().expect("run hale");
+    (
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+fn root(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir()
+        .join(format!("hale_init_{}_{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&d);
+    d
+}
+
+#[test]
+fn init_scaffold_runs_tests_and_verifies() {
+    let d = root("full");
+    let (out, code) = hale(&["init", d.to_str().unwrap()], None);
+    assert_eq!(code, 0, "{}", out);
+    for f in ["hale.toml", "main.hl", "tests/main_test.hl", ".gitignore"] {
+        assert!(d.join(f).exists(), "scaffold creates {}: {}", f, out);
+    }
+
+    // Canonical from birth: the generated files pass the fmt gate.
+    let (out, code) = hale(&["fmt", "--check", d.to_str().unwrap()], None);
+    assert_eq!(code, 0, "scaffold must be fmt-canonical: {}", out);
+
+    // Runs...
+    let (out, code) = hale(&["run", d.to_str().unwrap()], None);
+    assert_eq!(code, 0, "{}", out);
+    assert!(out.contains("Hello from Hale."), "{}", out);
+
+    // ...its test passes (cross-seed import of the parent)...
+    let (out, code) = hale(&["test", "."], Some(&d));
+    assert_eq!(code, 0, "{}", out);
+    assert!(out.contains("1 passed, 0 failed"), "{}", out);
+
+    // ...and the discipline gate is clean.
+    let (out, code) = hale(&["verify", "."], Some(&d));
+    assert_eq!(code, 0, "verify must be clean: {}", out);
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+#[test]
+fn init_is_non_destructive() {
+    let d = root("keep");
+    std::fs::create_dir_all(&d).unwrap();
+    // A pre-existing main.hl must survive byte-for-byte.
+    let mine = "fn main() { println(\"mine\"); }\n";
+    std::fs::write(d.join("main.hl"), mine).unwrap();
+
+    let (out, code) = hale(&["init", d.to_str().unwrap()], None);
+    assert_eq!(code, 0, "{}", out);
+    assert!(out.contains("kept"), "reports the kept file: {}", out);
+    assert_eq!(
+        std::fs::read_to_string(d.join("main.hl")).unwrap(),
+        mine,
+        "existing files are never touched"
+    );
+    assert!(d.join("hale.toml").exists(), "missing files are filled in");
+
+    // Second full run: everything exists, nothing changes.
+    let (out, code) = hale(&["init", d.to_str().unwrap()], None);
+    assert_eq!(code, 0, "{}", out);
+    assert!(
+        out.contains("nothing to do"),
+        "idempotent re-run: {}",
+        out
+    );
+    let _ = std::fs::remove_dir_all(&d);
+}

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -43,6 +43,7 @@ diagnostic's meaning, go there.
 
 | Command | Does |
 |---|---|
+| `hale init [dir]` | bootstrap a project: `hale.toml`, a hello-world seed, a first test, `.gitignore` — non-destructive, fills in only what's missing |
 | `hale run <file/dir>` | compile + run (fast feedback) |
 | `hale build <file/dir>` | compile to a native binary |
 | `hale check` | parse + typecheck only |

--- a/spec/packages.md
+++ b/spec/packages.md
@@ -29,8 +29,11 @@ See `spec/decisions.md` F.26 for the rationale.
 
 The manifest lives at the project root — the same directory
 that hosts the top-level `.hl` sources and (after `hale
-fetch`) the `vendor/` directory. It is a TOML file with one
-required section, `[deps]`:
+fetch`) the `vendor/` directory. `hale init [dir]` writes this
+skeleton (plus a hello-world seed, a first `tests/*_test.hl`,
+and a `.gitignore`; strictly non-destructive — existing files
+are kept, only missing ones are filled in; 2026-08-11). It is a
+TOML file with one required section, `[deps]`:
 
 ```toml
 [deps]


### PR DESCRIPTION
There was no way to scaffold a project — `hale.toml` was hand-written from the spec. `hale init [dir]` (default: cwd) writes the canonical minimal shape:

- **`hale.toml`** — the `[deps]`-only skeleton (no `[package]` table exists by design), with the dep-entry syntax in a comment
- **`main.hl`** — hello-world seed
- **`tests/main_test.hl`** — in a *subdirectory*, per the seed model: a test file carries its own `fn main`, so beside `main.hl` it would collide; it imports the parent seed (`import ".." as app;`), the pond/stdlib convention. `hale test` finds it recursively, so testing works from minute one
- **`.gitignore`** — the build artifact (named after the directory) and `vendor/`

Properties, all asserted by test (`crates/hale-cli/tests/init.rs`):
- the scaffold is **fmt-canonical from birth** (`hale fmt --check` clean — caught a real bug during development: Rust `\`-continuations were eating the generated indentation)
- passes `run`, `test`, and `verify` out of the box
- **strictly non-destructive**: existing files are kept byte-for-byte and reported (`kept … (already exists)`), so `init` also fills gaps in a partially-scaffolded directory; a full re-run reports "nothing to do"

Docs command table, `spec/packages.md`'s manifest section, and CHANGELOG updated. Workspace suite 2532/2532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)