### PR TITLE
feat(placement): replica-sharded delivery + pool affinity — the missing pairings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,10 @@ real services; full treatment in `docs/src/services/patterns.md`):
   that entity's traffic — never filter in the handler. The answer
   to "N dynamic keyed children with lifecycle"; the bus *is* the
   keyed routing table, so you never need a map of loci. Declare
-  `release(c)` so children reclaim.
+  `release(c)` so children reclaim. For a FIXED worker fleet
+  (parallelism, not per-entity state) use the replica variant
+  instead: `pinned(..., replicas = K)` + `subscribe T as h where
+  key == replica` — K shards, one subscribe line, K spelled once.
 - **Demand-driven discovery** — a subscription triggers the
   `accept()`; topology grows from the data, zero hardcoded children.
 - **Hot-path counters/gauges** — locus methods returning locus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,36 @@ batch:
   the observer attached after steady state — counts correctly on
   current HEAD (40/40, five runs), and is now a permanent pin
   beside the four earlier flavors.
+### Placement pairings: replica-sharded delivery and pool affinity
+
+Two compositions the placement matrix was missing, found writing a
+webserver tutorial: partitioned *placement* never meant partitioned
+*delivery* (bus pubsub is broadcast; delivery selection lives on the
+subscription — deliberately, so placement stays semantics-free), but
+the two axes had no bridge, and cooperative pools took no affinity
+at all.
+
+- **`where key == replica`** — each instance of a
+  `pinned(..., replicas = K)` fan-out registers its 0-based replica
+  index as its subscription key, so K replicas shard an Int-keyed
+  topic with one subscribe line and K spelled once, in the placement
+  entry. A non-replicated instance is replica 0. Placement stays
+  semantics-free: the filter is written on the subscription; the
+  placement only decides how many indices exist. The webserver
+  shape becomes: listener publishes `Conn { fd, shard: fd % K }`,
+  workers subscribe `where key == replica`. Requires an Int-family
+  key; `replica` is contextual (only that exact RHS position).
+- **Every `where key == …` filter now requires a keyed topic.**
+  Closes a silent pre-existing trap: a Specific filter on an
+  unkeyed topic registered a key match no publish would ever run —
+  the subscriber received nothing, forever, with `check` green.
+- **Pool affinity** — `cooperative(pool = X, core/cores/node/l3 =
+  …)` binds pool X's worker thread to the core set, the same forms
+  and topology-name resolution `pinned` has, kernel-verified by
+  test. One pool has one worker: entries naming a pool must agree
+  (a bare entry inherits; a *different* affinity is a type error
+  citing both entries), and affinity on the main pool is rejected
+  (that thread belongs to the operator).
 
 ### `std::http::Router.add_fn` — a route can be a bare function
 

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -7319,6 +7319,12 @@ typedef struct lotus_coop_pool {
     lotus_coro_t     *free_head;
     int               free_count;
 #endif
+    /* Pool affinity (2026-08-12): a core set stashed by codegen
+     * before start_all spawns the worker; applied right after
+     * pthread_create with the same best-effort contract as pinned
+     * affinity. count == 0 means no mask (today's behavior). */
+    int32_t           aff_cores[64];
+    int32_t           aff_count;
 } lotus_coop_pool_t;
 
 /* F.35 Slice 1: per-coro stack size. 64 KiB is the same default the
@@ -7359,6 +7365,22 @@ lotus_coop_pool_t *lotus_coop_pool_lookup(const char *name) {
  * resolve to it). Pool "main" is a no-op: it returns NULL since
  * its work runs inline on the main thread's existing
  * cooperative queue. */
+/* Forward decl: defined with the other affinity helpers below. */
+void lotus_set_core_affinity_set(unsigned long tid,
+                                 const int32_t *cores,
+                                 int32_t count);
+
+/* Pool affinity (2026-08-12). Copies up to 64 cores; called from
+ * the codegen prelude between register and start_all. */
+void lotus_coop_pool_set_affinity(lotus_coop_pool_t *p,
+                                  const int32_t *cores,
+                                  int32_t count) {
+    if (!p || !cores || count <= 0) return;
+    if (count > 64) count = 64;
+    memcpy(p->aff_cores, cores, (size_t)count * sizeof(int32_t));
+    p->aff_count = count;
+}
+
 lotus_coop_pool_t *lotus_coop_pool_register(const char *name) {
     if (!name) return NULL;
     if (strcmp(name, "main") == 0) return NULL;
@@ -7389,6 +7411,7 @@ lotus_coop_pool_t *lotus_coop_pool_register(const char *name) {
         free(p);
         return NULL;
     }
+    p->aff_count = 0;
     atomic_store_explicit(&p->parked, 0, memory_order_relaxed);
     atomic_store_explicit(&p->producers_waiting, 0, memory_order_relaxed);
     atomic_store_explicit(&p->shutdown, 0, memory_order_relaxed);
@@ -8241,6 +8264,12 @@ void lotus_coop_pool_start_all(void) {
         if (pthread_create(&p->worker, NULL,
                            lotus_coop_pool_worker, p) == 0) {
             p->worker_started = 1;
+            /* Pool affinity (2026-08-12): bind the worker thread to
+             * the stashed core set, best-effort. */
+            if (p->aff_count > 0) {
+                lotus_set_core_affinity_set(
+                    (unsigned long)p->worker, p->aff_cores, p->aff_count);
+            }
         }
     }
 }

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -1,7 +1,7 @@
 /*
  * Hale native observation emission — iris handoff P4 (2026-07-27).
  *
- * Implements the iris observation protocol (PROTOCOL.md v0.1 on
+ * Implements the iris observation protocol (PROTOCOL.md v0.2 on
  * the iris-observer `observer` branch) as a runtime capability:
  * with `LOTUS_OBS=1` in the environment, the process publishes a
  * `/hale-obs-<pid>` shm segment + registration file, and the

--- a/crates/hale-codegen/src/bus/dispatch.rs
+++ b/crates/hale-codegen/src/bus/dispatch.rs
@@ -102,6 +102,24 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
                     i64_t.const_zero(),
                 ))
             }
+            Some(KeyFilter::Replica { .. }) => {
+                // Replica keys (2026-08-12): register THIS
+                // instance's replica index as the key — the
+                // Phase-1c fan-out threads it through
+                // `current_instantiation_replica_index`; a
+                // non-replicated instance is replica 0. Delivery
+                // stays a subscription property (placement remains
+                // semantics-free): the placement entry only decides
+                // how many indices exist.
+                let _ = self_ptr;
+                let _ = subject;
+                let idx = self.current_instantiation_replica_index;
+                Ok(LoweredKeyFilter::Scalar(
+                    1,
+                    i64_t.const_int(idx, false),
+                    i64_t.const_zero(),
+                ))
+            }
             Some(KeyFilter::Specific { expr, .. }) => {
                 // Lower the EXPR. `lower_expr` reads `self.X`
                 // through `self.current_self` (set by the caller —

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1387,6 +1387,8 @@ pub fn build_executable_with_options(
         returned_bindings: compute_returned_bindings(&merged),
         assign_moved_bindings: compute_assign_moved_bindings(&merged),
         model_hash: options.model_hash,
+        replica_index_for_next_locus_instantiation: None,
+        current_instantiation_replica_index: 0,
         suppress_fresh_temp: false,
         in_fresh_temp_hook: false,
         current_fn_skip_exit_drain: false,
@@ -4007,6 +4009,16 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// P26: the build-time model identity to stamp into the obs
     /// segment header (None = harness build, header reads 0).
     pub(crate) model_hash: Option<u64>,
+    /// Replica keys (2026-08-12): the replica index the NEXT locus
+    /// instantiation carries — set by the Phase-1c fan-out loop for
+    /// replicas 1..K, absent (= replica 0) everywhere else. Consumed
+    /// at `lower_locus_instantiation` entry like the placement
+    /// override.
+    pub(crate) replica_index_for_next_locus_instantiation: Option<u64>,
+    /// The CURRENT instantiation's replica index, live while its
+    /// params/subscriptions lower — what a `where key == replica`
+    /// filter registers as the subscription key.
+    pub(crate) current_instantiation_replica_index: u64,
     pub(crate) suppress_fresh_temp: bool,
     /// GH #402: re-entry guard for the fresh-temp hook, cleared
     /// immediately on entry so nested calls still get their own.
@@ -8771,6 +8783,46 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         )
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                 }
+                // Pool affinity (2026-08-12): stash the resolved
+                // core set on the pool BEFORE start_all spawns its
+                // worker — the spawn applies it right after
+                // pthread_create, same best-effort contract as
+                // pinned affinity.
+                if let Some(cores) =
+                    self.deployment.coop_pool_affinity.get(name).cloned()
+                {
+                    let i32_t = self.context.i32_type();
+                    let vals: Vec<_> = cores
+                        .iter()
+                        .map(|c| i32_t.const_int(*c as u64, true))
+                        .collect();
+                    let arr = i32_t.const_array(&vals);
+                    let g = self.module.add_global(
+                        arr.get_type(),
+                        None,
+                        &format!("coop_pool.{}.cores", name),
+                    );
+                    g.set_initializer(&arr);
+                    g.set_constant(true);
+                    g.set_linkage(inkwell::module::Linkage::Internal);
+                    let set_fn = self
+                        .module
+                        .get_function("lotus_coop_pool_set_affinity")
+                        .expect("lotus_coop_pool_set_affinity declared");
+                    self.builder
+                        .build_call(
+                            set_fn,
+                            &[
+                                pool_ptr_val.into(),
+                                g.as_pointer_value().into(),
+                                i32_t
+                                    .const_int(cores.len() as u64, false)
+                                    .into(),
+                            ],
+                            &format!("coop_pool.set_affinity.{}", name),
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                }
             }
             let start_all_fn = self
                 .module
@@ -9381,7 +9433,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                                 ScheduleClass::Pinned(cores)
                             }
                         }
-                        PlacementSpec::Cooperative { pool } => {
+                        PlacementSpec::Cooperative { pool, affinity } => {
                             // F.31 Phase 4: capture the pool name
                             // when present. `None` means default
                             // pool "main" (no entry needed; the
@@ -9393,6 +9445,26 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                                         entry.field.name.clone(),
                                         name.name.clone(),
                                     );
+                                    // Pool affinity (2026-08-12):
+                                    // resolve like pinned and record
+                                    // per pool (typecheck already
+                                    // rejected conflicting entries;
+                                    // first resolution wins here).
+                                    if let Some(spec) =
+                                        Self::resolve_pin_affinity(
+                                            affinity,
+                                            topology,
+                                        )
+                                    {
+                                        let cores: Vec<i64> =
+                                            spec.expand();
+                                        if !cores.is_empty() {
+                                            self.deployment
+                                                .coop_pool_affinity
+                                                .entry(name.name.clone())
+                                                .or_insert(cores);
+                                        }
+                                    }
                                     // Phase 4b: track the locus
                                     // type so a __coop_pool_run
                                     // wrapper gets synthesized for
@@ -9433,7 +9505,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         matches!(c.kind, PlacementConstraint::AsyncIo)
                     });
                     if has_async_io {
-                        if let PlacementSpec::Cooperative { pool: Some(name) } =
+                        if let PlacementSpec::Cooperative { pool: Some(name), .. } =
                             &entry.spec
                         {
                             if name.name != "main" {

--- a/crates/hale-codegen/src/deployment.rs
+++ b/crates/hale-codegen/src/deployment.rs
@@ -50,6 +50,12 @@ pub struct DeploymentPlan {
     /// `cooperative(pool = X)` entries. Drives pool registration in
     /// the prelude and the per-field pool override at instantiation.
     pub main_cooperative_pools: BTreeMap<String, String>,
+    /// Pool affinity (2026-08-12): pool name -> the resolved core
+    /// set its worker thread binds to (`cooperative(pool = X,
+    /// cores/node/l3 = …)`). Resolved against `topology { }` in
+    /// the placement pre-pass; conflicting declarations across
+    /// entries were rejected at typecheck.
+    pub coop_pool_affinity: BTreeMap<String, Vec<i64>>,
     /// Pool names declared `where async_io` (green-I/O scheduling).
     pub async_io_pools: BTreeSet<String>,
     /// Locus TYPE names placed on a named cooperative pool —

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -102,6 +102,19 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
         let numa_node_override = std::mem::take(
             &mut self.numa_node_for_next_locus_instantiation,
         );
+        // Replica keys (2026-08-12): consume the replica-index
+        // override for THIS instantiation and expose it to the
+        // subscription-registration loop below (a `where key ==
+        // replica` filter registers the index as the key). Taken
+        // like the placement override so nested instantiations
+        // read their own (absent = replica 0).
+        let replica_index_override = std::mem::take(
+            &mut self.replica_index_for_next_locus_instantiation,
+        );
+        let prev_replica_index = std::mem::replace(
+            &mut self.current_instantiation_replica_index,
+            replica_index_override.unwrap_or(0),
+        );
         // F.31 Phase 4: consume the parallel pool-name override
         // before any recursion happens (a nested instantiation
         // in this locus's params-init loop would otherwise
@@ -195,6 +208,7 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
             // Restore the cooperative-pool context we swapped in above
             // (the normal path restores it at fn exit; we early-return).
             self.current_cooperative_pool = prev_current_coop_pool;
+            self.current_instantiation_replica_index = prev_replica_index;
             return self.emit_crosspool_bubble_spawn(
                 locus_name,
                 &info,
@@ -1968,6 +1982,12 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                             ScheduleClass::Pinned(core.map(CoreSpec::Single)),
                         );
                         self.numa_node_for_next_locus_instantiation = node;
+                        // Replica keys: replica i's subscriptions
+                        // register i as their `where key == replica`
+                        // key. Replica 0 takes the normal path below
+                        // with the default index 0.
+                        self.replica_index_for_next_locus_instantiation =
+                            Some(i as u64);
                         let prev_flag = self.instantiating_for_parent_field;
                         self.instantiating_for_parent_field = true;
                         // The extra replica's self_ptr isn't stored in a
@@ -3557,6 +3577,7 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
 
             // F.31 Phase 4: pinned-branch restore mirror.
             self.current_cooperative_pool = prev_current_coop_pool;
+            self.current_instantiation_replica_index = prev_replica_index;
             return Ok(self_ptr);
         }
 
@@ -4139,6 +4160,7 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
         // prev_current_coop_pool; we restore it here so
         // nesting works correctly.
         self.current_cooperative_pool = prev_current_coop_pool;
+        self.current_instantiation_replica_index = prev_replica_index;
         Ok(self_ptr)
     }
 

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1638,6 +1638,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // F.31 Phase 4: cooperative-pool worker surface.
         // declare ptr  @lotus_coop_pool_register(ptr name)
         // declare ptr  @lotus_coop_pool_lookup(ptr name)
+        // Pool affinity (2026-08-12): stash a core set on a pool
+        // before its worker spawns.
+        // declare void @lotus_coop_pool_set_affinity(ptr pool, ptr cores, i32 count)
+        self.module.add_function(
+            "lotus_coop_pool_set_affinity",
+            self.context.void_type().fn_type(
+                &[ptr_t.into(), ptr_t.into(), self.context.i32_type().into()],
+                false,
+            ),
+            None,
+        );
         // declare void @lotus_coop_pool_start_all()
         // declare void @lotus_coop_pool_shutdown_all()
         // declare void @lotus_coop_pool_destroy_all()

--- a/crates/hale-codegen/tests/pool_affinity.rs
+++ b/crates/hale-codegen/tests/pool_affinity.rs
@@ -1,0 +1,94 @@
+//! Pool affinity (2026-08-12) — `cooperative(pool = X, cores = …)`
+//! binds pool X's worker thread to the core set, completing the
+//! placement pairing matrix's "cooperative × affinity" cell (the
+//! same forms pinned takes; resolved against `topology { }`;
+//! best-effort like all affinity). Verified against the kernel:
+//! the spawned process must contain exactly one task whose
+//! `Cpus_allowed_list` is the declared set.
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+const SRC: &str = r#"
+    type Tick { n: Int; }
+    locus Sink {
+        params { seen: Int = 0; }
+        bus { subscribe "aff.t" as on_t of type Tick; }
+        fn on_t(t: Tick) { self.seen = self.seen + 1; }
+    }
+    locus Pub {
+        bus { publish "aff.t" of type Tick; }
+        run() {
+            std::time::sleep(150ms);
+            let mut i = 0;
+            while i < 5 { "aff.t" <- Tick { n: i }; i = i + 1; }
+        }
+    }
+    main locus App {
+        params { s: Sink = Sink { }; p: Pub = Pub { }; }
+        placement { s: cooperative(pool = io, cores = 0..=1); }
+        run() { std::time::sleep(900ms); }
+    }
+    fn main() { App { }; }
+"#;
+
+fn cpus_allowed_lists(pid: u32) -> Vec<String> {
+    let mut out = Vec::new();
+    let Ok(tasks) = std::fs::read_dir(format!("/proc/{}/task", pid)) else {
+        return out;
+    };
+    for t in tasks.flatten() {
+        let status = t.path().join("status");
+        if let Ok(s) = std::fs::read_to_string(status) {
+            for line in s.lines() {
+                if let Some(v) = line.strip_prefix("Cpus_allowed_list:") {
+                    out.push(v.trim().to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn pool_worker_thread_carries_the_declared_core_set() {
+    if std::thread::available_parallelism()
+        .map(|n| n.get() < 2)
+        .unwrap_or(true)
+    {
+        eprintln!("skipping: needs >= 2 CPUs");
+        return;
+    }
+    let program = hale_syntax::parse_source(SRC).expect("parse");
+    let bin = harness::unique_bin("hale_pool_affinity");
+    build_executable(&program, &bin).expect("build");
+    let mut child = Command::new(&bin)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    let pid = child.id();
+    // Let the pool spawn its worker.
+    std::thread::sleep(Duration::from_millis(400));
+    let masks = cpus_allowed_lists(pid);
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_file(&bin);
+    assert!(
+        masks.iter().any(|m| m == "0-1"),
+        "one task (the io pool worker) must be bound to cores 0-1; \
+         saw masks: {:?}",
+        masks
+    );
+    assert!(
+        masks.iter().any(|m| m != "0-1"),
+        "the main thread must NOT be bound (affinity is the pool's \
+         alone): {:?}",
+        masks
+    );
+}

--- a/crates/hale-codegen/tests/replica_keys.rs
+++ b/crates/hale-codegen/tests/replica_keys.rs
@@ -1,0 +1,129 @@
+//! Replica keys (2026-08-12) — `where key == replica` bridges the
+//! placement scale axis and the delivery axis: each instance of a
+//! `pinned(..., replicas = K)` fan-out registers its 0-based
+//! replica index as its subscription key, so K replicas shard an
+//! Int-keyed topic with ONE subscribe line and N spelled once (in
+//! the placement entry). Placement stays semantics-free: the
+//! filter is written on the subscription; the placement only
+//! decides how many indices exist.
+//!
+//! This is the webserver fan-out shape that motivated it: a
+//! listener publishing connections `keyed_by shard`, workers
+//! subscribing `where key == replica`.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+fn run_src(name: &str, src: &str) -> (String, std::process::ExitStatus) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(name);
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    (String::from_utf8_lossy(&out.stdout).to_string(), out.status)
+}
+
+#[test]
+fn replicas_shard_a_keyed_topic_one_index_each() {
+    // Shards 0/1/2 get 1/2/3 messages. Broadcast would print
+    // 6,6,6; sharded delivery prints 1,2,3.
+    let src = r#"
+        type Job { shard: Int; v: Int; }
+        topic Work { payload: Job; keyed_by shard; }
+
+        locus Worker {
+            params { seen: Int = 0; }
+            bus { subscribe Work as on_job where key == replica; }
+            fn on_job(j: Job) { self.seen = self.seen + 1; }
+            run() {
+                std::time::sleep(600ms);
+                println("seen=", to_string(self.seen));
+            }
+        }
+
+        locus Pub {
+            bus { publish Work; }
+            run() {
+                std::time::sleep(150ms);
+                Work <- Job { shard: 0, v: 1 };
+                Work <- Job { shard: 1, v: 1 };
+                Work <- Job { shard: 1, v: 1 };
+                Work <- Job { shard: 2, v: 1 };
+                Work <- Job { shard: 2, v: 1 };
+                Work <- Job { shard: 2, v: 1 };
+            }
+        }
+
+        main locus App {
+            params { w: Worker = Worker { }; p: Pub = Pub { }; }
+            placement { w: pinned(replicas = 3); }
+            run() { std::time::sleep(900ms); }
+        }
+
+        fn main() { App { }; }
+    "#;
+    let (out, st) = run_src("replica_shard", src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    let mut counts: Vec<&str> = out
+        .lines()
+        .filter_map(|l| l.strip_prefix("seen="))
+        .collect();
+    counts.sort();
+    assert_eq!(
+        counts,
+        vec!["1", "2", "3"],
+        "each replica receives exactly its shard (broadcast would \
+         be 6,6,6): {}",
+        out
+    );
+}
+
+#[test]
+fn a_non_replicated_instance_is_replica_zero() {
+    // The same subscribe line works without a replicas entry: the
+    // single instance is replica 0 and receives shard-0 traffic
+    // only.
+    let src = r#"
+        type Job { shard: Int; }
+        topic Work { payload: Job; keyed_by shard; }
+
+        locus Worker {
+            params { seen: Int = 0; }
+            bus { subscribe Work as on_job where key == replica; }
+            fn on_job(j: Job) { self.seen = self.seen + 1; }
+            run() {
+                std::time::sleep(400ms);
+                println("seen=", to_string(self.seen));
+            }
+        }
+
+        locus Pub {
+            bus { publish Work; }
+            run() {
+                std::time::sleep(100ms);
+                Work <- Job { shard: 0 };
+                Work <- Job { shard: 1 };
+                Work <- Job { shard: 2 };
+            }
+        }
+
+        main locus App {
+            params { w: Worker = Worker { }; p: Pub = Pub { }; }
+            placement { w: pinned; }
+            run() { std::time::sleep(700ms); }
+        }
+
+        fn main() { App { }; }
+    "#;
+    let (out, st) = run_src("replica_zero", src);
+    assert!(st.success(), "non-zero: {:?}\n{}", st, out);
+    assert!(
+        out.contains("seen=1"),
+        "a lone instance is replica 0 and sees only shard 0: {}",
+        out
+    );
+}

--- a/crates/hale-lsp/src/lib.rs
+++ b/crates/hale-lsp/src/lib.rs
@@ -1989,7 +1989,7 @@ fn references(
 fn placement_spec_str(e: &hale_syntax::ast::PlacementEntry) -> String {
     use hale_syntax::ast::PlacementSpec;
     let mut out = match &e.spec {
-        PlacementSpec::Cooperative { pool } => match pool {
+        PlacementSpec::Cooperative { pool, .. } => match pool {
             Some(p) => format!("cooperative(pool = {})", p.name),
             None => "cooperative(pool = main)".to_string(),
         },

--- a/crates/hale-syntax/src/ast.rs
+++ b/crates/hale-syntax/src/ast.rs
@@ -1157,7 +1157,16 @@ pub enum PlacementSpec {
     /// on the same pool. `None` means pool `main` (the program's
     /// main OS thread) — equivalent to writing
     /// `cooperative(pool = main)`.
-    Cooperative { pool: Option<Ident> },
+    Cooperative {
+        pool: Option<Ident>,
+        /// Pool affinity (2026-08-12): `cooperative(pool = X,
+        /// cores = …)` binds pool X's worker THREAD to the core
+        /// set (same forms as pinned: core / cores / node / l3,
+        /// resolved against `topology { }`). Declared per entry;
+        /// entries naming one pool must agree (typecheck).
+        /// `PinAffinity::Any` = no mask, today's behavior.
+        affinity: PinAffinity,
+    },
     /// `pinned` and its affinity variants. The locus owns its
     /// own OS thread; the [`PinAffinity`] says which logical CPUs
     /// the runtime asks the OS to keep it on (`pthread_setaffinity_np`).
@@ -1694,12 +1703,23 @@ pub enum KeyFilter {
     /// `where key == _`. Catch-unmatched subscriber. Only legal
     /// when the topic declares `on_unmatched: fallback`.
     Unmatched { span: Span },
+    /// `where key == replica` (2026-08-12): the subscribing
+    /// instance's replica index — 0-based for a
+    /// `pinned(..., replicas = K)` fan-out, and 0 for any
+    /// non-replicated instance. The bridge between the placement
+    /// scale axis and the delivery axis: K replicas shard an
+    /// Int-keyed topic with one subscribe line, N spelled once in
+    /// the placement entry. `replica` is contextual — only this
+    /// exact RHS position; requires an Int-family key.
+    Replica { span: Span },
 }
 
 impl KeyFilter {
     pub fn span(&self) -> Span {
         match self {
-            KeyFilter::Specific { span, .. } | KeyFilter::Unmatched { span } => *span,
+            KeyFilter::Specific { span, .. }
+            | KeyFilter::Unmatched { span }
+            | KeyFilter::Replica { span } => *span,
         }
     }
 }

--- a/crates/hale-syntax/src/desugar.rs
+++ b/crates/hale-syntax/src/desugar.rs
@@ -1003,7 +1003,7 @@ fn collect_off_owner_thread_fields(
                         if let LocusMember::Placement(pb) = member {
                             for e in &pb.entries {
                                 let off_thread = match &e.spec {
-                                    PlacementSpec::Cooperative { pool } => pool
+                                    PlacementSpec::Cooperative { pool, .. } => pool
                                         .as_ref()
                                         .is_some_and(|p| p.name != "main"),
                                     PlacementSpec::Pinned { .. } => true,

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -3858,43 +3858,93 @@ impl Parser {
         self.bump();
         match head.as_str() {
             "cooperative" => {
-                let pool = if matches!(self.peek(), TokenKind::LParen) {
+                // `cooperative` takes a comma-separated attribute
+                // list: an optional `pool = NAME` and (2026-08-12)
+                // at most one affinity (`core`/`cores`/`node`/`l3`)
+                // binding the pool's worker THREAD to a core set —
+                // the same forms `pinned(...)` takes. Bare
+                // `cooperative` is pool `main`, no mask.
+                let mut pool: Option<Ident> = None;
+                let mut affinity = PinAffinity::Any;
+                let mut affinity_set = false;
+                if matches!(self.peek(), TokenKind::LParen) {
                     self.bump();
-                    let kw_tok = self.peek_token().clone();
-                    let kw = match &kw_tok.kind {
-                        TokenKind::Ident(s) => s.clone(),
-                        other => {
-                            return Err(Diag::parse(
-                                kw_tok.span,
-                                format!(
-                                    "expected `pool` inside `cooperative(...)`, got {:?}",
-                                    other
-                                ),
-                            ));
-                        }
-                    };
-                    if kw != "pool" {
-                        return Err(Diag::parse(
-                            kw_tok.span,
-                            format!(
-                                "unknown cooperative attribute `{}`; only `pool` \
-                                 is recognized",
-                                kw
-                            ),
-                        ));
-                    }
-                    self.bump();
-                    self.expect(TokenKind::Eq, "expected `=` after `pool`")?;
-                    let name = self.expect_ident("pool name")?;
-                    // Topology Phase 1c: `replicas` is pinned-only —
-                    // K cooperative loci on one pool share a single
-                    // thread (not parallel), so `cooperative(...,
-                    // replicas = K)` is rejected with guidance.
-                    if matches!(self.peek(), TokenKind::Comma) {
-                        if let TokenKind::Ident(s) = self.peek_at(1) {
-                            if s == "replicas" {
+                    loop {
+                        let kw_tok = self.peek_token().clone();
+                        let kw = match &kw_tok.kind {
+                            TokenKind::Ident(s) => s.clone(),
+                            other => {
                                 return Err(Diag::parse(
-                                    self.peek_token().span,
+                                    kw_tok.span,
+                                    format!(
+                                        "expected `pool`, `core`, `cores`, \
+                                         `node`, or `l3` inside \
+                                         `cooperative(...)`, got {:?}",
+                                        other
+                                    ),
+                                ));
+                            }
+                        };
+                        match kw.as_str() {
+                            "pool" => {
+                                if pool.is_some() {
+                                    return Err(Diag::parse(
+                                        kw_tok.span,
+                                        "`cooperative(...)` already has a \
+                                         `pool`"
+                                            .to_string(),
+                                    ));
+                                }
+                                self.bump();
+                                self.expect(
+                                    TokenKind::Eq,
+                                    "expected `=` after `pool`",
+                                )?;
+                                pool = Some(self.expect_ident("pool name")?);
+                            }
+                            "core" | "cores" | "node" | "l3" => {
+                                if affinity_set {
+                                    return Err(Diag::parse(
+                                        kw_tok.span,
+                                        format!(
+                                            "`cooperative(...)` already has \
+                                             an affinity; `{}` is a second \
+                                             one (use just one of core / \
+                                             cores / node / l3)",
+                                            kw
+                                        ),
+                                    ));
+                                }
+                                self.bump();
+                                self.expect(
+                                    TokenKind::Eq,
+                                    "expected `=` after affinity attribute",
+                                )?;
+                                affinity = match kw.as_str() {
+                                    "core" => PinAffinity::Cores(
+                                        CoreSpec::Single(
+                                            self.parse_core_index()?,
+                                        ),
+                                    ),
+                                    "cores" => PinAffinity::Cores(
+                                        self.parse_core_set()?,
+                                    ),
+                                    "node" => PinAffinity::Node(
+                                        self.parse_core_index()?,
+                                    ),
+                                    // "l3"
+                                    _ => PinAffinity::L3(
+                                        self.expect_ident("l3 domain name")?,
+                                    ),
+                                };
+                                affinity_set = true;
+                            }
+                            // Topology Phase 1c: `replicas` is pinned-only —
+                            // K cooperative loci on one pool share a single
+                            // thread (not parallel).
+                            "replicas" => {
+                                return Err(Diag::parse(
+                                    kw_tok.span,
                                     "`replicas` is only valid on a `pinned` \
                                      placement — K cooperative loci on one \
                                      pool would share a single thread, not \
@@ -3904,17 +3954,32 @@ impl Parser {
                                         .to_string(),
                                 ));
                             }
+                            _ => {
+                                return Err(Diag::parse(
+                                    kw_tok.span,
+                                    format!(
+                                        "unknown cooperative attribute `{}`; \
+                                         expected `pool`, or an affinity \
+                                         (`core` / `cores` / `node` / `l3`)",
+                                        kw
+                                    ),
+                                ));
+                            }
                         }
+                        if self.eat(&TokenKind::Comma) {
+                            if matches!(self.peek(), TokenKind::RParen) {
+                                break;
+                            }
+                            continue;
+                        }
+                        break;
                     }
                     self.expect(
                         TokenKind::RParen,
-                        "expected `)` after cooperative(pool = X)",
+                        "expected `)` after cooperative(...)",
                     )?;
-                    Some(name)
-                } else {
-                    None
-                };
-                Ok(PlacementSpec::Cooperative { pool })
+                }
+                Ok(PlacementSpec::Cooperative { pool, affinity })
             }
             "pinned" => {
                 // `pinned` takes a comma-separated attribute list:
@@ -4726,9 +4791,24 @@ impl Parser {
                         self.peek(),
                         TokenKind::Ident(s) if s == "_"
                     );
+                    // `replica` — contextual keyword in exactly this
+                    // position (2026-08-12): the instance's replica
+                    // index. Only when it stands ALONE (next token
+                    // ends the clause), so `key == replica_count`
+                    // or a const named replica in a larger
+                    // expression still parse as expressions.
+                    let is_replica = matches!(
+                        self.peek(),
+                        TokenKind::Ident(s) if s == "replica"
+                    ) && matches!(self.peek_at(1), TokenKind::Semi);
                     let filter = if is_underscore {
                         self.bump();
                         KeyFilter::Unmatched {
+                            span: where_tok.span,
+                        }
+                    } else if is_replica {
+                        self.bump();
+                        KeyFilter::Replica {
                             span: where_tok.span,
                         }
                     } else {
@@ -9334,7 +9414,7 @@ main locus App {
         let prog = parse_str(src).expect("parse failed");
         let pb = placement_block_of(&prog);
         match &pb.entries[0].spec {
-            PlacementSpec::Cooperative { pool: None } => {}
+            PlacementSpec::Cooperative { pool: None, .. } => {}
             other => panic!(
                 "expected Cooperative{{ pool: None }}, got {:?}", other
             ),
@@ -9354,7 +9434,7 @@ main locus App {
         let prog = parse_str(src).expect("parse failed");
         let pb = placement_block_of(&prog);
         match &pb.entries[0].spec {
-            PlacementSpec::Cooperative { pool: Some(p) } => {
+            PlacementSpec::Cooperative { pool: Some(p), .. } => {
                 assert_eq!(p.name, "io");
             }
             other => panic!(
@@ -9625,7 +9705,7 @@ fn main() { Sub { my_id: 1 }; }
         }).expect("subscribe");
         match sub.as_ref().expect("key_filter") {
             KeyFilter::Specific { .. } => { /* ok */ }
-            KeyFilter::Unmatched { .. } => panic!("expected Specific"),
+            other => panic!("expected Specific, got {:?}", other),
         }
     }
 

--- a/crates/hale-types/src/bus_graph.rs
+++ b/crates/hale-types/src/bus_graph.rs
@@ -547,7 +547,7 @@ pub(crate) fn collect_subscriber_placements(bundle: &Bundle<'_>) -> BTreeMap<Str
                                     continue;
                                 };
                                 let placement = match &e.spec {
-                                    PlacementSpec::Cooperative { pool } => match pool {
+                                    PlacementSpec::Cooperative { pool, .. } => match pool {
                                         Some(p) if p.name != "main" => {
                                             Placement::CrossPool(p.name.clone())
                                         }
@@ -599,7 +599,7 @@ pub fn has_offthread_placement(bundle: &Bundle<'_>) -> bool {
                         if let LocusMember::Placement(pb) = member {
                             for e in &pb.entries {
                                 match &e.spec {
-                                    PlacementSpec::Cooperative { pool } => {
+                                    PlacementSpec::Cooperative { pool, .. } => {
                                         if let Some(p) = pool {
                                             if p.name != "main" {
                                                 return true;

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -392,6 +392,10 @@ pub fn check_bundle(
     // not a direct method call. See spec/types.md
     // § "Single-threaded-method invariant (F.31)".
     check_placement_single_thread(bundle, top, &mut diags);
+    // Pool affinity (2026-08-12): `cooperative(pool = X, cores/…)`
+    // entries naming one pool must agree, and affinity on the main
+    // pool has no thread to bind.
+    check_pool_affinity(bundle, &mut diags);
     // #334 / #333: F.31 above reasons per field DECLARATION, so it
     // cannot see one instance aliased into two towers.
     check_instance_aliasing(bundle, &mut diags);
@@ -2198,7 +2202,7 @@ fn check_cooperative_pool_blocking(
             let mut errored_pools: BTreeSet<String> = BTreeSet::new();
 
             for entry in pb.map(|pb| pb.entries.as_slice()).unwrap_or(&[]) {
-                let PlacementSpec::Cooperative { pool } = &entry.spec else {
+                let PlacementSpec::Cooperative { pool, .. } = &entry.spec else {
                     continue;
                 };
                 // `where async_io` parks blocking I/O — not a stall.
@@ -2354,7 +2358,7 @@ fn check_cooperative_pool_blocking(
                     });
                     let pool_name: String = match entry.map(|e| (&e.spec, e)) {
                         Some((PlacementSpec::Pinned { .. }, _)) => continue,
-                        Some((PlacementSpec::Cooperative { pool }, e)) => {
+                        Some((PlacementSpec::Cooperative { pool, .. }, e)) => {
                             // `where async_io` run-cells are parkable
                             // coros — co-scheduled runs interleave at
                             // park points, so no starvation claim.
@@ -2524,7 +2528,7 @@ fn check_cooperative_pool_blocking(
                         // elsewhere; `where async_io` parks.
                         let inline_on_main = match entry.map(|e| (&e.spec, e)) {
                             Some((PlacementSpec::Pinned { .. }, _)) => false,
-                            Some((PlacementSpec::Cooperative { pool }, e)) => {
+                            Some((PlacementSpec::Cooperative { pool, .. }, e)) => {
                                 !e.constraints.iter().any(|c| {
                                     matches!(c.kind, PlacementConstraint::AsyncIo)
                                 }) && pool
@@ -2855,6 +2859,82 @@ pub fn compute_pool_of_locus_type(
     pool_of_locus_type
 }
 
+/// Pool affinity (2026-08-12): validity of `cooperative(pool = X,
+/// core/cores/node/l3 = ...)` placement entries.
+///
+/// * Affinity with no pool (or pool `main`) is rejected — the main
+///   pool is the program's main thread; binding it belongs to the
+///   operator (taskset), not a placement entry.
+/// * Two entries naming ONE pool with two different affinities is a
+///   contradiction: the pool has one worker thread. An entry that
+///   names the pool without an affinity is compatible with any.
+fn check_pool_affinity(bundle: &Bundle<'_>, diags: &mut Vec<Diag>) {
+    for program in bundle.programs.values() {
+        for item in &program.items {
+            let TopDecl::Locus(l) = item else { continue };
+            if !l.is_main {
+                continue;
+            }
+            let mut declared: BTreeMap<String, (PinAffinity, Span)> =
+                BTreeMap::new();
+            for m in &l.members {
+                let LocusMember::Placement(pb) = m else { continue };
+                for entry in &pb.entries {
+                    let PlacementSpec::Cooperative { pool, affinity } =
+                        &entry.spec
+                    else {
+                        continue;
+                    };
+                    if matches!(affinity, PinAffinity::Any) {
+                        continue;
+                    }
+                    let pool_name = match pool {
+                        Some(p) if p.name != "main" => p.name.clone(),
+                        _ => {
+                            diags.push(Diag::ty(
+                                entry.span,
+                                "cooperative affinity needs a named pool \
+                                 (`cooperative(pool = X, cores = ...)`) — \
+                                 the main pool is the program's main \
+                                 thread, whose affinity belongs to the \
+                                 operator, not a placement entry",
+                            ));
+                            continue;
+                        }
+                    };
+                    match declared.get(&pool_name) {
+                        None => {
+                            declared.insert(
+                                pool_name,
+                                (affinity.clone(), entry.span),
+                            );
+                        }
+                        Some((prev, _)) if prev == affinity => {}
+                        Some((_, prev_span)) => {
+                            diags.push(
+                                Diag::ty(
+                                    entry.span,
+                                    format!(
+                                        "pool `{}` is given two different \
+                                         affinities — a pool has ONE worker \
+                                         thread; declare the affinity on \
+                                         one entry (the others inherit it)",
+                                        pool_name
+                                    ),
+                                )
+                                .with_related(
+                                    *prev_span,
+                                    "first affinity declared here",
+                                ),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn check_placement_single_thread(
     bundle: &Bundle<'_>,
     top: &TopScope,
@@ -2959,7 +3039,7 @@ fn placement_spec_to_pool(
 ) -> PoolId {
     use hale_syntax::ast::PlacementSpec;
     match spec {
-        PlacementSpec::Cooperative { pool } => {
+        PlacementSpec::Cooperative { pool, .. } => {
             let name = pool
                 .as_ref()
                 .map(|p| p.name.clone())
@@ -4066,6 +4146,44 @@ fn check_phase3_fallback_subscribers(
         BTreeMap::new();
     let mut by_wire: BTreeMap<String, (Option<UnmatchedPolicy>, Span)> =
         BTreeMap::new();
+    // Filter validity (2026-08-12): (is_keyed, key_is_string) per
+    // topic, for the `where key ==` rules below. The String
+    // question resolves the payload struct's keyed_by field type
+    // directly against the bundle's type decls.
+    let mut key_shape_by_name: BTreeMap<String, (bool, bool)> =
+        BTreeMap::new();
+    let mut key_shape_by_wire: BTreeMap<String, (bool, bool)> =
+        BTreeMap::new();
+    let field_is_string = |payload: &TypeExpr, field: &str| -> bool {
+        let TypeExpr::Named { path, .. } = payload else {
+            return false;
+        };
+        if path.segments.len() != 1 {
+            return false;
+        }
+        let tname = &path.segments[0].name;
+        for program in bundle.programs.values() {
+            for item in &program.items {
+                if let TopDecl::Type(td) = item {
+                    if &td.name.name == tname {
+                        if let TypeDeclBody::Struct(fields) = &td.body {
+                            return fields.iter().any(|f| {
+                                f.name.name == field
+                                    && matches!(
+                                        &f.ty,
+                                        TypeExpr::Primitive(
+                                            PrimType::String,
+                                            _,
+                                        )
+                                    )
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        false
+    };
     for program in bundle.programs.values() {
         for item in &program.items {
             if let TopDecl::Topic(t) = item {
@@ -4073,10 +4191,19 @@ fn check_phase3_fallback_subscribers(
                     t.name.name.clone(),
                     (t.on_unmatched, t.span),
                 );
+                let key_shape = match &t.keyed_by {
+                    Some(f) => {
+                        (true, field_is_string(&t.payload, &f.name))
+                    }
+                    None => (false, false),
+                };
+                key_shape_by_name
+                    .insert(t.name.name.clone(), key_shape);
                 let wire = t
                     .subject
                     .clone()
                     .unwrap_or_else(|| t.name.name.clone());
+                key_shape_by_wire.insert(wire.clone(), key_shape);
                 by_wire.insert(wire, (t.on_unmatched, t.span));
             }
         }
@@ -4102,6 +4229,53 @@ fn check_phase3_fallback_subscribers(
                         continue;
                     };
                     let Some(kf) = key_filter else { continue };
+                    // 2026-08-12: every `where key ==` filter needs a
+                    // KEYED topic — an unkeyed publish never runs the
+                    // key match, so a filtered subscriber would
+                    // silently receive nothing, forever (previously
+                    // accepted without a word). Cross-seed / string
+                    // subjects that resolve to no declared topic stay
+                    // permissive, matching the rest of this pass.
+                    {
+                        let shape = match subject {
+                            BusSubject::Topic(i) => {
+                                key_shape_by_name.get(&i.name).copied()
+                            }
+                            BusSubject::Literal { subject: sname, .. } => {
+                                key_shape_by_wire.get(sname).copied()
+                            }
+                            BusSubject::QualifiedTopic(_) => None,
+                        };
+                        if let Some((is_keyed, key_is_string)) = shape {
+                            if !is_keyed {
+                                diags.push(Diag::ty(
+                                    kf.span(),
+                                    format!(
+                                        "`where key == …` requires a keyed topic, and `{}` \
+                                         declares no `keyed_by` — an unkeyed publish never \
+                                         runs the key match, so this subscriber would \
+                                         silently receive nothing",
+                                        subject.canonical()
+                                    ),
+                                ));
+                                continue;
+                            }
+                            if key_is_string
+                                && matches!(kf, KeyFilter::Replica { .. })
+                            {
+                                diags.push(Diag::ty(
+                                    kf.span(),
+                                    format!(
+                                        "`where key == replica` needs an Int-family key; \
+                                         topic `{}` is keyed by a String field — shard on \
+                                         an Int field to fan out across replicas",
+                                        subject.canonical()
+                                    ),
+                                ));
+                                continue;
+                            }
+                        }
+                    }
                     let is_catchall = matches!(kf, KeyFilter::Unmatched { .. });
                     if !is_catchall {
                         continue;
@@ -7105,7 +7279,7 @@ impl<'a> Checker<'a> {
                                     ),
                                 ));
                             }
-                            PlacementSpec::Cooperative { pool } => {
+                            PlacementSpec::Cooperative { pool, .. } => {
                                 let pool_name = pool
                                     .as_ref()
                                     .map(|i| i.name.as_str())
@@ -7144,7 +7318,7 @@ impl<'a> Checker<'a> {
             BTreeMap::new();
         for entry in &pb.entries {
             let pool_name = match &entry.spec {
-                PlacementSpec::Cooperative { pool: Some(name) } => {
+                PlacementSpec::Cooperative { pool: Some(name), .. } => {
                     name.name.clone()
                 }
                 _ => continue,

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -540,7 +540,7 @@ fn placement_implied_diags(
                         if !is_async {
                             continue;
                         }
-                        let PlacementSpec::Cooperative { pool } = &e.spec
+                        let PlacementSpec::Cooperative { pool, .. } = &e.spec
                         else {
                             continue;
                         };

--- a/crates/hale-types/src/ownership_graph.rs
+++ b/crates/hale-types/src/ownership_graph.rs
@@ -720,7 +720,7 @@ fn collect_placements(bundle: &Bundle<'_>) -> BTreeMap<String, Placement> {
                                     continue;
                                 };
                                 let placement = match &e.spec {
-                                    PlacementSpec::Cooperative { pool } => {
+                                    PlacementSpec::Cooperative { pool, .. } => {
                                         match pool {
                                             Some(p) if p.name != "main" => {
                                                 Placement::CrossPool(

--- a/crates/hale-types/src/resource_budget.rs
+++ b/crates/hale-types/src/resource_budget.rs
@@ -199,7 +199,7 @@ fn collect_locus(l: &LocusDecl, b: &mut ResourceBudget) {
                 for entry in &pb.entries {
                     match &entry.spec {
                         PlacementSpec::Pinned { .. } => b.pinned_threads += 1,
-                        PlacementSpec::Cooperative { pool } => {
+                        PlacementSpec::Cooperative { pool, .. } => {
                             let name = pool
                                 .as_ref()
                                 .map(|p| p.name.clone())

--- a/crates/hale-types/src/sync_inference.rs
+++ b/crates/hale-types/src/sync_inference.rs
@@ -517,7 +517,7 @@ mod tests {
                             if let LocusMember::Placement(pb) = m {
                                 for entry in &pb.entries {
                                     let pool = match &entry.spec {
-                                        hale_syntax::ast::PlacementSpec::Cooperative { pool } => {
+                                        hale_syntax::ast::PlacementSpec::Cooperative { pool, .. } => {
                                             let name = pool
                                                 .as_ref()
                                                 .map(|p| p.name.clone())

--- a/crates/hale-types/tests/placement_pairings.rs
+++ b/crates/hale-types/tests/placement_pairings.rs
@@ -1,0 +1,151 @@
+//! The 2026-08-12 placement pairings — check-side rules.
+//!
+//! Replica keys: `where key == …` filters (Specific AND the new
+//! `replica`) require a keyed topic — an unkeyed publish never
+//! runs the key match, so a filtered subscriber would silently
+//! receive nothing, forever (previously accepted without a word).
+//! `replica` additionally needs an Int-family key.
+//!
+//! Pool affinity: entries naming one pool must agree, and affinity
+//! on the main pool has no worker thread to bind.
+
+use hale_types::check_program;
+
+fn errors(src: &str) -> Vec<String> {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    check_program(&program)
+        .into_iter()
+        .filter(|d| d.is_error())
+        .map(|d| d.message)
+        .collect()
+}
+
+#[test]
+fn key_filters_require_a_keyed_topic() {
+    let replica = r#"
+        type Job { shard: Int; }
+        topic Work { payload: Job; }
+        locus W {
+            bus { subscribe Work as on_j where key == replica; }
+            fn on_j(j: Job) { }
+        }
+        fn main() { W { }; }
+    "#;
+    let errs = errors(replica);
+    assert!(
+        errs.iter().any(|e| e.contains("requires a keyed topic")),
+        "replica filter on unkeyed topic rejected: {:?}",
+        errs
+    );
+
+    // The same rule closes a pre-existing silent trap for Specific
+    // filters.
+    let specific = r#"
+        type Job { shard: Int; }
+        topic Work { payload: Job; }
+        locus W {
+            bus { subscribe Work as on_j where key == 3; }
+            fn on_j(j: Job) { }
+        }
+        fn main() { W { }; }
+    "#;
+    let errs = errors(specific);
+    assert!(
+        errs.iter().any(|e| e.contains("requires a keyed topic")),
+        "specific filter on unkeyed topic rejected: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn replica_filter_needs_an_int_family_key() {
+    let src = r#"
+        type Job { tag: String; }
+        topic Work { payload: Job; keyed_by tag; }
+        locus W {
+            bus { subscribe Work as on_j where key == replica; }
+            fn on_j(j: Job) { }
+        }
+        fn main() { W { }; }
+    "#;
+    let errs = errors(src);
+    assert!(
+        errs.iter().any(|e| e.contains("Int-family key")),
+        "replica on a String-keyed topic rejected: {:?}",
+        errs
+    );
+
+    // Control: a String-keyed SPECIFIC filter stays legal (Gap B).
+    let control = r#"
+        type Job { tag: String; }
+        topic Work { payload: Job; keyed_by tag; }
+        locus W {
+            params { name: String = "a"; }
+            bus { subscribe Work as on_j where key == self.name; }
+            fn on_j(j: Job) { }
+        }
+        fn main() { W { }; }
+    "#;
+    assert!(
+        errors(control).is_empty(),
+        "String-keyed specific filters unchanged: {:?}",
+        errors(control)
+    );
+}
+
+#[test]
+fn pool_affinity_conflicts_and_main_pool_are_rejected() {
+    let conflict = r#"
+        locus A { params { n: Int = 0; } }
+        locus B { params { n: Int = 0; } }
+        main locus App {
+            params { a: A = A { }; b: B = B { }; }
+            placement {
+                a: cooperative(pool = io, cores = 0..=1);
+                b: cooperative(pool = io, cores = 2..=3);
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let errs = errors(conflict);
+    assert!(
+        errs.iter().any(|e| e.contains("two different") && e.contains("affinities")),
+        "conflicting pool affinity rejected: {:?}",
+        errs
+    );
+
+    let main_pool = r#"
+        locus A { params { n: Int = 0; } }
+        main locus App {
+            params { a: A = A { }; }
+            placement { a: cooperative(core = 3); }
+        }
+        fn main() { App { }; }
+    "#;
+    let errs = errors(main_pool);
+    assert!(
+        errs.iter().any(|e| e.contains("needs a named pool")),
+        "affinity on the main pool rejected: {:?}",
+        errs
+    );
+
+    // Control: one declaring entry + one bare entry naming the
+    // pool is fine (the bare entry inherits).
+    let ok = r#"
+        locus A { params { n: Int = 0; } }
+        locus B { params { n: Int = 0; } }
+        main locus App {
+            params { a: A = A { }; b: B = B { }; }
+            placement {
+                a: cooperative(pool = io, cores = 0..=1);
+                b: cooperative(pool = io);
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    assert!(
+        errors(ok).is_empty(),
+        "declaring + inheriting entries coexist: {:?}",
+        errors(ok)
+    );
+}

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -876,11 +876,11 @@ reports as *unverifiable* rather than as valid — a consumer may
 choose to accept it, but must never read "nothing to check" as
 "checked and intact".
 
-The artifact shape (schema `1.7`):
+The artifact shape (schema `1.10`):
 
 ```text
 {
-  "schema": "1.7",
+  "schema": "1.10",
   "shape_hash": "<fnv1a-64 over the model half>",
   "sorts":     { "loci": […], "fns": […], "topics": […] },
   "relations": {
@@ -895,12 +895,16 @@ The artifact shape (schema `1.7`):
   "phases":    { "<fn>": {"phase", "kind": "hook"|"method"} },
   "seeds":     { "<alias>": [member decls] },
   "effects":   { "<fn>": [derived effect classes] },
+  "supervision": [ {"locus", "child", "err", "ops": […],
+                  "retry_bound"?} ],
   "unknowns":  [ {"fn": …, "reasons": ["indirect_call" |
                   "untyped_receiver_call:<callee>" |
                   "uninhabited_interface_call:<iface>.<callee>" |
                   "computed_publish"]} ],
   "provenance": { "calls": [+span], "publishes": [+span],
-                  "subscribes": [+span], "decls": {name: span} },
+                  "subscribes": [+span],
+                  "decls": {name: span, topics included},
+                  "supervision": [+span] },
   "topics":    [ {"name", "subject", "shape", "payload_hash"} ],
   "claims":    [ {"name", "form", "result": <verdict>, "source"?} ],
   "lowered":   [ {"subject", "form", "result": <verdict>} ],

--- a/docs/src/getting-started/install.md
+++ b/docs/src/getting-started/install.md
@@ -178,4 +178,9 @@ Throughout this guide we write `hale run` / `hale build` as if
 `hale` is on your path. From a source checkout without it
 installed, prefix with `cargo run -p hale-cli --bin hale --`.
 
+Starting a project rather than a scratch file? `hale init my-app`
+scaffolds the canonical minimal shape — `hale.toml`, a hello-world
+seed, a first test — ready for `hale run` / `hale test` / `hale
+verify` out of the box.
+
 Next: [Your first run](./first-run.md).

--- a/docs/src/services/bus.md
+++ b/docs/src/services/bus.md
@@ -208,7 +208,13 @@ reaches only the `Feed` instances that subscribed with
   `String` key yourself.)
 - **`where key == EXPR`** on a subscribe filters that subscriber.
   `EXPR` can be a literal, a `const`, or `self.<field>` — the
-  common case, one instance per shard.
+  common case, one instance per shard. It can also be the bare
+  word **`replica`**: the instance's 0-based replica index, so a
+  `pinned(..., replicas = K)` fan-out shards an Int-keyed topic
+  with one subscribe line (see the concurrency chapter's
+  fan-out pattern). A filter of any shape requires a *keyed*
+  topic — on an unkeyed one it would silently match nothing, and
+  the checker now says so.
 - The key is **captured by value when the locus is constructed.**
   Reassigning `self.symbol_id` later does *not* re-route the
   subscription; to change shards, dissolve the locus and

--- a/docs/src/services/concurrency.md
+++ b/docs/src/services/concurrency.md
@@ -72,7 +72,11 @@ main locus App {
 ```
 
 - `cooperative(pool = X)` puts the locus on pool `X`'s thread.
-  The runtime spawns one OS worker per pool name it sees.
+  The runtime spawns one OS worker per pool name it sees. A pool
+  can take the same affinity forms as `pinned` —
+  `cooperative(pool = io, cores = 0..=1)` binds the pool's worker
+  thread to those cores (declare it on one entry; others naming
+  the pool inherit it).
 - `pinned` / `pinned(core = N)` gives the locus its own thread,
   optionally pinned to a CPU core.
 - `pinned(cores = 4..8)` (or `4..=7`, or `{4, 5, 6, 7}`) pins
@@ -177,9 +181,28 @@ with the topology targets — `pinned(node = 0, replicas = 4)` fans
 4 workers across node 0's cores, each with its arena on node 0.
 
 The replicas are **workers, not handles**: there's no
-`workers[i]` to call. They pull work — typically by subscribing a
-bus topic (all K register, so the topic fans out to every
-replica) or by running their own loop. `replicas` is pinned-only;
+`workers[i]` to call. They pull work — by subscribing a bus topic
+or running their own loop. A plain subscription registers all K,
+so the topic *broadcasts* to every replica. To **shard** instead,
+key the topic and subscribe with the replica's own index:
+
+```hale,fragment
+type Conn { fd: Int; shard: Int; }
+topic NewConn { payload: Conn; keyed_by shard; }
+
+locus Worker {
+    bus { subscribe NewConn as on_conn where key == replica; }
+    fn on_conn(c: Conn) { /* only shard == my index arrives */ }
+}
+// placement { workers: pinned(cores = 4..12, replicas = 8); }
+// listener publishes: NewConn <- Conn { fd: fd, shard: fd % 8 };
+```
+
+`replica` is the instance's 0-based index (a non-replicated
+instance is replica 0), so K lives in exactly one place — the
+placement entry — and each connection lands on one worker. This
+is the webserver fan-out shape: a pinned listener accepting,
+K workers each owning their shard. `replicas` is pinned-only;
 `cooperative(..., replicas = K)` is rejected (K loci on one pool
 would share a thread, which isn't parallel).
 

--- a/spec/decisions.md
+++ b/spec/decisions.md
@@ -3211,6 +3211,28 @@ Per-registration `dropped_full` counting rides the entry.
 
 ---
 
+### F.38 Placement is semantics-free; delivery selection belongs to subscriptions
+
+Tested by a real ask (2026-08-12, a webserver tutorial): "partitioned
+placement" was expected to mean partitioned delivery, and it does not
+— bus pubsub is broadcast, and no placement axis may change WHO
+receives a message. The line held, and the resolution is the pattern
+for future asks of this shape: **bridge the axes on the subscription
+side.** `where key == replica` gives a `pinned(..., replicas = K)`
+fan-out sharded delivery with the filter still written on the
+subscription — placement only decides how many indices exist, so
+moving or scaling placement entries still never changes semantics.
+The same ruling closed the matrix's other gap the ergonomic way:
+pool affinity (`cooperative(pool = X, cores = …)`) is placement
+changing WHERE a pool's worker runs, never WHAT it receives.
+
+Named non-goals recorded with it: a `delivery: one_of`
+competing-consumers mode (real work-queue semantics — ordering and
+backpressure questions, its own design conversation), and
+`cooperative(..., replicas = K)` (K loci on one pool share one
+thread; parallelism is more single-threaded units, never a
+multi-worker pool).
+
 ## Deferred & future work
 
 Forward-looking items lifted from the spec files. These are design

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -531,11 +531,18 @@ placement_block   = "placement" , "{" , { placement_entry } , "}" ;
 placement_entry   = IDENTIFIER , ":" , placement_spec ,
                     [ "where" , placement_constraint ,
                       { "," , placement_constraint } ] , ";" ;
-placement_spec    = "cooperative" , [ "(" , "pool" , "=" , IDENTIFIER , ")" ]
+placement_spec    = "cooperative" , [ "(" , coop_attr ,
+                                 { "," , coop_attr } , [ "," ] , ")" ]
                   | "pinned" , [ "(" , pin_attr , { "," , pin_attr } ,
                                  [ "," ] , ")" ] ;
-(* At most one affinity attr and at most one `replicas` per
-   `pinned(...)`; enforced by the parser, not the grammar. *)
+(* At most one affinity attr per spec, at most one `pool`, and at
+   most one `replicas` per `pinned(...)`; enforced by the parser,
+   not the grammar. Pool affinity (2026-08-12): `cooperative`
+   takes the same affinity forms as `pinned` — it binds the
+   POOL's worker thread; entries naming one pool must agree
+   (typecheck) and `replicas` stays pinned-only. *)
+coop_attr         = "pool" , "=" , IDENTIFIER
+                  | pin_affinity ;
 pin_attr          = pin_affinity
                   | "replicas" , "=" , INT_LIT ;
 pin_affinity      = "core"  , "=" , INT_LIT
@@ -645,12 +652,18 @@ bus_publish       = "publish" , bus_subject ,
    - a const identifier resolving to such a literal
    - `self.<field>` — captured at locus instantiation
    - the sentinel `_`, only legal when the topic declared
-     `on_unmatched: fallback` (catch-unmatched subscriber).
+     `on_unmatched: fallback` (catch-unmatched subscriber)
+   - the bare word `replica` (2026-08-12, contextual in exactly
+     this position): the subscribing instance's 0-based replica
+     index — K `pinned(replicas = K)` instances shard an
+     Int-keyed topic with one subscribe line. A filter of any
+     shape now REQUIRES a keyed topic (typecheck).
    Bare-Int and through-enum key types are both accepted; the
    bus stores the underlying integer tag. See `spec/semantics.md`
    § "Phase 3: routing keys". *)
 key_filter        = "where" , "key" , "==" , key_filter_rhs ;
 key_filter_rhs    = "_"
+                  | "replica"
                   | expr ;
 
 

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -778,7 +778,11 @@ Cooperative subscribers can be partitioned across N pools
 (N OS threads, each running its own
 `lotus_coop_pool_worker` drain loop against its own per-pool
 ring buffer); cross-pool bus dispatch reuses the m28b
-condvar+memcpy machinery. The single-threaded-method invariant
+condvar+memcpy machinery. A pool's worker thread can take the
+same affinity forms as `pinned` — `cooperative(pool = X,
+core/cores/node/l3 = …)`, applied right after the worker spawns
+(2026-08-12; entries naming one pool must agree, and the main
+pool takes none). The single-threaded-method invariant
 — a locus's methods may be invoked only from its pool's thread
 or via the bus — ships as a typecheck rule (Phase 5).
 

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1732,6 +1732,23 @@ handler's self pointer. v0.1 restricts EXPR to:
 3. A `self.<field>` path read, where `<field>` is a `params`-block
    field of the subscribing locus (for a String-keyed topic, a
    `String` field — e.g. `where key == self.name`)
+4. The bare word `replica` (2026-08-12, contextual — only this
+   exact RHS position): the subscribing INSTANCE's 0-based replica
+   index. Each instance of a `pinned(..., replicas = K)` fan-out
+   registers its own index, so K replicas shard an Int-keyed topic
+   with one subscribe line and K spelled once, in the placement
+   entry; a non-replicated instance is replica 0. Requires an
+   Int-family key (String keys rejected — the index is a number).
+   This is the bridge between the placement scale axis and the
+   delivery axis, built so that placement itself stays
+   semantics-free: the filter is still written on the
+   subscription; the placement only decides how many indices
+   exist.
+
+A `where key == …` filter of any shape requires a KEYED topic
+(2026-08-12): an unkeyed publish never runs the key match, so a
+filtered subscriber would silently receive nothing — previously
+accepted without a word, now a type error.
 
 Higher-shape expressions (`self.a + self.b`, method calls in the
 filter, cross-locus reads) are reserved for later. The
@@ -2139,6 +2156,19 @@ main locus App {
     the target node) and are non-addressable (no `field[i]` surface;
     they are bus-subscribing or run-loop workers). All K are joined
     and dissolved at parent teardown. (Topology Phase 1c, 2026-07-05.)
+    Replicas compose with KEYED DELIVERY via `where key == replica`
+    (2026-08-12) — see the routing-key filter rules.
+16. **Pool affinity (2026-08-12).** `cooperative(pool = X,
+    core/cores/node/l3 = …)` binds pool X's worker THREAD to the
+    core set — the same affinity forms `pinned` takes, resolved
+    against `topology { }`, same best-effort contract. The pool has
+    one worker, so entries naming one pool must agree: a second
+    entry may name the pool bare (it inherits) but a different
+    affinity is a type error citing both entries. Affinity without
+    a named pool (or on pool `main`) is rejected — the main pool is
+    the program's main thread, whose affinity belongs to the
+    operator. Thread affinity only; pool workers own no arena to
+    node-bind (handler scratch lives in each locus's own arena).
 
 ### Single-threaded-method invariant
 


### PR DESCRIPTION
From the webserver-tutorial conversation: partitioned *placement* never meant partitioned *delivery* — bus pubsub is broadcast, and delivery selection lives on the subscription (deliberately: placement must stay semantics-free). But the two axes had no bridge, and cooperative pools took no affinity. This completes both cells of the pairwise matrix.

## `where key == replica`

Each instance of a `pinned(..., replicas = K)` fan-out registers its **0-based replica index** as its subscription key:

```hale
type Conn { fd: Int; shard: Int; }
topic NewConn { payload: Conn; keyed_by shard; }

locus Worker {
    bus { subscribe NewConn as on_conn where key == replica; }
    fn on_conn(c: Conn) { /* only shard == my index arrives */ }
}
// placement { workers: pinned(cores = 4..12, replicas = 8); }
// listener: NewConn <- Conn { fd: fd, shard: fd % 8 };
```

K replicas shard an Int-keyed topic with **one subscribe line and K spelled once** (in the placement entry); a non-replicated instance is replica 0. The semantics-free-placement rule survives — the filter is written on the subscription; placement only decides how many indices exist. `replica` is contextual (exactly that RHS position; a const named `replica` in a larger expression still parses as an expression). End-to-end pinned: 3 replicas × shards loaded 1/2/3 receive exactly 1/2/3 (broadcast would be 6/6/6).

**Bonus rule that closes a pre-existing silent trap**: every `where key == …` filter now requires a *keyed* topic. A Specific filter on an unkeyed topic used to register a key match no publish would ever run — the subscriber received nothing, forever, with `check` green.

## Pool affinity

`cooperative(pool = X, core/cores/node/l3 = …)` binds pool X's worker thread to the core set — the same forms and `topology { }` name resolution `pinned` has, applied right after the worker spawns, same best-effort contract. Kernel-verified by test (`/proc/<pid>/task/*/status` `Cpus_allowed_list`). One pool has one worker, so entries naming a pool must agree: bare entries inherit, a *different* affinity is a type error whose related span cites the first declaration (riding the new `related` machinery), and affinity on the main pool is rejected — that thread belongs to the operator.

Tests: `replica_keys.rs`, `pool_affinity.rs`, `placement_pairings.rs` (validation edges + the inherit control + the String-keyed-Specific control). Spec routing-key + placement sections and the docs concurrency chapter updated — the chapter now teaches the webserver fan-out shape directly. Workspace 2546/2546; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)