### PR TITLE
feat(replay): deterministic record & replay — `hale replay` (GH #296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,30 @@ behavior.
 
 ### Record & replay, phases 2–4: `hale replay` (GH #296)
 
-Building on the phase-0/1 recording below, the rest of the RFC's
-core promise ships: **re-run a recorded execution and get the same
-deliveries in the same order, with the same inputs.**
+Building on the phase-0/1 recording below: **re-run a recorded
+execution and get the same schedule and the same journaled inputs,
+with an explicit, checked coverage boundary.** (Scoped per review:
+external ingress and non-journaled I/O re-execute live and are
+gated — see the safety flag below.)
+
+Hardened by a full review round before merge: recorder events
+moved off iris protocol ekinds onto process-private rings; replay
+admission is by executable identity (`exec_digest` = compiler
+version + source bytes), not just structural `shape_hash`, and
+unstamped recordings are refused without `--allow-unverified-model`;
+replay is **safe by default** — a program whose effect frontier
+reaches `syscall`/`ffi` is refused without `--allow-live-effects`;
+capture failure, write failure, and finalize failure all fail the
+run (never a silent gap); a recording is clean only if the entire
+artifact validates (exact trailer position + entry count); the
+journal carries per-call argument identity (a changed env name or
+rand bound is a named divergence, not a substituted value);
+`--diff` is bidirectional and fails on ANY runtime divergence via
+a machine-readable verdict; payload topic identity is a stable
+subject hash (manifest ids are registration-order and race);
+raw-struct payload captures are flagged as ABI snapshots and
+compared by size (canonical recording codecs staged); `--at
+consumer:N` is the stable multi-consumer debugger coordinate.
 
 - **`hale replay <recording> <program.hl>`** — compiles through the
   same pipeline as `hale run`, admits the recording by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,28 @@ with an explicit, checked coverage boundary.** (Scoped per review:
 external ingress and non-journaled I/O re-execute live and are
 gated — see the safety flag below.)
 
-Hardened by a full review round before merge: recorder events
+Hardened by two full review rounds before merge. Round 2 (the
+identity/admission/trust round): the safety gate consumes TYPED
+effect rows and fails closed on `unclassified` and on
+transport-bound `bindings` (a bound publish sends real traffic
+that user-level effects cannot show); `exec_digest` is a framed
+SHA-256 over the toolchain source hash + version + options + full
+source paths/lengths/contents (32 bytes in the header, stamped in
+four parts, re-stamped at finalize); journal entries carry their
+EXACT encoded arguments (replay memcmps them — the 32-bit hashes
+they replace folded adjacent integers); env VALUES are withheld
+from recordings by default (`LOTUS_OBS_RECORD_ENV=full` opts in;
+withheld reads replay as named divergences); raw in-process
+payloads store metadata only (no pointer/padding bytes on disk);
+`msg_id` is full-width (consumer:16|seq:48, loudly guarded) and
+the delivery identity includes the target locus; the runtime
+loader independently validates the whole artifact (one open +
+fstat + private mmap, checked arithmetic, exact trailer position
+and count, per-kind value shapes); `--diff` compares per-consumer
+PUBLIC bus streams via file-side identity maps (direct dispatch
+is visible) and groups journal comparison per consumer.
+
+Round 1: recorder events
 moved off iris protocol ekinds onto process-private rings; replay
 admission is by executable identity (`exec_digest` = compiler
 version + source bytes), not just structural `shape_hash`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,88 @@ behavior.
 
 ## Unreleased
 
+### Record & replay, phases 2–4: `hale replay` (GH #296)
+
+Building on the phase-0/1 recording below, the rest of the RFC's
+core promise ships: **re-run a recorded execution and get the same
+deliveries in the same order, with the same inputs.**
+
+- **`hale replay <recording> <program.hl>`** — compiles through the
+  same pipeline as `hale run`, admits the recording by
+  `model_hash` (a recording from a different model is rejected,
+  never misreplayed; a truncated recording is refused), then
+  re-executes under `LOTUS_REPLAY`. `--diff` records the replay and
+  reports the first per-consumer divergence; `--at N` stops
+  (SIGSTOP) at the Nth consume so a debugger can attach.
+- **Delivery identity + payload capture** (format v0.2, tagged
+  entries): every queued delivery carries a deterministic
+  `pub_id` (stable consumer id + per-publisher-thread seq — a
+  re-executed run re-derives the same ids with no global
+  coordination); payload bytes are captured once per queued
+  publish, external wire ingress flagged. Synchronous direct
+  dispatch captures nothing by design: a closed-world same-thread
+  call cannot carry external input.
+- **The input journal**: `std::time::now`, `std::time::monotonic`
+  / `monotonic_ns` (now a named runtime primitive —
+  they lowered as inline `clock_gettime` IR nothing could
+  interpose), `std::rand::next_int`, `std::os::getrandom`, and the
+  `std::env` surface are journaled per consumer under recording
+  and served back under replay. A read past the recorded history
+  falls back live and is counted — **replay degrades, never
+  refuses** — with a divergence summary at exit.
+- **Recorded-order enforcement**: each consumer (cooperative pool
+  worker, pinned mailbox, main queue) re-consumes its queued
+  deliveries in the recorded order, holding early arrivals in a
+  per-consumer buffer with a bounded (1s) degrade path, so two
+  racing pinned publishers replay in exactly the interleaving that
+  was recorded — pinned end-to-end by a CLI test that replays a
+  40+40-delivery race twice. `where async_io` pools refuse replay
+  loudly (their coro interleaving is a later milestone).
+- Remaining, explicitly staged: ingress injection + fleet replay
+  (Phase 5, needs `LOTUS_OBS_WIRE` fleet identity), and
+  replay-under-a-different-plan (Phase 6, blocked on #262's plan
+  admission).
+
+### Record & replay, phases 0–1: the determinism guarantee, and a recording that never drops (GH #296)
+
+- **Single-pool determinism is now a stated guarantee**, not an
+  implementation accident. A program whose loci all run on the main
+  cooperative scheduler produces the same publishes and deliveries
+  in the same order on every run, given the same inputs — one pool
+  is one consumer thread by construction, so there is no scheduling
+  freedom for an order to vary within. Written into
+  `spec/testing.md` § Determinism (both former "determinism mode"
+  open questions resolved against it), pinned by
+  `replay_determinism.rs`, which compares the complete ordered
+  BUS_PUBLISH/BUS_DELIVER stream across repeated runs. A divergence
+  there is a runtime bug, never a flaky test.
+- **`LOTUS_OBS_RECORD=<path>` — lossless recording mode.** The
+  observation plane's sampler disposition (overwrite-oldest,
+  count the drops) becomes a flight recorder's: an in-process
+  drain appends every ring record to the file, a producer whose
+  ring is full **blocks** against the drain cursor instead of
+  overwriting, a thread that cannot get a ring **fails the run**
+  (recording defaults to the 64-ring maximum first), and a write
+  failure fails the run rather than truncating silently. Never
+  drop, by construction. Implies `LOTUS_OBS=1` and counts as an
+  attached observer, so a recording needs no external consumer.
+  Wholly opt-in: unset, the lowering is instruction-identical to
+  the unobserved build, per the established gate discipline.
+- **`BUS_CONSUME` (ekind 8, recording mode only): the per-consumer
+  delivery order.** BUS_DELIVER is enqueue-time and lands on the
+  publisher's ring — it cannot say in what order a consumer ran
+  its handlers. Under recording, every dequeue-driven handler
+  invoke stamps a consume record on the consuming thread
+  (subscriber locus + the thread's gapless count); its ring
+  position is the order a replay will serve back. Synchronous
+  direct dispatch deliberately emits none — its deliver record is
+  its consumption point. Never emitted outside recording, so
+  existing consumers never meet an unknown ekind.
+- The recording file format is **pre-stable** (v0.2 as shipped:
+  tagged header + ring records + payload/journal blobs +
+  clean-finalize trailer); the fully self-describing artifact
+  shape may still evolve with the remaining GH #296 phases.
+
 ### Observability: supervision in the model, backpressure on the wire, identity in the segment
 
 Five items from a downstream observability handoff, resolved as one

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "hale-lsp",
  "hale-syntax",
  "hale-types",
+ "libc",
  "openssl",
  "serde",
  "serde_json",

--- a/crates/hale-cli/Cargo.toml
+++ b/crates/hale-cli/Cargo.toml
@@ -24,3 +24,4 @@ toml = "0.8"
 # lotus_tls.c implements std::crypto's ES256 with it), so this
 # adds no second crypto provider to the system.
 openssl = "0.10"
+libc = "0.2"

--- a/crates/hale-cli/build.rs
+++ b/crates/hale-cli/build.rs
@@ -66,6 +66,164 @@ fn embed_spec() {
     fs::write(dest, out).unwrap();
 }
 
+/// Minimal SHA-256 (no deps; build-script only). FIPS 180-4.
+fn sha256(data: &[u8]) -> [u8; 32] {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b,
+        0x59f111f1, 0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01,
+        0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7,
+        0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152,
+        0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+        0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819,
+        0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116, 0x1e376c08,
+        0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f,
+        0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+    ];
+    let mut h: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f,
+        0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    ];
+    let mut msg = data.to_vec();
+    let bitlen = (data.len() as u64).wrapping_mul(8);
+    msg.push(0x80);
+    while msg.len() % 64 != 56 {
+        msg.push(0);
+    }
+    msg.extend_from_slice(&bitlen.to_be_bytes());
+    for chunk in msg.chunks(64) {
+        let mut w = [0u32; 64];
+        for (i, word) in w.iter_mut().take(16).enumerate() {
+            *word = u32::from_be_bytes(
+                chunk[i * 4..i * 4 + 4].try_into().unwrap(),
+            );
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7)
+                ^ w[i - 15].rotate_right(18)
+                ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17)
+                ^ w[i - 2].rotate_right(19)
+                ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let (mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh) =
+            (h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7]);
+        for i in 0..64 {
+            let s1 = e.rotate_right(6)
+                ^ e.rotate_right(11)
+                ^ e.rotate_right(25);
+            let ch = (e & f) ^ ((!e) & g);
+            let t1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2)
+                ^ a.rotate_right(13)
+                ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+        h[0] = h[0].wrapping_add(a);
+        h[1] = h[1].wrapping_add(b);
+        h[2] = h[2].wrapping_add(c);
+        h[3] = h[3].wrapping_add(d);
+        h[4] = h[4].wrapping_add(e);
+        h[5] = h[5].wrapping_add(f);
+        h[6] = h[6].wrapping_add(g);
+        h[7] = h[7].wrapping_add(hh);
+    }
+    let mut out = [0u8; 32];
+    for (i, word) in h.iter().enumerate() {
+        out[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
+    }
+    out
+}
+
+fn walk_sources(dir: &PathBuf, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else { return };
+    let mut items: Vec<PathBuf> =
+        entries.filter_map(|e| e.ok()).map(|e| e.path()).collect();
+    items.sort();
+    for p in items {
+        if p.is_dir() {
+            walk_sources(&p, out);
+        } else if matches!(
+            p.extension().and_then(|s| s.to_str()),
+            Some("rs") | Some("c") | Some("h") | Some("hl")
+        ) {
+            out.push(p);
+        }
+    }
+}
+
+/// GH #296 review round 3: the RECORD/REPLAY toolchain identity —
+/// a length-framed SHA-256 over every compiler-side source that
+/// shapes what a build emits or how a recording is produced,
+/// parsed, and served: the full hale-syntax / hale-types /
+/// hale-codegen / hale-cli source trees (which cover the parser,
+/// effect analysis, IR emit, EVERY runtime TU incl. lotus_obs.c,
+/// the stdlib seeds, and the replay CLI), plus the rustc version
+/// and the git commit when available. The 64-bit stale-CLI hash
+/// keeps its separate, narrower job.
+fn toolchain_digest(workspace_root: &PathBuf) {
+    let mut buf: Vec<u8> = Vec::new();
+    let frame = |b: &[u8], buf: &mut Vec<u8>| {
+        buf.extend_from_slice(&(b.len() as u64).to_le_bytes());
+        buf.extend_from_slice(b);
+    };
+    let rustc = std::process::Command::new(
+        env::var("RUSTC").unwrap_or_else(|_| "rustc".into()),
+    )
+    .arg("--version")
+    .output()
+    .map(|o| o.stdout)
+    .unwrap_or_default();
+    frame(&rustc, &mut buf);
+    let commit = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(workspace_root)
+        .output()
+        .map(|o| o.stdout)
+        .unwrap_or_default();
+    frame(&commit, &mut buf);
+    let mut files: Vec<PathBuf> = Vec::new();
+    for krate in ["hale-syntax", "hale-types", "hale-codegen", "hale-cli"] {
+        let root = workspace_root.join("crates").join(krate);
+        walk_sources(&root.join("src"), &mut files);
+        walk_sources(&root.join("runtime"), &mut files);
+    }
+    files.sort();
+    for f in &files {
+        println!("cargo:rerun-if-changed={}", f.display());
+        let rel = f
+            .strip_prefix(workspace_root)
+            .unwrap_or(f)
+            .to_string_lossy()
+            .into_owned();
+        frame(rel.as_bytes(), &mut buf);
+        frame(&fs::read(f).unwrap_or_default(), &mut buf);
+    }
+    let d = sha256(&buf);
+    let hex: String = d.iter().map(|b| format!("{:02x}", b)).collect();
+    println!("cargo:rustc-env=HALE_TOOLCHAIN_SHA256={}", hex);
+}
+
 fn main() {
     embed_spec();
     let manifest_dir = env::var("CARGO_MANIFEST_DIR")
@@ -83,9 +241,13 @@ fn main() {
             // skips itself.
             println!("cargo:rustc-env=HALE_CODEGEN_SRC_HASH=");
             println!("cargo:rustc-env=HALE_CODEGEN_DIR=");
+            println!("cargo:rustc-env=HALE_TOOLCHAIN_SHA256=");
             return;
         }
     };
+    if let Some(root) = workspace_root.as_ref() {
+        toolchain_digest(root);
+    }
 
     // Files we hash. codegen.rs is the IR-emit; lotus_arena.c is
     // the C runtime bundled via include_str!; everything under

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -4510,6 +4510,7 @@ fn compile_and_exec(
     renames: &[(Vec<String>, String)],
     user_args: &[String],
     model_hash: u64,
+    exec_digest: u64,
 ) -> ExitCode {
     let mut bin = std::env::temp_dir();
     let mut h = DefaultHasher::new();
@@ -4518,6 +4519,7 @@ fn compile_and_exec(
     bin.push(format!("hale_run_{:016x}", h.finish()));
     let options = hale_codegen::BuildOptions {
         model_hash: Some(model_hash),
+        exec_digest: Some(exec_digest),
         ..Default::default()
     };
     if let Err(e) = hale_codegen::build_executable_with_options(
@@ -4537,6 +4539,30 @@ fn compile_and_exec(
             ExitCode::from(1)
         }
     }
+}
+
+/// GH #296: executable identity — fnv1a64 over the compiler
+/// version and every source file's name + content (BTreeMap order,
+/// so deterministic). Structural shape_hash says "same model";
+/// this says "same build inputs". It does not cover the LLVM/libc
+/// toolchain outside this binary — recorded in the review as the
+/// staged residue.
+fn exec_digest(sources: &BTreeMap<PathBuf, String>) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    let mut eat = |bytes: &[u8]| {
+        for b in bytes {
+            h ^= *b as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+    };
+    eat(env!("CARGO_PKG_VERSION").as_bytes());
+    for (path, src) in sources {
+        if let Some(name) = path.file_name() {
+            eat(name.to_string_lossy().as_bytes());
+        }
+        eat(src.as_bytes());
+    }
+    if h == 0 { 1 } else { h }
 }
 
 /// Escape a string for embedding in a JSON string literal.
@@ -4852,21 +4878,42 @@ fn run_replay(args: &[String]) -> ExitCode {
     let mut rec_arg: Option<PathBuf> = None;
     let mut prog: Option<PathBuf> = None;
     let mut diff = false;
-    let mut at: Option<u64> = None;
+    let mut at: Option<String> = None;
+    let mut allow_live_effects = false;
+    let mut allow_unverified = false;
     let mut i = 0;
     while i < args.len() {
         let a = args[i].as_str();
         if a == "--diff" {
             diff = true;
             i += 1;
+        } else if a == "--allow-live-effects" {
+            allow_live_effects = true;
+            i += 1;
+        } else if a == "--allow-unverified-model" {
+            allow_unverified = true;
+            i += 1;
         } else if a == "--at" {
-            match args.get(i + 1).and_then(|v| v.parse::<u64>().ok()) {
-                Some(n) if n > 0 => {
-                    at = Some(n);
+            // N (process-wide consume ordinal — only meaningful
+            // for a single consumer) or consumer:N (stable across
+            // multi-consumer runs).
+            match args.get(i + 1) {
+                Some(v)
+                    if v.parse::<u64>().map(|n| n > 0).unwrap_or(false)
+                        || v.split_once(':').is_some_and(|(c, n)| {
+                            c.parse::<u64>().is_ok()
+                                && n.parse::<u64>()
+                                    .map(|n| n > 0)
+                                    .unwrap_or(false)
+                        }) =>
+                {
+                    at = Some(v.clone());
                     i += 2;
                 }
                 _ => {
-                    eprintln!("hale replay: --at requires a positive count");
+                    eprintln!(
+                        "hale replay: --at takes N or consumer:N                          (positive)"
+                    );
                     return ExitCode::from(2);
                 }
             }
@@ -4947,10 +4994,27 @@ fn run_replay(args: &[String]) -> ExitCode {
         }
     }
     let model_hash = hale_types::topology::model_shape_hash(&bundle);
+    let digest = exec_digest(&sources);
 
-    // Admission (#262's shape): a recording that no longer matches
-    // the model is rejected, never silently misreplayed. 0 =
-    // unstamped (harness recording) — allowed with a warning.
+    // Admission, strongest check first (review finding 2):
+    // exec_digest is build-input identity (compiler version +
+    // source bytes); shape_hash alone is only structural
+    // compatibility and admits behaviorally different bodies.
+    if rec.exec_digest != 0 && rec.exec_digest != digest {
+        eprintln!(
+            "hale replay: `{}` was recorded from different build \
+             inputs (recorded exec digest {:016x}, this compile is \
+             {:016x}) — a structurally compatible model is not the \
+             same executable; re-record, or accept behavioral \
+             divergence explicitly with --allow-unverified-model",
+            rec_path.display(),
+            rec.exec_digest,
+            digest
+        );
+        if !allow_unverified {
+            return ExitCode::from(1);
+        }
+    }
     if rec.model_hash != 0 && rec.model_hash != model_hash {
         eprintln!(
             "hale replay: `{}` was recorded from a different model \
@@ -4963,11 +5027,47 @@ fn run_replay(args: &[String]) -> ExitCode {
         );
         return ExitCode::from(1);
     }
-    if rec.model_hash == 0 {
+    if (rec.exec_digest == 0 || rec.model_hash == 0) && !allow_unverified {
         eprintln!(
-            "hale replay: recording carries no model identity \
-             (unstamped build) — admission check skipped"
+            "hale replay: `{}` carries no execution identity \
+             (unstamped build) — exact replay cannot be admitted. \
+             Pass --allow-unverified-model to proceed anyway",
+            rec_path.display()
         );
+        return ExitCode::from(1);
+    }
+
+    // Safe by default (review finding 3): re-execution repeats the
+    // program's real side effects. Until per-primitive replay
+    // classes exist, the gate is the coarse effect frontier: any
+    // reachable syscall/ffi beyond the journaled read set requires
+    // an explicit, alarming opt-in. (Yes, that flags a lone
+    // `sleep` too — the class granularity is the current limit,
+    // and over-refusing is the safe direction.)
+    if !allow_live_effects {
+        let manifest = hale_types::dump_effects_manifest(&bundle);
+        let mut residue = std::collections::BTreeSet::new();
+        for part in manifest.split("does={").skip(1) {
+            if let Some(inner) = part.split('}').next() {
+                for class in inner.split(',') {
+                    let class = class.trim();
+                    if class == "syscall" || class == "ffi" {
+                        residue.insert(class.to_string());
+                    }
+                }
+            }
+        }
+        if !residue.is_empty() {
+            eprintln!(
+                "hale replay: this program's effect frontier \
+                 reaches {{{}}} — re-executing it repeats real \
+                 side effects (sends, writes, spawns) against the \
+                 live world. Refusing by default; pass \
+                 --allow-live-effects if you accept that",
+                residue.into_iter().collect::<Vec<_>>().join(", ")
+            );
+            return ExitCode::from(1);
+        }
     }
 
     let rec_abs = rec_path
@@ -4981,6 +5081,7 @@ fn run_replay(args: &[String]) -> ExitCode {
     bin.push(format!("hale_replay_{:016x}", h.finish()));
     let options = hale_codegen::BuildOptions {
         model_hash: Some(model_hash),
+        exec_digest: Some(digest),
         ..Default::default()
     };
     if let Err(e) = hale_codegen::build_executable_with_options(
@@ -5003,10 +5104,26 @@ fn run_replay(args: &[String]) -> ExitCode {
         None
     };
 
+    let mut status_path = std::env::temp_dir();
+    status_path.push(format!(
+        "hale_replay_status_{}_{:016x}",
+        std::process::id(),
+        model_hash
+    ));
+    let _ = std::fs::remove_file(&status_path);
     let mut cmd = std::process::Command::new(&bin);
     cmd.env("LOTUS_REPLAY", &rec_abs);
-    if let Some(n) = at {
-        cmd.env("LOTUS_REPLAY_AT", n.to_string());
+    cmd.env("LOTUS_REPLAY_STATUS", &status_path);
+    if let Some(spec) = &at {
+        match spec.split_once(':') {
+            Some((c, n)) => {
+                cmd.env("LOTUS_REPLAY_AT_CONSUMER", c);
+                cmd.env("LOTUS_REPLAY_AT", n);
+            }
+            None => {
+                cmd.env("LOTUS_REPLAY_AT", spec);
+            }
+        }
     }
     if let Some(v) = &verify_path {
         cmd.env("LOTUS_OBS_RECORD", v);
@@ -5024,7 +5141,37 @@ fn run_replay(args: &[String]) -> ExitCode {
         }
     };
 
+    // The runtime's machine-readable verdict (review finding 6:
+    // success must come from the verdict, not from the absence of
+    // one comparator mismatch).
+    let runtime_divergences: u64 = std::fs::read_to_string(&status_path)
+        .ok()
+        .map(|body| {
+            body.lines()
+                .filter_map(|l| l.split_once('='))
+                .filter(|(k, _)| *k != "consumes")
+                .filter_map(|(_, v)| v.trim().parse::<u64>().ok())
+                .sum()
+        })
+        .unwrap_or_else(|| {
+            eprintln!(
+                "hale replay: no runtime verdict was written — \
+                 treating as divergent"
+            );
+            1
+        });
+    let _ = std::fs::remove_file(&status_path);
+
     if let Some(v) = &verify_path {
+        if runtime_divergences > 0 {
+            eprintln!(
+                "replay DIVERGED: {} runtime divergences (see the \
+                 summary above)",
+                runtime_divergences
+            );
+            let _ = std::fs::remove_file(v);
+            return ExitCode::from(1);
+        }
         let result = match replay::parse(v) {
             Ok(vr) => match replay::diff(&rec, &vr) {
                 None => {
@@ -5040,7 +5187,7 @@ fn run_replay(args: &[String]) -> ExitCode {
                         consumes,
                         rec.consume_streams.len(),
                         rec.ring_records,
-                        rec.journal_entries
+                        rec.journal.len()
                     );
                     ExitCode::from(code)
                 }
@@ -5110,7 +5257,10 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         // P26: stamp the model identity of the bundle just checked.
         let model_hash =
             hale_types::topology::model_shape_hash(&bundle);
-        return compile_and_exec(&program, &renames, user_args, model_hash);
+        let digest = exec_digest(&sources);
+        return compile_and_exec(
+            &program, &renames, user_args, model_hash, digest,
+        );
     }
 
     let files = match collect_ap_files(target) {
@@ -5231,7 +5381,8 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
     }
     // P26: stamp the model identity of the bundle just checked.
     let model_hash = hale_types::topology::model_shape_hash(&bundle);
-    compile_and_exec(&program, &renames, user_args, model_hash)
+    let digest = exec_digest(&path_sources);
+    compile_and_exec(&program, &renames, user_args, model_hash, digest)
 }
 
 fn run_build(target: &Path) -> ExitCode {

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -214,7 +214,9 @@ fn usage() {
     eprintln!("    hale run   <file.hl | dir>    compile + run as a native binary");
     eprintln!("    hale build <file.hl | dir>    parse + typecheck + emit native binary");
     eprintln!("    hale replay <rec> <file.hl>   re-run a LOTUS_OBS_RECORD recording");
-    eprintln!("        [--diff: report first divergence] [--at N: SIGSTOP at Nth consume]");
+    eprintln!("        [--diff: report first divergence, fail on any]");
+    eprintln!("        [--at <n> | --at <consumer-id>:<ordinal>: SIGSTOP at that consume]");
+    eprintln!("        [--allow-live-effects] [--allow-unverified-model]");
     eprintln!("    hale test  [file | dir]       compile + run *_test.hl (default: cwd)");
     eprintln!("        [-run <substr>] [--json]");
     eprintln!("    hale bench [file | dir]       run *_bench.hl bench_* fns (default: cwd)");
@@ -4510,7 +4512,7 @@ fn compile_and_exec(
     renames: &[(Vec<String>, String)],
     user_args: &[String],
     model_hash: u64,
-    exec_digest: u64,
+    exec_digest: [u64; 4],
 ) -> ExitCode {
     let mut bin = std::env::temp_dir();
     let mut h = DefaultHasher::new();
@@ -4541,28 +4543,50 @@ fn compile_and_exec(
     }
 }
 
-/// GH #296: executable identity — fnv1a64 over the compiler
-/// version and every source file's name + content (BTreeMap order,
-/// so deterministic). Structural shape_hash says "same model";
-/// this says "same build inputs". It does not cover the LLVM/libc
-/// toolchain outside this binary — recorded in the review as the
-/// staged residue.
-fn exec_digest(sources: &BTreeMap<PathBuf, String>) -> u64 {
-    let mut h: u64 = 0xcbf29ce484222325;
-    let mut eat = |bytes: &[u8]| {
-        for b in bytes {
-            h ^= *b as u64;
-            h = h.wrapping_mul(0x100000001b3);
-        }
+/// GH #296: build-manifest identity — a FRAMED SHA-256 over the
+/// build inputs this binary can see:
+///
+///   - the toolchain source hash (`HALE_CODEGEN_SRC_HASH`, computed
+///     by build.rs over the codegen + runtime + stdlib sources this
+///     CLI was linked against — so two different compiler/runtime
+///     commits under one version differ);
+///   - the CLI crate version;
+///   - the build options that alter emitted code;
+///   - every source file's FULL normalized path, byte length, and
+///     contents, each length-framed (no concatenation ambiguity).
+///
+/// Structural `shape_hash` says "same model"; this says "same build
+/// inputs". Residue it cannot see: the LLVM/libc toolchain outside
+/// this binary and the linker environment — a post-link binary
+/// digest is the staged stronger form.
+fn exec_digest(sources: &BTreeMap<PathBuf, String>) -> [u64; 4] {
+    let mut buf: Vec<u8> = Vec::new();
+    let frame = |b: &[u8], buf: &mut Vec<u8>| {
+        buf.extend_from_slice(&(b.len() as u64).to_le_bytes());
+        buf.extend_from_slice(b);
     };
-    eat(env!("CARGO_PKG_VERSION").as_bytes());
+    frame(env!("HALE_CODEGEN_SRC_HASH").as_bytes(), &mut buf);
+    frame(env!("CARGO_PKG_VERSION").as_bytes(), &mut buf);
+    frame(b"target=native;profile=release", &mut buf);
+    buf.extend_from_slice(&(sources.len() as u64).to_le_bytes());
     for (path, src) in sources {
-        if let Some(name) = path.file_name() {
-            eat(name.to_string_lossy().as_bytes());
-        }
-        eat(src.as_bytes());
+        let full = path
+            .canonicalize()
+            .unwrap_or_else(|_| path.clone())
+            .display()
+            .to_string();
+        frame(full.as_bytes(), &mut buf);
+        frame(src.as_bytes(), &mut buf);
     }
-    if h == 0 { 1 } else { h }
+    let d = openssl::sha::sha256(&buf);
+    let mut out = [0u64; 4];
+    for (i, part) in out.iter_mut().enumerate() {
+        *part = u64::from_le_bytes(d[i * 8..i * 8 + 8].try_into().unwrap());
+    }
+    if out == [0; 4] {
+        out[0] = 1;
+    }
+    out
 }
 
 /// Escape a string for embedding in a JSON string literal.
@@ -4936,7 +4960,8 @@ fn run_replay(args: &[String]) -> ExitCode {
         _ => {
             eprintln!(
                 "usage: hale replay <recording> <program.hl> \
-                 [--diff] [--at N]"
+                 [--diff] [--at <n> | --at <consumer-id>:<ordinal>] \
+                 [--allow-live-effects] [--allow-unverified-model]"
             );
             return ExitCode::from(2);
         }
@@ -4997,19 +5022,19 @@ fn run_replay(args: &[String]) -> ExitCode {
     let digest = exec_digest(&sources);
 
     // Admission, strongest check first (review finding 2):
-    // exec_digest is build-input identity (compiler version +
-    // source bytes); shape_hash alone is only structural
-    // compatibility and admits behaviorally different bodies.
-    if rec.exec_digest != 0 && rec.exec_digest != digest {
+    // exec_digest is framed-SHA-256 build-input identity;
+    // shape_hash alone is only structural compatibility and admits
+    // behaviorally different bodies.
+    if rec.exec_digest != [0; 4] && rec.exec_digest != digest {
         eprintln!(
             "hale replay: `{}` was recorded from different build \
-             inputs (recorded exec digest {:016x}, this compile is \
-             {:016x}) — a structurally compatible model is not the \
-             same executable; re-record, or accept behavioral \
+             inputs (recorded exec digest {:016x}…, this compile \
+             is {:016x}…) — a structurally compatible model is not \
+             the same executable; re-record, or accept behavioral \
              divergence explicitly with --allow-unverified-model",
             rec_path.display(),
-            rec.exec_digest,
-            digest
+            rec.exec_digest[0],
+            digest[0]
         );
         if !allow_unverified {
             return ExitCode::from(1);
@@ -5027,7 +5052,9 @@ fn run_replay(args: &[String]) -> ExitCode {
         );
         return ExitCode::from(1);
     }
-    if (rec.exec_digest == 0 || rec.model_hash == 0) && !allow_unverified {
+    if (rec.exec_digest == [0; 4] || rec.model_hash == 0)
+        && !allow_unverified
+    {
         eprintln!(
             "hale replay: `{}` carries no execution identity \
              (unstamped build) — exact replay cannot be admitted. \
@@ -5037,39 +5064,74 @@ fn run_replay(args: &[String]) -> ExitCode {
         return ExitCode::from(1);
     }
 
-    // Safe by default (review finding 3): re-execution repeats the
-    // program's real side effects. Until per-primitive replay
-    // classes exist, the gate is the coarse effect frontier: any
-    // reachable syscall/ffi beyond the journaled read set requires
-    // an explicit, alarming opt-in. (Yes, that flags a lone
-    // `sleep` too — the class granularity is the current limit,
-    // and over-refusing is the safe direction.)
+    // Safe by default (review finding 3, both rounds): re-execution
+    // repeats the program's real side effects. The gate consumes
+    // the TYPED inferred rows, and it must fail CLOSED on the two
+    // paths the first version failed open on: `unclassified`
+    // ("may do anything") and a `publish` whose subject is bound to
+    // an external transport (the send is generated deployment
+    // machinery, invisible in user-level effects). Coarse by class
+    // granularity — over-refusing is the safe direction;
+    // per-primitive replay classes are the staged refinement.
     if !allow_live_effects {
-        let manifest = hale_types::dump_effects_manifest(&bundle);
+        let programs: Vec<&Program> =
+            bundle.programs.values().copied().collect();
+        let rows =
+            hale_types::effects::effect_manifest_with_inference(&programs);
         let mut residue = std::collections::BTreeSet::new();
-        for part in manifest.split("does={").skip(1) {
-            if let Some(inner) = part.split('}').next() {
-                for class in inner.split(',') {
-                    let class = class.trim();
-                    if class == "syscall" || class == "ffi" {
-                        residue.insert(class.to_string());
+        for row in &rows {
+            for class in &row.inferred {
+                if class == "syscall"
+                    || class == "ffi"
+                    || class == "unclassified"
+                {
+                    residue.insert(class.clone());
+                }
+            }
+        }
+        // External transport bindings: any `bindings { }` block
+        // makes publishes (and listener startup) touch the real
+        // world during re-execution.
+        let mut has_bindings = false;
+        for prog in bundle.programs.values() {
+            for item in &prog.items {
+                if let hale_syntax::ast::TopDecl::Locus(l) = item {
+                    if l.members.iter().any(|m| {
+                        matches!(
+                            m,
+                            hale_syntax::ast::LocusMember::Bindings(_)
+                        )
+                    }) {
+                        has_bindings = true;
                     }
                 }
             }
         }
+        if has_bindings {
+            residue.insert("external-bindings".to_string());
+        }
         if !residue.is_empty() {
             eprintln!(
-                "hale replay: this program's effect frontier \
-                 reaches {{{}}} — re-executing it repeats real \
-                 side effects (sends, writes, spawns) against the \
-                 live world. Refusing by default; pass \
-                 --allow-live-effects if you accept that",
+                "hale replay: this program can reach the live world \
+                 during re-execution ({{{}}}) — publishes to bound \
+                 topics send real traffic, unclassified calls may \
+                 do anything, and syscall/ffi writes repeat. \
+                 Refusing by default; pass --allow-live-effects if \
+                 you accept that",
                 residue.into_iter().collect::<Vec<_>>().join(", ")
             );
             return ExitCode::from(1);
         }
     }
 
+    if rec.env_redacted {
+        eprintln!(
+            "hale replay: this recording withholds env VALUES \
+             (default policy; record with LOTUS_OBS_RECORD_ENV=full \
+             to include them) — env reads will replay as named \
+             withheld divergences"
+        );
+    }
     let rec_abs = rec_path
         .canonicalize()
         .unwrap_or_else(|_| rec_path.clone());
@@ -5111,6 +5173,16 @@ fn run_replay(args: &[String]) -> ExitCode {
         model_hash
     ));
     let _ = std::fs::remove_file(&status_path);
+    // Pre-create 0600 so the child's fopen("w") inherits restrictive
+    // permissions rather than racing a predictable /tmp name.
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let _ = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&status_path);
+    }
     let mut cmd = std::process::Command::new(&bin);
     cmd.env("LOTUS_REPLAY", &rec_abs);
     cmd.env("LOTUS_REPLAY_STATUS", &status_path);
@@ -5127,6 +5199,12 @@ fn run_replay(args: &[String]) -> ExitCode {
     }
     if let Some(v) = &verify_path {
         cmd.env("LOTUS_OBS_RECORD", v);
+        // The verification recording must apply the SAME env policy
+        // the original did, or a full-env recording diffs against a
+        // redacted one and reports a spurious withheld divergence.
+        if !rec.env_redacted {
+            cmd.env("LOTUS_OBS_RECORD_ENV", "full");
+        }
     }
     let status = cmd.status();
     let _ = std::fs::remove_file(&bin);
@@ -5182,7 +5260,8 @@ fn run_replay(args: &[String]) -> ExitCode {
                         .sum();
                     println!(
                         "replay matches the recording: {} consumes \
-                         across {} consumers, payloads identical \
+                         across {} consumers; canonical payloads \
+                         identical, raw ABI payload sizes matched \
                          ({} ring records, {} journal reads)",
                         consumes,
                         rec.consume_streams.len(),

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -30,6 +30,7 @@ use hale_lsp as lsp;
 mod fleet;
 mod mcp;
 mod pkg;
+mod replay;
 mod sign;
 
 fn main() -> ExitCode {
@@ -106,6 +107,13 @@ fn main() -> ExitCode {
     if cmd == "test" {
         let rest: Vec<String> = args.iter().skip(2).cloned().collect();
         return run_test(&rest);
+    }
+
+    // `replay` takes a recording and a program (its own arg shape,
+    // so it parses `rest` itself like `test` does). GH #296.
+    if cmd == "replay" {
+        let rest: Vec<String> = args.iter().skip(2).cloned().collect();
+        return run_replay(&rest);
     }
 
     // `lsp` speaks stdio and takes no target — the seed to check is
@@ -205,6 +213,8 @@ fn usage() {
     eprintln!("    hale verify <file.hl | dir>   check + FAIL on any advisory (discipline gate)");
     eprintln!("    hale run   <file.hl | dir>    compile + run as a native binary");
     eprintln!("    hale build <file.hl | dir>    parse + typecheck + emit native binary");
+    eprintln!("    hale replay <rec> <file.hl>   re-run a LOTUS_OBS_RECORD recording");
+    eprintln!("        [--diff: report first divergence] [--at N: SIGSTOP at Nth consume]");
     eprintln!("    hale test  [file | dir]       compile + run *_test.hl (default: cwd)");
     eprintln!("        [-run <substr>] [--json]");
     eprintln!("    hale bench [file | dir]       run *_bench.hl bench_* fns (default: cwd)");
@@ -4828,6 +4838,229 @@ fn run_test(args: &[String]) -> ExitCode {
     } else {
         ExitCode::from(1)
     }
+}
+
+/// `hale replay <recording> <program.hl> [--diff] [--at N]` —
+/// GH #296. Re-runs a recorded execution: the same binary (model
+/// identity checked against the recording header), with the
+/// runtime serving journaled inputs (time/entropy/env) and
+/// enforcing each consumer's recorded delivery order. `--diff`
+/// records the replay and reports the first divergence; `--at N`
+/// stops the program (SIGSTOP) at the Nth consume so a debugger
+/// can attach.
+fn run_replay(args: &[String]) -> ExitCode {
+    let mut rec_arg: Option<PathBuf> = None;
+    let mut prog: Option<PathBuf> = None;
+    let mut diff = false;
+    let mut at: Option<u64> = None;
+    let mut i = 0;
+    while i < args.len() {
+        let a = args[i].as_str();
+        if a == "--diff" {
+            diff = true;
+            i += 1;
+        } else if a == "--at" {
+            match args.get(i + 1).and_then(|v| v.parse::<u64>().ok()) {
+                Some(n) if n > 0 => {
+                    at = Some(n);
+                    i += 2;
+                }
+                _ => {
+                    eprintln!("hale replay: --at requires a positive count");
+                    return ExitCode::from(2);
+                }
+            }
+        } else if a.starts_with('-') {
+            eprintln!("hale replay: unknown flag `{}`", a);
+            return ExitCode::from(2);
+        } else if rec_arg.is_none() {
+            rec_arg = Some(PathBuf::from(a));
+            i += 1;
+        } else if prog.is_none() {
+            prog = Some(PathBuf::from(a));
+            i += 1;
+        } else {
+            eprintln!("hale replay: unexpected extra argument `{}`", a);
+            return ExitCode::from(2);
+        }
+    }
+    let (rec_path, prog) = match (rec_arg, prog) {
+        (Some(r), Some(p)) => (r, p),
+        _ => {
+            eprintln!(
+                "usage: hale replay <recording> <program.hl> \
+                 [--diff] [--at N]"
+            );
+            return ExitCode::from(2);
+        }
+    };
+
+    let rec = match replay::parse(&rec_path) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("hale replay: {}", e);
+            return ExitCode::from(1);
+        }
+    };
+    if !rec.clean {
+        eprintln!(
+            "hale replay: `{}` has no clean-finalize trailer — the \
+             recording is truncated and a partial history replays \
+             as a silent divergence; re-record",
+            rec_path.display()
+        );
+        return ExitCode::from(1);
+    }
+
+    if !prog.is_file() {
+        eprintln!(
+            "hale replay: `{}` is not a file (directory seeds are \
+             not replayable yet)",
+            prog.display()
+        );
+        return ExitCode::from(1);
+    }
+    // Same compile pipeline as `hale run` (parse → check → model
+    // hash), so a recording is admitted against exactly what runs.
+    let (program, renames, sources, file_bases, _ctx) =
+        match parse_with_imports(&prog) {
+            Ok(x) => x,
+            Err(errors) => {
+                for (path, d, src) in &errors {
+                    eprintln!("{}:", path.display());
+                    eprintln!("  {}", d.render(src));
+                }
+                return ExitCode::from(1);
+            }
+        };
+    let mut bundle_programs: BTreeMap<String, &Program> = BTreeMap::new();
+    bundle_programs.insert(prog.display().to_string(), &program);
+    let mut bundle = hale_types::Bundle::new(bundle_programs);
+    bundle.import_renames = renames.clone();
+    let diags = hale_types::check_bundle_opts(&bundle, false);
+    if !diags.is_empty() {
+        for d in &diags {
+            eprintln!("{}", render_located(d, &file_bases, &sources));
+        }
+        if diags.iter().any(|d| d.is_error()) {
+            return ExitCode::from(1);
+        }
+    }
+    let model_hash = hale_types::topology::model_shape_hash(&bundle);
+
+    // Admission (#262's shape): a recording that no longer matches
+    // the model is rejected, never silently misreplayed. 0 =
+    // unstamped (harness recording) — allowed with a warning.
+    if rec.model_hash != 0 && rec.model_hash != model_hash {
+        eprintln!(
+            "hale replay: `{}` was recorded from a different model \
+             (recorded shape_hash {:016x}, this program is {:016x}) \
+             — refusing to misreplay; re-record against this \
+             program",
+            rec_path.display(),
+            rec.model_hash,
+            model_hash
+        );
+        return ExitCode::from(1);
+    }
+    if rec.model_hash == 0 {
+        eprintln!(
+            "hale replay: recording carries no model identity \
+             (unstamped build) — admission check skipped"
+        );
+    }
+
+    let rec_abs = rec_path
+        .canonicalize()
+        .unwrap_or_else(|_| rec_path.clone());
+
+    let mut bin = std::env::temp_dir();
+    let mut h = DefaultHasher::new();
+    h.write_usize(program.items.len());
+    h.write_u32(std::process::id());
+    bin.push(format!("hale_replay_{:016x}", h.finish()));
+    let options = hale_codegen::BuildOptions {
+        model_hash: Some(model_hash),
+        ..Default::default()
+    };
+    if let Err(e) = hale_codegen::build_executable_with_options(
+        &program, &bin, &renames, &options,
+    ) {
+        eprintln!("build error: {:?}", e);
+        return ExitCode::from(1);
+    }
+
+    let verify_path = if diff {
+        let mut v = std::env::temp_dir();
+        v.push(format!(
+            "hale_replay_verify_{}_{:016x}.halerec",
+            std::process::id(),
+            model_hash
+        ));
+        let _ = std::fs::remove_file(&v);
+        Some(v)
+    } else {
+        None
+    };
+
+    let mut cmd = std::process::Command::new(&bin);
+    cmd.env("LOTUS_REPLAY", &rec_abs);
+    if let Some(n) = at {
+        cmd.env("LOTUS_REPLAY_AT", n.to_string());
+    }
+    if let Some(v) = &verify_path {
+        cmd.env("LOTUS_OBS_RECORD", v);
+    }
+    let status = cmd.status();
+    let _ = std::fs::remove_file(&bin);
+    let code = match status {
+        Ok(s) => s.code().unwrap_or(1).clamp(0, 255) as u8,
+        Err(e) => {
+            eprintln!("could not execute compiled program: {}", e);
+            if let Some(v) = &verify_path {
+                let _ = std::fs::remove_file(v);
+            }
+            return ExitCode::from(1);
+        }
+    };
+
+    if let Some(v) = &verify_path {
+        let result = match replay::parse(v) {
+            Ok(vr) => match replay::diff(&rec, &vr) {
+                None => {
+                    let consumes: usize = rec
+                        .consume_streams
+                        .iter()
+                        .map(|(_, s)| s.len())
+                        .sum();
+                    println!(
+                        "replay matches the recording: {} consumes \
+                         across {} consumers, payloads identical \
+                         ({} ring records, {} journal reads)",
+                        consumes,
+                        rec.consume_streams.len(),
+                        rec.ring_records,
+                        rec.journal_entries
+                    );
+                    ExitCode::from(code)
+                }
+                Some(msg) => {
+                    eprintln!("replay DIVERGED: {}", msg);
+                    ExitCode::from(1)
+                }
+            },
+            Err(e) => {
+                eprintln!(
+                    "hale replay: verification recording unreadable: {}",
+                    e
+                );
+                ExitCode::from(1)
+            }
+        };
+        let _ = std::fs::remove_file(v);
+        return result;
+    }
+    ExitCode::from(code)
 }
 
 fn run_program(target: &Path, user_args: &[String]) -> ExitCode {

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -4559,23 +4559,40 @@ fn compile_and_exec(
 /// inputs". Residue it cannot see: the LLVM/libc toolchain outside
 /// this binary and the linker environment — a post-link binary
 /// digest is the staged stronger form.
-fn exec_digest(sources: &BTreeMap<PathBuf, String>) -> [u64; 4] {
+fn exec_digest(
+    sources: &BTreeMap<PathBuf, String>,
+    entry: &Path,
+    options_fp: &str,
+) -> [u64; 4] {
     let mut buf: Vec<u8> = Vec::new();
     let frame = |b: &[u8], buf: &mut Vec<u8>| {
         buf.extend_from_slice(&(b.len() as u64).to_le_bytes());
         buf.extend_from_slice(b);
     };
-    frame(env!("HALE_CODEGEN_SRC_HASH").as_bytes(), &mut buf);
+    // Round 3: the toolchain half is the FULL workspace-source
+    // SHA-256 (parser, analyses, codegen, every runtime TU incl.
+    // lotus_obs.c, stdlib seeds, the replay CLI) + rustc version +
+    // git commit — computed by build.rs. The old 64-bit stale-CLI
+    // hash covered three files and missed the record/replay
+    // implementation entirely.
+    frame(env!("HALE_TOOLCHAIN_SHA256").as_bytes(), &mut buf);
     frame(env!("CARGO_PKG_VERSION").as_bytes(), &mut buf);
-    frame(b"target=native;profile=release", &mut buf);
+    frame(options_fp.as_bytes(), &mut buf);
     buf.extend_from_slice(&(sources.len() as u64).to_le_bytes());
+    // Logical (entry-relative) source ids: identical trees checked
+    // out under different roots are the same build inputs.
+    let base = entry.parent().map(Path::to_path_buf);
     for (path, src) in sources {
-        let full = path
-            .canonicalize()
-            .unwrap_or_else(|_| path.clone())
-            .display()
-            .to_string();
-        frame(full.as_bytes(), &mut buf);
+        let logical = base
+            .as_deref()
+            .and_then(|b| path.strip_prefix(b).ok())
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| {
+                path.file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default()
+            });
+        frame(logical.as_bytes(), &mut buf);
         frame(src.as_bytes(), &mut buf);
     }
     let d = openssl::sha::sha256(&buf);
@@ -5019,7 +5036,85 @@ fn run_replay(args: &[String]) -> ExitCode {
         }
     }
     let model_hash = hale_types::topology::model_shape_hash(&bundle);
-    let digest = exec_digest(&sources);
+    let base_options = hale_codegen::BuildOptions::default();
+    let options_fp = format!(
+        "target={:?};cpu={:?};dev={};debug={}",
+        base_options.target,
+        base_options.target_cpu,
+        base_options.dev_profile,
+        base_options.debug.is_some()
+    );
+    let digest = exec_digest(&sources, &prog, &options_fp);
+
+    // Ordered BEFORE identity admission: this refusal is inherent
+    // to the PROGRAM, so it must not be masked by a
+    // recording-mismatch message (and module-gate canaries can
+    // assert it with any recording).
+    // Safe by default (review finding 3, both rounds): re-execution
+    // repeats the program's real side effects. The gate consumes
+    // the TYPED inferred rows, and it must fail CLOSED on the two
+    // paths the first version failed open on: `unclassified`
+    // ("may do anything") and a `publish` whose subject is bound to
+    // an external transport (the send is generated deployment
+    // machinery, invisible in user-level effects). Coarse by class
+    // granularity — over-refusing is the safe direction;
+    // per-primitive replay classes are the staged refinement.
+    if !allow_live_effects {
+        let programs: Vec<&Program> =
+            bundle.programs.values().copied().collect();
+        let rows =
+            hale_types::effects::effect_manifest_with_inference(&programs);
+        let mut residue = std::collections::BTreeSet::new();
+        for row in &rows {
+            for class in &row.inferred {
+                if class == "syscall"
+                    || class == "ffi"
+                    || class == "unclassified"
+                {
+                    residue.insert(class.clone());
+                }
+            }
+        }
+        // External transport bindings: any `bindings { }` block
+        // makes publishes (and listener startup) touch the real
+        // world during re-execution.
+        // Modules nest top declarations arbitrarily deep (round 3,
+        // finding 2) — walk them, or a module-contained binding
+        // fails open.
+        fn scan_bindings(items: &[hale_syntax::ast::TopDecl]) -> bool {
+            items.iter().any(|item| match item {
+                hale_syntax::ast::TopDecl::Locus(l) => {
+                    l.members.iter().any(|m| {
+                        matches!(
+                            m,
+                            hale_syntax::ast::LocusMember::Bindings(_)
+                        )
+                    })
+                }
+                hale_syntax::ast::TopDecl::Module(md) => {
+                    scan_bindings(&md.items)
+                }
+                _ => false,
+            })
+        }
+        let has_bindings =
+            bundle.programs.values().any(|p| scan_bindings(&p.items));
+        if has_bindings {
+            residue.insert("external-bindings".to_string());
+        }
+        if !residue.is_empty() {
+            eprintln!(
+                "hale replay: this program can reach the live world \
+                 during re-execution ({{{}}}) — publishes to bound \
+                 topics send real traffic, unclassified calls may \
+                 do anything, and syscall/ffi writes repeat. \
+                 Refusing by default; pass --allow-live-effects if \
+                 you accept that",
+                residue.into_iter().collect::<Vec<_>>().join(", ")
+            );
+            return ExitCode::from(1);
+        }
+    }
 
     // Admission, strongest check first (review finding 2):
     // exec_digest is framed-SHA-256 build-input identity;
@@ -5062,66 +5157,6 @@ fn run_replay(args: &[String]) -> ExitCode {
             rec_path.display()
         );
         return ExitCode::from(1);
-    }
-
-    // Safe by default (review finding 3, both rounds): re-execution
-    // repeats the program's real side effects. The gate consumes
-    // the TYPED inferred rows, and it must fail CLOSED on the two
-    // paths the first version failed open on: `unclassified`
-    // ("may do anything") and a `publish` whose subject is bound to
-    // an external transport (the send is generated deployment
-    // machinery, invisible in user-level effects). Coarse by class
-    // granularity — over-refusing is the safe direction;
-    // per-primitive replay classes are the staged refinement.
-    if !allow_live_effects {
-        let programs: Vec<&Program> =
-            bundle.programs.values().copied().collect();
-        let rows =
-            hale_types::effects::effect_manifest_with_inference(&programs);
-        let mut residue = std::collections::BTreeSet::new();
-        for row in &rows {
-            for class in &row.inferred {
-                if class == "syscall"
-                    || class == "ffi"
-                    || class == "unclassified"
-                {
-                    residue.insert(class.clone());
-                }
-            }
-        }
-        // External transport bindings: any `bindings { }` block
-        // makes publishes (and listener startup) touch the real
-        // world during re-execution.
-        let mut has_bindings = false;
-        for prog in bundle.programs.values() {
-            for item in &prog.items {
-                if let hale_syntax::ast::TopDecl::Locus(l) = item {
-                    if l.members.iter().any(|m| {
-                        matches!(
-                            m,
-                            hale_syntax::ast::LocusMember::Bindings(_)
-                        )
-                    }) {
-                        has_bindings = true;
-                    }
-                }
-            }
-        }
-        if has_bindings {
-            residue.insert("external-bindings".to_string());
-        }
-        if !residue.is_empty() {
-            eprintln!(
-                "hale replay: this program can reach the live world \
-                 during re-execution ({{{}}}) — publishes to bound \
-                 topics send real traffic, unclassified calls may \
-                 do anything, and syscall/ffi writes repeat. \
-                 Refusing by default; pass --allow-live-effects if \
-                 you accept that",
-                residue.into_iter().collect::<Vec<_>>().join(", ")
-            );
-            return ExitCode::from(1);
-        }
     }
 
     if rec.env_redacted {
@@ -5186,6 +5221,44 @@ fn run_replay(args: &[String]) -> ExitCode {
     let mut cmd = std::process::Command::new(&bin);
     cmd.env("LOTUS_REPLAY", &rec_abs);
     cmd.env("LOTUS_REPLAY_STATUS", &status_path);
+    // Round 3 (artifact trust): the CHILD reads the same file
+    // OBJECT the CLI validated — the fd is inherited (dup2'd to a
+    // fixed number post-fork), so there is no path re-resolution
+    // window between the two validations. The runtime still
+    // revalidates fully and snapshots the bytes into anonymous
+    // memory before serving.
+    {
+        use std::os::unix::io::AsRawFd;
+        use std::os::unix::process::CommandExt;
+        match std::fs::File::open(&rec_abs) {
+            Ok(f) => {
+                let raw = f.as_raw_fd();
+                const REPLAY_FD: i32 = 973;
+                cmd.env("LOTUS_REPLAY_FD", REPLAY_FD.to_string());
+                unsafe {
+                    cmd.pre_exec(move || {
+                        if libc::dup2(raw, REPLAY_FD) < 0 {
+                            return Err(
+                                std::io::Error::last_os_error(),
+                            );
+                        }
+                        Ok(())
+                    });
+                }
+                // Keep the File alive across spawn.
+                std::mem::forget(f);
+            }
+            Err(e) => {
+                eprintln!(
+                    "hale replay: could not reopen `{}` for the \
+                     child: {}",
+                    rec_abs.display(),
+                    e
+                );
+                return ExitCode::from(1);
+            }
+        }
+    }
     if let Some(spec) = &at {
         match spec.split_once(':') {
             Some((c, n)) => {
@@ -5336,7 +5409,15 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         // P26: stamp the model identity of the bundle just checked.
         let model_hash =
             hale_types::topology::model_shape_hash(&bundle);
-        let digest = exec_digest(&sources);
+        let base_options = hale_codegen::BuildOptions::default();
+        let options_fp = format!(
+            "target={:?};cpu={:?};dev={};debug={}",
+            base_options.target,
+            base_options.target_cpu,
+            base_options.dev_profile,
+            base_options.debug.is_some()
+        );
+        let digest = exec_digest(&sources, target, &options_fp);
         return compile_and_exec(
             &program, &renames, user_args, model_hash, digest,
         );
@@ -5460,7 +5541,15 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
     }
     // P26: stamp the model identity of the bundle just checked.
     let model_hash = hale_types::topology::model_shape_hash(&bundle);
-    let digest = exec_digest(&path_sources);
+    let base_options = hale_codegen::BuildOptions::default();
+    let options_fp = format!(
+        "target={:?};cpu={:?};dev={};debug={}",
+        base_options.target,
+        base_options.target_cpu,
+        base_options.dev_profile,
+        base_options.debug.is_some()
+    );
+    let digest = exec_digest(&path_sources, target, &options_fp);
     compile_and_exec(&program, &renames, user_args, model_hash, digest)
 }
 

--- a/crates/hale-cli/src/replay.rs
+++ b/crates/hale-cli/src/replay.rs
@@ -12,8 +12,11 @@ use std::path::Path;
 pub const REC_MAGIC: u64 = 0x30434552454C4148; // "HALEREC0"
 pub const REC_END: u64 = 0x30444E45454C4148; // "HALEEND0"
 
-const EK_BUS_CONSUME: u32 = 8;
-const EK_CONSUMER: u32 = 12;
+// Private recorder-event namespace (tag-0 entries whose ring
+// carries PRIV_RING) — disjoint from iris protocol ekinds.
+const REC_EV_CONSUMER: u32 = 1;
+const REC_EV_CONSUME: u32 = 2;
+const PRIV_RING: u32 = 0x8000_0000;
 
 fn u32_at(b: &[u8], off: usize) -> u32 {
     u32::from_le_bytes(b[off..off + 4].try_into().unwrap())
@@ -24,10 +27,14 @@ fn u64_at(b: &[u8], off: usize) -> u64 {
 
 pub struct Recording {
     pub model_hash: u64,
+    pub exec_digest: u64,
     pub clean: bool,
     pub ring_records: usize,
-    pub payloads: Vec<(u64, u64, Vec<u8>)>, // (pub_id, flags, bytes)
-    pub journal_entries: usize,
+    /// (pub_id, topic, flags, bytes); flags bit 0 = ingress,
+    /// bit 1 = raw in-process struct (NOT byte-comparable).
+    pub payloads: Vec<(u64, u32, u64, Vec<u8>)>,
+    /// (consumer, jkind, arghash, bytes) in file order.
+    pub journal: Vec<(u64, u32, u32, Vec<u8>)>,
     /// Per consumer id: the ordered pub_id consume stream.
     pub consume_streams: Vec<(u64, Vec<u64>)>,
 }
@@ -53,17 +60,28 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
         ));
     }
     let header_len = u32_at(&buf, 12) as usize;
+    if header_len != 64 {
+        return Err(format!(
+            "`{}`: unexpected header length {}",
+            path.display(),
+            header_len
+        ));
+    }
     let model_hash = u64_at(&buf, 48);
+    let exec_digest = u64_at(&buf, 56);
     let mut end = buf.len();
-    let clean = end >= header_len + 16 && u64_at(&buf, end - 16) == REC_END;
-    if clean {
+    let has_trailer =
+        end >= header_len + 16 && u64_at(&buf, end - 16) == REC_END;
+    let trailer_count = if has_trailer { u64_at(&buf, end - 8) } else { 0 };
+    if has_trailer {
         end -= 16;
     }
 
     let mut ring_consumer = [0u64; 64];
     let mut streams: Vec<(u64, Vec<u64>)> = Vec::new();
     let mut payloads = Vec::new();
-    let mut journal_entries = 0usize;
+    let mut journal = Vec::new();
+    let mut total_entries = 0u64;
     let mut ring_records = 0usize;
     let mut off = header_len;
     while off + 8 <= end {
@@ -74,19 +92,29 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
                 if off + 24 > end {
                     break;
                 }
+                total_entries += 1;
                 ring_records += 1;
                 let w0 = u64_at(&buf, off + 8);
                 let w1 = u64_at(&buf, off + 16);
                 let ekind = ((w0 >> 20) & 0x1F) as u32;
-                let ring = a as usize;
-                if ekind == EK_CONSUMER && ring < 64 {
-                    ring_consumer[ring] = w1;
-                } else if ekind == EK_BUS_CONSUME && ring < 64 {
-                    let cid = ring_consumer[ring];
-                    let pub_id = w1 & 0xFFF_FFFF_FFFF;
-                    match streams.iter_mut().find(|(c, _)| *c == cid) {
-                        Some((_, v)) => v.push(pub_id),
-                        None => streams.push((cid, vec![pub_id])),
+                if a & PRIV_RING != 0 {
+                    let pr = (a & !PRIV_RING) as usize;
+                    if pr < 64 {
+                        if ekind == REC_EV_CONSUMER {
+                            ring_consumer[pr] = w1;
+                        } else if ekind == REC_EV_CONSUME {
+                            let cid = ring_consumer[pr];
+                            let pub_id = w1 & 0xFFF_FFFF_FFFF;
+                            match streams
+                                .iter_mut()
+                                .find(|(c, _)| *c == cid)
+                            {
+                                Some((_, v)) => v.push(pub_id),
+                                None => {
+                                    streams.push((cid, vec![pub_id]))
+                                }
+                            }
+                        }
                     }
                 }
                 off += 24;
@@ -102,14 +130,21 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
                 if off + 32 + padded > end {
                     break;
                 }
+                total_entries += 1;
                 if tag == 1 {
                     payloads.push((
                         b,
+                        a,
                         c,
                         buf[off + 32..off + 32 + size].to_vec(),
                     ));
                 } else {
-                    journal_entries += 1;
+                    journal.push((
+                        b,
+                        a,
+                        (c >> 32) as u32,
+                        buf[off + 32..off + 32 + size].to_vec(),
+                    ));
                 }
                 off += 32 + padded;
             }
@@ -124,12 +159,18 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
             }
         }
     }
+    // A clean recording means the WHOLE artifact validated: parse
+    // must end exactly at the trailer and the trailer's count must
+    // match what was parsed (review finding 5 — trailer magic at
+    // EOF alone admits internally truncated files).
+    let clean = has_trailer && off == end && trailer_count == total_entries;
     Ok(Recording {
         model_hash,
+        exec_digest,
         clean,
         ring_records,
         payloads,
-        journal_entries,
+        journal,
         consume_streams: streams,
     })
 }
@@ -176,20 +217,81 @@ pub fn diff(original: &Recording, replayed: &Recording) -> Option<String> {
             ));
         }
     }
-    // Payload comparison: same pub_id → same bytes.
-    for (pub_id, _, bytes) in &original.payloads {
-        if let Some((_, _, rb)) =
-            replayed.payloads.iter().find(|(p, _, _)| p == pub_id)
+    // Payloads, bidirectionally: every recorded publish must exist
+    // in the replay and vice versa; topic and flags must agree; a
+    // raw-struct payload (flag bit 1) is an ABI snapshot whose
+    // bytes are ASLR-dependent, so it compares by size only.
+    for (pub_id, topic, flags, bytes) in &original.payloads {
+        match replayed.payloads.iter().find(|(p, _, _, _)| p == pub_id)
         {
-            if rb != bytes {
+            None => {
                 return Some(format!(
-                    "delivery {:#x}: payload bytes differ ({} vs {} \
-                     bytes)",
-                    pub_id,
-                    bytes.len(),
-                    rb.len()
+                    "publish {:#x} (topic {}) has no counterpart \
+                     in the replay",
+                    pub_id, topic
                 ));
             }
+            Some((_, rt, rf, rb)) => {
+                if rt != topic || rf != flags {
+                    return Some(format!(
+                        "publish {:#x}: topic/flags differ \
+                         ({}/{:#x} vs {}/{:#x})",
+                        pub_id, topic, flags, rt, rf
+                    ));
+                }
+                let raw = flags & 2 != 0;
+                if (raw && rb.len() != bytes.len())
+                    || (!raw && rb != bytes)
+                {
+                    return Some(format!(
+                        "publish {:#x}: payload {} differ ({} vs \
+                         {} bytes)",
+                        pub_id,
+                        if raw { "sizes" } else { "bytes" },
+                        bytes.len(),
+                        rb.len()
+                    ));
+                }
+            }
+        }
+    }
+    for (pub_id, topic, _, _) in &replayed.payloads {
+        if !original.payloads.iter().any(|(p, _, _, _)| p == pub_id) {
+            return Some(format!(
+                "replay produced publish {:#x} (topic {}) that the \
+                 recording does not contain",
+                pub_id, topic
+            ));
+        }
+    }
+    // Journal streams: same reads, same identities, same values,
+    // in the same per-consumer order.
+    if original.journal.len() != replayed.journal.len() {
+        return Some(format!(
+            "{} journaled reads recorded, {} in the replay",
+            original.journal.len(),
+            replayed.journal.len()
+        ));
+    }
+    for (i, (o, r)) in original
+        .journal
+        .iter()
+        .zip(replayed.journal.iter())
+        .enumerate()
+    {
+        if o != r {
+            return Some(format!(
+                "journal read #{}: (consumer {}, kind {}, args \
+                 {:#x}) recorded vs (consumer {}, kind {}, args \
+                 {:#x}) replayed",
+                i + 1,
+                o.0,
+                o.1,
+                o.2,
+                r.0,
+                r.1,
+                r.2
+            ));
         }
     }
     None

--- a/crates/hale-cli/src/replay.rs
+++ b/crates/hale-cli/src/replay.rs
@@ -266,7 +266,21 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
 
     // Resolve public bus records into per-consumer, subject-aligned
     // streams. A ring with no consumer mapping keys under 0.
+    //
+    // Sequence NORMALIZATION (round 3 CI finding): the per-topic
+    // seq counter is shared by every publisher of a subject, so the
+    // raw values assigned to two RACING publishers depend on their
+    // interleaving — which is exactly the cross-consumer ordering
+    // the recording never promises. Within one consumer's stream,
+    // what is deterministic is the publish's rank, and what pairing
+    // needs is only that a publish and its delivers share an
+    // identity. So each raw seq maps to its first-appearance
+    // ordinal within (consumer, subject): stable across runs,
+    // pairing-preserving within the stream, and a genuinely
+    // different publish count or order still diverges.
     let mut public: Vec<(u64, Vec<PubEvent>)> = Vec::new();
+    let mut ranks: BTreeMap<(u64, u32, u64), u64> = BTreeMap::new();
+    let mut next_rank: BTreeMap<(u64, u32), u64> = BTreeMap::new();
     for (ring, w0, w1) in public_raw {
         let ekind = ((w0 >> 20) & 0x1F) as u32;
         if ekind != EK_BUS_PUBLISH && ekind != EK_BUS_DELIVER {
@@ -274,6 +288,13 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
         }
         let id = (w0 & 0xFFFFF) as u32;
         let cid = pub_ring_consumer.get(&ring).copied().unwrap_or(0);
+        let raw_seq = w1 & 0xFFF_FFFF_FFFF;
+        let rank = *ranks.entry((cid, id, raw_seq)).or_insert_with(|| {
+            let n = next_rank.entry((cid, id)).or_insert(0);
+            let r = *n;
+            *n += 1;
+            r
+        });
         let ev = PubEvent {
             subject: topic_names
                 .get(&id)
@@ -281,7 +302,7 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
                 .unwrap_or_else(|| format!("<topic-{}>", id)),
             ekind,
             locus: ((w1 >> 44) & 0xFFFFF) as u32,
-            seq: w1 & 0xFFF_FFFF_FFFF,
+            seq: rank,
         };
         match public.iter_mut().find(|(c, _)| *c == cid) {
             Some((_, v)) => v.push(ev),

--- a/crates/hale-cli/src/replay.rs
+++ b/crates/hale-cli/src/replay.rs
@@ -1,0 +1,196 @@
+//! GH #296: recording-file parsing and comparison for `hale replay`.
+//!
+//! Format v0.2 (PRE-STABLE — the runtime's `lotus_obs.c` is the
+//! producer; this reader and the test-support reader in
+//! `hale-codegen/tests/support/obs.rs` must track it): 64-byte
+//! header, tagged entries (tag 0 = 24-byte ring record, tag 1 =
+//! payload blob, tag 2 = journal blob; blobs are a 32-byte header +
+//! bytes padded to 8), 16-byte clean-finalize trailer.
+
+use std::path::Path;
+
+pub const REC_MAGIC: u64 = 0x30434552454C4148; // "HALEREC0"
+pub const REC_END: u64 = 0x30444E45454C4148; // "HALEEND0"
+
+const EK_BUS_CONSUME: u32 = 8;
+const EK_CONSUMER: u32 = 12;
+
+fn u32_at(b: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes(b[off..off + 4].try_into().unwrap())
+}
+fn u64_at(b: &[u8], off: usize) -> u64 {
+    u64::from_le_bytes(b[off..off + 8].try_into().unwrap())
+}
+
+pub struct Recording {
+    pub model_hash: u64,
+    pub clean: bool,
+    pub ring_records: usize,
+    pub payloads: Vec<(u64, u64, Vec<u8>)>, // (pub_id, flags, bytes)
+    pub journal_entries: usize,
+    /// Per consumer id: the ordered pub_id consume stream.
+    pub consume_streams: Vec<(u64, Vec<u64>)>,
+}
+
+pub fn parse(path: &Path) -> Result<Recording, String> {
+    let buf = std::fs::read(path)
+        .map_err(|e| format!("could not read `{}`: {}", path.display(), e))?;
+    if buf.len() < 80 || u64_at(&buf, 0) != REC_MAGIC {
+        return Err(format!(
+            "`{}` is not a hale recording (bad magic)",
+            path.display()
+        ));
+    }
+    let maj = u16::from_le_bytes(buf[8..10].try_into().unwrap());
+    let min = u16::from_le_bytes(buf[10..12].try_into().unwrap());
+    if maj != 0 || min < 2 {
+        return Err(format!(
+            "`{}` is a v{}.{} recording; this hale replays v0.2+ \
+             (re-record with this toolchain)",
+            path.display(),
+            maj,
+            min
+        ));
+    }
+    let header_len = u32_at(&buf, 12) as usize;
+    let model_hash = u64_at(&buf, 48);
+    let mut end = buf.len();
+    let clean = end >= header_len + 16 && u64_at(&buf, end - 16) == REC_END;
+    if clean {
+        end -= 16;
+    }
+
+    let mut ring_consumer = [0u64; 64];
+    let mut streams: Vec<(u64, Vec<u64>)> = Vec::new();
+    let mut payloads = Vec::new();
+    let mut journal_entries = 0usize;
+    let mut ring_records = 0usize;
+    let mut off = header_len;
+    while off + 8 <= end {
+        let tag = u32_at(&buf, off);
+        let a = u32_at(&buf, off + 4);
+        match tag {
+            0 => {
+                if off + 24 > end {
+                    break;
+                }
+                ring_records += 1;
+                let w0 = u64_at(&buf, off + 8);
+                let w1 = u64_at(&buf, off + 16);
+                let ekind = ((w0 >> 20) & 0x1F) as u32;
+                let ring = a as usize;
+                if ekind == EK_CONSUMER && ring < 64 {
+                    ring_consumer[ring] = w1;
+                } else if ekind == EK_BUS_CONSUME && ring < 64 {
+                    let cid = ring_consumer[ring];
+                    let pub_id = w1 & 0xFFF_FFFF_FFFF;
+                    match streams.iter_mut().find(|(c, _)| *c == cid) {
+                        Some((_, v)) => v.push(pub_id),
+                        None => streams.push((cid, vec![pub_id])),
+                    }
+                }
+                off += 24;
+            }
+            1 | 2 => {
+                if off + 32 > end {
+                    break;
+                }
+                let b = u64_at(&buf, off + 8);
+                let c = u64_at(&buf, off + 16);
+                let size = u64_at(&buf, off + 24) as usize;
+                let padded = (size + 7) & !7;
+                if off + 32 + padded > end {
+                    break;
+                }
+                if tag == 1 {
+                    payloads.push((
+                        b,
+                        c,
+                        buf[off + 32..off + 32 + size].to_vec(),
+                    ));
+                } else {
+                    journal_entries += 1;
+                }
+                off += 32 + padded;
+            }
+            other => {
+                return Err(format!(
+                    "`{}`: unknown entry tag {} at offset {} — \
+                     recording from a newer hale?",
+                    path.display(),
+                    other,
+                    off
+                ));
+            }
+        }
+    }
+    Ok(Recording {
+        model_hash,
+        clean,
+        ring_records,
+        payloads,
+        journal_entries,
+        consume_streams: streams,
+    })
+}
+
+/// Compare two recordings' per-consumer consume streams and payload
+/// bytes. Returns None when equivalent, or a human-readable first
+/// divergence.
+pub fn diff(original: &Recording, replayed: &Recording) -> Option<String> {
+    for (cid, orig) in &original.consume_streams {
+        let rep = replayed
+            .consume_streams
+            .iter()
+            .find(|(c, _)| c == cid)
+            .map(|(_, v)| v.as_slice())
+            .unwrap_or(&[]);
+        let n = orig.len().min(rep.len());
+        for i in 0..n {
+            if orig[i] != rep[i] {
+                return Some(format!(
+                    "consumer {}: consume #{} was delivery {:#x} in \
+                     the recording, {:#x} in the replay",
+                    cid,
+                    i + 1,
+                    orig[i],
+                    rep[i]
+                ));
+            }
+        }
+        if orig.len() != rep.len() {
+            return Some(format!(
+                "consumer {}: {} consumes recorded, {} replayed",
+                cid,
+                orig.len(),
+                rep.len()
+            ));
+        }
+    }
+    for (cid, _) in &replayed.consume_streams {
+        if !original.consume_streams.iter().any(|(c, _)| c == cid) {
+            return Some(format!(
+                "consumer {} appeared in the replay but not in the \
+                 recording",
+                cid
+            ));
+        }
+    }
+    // Payload comparison: same pub_id → same bytes.
+    for (pub_id, _, bytes) in &original.payloads {
+        if let Some((_, _, rb)) =
+            replayed.payloads.iter().find(|(p, _, _)| p == pub_id)
+        {
+            if rb != bytes {
+                return Some(format!(
+                    "delivery {:#x}: payload bytes differ ({} vs {} \
+                     bytes)",
+                    pub_id,
+                    bytes.len(),
+                    rb.len()
+                ));
+            }
+        }
+    }
+    None
+}

--- a/crates/hale-cli/src/replay.rs
+++ b/crates/hale-cli/src/replay.rs
@@ -1,22 +1,32 @@
 //! GH #296: recording-file parsing and comparison for `hale replay`.
 //!
-//! Format v0.2 (PRE-STABLE — the runtime's `lotus_obs.c` is the
+//! Format v0.3 (PRE-STABLE — the runtime's `lotus_obs.c` is the
 //! producer; this reader and the test-support reader in
-//! `hale-codegen/tests/support/obs.rs` must track it): 64-byte
-//! header, tagged entries (tag 0 = 24-byte ring record, tag 1 =
-//! payload blob, tag 2 = journal blob; blobs are a 32-byte header +
-//! bytes padded to 8), 16-byte clean-finalize trailer.
+//! `hale-codegen/tests/support/obs.rs` must track it): 96-byte
+//! header, tagged entries (tag 0 = 24-byte ring record; tags 1–3 =
+//! payload / journal / meta blobs, each a 32-byte header + bytes
+//! padded to 8), 16-byte clean-finalize trailer. `clean` means the
+//! WHOLE artifact validated: exact parse to the trailer and a
+//! matching entry count — trailer magic at EOF alone proves nothing.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 
 pub const REC_MAGIC: u64 = 0x30434552454C4148; // "HALEREC0"
 pub const REC_END: u64 = 0x30444E45454C4148; // "HALEEND0"
 
-// Private recorder-event namespace (tag-0 entries whose ring
+// Private recorder-event namespace (tag-0 entries whose ring field
 // carries PRIV_RING) — disjoint from iris protocol ekinds.
 const REC_EV_CONSUMER: u32 = 1;
 const REC_EV_CONSUME: u32 = 2;
 const PRIV_RING: u32 = 0x8000_0000;
+
+// Public iris ekinds the comparator aligns across runs.
+const EK_BUS_PUBLISH: u32 = 1;
+const EK_BUS_DELIVER: u32 = 2;
+
+const META_TOPIC: u64 = 1;
+const META_PUBRING: u64 = 2;
 
 fn u32_at(b: &[u8], off: usize) -> u32 {
     u32::from_le_bytes(b[off..off + 4].try_into().unwrap())
@@ -25,34 +35,66 @@ fn u64_at(b: &[u8], off: usize) -> u64 {
     u64::from_le_bytes(b[off..off + 8].try_into().unwrap())
 }
 
+pub struct RecPayload {
+    pub pub_id: u64,
+    pub topic: u32,
+    /// bit 0 = external ingress; bit 1 = raw in-process struct
+    /// (metadata only — no bytes stored, declared size in
+    /// `raw_size`).
+    pub flags: u32,
+    pub raw_size: u64,
+    pub bytes: Vec<u8>,
+}
+
+pub struct RecJournal {
+    pub consumer: u64,
+    pub jkind: u32,
+    pub withheld: bool,
+    pub args: Vec<u8>,
+    pub result: Vec<u8>,
+}
+
+/// One public bus event, aligned across runs by subject name (the
+/// manifest id is registration-order and races) and consumer id
+/// (the ring index is claim-order and races).
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct PubEvent {
+    pub subject: String,
+    pub ekind: u32,
+    pub locus: u32,
+    pub seq: u64,
+}
+
 pub struct Recording {
     pub model_hash: u64,
-    pub exec_digest: u64,
+    pub exec_digest: [u64; 4],
+    pub env_redacted: bool,
     pub clean: bool,
     pub ring_records: usize,
-    /// (pub_id, topic, flags, bytes); flags bit 0 = ingress,
-    /// bit 1 = raw in-process struct (NOT byte-comparable).
-    pub payloads: Vec<(u64, u32, u64, Vec<u8>)>,
-    /// (consumer, jkind, arghash, bytes) in file order.
-    pub journal: Vec<(u64, u32, u32, Vec<u8>)>,
-    /// Per consumer id: the ordered pub_id consume stream.
-    pub consume_streams: Vec<(u64, Vec<u64>)>,
+    pub payloads: Vec<RecPayload>,
+    pub journal: Vec<RecJournal>,
+    /// Per consumer id: the ordered (target locus, msg_id) stream.
+    pub consume_streams: Vec<(u64, Vec<(u32, u64)>)>,
+    /// Per consumer id: the ordered PUBLIC bus stream (publish +
+    /// deliver), subject-aligned — this is what makes synchronous
+    /// direct dispatch visible to `--diff`.
+    pub public_streams: Vec<(u64, Vec<PubEvent>)>,
 }
 
 pub fn parse(path: &Path) -> Result<Recording, String> {
     let buf = std::fs::read(path)
         .map_err(|e| format!("could not read `{}`: {}", path.display(), e))?;
-    if buf.len() < 80 || u64_at(&buf, 0) != REC_MAGIC {
+    if buf.len() < 112 || u64_at(&buf, 0) != REC_MAGIC {
         return Err(format!(
-            "`{}` is not a hale recording (bad magic)",
+            "`{}` is not a hale recording (bad magic or too small)",
             path.display()
         ));
     }
     let maj = u16::from_le_bytes(buf[8..10].try_into().unwrap());
     let min = u16::from_le_bytes(buf[10..12].try_into().unwrap());
-    if maj != 0 || min < 2 {
+    if maj != 0 || min < 3 {
         return Err(format!(
-            "`{}` is a v{}.{} recording; this hale replays v0.2+ \
+            "`{}` is a v{}.{} recording; this hale replays v0.3+ \
              (re-record with this toolchain)",
             path.display(),
             maj,
@@ -60,7 +102,7 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
         ));
     }
     let header_len = u32_at(&buf, 12) as usize;
-    if header_len != 64 {
+    if header_len != 96 {
         return Err(format!(
             "`{}`: unexpected header length {}",
             path.display(),
@@ -68,7 +110,12 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
         ));
     }
     let model_hash = u64_at(&buf, 48);
-    let exec_digest = u64_at(&buf, 56);
+    let mut exec_digest = [0u64; 4];
+    for (i, part) in exec_digest.iter_mut().enumerate() {
+        *part = u64_at(&buf, 56 + i * 8);
+    }
+    let env_redacted = u64_at(&buf, 88) & 1 != 0;
+
     let mut end = buf.len();
     let has_trailer =
         end >= header_len + 16 && u64_at(&buf, end - 16) == REC_END;
@@ -77,8 +124,13 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
         end -= 16;
     }
 
-    let mut ring_consumer = [0u64; 64];
-    let mut streams: Vec<(u64, Vec<u64>)> = Vec::new();
+    let mut priv_ring_consumer = [0u64; 64];
+    let mut pub_ring_consumer: BTreeMap<u32, u64> = BTreeMap::new();
+    let mut topic_names: BTreeMap<u32, String> = BTreeMap::new();
+    let mut consume: Vec<(u64, Vec<(u32, u64)>)> = Vec::new();
+    // Public records buffered raw (ring, w0, w1) and resolved into
+    // streams at the end, once the meta maps are complete.
+    let mut public_raw: Vec<(u32, u64, u64)> = Vec::new();
     let mut payloads = Vec::new();
     let mut journal = Vec::new();
     let mut total_entries = 0u64;
@@ -87,64 +139,115 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
     while off + 8 <= end {
         let tag = u32_at(&buf, off);
         let a = u32_at(&buf, off + 4);
+        total_entries += 1;
         match tag {
             0 => {
-                if off + 24 > end {
-                    break;
+                if end - off < 24 {
+                    return Err("truncated ring record".into());
                 }
-                total_entries += 1;
                 ring_records += 1;
                 let w0 = u64_at(&buf, off + 8);
                 let w1 = u64_at(&buf, off + 16);
                 let ekind = ((w0 >> 20) & 0x1F) as u32;
                 if a & PRIV_RING != 0 {
                     let pr = (a & !PRIV_RING) as usize;
-                    if pr < 64 {
-                        if ekind == REC_EV_CONSUMER {
-                            ring_consumer[pr] = w1;
-                        } else if ekind == REC_EV_CONSUME {
-                            let cid = ring_consumer[pr];
-                            let pub_id = w1 & 0xFFF_FFFF_FFFF;
-                            match streams
-                                .iter_mut()
-                                .find(|(c, _)| *c == cid)
-                            {
-                                Some((_, v)) => v.push(pub_id),
-                                None => {
-                                    streams.push((cid, vec![pub_id]))
-                                }
+                    if pr >= 64 {
+                        return Err("private ring out of range".into());
+                    }
+                    if ekind == REC_EV_CONSUMER {
+                        priv_ring_consumer[pr] = w1;
+                    } else if ekind == REC_EV_CONSUME {
+                        let cid = priv_ring_consumer[pr];
+                        let locus = (w0 & 0xFFFFF) as u32;
+                        match consume.iter_mut().find(|(c, _)| *c == cid)
+                        {
+                            Some((_, v)) => v.push((locus, w1)),
+                            None => {
+                                consume.push((cid, vec![(locus, w1)]))
                             }
                         }
                     }
+                } else {
+                    public_raw.push((a, w0, w1));
                 }
                 off += 24;
             }
-            1 | 2 => {
-                if off + 32 > end {
-                    break;
+            1 | 2 | 3 => {
+                if end - off < 32 {
+                    return Err("truncated blob header".into());
                 }
                 let b = u64_at(&buf, off + 8);
                 let c = u64_at(&buf, off + 16);
                 let size = u64_at(&buf, off + 24) as usize;
-                let padded = (size + 7) & !7;
-                if off + 32 + padded > end {
-                    break;
+                if size > end - off - 32 {
+                    return Err("blob length out of range".into());
                 }
-                total_entries += 1;
-                if tag == 1 {
-                    payloads.push((
-                        b,
-                        a,
-                        c,
-                        buf[off + 32..off + 32 + size].to_vec(),
-                    ));
-                } else {
-                    journal.push((
-                        b,
-                        a,
-                        (c >> 32) as u32,
-                        buf[off + 32..off + 32 + size].to_vec(),
-                    ));
+                let padded = (size + 7) & !7;
+                if padded > end - off - 32 {
+                    return Err("blob padding out of range".into());
+                }
+                let bytes = &buf[off + 32..off + 32 + size];
+                match tag {
+                    1 => {
+                        let flags = c as u32;
+                        let raw = flags & 2 != 0;
+                        payloads.push(RecPayload {
+                            pub_id: b,
+                            topic: a,
+                            flags,
+                            raw_size: if raw {
+                                c >> 32
+                            } else {
+                                size as u64
+                            },
+                            bytes: if raw {
+                                Vec::new()
+                            } else {
+                                bytes.to_vec()
+                            },
+                        });
+                    }
+                    2 => {
+                        if size < 4 {
+                            return Err("journal entry too small".into());
+                        }
+                        let args_len = u32_at(bytes, 0) as usize;
+                        if args_len + 4 > size {
+                            return Err(
+                                "journal argument frame out of range"
+                                    .into(),
+                            );
+                        }
+                        journal.push(RecJournal {
+                            consumer: b,
+                            jkind: a,
+                            withheld: c >> 63 != 0,
+                            args: bytes[4..4 + args_len].to_vec(),
+                            result: bytes[4 + args_len..].to_vec(),
+                        });
+                    }
+                    _ => match b {
+                        META_TOPIC => {
+                            let name = bytes
+                                .split(|x| *x == 0)
+                                .next()
+                                .unwrap_or(&[]);
+                            topic_names.insert(
+                                a,
+                                String::from_utf8_lossy(name)
+                                    .into_owned(),
+                            );
+                        }
+                        META_PUBRING => {
+                            pub_ring_consumer.insert(a, c);
+                        }
+                        _ => {
+                            return Err(format!(
+                                "unknown meta subtype {}",
+                                b
+                            ));
+                        }
+                    },
                 }
                 off += 32 + padded;
             }
@@ -159,140 +262,187 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
             }
         }
     }
-    // A clean recording means the WHOLE artifact validated: parse
-    // must end exactly at the trailer and the trailer's count must
-    // match what was parsed (review finding 5 — trailer magic at
-    // EOF alone admits internally truncated files).
     let clean = has_trailer && off == end && trailer_count == total_entries;
+
+    // Resolve public bus records into per-consumer, subject-aligned
+    // streams. A ring with no consumer mapping keys under 0.
+    let mut public: Vec<(u64, Vec<PubEvent>)> = Vec::new();
+    for (ring, w0, w1) in public_raw {
+        let ekind = ((w0 >> 20) & 0x1F) as u32;
+        if ekind != EK_BUS_PUBLISH && ekind != EK_BUS_DELIVER {
+            continue;
+        }
+        let id = (w0 & 0xFFFFF) as u32;
+        let cid = pub_ring_consumer.get(&ring).copied().unwrap_or(0);
+        let ev = PubEvent {
+            subject: topic_names
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| format!("<topic-{}>", id)),
+            ekind,
+            locus: ((w1 >> 44) & 0xFFFFF) as u32,
+            seq: w1 & 0xFFF_FFFF_FFFF,
+        };
+        match public.iter_mut().find(|(c, _)| *c == cid) {
+            Some((_, v)) => v.push(ev),
+            None => public.push((cid, vec![ev])),
+        }
+    }
+
     Ok(Recording {
         model_hash,
         exec_digest,
+        env_redacted,
         clean,
         ring_records,
         payloads,
         journal,
-        consume_streams: streams,
+        consume_streams: consume,
+        public_streams: public,
     })
 }
 
-/// Compare two recordings' per-consumer consume streams and payload
-/// bytes. Returns None when equivalent, or a human-readable first
-/// divergence.
+/// Compare two recordings. Bidirectional over every surface the
+/// artifact carries: per-consumer queued consume streams (target
+/// locus + msg_id), per-consumer PUBLIC bus streams (subject-aligned
+/// — synchronous direct dispatch shows up here), payloads both ways
+/// (topic, flags, bytes; raw ABI snapshots by declared size), and
+/// per-consumer journal streams (kind, args, withheld state, value).
+/// Returns None when equivalent, or the first divergence.
 pub fn diff(original: &Recording, replayed: &Recording) -> Option<String> {
-    for (cid, orig) in &original.consume_streams {
-        let rep = replayed
-            .consume_streams
-            .iter()
-            .find(|(c, _)| c == cid)
-            .map(|(_, v)| v.as_slice())
-            .unwrap_or(&[]);
-        let n = orig.len().min(rep.len());
-        for i in 0..n {
-            if orig[i] != rep[i] {
+    fn stream_diff<T: PartialEq + std::fmt::Debug>(
+        what: &str,
+        a: &[(u64, Vec<T>)],
+        b: &[(u64, Vec<T>)],
+    ) -> Option<String> {
+        for (cid, orig) in a {
+            let rep = b
+                .iter()
+                .find(|(c, _)| c == cid)
+                .map(|(_, v)| v.as_slice())
+                .unwrap_or(&[]);
+            let n = orig.len().min(rep.len());
+            for i in 0..n {
+                if orig[i] != rep[i] {
+                    return Some(format!(
+                        "consumer {}: {} #{} was {:?} in the \
+                         recording, {:?} in the replay",
+                        cid,
+                        what,
+                        i + 1,
+                        orig[i],
+                        rep[i]
+                    ));
+                }
+            }
+            if orig.len() != rep.len() {
                 return Some(format!(
-                    "consumer {}: consume #{} was delivery {:#x} in \
-                     the recording, {:#x} in the replay",
+                    "consumer {}: {} {}s recorded, {} replayed",
                     cid,
-                    i + 1,
-                    orig[i],
-                    rep[i]
+                    orig.len(),
+                    what,
+                    rep.len()
                 ));
             }
         }
-        if orig.len() != rep.len() {
-            return Some(format!(
-                "consumer {}: {} consumes recorded, {} replayed",
-                cid,
-                orig.len(),
-                rep.len()
-            ));
+        for (cid, v) in b {
+            if !v.is_empty() && !a.iter().any(|(c, _)| c == cid) {
+                return Some(format!(
+                    "consumer {} produced {}s in the replay but not \
+                     in the recording",
+                    cid, what
+                ));
+            }
         }
+        None
     }
-    for (cid, _) in &replayed.consume_streams {
-        if !original.consume_streams.iter().any(|(c, _)| c == cid) {
-            return Some(format!(
-                "consumer {} appeared in the replay but not in the \
-                 recording",
-                cid
-            ));
-        }
+
+    if let Some(d) = stream_diff(
+        "queued consume",
+        &original.consume_streams,
+        &replayed.consume_streams,
+    ) {
+        return Some(d);
     }
-    // Payloads, bidirectionally: every recorded publish must exist
-    // in the replay and vice versa; topic and flags must agree; a
-    // raw-struct payload (flag bit 1) is an ABI snapshot whose
-    // bytes are ASLR-dependent, so it compares by size only.
-    for (pub_id, topic, flags, bytes) in &original.payloads {
-        match replayed.payloads.iter().find(|(p, _, _, _)| p == pub_id)
-        {
+    if let Some(d) = stream_diff(
+        "public bus event",
+        &original.public_streams,
+        &replayed.public_streams,
+    ) {
+        return Some(d);
+    }
+
+    // Payloads, bidirectionally.
+    for p in &original.payloads {
+        match replayed.payloads.iter().find(|r| r.pub_id == p.pub_id) {
             None => {
                 return Some(format!(
-                    "publish {:#x} (topic {}) has no counterpart \
-                     in the replay",
-                    pub_id, topic
+                    "publish {:#x} (topic {}) has no counterpart in \
+                     the replay",
+                    p.pub_id, p.topic
                 ));
             }
-            Some((_, rt, rf, rb)) => {
-                if rt != topic || rf != flags {
+            Some(r) => {
+                if r.topic != p.topic || r.flags != p.flags {
                     return Some(format!(
                         "publish {:#x}: topic/flags differ \
                          ({}/{:#x} vs {}/{:#x})",
-                        pub_id, topic, flags, rt, rf
+                        p.pub_id, p.topic, p.flags, r.topic, r.flags
                     ));
                 }
-                let raw = flags & 2 != 0;
-                if (raw && rb.len() != bytes.len())
-                    || (!raw && rb != bytes)
+                let raw = p.flags & 2 != 0;
+                if (raw && r.raw_size != p.raw_size)
+                    || (!raw && r.bytes != p.bytes)
                 {
                     return Some(format!(
-                        "publish {:#x}: payload {} differ ({} vs \
-                         {} bytes)",
-                        pub_id,
-                        if raw { "sizes" } else { "bytes" },
-                        bytes.len(),
-                        rb.len()
+                        "publish {:#x}: payload {} differ ({} vs {})",
+                        p.pub_id,
+                        if raw { "declared sizes" } else { "bytes" },
+                        p.raw_size,
+                        r.raw_size
                     ));
                 }
             }
         }
     }
-    for (pub_id, topic, _, _) in &replayed.payloads {
-        if !original.payloads.iter().any(|(p, _, _, _)| p == pub_id) {
+    for r in &replayed.payloads {
+        if !original.payloads.iter().any(|p| p.pub_id == r.pub_id) {
             return Some(format!(
                 "replay produced publish {:#x} (topic {}) that the \
                  recording does not contain",
-                pub_id, topic
+                r.pub_id, r.topic
             ));
         }
     }
-    // Journal streams: same reads, same identities, same values,
-    // in the same per-consumer order.
-    if original.journal.len() != replayed.journal.len() {
-        return Some(format!(
-            "{} journaled reads recorded, {} in the replay",
-            original.journal.len(),
-            replayed.journal.len()
-        ));
-    }
-    for (i, (o, r)) in original
-        .journal
-        .iter()
-        .zip(replayed.journal.iter())
-        .enumerate()
-    {
-        if o != r {
-            return Some(format!(
-                "journal read #{}: (consumer {}, kind {}, args \
-                 {:#x}) recorded vs (consumer {}, kind {}, args \
-                 {:#x}) replayed",
-                i + 1,
-                o.0,
-                o.1,
-                o.2,
-                r.0,
-                r.1,
-                r.2
-            ));
+
+    // Journal, grouped PER CONSUMER (the drain interleaves
+    // concurrent threads' blobs in incidental order — comparing
+    // one global vector would report divergence for runs whose
+    // every consumer saw exactly its recorded inputs; review
+    // round 2, finding 6).
+    fn by_consumer(
+        j: &[RecJournal],
+    ) -> Vec<(u64, Vec<(u32, bool, &[u8], &[u8])>)> {
+        let mut out: Vec<(u64, Vec<(u32, bool, &[u8], &[u8])>)> =
+            Vec::new();
+        for e in j {
+            let row = (
+                e.jkind,
+                e.withheld,
+                e.args.as_slice(),
+                e.result.as_slice(),
+            );
+            match out.iter_mut().find(|(c, _)| *c == e.consumer) {
+                Some((_, v)) => v.push(row),
+                None => out.push((e.consumer, vec![row])),
+            }
         }
+        out
+    }
+    let a = by_consumer(&original.journal);
+    let b = by_consumer(&replayed.journal);
+    if let Some(d) = stream_diff("journal read", &a, &b) {
+        return Some(d);
     }
     None
 }

--- a/crates/hale-cli/tests/obs_model_hash.rs
+++ b/crates/hale-cli/tests/obs_model_hash.rs
@@ -32,8 +32,15 @@ fn build(dir: &Path, src: &str, tag: &str) -> PathBuf {
 /// Run the binary under LOTUS_OBS=1 and read the header's
 /// model_hash field (u64 at 0x80) from the live segment.
 fn segment_model_hash(bin: &Path) -> u64 {
-    let mut child = Command::new(bin)
-        .env("LOTUS_OBS", "1")
+    segment_model_hash_env(bin, &[("LOTUS_OBS", "1".into())])
+}
+
+fn segment_model_hash_env(bin: &Path, envs: &[(&str, String)]) -> u64 {
+    let mut cmd = Command::new(bin);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let mut child = cmd
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -99,5 +106,45 @@ fn model_identity_is_stamped_and_tracks_the_model() {
     let h_c = segment_model_hash(&c);
     assert_ne!(h_a, h_c, "adding a locus changes the model identity");
 
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// GH #296 round 5: the LIVE segment of a RECORDING process must
+/// carry the same nonzero model identity as an ordinary observed
+/// run. Eager recording init used to create the segment from the C
+/// constructor — before the prelude stamped the identity — so an
+/// attached iris consumer saw model_hash 0 for the process's whole
+/// life (the .halerec artifact was silently repaired by
+/// finalize-time restamping, which is exactly why the recording
+/// canary missed it). Init now runs from the prelude, after the
+/// setters.
+#[test]
+fn recording_processes_publish_the_same_live_model_identity() {
+    let dir = std::env::temp_dir().join(format!(
+        "hale_obs_rec_ident_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let bin = build(&dir, BASE, "ident");
+
+    let observed = segment_model_hash(&bin);
+    assert_ne!(observed, 0, "baseline observed run is unstamped");
+
+    let rec = dir.join("ident.halerec");
+    let recorded = segment_model_hash_env(
+        &bin,
+        &[
+            ("LOTUS_OBS_RECORD", rec.display().to_string()),
+        ],
+    );
+    assert_ne!(
+        recorded, 0,
+        "a recording process published an unstamped live segment"
+    );
+    assert_eq!(
+        recorded, observed,
+        "recording changed the live model identity"
+    );
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/hale-cli/tests/replay_cli.rs
+++ b/crates/hale-cli/tests/replay_cli.rs
@@ -1,0 +1,241 @@
+//! GH #296: `hale replay` end to end — record with `hale run`
+//! under LOTUS_OBS_RECORD, then re-execute the recording.
+//!
+//! What is pinned here, per RFC phase:
+//!   - Phase 3: journaled inputs (time, rand) serve back with zero
+//!     divergences — a program whose payloads depend on
+//!     `std::rand` replays with identical payload bytes.
+//!   - Phase 4: two racing pinned publishers produce a
+//!     nondeterministic recorded interleaving; the replay must
+//!     reproduce THAT interleaving, which only order enforcement
+//!     can do reliably.
+//!   - Admission: a recording made from a different model is
+//!     rejected by shape_hash, and a truncated recording is
+//!     refused outright.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn hale() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_hale"))
+}
+
+fn workdir(name: &str) -> PathBuf {
+    let mut d = std::env::temp_dir();
+    d.push(format!("hale_replay_cli_{}_{}", std::process::id(), name));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).expect("mkdir");
+    d
+}
+
+fn record(dir: &Path, prog: &Path) -> PathBuf {
+    let rec = dir.join("run.halerec");
+    let out = hale()
+        .arg("run")
+        .arg(prog)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .output()
+        .expect("hale run");
+    assert!(
+        out.status.success(),
+        "recorded run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(rec.is_file(), "no recording produced");
+    rec
+}
+
+const JOURNALED: &str = r#"
+type Tick { n: Int = 0; }
+
+locus Sink {
+    params { seen: Int = 0; }
+    bus { subscribe "e2e.tick" as on_t of type Tick; }
+    fn on_t(t: Tick) { self.seen = self.seen + 1; }
+}
+
+locus Pub {
+    bus { publish "e2e.tick" of type Tick; }
+    run() {
+        let mut i = 0;
+        while i < 20 {
+            let r = std::rand::next_int(1000000);
+            "e2e.tick" <- Tick { n: r };
+            i = i + 1;
+        }
+    }
+}
+
+main locus App {
+    params { s: Sink = Sink { }; p: Pub = Pub { }; }
+    placement { p: pinned(core = 0); }
+    run() { std::time::sleep(800ms); }
+}
+
+fn main() { App { }; }
+"#;
+
+/// Two pinned publishers racing into one main-tree sink: the
+/// recorded consume interleaving is one of astronomically many;
+/// replay must serve back exactly it.
+const RACING: &str = r#"
+type A { n: Int = 0; }
+type B { n: Int = 0; }
+
+locus Sink {
+    params { seen: Int = 0; }
+    bus {
+        subscribe "race.a" as on_a of type A;
+        subscribe "race.b" as on_b of type B;
+    }
+    fn on_a(a: A) { self.seen = self.seen + 1; }
+    fn on_b(b: B) { self.seen = self.seen + 1; }
+}
+
+locus PubA {
+    bus { publish "race.a" of type A; }
+    run() {
+        let mut i = 0;
+        while i < 40 { "race.a" <- A { n: i }; i = i + 1; }
+    }
+}
+
+locus PubB {
+    bus { publish "race.b" of type B; }
+    run() {
+        let mut i = 0;
+        while i < 40 { "race.b" <- B { n: i }; i = i + 1; }
+    }
+}
+
+main locus App {
+    params {
+        s: Sink = Sink { };
+        a: PubA = PubA { };
+        b: PubB = PubB { };
+    }
+    placement { a: pinned(core = 0); b: pinned(core = 1); }
+    run() { std::time::sleep(900ms); }
+}
+
+fn main() { App { }; }
+"#;
+
+#[test]
+fn journaled_inputs_replay_without_divergence() {
+    let dir = workdir("journal");
+    let prog = dir.join("demo.hl");
+    std::fs::write(&prog, JOURNALED).unwrap();
+    let rec = record(&dir, &prog);
+
+    let out = hale()
+        .arg("replay")
+        .arg(&rec)
+        .arg(&prog)
+        .arg("--diff")
+        .output()
+        .expect("hale replay");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "replay failed:\n{}\n{}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("replay matches the recording"),
+        "no match report:\n{}\n{}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stderr.contains("journal served fully — 0 divergences"),
+        "journal diverged:\n{}",
+        stderr
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn racing_publishers_replay_in_the_recorded_interleaving() {
+    let dir = workdir("racing");
+    let prog = dir.join("race.hl");
+    std::fs::write(&prog, RACING).unwrap();
+    let rec = record(&dir, &prog);
+
+    // Replay twice: each must reproduce the recorded interleaving
+    // exactly (without Phase-4 enforcement this is a coin flip per
+    // delivery — 80 queued deliveries from two racing threads).
+    for round in 0..2 {
+        let out = hale()
+            .arg("replay")
+            .arg(&rec)
+            .arg(&prog)
+            .arg("--diff")
+            .output()
+            .expect("hale replay");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            out.status.success() && stdout.contains("replay matches"),
+            "round {}: replay diverged from the recorded \
+             interleaving:\n{}\n{}",
+            round,
+            stdout,
+            stderr
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn admission_rejects_model_mismatch_and_truncation() {
+    let dir = workdir("admission");
+    let prog = dir.join("demo.hl");
+    std::fs::write(&prog, JOURNALED).unwrap();
+    let rec = record(&dir, &prog);
+
+    // Different model (one extra locus): rejected by shape_hash.
+    let prog2 = dir.join("demo2.hl");
+    std::fs::write(
+        &prog2,
+        JOURNALED.replace(
+            "locus Sink {",
+            "locus Extra { params { x: Int = 0; } }\nlocus Sink {",
+        ),
+    )
+    .unwrap();
+    let out = hale()
+        .arg("replay")
+        .arg(&rec)
+        .arg(&prog2)
+        .output()
+        .expect("hale replay");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("recorded from a different model"),
+        "wrong rejection:\n{}",
+        stderr
+    );
+
+    // Truncated recording: refused before anything runs.
+    let trunc = dir.join("trunc.halerec");
+    let bytes = std::fs::read(&rec).unwrap();
+    std::fs::write(&trunc, &bytes[..bytes.len() - 100]).unwrap();
+    let out = hale()
+        .arg("replay")
+        .arg(&trunc)
+        .arg(&prog)
+        .output()
+        .expect("hale replay");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("truncated"),
+        "wrong refusal:\n{}",
+        stderr
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-cli/tests/replay_cli.rs
+++ b/crates/hale-cli/tests/replay_cli.rs
@@ -132,6 +132,7 @@ fn journaled_inputs_replay_without_divergence() {
         .arg("replay")
         .arg(&rec)
         .arg(&prog)
+        .arg("--allow-live-effects")
         .arg("--diff")
         .output()
         .expect("hale replay");
@@ -172,6 +173,7 @@ fn racing_publishers_replay_in_the_recorded_interleaving() {
             .arg("replay")
             .arg(&rec)
             .arg(&prog)
+            .arg("--allow-live-effects")
             .arg("--diff")
             .output()
             .expect("hale replay");
@@ -210,12 +212,15 @@ fn admission_rejects_model_mismatch_and_truncation() {
         .arg("replay")
         .arg(&rec)
         .arg(&prog2)
+        .arg("--allow-live-effects")
         .output()
         .expect("hale replay");
     assert!(!out.status.success());
     let stderr = String::from_utf8_lossy(&out.stderr);
+    // The exec-digest check fires first: changed source = changed
+    // build inputs, which is the stronger rejection.
     assert!(
-        stderr.contains("recorded from a different model"),
+        stderr.contains("different build inputs"),
         "wrong rejection:\n{}",
         stderr
     );
@@ -228,6 +233,7 @@ fn admission_rejects_model_mismatch_and_truncation() {
         .arg("replay")
         .arg(&trunc)
         .arg(&prog)
+        .arg("--allow-live-effects")
         .output()
         .expect("hale replay");
     assert!(!out.status.success());
@@ -236,6 +242,26 @@ fn admission_rejects_model_mismatch_and_truncation() {
         stderr.contains("truncated"),
         "wrong refusal:\n{}",
         stderr
+    );
+
+    // The review's sharper case: bytes removed from the MIDDLE with
+    // the original trailer intact. Trailer magic at EOF alone would
+    // call this clean; exact-end + entry-count validation must not.
+    let corrupt = dir.join("corrupt.halerec");
+    let mut mangled = bytes.clone();
+    let cut = mangled.len() / 2;
+    mangled.drain(cut..cut + 48);
+    std::fs::write(&corrupt, &mangled).unwrap();
+    let out = hale()
+        .arg("replay")
+        .arg(&corrupt)
+        .arg(&prog)
+        .arg("--allow-live-effects")
+        .output()
+        .expect("hale replay");
+    assert!(
+        !out.status.success(),
+        "an internally corrupted recording was admitted"
     );
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/hale-cli/tests/replay_cli.rs
+++ b/crates/hale-cli/tests/replay_cli.rs
@@ -598,3 +598,165 @@ fn main() { wired::App { }; }
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Round 4, finding 1's canary: a probe-free program must still
+/// produce a recording — and REPLACE whatever sat at the path. Lazy
+/// creation let `fn main() { let x = 1 + 1; }` exit successfully
+/// with no file, while a stale artifact at the path silently
+/// impersonated the requested run.
+#[test]
+fn probe_free_run_replaces_the_artifact_at_the_path() {
+    let dir = workdir("probefree");
+    let prog = dir.join("quiet.hl");
+    std::fs::write(&prog, "fn main() { let x = 1 + 1; }\n").unwrap();
+    let rec = dir.join("run.halerec");
+    std::fs::write(&rec, b"SENTINEL: not a recording").unwrap();
+
+    let out = hale()
+        .arg("run")
+        .arg(&prog)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .output()
+        .expect("record quiet program");
+    assert!(
+        out.status.success(),
+        "quiet run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let bytes = std::fs::read(&rec).unwrap();
+    assert!(
+        !bytes.starts_with(b"SENTINEL"),
+        "the stale artifact at the path was left impersonating \
+         this run"
+    );
+    // It must parse as a CLEAN current recording with zero
+    // semantic events and a real execution identity.
+    let r = crate::parse_rec(&rec);
+    assert!(r.0, "probe-free recording is not clean");
+    assert_eq!(r.1, 0, "a probe-free run recorded semantic events");
+    assert!(r.2, "probe-free recording carries no exec identity");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Minimal v0.3 reader for the canary above: (clean, semantic ring
+/// records, exec_digest nonzero). Semantic = any ring record other
+/// than the private CONSUMER identity stamp.
+fn parse_rec(p: &Path) -> (bool, usize, bool) {
+    let b = std::fs::read(p).unwrap();
+    let u64at = |o: usize| {
+        u64::from_le_bytes(b[o..o + 8].try_into().unwrap())
+    };
+    let u32at = |o: usize| {
+        u32::from_le_bytes(b[o..o + 4].try_into().unwrap())
+    };
+    if b.len() < 112 || u64at(0) != 0x30434552454C4148 {
+        return (false, usize::MAX, false);
+    }
+    let exec_nonzero = (0..4).any(|i| u64at(56 + i * 8) != 0);
+    let mut end = b.len();
+    let has_trailer = u64at(end - 16) == 0x30444E45454C4148;
+    let trailer_count = if has_trailer { u64at(end - 8) } else { 0 };
+    if has_trailer {
+        end -= 16;
+    }
+    let mut off = 96usize;
+    let mut total = 0u64;
+    let mut semantic = 0usize;
+    while off + 8 <= end {
+        let tag = u32at(off);
+        total += 1;
+        if tag == 0 {
+            if end - off < 24 {
+                return (false, semantic, exec_nonzero);
+            }
+            let w0 = u64at(off + 8);
+            let ekind = ((w0 >> 20) & 0x1F) as u32;
+            let ring = u32at(off + 4);
+            if !(ring & 0x8000_0000 != 0 && ekind == 1) {
+                semantic += 1;
+            }
+            off += 24;
+        } else if (1..=3).contains(&tag) {
+            if end - off < 32 {
+                return (false, semantic, exec_nonzero);
+            }
+            let size = u64at(off + 24) as usize;
+            let padded = (size + 7) & !7;
+            if padded > end - off - 32 {
+                return (false, semantic, exec_nonzero);
+            }
+            off += 32 + padded;
+        } else {
+            return (false, semantic, exec_nonzero);
+        }
+    }
+    (
+        has_trailer && off == end && trailer_count == total,
+        semantic,
+        exec_nonzero,
+    )
+}
+
+/// Round 4, finding 2's canary, reshaped by a checker fact: the
+/// literal same-name collision CANNOT typecheck — module-scoped
+/// names share the flat top-level namespace ("duplicate top-level
+/// name `Worker`"), so the aliasing shape is unreachable through
+/// any checked path (and `hale replay` checks before admitting).
+/// The qualified summary key stays as defense-in-depth for any
+/// future namespace relaxation and for unchecked callers of the
+/// manifest API. What IS reachable — a module LOCUS whose
+/// lifecycle body carries a live effect — must fail closed as
+/// `unclassified` under its qualified key and be refused.
+#[test]
+fn module_locus_lifecycle_fails_closed_under_qualified_key() {
+    let dir = workdir("modalias");
+    let plain = dir.join("plain.hl");
+    std::fs::write(&plain, JOURNALED).unwrap();
+    let rec = record(&dir, &plain);
+
+    let prog = dir.join("alias.hl");
+    std::fs::write(
+        &prog,
+        r#"
+module inner {
+    locus Worker {
+        params { n: Int = 0; }
+        run() {
+            let result = std::process::run("true") or raise;
+        }
+    }
+}
+type Tick { n: Int = 0; }
+locus Sink {
+    params { seen: Int = 0; }
+    bus { subscribe "a.t" as on_t of type Tick; }
+    fn on_t(t: Tick) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { s: Sink = Sink { }; w: Worker = Worker { }; }
+    bus { publish "a.t" of type Tick; }
+    run() { "a.t" <- Tick { n: 1 }; }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let out = hale()
+        .arg("replay")
+        .arg(&rec)
+        .arg(&prog)
+        .output()
+        .expect("hale replay");
+    assert!(
+        !out.status.success(),
+        "a module locus aliased a pure top-level locus and passed \
+         the gate"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("live world") && stderr.contains("unclassified"),
+        "wrong refusal:\n{}",
+        stderr
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-cli/tests/replay_cli.rs
+++ b/crates/hale-cli/tests/replay_cli.rs
@@ -421,3 +421,180 @@ fn main() { App { }; }
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Round 3, finding 3's canaries: (a) two pinned publishers racing
+/// on ONE subject — the old deliver probe reloaded the topic's
+/// high-water mark and attributed both racing deliveries to the
+/// later publish; (b) a handler that republishes to the SAME
+/// subject before the outer fanout's remaining delivers, which
+/// clobbers any TLS-based seq handoff (the token is a local).
+const SAME_SUBJECT: &str = r#"
+type T { n: Int = 0; }
+
+locus Sink {
+    params { seen: Int = 0; }
+    bus {
+        subscribe "one.subj" as on_t of type T;
+        publish "one.subj" of type T;
+    }
+    fn on_t(t: T) {
+        self.seen = self.seen + 1;
+        if t.n == 777 { "one.subj" <- T { n: 1000 }; }
+    }
+}
+
+locus PubA {
+    bus { publish "one.subj" of type T; }
+    run() {
+        let mut i = 0;
+        while i < 30 { "one.subj" <- T { n: i }; i = i + 1; }
+        "one.subj" <- T { n: 777 };
+    }
+}
+
+locus PubB {
+    bus { publish "one.subj" of type T; }
+    run() {
+        let mut i = 0;
+        while i < 30 { "one.subj" <- T { n: 100 + i }; i = i + 1; }
+    }
+}
+
+main locus App {
+    params {
+        s: Sink = Sink { };
+        a: PubA = PubA { };
+        b: PubB = PubB { };
+    }
+    placement { a: pinned(core = 0); b: pinned(core = 1); }
+    run() { std::time::sleep(900ms); }
+}
+
+fn main() { App { }; }
+"#;
+
+#[test]
+fn same_subject_race_and_nested_republish_replay_exactly() {
+    let dir = workdir("samesubj");
+    let prog = dir.join("one.hl");
+    std::fs::write(&prog, SAME_SUBJECT).unwrap();
+    let rec = record(&dir, &prog);
+
+    for round in 0..2 {
+        let out = hale()
+            .arg("replay")
+            .arg(&rec)
+            .arg(&prog)
+            .arg("--allow-live-effects")
+            .arg("--diff")
+            .output()
+            .expect("hale replay");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            out.status.success() && stdout.contains("replay matches"),
+            "round {}: same-subject replay diverged:\n{}\n{}",
+            round,
+            stdout,
+            stderr
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Round 3, finding 2's negative controls: modules nest top
+/// declarations, and both admission walkers (effect rows, binding
+/// scan) must recurse into them — a module-contained live effect
+/// or transport binding failing open was the review's exact case.
+#[test]
+fn module_contained_effects_and_bindings_are_refused() {
+    let dir = workdir("modgate");
+    // Inline-module fns don't lower through codegen yet, so these
+    // programs never RUN — which is fine: the safety gate fires
+    // before the build, and it is deliberately ordered before
+    // identity admission so a program-inherent refusal is never
+    // masked by a recording mismatch. Any valid recording arms the
+    // test.
+    let plain = dir.join("plain.hl");
+    std::fs::write(&plain, JOURNALED).unwrap();
+    let rec = record(&dir, &plain);
+
+    // (a) module-contained fn with a live effect (subprocess run).
+    let prog_fx = dir.join("modfx.hl");
+    std::fs::write(
+        &prog_fx,
+        r#"
+module inner {
+    fn danger() {
+        let out = std::process::run("true") or raise;
+        let c = out.code;
+    }
+}
+type Tick { n: Int = 0; }
+locus Sink {
+    params { seen: Int = 0; }
+    bus { subscribe "m.t" as on_t of type Tick; }
+    fn on_t(t: Tick) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { s: Sink = Sink { }; }
+    bus { publish "m.t" of type Tick; }
+    run() {
+        inner::danger();
+        "m.t" <- Tick { n: 1 };
+    }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let out = hale()
+        .arg("replay")
+        .arg(&rec)
+        .arg(&prog_fx)
+        .output()
+        .expect("hale replay");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("live world"),
+        "module-contained effect passed the gate:\n{}",
+        stderr
+    );
+
+    // (b) module-contained transport binding.
+    let prog_b = dir.join("modbind.hl");
+    std::fs::write(
+        &prog_b,
+        r#"
+module wired {
+    type Tick { n: Int = 0; }
+    topic Wire { payload: Tick; subject: "m.wire"; }
+    main locus App {
+        bus { publish Wire; }
+        bindings { Wire: unix("/tmp/hale_replay_modcanary.sock", role: listen); }
+        run() { Wire <- Tick { n: 1 }; std::time::sleep(200ms); }
+    }
+}
+fn main() { wired::App { }; }
+"#,
+    )
+    .unwrap();
+    // The module-main shape may not even record (main-in-module is
+    // its own question) — the load-bearing assertion is the GATE:
+    // admission must see the binding regardless of a recording.
+    let out = hale()
+        .arg("replay")
+        .arg(&rec)
+        .arg(&prog_b)
+        .output()
+        .expect("hale replay");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("live world"),
+        "module-contained binding passed the gate:\n{}",
+        stderr
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-cli/tests/replay_cli.rs
+++ b/crates/hale-cli/tests/replay_cli.rs
@@ -96,7 +96,11 @@ locus PubA {
     bus { publish "race.a" of type A; }
     run() {
         let mut i = 0;
-        while i < 40 { "race.a" <- A { n: i }; i = i + 1; }
+        while i < 40 {
+            let r = std::rand::next_int(1000);
+            "race.a" <- A { n: r };
+            i = i + 1;
+        }
     }
 }
 
@@ -104,7 +108,11 @@ locus PubB {
     bus { publish "race.b" of type B; }
     run() {
         let mut i = 0;
-        while i < 40 { "race.b" <- B { n: i }; i = i + 1; }
+        while i < 40 {
+            let r = std::rand::next_int(1000);
+            "race.b" <- B { n: r };
+            i = i + 1;
+        }
     }
 }
 
@@ -262,6 +270,154 @@ fn admission_rejects_model_mismatch_and_truncation() {
     assert!(
         !out.status.success(),
         "an internally corrupted recording was admitted"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Review round 2, finding 1's canary: an otherwise deterministic
+/// program that publishes to a transport-BOUND topic (a unix
+/// socket here; same class as udp) must be
+/// refused by default — the user-level effect is `publish`, but
+/// re-executing it sends real datagrams.
+const UDP_BOUND: &str = r#"
+type Tick { n: Int = 0; }
+topic Wire { payload: Tick; subject: "wire.tick"; }
+
+main locus App {
+    bus { publish Wire; }
+    bindings { Wire: unix("/tmp/hale_replay_canary.sock", role: listen); }
+    run() {
+        let mut i = 0;
+        while i < 5 { Wire <- Tick { n: i }; i = i + 1; }
+        std::time::sleep(300ms);
+    }
+}
+
+fn main() { App { }; }
+"#;
+
+#[test]
+fn externally_bound_publish_is_refused_by_default() {
+    let dir = workdir("udpbound");
+    let prog = dir.join("wire.hl");
+    std::fs::write(&prog, UDP_BOUND).unwrap();
+    let rec = record(&dir, &prog);
+
+    let out = hale()
+        .arg("replay")
+        .arg(&rec)
+        .arg(&prog)
+        .output()
+        .expect("hale replay");
+    assert!(
+        !out.status.success(),
+        "a transport-bound program replayed without the safety flag"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("live world") && stderr.contains("--allow-live-effects"),
+        "wrong refusal:\n{}",
+        stderr
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Review round 2, finding 8: env VALUES are withheld by default.
+/// The recording must say so, a replayed env read must surface as a
+/// named divergence (never a substituted value), and opting in with
+/// LOTUS_OBS_RECORD_ENV=full must restore exact replay.
+#[test]
+fn env_values_redact_by_default_and_opt_in_restores_replay() {
+    let dir = workdir("envredact");
+    let prog = dir.join("env.hl");
+    std::fs::write(
+        &prog,
+        r#"
+type Tick { n: Int = 0; }
+locus Sink {
+    params { seen: Int = 0; }
+    bus { subscribe "e.t" as on_t of type Tick; }
+    fn on_t(t: Tick) { self.seen = self.seen + 1; }
+}
+locus Pub {
+    bus { publish "e.t" of type Tick; }
+    run() {
+        let v = std::env::var("HALE_REPLAY_TEST_ENV");
+        let n = len(v);
+        "e.t" <- Tick { n: n };
+    }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Pub = Pub { }; }
+    placement { p: pinned(core = 0); }
+    run() { std::time::sleep(600ms); }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+
+    // Default policy: value withheld → replay diverges, namedly.
+    let rec = dir.join("redacted.halerec");
+    let out = hale()
+        .arg("run")
+        .arg(&prog)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .env("HALE_REPLAY_TEST_ENV", "hunter2-not-in-artifact")
+        .output()
+        .expect("record");
+    assert!(out.status.success());
+    let raw = std::fs::read(&rec).unwrap();
+    assert!(
+        !raw.windows(7).any(|w| w == b"hunter2"),
+        "redacted recording contains the env value"
+    );
+    let out = hale()
+        .arg("replay")
+        .arg(&rec)
+        .arg(&prog)
+        .arg("--allow-live-effects")
+        .arg("--diff")
+        .env("HALE_REPLAY_TEST_ENV", "hunter2-not-in-artifact")
+        .output()
+        .expect("replay");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "a redacted recording must not claim an exact match:\n{}",
+        stderr
+    );
+    assert!(
+        stderr.contains("withholds env VALUES") || stderr.contains("divergence"),
+        "redaction must be named:\n{}",
+        stderr
+    );
+
+    // Opt-in: full values → exact replay.
+    let rec2 = dir.join("full.halerec");
+    let out = hale()
+        .arg("run")
+        .arg(&prog)
+        .env("LOTUS_OBS_RECORD", &rec2)
+        .env("LOTUS_OBS_RECORD_ENV", "full")
+        .env("HALE_REPLAY_TEST_ENV", "hunter2-not-in-artifact")
+        .output()
+        .expect("record full");
+    assert!(out.status.success());
+    let out = hale()
+        .arg("replay")
+        .arg(&rec2)
+        .arg(&prog)
+        .arg("--allow-live-effects")
+        .arg("--diff")
+        .output()
+        .expect("replay full");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("replay matches"),
+        "full-env recording must replay exactly:\n{}\n{}",
+        stdout,
+        String::from_utf8_lossy(&out.stderr)
     );
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -6187,15 +6187,35 @@ void lotus_obs_record_consume(void *subscriber_self, uint64_t pub_id)
     __attribute__((weak));
 uint64_t lotus_obs_record_publish_payload(const char *subject,
                                           const void *payload,
-                                          uint64_t size)
+                                          uint64_t size,
+                                          int raw_struct)
     __attribute__((weak));
 void lotus_obs_record_enqueue(uint64_t pub_id, void *subscriber_self)
     __attribute__((weak));
 void lotus_obs_note_consumer(uint64_t id) __attribute__((weak));
-void lotus_obs_journal_i64(uint32_t jkind, int64_t v)
+void lotus_obs_journal_i64(uint32_t jkind, uint32_t arghash, int64_t v)
     __attribute__((weak));
-void lotus_obs_journal_bytes(uint32_t jkind, const void *p, uint64_t n)
+void lotus_obs_journal_bytes(uint32_t jkind, uint32_t arghash,
+                             const void *p, uint64_t n)
     __attribute__((weak));
+
+/* Journal call identity: a 32-bit hash of the invocation's
+ * arguments rides every entry, and replay refuses to serve an
+ * entry whose kind or arguments differ from the caller's — a
+ * changed env name, rand bound, or read length is the FIRST
+ * named divergence, never a silently substituted value. */
+static inline uint32_t lotus_jhash_str(const char *sarg) {
+    uint32_t h = 2166136261u;
+    for (const char *q = sarg; q && *q; q++) {
+        h ^= (uint8_t)*q;
+        h *= 16777619u;
+    }
+    return h ? h : 1u;
+}
+static inline uint32_t lotus_jhash_i64(int64_t v) {
+    uint64_t x = (uint64_t)v;
+    return (uint32_t)(x ^ (x >> 32)) | 1u;
+}
 /* GH #296 Phase 3: replay serving (LOTUS_REPLAY). serve_* return 1
  * and fill out when the journal has this thread's next value for
  * jkind; 0 = journal exhausted or absent → the caller falls back
@@ -6203,12 +6223,15 @@ void lotus_obs_journal_bytes(uint32_t jkind, const void *p, uint64_t n)
  * (replay degrades, never refuses). serve_str returns a pointer
  * into the loaded recording (stable for process life) or NULL. */
 extern int lotus_replay_active __attribute__((weak));
-int lotus_replay_serve_i64(uint32_t jkind, int64_t *out)
+int lotus_replay_serve_i64(uint32_t jkind, uint32_t arghash,
+                           int64_t *out)
     __attribute__((weak));
 int lotus_replay_expected_consume(uint64_t *out)
     __attribute__((weak));
 void lotus_replay_note_consume(void) __attribute__((weak));
-const void *lotus_replay_serve_blob(uint32_t jkind, uint64_t *out_n)
+const void *lotus_replay_serve_blob(uint32_t jkind, uint32_t arghash,
+                                    uint64_t want_size,
+                                    uint64_t *out_n)
     __attribute__((weak));
 
 /* journal kinds — MUST match lotus_obs.c's JK_* table. */
@@ -9317,8 +9340,11 @@ static inline int lotus_bus_post_entry(lotus_bus_entry_t *e,
                                        uint64_t rec_pub) {
     /* GH #296: the TLS is scoped to exactly this post (the wire-deser
      * pattern) so a structural cell posted outside any fanout can
-     * never inherit a stale publish identity. */
-    g_bus_pending_rec_pub = rec_pub;
+     * never inherit a stale publish identity. Stores are guarded so
+     * the identity-off path (rec_pub == 0, the default) adds no TLS
+     * writes here — the residual default-path cost is one TLS read
+     * per cell build. */
+    if (rec_pub) g_bus_pending_rec_pub = rec_pub;
     if (e->mailbox) {
         lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
                            payload, size);
@@ -9329,10 +9355,10 @@ static inline int lotus_bus_post_entry(lotus_bus_entry_t *e,
         lotus_bus_queue_enqueue(queue, e->handler, e->self_ptr,
                                 payload, size);
     } else {
-        g_bus_pending_rec_pub = 0;
+        if (rec_pub) g_bus_pending_rec_pub = 0;
         return 0;
     }
-    g_bus_pending_rec_pub = 0;
+    if (rec_pub) g_bus_pending_rec_pub = 0;
     if (rec_pub && lotus_obs_record_enqueue && lotus_obs_live) {
         lotus_obs_record_enqueue(rec_pub, e->self_ptr);
     }
@@ -9352,7 +9378,7 @@ void lotus_bus_local_dispatch(lotus_bus_queue_t *queue,
     if (lotus_obs_record_publish_payload && lotus_obs_live &&
         (lotus_obs_recording || lotus_replay_active)) {
         rec_pub = lotus_obs_record_publish_payload(
-            subject, payload, (uint64_t)payload_size);
+            subject, payload, (uint64_t)payload_size, 1);
     }
     if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)payload_size);
@@ -9475,7 +9501,7 @@ void lotus_bus_local_dispatch_keyed(lotus_bus_queue_t *queue,
     if (lotus_obs_record_publish_payload && lotus_obs_live &&
         (lotus_obs_recording || lotus_replay_active)) {
         rec_pub = lotus_obs_record_publish_payload(
-            subject, payload, (uint64_t)payload_size);
+            subject, payload, (uint64_t)payload_size, 1);
     }
     if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)payload_size);
@@ -13625,25 +13651,36 @@ void lotus_io_init(void) {
 int lotus_env_args_count(void) {
     if (lotus_replay_on()) {
         int64_t v;
-        if (lotus_replay_serve_i64(LOTUS_JK_ENV_ARGS_COUNT, &v))
+        if (lotus_replay_serve_i64(LOTUS_JK_ENV_ARGS_COUNT, 1u, &v)) {
+            if (lotus_journal_on())
+                lotus_obs_journal_i64(LOTUS_JK_ENV_ARGS_COUNT, 1u, v);
             return (int)v;
+        }
     }
     if (lotus_journal_on())
-        lotus_obs_journal_i64(LOTUS_JK_ENV_ARGS_COUNT, (int64_t)g_argc);
+        lotus_obs_journal_i64(LOTUS_JK_ENV_ARGS_COUNT, 1u,
+                              (int64_t)g_argc);
     return g_argc;
 }
 
 const char *lotus_env_arg(int i) {
     if (lotus_replay_on()) {
         uint64_t n = 0;
-        const void *v = lotus_replay_serve_blob(LOTUS_JK_ENV_ARG, &n);
-        if (v && n > 0) return (const char *)v; /* NUL included */
+        const void *v = lotus_replay_serve_blob(
+            LOTUS_JK_ENV_ARG, lotus_jhash_i64(i), 0, &n);
+        if (v && n > 0) {
+            if (lotus_journal_on())
+                lotus_obs_journal_bytes(LOTUS_JK_ENV_ARG,
+                                        lotus_jhash_i64(i), v, n);
+            return (const char *)v; /* NUL included */
+        }
     }
     const char *r = (i < 0 || i >= g_argc || !g_argv || !g_argv[i])
         ? g_empty_str
         : g_argv[i];
     if (lotus_journal_on())
-        lotus_obs_journal_bytes(LOTUS_JK_ENV_ARG, r, strlen(r) + 1);
+        lotus_obs_journal_bytes(LOTUS_JK_ENV_ARG, lotus_jhash_i64(i),
+                                r, strlen(r) + 1);
     return r;
 }
 
@@ -13651,13 +13688,21 @@ const char *lotus_env_var(const char *name) {
     if (!name) return g_empty_str;
     if (lotus_replay_on()) {
         uint64_t n = 0;
-        const void *v = lotus_replay_serve_blob(LOTUS_JK_ENV_VAR, &n);
-        if (v && n > 0) return (const char *)v; /* NUL included */
+        const void *v = lotus_replay_serve_blob(
+            LOTUS_JK_ENV_VAR, lotus_jhash_str(name), 0, &n);
+        if (v && n > 0) {
+            if (lotus_journal_on())
+                lotus_obs_journal_bytes(LOTUS_JK_ENV_VAR,
+                                        lotus_jhash_str(name), v, n);
+            return (const char *)v; /* NUL included */
+        }
     }
     const char *v = getenv(name);
     const char *r = v ? v : g_empty_str;
     if (lotus_journal_on())
-        lotus_obs_journal_bytes(LOTUS_JK_ENV_VAR, r, strlen(r) + 1);
+        lotus_obs_journal_bytes(LOTUS_JK_ENV_VAR,
+                                lotus_jhash_str(name), r,
+                                strlen(r) + 1);
     return r;
 }
 
@@ -13665,12 +13710,18 @@ int lotus_env_var_exists(const char *name) {
     if (!name) return 0;
     if (lotus_replay_on()) {
         int64_t v;
-        if (lotus_replay_serve_i64(LOTUS_JK_ENV_VAR_EXISTS, &v))
+        if (lotus_replay_serve_i64(LOTUS_JK_ENV_VAR_EXISTS,
+                                   lotus_jhash_str(name), &v)) {
+            if (lotus_journal_on())
+                lotus_obs_journal_i64(LOTUS_JK_ENV_VAR_EXISTS,
+                                      lotus_jhash_str(name), v);
             return (int)v;
+        }
     }
     int r = getenv(name) != NULL ? 1 : 0;
     if (lotus_journal_on())
-        lotus_obs_journal_i64(LOTUS_JK_ENV_VAR_EXISTS, (int64_t)r);
+        lotus_obs_journal_i64(LOTUS_JK_ENV_VAR_EXISTS,
+                              lotus_jhash_str(name), (int64_t)r);
     return r;
 }
 
@@ -15574,7 +15625,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
     if (lotus_obs_record_publish_payload && lotus_obs_live &&
         (lotus_obs_recording || lotus_replay_active)) {
         rec_pub = lotus_obs_record_publish_payload(
-            subject, wire_bytes, (uint64_t)wire_size);
+            subject, wire_bytes, (uint64_t)wire_size, 0);
     }
     if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)wire_size);
@@ -15720,7 +15771,7 @@ void lotus_bus_dispatch_wire(const char *subject,
     if (lotus_obs_record_publish_payload && lotus_obs_live &&
         (lotus_obs_recording || lotus_replay_active)) {
         rec_pub = lotus_obs_record_publish_payload(
-            subject, wire_bytes, (uint64_t)wire_size);
+            subject, wire_bytes, (uint64_t)wire_size, 0);
     }
     if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)wire_size);
@@ -15882,7 +15933,7 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
         if (lotus_obs_record_publish_payload && lotus_obs_live &&
             (lotus_obs_recording || lotus_replay_active)) {
             rec_pub = lotus_obs_record_publish_payload(
-                subject, struct_payload, (uint64_t)struct_size);
+                subject, struct_payload, (uint64_t)struct_size, 1);
         }
         /* iris P4 (mirrors the dynamic path). */
         if (lotus_obs_bus_publish && lotus_obs_live) {
@@ -15960,7 +16011,7 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
     if (lotus_obs_record_publish_payload && lotus_obs_live &&
         (lotus_obs_recording || lotus_replay_active)) {
         rec_pub = lotus_obs_record_publish_payload(
-            subject, struct_payload, (uint64_t)struct_size);
+            subject, struct_payload, (uint64_t)struct_size, 1);
     }
     if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)struct_size);
@@ -16469,12 +16520,17 @@ void *lotus_os_getrandom(int64_t n) {
     }
     if (lotus_replay_on()) {
         uint64_t jn = 0;
-        const void *jv =
-            lotus_replay_serve_blob(LOTUS_JK_OS_GETRANDOM, &jn);
+        const void *jv = lotus_replay_serve_blob(
+            LOTUS_JK_OS_GETRANDOM, lotus_jhash_i64(n), (uint64_t)n,
+            &jn);
         if (jv && jn == (uint64_t)n) {
             void *jblob = lotus_caller_or_global_bytes_create(n);
             if (jblob) {
                 memcpy(lotus_bytes_data(jblob), jv, (size_t)n);
+                if (lotus_journal_on())
+                    lotus_obs_journal_bytes(LOTUS_JK_OS_GETRANDOM,
+                                            lotus_jhash_i64(n), jv,
+                                            jn);
                 return jblob;
             }
         }
@@ -16514,7 +16570,8 @@ void *lotus_os_getrandom(int64_t n) {
     }
     if (left == 0) {
         if (lotus_journal_on())
-            lotus_obs_journal_bytes(LOTUS_JK_OS_GETRANDOM, body,
+            lotus_obs_journal_bytes(LOTUS_JK_OS_GETRANDOM,
+                                    lotus_jhash_i64(n), body,
                                     (uint64_t)n);
         return blob;
     }
@@ -16542,7 +16599,9 @@ void *lotus_os_getrandom(int64_t n) {
     }
     close(fd);
     if (lotus_journal_on())
-        lotus_obs_journal_bytes(LOTUS_JK_OS_GETRANDOM, body, (uint64_t)n);
+        lotus_obs_journal_bytes(LOTUS_JK_OS_GETRANDOM,
+                                lotus_jhash_i64(n), body,
+                                (uint64_t)n);
     return blob;
 }
 
@@ -18662,9 +18721,19 @@ void lotus_rand_seed_from_time(void) {
 }
 
 int64_t lotus_rand_next_int(int64_t max) {
+    /* max <= 0 returns 0 WITHOUT touching the journal on either
+     * side — the recording never journaled it (review finding 7's
+     * concrete bug: serving here consumed the next call's value). */
+    if (max <= 0) return 0;
     if (lotus_replay_on()) {
         int64_t v;
-        if (lotus_replay_serve_i64(LOTUS_JK_RAND_NEXT_INT, &v)) return v;
+        if (lotus_replay_serve_i64(LOTUS_JK_RAND_NEXT_INT,
+                                   lotus_jhash_i64(max), &v)) {
+            if (lotus_journal_on())
+                lotus_obs_journal_i64(LOTUS_JK_RAND_NEXT_INT,
+                                      lotus_jhash_i64(max), v);
+            return v;
+        }
     }
     pthread_mutex_lock(&g_rand_mutex);
     if (g_rand_state == 0) {
@@ -18684,10 +18753,10 @@ int64_t lotus_rand_next_int(int64_t max) {
     g_rand_state = x;
     uint64_t mixed = x * 0x2545F4914F6CDD1DULL;
     pthread_mutex_unlock(&g_rand_mutex);
-    if (max <= 0) return 0;
     int64_t r = (int64_t)(mixed % (uint64_t)max);
     if (lotus_journal_on())
-        lotus_obs_journal_i64(LOTUS_JK_RAND_NEXT_INT, r);
+        lotus_obs_journal_i64(LOTUS_JK_RAND_NEXT_INT,
+                              lotus_jhash_i64(max), r);
     return r;
 }
 
@@ -18702,13 +18771,17 @@ int64_t lotus_rand_next_int(int64_t max) {
 int64_t lotus_time_now_seconds(void) {
     if (lotus_replay_on()) {
         int64_t v;
-        if (lotus_replay_serve_i64(LOTUS_JK_TIME_NOW, &v)) return v;
+        if (lotus_replay_serve_i64(LOTUS_JK_TIME_NOW, 1u, &v)) {
+            if (lotus_journal_on())
+                lotus_obs_journal_i64(LOTUS_JK_TIME_NOW, 1u, v);
+            return v;
+        }
     }
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
     int64_t r = (int64_t)ts.tv_sec;
     if (lotus_journal_on())
-        lotus_obs_journal_i64(LOTUS_JK_TIME_NOW, r);
+        lotus_obs_journal_i64(LOTUS_JK_TIME_NOW, 1u, r);
     return r;
 }
 
@@ -18720,13 +18793,17 @@ int64_t lotus_time_now_seconds(void) {
 int64_t lotus_time_monotonic_ns(void) {
     if (lotus_replay_on()) {
         int64_t v;
-        if (lotus_replay_serve_i64(LOTUS_JK_TIME_MONO_NS, &v)) return v;
+        if (lotus_replay_serve_i64(LOTUS_JK_TIME_MONO_NS, 1u, &v)) {
+            if (lotus_journal_on())
+                lotus_obs_journal_i64(LOTUS_JK_TIME_MONO_NS, 1u, v);
+            return v;
+        }
     }
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     int64_t r = (int64_t)ts.tv_sec * 1000000000LL + (int64_t)ts.tv_nsec;
     if (lotus_journal_on())
-        lotus_obs_journal_i64(LOTUS_JK_TIME_MONO_NS, r);
+        lotus_obs_journal_i64(LOTUS_JK_TIME_MONO_NS, 1u, r);
     return r;
 }
 

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -5982,6 +5982,13 @@ typedef struct lotus_bus_cell {
      * nothing to destroy (non-wire cell, or self_ptr was NULL and
      * the deserialize fell back to the global arena). */
     void  *payload_region;
+    /* GH #296 Phase 2: the publish's deterministic recording
+     * identity (consumer_id:8 << 36 | per-publisher-thread seq:36),
+     * stamped from the g_bus_pending_rec_pub TLS by every cell
+     * builder. 0 = unidentified (not recording, or a structural
+     * run/create cell). Consumed by the drain paths' consume
+     * stamp and by replay's order enforcement. */
+    uint64_t rec_pub_id;
     /* 16-byte aligned. The inline buffer holds a verbatim copy of a
      * bus payload struct, which may carry an i128 / Decimal (align-16)
      * field. A subscriber handler reads such a field with an aligned
@@ -6037,6 +6044,14 @@ typedef struct lotus_bus_queue {
  * to exactly the one post call, with no signature change on the
  * three hot post entry points. NULL for every other caller. */
 static __thread void *g_bus_pending_wire_deser = NULL;
+
+/* GH #296 Phase 2: TLS side-channel feeding
+ * lotus_bus_cell_t.rec_pub_id, exactly the wire-deser pattern
+ * above — set by a fanout for the duration of its post calls
+ * (every target of one publish shares the publish's identity),
+ * cleared at fanout exit. 0 (the overwhelming default: not
+ * recording, or a structural cell) stamps 0 = unidentified. */
+static __thread uint64_t g_bus_pending_rec_pub = 0;
 
 /* Materialize a wire cell on its OWNER thread: deserialize the wire
  * payload into the subscriber's arena and replace the cell payload
@@ -6164,6 +6179,56 @@ static void bus_inline_drain_one(lotus_bus_queue_t *q);
  * WEAK like the probes; every guard tests a probe SYMBOL first, so
  * a TU-alone build short-circuits before touching this. */
 extern int lotus_obs_live __attribute__((weak));
+/* GH #296: recording mode (LOTUS_OBS_RECORD). Process-constant like
+ * lotus_obs_live, and gated behind it at every site, so the unset
+ * default stays one predictable branch. */
+extern int lotus_obs_recording __attribute__((weak));
+void lotus_obs_record_consume(void *subscriber_self, uint64_t pub_id)
+    __attribute__((weak));
+uint64_t lotus_obs_record_publish_payload(const char *subject,
+                                          const void *payload,
+                                          uint64_t size)
+    __attribute__((weak));
+void lotus_obs_record_enqueue(uint64_t pub_id, void *subscriber_self)
+    __attribute__((weak));
+void lotus_obs_note_consumer(uint64_t id) __attribute__((weak));
+void lotus_obs_journal_i64(uint32_t jkind, int64_t v)
+    __attribute__((weak));
+void lotus_obs_journal_bytes(uint32_t jkind, const void *p, uint64_t n)
+    __attribute__((weak));
+/* GH #296 Phase 3: replay serving (LOTUS_REPLAY). serve_* return 1
+ * and fill out when the journal has this thread's next value for
+ * jkind; 0 = journal exhausted or absent → the caller falls back
+ * to the live read and the miss is counted as a divergence
+ * (replay degrades, never refuses). serve_str returns a pointer
+ * into the loaded recording (stable for process life) or NULL. */
+extern int lotus_replay_active __attribute__((weak));
+int lotus_replay_serve_i64(uint32_t jkind, int64_t *out)
+    __attribute__((weak));
+int lotus_replay_expected_consume(uint64_t *out)
+    __attribute__((weak));
+void lotus_replay_note_consume(void) __attribute__((weak));
+const void *lotus_replay_serve_blob(uint32_t jkind, uint64_t *out_n)
+    __attribute__((weak));
+
+/* journal kinds — MUST match lotus_obs.c's JK_* table. */
+#define LOTUS_JK_TIME_NOW 1u
+#define LOTUS_JK_TIME_MONO_NS 2u
+#define LOTUS_JK_RAND_NEXT_INT 3u
+#define LOTUS_JK_OS_GETRANDOM 4u
+#define LOTUS_JK_ENV_VAR 5u
+#define LOTUS_JK_ENV_VAR_EXISTS 6u
+#define LOTUS_JK_ENV_ARG 7u
+#define LOTUS_JK_ENV_ARGS_COUNT 8u
+
+/* One branch on the default path (both flags weak process-constant
+ * ints), mirroring the probe discipline. */
+static inline int lotus_journal_on(void) {
+    return lotus_obs_journal_i64 && lotus_obs_live && lotus_obs_recording;
+}
+static inline int lotus_replay_on(void) {
+    return lotus_replay_serve_i64 && lotus_replay_active;
+}
 void lotus_obs_bus_publish(const char *subject, void *publisher_self,
                            uint64_t payload_bytes)
     __attribute__((weak));
@@ -6173,6 +6238,117 @@ void lotus_obs_bus_deliver(const char *subject, void *subscriber_self,
 int64_t lotus_obs_binding_register(const char *subject,
                                    int64_t transport_kind)
     __attribute__((weak));
+
+/* GH #296 Phase 1: stamp the CONSUMPTION of a queued delivery, on
+ * the consuming thread, right before its handler runs. Recording
+ * mode only. Every dequeue-driven dispatch path calls this (main
+ * queue, coop pool, mailbox, async coro start); the synchronous
+ * direct flavors deliberately do not — their handler runs at the
+ * BUS_DELIVER position on the same ring, so the deliver record IS
+ * the consumption point. Pairing: per queue, k-th consume = k-th
+ * queued delivery (single consumer thread, FIFO). */
+static inline void lotus_bus_note_consume(void *subscriber_self,
+                                          uint64_t pub_id) {
+    if (lotus_obs_record_consume && lotus_obs_live &&
+        lotus_obs_recording) {
+        lotus_obs_record_consume(subscriber_self, pub_id);
+    }
+    if (lotus_replay_note_consume && lotus_replay_active) {
+        lotus_replay_note_consume();
+    }
+}
+
+/* GH #296 Phase 4: per-consumer order enforcement under replay.
+ *
+ * Each consumer thread holds back dequeued cells that are not its
+ * recorded next delivery (TLS pending buffer — one consumer per
+ * queue, so TLS is exactly the right scope) and releases them in
+ * recorded order. Enforcement DEGRADES on divergence: if the
+ * expected delivery hasn't arrived within the hold timeout (the
+ * re-executed run genuinely diverged, or the expected publish never
+ * happened), the oldest held cell is released and the miss is
+ * counted — a replay reports what it couldn't reproduce, it never
+ * deadlocks. Cells with pub_id 0 (structural: run starts, create
+ * cells) match a recorded 0 slot.
+ *
+ * All of this is dead code unless lotus_replay_active. */
+#define LOTUS_REPLAY_HOLD_NS 1000000000LL /* 1s */
+static __thread lotus_bus_cell_t *t_rp_pending = NULL;
+static __thread size_t t_rp_pending_len = 0, t_rp_pending_cap = 0;
+static __thread int64_t t_rp_hold_since = 0;
+static _Atomic uint64_t g_rp_order_divergences = 0;
+uint64_t lotus_replay_order_divergences(void) {
+    return atomic_load_explicit(&g_rp_order_divergences,
+                                memory_order_relaxed);
+}
+
+static int64_t lotus_rp_now_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t)ts.tv_sec * 1000000000LL + (int64_t)ts.tv_nsec;
+}
+
+static void lotus_rp_pending_push(const lotus_bus_cell_t *cell) {
+    if (t_rp_pending_len == t_rp_pending_cap) {
+        t_rp_pending_cap = t_rp_pending_cap ? t_rp_pending_cap * 2 : 16;
+        t_rp_pending = realloc(
+            t_rp_pending, t_rp_pending_cap * sizeof(lotus_bus_cell_t));
+    }
+    t_rp_pending[t_rp_pending_len++] = *cell;
+    if (t_rp_pending_len == 1) t_rp_hold_since = lotus_rp_now_ns();
+}
+
+static int lotus_rp_pending_take(uint64_t want, lotus_bus_cell_t *out) {
+    for (size_t i = 0; i < t_rp_pending_len; i++) {
+        if (t_rp_pending[i].rec_pub_id == want) {
+            *out = t_rp_pending[i];
+            memmove(&t_rp_pending[i], &t_rp_pending[i + 1],
+                    (t_rp_pending_len - i - 1) * sizeof(lotus_bus_cell_t));
+            t_rp_pending_len--;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Gate a just-dequeued cell against the recorded order.
+ * Returns 1 = dispatch *cell now (possibly swapped for a held one),
+ * 0 = cell was parked; dequeue more (or wait). */
+static int lotus_replay_gate_cell(lotus_bus_cell_t *cell) {
+    uint64_t exp;
+    if (!lotus_replay_expected_consume ||
+        !lotus_replay_expected_consume(&exp)) {
+        return 1; /* recorded stream exhausted — no constraint */
+    }
+    if (cell->rec_pub_id == exp) return 1;
+    lotus_rp_pending_push(cell);
+    if (lotus_rp_pending_take(exp, cell)) return 1;
+    return 0;
+}
+
+/* Nothing new in the queue and cells are held: either keep waiting
+ * (returns 0) or — past the hold timeout — degrade by releasing the
+ * oldest held cell into *out (returns 1). */
+static int lotus_replay_gate_idle(lotus_bus_cell_t *out) {
+    if (t_rp_pending_len == 0) return 0;
+    uint64_t exp;
+    if (lotus_replay_expected_consume &&
+        lotus_replay_expected_consume(&exp) &&
+        lotus_rp_pending_take(exp, out)) {
+        return 1;
+    }
+    if (lotus_rp_now_ns() - t_rp_hold_since < LOTUS_REPLAY_HOLD_NS) {
+        return 0;
+    }
+    atomic_fetch_add_explicit(&g_rp_order_divergences, 1,
+                              memory_order_relaxed);
+    *out = t_rp_pending[0];
+    memmove(&t_rp_pending[0], &t_rp_pending[1],
+            (t_rp_pending_len - 1) * sizeof(lotus_bus_cell_t));
+    t_rp_pending_len--;
+    t_rp_hold_since = lotus_rp_now_ns();
+    return 1;
+}
 /* iris handoff-4 P14: subject leads so the probe can resolve the
  * record's topic id (the consumer join key); binding_id drives the
  * per-binding counter line only. */
@@ -6348,6 +6524,7 @@ static void bus_queue_enqueue_inner(lotus_bus_queue_t *q,
     slot->payload_size = payload_size;
     slot->payload_heap = heap_buf;
     slot->deserialize  = g_bus_pending_wire_deser;
+    slot->rec_pub_id   = g_bus_pending_rec_pub;
     if (!heap_buf && payload_size > 0 && payload_src) {
         memcpy(slot->payload_inline, payload_src, payload_size);
     }
@@ -6440,6 +6617,7 @@ static void bus_inline_drain_one(lotus_bus_queue_t *q) {
      * survive a handler-driven q->cells realloc. NULL on this
      * single-threaded inline path (no wire cells); kept uniform. */
     void  *region_ptr   = cell->payload_region;
+    uint64_t rec_pub_id  = cell->rec_pub_id;
     unsigned char stack_payload[LOTUS_PAYLOAD_INLINE]
         __attribute__((aligned(16)));
     void *payload_ptr = NULL;
@@ -6450,6 +6628,7 @@ static void bus_inline_drain_one(lotus_bus_queue_t *q) {
         payload_ptr = stack_payload;
     }
     g_bus_inline_drain_depth++;
+    lotus_bus_note_consume(handler_self, rec_pub_id);
     ((lotus_handler_fn)handler_fn)(handler_self, payload_ptr);
     g_bus_inline_drain_depth--;
     if (heap_ptr) free(heap_ptr);
@@ -6521,11 +6700,55 @@ void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
         for (;;) {
             pthread_mutex_lock(&q->lock);
             if (q->head >= q->tail) {
-                q->head = 0;
-                q->tail = 0;
-                g_bus_drain_active = 0;
+                /* GH #296 Phase 4: queue empty but cells held out
+                 * of recorded order — release what matches (or,
+                 * past the hold timeout, degrade). The queue lock
+                 * is NOT held while dispatching. */
                 pthread_mutex_unlock(&q->lock);
-                return;
+                if (lotus_replay_note_consume && lotus_replay_active
+                    && t_rp_pending_len > 0) {
+                    lotus_bus_cell_t held;
+                    if (lotus_replay_gate_idle(&held)) {
+                        if (held.handler) {
+                            lotus_bus_note_dispatched(held.handler,
+                                                      held.self_ptr);
+                        }
+                        if (held.handler &&
+                            lotus_bus_cell_materialize(&held)) {
+                            void *pp = NULL;
+                            if (held.payload_size > 0) {
+                                pp = held.payload_heap
+                                    ? held.payload_heap
+                                    : (void *)held.payload_inline;
+                            }
+                            lotus_bus_note_consume(held.self_ptr,
+                                                   held.rec_pub_id);
+                            ((lotus_handler_fn)held.handler)(
+                                held.self_ptr, pp);
+                            if (held.payload_heap)
+                                free(held.payload_heap);
+                            if (held.payload_region)
+                                lotus_arena_destroy(
+                                    held.payload_region);
+                        }
+                        continue;
+                    }
+                    /* Held cells but no releasable one: the drain
+                     * returns (this is a slice on the owner thread;
+                     * the next slice retries). */
+                }
+                pthread_mutex_lock(&q->lock);
+                if (q->head >= q->tail) {
+                    if (t_rp_pending_len == 0) {
+                        q->head = 0;
+                        q->tail = 0;
+                    }
+                    g_bus_drain_active = 0;
+                    pthread_mutex_unlock(&q->lock);
+                    return;
+                }
+                pthread_mutex_unlock(&q->lock);
+                continue;
             }
             lotus_bus_cell_t cell_copy = q->cells[q->head++];
             pthread_mutex_unlock(&q->lock);
@@ -6534,6 +6757,10 @@ void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
              * into the subscriber's arena here, on the queue's
              * owner thread (bug 3). */
             if (!cell_copy.handler) continue; /* GH #255 tombstone */
+            if (lotus_replay_note_consume && lotus_replay_active &&
+                !lotus_replay_gate_cell(&cell_copy)) {
+                continue; /* held; released in recorded order */
+            }
             lotus_bus_note_dispatched(cell_copy.handler,
                                       cell_copy.self_ptr);
             if (!lotus_bus_cell_materialize(&cell_copy)) continue;
@@ -6543,6 +6770,8 @@ void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
                     ? cell_copy.payload_heap
                     : (void *)cell_copy.payload_inline;
             }
+            lotus_bus_note_consume(cell_copy.self_ptr,
+                                   cell_copy.rec_pub_id);
             ((lotus_handler_fn)cell_copy.handler)(
                 cell_copy.self_ptr, payload_ptr);
             if (cell_copy.payload_heap) free(cell_copy.payload_heap);
@@ -6578,6 +6807,7 @@ void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
              * NULL on this single-threaded path (no wire cells), but
              * kept uniform with the concurrent drain. */
             void *region_ptr = cell->payload_region;
+            uint64_t rec_pub_id = cell->rec_pub_id;
             void *payload_ptr = NULL;
             if (heap_ptr) {
                 /* Heap pointer is stable across handler-driven
@@ -6592,6 +6822,7 @@ void lotus_bus_queue_drain(lotus_bus_queue_t *q) {
                 memcpy(stack_payload, cell->payload_inline, psize);
                 payload_ptr = stack_payload;
             }
+            lotus_bus_note_consume(handler_self, rec_pub_id);
             ((lotus_handler_fn)handler_fn)(handler_self, payload_ptr);
             if (heap_ptr) free(heap_ptr);
             if (region_ptr) lotus_arena_destroy((lotus_arena_t *)region_ptr);
@@ -6868,6 +7099,7 @@ static void lotus_mailbox_dispatch_cell(lotus_bus_cell_t *cell) {
             ? cell->payload_heap
             : (void *)cell->payload_inline;
     }
+    lotus_bus_note_consume(cell->self_ptr, cell->rec_pub_id);
     ((lotus_handler_fn)cell->handler)(cell->self_ptr, payload_ptr);
     if (cell->payload_heap) free(cell->payload_heap);
     if (cell->payload_region) lotus_arena_destroy(cell->payload_region);
@@ -6912,6 +7144,7 @@ void lotus_mailbox_post(lotus_mailbox_t *mb,
     cell.payload_size = payload_size;
     cell.payload_heap = heap_buf;
     cell.deserialize  = g_bus_pending_wire_deser;
+    cell.rec_pub_id   = g_bus_pending_rec_pub;
     if (!heap_buf && payload_size > 0 && payload_src) {
         memcpy(cell.payload_inline, payload_src, payload_size);
     }
@@ -7001,10 +7234,12 @@ void lotus_mailbox_post(lotus_mailbox_t *mb,
 int lotus_mailbox_drain_one(lotus_mailbox_t *mb) {
     if (!mb) return 0;
     lotus_bus_cell_t cell;
+    int replaying = lotus_replay_note_consume && lotus_replay_active;
     for (;;) {
         /* Ring first (lock-free), then the consumer-local overflow list. */
         if (lotus_mpsc_ring_try_dequeue(&mb->ring, &cell)) {
             lotus_mailbox_wake_producers(mb);   /* freed a slot (GH #125) */
+            if (replaying && !lotus_replay_gate_cell(&cell)) continue;
             lotus_mailbox_dispatch_cell(&cell);
             return 1;
         }
@@ -7014,8 +7249,20 @@ int lotus_mailbox_drain_one(lotus_mailbox_t *mb) {
             if (!mb->overflow_head) mb->overflow_tail = NULL;
             cell = node->cell;
             free(node);
+            if (replaying && !lotus_replay_gate_cell(&cell)) continue;
             lotus_mailbox_dispatch_cell(&cell);
             return 1;
+        }
+        /* GH #296 Phase 4: cells held out of order (see the coop
+         * drain's twin branch). */
+        if (replaying && t_rp_pending_len > 0) {
+            if (lotus_replay_gate_idle(&cell)) {
+                lotus_mailbox_dispatch_cell(&cell);
+                return 1;
+            }
+            struct timespec ts = {0, 200 * 1000};
+            nanosleep(&ts, NULL);
+            continue;
         }
 
         /* Both empty — park under the mutex with the seq_cst handshake. */
@@ -7032,6 +7279,7 @@ int lotus_mailbox_drain_one(lotus_mailbox_t *mb) {
             atomic_store_explicit(&mb->parked, 0, memory_order_seq_cst);
             pthread_mutex_unlock(&mb->lock);
             lotus_mailbox_wake_producers(mb);
+            if (replaying && !lotus_replay_gate_cell(&cell)) continue;
             lotus_mailbox_dispatch_cell(&cell);
             return 1;
         }
@@ -7223,6 +7471,9 @@ typedef struct lotus_coro {
     void             *handler;
     void             *self_ptr;
     void             *payload_ptr;
+    /* GH #296: the delivery's recording identity, copied from the
+     * cell at coro creation; consumed by the thunk's consume stamp. */
+    uint64_t          rec_pub_id;
     /* Per-coro snapshot of the `lotus_current_caller_arena` TLS
      * (downstream handoff 2026-07-15, item 3). That TLS decides where
      * stdlib primitives (recv result blobs, str builders, …) allocate,
@@ -7464,6 +7715,7 @@ static void lotus_coop_pool_dispatch_cell(lotus_bus_cell_t *cell) {
             ? cell->payload_heap
             : (void *)cell->payload_inline;
     }
+    lotus_bus_note_consume(cell->self_ptr, cell->rec_pub_id);
     ((lotus_handler_fn)cell->handler)(cell->self_ptr, payload_ptr);
     if (cell->payload_heap) free(cell->payload_heap);
     if (cell->payload_region) lotus_arena_destroy(cell->payload_region);
@@ -7508,6 +7760,7 @@ void lotus_coop_pool_post(lotus_coop_pool_t *p,
     cell.payload_size = payload_size;
     cell.payload_heap = heap_buf;
     cell.deserialize  = g_bus_pending_wire_deser;
+    cell.rec_pub_id   = g_bus_pending_rec_pub;
     if (!heap_buf && payload_size > 0 && payload_src) {
         memcpy(cell.payload_inline, payload_src, payload_size);
     }
@@ -7612,10 +7865,12 @@ void lotus_coop_pool_post(lotus_coop_pool_t *p,
  * after shutdown-empty. */
 static int lotus_coop_pool_drain_one(lotus_coop_pool_t *p) {
     lotus_bus_cell_t cell;
+    int replaying = lotus_replay_note_consume && lotus_replay_active;
     for (;;) {
         /* Ring first (lock-free), then the consumer-local overflow list. */
         if (lotus_mpsc_ring_try_dequeue(&p->ring, &cell)) {
             lotus_coop_pool_wake_producers(p);  /* freed a slot */
+            if (replaying && !lotus_replay_gate_cell(&cell)) continue;
             lotus_coop_pool_dispatch_cell(&cell);
             return 1;
         }
@@ -7625,8 +7880,24 @@ static int lotus_coop_pool_drain_one(lotus_coop_pool_t *p) {
             if (!p->overflow_head) p->overflow_tail = NULL;
             cell = node->cell;
             free(node);
+            if (replaying && !lotus_replay_gate_cell(&cell)) continue;
             lotus_coop_pool_dispatch_cell(&cell);
             return 1;
+        }
+        /* GH #296 Phase 4: queue empty but cells held out of order —
+         * release the expected one if it surfaced, keep a bounded
+         * wait otherwise (never park with held cells: the expected
+         * delivery may only exist in the pending buffer). */
+        if (replaying && t_rp_pending_len > 0) {
+            if (lotus_replay_gate_idle(&cell)) {
+                lotus_coop_pool_dispatch_cell(&cell);
+                return 1;
+            }
+            struct timespec ts = {0, 200 * 1000};
+            nanosleep(&ts, NULL);
+            if (atomic_load_explicit(&p->shutdown, memory_order_relaxed))
+                continue; /* drain held cells via the timeout path */
+            continue;
         }
 
         /* Both empty — park under the mutex with the seq_cst handshake.
@@ -7642,6 +7913,7 @@ static int lotus_coop_pool_drain_one(lotus_coop_pool_t *p) {
             atomic_store_explicit(&p->parked, 0, memory_order_seq_cst);
             pthread_mutex_unlock(&p->lock);
             lotus_coop_pool_wake_producers(p);
+            if (replaying && !lotus_replay_gate_cell(&cell)) continue;
             lotus_coop_pool_dispatch_cell(&cell);
             return 1;
         }
@@ -7696,6 +7968,18 @@ lotus_coop_pool_t *lotus_coop_pool_current(void) {
 int lotus_coop_pool_enable_async_io(lotus_coop_pool_t *p) {
     if (!p) return -1;
     if (p->async_io_enabled) return 0;
+    /* GH #296: the async drain multiplexes coros whose park/resume
+     * interleaving is epoll-driven — per-consumer order enforcement
+     * for it is a later milestone. Refuse loudly rather than replay
+     * wrongly. */
+    if (lotus_replay_note_consume && lotus_replay_active) {
+        fprintf(stderr,
+                "hale replay: `where async_io` pools are not "
+                "replayable yet (GH #296 Phase 4 covers classic "
+                "pools, mailboxes, and the main queue)\n");
+        fflush(NULL);
+        _exit(65);
+    }
     int fd = epoll_create1(EPOLL_CLOEXEC);
     if (fd < 0) {
         return -1;
@@ -7741,6 +8025,7 @@ static void lotus_coro_thunk(void) {
         }
         return;
     }
+    lotus_bus_note_consume(c->self_ptr, c->rec_pub_id);
     ((lotus_handler_fn)c->handler)(c->self_ptr, c->payload_ptr);
     c->done = 1;
     /* uc_link would handle this implicitly, but being explicit is
@@ -8155,10 +8440,13 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
      * leak shape becomes observable. */
     lotus_coro_t *c =
         lotus_coro_alloc(p, cell_copy.handler, cell_copy.self_ptr, payload_ptr);
+    if (c) c->rec_pub_id = cell_copy.rec_pub_id;
     if (!c) {
         /* OOM on coro alloc — fall back to direct invocation. The
          * handler runs on the worker's stack; if it parks via
          * `park_on_fd`, the call returns -1 (no current coro). */
+        lotus_bus_note_consume(cell_copy.self_ptr,
+                               cell_copy.rec_pub_id);
         ((lotus_handler_fn)cell_copy.handler)(
             cell_copy.self_ptr, payload_ptr);
         if (cell_copy.payload_heap) free(cell_copy.payload_heap);
@@ -8216,6 +8504,17 @@ int64_t lotus_time_sleep_park_try(int64_t ns) {
 static void *lotus_coop_pool_worker(void *arg) {
     lotus_coop_pool_t *p = (lotus_coop_pool_t *)arg;
     g_current_pool_tls = p;
+    /* GH #296: stable consumer identity — 16 + registration index
+     * (registration order is program structure, so it survives a
+     * re-run; the pthread id does not). */
+    if (lotus_obs_note_consumer) {
+        for (size_t i = 0; i < g_coop_pool_count; i++) {
+            if (g_coop_pools[i] == p) {
+                lotus_obs_note_consumer(16 + (uint64_t)i);
+                break;
+            }
+        }
+    }
     /* F.35 Slice 1: async_io vs classic-blocking branch. The flag
      * is acquire-loaded once per outer loop iteration so a late
      * enable (called between worker start and first drain) takes
@@ -9014,7 +9313,12 @@ static int lotus_bus_log_drop_enabled(void);
 static inline int lotus_bus_post_entry(lotus_bus_entry_t *e,
                                        lotus_bus_queue_t *queue,
                                        const void *payload,
-                                       size_t size) {
+                                       size_t size,
+                                       uint64_t rec_pub) {
+    /* GH #296: the TLS is scoped to exactly this post (the wire-deser
+     * pattern) so a structural cell posted outside any fanout can
+     * never inherit a stale publish identity. */
+    g_bus_pending_rec_pub = rec_pub;
     if (e->mailbox) {
         lotus_mailbox_post(e->mailbox, e->handler, e->self_ptr,
                            payload, size);
@@ -9025,7 +9329,12 @@ static inline int lotus_bus_post_entry(lotus_bus_entry_t *e,
         lotus_bus_queue_enqueue(queue, e->handler, e->self_ptr,
                                 payload, size);
     } else {
+        g_bus_pending_rec_pub = 0;
         return 0;
+    }
+    g_bus_pending_rec_pub = 0;
+    if (rec_pub && lotus_obs_record_enqueue && lotus_obs_live) {
+        lotus_obs_record_enqueue(rec_pub, e->self_ptr);
     }
     return 1;
 }
@@ -9039,6 +9348,12 @@ void lotus_bus_local_dispatch(lotus_bus_queue_t *queue,
      * matched target below (enqueue-time — see lotus_obs.c v0
      * scope notes). Publisher attribution rides the caller-arena
      * TLS owner when available; v0 passes NULL (unattributed). */
+    uint64_t rec_pub = 0;
+    if (lotus_obs_record_publish_payload && lotus_obs_live &&
+        (lotus_obs_recording || lotus_replay_active)) {
+        rec_pub = lotus_obs_record_publish_payload(
+            subject, payload, (uint64_t)payload_size);
+    }
     if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)payload_size);
     }
@@ -9058,7 +9373,7 @@ void lotus_bus_local_dispatch(lotus_bus_queue_t *queue,
          * filter — bypassing the routing-key contract. */
         if (e->key_filter_kind != 0) continue;
         delivered += (size_t)lotus_bus_post_entry(
-            e, queue, payload, payload_size);
+            e, queue, payload, payload_size, rec_pub);
         if (lotus_obs_bus_deliver && lotus_obs_live) {
             lotus_obs_bus_deliver(subject, e->self_ptr,
                                   (uint64_t)payload_size);
@@ -9156,6 +9471,12 @@ void lotus_bus_local_dispatch_keyed(lotus_bus_queue_t *queue,
      * feeds — recorded zero BUS_PUBLISH and a zero published counter.
      * Emit here (publisher-only path; never a reader re-dispatch
      * target) exactly as the non-keyed local fanout does. */
+    uint64_t rec_pub = 0;
+    if (lotus_obs_record_publish_payload && lotus_obs_live &&
+        (lotus_obs_recording || lotus_replay_active)) {
+        rec_pub = lotus_obs_record_publish_payload(
+            subject, payload, (uint64_t)payload_size);
+    }
     if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)payload_size);
     }
@@ -9181,7 +9502,7 @@ void lotus_bus_local_dispatch_keyed(lotus_bus_queue_t *queue,
             continue;
         }
         (void)lotus_bus_post_entry(e, queue,
-            payload, payload_size);
+            payload, payload_size, rec_pub);
         /* iris handoff-4 P15: BUS_DELIVER per matched keyed target
          * (sibling of the non-keyed local_dispatch probe — the keyed
          * flavor had none, so keyed deliveries never counted). */
@@ -9201,7 +9522,8 @@ void lotus_bus_local_dispatch_keyed(lotus_bus_queue_t *queue,
             if (!e->subject) continue;
             if (!lotus_subject_match(e->subject, subject)) continue;
             if (e->key_filter_kind != 2) continue;
-            (void)lotus_bus_post_entry(e, queue, payload, payload_size);
+            (void)lotus_bus_post_entry(e, queue, payload, payload_size,
+                                       rec_pub);
             if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
                                       (uint64_t)payload_size);
@@ -13301,25 +13623,55 @@ void lotus_io_init(void) {
 }
 
 int lotus_env_args_count(void) {
+    if (lotus_replay_on()) {
+        int64_t v;
+        if (lotus_replay_serve_i64(LOTUS_JK_ENV_ARGS_COUNT, &v))
+            return (int)v;
+    }
+    if (lotus_journal_on())
+        lotus_obs_journal_i64(LOTUS_JK_ENV_ARGS_COUNT, (int64_t)g_argc);
     return g_argc;
 }
 
 const char *lotus_env_arg(int i) {
-    if (i < 0 || i >= g_argc || !g_argv || !g_argv[i]) {
-        return g_empty_str;
+    if (lotus_replay_on()) {
+        uint64_t n = 0;
+        const void *v = lotus_replay_serve_blob(LOTUS_JK_ENV_ARG, &n);
+        if (v && n > 0) return (const char *)v; /* NUL included */
     }
-    return g_argv[i];
+    const char *r = (i < 0 || i >= g_argc || !g_argv || !g_argv[i])
+        ? g_empty_str
+        : g_argv[i];
+    if (lotus_journal_on())
+        lotus_obs_journal_bytes(LOTUS_JK_ENV_ARG, r, strlen(r) + 1);
+    return r;
 }
 
 const char *lotus_env_var(const char *name) {
     if (!name) return g_empty_str;
+    if (lotus_replay_on()) {
+        uint64_t n = 0;
+        const void *v = lotus_replay_serve_blob(LOTUS_JK_ENV_VAR, &n);
+        if (v && n > 0) return (const char *)v; /* NUL included */
+    }
     const char *v = getenv(name);
-    return v ? v : g_empty_str;
+    const char *r = v ? v : g_empty_str;
+    if (lotus_journal_on())
+        lotus_obs_journal_bytes(LOTUS_JK_ENV_VAR, r, strlen(r) + 1);
+    return r;
 }
 
 int lotus_env_var_exists(const char *name) {
     if (!name) return 0;
-    return getenv(name) != NULL ? 1 : 0;
+    if (lotus_replay_on()) {
+        int64_t v;
+        if (lotus_replay_serve_i64(LOTUS_JK_ENV_VAR_EXISTS, &v))
+            return (int)v;
+    }
+    int r = getenv(name) != NULL ? 1 : 0;
+    if (lotus_journal_on())
+        lotus_obs_journal_i64(LOTUS_JK_ENV_VAR_EXISTS, (int64_t)r);
+    return r;
 }
 
 /*
@@ -15218,6 +15570,12 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
     /* iris handoff-4 P15: keyed publish probe (sibling of the
      * non-keyed dispatch_wire path). This is the serialize-present
      * keyed local fanout — publisher-only, so no redispatch guard. */
+    uint64_t rec_pub = 0;
+    if (lotus_obs_record_publish_payload && lotus_obs_live &&
+        (lotus_obs_recording || lotus_replay_active)) {
+        rec_pub = lotus_obs_record_publish_payload(
+            subject, wire_bytes, (uint64_t)wire_size);
+    }
     if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)wire_size);
     }
@@ -15246,7 +15604,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
         if (!lotus_bus_target_owner_is_current(e, g_bus_queue_for_remote)) {
             g_bus_pending_wire_deser = (void *)e->deserialize;
             (void)lotus_bus_post_entry(e, g_bus_queue_for_remote,
-                wire_bytes, wire_size);
+                wire_bytes, wire_size, rec_pub);
             g_bus_pending_wire_deser = NULL;
             if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
@@ -15260,6 +15618,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
         ssize_t struct_size = e->deserialize(
             wire_bytes, wire_size, struct_buf, LOTUS_PAYLOAD_MAX);
         if (struct_size <= 0) continue;
+        g_bus_pending_rec_pub = rec_pub;
         if (e->mailbox) {
             lotus_mailbox_post(
                 e->mailbox, e->handler, e->self_ptr,
@@ -15277,6 +15636,10 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
             lotus_bus_queue_enqueue(
                 g_bus_queue_for_remote, e->handler, e->self_ptr,
                 struct_buf, (size_t)struct_size);
+        }
+        g_bus_pending_rec_pub = 0;
+        if (rec_pub && lotus_obs_record_enqueue && lotus_obs_live) {
+            lotus_obs_record_enqueue(rec_pub, e->self_ptr);
         }
         /* iris handoff-4 P15: BUS_DELIVER per matched keyed target. */
         if (lotus_obs_bus_deliver && lotus_obs_live) {
@@ -15296,7 +15659,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
             if (!lotus_bus_target_owner_is_current(e, g_bus_queue_for_remote)) {
                 g_bus_pending_wire_deser = (void *)e->deserialize;
                 (void)lotus_bus_post_entry(e, g_bus_queue_for_remote,
-                    wire_bytes, wire_size);
+                    wire_bytes, wire_size, rec_pub);
                 g_bus_pending_wire_deser = NULL;
                 if (lotus_obs_bus_deliver && lotus_obs_live) {
                     lotus_obs_bus_deliver(subject, e->self_ptr,
@@ -15310,6 +15673,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
             ssize_t struct_size = e->deserialize(
                 wire_bytes, wire_size, struct_buf, LOTUS_PAYLOAD_MAX);
             if (struct_size <= 0) continue;
+            g_bus_pending_rec_pub = rec_pub;
             if (e->mailbox) {
                 lotus_mailbox_post(
                     e->mailbox, e->handler, e->self_ptr,
@@ -15322,6 +15686,10 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
                 lotus_bus_queue_enqueue(
                     g_bus_queue_for_remote, e->handler, e->self_ptr,
                     struct_buf, (size_t)struct_size);
+            }
+            g_bus_pending_rec_pub = 0;
+            if (rec_pub && lotus_obs_record_enqueue && lotus_obs_live) {
+                lotus_obs_record_enqueue(rec_pub, e->self_ptr);
             }
             if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
@@ -15348,6 +15716,12 @@ void lotus_bus_dispatch_wire(const char *subject,
     if (!subject || !wire_bytes || wire_size == 0) return;
     /* iris P4: BUS_PUBLISH for the cross-thread wire path (the
      * deliver probe rides the per-subscriber fanout below). */
+    uint64_t rec_pub = 0;
+    if (lotus_obs_record_publish_payload && lotus_obs_live &&
+        (lotus_obs_recording || lotus_replay_active)) {
+        rec_pub = lotus_obs_record_publish_payload(
+            subject, wire_bytes, (uint64_t)wire_size);
+    }
     if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)wire_size);
     }
@@ -15404,7 +15778,7 @@ void lotus_bus_dispatch_wire(const char *subject,
         if (!lotus_bus_target_owner_is_current(e, g_bus_queue_for_remote)) {
             g_bus_pending_wire_deser = (void *)e->deserialize;
             (void)lotus_bus_post_entry(e, g_bus_queue_for_remote,
-                wire_bytes, wire_size);
+                wire_bytes, wire_size, rec_pub);
             g_bus_pending_wire_deser = NULL;
             /* handoff-8 P21: BUS_DELIVER per matched target — the
              * plain wire flavor was the one fanout without it (its
@@ -15435,7 +15809,8 @@ void lotus_bus_dispatch_wire(const char *subject,
             continue;
         }
         if (lotus_bus_post_entry(e, g_bus_queue_for_remote,
-                                 struct_buf, (size_t)struct_size)) {
+                                 struct_buf, (size_t)struct_size,
+                                 rec_pub)) {
             /* handoff-8 P21: BUS_DELIVER per matched target (see the
              * cross-thread branch above). */
             if (lotus_obs_bus_deliver && lotus_obs_live) {
@@ -15503,6 +15878,12 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
     if (flat) {
         /* Verbatim local fanout (mirror lotus_bus_local_dispatch). */
         size_t delivered = 0;
+        uint64_t rec_pub = 0;
+        if (lotus_obs_record_publish_payload && lotus_obs_live &&
+            (lotus_obs_recording || lotus_replay_active)) {
+            rec_pub = lotus_obs_record_publish_payload(
+                subject, struct_payload, (uint64_t)struct_size);
+        }
         /* iris P4 (mirrors the dynamic path). */
         if (lotus_obs_bus_publish && lotus_obs_live) {
             lotus_obs_bus_publish(subject, NULL, (uint64_t)struct_size);
@@ -15520,13 +15901,20 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
                  * takes the no-acquire-load _st enqueue; everything
                  * else routes through lotus_bus_post_entry. */
                 if (no_pinned && !e->mailbox && !e->coop_pool && queue) {
+                    g_bus_pending_rec_pub = rec_pub;
                     lotus_bus_queue_enqueue_st(queue, e->handler,
                                                e->self_ptr, struct_payload,
                                                (size_t)struct_size);
+                    g_bus_pending_rec_pub = 0;
+                    if (rec_pub && lotus_obs_record_enqueue &&
+                        lotus_obs_live) {
+                        lotus_obs_record_enqueue(rec_pub, e->self_ptr);
+                    }
                     delivered++;
                 } else {
                     delivered += (size_t)lotus_bus_post_entry(
-                        e, queue, struct_payload, (size_t)struct_size);
+                        e, queue, struct_payload, (size_t)struct_size,
+                        rec_pub);
                 }
             }
         }
@@ -15568,6 +15956,12 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
      * Counted before the serialize so a serialize FAILURE still
      * records the publish that was attempted; the drop is visible
      * separately via LOTUS_BUS_LOG_DROP. */
+    uint64_t rec_pub = 0;
+    if (lotus_obs_record_publish_payload && lotus_obs_live &&
+        (lotus_obs_recording || lotus_replay_active)) {
+        rec_pub = lotus_obs_record_publish_payload(
+            subject, struct_payload, (uint64_t)struct_size);
+    }
     if (lotus_obs_bus_publish && lotus_obs_live) {
         lotus_obs_bus_publish(subject, NULL, (uint64_t)struct_size);
     }
@@ -15590,13 +15984,20 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
                  * takes the no-acquire-load _st enqueue; everything
                  * else routes through lotus_bus_post_entry. */
                 if (no_pinned && !e->mailbox && !e->coop_pool && queue) {
+                    g_bus_pending_rec_pub = rec_pub;
                     lotus_bus_queue_enqueue_st(queue, e->handler,
                                                e->self_ptr, struct_payload,
                                                (size_t)struct_size);
+                    g_bus_pending_rec_pub = 0;
+                    if (rec_pub && lotus_obs_record_enqueue &&
+                        lotus_obs_live) {
+                        lotus_obs_record_enqueue(rec_pub, e->self_ptr);
+                    }
                     delivered++;
                 } else {
                     delivered += (size_t)lotus_bus_post_entry(
-                        e, queue, struct_payload, (size_t)struct_size);
+                        e, queue, struct_payload, (size_t)struct_size,
+                        rec_pub);
                 }
             }
         }
@@ -15647,7 +16048,8 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
                                                    g_bus_queue_for_remote)) {
                 g_bus_pending_wire_deser = (void *)e->deserialize;
                 (void)lotus_bus_post_entry(e, g_bus_queue_for_remote,
-                                           wire_buf, (size_t)wire_size);
+                                           wire_buf, (size_t)wire_size,
+                                           rec_pub);
                 g_bus_pending_wire_deser = NULL;
                 delivered++;
                 continue;
@@ -15662,13 +16064,20 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
              * rest routes through lotus_bus_post_entry. */
             if (no_pinned && !e->mailbox && !e->coop_pool
                 && g_bus_queue_for_remote) {
+                g_bus_pending_rec_pub = rec_pub;
                 lotus_bus_queue_enqueue_st(g_bus_queue_for_remote,
                                            e->handler, e->self_ptr,
                                            struct_buf, (size_t)ssz);
+                g_bus_pending_rec_pub = 0;
+                if (rec_pub && lotus_obs_record_enqueue &&
+                    lotus_obs_live) {
+                    lotus_obs_record_enqueue(rec_pub, e->self_ptr);
+                }
                 delivered++;
             } else {
                 delivered += (size_t)lotus_bus_post_entry(
-                    e, g_bus_queue_for_remote, struct_buf, (size_t)ssz);
+                    e, g_bus_queue_for_remote, struct_buf, (size_t)ssz,
+                    rec_pub);
             }
         }
     }
@@ -16058,6 +16467,18 @@ void *lotus_os_getrandom(int64_t n) {
     if (n <= 0) {
         return lotus_caller_or_global_bytes_create(0);
     }
+    if (lotus_replay_on()) {
+        uint64_t jn = 0;
+        const void *jv =
+            lotus_replay_serve_blob(LOTUS_JK_OS_GETRANDOM, &jn);
+        if (jv && jn == (uint64_t)n) {
+            void *jblob = lotus_caller_or_global_bytes_create(n);
+            if (jblob) {
+                memcpy(lotus_bytes_data(jblob), jv, (size_t)n);
+                return jblob;
+            }
+        }
+    }
     if (n > LOTUS_GETRANDOM_PER_CALL_MAX) {
         errno = EINVAL;
         return NULL;
@@ -16092,6 +16513,9 @@ void *lotus_os_getrandom(int64_t n) {
         return NULL;
     }
     if (left == 0) {
+        if (lotus_journal_on())
+            lotus_obs_journal_bytes(LOTUS_JK_OS_GETRANDOM, body,
+                                    (uint64_t)n);
         return blob;
     }
 #endif
@@ -16117,6 +16541,8 @@ void *lotus_os_getrandom(int64_t n) {
         return NULL;
     }
     close(fd);
+    if (lotus_journal_on())
+        lotus_obs_journal_bytes(LOTUS_JK_OS_GETRANDOM, body, (uint64_t)n);
     return blob;
 }
 
@@ -18236,6 +18662,10 @@ void lotus_rand_seed_from_time(void) {
 }
 
 int64_t lotus_rand_next_int(int64_t max) {
+    if (lotus_replay_on()) {
+        int64_t v;
+        if (lotus_replay_serve_i64(LOTUS_JK_RAND_NEXT_INT, &v)) return v;
+    }
     pthread_mutex_lock(&g_rand_mutex);
     if (g_rand_state == 0) {
         /* Auto-seed on first use so callers that forget the
@@ -18255,7 +18685,10 @@ int64_t lotus_rand_next_int(int64_t max) {
     uint64_t mixed = x * 0x2545F4914F6CDD1DULL;
     pthread_mutex_unlock(&g_rand_mutex);
     if (max <= 0) return 0;
-    return (int64_t)(mixed % (uint64_t)max);
+    int64_t r = (int64_t)(mixed % (uint64_t)max);
+    if (lotus_journal_on())
+        lotus_obs_journal_i64(LOTUS_JK_RAND_NEXT_INT, r);
+    return r;
 }
 
 /*
@@ -18267,9 +18700,34 @@ int64_t lotus_rand_next_int(int64_t max) {
  * `std::time::now_ns` if a consumer surfaces it.
  */
 int64_t lotus_time_now_seconds(void) {
+    if (lotus_replay_on()) {
+        int64_t v;
+        if (lotus_replay_serve_i64(LOTUS_JK_TIME_NOW, &v)) return v;
+    }
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
-    return (int64_t)ts.tv_sec;
+    int64_t r = (int64_t)ts.tv_sec;
+    if (lotus_journal_on())
+        lotus_obs_journal_i64(LOTUS_JK_TIME_NOW, r);
+    return r;
+}
+
+/* GH #296 Phase 3: `std::time::monotonic` / `monotonic_ns` used to
+ * lower as inline clock_gettime IR — no symbol, so nothing a
+ * journal or a replay could interpose (the same rationale that
+ * made `now` a named primitive). Codegen now routes both through
+ * this. */
+int64_t lotus_time_monotonic_ns(void) {
+    if (lotus_replay_on()) {
+        int64_t v;
+        if (lotus_replay_serve_i64(LOTUS_JK_TIME_MONO_NS, &v)) return v;
+    }
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    int64_t r = (int64_t)ts.tv_sec * 1000000000LL + (int64_t)ts.tv_nsec;
+    if (lotus_journal_on())
+        lotus_obs_journal_i64(LOTUS_JK_TIME_MONO_NS, r);
+    return r;
 }
 
 /*

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -6220,6 +6220,7 @@ int lotus_replay_expected_consume(uint64_t *out_msg,
     __attribute__((weak));
 uint64_t lotus_obs_pub_inst_id(void *self) __attribute__((weak));
 void lotus_replay_note_consume(void) __attribute__((weak));
+void lotus_replay_note_unexpected(void) __attribute__((weak));
 const void *lotus_replay_serve_blob(uint32_t jkind, const void *args,
                                     uint64_t args_len,
                                     uint64_t want_size,
@@ -6244,11 +6245,12 @@ static inline int lotus_journal_on(void) {
 static inline int lotus_replay_on(void) {
     return lotus_replay_serve_i64 && lotus_replay_active;
 }
-void lotus_obs_bus_publish(const char *subject, void *publisher_self,
-                           uint64_t payload_bytes)
+uint64_t lotus_obs_bus_publish(const char *subject,
+                               void *publisher_self,
+                               uint64_t payload_bytes)
     __attribute__((weak));
 void lotus_obs_bus_deliver(const char *subject, void *subscriber_self,
-                           uint64_t payload_bytes)
+                           uint64_t payload_bytes, uint64_t seq_token)
     __attribute__((weak));
 int64_t lotus_obs_binding_register(const char *subject,
                                    int64_t transport_kind)
@@ -6305,9 +6307,17 @@ static int64_t lotus_rp_now_ns(void) {
 
 static void lotus_rp_pending_push(const lotus_bus_cell_t *cell) {
     if (t_rp_pending_len == t_rp_pending_cap) {
-        t_rp_pending_cap = t_rp_pending_cap ? t_rp_pending_cap * 2 : 16;
-        t_rp_pending = realloc(
-            t_rp_pending, t_rp_pending_cap * sizeof(lotus_bus_cell_t));
+        size_t ncap = t_rp_pending_cap ? t_rp_pending_cap * 2 : 16;
+        lotus_bus_cell_t *g = realloc(
+            t_rp_pending, ncap * sizeof(lotus_bus_cell_t));
+        if (!g) {
+            fprintf(stderr,
+                    "hale replay: hold-buffer allocation failed\n");
+            fflush(NULL);
+            _exit(65);
+        }
+        t_rp_pending = g;
+        t_rp_pending_cap = ncap;
     }
     t_rp_pending[t_rp_pending_len++] = *cell;
     if (t_rp_pending_len == 1) t_rp_hold_since = lotus_rp_now_ns();
@@ -6341,7 +6351,15 @@ static int lotus_replay_gate_cell(lotus_bus_cell_t *cell) {
     uint32_t exp_locus;
     if (!lotus_replay_expected_consume ||
         !lotus_replay_expected_consume(&exp_msg, &exp_locus)) {
-        return 1; /* recorded stream exhausted — no constraint */
+        /* Recorded stream exhausted (or consumer unknown to the
+         * recording): dispatch freely, but an IDENTIFIED delivery
+         * here is history the recording does not contain — count
+         * it (round 3 follow-up: silence here let plain replay
+         * under-report). Structural cells stay uncounted. */
+        if (cell->rec_pub_id && lotus_replay_note_unexpected) {
+            lotus_replay_note_unexpected();
+        }
+        return 1;
     }
     uint32_t cell_locus = (uint32_t)(
         lotus_obs_pub_inst_id ? lotus_obs_pub_inst_id(cell->self_ptr)
@@ -9385,8 +9403,9 @@ void lotus_bus_local_dispatch(lotus_bus_queue_t *queue,
         rec_pub = lotus_obs_record_publish_payload(
             subject, payload, (uint64_t)payload_size, 1);
     }
+    uint64_t obs_tok = 0;
     if (lotus_obs_bus_publish && lotus_obs_live) {
-        lotus_obs_bus_publish(subject, NULL, (uint64_t)payload_size);
+        obs_tok = lotus_obs_bus_publish(subject, NULL, (uint64_t)payload_size);
     }
     size_t delivered = 0;
     for (size_t i = 0; i < g_bus_count; i++) {
@@ -9407,7 +9426,7 @@ void lotus_bus_local_dispatch(lotus_bus_queue_t *queue,
             e, queue, payload, payload_size, rec_pub);
         if (lotus_obs_bus_deliver && lotus_obs_live) {
             lotus_obs_bus_deliver(subject, e->self_ptr,
-                                  (uint64_t)payload_size);
+                                  (uint64_t)payload_size, obs_tok);
         }
     }
     if (delivered == 0 && lotus_bus_log_drop_enabled()) {
@@ -9508,8 +9527,9 @@ void lotus_bus_local_dispatch_keyed(lotus_bus_queue_t *queue,
         rec_pub = lotus_obs_record_publish_payload(
             subject, payload, (uint64_t)payload_size, 1);
     }
+    uint64_t obs_tok = 0;
     if (lotus_obs_bus_publish && lotus_obs_live) {
-        lotus_obs_bus_publish(subject, NULL, (uint64_t)payload_size);
+        obs_tok = lotus_obs_bus_publish(subject, NULL, (uint64_t)payload_size);
     }
     int matched_specific = 0;
     size_t specific_subs_on_subject = 0;
@@ -9539,7 +9559,7 @@ void lotus_bus_local_dispatch_keyed(lotus_bus_queue_t *queue,
          * flavor had none, so keyed deliveries never counted). */
         if (lotus_obs_bus_deliver && lotus_obs_live) {
             lotus_obs_bus_deliver(subject, e->self_ptr,
-                                  (uint64_t)payload_size);
+                                  (uint64_t)payload_size, obs_tok);
         }
     }
     /* Phase 3 v0.2 hook: when no specific-key match fired AND
@@ -9557,7 +9577,7 @@ void lotus_bus_local_dispatch_keyed(lotus_bus_queue_t *queue,
                                        rec_pub);
             if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
-                                      (uint64_t)payload_size);
+                                      (uint64_t)payload_size, obs_tok);
             }
         }
         if (lotus_bus_log_unmatched_enabled()) {
@@ -15634,8 +15654,9 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
         rec_pub = lotus_obs_record_publish_payload(
             subject, wire_bytes, (uint64_t)wire_size, 0);
     }
+    uint64_t obs_tok = 0;
     if (lotus_obs_bus_publish && lotus_obs_live) {
-        lotus_obs_bus_publish(subject, NULL, (uint64_t)wire_size);
+        obs_tok = lotus_obs_bus_publish(subject, NULL, (uint64_t)wire_size);
     }
     char *struct_buf = g_tls_bus_struct_buf;   /* off the coro stack */
     lotus_arena_t *prev_tls = lotus_current_caller_arena;
@@ -15666,7 +15687,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
             g_bus_pending_wire_deser = NULL;
             if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
-                                      (uint64_t)wire_size);
+                                      (uint64_t)wire_size, obs_tok);
             }
             continue;
         }
@@ -15702,7 +15723,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
         /* iris handoff-4 P15: BUS_DELIVER per matched keyed target. */
         if (lotus_obs_bus_deliver && lotus_obs_live) {
             lotus_obs_bus_deliver(subject, e->self_ptr,
-                                  (uint64_t)wire_size);
+                                  (uint64_t)wire_size, obs_tok);
         }
     }
     if (!matched_specific) {
@@ -15721,7 +15742,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
                 g_bus_pending_wire_deser = NULL;
                 if (lotus_obs_bus_deliver && lotus_obs_live) {
                     lotus_obs_bus_deliver(subject, e->self_ptr,
-                                          (uint64_t)wire_size);
+                                          (uint64_t)wire_size, obs_tok);
                 }
                 continue;
             }
@@ -15751,7 +15772,7 @@ void lotus_bus_dispatch_wire_keyed(const char *subject,
             }
             if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
-                                      (uint64_t)wire_size);
+                                      (uint64_t)wire_size, obs_tok);
             }
         }
         if (lotus_bus_log_unmatched_enabled()) {
@@ -15780,8 +15801,9 @@ void lotus_bus_dispatch_wire(const char *subject,
         rec_pub = lotus_obs_record_publish_payload(
             subject, wire_bytes, (uint64_t)wire_size, 0);
     }
+    uint64_t obs_tok = 0;
     if (lotus_obs_bus_publish && lotus_obs_live) {
-        lotus_obs_bus_publish(subject, NULL, (uint64_t)wire_size);
+        obs_tok = lotus_obs_bus_publish(subject, NULL, (uint64_t)wire_size);
     }
     /* Phase-3 Task 9 (2026-05-20): per-subscriber arena routing.
      * Previously this deserialize-once-then-fanout shape parked
@@ -15843,7 +15865,7 @@ void lotus_bus_dispatch_wire(const char *subject,
              * keyed sibling gained the probe in handoff-4). */
             if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
-                                      (uint64_t)wire_size);
+                                      (uint64_t)wire_size, obs_tok);
             }
             delivered++;
             continue;
@@ -15873,7 +15895,7 @@ void lotus_bus_dispatch_wire(const char *subject,
              * cross-thread branch above). */
             if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
-                                      (uint64_t)wire_size);
+                                      (uint64_t)wire_size, obs_tok);
             }
             delivered++;
         } else if (lotus_bus_log_drop_enabled()) {
@@ -15943,8 +15965,9 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
                 subject, struct_payload, (uint64_t)struct_size, 1);
         }
         /* iris P4 (mirrors the dynamic path). */
+        uint64_t obs_tok = 0;
         if (lotus_obs_bus_publish && lotus_obs_live) {
-            lotus_obs_bus_publish(subject, NULL, (uint64_t)struct_size);
+            obs_tok = lotus_obs_bus_publish(subject, NULL, (uint64_t)struct_size);
         }
         if (b) {
             for (size_t k = 0; k < b->count; k++) {
@@ -15953,7 +15976,7 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
                 if (e->key_filter_kind != 0) continue;
                 if (lotus_obs_bus_deliver && lotus_obs_live) {
                     lotus_obs_bus_deliver(subject, e->self_ptr,
-                                          (uint64_t)struct_size);
+                                          (uint64_t)struct_size, obs_tok);
                 }
                 /* R4 exception: the build #3 no-pinned fast path
                  * takes the no-acquire-load _st enqueue; everything
@@ -16020,8 +16043,9 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
         rec_pub = lotus_obs_record_publish_payload(
             subject, struct_payload, (uint64_t)struct_size, 1);
     }
+    uint64_t obs_tok = 0;
     if (lotus_obs_bus_publish && lotus_obs_live) {
-        lotus_obs_bus_publish(subject, NULL, (uint64_t)struct_size);
+        obs_tok = lotus_obs_bus_publish(subject, NULL, (uint64_t)struct_size);
     }
 
     /* Non-flat: serialize once, then deserialize into each subscriber's
@@ -16098,7 +16122,7 @@ void lotus_bus_dispatch_static(lotus_bus_queue_t *queue,
              * gap. Both halves of the same omission. */
             if (lotus_obs_bus_deliver && lotus_obs_live) {
                 lotus_obs_bus_deliver(subject, e->self_ptr,
-                                      (uint64_t)struct_size);
+                                      (uint64_t)struct_size, obs_tok);
             }
             /* Bug 3: cross-thread target — post WIRE bytes +
              * deserialize fn; the owner materializes at drain. */
@@ -16194,8 +16218,9 @@ void lotus_bus_dispatch_static_direct(uint32_t id,
      * subject on this path was invisible to observation (no topic
      * registration, no counters, no BUS records). Publish once,
      * deliver per matched target, exactly as the other flavors. */
+    uint64_t obs_tok = 0;
     if (lotus_obs_bus_publish && lotus_obs_live) {
-        lotus_obs_bus_publish(subject, NULL, size);
+        obs_tok = lotus_obs_bus_publish(subject, NULL, size);
     }
     if (b) {
         for (size_t k = 0; k < b->count; k++) {
@@ -16218,7 +16243,7 @@ void lotus_bus_dispatch_static_direct(uint32_t id,
                 ((lotus_handler_fn)e->handler)(e->self_ptr, (void *)payload);
             }
             if (lotus_obs_bus_deliver && lotus_obs_live) {
-                lotus_obs_bus_deliver(subject, e->self_ptr, size);
+                lotus_obs_bus_deliver(subject, e->self_ptr, size, obs_tok);
             }
             delivered++;
         }

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -6193,29 +6193,18 @@ uint64_t lotus_obs_record_publish_payload(const char *subject,
 void lotus_obs_record_enqueue(uint64_t pub_id, void *subscriber_self)
     __attribute__((weak));
 void lotus_obs_note_consumer(uint64_t id) __attribute__((weak));
-void lotus_obs_journal_i64(uint32_t jkind, uint32_t arghash, int64_t v)
+void lotus_obs_journal_i64(uint32_t jkind, const void *args,
+                           uint64_t args_len, int64_t v)
     __attribute__((weak));
-void lotus_obs_journal_bytes(uint32_t jkind, uint32_t arghash,
-                             const void *p, uint64_t n)
+void lotus_obs_journal_bytes(uint32_t jkind, const void *args,
+                             uint64_t args_len, const void *p,
+                             uint64_t n)
     __attribute__((weak));
-
-/* Journal call identity: a 32-bit hash of the invocation's
- * arguments rides every entry, and replay refuses to serve an
- * entry whose kind or arguments differ from the caller's — a
- * changed env name, rand bound, or read length is the FIRST
- * named divergence, never a silently substituted value. */
-static inline uint32_t lotus_jhash_str(const char *sarg) {
-    uint32_t h = 2166136261u;
-    for (const char *q = sarg; q && *q; q++) {
-        h ^= (uint8_t)*q;
-        h *= 16777619u;
-    }
-    return h ? h : 1u;
-}
-static inline uint32_t lotus_jhash_i64(int64_t v) {
-    uint64_t x = (uint64_t)v;
-    return (uint32_t)(x ^ (x >> 32)) | 1u;
-}
+/* Journal call identity is the EXACT encoded argument bytes —
+ * replay memcmps them, so a changed env name, arg index, rand
+ * bound, or read length is the first NAMED divergence, never a
+ * silently substituted value (review round 2: the 32-bit hashes
+ * this replaces folded adjacent integers — hash(0) == hash(1)). */
 /* GH #296 Phase 3: replay serving (LOTUS_REPLAY). serve_* return 1
  * and fill out when the journal has this thread's next value for
  * jkind; 0 = journal exhausted or absent → the caller falls back
@@ -6223,13 +6212,16 @@ static inline uint32_t lotus_jhash_i64(int64_t v) {
  * (replay degrades, never refuses). serve_str returns a pointer
  * into the loaded recording (stable for process life) or NULL. */
 extern int lotus_replay_active __attribute__((weak));
-int lotus_replay_serve_i64(uint32_t jkind, uint32_t arghash,
-                           int64_t *out)
+int lotus_replay_serve_i64(uint32_t jkind, const void *args,
+                           uint64_t args_len, int64_t *out)
     __attribute__((weak));
-int lotus_replay_expected_consume(uint64_t *out)
+int lotus_replay_expected_consume(uint64_t *out_msg,
+                                  uint32_t *out_locus)
     __attribute__((weak));
+uint64_t lotus_obs_pub_inst_id(void *self) __attribute__((weak));
 void lotus_replay_note_consume(void) __attribute__((weak));
-const void *lotus_replay_serve_blob(uint32_t jkind, uint32_t arghash,
+const void *lotus_replay_serve_blob(uint32_t jkind, const void *args,
+                                    uint64_t args_len,
                                     uint64_t want_size,
                                     uint64_t *out_n)
     __attribute__((weak));
@@ -6321,9 +6313,14 @@ static void lotus_rp_pending_push(const lotus_bus_cell_t *cell) {
     if (t_rp_pending_len == 1) t_rp_hold_since = lotus_rp_now_ns();
 }
 
-static int lotus_rp_pending_take(uint64_t want, lotus_bus_cell_t *out) {
+static int lotus_rp_pending_take(uint64_t want_msg, uint32_t want_locus,
+                                 lotus_bus_cell_t *out) {
     for (size_t i = 0; i < t_rp_pending_len; i++) {
-        if (t_rp_pending[i].rec_pub_id == want) {
+        if (t_rp_pending[i].rec_pub_id == want_msg &&
+            (uint32_t)(lotus_obs_pub_inst_id
+                           ? lotus_obs_pub_inst_id(
+                                 t_rp_pending[i].self_ptr)
+                           : 0) == want_locus) {
             *out = t_rp_pending[i];
             memmove(&t_rp_pending[i], &t_rp_pending[i + 1],
                     (t_rp_pending_len - i - 1) * sizeof(lotus_bus_cell_t));
@@ -6334,18 +6331,25 @@ static int lotus_rp_pending_take(uint64_t want, lotus_bus_cell_t *out) {
     return 0;
 }
 
-/* Gate a just-dequeued cell against the recorded order.
- * Returns 1 = dispatch *cell now (possibly swapped for a held one),
- * 0 = cell was parked; dequeue more (or wait). */
+/* Gate a just-dequeued cell against the recorded order. The
+ * delivery identity is (target locus, msg_id) — two subscribers of
+ * one publish on one consumer are distinguishable (review round 2,
+ * finding 5). Returns 1 = dispatch *cell now (possibly swapped for
+ * a held one), 0 = cell was parked; dequeue more (or wait). */
 static int lotus_replay_gate_cell(lotus_bus_cell_t *cell) {
-    uint64_t exp;
+    uint64_t exp_msg;
+    uint32_t exp_locus;
     if (!lotus_replay_expected_consume ||
-        !lotus_replay_expected_consume(&exp)) {
+        !lotus_replay_expected_consume(&exp_msg, &exp_locus)) {
         return 1; /* recorded stream exhausted — no constraint */
     }
-    if (cell->rec_pub_id == exp) return 1;
+    uint32_t cell_locus = (uint32_t)(
+        lotus_obs_pub_inst_id ? lotus_obs_pub_inst_id(cell->self_ptr)
+                              : 0);
+    if (cell->rec_pub_id == exp_msg && cell_locus == exp_locus)
+        return 1;
     lotus_rp_pending_push(cell);
-    if (lotus_rp_pending_take(exp, cell)) return 1;
+    if (lotus_rp_pending_take(exp_msg, exp_locus, cell)) return 1;
     return 0;
 }
 
@@ -6354,10 +6358,11 @@ static int lotus_replay_gate_cell(lotus_bus_cell_t *cell) {
  * oldest held cell into *out (returns 1). */
 static int lotus_replay_gate_idle(lotus_bus_cell_t *out) {
     if (t_rp_pending_len == 0) return 0;
-    uint64_t exp;
+    uint64_t exp_msg;
+    uint32_t exp_locus;
     if (lotus_replay_expected_consume &&
-        lotus_replay_expected_consume(&exp) &&
-        lotus_rp_pending_take(exp, out)) {
+        lotus_replay_expected_consume(&exp_msg, &exp_locus) &&
+        lotus_rp_pending_take(exp_msg, exp_locus, out)) {
         return 1;
     }
     if (lotus_rp_now_ns() - t_rp_hold_since < LOTUS_REPLAY_HOLD_NS) {
@@ -13651,27 +13656,30 @@ void lotus_io_init(void) {
 int lotus_env_args_count(void) {
     if (lotus_replay_on()) {
         int64_t v;
-        if (lotus_replay_serve_i64(LOTUS_JK_ENV_ARGS_COUNT, 1u, &v)) {
+        if (lotus_replay_serve_i64(LOTUS_JK_ENV_ARGS_COUNT, NULL, 0,
+                                   &v)) {
             if (lotus_journal_on())
-                lotus_obs_journal_i64(LOTUS_JK_ENV_ARGS_COUNT, 1u, v);
+                lotus_obs_journal_i64(LOTUS_JK_ENV_ARGS_COUNT, NULL,
+                                      0, v);
             return (int)v;
         }
     }
     if (lotus_journal_on())
-        lotus_obs_journal_i64(LOTUS_JK_ENV_ARGS_COUNT, 1u,
+        lotus_obs_journal_i64(LOTUS_JK_ENV_ARGS_COUNT, NULL, 0,
                               (int64_t)g_argc);
     return g_argc;
 }
 
 const char *lotus_env_arg(int i) {
+    int64_t arg_ix = (int64_t)i;
     if (lotus_replay_on()) {
         uint64_t n = 0;
         const void *v = lotus_replay_serve_blob(
-            LOTUS_JK_ENV_ARG, lotus_jhash_i64(i), 0, &n);
+            LOTUS_JK_ENV_ARG, &arg_ix, 8, 0, &n);
         if (v && n > 0) {
             if (lotus_journal_on())
-                lotus_obs_journal_bytes(LOTUS_JK_ENV_ARG,
-                                        lotus_jhash_i64(i), v, n);
+                lotus_obs_journal_bytes(LOTUS_JK_ENV_ARG, &arg_ix, 8,
+                                        v, n);
             return (const char *)v; /* NUL included */
         }
     }
@@ -13679,7 +13687,7 @@ const char *lotus_env_arg(int i) {
         ? g_empty_str
         : g_argv[i];
     if (lotus_journal_on())
-        lotus_obs_journal_bytes(LOTUS_JK_ENV_ARG, lotus_jhash_i64(i),
+        lotus_obs_journal_bytes(LOTUS_JK_ENV_ARG, &arg_ix, 8,
                                 r, strlen(r) + 1);
     return r;
 }
@@ -13689,20 +13697,19 @@ const char *lotus_env_var(const char *name) {
     if (lotus_replay_on()) {
         uint64_t n = 0;
         const void *v = lotus_replay_serve_blob(
-            LOTUS_JK_ENV_VAR, lotus_jhash_str(name), 0, &n);
+            LOTUS_JK_ENV_VAR, name, strlen(name) + 1, 0, &n);
         if (v && n > 0) {
             if (lotus_journal_on())
-                lotus_obs_journal_bytes(LOTUS_JK_ENV_VAR,
-                                        lotus_jhash_str(name), v, n);
+                lotus_obs_journal_bytes(LOTUS_JK_ENV_VAR, name,
+                                        strlen(name) + 1, v, n);
             return (const char *)v; /* NUL included */
         }
     }
     const char *v = getenv(name);
     const char *r = v ? v : g_empty_str;
     if (lotus_journal_on())
-        lotus_obs_journal_bytes(LOTUS_JK_ENV_VAR,
-                                lotus_jhash_str(name), r,
-                                strlen(r) + 1);
+        lotus_obs_journal_bytes(LOTUS_JK_ENV_VAR, name,
+                                strlen(name) + 1, r, strlen(r) + 1);
     return r;
 }
 
@@ -13710,18 +13717,18 @@ int lotus_env_var_exists(const char *name) {
     if (!name) return 0;
     if (lotus_replay_on()) {
         int64_t v;
-        if (lotus_replay_serve_i64(LOTUS_JK_ENV_VAR_EXISTS,
-                                   lotus_jhash_str(name), &v)) {
+        if (lotus_replay_serve_i64(LOTUS_JK_ENV_VAR_EXISTS, name,
+                                   strlen(name) + 1, &v)) {
             if (lotus_journal_on())
-                lotus_obs_journal_i64(LOTUS_JK_ENV_VAR_EXISTS,
-                                      lotus_jhash_str(name), v);
+                lotus_obs_journal_i64(LOTUS_JK_ENV_VAR_EXISTS, name,
+                                      strlen(name) + 1, v);
             return (int)v;
         }
     }
     int r = getenv(name) != NULL ? 1 : 0;
     if (lotus_journal_on())
-        lotus_obs_journal_i64(LOTUS_JK_ENV_VAR_EXISTS,
-                              lotus_jhash_str(name), (int64_t)r);
+        lotus_obs_journal_i64(LOTUS_JK_ENV_VAR_EXISTS, name,
+                              strlen(name) + 1, (int64_t)r);
     return r;
 }
 
@@ -16521,16 +16528,14 @@ void *lotus_os_getrandom(int64_t n) {
     if (lotus_replay_on()) {
         uint64_t jn = 0;
         const void *jv = lotus_replay_serve_blob(
-            LOTUS_JK_OS_GETRANDOM, lotus_jhash_i64(n), (uint64_t)n,
-            &jn);
+            LOTUS_JK_OS_GETRANDOM, &n, 8, (uint64_t)n, &jn);
         if (jv && jn == (uint64_t)n) {
             void *jblob = lotus_caller_or_global_bytes_create(n);
             if (jblob) {
                 memcpy(lotus_bytes_data(jblob), jv, (size_t)n);
                 if (lotus_journal_on())
                     lotus_obs_journal_bytes(LOTUS_JK_OS_GETRANDOM,
-                                            lotus_jhash_i64(n), jv,
-                                            jn);
+                                            &n, 8, jv, jn);
                 return jblob;
             }
         }
@@ -16570,9 +16575,8 @@ void *lotus_os_getrandom(int64_t n) {
     }
     if (left == 0) {
         if (lotus_journal_on())
-            lotus_obs_journal_bytes(LOTUS_JK_OS_GETRANDOM,
-                                    lotus_jhash_i64(n), body,
-                                    (uint64_t)n);
+            lotus_obs_journal_bytes(LOTUS_JK_OS_GETRANDOM, &n, 8,
+                                    body, (uint64_t)n);
         return blob;
     }
 #endif
@@ -16599,8 +16603,7 @@ void *lotus_os_getrandom(int64_t n) {
     }
     close(fd);
     if (lotus_journal_on())
-        lotus_obs_journal_bytes(LOTUS_JK_OS_GETRANDOM,
-                                lotus_jhash_i64(n), body,
+        lotus_obs_journal_bytes(LOTUS_JK_OS_GETRANDOM, &n, 8, body,
                                 (uint64_t)n);
     return blob;
 }
@@ -18727,11 +18730,11 @@ int64_t lotus_rand_next_int(int64_t max) {
     if (max <= 0) return 0;
     if (lotus_replay_on()) {
         int64_t v;
-        if (lotus_replay_serve_i64(LOTUS_JK_RAND_NEXT_INT,
-                                   lotus_jhash_i64(max), &v)) {
+        if (lotus_replay_serve_i64(LOTUS_JK_RAND_NEXT_INT, &max, 8,
+                                   &v)) {
             if (lotus_journal_on())
-                lotus_obs_journal_i64(LOTUS_JK_RAND_NEXT_INT,
-                                      lotus_jhash_i64(max), v);
+                lotus_obs_journal_i64(LOTUS_JK_RAND_NEXT_INT, &max,
+                                      8, v);
             return v;
         }
     }
@@ -18755,8 +18758,7 @@ int64_t lotus_rand_next_int(int64_t max) {
     pthread_mutex_unlock(&g_rand_mutex);
     int64_t r = (int64_t)(mixed % (uint64_t)max);
     if (lotus_journal_on())
-        lotus_obs_journal_i64(LOTUS_JK_RAND_NEXT_INT,
-                              lotus_jhash_i64(max), r);
+        lotus_obs_journal_i64(LOTUS_JK_RAND_NEXT_INT, &max, 8, r);
     return r;
 }
 
@@ -18771,9 +18773,9 @@ int64_t lotus_rand_next_int(int64_t max) {
 int64_t lotus_time_now_seconds(void) {
     if (lotus_replay_on()) {
         int64_t v;
-        if (lotus_replay_serve_i64(LOTUS_JK_TIME_NOW, 1u, &v)) {
+        if (lotus_replay_serve_i64(LOTUS_JK_TIME_NOW, NULL, 0, &v)) {
             if (lotus_journal_on())
-                lotus_obs_journal_i64(LOTUS_JK_TIME_NOW, 1u, v);
+                lotus_obs_journal_i64(LOTUS_JK_TIME_NOW, NULL, 0, v);
             return v;
         }
     }
@@ -18781,7 +18783,7 @@ int64_t lotus_time_now_seconds(void) {
     clock_gettime(CLOCK_REALTIME, &ts);
     int64_t r = (int64_t)ts.tv_sec;
     if (lotus_journal_on())
-        lotus_obs_journal_i64(LOTUS_JK_TIME_NOW, 1u, r);
+        lotus_obs_journal_i64(LOTUS_JK_TIME_NOW, NULL, 0, r);
     return r;
 }
 
@@ -18793,9 +18795,11 @@ int64_t lotus_time_now_seconds(void) {
 int64_t lotus_time_monotonic_ns(void) {
     if (lotus_replay_on()) {
         int64_t v;
-        if (lotus_replay_serve_i64(LOTUS_JK_TIME_MONO_NS, 1u, &v)) {
+        if (lotus_replay_serve_i64(LOTUS_JK_TIME_MONO_NS, NULL, 0,
+                                   &v)) {
             if (lotus_journal_on())
-                lotus_obs_journal_i64(LOTUS_JK_TIME_MONO_NS, 1u, v);
+                lotus_obs_journal_i64(LOTUS_JK_TIME_MONO_NS, NULL, 0,
+                                      v);
             return v;
         }
     }
@@ -18803,7 +18807,7 @@ int64_t lotus_time_monotonic_ns(void) {
     clock_gettime(CLOCK_MONOTONIC, &ts);
     int64_t r = (int64_t)ts.tv_sec * 1000000000LL + (int64_t)ts.tv_nsec;
     if (lotus_journal_on())
-        lotus_obs_journal_i64(LOTUS_JK_TIME_MONO_NS, 1u, r);
+        lotus_obs_journal_i64(LOTUS_JK_TIME_MONO_NS, NULL, 0, r);
     return r;
 }
 

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -556,6 +556,14 @@ static rp_consumer_t g_rp_consumers[RP_MAX_CONSUMERS];
 static int g_rp_consumer_count = 0;
 static _Atomic uint64_t g_rp_divergences[RP_MAX_JK];
 static _Atomic uint64_t g_rp_consume_count = 0;
+/* Round 3 follow-up: deliveries past the recorded stream's end (or
+ * on a consumer the recording never saw) are counted, not silently
+ * unconstrained — plain `hale replay` reports them even without
+ * --diff. Structural cells (pub_id 0) stay uncounted. */
+static _Atomic uint64_t g_rp_unexpected = 0;
+void lotus_replay_note_unexpected(void) {
+  atomic_fetch_add_explicit(&g_rp_unexpected, 1, memory_order_relaxed);
+}
 typedef struct { uint64_t pub_id; uint32_t topic; uint32_t flags;
                  rp_blob_ref_t bytes; } rp_payload_t;
 static rp_payload_t *g_rp_payloads = NULL;
@@ -605,11 +613,20 @@ static void rp_fail(const char *why) {
 }
 
 static void rp_load(void) {
-  /* One open + fstat + mmap — no reopen window (review round 2,
-   * finding 4: the fopen-then-open pair was its own TOCTOU). The
-   * mapping is MAP_PRIVATE; later file mutation cannot change the
-   * validated bytes this process serves. */
-  int fd = open(g_replay_path, O_RDONLY | O_NOFOLLOW);
+  /* Round 3: the validated artifact must be an IMMUTABLE snapshot.
+   * MAP_PRIVATE does not provide that (whether later file writes
+   * appear through a private mapping is unspecified), so the bytes
+   * are READ once into anonymous memory and every served pointer
+   * aliases that copy — post-validation file mutation is
+   * structurally irrelevant. The fd itself comes from the CLI when
+   * available (LOTUS_REPLAY_FD, inherited): the object the CLI
+   * validated and admitted is the object this process reads, with
+   * no path re-resolution window. Direct LOTUS_REPLAY invocation
+   * (no fd) opens once with O_NOFOLLOW and revalidates fully. */
+  int fd = -1;
+  const char *fdenv = getenv("LOTUS_REPLAY_FD");
+  if (fdenv && fdenv[0]) fd = atoi(fdenv);
+  if (fd < 0) fd = open(g_replay_path, O_RDONLY | O_NOFOLLOW);
   if (fd < 0) rp_fail(strerror(errno));
   struct stat st;
   if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || st.st_size < 112) {
@@ -617,13 +634,27 @@ static void rp_load(void) {
     rp_fail("not a recording (too small or not a regular file)");
   }
   g_rp_len = (size_t)st.st_size;
-  g_rp_base = mmap(NULL, g_rp_len, PROT_READ, MAP_PRIVATE, fd, 0);
-  close(fd);
-  if (g_rp_base == MAP_FAILED) {
-    fprintf(stderr, "hale: LOTUS_REPLAY mmap failed: %s\n",
-            strerror(errno));
-    _exit(66);
+  uint8_t *snap = malloc(g_rp_len);
+  if (!snap) {
+    close(fd);
+    rp_fail("out of memory loading the recording");
   }
+  size_t got = 0;
+  if (lseek(fd, 0, SEEK_SET) != 0) {
+    close(fd);
+    rp_fail("recording fd is not seekable");
+  }
+  while (got < g_rp_len) {
+    ssize_t r = read(fd, snap + got, g_rp_len - got);
+    if (r < 0 && errno == EINTR) continue;
+    if (r <= 0) {
+      close(fd);
+      rp_fail("short read loading the recording");
+    }
+    got += (size_t)r;
+  }
+  close(fd);
+  g_rp_base = snap;
   const obs_rec_hdr_t *h = (const obs_rec_hdr_t *)g_rp_base;
   if (h->magic != OBS_REC_MAGIC || h->maj != 0 || h->min < 3) {
     rp_fail("not a v0.3+ recording (magic/version mismatch)");
@@ -888,6 +919,8 @@ static void rp_report(void) {
   uint64_t order_div = lotus_replay_order_divergences
       ? lotus_replay_order_divergences()
       : 0;
+  uint64_t unexpected =
+      atomic_load_explicit(&g_rp_unexpected, memory_order_relaxed);
   const char *status_path = getenv("LOTUS_REPLAY_STATUS");
   if (status_path && status_path[0]) {
     FILE *sf = fopen(status_path, "w");
@@ -898,10 +931,11 @@ static void rp_report(void) {
       fprintf(sf,
               "journal_divergences=%llu\norder_divergences=%llu\n"
               "unconsumed_journal=%llu\nunconsumed_deliveries=%llu\n"
-              "consumes=%llu\n",
+              "unexpected_deliveries=%llu\nconsumes=%llu\n",
               (unsigned long long)jd, (unsigned long long)order_div,
               (unsigned long long)unconsumed_journal,
               (unsigned long long)unconsumed_deliveries,
+              (unsigned long long)unexpected,
               (unsigned long long)atomic_load(&g_rp_consume_count));
       fclose(sf);
     }
@@ -911,7 +945,7 @@ static void rp_report(void) {
     "os.getrandom", "env.var", "env.var_exists", "env.arg",
     "env.args_count" };
   uint64_t total = order_div + unconsumed_journal
-      + unconsumed_deliveries;
+      + unconsumed_deliveries + unexpected;
   for (int i = 0; i < RP_MAX_JK; i++)
     total += atomic_load(&g_rp_divergences[i]);
   if (total == 0) {
@@ -939,6 +973,9 @@ static void rp_report(void) {
   if (unconsumed_deliveries)
     fprintf(stderr, "  %-22s %llu\n", "unconsumed-deliveries",
             (unsigned long long)unconsumed_deliveries);
+  if (unexpected)
+    fprintf(stderr, "  %-22s %llu\n", "unexpected-deliveries",
+            (unsigned long long)unexpected);
 }
 
 /* Pinned-locus threads: identity = 64 + the locus's obs instance
@@ -1822,9 +1859,19 @@ static uint32_t obs_inst_id_of(void *self) {
 
 /* ---- public probes (called from lotus_arena.c + codegen) ------- */
 
-void lotus_obs_bus_publish(const char *subject, void *publisher_self,
-                           uint64_t payload_bytes) {
-  if (!obs_on() || !subject) return;
+/* Returns a sequence TOKEN: the assigned per-topic seq + 1, or 0
+ * when nothing was recorded (obs off, redispatch, unregistered
+ * topic). Fanout passes the token to every lotus_obs_bus_deliver
+ * for this publish, so a deliver record names the EXACT publish it
+ * belongs to — the old reload-high-water-minus-one attributed both
+ * of two racing same-subject deliveries to the later publish
+ * (review round 3, finding 3). A local/SSA token also survives a
+ * nested same-subject publish inside a handler, which any
+ * TLS-based handoff would not. */
+uint64_t lotus_obs_bus_publish(const char *subject,
+                               void *publisher_self,
+                               uint64_t payload_bytes) {
+  if (!obs_on() || !subject) return 0;
   /* iris handoff-4 P15: consume the redispatch mark FIRST. An inbound
    * wire message re-dispatched by the reader thread is a delivery, not
    * a publish (it's covered by NET_DELIVER + per-subscriber
@@ -1838,9 +1885,9 @@ void lotus_obs_bus_publish(const char *subject, void *publisher_self,
   g_obs_tls_redispatch = 0;
   void *pub = publisher_self ? publisher_self : g_obs_tls_publisher;
   g_obs_tls_publisher = NULL;
-  if (redispatch) return; /* inbound re-dispatch — not a publish */
+  if (redispatch) return 0; /* inbound re-dispatch — not a publish */
   obs_topic_slot_t *t = obs_topic_slot(subject, 0);
-  if (!t) return;
+  if (!t) return 0;
   uint64_t seq =
       atomic_fetch_add_explicit(&t->seq, 1, memory_order_relaxed);
   /* Counters are the dormant-mode contract (P4: enabled-but-unobserved
@@ -1848,9 +1895,9 @@ void lotus_obs_bus_publish(const char *subject, void *publisher_self,
    * of attribution. */
   obs_count(MK_TOPIC, t->id, 0, 1);              /* published */
   obs_count(MK_TOPIC, t->id, 2, payload_bytes);  /* bytes */
-  if (!obs_gate()) return;
+  if (!obs_gate()) return seq + 1;
   uint8_t mode = MODE[t->id & (OBS_ENTRY_CAP - 1)];
-  if (mode < 2) return; /* OFF / COUNTERS */
+  if (mode < 2) return seq + 1; /* OFF / COUNTERS */
   uint32_t locus = pub ? obs_inst_id_of(pub) : 0; /* best-effort */
   /* iris handoff-7: w1 = locus:20 (HIGH bits 44..63) | seq:44
    * (low) — PROTOCOL §8 / iris emitter/protocol.h `obs_bus_w1`.
@@ -1863,15 +1910,27 @@ void lotus_obs_bus_publish(const char *subject, void *publisher_self,
            obs_size_class(payload_bytes),
            (((uint64_t)locus & 0xFFFFFu) << 44)
                | (seq & 0xFFFFFFFFFFFULL));
+  return seq + 1;
 }
 
 void lotus_obs_bus_deliver(const char *subject, void *subscriber_self,
-                           uint64_t payload_bytes) {
+                           uint64_t payload_bytes, uint64_t seq_token) {
   if (!obs_on() || !subject) return;
   obs_topic_slot_t *t = obs_topic_slot(subject, 0);
   if (!t) return;
-  uint64_t seq =
-      atomic_load_explicit(&t->seq, memory_order_relaxed);
+  /* seq_token = the OWNING publish's seq + 1, from that publish's
+   * probe return. 0 (no publish probe fired — dormant publish,
+   * inbound redispatch) falls back to the old approximate
+   * high-water read, which is only reachable when no exact pairing
+   * exists to get wrong. */
+  uint64_t seq;
+  if (seq_token) {
+    seq = seq_token - 1;
+  } else {
+    uint64_t hw =
+        atomic_load_explicit(&t->seq, memory_order_relaxed);
+    seq = hw ? hw - 1 : 0;
+  }
   obs_count(MK_TOPIC, t->id, 1, 1); /* delivered */
   if (!obs_gate()) return;
   uint8_t mode = MODE[t->id & (OBS_ENTRY_CAP - 1)];
@@ -1881,7 +1940,7 @@ void lotus_obs_bus_deliver(const char *subject, void *subscriber_self,
   obs_emit(EK_BUS_DELIVER, (uint32_t)t->id,
            obs_size_class(payload_bytes),
            (((uint64_t)locus & 0xFFFFFu) << 44)
-               | ((seq ? seq - 1 : 0) & 0xFFFFFFFFFFFULL));
+               | (seq & 0xFFFFFFFFFFFULL));
 }
 
 /* GH #296 Phase 1: the consumption event. Emitted by the arena's
@@ -2020,7 +2079,11 @@ void lotus_obs_journal_bytes(uint32_t jkind, const void *args,
       (jkind == JK_ENV_VAR || jkind == JK_ENV_ARG);
   if (args_len > 0xFFFFFFFFull) return;
   uint32_t al = (uint32_t)args_len;
-  uint64_t body_len = 4ull + al + (withhold ? 0 : n);
+  /* A withheld value still records its LENGTH (8-byte LE in the
+   * result slot) so the artifact can truthfully report coverage —
+   * a missing value and a 4KiB withheld credential are different
+   * facts (round 3 follow-up). */
+  uint64_t body_len = 4ull + al + (withhold ? 8 : n);
   uint8_t small[256];
   uint8_t *buf = body_len <= sizeof small ? small : malloc(body_len);
   if (!buf) {
@@ -2031,7 +2094,12 @@ void lotus_obs_journal_bytes(uint32_t jkind, const void *args,
   }
   memcpy(buf, &al, 4);
   if (al) memcpy(buf + 4, args, al);
-  if (!withhold && n) memcpy(buf + 4 + al, p, n);
+  if (withhold) {
+    uint64_t vlen = n;
+    memcpy(buf + 4 + al, &vlen, 8);
+  } else if (n) {
+    memcpy(buf + 4 + al, p, n);
+  }
   uint64_t cfield = (seq & 0x7FFFFFFFFFFFFFFFull)
       | (withhold ? (1ull << 63) : 0);
   obs_rec_blob_push(OBS_REC_TAG_JOURNAL, jkind, cid, cfield, buf,

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -163,8 +163,10 @@ void lotus_obs_model_hash_set(uint64_t h) { g_obs_model_hash = h; }
 /* GH #296 review finding 2: shape_hash is structural compatibility,
  * not executable identity. The CLI stamps a digest of the compiler
  * version + every source byte; exact replay admits on THIS. */
-static uint64_t g_obs_exec_digest = 0;
-void lotus_obs_exec_digest_set(uint64_t h) { g_obs_exec_digest = h; }
+static uint64_t g_obs_exec_digest[4] = {0, 0, 0, 0};
+void lotus_obs_exec_digest_set(uint64_t part, uint64_t v) {
+  if (part < 4) g_obs_exec_digest[part] = v;
+}
 
 /* iris handoff-2 P10: publisher attribution. Codegen notes the
  * publishing locus's self in this TLS right before lowering a
@@ -310,6 +312,13 @@ static __thread uint32_t t_since_epoch = 0;
  * order preserved; cross-ring interleaving meaningless), then a
  * 16-byte trailer whose presence marks a clean finalize. */
 int lotus_obs_recording = 0; /* read (weak) from lotus_arena.c */
+/* Review round 2, finding 8: env VALUES are redacted from the
+ * journal by default — names, existence, and lengths are recorded;
+ * the value itself is withheld unless LOTUS_OBS_RECORD_ENV=full.
+ * A withheld read replays as a NAMED divergence (live fallback),
+ * never as a silently substituted value, and the artifact header
+ * says which policy produced it. */
+static int g_rec_env_full = 0;
 /* Defined (with its story) next to obs_gate; obs_create pre-arms
  * it under recording. Tentative declaration so it's visible here. */
 static _Atomic uint32_t g_last_observed;
@@ -339,22 +348,37 @@ static __thread uint64_t t_consume_seq = 0;
  *   tag 2 (journal): u32 tag, u32 jkind, u64 consumer_id,
  *                    u64 seq, u64 size, size bytes padded to 8
  *
- * Identity. pub_id = consumer_id:8 << 36 | per-thread publish
- * seq:36 — deterministic across runs (a re-executed publisher
+ * Identity. msg_id = consumer_id:16 << 48 | per-thread publish
+ * seq:48 — deterministic across runs (a re-executed publisher
  * thread re-derives the same ids in the same order), which is what
  * lets a replay match a re-executed delivery to its recorded
- * consume without any global coordination. 0 = unidentified
- * (structural cells: run starts, cross-pool creates — matched by
- * per-queue count, not id).
+ * consume without any global coordination. 48-bit seqs do not
+ * wrap in any realistic recording (~8,900 years at 1M msg/s), and
+ * range guards below FAIL LOUDLY rather than letting components
+ * overlap. 0 = unidentified (structural cells: run starts,
+ * cross-pool creates — matched by per-queue count, not id).
  *
  * Consumer identity. Stable across runs, unlike pthread ids:
  * main = 1, cooperative pool workers = 16 + registration index,
- * pinned locus threads = 64 + obs instance id, recording drain and
- * heartbeat never claim one. Stamped as each ring's first record
- * (EK_CONSUMER) and carried in journal entries. */
+ * pinned locus threads = 64 + obs instance id (guarded: an id
+ * reaching the anonymous floor fails the recording), anonymous
+ * (ingress) threads = 60000 + claim order — a range DISJOINT from
+ * every stable class by construction. The drain and heartbeat
+ * never claim one. Carried in each private ring's first record
+ * and in journal entries. */
+#define OBS_REC_ANON_BASE 60000u
+#define OBS_REC_CONSUMER_MAX 0xFFFFu
 #define OBS_REC_TAG_RING 0u
 #define OBS_REC_TAG_PAYLOAD 1u
 #define OBS_REC_TAG_JOURNAL 2u
+/* v0.3: run-stable identity maps for the comparator — a = subtype
+ * (1 = topic id→subject name, 2 = public ring→consumer id),
+ * b/cfield = ids, bytes = name (subtype 1). Manifest topic ids and
+ * public ring indices are per-run registration/claim order, so the
+ * file must carry its own maps for cross-run comparison. */
+#define OBS_REC_TAG_META 3u
+#define OBS_REC_META_TOPIC 1u
+#define OBS_REC_META_PUBRING 2u
 
 /* journal kinds — one per interposed runtime read */
 #define JK_TIME_NOW 1u
@@ -407,6 +431,15 @@ static void obs_rec_blob_push(uint32_t tag, uint32_t a, uint64_t b,
   /* Reserve BEFORE allocating (concurrent producers cannot
    * overshoot the budget), back off while over. */
   uint64_t need = sizeof(obs_rec_blob_t) + size;
+  if (size > OBS_REC_BLOB_BUDGET / 2 || need < size) {
+    fprintf(stderr,
+            "hale: LOTUS_OBS_RECORD capture of %llu bytes exceeds "
+            "the recorder's budget — failing the run rather than "
+            "hanging on an unsatisfiable reservation\n",
+            (unsigned long long)size);
+    fflush(NULL);
+    _exit(74);
+  }
   for (;;) {
     uint64_t prev = atomic_fetch_add_explicit(
         &g_rec_blob_bytes, need, memory_order_relaxed);
@@ -442,13 +475,18 @@ static void obs_rec_blob_push(uint32_t tag, uint32_t a, uint64_t b,
 typedef struct {
   uint64_t magic;
   uint16_t maj, min;
-  uint32_t header_len; /* 64 */
+  uint32_t header_len; /* 96 */
   uint32_t pid, ring_count, ring_slots, ts_shift;
   uint64_t started_mono_ns, started_wall_ns;
   uint64_t model_hash;
-  uint64_t exec_digest; /* compiler ver + source bytes; 0 = unstamped */
+  /* Framed SHA-256 build-manifest digest (full 32 bytes — review
+   * round 2, finding 2): toolchain source hash + compiler version
+   * + build options + framed source paths/lengths/contents. All
+   * zero = unstamped. Env-value redaction state rides flags. */
+  uint64_t exec_digest[4];
+  uint64_t flags; /* bit 0 = env values redacted */
 } obs_rec_hdr_t;
-_Static_assert(sizeof(obs_rec_hdr_t) == 64, "recording header is 64B");
+_Static_assert(sizeof(obs_rec_hdr_t) == 96, "recording header is 96B");
 
 typedef struct {
   uint32_t tag; /* OBS_REC_TAG_RING */
@@ -488,8 +526,16 @@ static uint64_t g_replay_at_consumer = 0; /* 0 = process-wide count */
 #define RP_MAX_CONSUMERS 96
 #define RP_MAX_JK 9
 
-typedef struct { const uint8_t *p; uint64_t size;
-                 uint32_t jkind, arghash; } rp_blob_ref_t;
+typedef struct {
+  const uint8_t *args;   /* framed invocation arguments */
+  uint64_t args_len;
+  const uint8_t *p;      /* result bytes */
+  uint64_t size;
+  uint32_t jkind;
+  uint32_t withheld;     /* value redacted at record time */
+} rp_blob_ref_t;
+typedef struct { uint32_t locus; uint64_t msg; } rp_consume_t;
+static uint32_t obs_inst_id_of(void *self);
 typedef struct {
   rp_blob_ref_t *items;
   uint32_t len, cap, cursor;
@@ -501,7 +547,7 @@ typedef struct {
    * cross-kind reordering or a changed argument is the FIRST
    * named divergence instead of a plausible wrong value. */
   rp_queue_t journal;
-  uint64_t *consume;               /* recorded pub_id order */
+  rp_consume_t *consume;           /* recorded delivery order */
   uint32_t consume_len, consume_cap, consume_cursor;
 } rp_consumer_t;
 static rp_consumer_t g_rp_consumers[RP_MAX_CONSUMERS];
@@ -534,38 +580,41 @@ static rp_consumer_t *rp_consumer(uint64_t cid) {
   return NULL;
 }
 
-static void rp_queue_push(rp_queue_t *q, const uint8_t *p, uint64_t n,
-                          uint32_t jkind, uint32_t arghash) {
+static void rp_queue_push(rp_queue_t *q, rp_blob_ref_t e) {
   if (q->len == q->cap) {
     q->cap = q->cap ? q->cap * 2 : 16;
-    q->items = realloc(q->items, q->cap * sizeof(rp_blob_ref_t));
+    rp_blob_ref_t *g = realloc(q->items,
+                               q->cap * sizeof(rp_blob_ref_t));
+    if (!g) {
+      fprintf(stderr, "hale: LOTUS_REPLAY out of memory\n");
+      _exit(66);
+    }
+    q->items = g;
   }
-  q->items[q->len].p = p;
-  q->items[q->len].size = n;
-  q->items[q->len].jkind = jkind;
-  q->items[q->len].arghash = arghash;
-  q->len++;
+  q->items[q->len++] = e;
 }
 
 static uint64_t rp_ring_consumer[64]; /* ring idx → consumer id */
 
+static void rp_fail(const char *why) {
+  fprintf(stderr, "hale: LOTUS_REPLAY `%s`: %s\n", g_replay_path, why);
+  fflush(NULL);
+  _exit(66);
+}
+
 static void rp_load(void) {
-  FILE *f = fopen(g_replay_path, "rb");
-  if (!f) {
-    fprintf(stderr, "hale: LOTUS_REPLAY could not open `%s`: %s\n",
-            g_replay_path, strerror(errno));
-    _exit(66);
+  /* One open + fstat + mmap — no reopen window (review round 2,
+   * finding 4: the fopen-then-open pair was its own TOCTOU). The
+   * mapping is MAP_PRIVATE; later file mutation cannot change the
+   * validated bytes this process serves. */
+  int fd = open(g_replay_path, O_RDONLY | O_NOFOLLOW);
+  if (fd < 0) rp_fail(strerror(errno));
+  struct stat st;
+  if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || st.st_size < 112) {
+    close(fd);
+    rp_fail("not a recording (too small or not a regular file)");
   }
-  fseek(f, 0, SEEK_END);
-  long fl = ftell(f);
-  fclose(f);
-  int fd = open(g_replay_path, O_RDONLY);
-  if (fd < 0 || fl < 80) {
-    fprintf(stderr, "hale: LOTUS_REPLAY `%s` is not a recording\n",
-            g_replay_path);
-    _exit(66);
-  }
-  g_rp_len = (size_t)fl;
+  g_rp_len = (size_t)st.st_size;
   g_rp_base = mmap(NULL, g_rp_len, PROT_READ, MAP_PRIVATE, fd, 0);
   close(fd);
   if (g_rp_base == MAP_FAILED) {
@@ -574,82 +623,117 @@ static void rp_load(void) {
     _exit(66);
   }
   const obs_rec_hdr_t *h = (const obs_rec_hdr_t *)g_rp_base;
-  if (h->magic != OBS_REC_MAGIC || h->maj != 0 || h->min < 2) {
-    fprintf(stderr,
-            "hale: LOTUS_REPLAY `%s`: not a v0.2+ recording "
-            "(magic/version mismatch)\n",
-            g_replay_path);
-    _exit(66);
+  if (h->magic != OBS_REC_MAGIC || h->maj != 0 || h->min < 3) {
+    rp_fail("not a v0.3+ recording (magic/version mismatch)");
+  }
+  if (h->header_len != sizeof(obs_rec_hdr_t)) {
+    rp_fail("unexpected header length");
   }
   size_t end = g_rp_len;
-  if (end >= 16 &&
+  uint64_t trailer_count = 0;
+  if (end >= sizeof(obs_rec_hdr_t) + 16 &&
       *(const uint64_t *)(g_rp_base + end - 16) == OBS_REC_END) {
+    trailer_count = *(const uint64_t *)(g_rp_base + end - 8);
     end -= 16;
   } else {
-    fprintf(stderr,
-            "hale: LOTUS_REPLAY `%s`: no clean-finalize trailer — "
-            "the recording is truncated; refusing to replay a "
-            "partial history (re-record, or accept divergence by "
-            "trimming the file yourself)\n",
-            g_replay_path);
-    _exit(66);
+    rp_fail("no clean-finalize trailer — the recording is "
+            "truncated; refusing to replay a partial history");
   }
+  uint64_t parsed = 0;
   memset(rp_ring_consumer, 0, sizeof rp_ring_consumer);
   size_t off = h->header_len;
   while (off + 8 <= end) {
     uint32_t tag = *(const uint32_t *)(g_rp_base + off);
     uint32_t a = *(const uint32_t *)(g_rp_base + off + 4);
+    parsed++;
     if (tag == OBS_REC_TAG_RING) {
-      if (off + 24 > end) break;
+      if (end - off < 24) rp_fail("truncated ring record");
       uint64_t w0 = *(const uint64_t *)(g_rp_base + off + 8);
       uint64_t w1 = *(const uint64_t *)(g_rp_base + off + 16);
       uint32_t ekind = (uint32_t)((w0 >> 20) & 0x1F);
       if (a & OBS_REC_PRIV_RING) {
         uint32_t pr = a & ~OBS_REC_PRIV_RING;
-        if (pr < 64) {
-          if (ekind == REC_EV_CONSUMER) {
-            rp_ring_consumer[pr] = w1;
-          } else if (ekind == REC_EV_CONSUME) {
-            rp_consumer_t *c =
-                rp_consumer_create(rp_ring_consumer[pr]);
-            if (c) {
-              if (c->consume_len == c->consume_cap) {
-                c->consume_cap =
-                    c->consume_cap ? c->consume_cap * 2 : 64;
-                c->consume = realloc(
-                    c->consume, c->consume_cap * sizeof(uint64_t));
-              }
-              c->consume[c->consume_len++] = w1 & 0xFFFFFFFFFFFULL;
+        if (pr >= 64) rp_fail("private ring index out of range");
+        if (ekind == REC_EV_CONSUMER) {
+          rp_ring_consumer[pr] = w1;
+        } else if (ekind == REC_EV_CONSUME) {
+          rp_consumer_t *c =
+              rp_consumer_create(rp_ring_consumer[pr]);
+          if (c) {
+            if (c->consume_len == c->consume_cap) {
+              c->consume_cap =
+                  c->consume_cap ? c->consume_cap * 2 : 64;
+              rp_consume_t *g = realloc(
+                  c->consume,
+                  c->consume_cap * sizeof(rp_consume_t));
+              if (!g) rp_fail("out of memory");
+              c->consume = g;
             }
+            c->consume[c->consume_len].locus =
+                (uint32_t)(w0 & 0xFFFFFu);
+            c->consume[c->consume_len].msg = w1;
+            c->consume_len++;
           }
         }
       } /* public-ring records: standard iris protocol, no
          * recorder meaning — nothing to index for replay */
       off += 24;
-    } else if (tag == OBS_REC_TAG_PAYLOAD || tag == OBS_REC_TAG_JOURNAL) {
-      if (off + 32 > end) break;
+    } else if (tag == OBS_REC_TAG_PAYLOAD || tag == OBS_REC_TAG_JOURNAL
+               || tag == OBS_REC_TAG_META) {
+      if (end - off < 32) rp_fail("truncated blob header");
       uint64_t b = *(const uint64_t *)(g_rp_base + off + 8);
       uint64_t cfield = *(const uint64_t *)(g_rp_base + off + 16);
       uint64_t size = *(const uint64_t *)(g_rp_base + off + 24);
       const uint8_t *bytes = g_rp_base + off + 32;
+      if (size > end - off - 32) rp_fail("blob length out of range");
       uint64_t padded = (size + 7) & ~7ull;
-      if (off + 32 + padded > end) break;
+      if (padded < size || padded > end - off - 32) {
+        rp_fail("blob padding out of range");
+      }
       if (tag == OBS_REC_TAG_JOURNAL) {
-        /* a = jkind, b = consumer, cfield = seq (order = file order
-         * per consumer, which the drain preserved) */
-        (void)cfield;
-        if (a < RP_MAX_JK) {
-          rp_consumer_t *c = rp_consumer_create(b);
-          /* cfield = arghash:32 (high) | per-thread seq:32 */
-          if (c) rp_queue_push(&c->journal, bytes, size, a,
-                               (uint32_t)(cfield >> 32));
+        /* a = jkind; b = consumer; cfield bit 63 = value withheld
+         * (redaction); bytes = [u32 args_len][args][result]. */
+        if (a >= RP_MAX_JK) rp_fail("journal kind out of range");
+        if (size < 4) rp_fail("journal entry too small");
+        uint32_t args_len;
+        memcpy(&args_len, bytes, 4);
+        if ((uint64_t)args_len + 4 > size) {
+          rp_fail("journal argument frame out of range");
         }
-      } else {
+        rp_blob_ref_t e;
+        e.args = bytes + 4;
+        e.args_len = args_len;
+        e.p = bytes + 4 + args_len;
+        e.size = size - 4 - args_len;
+        e.jkind = a;
+        e.withheld = (cfield >> 63) & 1;
+        /* per-kind result shape (review round 2, finding 4) */
+        if (!e.withheld) {
+          switch (a) {
+            case JK_TIME_NOW: case JK_TIME_MONO_NS:
+            case JK_RAND_NEXT_INT: case JK_ENV_VAR_EXISTS:
+            case JK_ENV_ARGS_COUNT:
+              if (e.size != 8) rp_fail("journal i64 wrong size");
+              break;
+            case JK_ENV_VAR: case JK_ENV_ARG:
+              if (e.size == 0 || e.p[e.size - 1] != 0) {
+                rp_fail("journal string not NUL-terminated");
+              }
+              break;
+            default: break;
+          }
+        }
+        rp_consumer_t *c = rp_consumer_create(b);
+        if (c) rp_queue_push(&c->journal, e);
+      } else if (tag == OBS_REC_TAG_PAYLOAD) {
         if (g_rp_payload_len == g_rp_payload_cap) {
           g_rp_payload_cap =
               g_rp_payload_cap ? g_rp_payload_cap * 2 : 64;
-          g_rp_payloads = realloc(
-              g_rp_payloads, g_rp_payload_cap * sizeof(rp_payload_t));
+          rp_payload_t *g = realloc(
+              g_rp_payloads,
+              g_rp_payload_cap * sizeof(rp_payload_t));
+          if (!g) rp_fail("out of memory");
+          g_rp_payloads = g;
         }
         rp_payload_t *pl = &g_rp_payloads[g_rp_payload_len++];
         pl->pub_id = b;
@@ -657,24 +741,30 @@ static void rp_load(void) {
         pl->flags = (uint32_t)cfield;
         pl->bytes.p = bytes;
         pl->bytes.size = size;
-      }
+        pl->bytes.args = NULL;
+        pl->bytes.args_len = 0;
+        pl->bytes.jkind = 0;
+        pl->bytes.withheld = 0;
+      } /* META entries carry no replay state; validated + skipped */
       off += 32 + padded;
     } else {
-      fprintf(stderr,
-              "hale: LOTUS_REPLAY `%s`: unknown entry tag %u at "
-              "offset %zu — recording from a newer hale?\n",
-              g_replay_path, tag, off);
-      _exit(66);
+      rp_fail("unknown entry tag — recording from a newer hale?");
     }
+  }
+  if (off != end) rp_fail("entries do not end at the trailer");
+  if (parsed != trailer_count) {
+    rp_fail("trailer count disagrees with parsed entries");
   }
 }
 
 /* The next recorded input for this consumer, iff it matches the
- * caller's kind + argument identity + (when nonzero) size. A
- * mismatch is a named divergence and the entry is NOT consumed —
- * the first wrong read surfaces instead of cascading plausible
- * wrong values (review finding 7). */
-static const rp_blob_ref_t *rp_serve(uint32_t jkind, uint32_t arghash,
+ * caller's kind AND its EXACT encoded arguments (memcmp — hashes
+ * were collision-prone: value|1 folded adjacent integers; review
+ * round 2, finding 3) and, when nonzero, the result size. Any
+ * mismatch — including a withheld (redacted) value — is a named
+ * divergence, and a mismatched entry is NOT consumed. */
+static const rp_blob_ref_t *rp_serve(uint32_t jkind, const void *args,
+                                     uint64_t args_len,
                                      uint64_t want_size) {
   if (!lotus_replay_active || jkind >= RP_MAX_JK) return NULL;
   rp_consumer_t *c = rp_consumer(t_consumer_id);
@@ -690,28 +780,38 @@ static const rp_blob_ref_t *rp_serve(uint32_t jkind, uint32_t arghash,
     return NULL;
   }
   const rp_blob_ref_t *e = &q->items[q->cursor];
-  if (e->jkind != jkind || e->arghash != arghash ||
-      (want_size && e->size != want_size)) {
+  if (e->jkind != jkind || e->args_len != args_len ||
+      (args_len && memcmp(e->args, args, args_len) != 0) ||
+      e->withheld || (want_size && e->size != want_size)) {
     atomic_fetch_add_explicit(&g_rp_divergences[jkind], 1,
                               memory_order_relaxed);
+    if (!e->withheld) return NULL;
+    /* A withheld value still ADVANCES the stream (its identity
+     * matched the recording's shape; only the value is absent) so
+     * subsequent reads stay aligned. */
+    if (e->jkind == jkind && e->args_len == args_len &&
+        (!args_len || memcmp(e->args, args, args_len) == 0)) {
+      q->cursor++;
+    }
     return NULL;
   }
   q->cursor++;
   return e;
 }
 
-int lotus_replay_serve_i64(uint32_t jkind, uint32_t arghash,
-                           int64_t *out) {
-  const rp_blob_ref_t *e = rp_serve(jkind, arghash, 8);
+int lotus_replay_serve_i64(uint32_t jkind, const void *args,
+                           uint64_t args_len, int64_t *out) {
+  const rp_blob_ref_t *e = rp_serve(jkind, args, args_len, 8);
   if (!e) return 0;
   memcpy(out, e->p, 8);
   return 1;
 }
 
-const void *lotus_replay_serve_blob(uint32_t jkind, uint32_t arghash,
+const void *lotus_replay_serve_blob(uint32_t jkind, const void *args,
+                                    uint64_t args_len,
                                     uint64_t want_size,
                                     uint64_t *out_n) {
-  const rp_blob_ref_t *e = rp_serve(jkind, arghash, want_size);
+  const rp_blob_ref_t *e = rp_serve(jkind, args, args_len, want_size);
   if (!e) return NULL;
   *out_n = e->size;
   return e->p;
@@ -721,12 +821,21 @@ const void *lotus_replay_serve_blob(uint32_t jkind, uint32_t arghash,
  * Returns 1 with *out = pub_id (0 = a structural cell) when the
  * recorded stream has one left; 0 = stream exhausted (no
  * constraint — consume freely). */
-int lotus_replay_expected_consume(uint64_t *out) {
+int lotus_replay_expected_consume(uint64_t *out_msg,
+                                  uint32_t *out_locus) {
   if (!lotus_replay_active) return 0;
   rp_consumer_t *c = rp_consumer(t_consumer_id);
   if (!c || c->consume_cursor >= c->consume_len) return 0;
-  *out = c->consume[c->consume_cursor];
+  *out_msg = c->consume[c->consume_cursor].msg;
+  *out_locus = c->consume[c->consume_cursor].locus;
   return 1;
+}
+
+/* Subscriber instance id for the enforcement gate (delivery
+ * identity = target locus + message id). */
+uint64_t lotus_obs_pub_inst_id(void *self) {
+  if (!self || !obs_on()) return 0;
+  return obs_inst_id_of(self);
 }
 
 /* Called at every dequeue-driven handler invoke under replay:
@@ -865,6 +974,24 @@ void lotus_obs_teardown(void) {
     pthread_join(g_rec_thread, NULL);
     g_rec_thread_started = 0;
     if (g_rec_file) {
+      /* Re-stamp the identity fields at finalize: the header is
+       * first written at segment creation, which the FIRST PROBE
+       * triggers — and a prelude registration (a topic binding)
+       * can probe before the model/exec stamps run, snapshotting
+       * zeros. Finalize-time values are the authoritative ones. */
+      uint64_t ident[6] = { g_obs_model_hash,
+                            g_obs_exec_digest[0], g_obs_exec_digest[1],
+                            g_obs_exec_digest[2], g_obs_exec_digest[3],
+                            g_rec_env_full ? 0u : 1u };
+      if (fseek(g_rec_file, 48, SEEK_SET) != 0 ||
+          fwrite(ident, sizeof ident, 1, g_rec_file) != 1 ||
+          fseek(g_rec_file, 0, SEEK_END) != 0) {
+        g_rec_file = NULL;
+        fprintf(stderr,
+                "hale: LOTUS_OBS_RECORD identity re-stamp failed\n");
+        fflush(NULL);
+        _exit(74);
+      }
       uint64_t trailer[2] = { OBS_REC_END, g_rec_written };
       if (fwrite(trailer, sizeof trailer, 1, g_rec_file) != 1 ||
           fflush(g_rec_file) != 0 || fclose(g_rec_file) != 0) {
@@ -1092,13 +1219,15 @@ static int obs_create(int64_t rings, int64_t slots) {
       _exit(74);
     }
     setvbuf(g_rec_file, NULL, _IOFBF, 1 << 20);
-    obs_rec_hdr_t rh = { .magic = OBS_REC_MAGIC, .maj = 0, .min = 2,
+    obs_rec_hdr_t rh = { .magic = OBS_REC_MAGIC, .maj = 0, .min = 3,
       .header_len = sizeof(obs_rec_hdr_t), .pid = (uint32_t)getpid(),
       .ring_count = (uint32_t)rings, .ring_slots = (uint32_t)slots,
       .ts_shift = 4, .started_mono_ns = H->started_mono_ns,
       .started_wall_ns = H->started_wall_ns,
       .model_hash = g_obs_model_hash,
-      .exec_digest = g_obs_exec_digest };
+      .exec_digest = { g_obs_exec_digest[0], g_obs_exec_digest[1],
+                       g_obs_exec_digest[2], g_obs_exec_digest[3] },
+      .flags = g_rec_env_full ? 0 : 1 };
     if (fwrite(&rh, sizeof rh, 1, g_rec_file) != 1) {
       fprintf(stderr, "hale: LOTUS_OBS_RECORD header write failed\n");
       fflush(NULL);
@@ -1187,6 +1316,8 @@ __attribute__((constructor)) static void obs_live_ctor(void) {
     lotus_obs_live = 1;
     atexit(rp_report);
   }
+  const char *envmode = getenv("LOTUS_OBS_RECORD_ENV");
+  if (envmode && strcmp(envmode, "full") == 0) g_rec_env_full = 1;
   const char *rec = getenv("LOTUS_OBS_RECORD");
   if (rec && rec[0]) {
     size_t n = strlen(rec);
@@ -1375,6 +1506,7 @@ static void obs_emit_raw(uint64_t w0, uint64_t w1) {
  * lossless (blocks against the drain cursor), never the public
  * segment. Recording mode only. */
 static void obs_rec_emit(uint32_t ev, uint64_t w1);
+static void obs_rec_emit2(uint32_t ev, uint32_t id20, uint64_t w1);
 
 /* Claim this thread's private ring (assigning a unique anonymous
  * consumer id if the thread has none). Split from the emit so an
@@ -1403,14 +1535,39 @@ static void obs_rec_claim(void) {
     /* A thread with no stable identity (ingress readers) gets a
      * unique anonymous id — unique within the run, NOT stable
      * across runs (their consume streams replay by count only;
-     * fleet identity is Phase 5). Never a shared fallback. */
-    if (t_consumer_id == 0) t_consumer_id = 2048u + (uint64_t)r;
+     * fleet identity is Phase 5). Never a shared fallback, and the
+     * range starts at OBS_REC_ANON_BASE so it cannot overlap the
+     * pinned range (guarded at note_consumer_locus). */
+    if (t_consumer_id == 0)
+      t_consumer_id = OBS_REC_ANON_BASE + (uint64_t)r;
     g_rec_rings[r].consumer = t_consumer_id;
     atomic_store_explicit(&g_rec_rings[r].head, 0,
                           memory_order_relaxed);
     t_rec_ring = r;
     obs_rec_emit(REC_EV_CONSUMER, g_rec_rings[r].consumer);
   }
+}
+
+static void obs_rec_emit2(uint32_t ev, uint32_t id20, uint64_t w1) {
+  if (!lotus_obs_recording) return;
+  obs_rec_claim();
+  if (t_rec_ring < 0) return;
+  obs_rec_ring_t *rr2 = &g_rec_rings[t_rec_ring];
+  uint64_t h2 = atomic_load_explicit(&rr2->head, memory_order_relaxed);
+  while (h2 - atomic_load_explicit(
+             &g_rec_priv_cursor[t_rec_ring], memory_order_acquire)
+         >= (uint64_t)H->ring_slots) {
+    if (atomic_load_explicit(&g_rec_stop, memory_order_relaxed))
+      return;
+    struct timespec ts = {0, 50 * 1000};
+    nanosleep(&ts, NULL);
+  }
+  uint64_t *slot2 =
+      rr2->slots + (h2 & ((uint64_t)H->ring_slots - 1)) * 2;
+  slot2[0] = ((uint64_t)(id20 & 0xFFFFFu))
+      | (((uint64_t)ev & 0x1Fu) << 20);
+  slot2[1] = w1;
+  atomic_store_explicit(&rr2->head, h2 + 1, memory_order_release);
 }
 
 static void obs_rec_emit(uint32_t ev, uint64_t w1) {
@@ -1624,6 +1781,14 @@ static obs_topic_slot_t *obs_topic_slot(const char *subject,
         slot = &g_topics[n];
         atomic_store_explicit(&g_topic_count, n + 1,
                               memory_order_release);
+        /* v0.3: file-side map manifest topic id → subject name, so
+         * the comparator can align PUBLIC bus streams across runs
+         * (manifest ids are registration order, which races). */
+        if (lotus_obs_recording) {
+          obs_rec_blob_push(OBS_REC_TAG_META, OBS_REC_META_TOPIC,
+                            (uint64_t)id, 0,
+                            subject, strlen(subject) + 1);
+        }
       }
     }
   }
@@ -1721,16 +1886,30 @@ void lotus_obs_record_consume(void *subscriber_self, uint64_t pub_id) {
   (void)obs_gate();
   (void)t_consume_seq; /* order = ring position since v0.2 */
   uint32_t locus = subscriber_self ? obs_inst_id_of(subscriber_self) : 0;
-  obs_rec_emit(REC_EV_CONSUME,
-               (((uint64_t)locus & 0xFFFFFu) << 44)
-                   | (pub_id & 0xFFFFFFFFFFFULL));
+  /* Target locus rides w0's 20-bit id field; w1 is the FULL 64-bit
+   * message id. (locus, msg_id) is the delivery identity — two
+   * subscribers of one publish on one consumer are distinguishable
+   * (review round 2, finding 5). */
+  obs_rec_emit2(REC_EV_CONSUME, locus, pub_id);
 }
 
 void lotus_obs_note_consumer_locus(void *self) {
   if (!lotus_obs_live || !self) return;
   if (!obs_on()) return;
   uint32_t id = obs_inst_id_of(self);
-  if (id) t_consumer_id = 64 + (uint64_t)id;
+  if (!id) return;
+  uint64_t cid = 64 + (uint64_t)id;
+  if ((lotus_obs_recording || lotus_replay_active) &&
+      cid >= OBS_REC_ANON_BASE) {
+    fprintf(stderr,
+            "hale: recording/replay supports pinned consumer ids "
+            "below %u (got %llu) — this run cannot be identified "
+            "faithfully\n",
+            OBS_REC_ANON_BASE, (unsigned long long)cid);
+    fflush(NULL);
+    _exit(70);
+  }
+  t_consumer_id = cid;
 }
 
 /* GH #296 Phase 2: capture a publish's payload once, on the
@@ -1751,11 +1930,20 @@ uint64_t lotus_obs_record_publish_payload(const char *subject,
   int ingress = g_obs_tls_redispatch; /* peek only */
   if (t_consumer_id == 0) obs_rec_claim(); /* unique anon id */
   uint64_t cid = t_consumer_id;
-  /* cid:12 | seq:32 (44 bits total — fits BUS_CONSUME/ENQ w1's
-   * pub field). 12 bits cover main/pool/pinned/anonymous id
-   * ranges without truncation (review finding 8). */
-  uint64_t pub_id = ((cid & 0xFFFu) << 32)
-      | (++t_pub_seq & 0xFFFFFFFFULL);
+  /* msg_id = consumer:16 | seq:48, full width — recorder records
+   * are a private format, so nothing forces identity into 44 bits
+   * (review round 2, finding 7). The guards fail loudly instead of
+   * wrapping or overlapping. */
+  if (cid > OBS_REC_CONSUMER_MAX || t_pub_seq >= 0xFFFFFFFFFFFFULL) {
+    fprintf(stderr,
+            "hale: recording identity out of range (consumer %llu, "
+            "seq %llu) — refusing to record ambiguously\n",
+            (unsigned long long)cid,
+            (unsigned long long)t_pub_seq);
+    fflush(NULL);
+    _exit(70);
+  }
+  uint64_t pub_id = (cid << 48) | (++t_pub_seq & 0xFFFFFFFFFFFFULL);
   /* Under replay the identity is re-derived (same threads, same
    * per-thread order → same ids) so dequeues can be matched to the
    * recorded consume order; nothing is written anywhere. */
@@ -1770,15 +1958,22 @@ uint64_t lotus_obs_record_publish_payload(const char *subject,
     topic *= 16777619u;
   }
   /* flags: bit 0 = external ingress (wire re-dispatch); bit 1 =
-   * raw in-process struct bytes — an ABI snapshot (pointers for
-   * String/Bytes fields, padding, ASLR-dependent), NOT a portable
-   * encoding. Consumers must not byte-compare or decode flagged
-   * payloads; canonical per-topic recording codecs are the staged
-   * fix (review finding 9). Wire captures are canonical bytes and
-   * carry no flag. */
-  uint64_t flags = (ingress ? 1u : 0u) | (raw_struct ? 2u : 0u);
-  obs_rec_blob_push(OBS_REC_TAG_PAYLOAD, topic, pub_id, flags,
-                    payload, size);
+   * raw in-process struct — for which the artifact stores METADATA
+   * ONLY (declared size in flags bits 32..63, zero bytes): an ABI
+   * snapshot would carry heap pointers, uninitialized padding, and
+   * potentially secret-derived bytes while being unusable for
+   * comparison anyway (review round 2, finding 8). Canonical
+   * per-topic recording codecs are the staged fix. Wire captures
+   * are canonical bytes, stored verbatim, unflagged. */
+  if (raw_struct) {
+    uint64_t flags = 2u | (ingress ? 1u : 0u) | (size << 32);
+    obs_rec_blob_push(OBS_REC_TAG_PAYLOAD, topic, pub_id, flags,
+                      NULL, 0);
+  } else {
+    uint64_t flags = ingress ? 1u : 0u;
+    obs_rec_blob_push(OBS_REC_TAG_PAYLOAD, topic, pub_id, flags,
+                      payload, size);
+  }
   return pub_id;
 }
 
@@ -1789,30 +1984,52 @@ void lotus_obs_record_enqueue(uint64_t pub_id, void *subscriber_self) {
   if (!lotus_obs_recording || !pub_id) return;
   if (!obs_on()) return;
   uint32_t locus = subscriber_self ? obs_inst_id_of(subscriber_self) : 0;
-  obs_rec_emit(REC_EV_ENQ,
-               (((uint64_t)locus & 0xFFFFFu) << 44)
-                   | (pub_id & 0xFFFFFFFFFFFULL));
+  obs_rec_emit2(REC_EV_ENQ, locus, pub_id);
 }
 
 /* GH #296 Phase 3: journal a nondeterministic input read. The
  * value blob rides the capture list keyed (jkind, consumer, seq);
  * the ring record is the interleaving marker. */
-void lotus_obs_journal_bytes(uint32_t jkind, uint32_t arghash,
-                             const void *p, uint64_t n) {
+void lotus_obs_journal_bytes(uint32_t jkind, const void *args,
+                             uint64_t args_len, const void *p,
+                             uint64_t n) {
   if (!lotus_obs_recording) return;
   if (!obs_on()) return;
   if (t_consumer_id == 0) obs_rec_claim();
   uint64_t cid = t_consumer_id;
-  uint64_t seq = ((uint64_t)arghash << 32)
-      | (++t_journal_seq & 0xFFFFFFFFULL);
-  obs_rec_blob_push(OBS_REC_TAG_JOURNAL, jkind, cid, seq, p, n);
+  uint64_t seq = ++t_journal_seq;
+  /* Env VALUES are withheld under the default policy — the entry
+   * keeps the call's exact identity (kind + args) and the value's
+   * length, so replay reports a NAMED withheld divergence instead
+   * of substituting anything. */
+  int withhold = !g_rec_env_full &&
+      (jkind == JK_ENV_VAR || jkind == JK_ENV_ARG);
+  if (args_len > 0xFFFFFFFFull) return;
+  uint32_t al = (uint32_t)args_len;
+  uint64_t body_len = 4ull + al + (withhold ? 0 : n);
+  uint8_t small[256];
+  uint8_t *buf = body_len <= sizeof small ? small : malloc(body_len);
+  if (!buf) {
+    fprintf(stderr,
+            "hale: LOTUS_OBS_RECORD journal allocation failed\n");
+    fflush(NULL);
+    _exit(74);
+  }
+  memcpy(buf, &al, 4);
+  if (al) memcpy(buf + 4, args, al);
+  if (!withhold && n) memcpy(buf + 4 + al, p, n);
+  uint64_t cfield = (seq & 0x7FFFFFFFFFFFFFFFull)
+      | (withhold ? (1ull << 63) : 0);
+  obs_rec_blob_push(OBS_REC_TAG_JOURNAL, jkind, cid, cfield, buf,
+                    body_len);
+  if (buf != small) free(buf);
   obs_rec_emit(REC_EV_JOURNAL,
                ((uint64_t)jkind << 56) | (seq & 0xFFFFFFFFFFFFFFULL));
 }
 
-void lotus_obs_journal_i64(uint32_t jkind, uint32_t arghash,
-                           int64_t v) {
-  lotus_obs_journal_bytes(jkind, arghash, &v, 8);
+void lotus_obs_journal_i64(uint32_t jkind, const void *args,
+                           uint64_t args_len, int64_t v) {
+  lotus_obs_journal_bytes(jkind, args, args_len, &v, 8);
 }
 
 /* binding_obs_id: cached on the remote entry by the caller (the

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -86,25 +86,31 @@
  * consumption point. w1 packs locus:20 (subscriber) | pub_id:44
  * (the delivery's deterministic identity — see the v0.2 note);
  * id = 0. */
-#define EK_BUS_CONSUME 8
-/* GH #296 Phase 2 (recording mode only): one record per QUEUED
- * delivery at enqueue, on the publishing thread's ring —
- * w1 = locus:20 (subscriber) | pub_id:44. Pairs the eventual
- * BUS_CONSUME (same pub_id) with the publish whose payload blob
- * carries the bytes. */
-#define EK_BUS_ENQ 9
-/* GH #296 Phase 3 (recording mode only): a journaled input read
- * (time/entropy/env) happened on this thread —
- * w1 = jkind:8 << 56 | per-thread journal seq:56. The VALUE lives
- * in a tag-2 blob in the recording file; this ring record is the
- * interleaving marker. */
-#define EK_JOURNAL 11
-/* GH #296 (recording mode only): first record of every claimed
- * ring — w1 = the claiming thread's stable consumer id, so a
- * reader can attribute per-ring streams across runs (pthread ids
- * don't survive a re-run; these do). */
-#define EK_CONSUMER 12
 #define EK_DROP_MARK 14
+
+/* GH #296 recorder events live in a PRIVATE event namespace on
+ * PRIVATE per-thread rings that are never part of the public
+ * observation segment — iris protocol ekinds 8/9/11/12 are
+ * SUPERV_TRANS/PLACEMENT/BINDING_UP/BINDING_DOWN, and an observer
+ * attaching to a recording process must never decode recorder
+ * bookkeeping as lifecycle transitions (review of PR #463,
+ * finding 1). In the recording file, tag-0 entries from private
+ * rings carry ring | OBS_REC_PRIV_RING; the two namespaces can
+ * never be confused because they never share a ring.
+ *
+ *   REC_EV_CONSUMER 1  — private ring's first record; w1 = the
+ *                        claiming thread's stable consumer id
+ *   REC_EV_CONSUME  2  — dequeue-driven handler invoke;
+ *                        w1 = locus:20 | pub_id:44
+ *   REC_EV_ENQ      3  — queued target at enqueue; same w1 shape
+ *   REC_EV_JOURNAL  4  — journaled read marker;
+ *                        w1 = jkind:8 << 56 | per-thread seq
+ */
+#define REC_EV_CONSUMER 1
+#define REC_EV_CONSUME 2
+#define REC_EV_ENQ 3
+#define REC_EV_JOURNAL 4
+#define OBS_REC_PRIV_RING 0x80000000u
 
 /* manifest kinds */
 #define MK_TOPIC 0
@@ -154,6 +160,11 @@ static _Atomic int g_obs_state = 0;
  * any probe can lazily create the segment. */
 static uint64_t g_obs_model_hash = 0;
 void lotus_obs_model_hash_set(uint64_t h) { g_obs_model_hash = h; }
+/* GH #296 review finding 2: shape_hash is structural compatibility,
+ * not executable identity. The CLI stamps a digest of the compiler
+ * version + every source byte; exact replay admits on THIS. */
+static uint64_t g_obs_exec_digest = 0;
+void lotus_obs_exec_digest_set(uint64_t h) { g_obs_exec_digest = h; }
 
 /* iris handoff-2 P10: publisher attribution. Codegen notes the
  * publishing locus's self in this TLS right before lowering a
@@ -372,6 +383,20 @@ typedef struct obs_rec_blob {
   uint64_t size;
   /* bytes follow */
 } obs_rec_blob_t;
+/* Private recorder rings: one per emitting thread, same 16-byte
+ * slot + release-store discipline as the public SPSC, but in
+ * process-private memory (see the REC_EV note above). The drain
+ * sweeps them with the same blocking-cursor contract. */
+typedef struct {
+  uint64_t *slots;           /* H->ring_slots * 2 u64s */
+  _Atomic uint64_t head;
+  uint64_t consumer;
+} obs_rec_ring_t;
+static obs_rec_ring_t g_rec_rings[64];
+static _Atomic int g_rec_ring_next = 0;
+static __thread int t_rec_ring = -2; /* -2 = unassigned */
+static _Atomic uint64_t g_rec_priv_cursor[64];
+
 static obs_rec_blob_t *_Atomic g_rec_blob_head = NULL;
 static _Atomic uint64_t g_rec_blob_bytes = 0;
 #define OBS_REC_BLOB_BUDGET (64ull << 20)
@@ -379,20 +404,32 @@ static _Atomic uint64_t g_rec_blob_bytes = 0;
 static void obs_rec_blob_push(uint32_t tag, uint32_t a, uint64_t b,
                               uint64_t c, const void *bytes,
                               uint64_t size) {
-  while (atomic_load_explicit(&g_rec_blob_bytes, memory_order_relaxed)
-         > OBS_REC_BLOB_BUDGET) {
-    if (atomic_load_explicit(&g_rec_stop, memory_order_relaxed)) return;
+  /* Reserve BEFORE allocating (concurrent producers cannot
+   * overshoot the budget), back off while over. */
+  uint64_t need = sizeof(obs_rec_blob_t) + size;
+  for (;;) {
+    uint64_t prev = atomic_fetch_add_explicit(
+        &g_rec_blob_bytes, need, memory_order_relaxed);
+    if (prev + need <= OBS_REC_BLOB_BUDGET) break;
+    atomic_fetch_sub_explicit(&g_rec_blob_bytes, need,
+                              memory_order_relaxed);
+    if (atomic_load_explicit(&g_rec_stop, memory_order_relaxed))
+      return;
     struct timespec ts = {0, 50 * 1000};
     nanosleep(&ts, NULL);
   }
-  obs_rec_blob_t *n = malloc(sizeof(obs_rec_blob_t) + size);
-  if (!n) return; /* OOM under recording: the drain detects the
-                   * gap at replay-match time, not silently here */
+  obs_rec_blob_t *n = malloc(need);
+  if (!n) {
+    /* Never a silent hole: a recording that cannot capture is a
+     * failed recording (review finding 4). */
+    fprintf(stderr,
+            "hale: LOTUS_OBS_RECORD capture allocation failed — "
+            "failing the run rather than recording a gap\n");
+    fflush(NULL);
+    _exit(74);
+  }
   n->tag = tag; n->a = a; n->b = b; n->c = c; n->size = size;
   if (size && bytes) memcpy(n + 1, bytes, size);
-  atomic_fetch_add_explicit(&g_rec_blob_bytes,
-                            sizeof(obs_rec_blob_t) + size,
-                            memory_order_relaxed);
   obs_rec_blob_t *old = atomic_load_explicit(&g_rec_blob_head,
                                              memory_order_relaxed);
   do {
@@ -409,7 +446,7 @@ typedef struct {
   uint32_t pid, ring_count, ring_slots, ts_shift;
   uint64_t started_mono_ns, started_wall_ns;
   uint64_t model_hash;
-  uint8_t reserved[8];
+  uint64_t exec_digest; /* compiler ver + source bytes; 0 = unstamped */
 } obs_rec_hdr_t;
 _Static_assert(sizeof(obs_rec_hdr_t) == 64, "recording header is 64B");
 
@@ -446,18 +483,24 @@ static char g_replay_path[512];
 static const uint8_t *g_rp_base; /* mmap'd recording */
 static size_t g_rp_len;
 static uint64_t g_replay_at = 0; /* LOTUS_REPLAY_AT: stop at Nth consume */
+static uint64_t g_replay_at_consumer = 0; /* 0 = process-wide count */
 
 #define RP_MAX_CONSUMERS 96
 #define RP_MAX_JK 9
 
-typedef struct { const uint8_t *p; uint64_t size; } rp_blob_ref_t;
+typedef struct { const uint8_t *p; uint64_t size;
+                 uint32_t jkind, arghash; } rp_blob_ref_t;
 typedef struct {
   rp_blob_ref_t *items;
   uint32_t len, cap, cursor;
 } rp_queue_t;
 typedef struct {
   uint64_t consumer;
-  rp_queue_t journal[RP_MAX_JK];   /* per jkind */
+  /* ONE unified input queue per consumer (review finding 7): the
+   * next read must match in kind AND argument identity, so a
+   * cross-kind reordering or a changed argument is the FIRST
+   * named divergence instead of a plausible wrong value. */
+  rp_queue_t journal;
   uint64_t *consume;               /* recorded pub_id order */
   uint32_t consume_len, consume_cap, consume_cursor;
 } rp_consumer_t;
@@ -491,13 +534,16 @@ static rp_consumer_t *rp_consumer(uint64_t cid) {
   return NULL;
 }
 
-static void rp_queue_push(rp_queue_t *q, const uint8_t *p, uint64_t n) {
+static void rp_queue_push(rp_queue_t *q, const uint8_t *p, uint64_t n,
+                          uint32_t jkind, uint32_t arghash) {
   if (q->len == q->cap) {
     q->cap = q->cap ? q->cap * 2 : 16;
     q->items = realloc(q->items, q->cap * sizeof(rp_blob_ref_t));
   }
   q->items[q->len].p = p;
   q->items[q->len].size = n;
+  q->items[q->len].jkind = jkind;
+  q->items[q->len].arghash = arghash;
   q->len++;
 }
 
@@ -557,21 +603,28 @@ static void rp_load(void) {
       if (off + 24 > end) break;
       uint64_t w0 = *(const uint64_t *)(g_rp_base + off + 8);
       uint64_t w1 = *(const uint64_t *)(g_rp_base + off + 16);
-      uint32_t ring = a;
       uint32_t ekind = (uint32_t)((w0 >> 20) & 0x1F);
-      if (ekind == EK_CONSUMER && ring < 64) {
-        rp_ring_consumer[ring] = w1;
-      } else if (ekind == EK_BUS_CONSUME && ring < 64) {
-        rp_consumer_t *c = rp_consumer_create(rp_ring_consumer[ring]);
-        if (c) {
-          if (c->consume_len == c->consume_cap) {
-            c->consume_cap = c->consume_cap ? c->consume_cap * 2 : 64;
-            c->consume = realloc(
-                c->consume, c->consume_cap * sizeof(uint64_t));
+      if (a & OBS_REC_PRIV_RING) {
+        uint32_t pr = a & ~OBS_REC_PRIV_RING;
+        if (pr < 64) {
+          if (ekind == REC_EV_CONSUMER) {
+            rp_ring_consumer[pr] = w1;
+          } else if (ekind == REC_EV_CONSUME) {
+            rp_consumer_t *c =
+                rp_consumer_create(rp_ring_consumer[pr]);
+            if (c) {
+              if (c->consume_len == c->consume_cap) {
+                c->consume_cap =
+                    c->consume_cap ? c->consume_cap * 2 : 64;
+                c->consume = realloc(
+                    c->consume, c->consume_cap * sizeof(uint64_t));
+              }
+              c->consume[c->consume_len++] = w1 & 0xFFFFFFFFFFFULL;
+            }
           }
-          c->consume[c->consume_len++] = w1 & 0xFFFFFFFFFFFULL;
         }
-      }
+      } /* public-ring records: standard iris protocol, no
+         * recorder meaning — nothing to index for replay */
       off += 24;
     } else if (tag == OBS_REC_TAG_PAYLOAD || tag == OBS_REC_TAG_JOURNAL) {
       if (off + 32 > end) break;
@@ -587,7 +640,9 @@ static void rp_load(void) {
         (void)cfield;
         if (a < RP_MAX_JK) {
           rp_consumer_t *c = rp_consumer_create(b);
-          if (c) rp_queue_push(&c->journal[a], bytes, size);
+          /* cfield = arghash:32 (high) | per-thread seq:32 */
+          if (c) rp_queue_push(&c->journal, bytes, size, a,
+                               (uint32_t)(cfield >> 32));
         }
       } else {
         if (g_rp_payload_len == g_rp_payload_cap) {
@@ -614,33 +669,52 @@ static void rp_load(void) {
   }
 }
 
-int lotus_replay_serve_i64(uint32_t jkind, int64_t *out) {
-  if (!lotus_replay_active || jkind >= RP_MAX_JK) return 0;
-  rp_consumer_t *c = rp_consumer(t_consumer_id ? t_consumer_id : 999);
-  if (!c) return 0;
-  rp_queue_t *q = &c->journal[jkind];
-  if (q->cursor >= q->len || q->items[q->cursor].size != 8) {
+/* The next recorded input for this consumer, iff it matches the
+ * caller's kind + argument identity + (when nonzero) size. A
+ * mismatch is a named divergence and the entry is NOT consumed —
+ * the first wrong read surfaces instead of cascading plausible
+ * wrong values (review finding 7). */
+static const rp_blob_ref_t *rp_serve(uint32_t jkind, uint32_t arghash,
+                                     uint64_t want_size) {
+  if (!lotus_replay_active || jkind >= RP_MAX_JK) return NULL;
+  rp_consumer_t *c = rp_consumer(t_consumer_id);
+  if (!c) {
     atomic_fetch_add_explicit(&g_rp_divergences[jkind], 1,
                               memory_order_relaxed);
-    return 0;
+    return NULL;
   }
-  memcpy(out, q->items[q->cursor].p, 8);
-  q->cursor++;
-  return 1;
-}
-
-const void *lotus_replay_serve_blob(uint32_t jkind, uint64_t *out_n) {
-  if (!lotus_replay_active || jkind >= RP_MAX_JK) return NULL;
-  rp_consumer_t *c = rp_consumer(t_consumer_id ? t_consumer_id : 999);
-  if (!c) return NULL;
-  rp_queue_t *q = &c->journal[jkind];
+  rp_queue_t *q = &c->journal;
   if (q->cursor >= q->len) {
     atomic_fetch_add_explicit(&g_rp_divergences[jkind], 1,
                               memory_order_relaxed);
     return NULL;
   }
-  *out_n = q->items[q->cursor].size;
-  return q->items[q->cursor++].p;
+  const rp_blob_ref_t *e = &q->items[q->cursor];
+  if (e->jkind != jkind || e->arghash != arghash ||
+      (want_size && e->size != want_size)) {
+    atomic_fetch_add_explicit(&g_rp_divergences[jkind], 1,
+                              memory_order_relaxed);
+    return NULL;
+  }
+  q->cursor++;
+  return e;
+}
+
+int lotus_replay_serve_i64(uint32_t jkind, uint32_t arghash,
+                           int64_t *out) {
+  const rp_blob_ref_t *e = rp_serve(jkind, arghash, 8);
+  if (!e) return 0;
+  memcpy(out, e->p, 8);
+  return 1;
+}
+
+const void *lotus_replay_serve_blob(uint32_t jkind, uint32_t arghash,
+                                    uint64_t want_size,
+                                    uint64_t *out_n) {
+  const rp_blob_ref_t *e = rp_serve(jkind, arghash, want_size);
+  if (!e) return NULL;
+  *out_n = e->size;
+  return e->p;
 }
 
 /* Phase 4: the calling thread's next expected delivery identity.
@@ -649,7 +723,7 @@ const void *lotus_replay_serve_blob(uint32_t jkind, uint64_t *out_n) {
  * constraint — consume freely). */
 int lotus_replay_expected_consume(uint64_t *out) {
   if (!lotus_replay_active) return 0;
-  rp_consumer_t *c = rp_consumer(t_consumer_id ? t_consumer_id : 999);
+  rp_consumer_t *c = rp_consumer(t_consumer_id);
   if (!c || c->consume_cursor >= c->consume_len) return 0;
   *out = c->consume[c->consume_cursor];
   return 1;
@@ -661,11 +735,25 @@ int lotus_replay_expected_consume(uint64_t *out) {
  * so a debugger can attach). */
 void lotus_replay_note_consume(void) {
   if (!lotus_replay_active) return;
-  rp_consumer_t *c = rp_consumer(t_consumer_id ? t_consumer_id : 999);
+  rp_consumer_t *c = rp_consumer(t_consumer_id);
   if (c && c->consume_cursor < c->consume_len) c->consume_cursor++;
   uint64_t n = atomic_fetch_add_explicit(&g_rp_consume_count, 1,
                                          memory_order_relaxed) + 1;
-  if (g_replay_at && n == g_replay_at) {
+  /* consumer:N form — stable across multi-consumer runs, unlike
+   * the process-wide ordinal (review, --at stability note). */
+  if (g_replay_at_consumer && g_replay_at && c &&
+      t_consumer_id == g_replay_at_consumer &&
+      (uint64_t)c->consume_cursor == g_replay_at) {
+    fprintf(stderr,
+            "hale replay: stopped at consumer %llu consume #%llu "
+            "(pid %d) — attach a debugger, then SIGCONT\n",
+            (unsigned long long)t_consumer_id,
+            (unsigned long long)g_replay_at, (int)getpid());
+    fflush(NULL);
+    raise(SIGSTOP);
+    return;
+  }
+  if (!g_replay_at_consumer && g_replay_at && n == g_replay_at) {
     fprintf(stderr,
             "hale replay: stopped at consume #%llu (pid %d) — "
             "attach a debugger, then SIGCONT\n",
@@ -676,13 +764,43 @@ void lotus_replay_note_consume(void) {
 }
 
 /* Teardown summary: replay honesty is the divergence report. */
+uint64_t lotus_replay_order_divergences(void) __attribute__((weak));
+
 static void rp_report(void) {
   if (!lotus_replay_active) return;
+  uint64_t unconsumed_journal = 0, unconsumed_deliveries = 0;
+  for (int i = 0; i < g_rp_consumer_count; i++) {
+    rp_consumer_t *c = &g_rp_consumers[i];
+    unconsumed_journal += c->journal.len - c->journal.cursor;
+    unconsumed_deliveries += c->consume_len - c->consume_cursor;
+  }
+  uint64_t order_div = lotus_replay_order_divergences
+      ? lotus_replay_order_divergences()
+      : 0;
+  const char *status_path = getenv("LOTUS_REPLAY_STATUS");
+  if (status_path && status_path[0]) {
+    FILE *sf = fopen(status_path, "w");
+    if (sf) {
+      uint64_t jd = 0;
+      for (int i = 0; i < RP_MAX_JK; i++)
+        jd += atomic_load(&g_rp_divergences[i]);
+      fprintf(sf,
+              "journal_divergences=%llu\norder_divergences=%llu\n"
+              "unconsumed_journal=%llu\nunconsumed_deliveries=%llu\n"
+              "consumes=%llu\n",
+              (unsigned long long)jd, (unsigned long long)order_div,
+              (unsigned long long)unconsumed_journal,
+              (unsigned long long)unconsumed_deliveries,
+              (unsigned long long)atomic_load(&g_rp_consume_count));
+      fclose(sf);
+    }
+  }
   static const char *jk_names[RP_MAX_JK] = {
     "?", "time.now", "time.monotonic", "rand.next_int",
     "os.getrandom", "env.var", "env.var_exists", "env.arg",
     "env.args_count" };
-  uint64_t total = 0;
+  uint64_t total = order_div + unconsumed_journal
+      + unconsumed_deliveries;
   for (int i = 0; i < RP_MAX_JK; i++)
     total += atomic_load(&g_rp_divergences[i]);
   if (total == 0) {
@@ -693,14 +811,23 @@ static void rp_report(void) {
     return;
   }
   fprintf(stderr,
-          "hale replay: %llu journal divergences (reads past the "
-          "recorded history fell back live):\n",
+          "hale replay: %llu divergences from the recorded "
+          "history:\n",
           (unsigned long long)total);
   for (int i = 0; i < RP_MAX_JK; i++) {
     uint64_t d = atomic_load(&g_rp_divergences[i]);
-    if (d) fprintf(stderr, "  %-16s %llu\n", jk_names[i],
+    if (d) fprintf(stderr, "  %-22s %llu\n", jk_names[i],
                    (unsigned long long)d);
   }
+  if (order_div)
+    fprintf(stderr, "  %-22s %llu\n", "delivery-order",
+            (unsigned long long)order_div);
+  if (unconsumed_journal)
+    fprintf(stderr, "  %-22s %llu\n", "unconsumed-journal",
+            (unsigned long long)unconsumed_journal);
+  if (unconsumed_deliveries)
+    fprintf(stderr, "  %-22s %llu\n", "unconsumed-deliveries",
+            (unsigned long long)unconsumed_deliveries);
 }
 
 /* Pinned-locus threads: identity = 64 + the locus's obs instance
@@ -740,13 +867,21 @@ void lotus_obs_teardown(void) {
     if (g_rec_file) {
       uint64_t trailer[2] = { OBS_REC_END, g_rec_written };
       if (fwrite(trailer, sizeof trailer, 1, g_rec_file) != 1 ||
-          fflush(g_rec_file) != 0) {
+          fflush(g_rec_file) != 0 || fclose(g_rec_file) != 0) {
+        g_rec_file = NULL;
         fprintf(stderr,
-                "hale: LOTUS_OBS_RECORD finalize failed: %s\n",
+                "hale: LOTUS_OBS_RECORD finalize failed: %s — "
+                "failing the run (an unfinalized recording must "
+                "not pass silently)\n",
                 strerror(errno));
+        fflush(NULL);
+        _exit(74);
       }
-      fclose(g_rec_file);
       g_rec_file = NULL;
+    }
+    for (int r = 0; r < 64; r++) {
+      free(g_rec_rings[r].slots);
+      g_rec_rings[r].slots = NULL;
     }
   }
   /* Serialize against the P18 heartbeat: it probes the segment
@@ -945,7 +1080,10 @@ static int obs_create(int64_t rings, int64_t slots) {
    * recording counts as an attached observer — ring emission is on
    * from the first probe without anyone mmapping the segment. */
   if (lotus_obs_recording) {
-    g_rec_file = fopen(g_rec_path, "wb");
+    unlink(g_rec_path);
+    int rec_fd = open(g_rec_path,
+                      O_CREAT | O_EXCL | O_WRONLY | O_NOFOLLOW, 0600);
+    g_rec_file = rec_fd >= 0 ? fdopen(rec_fd, "wb") : NULL;
     if (!g_rec_file) {
       fprintf(stderr,
               "hale: LOTUS_OBS_RECORD could not open `%s`: %s\n",
@@ -959,7 +1097,8 @@ static int obs_create(int64_t rings, int64_t slots) {
       .ring_count = (uint32_t)rings, .ring_slots = (uint32_t)slots,
       .ts_shift = 4, .started_mono_ns = H->started_mono_ns,
       .started_wall_ns = H->started_wall_ns,
-      .model_hash = g_obs_model_hash, .reserved = {0} };
+      .model_hash = g_obs_model_hash,
+      .exec_digest = g_obs_exec_digest };
     if (fwrite(&rh, sizeof rh, 1, g_rec_file) != 1) {
       fprintf(stderr, "hale: LOTUS_OBS_RECORD header write failed\n");
       fflush(NULL);
@@ -1041,6 +1180,8 @@ __attribute__((constructor)) static void obs_live_ctor(void) {
     memcpy(g_replay_path, rp, n + 1);
     const char *at = getenv("LOTUS_REPLAY_AT");
     if (at && at[0]) g_replay_at = (uint64_t)atoll(at);
+    const char *atc = getenv("LOTUS_REPLAY_AT_CONSUMER");
+    if (atc && atc[0]) g_replay_at_consumer = (uint64_t)atoll(atc);
     rp_load();
     lotus_replay_active = 1;
     lotus_obs_live = 1;
@@ -1205,15 +1346,6 @@ static void obs_emit_raw(uint64_t w0, uint64_t w1) {
     }
     t_ring = r;
     RD[r].tag_b = (uint32_t)(uintptr_t)pthread_self();
-    /* GH #296: under recording, a ring's first record names its
-     * claiming thread's stable consumer id (pthread ids don't
-     * survive a re-run; these do). 1000+r = anonymous thread. */
-    if (lotus_obs_recording) {
-      uint64_t cid = t_consumer_id ? t_consumer_id : 1000u + (uint64_t)r;
-      lotus_spsc_emit(g_seg, &RD[r], H->ring_slots,
-                      (int64_t)((uint64_t)EK_CONSUMER << 20),
-                      (int64_t)cid);
-    }
   }
   /* GH #296 recording disposition: overwrite-oldest becomes
    * block-the-producer. The ring is effectively a bounded SPSC
@@ -1237,6 +1369,70 @@ static void obs_emit_raw(uint64_t w0, uint64_t w1) {
   lotus_spsc_emit(g_seg, &RD[t_ring], H->ring_slots, (int64_t)w0,
                   (int64_t)w1);
   atomic_fetch_add_explicit(&CNT[0].c[2], 1, memory_order_relaxed);
+}
+
+/* Emit a recorder event onto this thread's PRIVATE ring —
+ * lossless (blocks against the drain cursor), never the public
+ * segment. Recording mode only. */
+static void obs_rec_emit(uint32_t ev, uint64_t w1);
+
+/* Claim this thread's private ring (assigning a unique anonymous
+ * consumer id if the thread has none). Split from the emit so an
+ * identity-only claim never writes a spurious marker. */
+static void obs_rec_claim(void) {
+  if (!lotus_obs_recording || t_rec_ring != -2) return;
+  {
+    int r = atomic_fetch_add(&g_rec_ring_next, 1);
+    if (r >= 64) {
+      fprintf(stderr,
+              "hale: LOTUS_OBS_RECORD supports at most 64 emitting "
+              "threads — a recording that drops records is not a "
+              "recording\n");
+      fflush(NULL);
+      _exit(70);
+    }
+    uint64_t *slots = calloc((size_t)H->ring_slots, 16);
+    if (!slots) {
+      fprintf(stderr,
+              "hale: LOTUS_OBS_RECORD private ring allocation "
+              "failed\n");
+      fflush(NULL);
+      _exit(74);
+    }
+    g_rec_rings[r].slots = slots;
+    /* A thread with no stable identity (ingress readers) gets a
+     * unique anonymous id — unique within the run, NOT stable
+     * across runs (their consume streams replay by count only;
+     * fleet identity is Phase 5). Never a shared fallback. */
+    if (t_consumer_id == 0) t_consumer_id = 2048u + (uint64_t)r;
+    g_rec_rings[r].consumer = t_consumer_id;
+    atomic_store_explicit(&g_rec_rings[r].head, 0,
+                          memory_order_relaxed);
+    t_rec_ring = r;
+    obs_rec_emit(REC_EV_CONSUMER, g_rec_rings[r].consumer);
+  }
+}
+
+static void obs_rec_emit(uint32_t ev, uint64_t w1) {
+  if (!lotus_obs_recording) return;
+  obs_rec_claim();
+  if (t_rec_ring < 0) return;
+  obs_rec_ring_t *rr = &g_rec_rings[t_rec_ring];
+  uint64_t head =
+      atomic_load_explicit(&rr->head, memory_order_relaxed);
+  while (head - atomic_load_explicit(
+             &g_rec_priv_cursor[t_rec_ring], memory_order_acquire)
+         >= (uint64_t)H->ring_slots) {
+    if (atomic_load_explicit(&g_rec_stop, memory_order_relaxed))
+      return;
+    struct timespec ts = {0, 50 * 1000};
+    nanosleep(&ts, NULL);
+  }
+  uint64_t *slot =
+      rr->slots + (head & ((uint64_t)H->ring_slots - 1)) * 2;
+  slot[0] = ((uint64_t)ev & 0x1Fu) << 20;
+  slot[1] = w1;
+  atomic_store_explicit(&rr->head, head + 1, memory_order_release);
 }
 
 static void obs_rec_write_failed(void) {
@@ -1282,6 +1478,33 @@ static void *obs_record_drain_main(void *arg) {
       atomic_store_explicit(&g_rec_cursor[r], cur,
                             memory_order_release);
     }
+    /* Private recorder rings (consume/enq/journal markers). Read
+     * head FIRST (acquire): a nonzero head guarantees the slots
+     * pointer is visible (the claim stores slots before its first
+     * release-store of head). */
+    for (uint32_t r = 0; r < 64; r++) {
+      uint64_t head = atomic_load_explicit(&g_rec_rings[r].head,
+                                           memory_order_acquire);
+      uint64_t cur = atomic_load_explicit(&g_rec_priv_cursor[r],
+                                          memory_order_relaxed);
+      if (cur >= head) continue;
+      const uint64_t *slots = g_rec_rings[r].slots;
+      while (cur < head) {
+        const uint64_t *slot =
+            slots + (cur & ((uint64_t)H->ring_slots - 1)) * 2;
+        obs_rec_entry_t ent = { .tag = OBS_REC_TAG_RING,
+                                .ring = OBS_REC_PRIV_RING | r,
+                                .w0 = slot[0], .w1 = slot[1] };
+        if (fwrite(&ent, sizeof ent, 1, g_rec_file) != 1) {
+          obs_rec_write_failed();
+        }
+        g_rec_written++;
+        cur++;
+        wrote = 1;
+      }
+      atomic_store_explicit(&g_rec_priv_cursor[r], cur,
+                            memory_order_release);
+    }
     /* Blobs (payloads + journal values): pop the MPSC list. The
      * exchange yields newest-first; reverse to restore push order
      * (each pushing thread's own order survives the reversal). */
@@ -1314,6 +1537,9 @@ static void *obs_record_drain_main(void *arg) {
       free(b);
       g_rec_written++;
       wrote = 1;
+    }
+    if (wrote && fflush(g_rec_file) != 0) {
+      obs_rec_write_failed();
     }
     if (stop) break;
     if (!wrote) {
@@ -1495,9 +1721,9 @@ void lotus_obs_record_consume(void *subscriber_self, uint64_t pub_id) {
   (void)obs_gate();
   (void)t_consume_seq; /* order = ring position since v0.2 */
   uint32_t locus = subscriber_self ? obs_inst_id_of(subscriber_self) : 0;
-  obs_emit(EK_BUS_CONSUME, 0, 0,
-           (((uint64_t)locus & 0xFFFFFu) << 44)
-               | (pub_id & 0xFFFFFFFFFFFULL));
+  obs_rec_emit(REC_EV_CONSUME,
+               (((uint64_t)locus & 0xFFFFFu) << 44)
+                   | (pub_id & 0xFFFFFFFFFFFULL));
 }
 
 void lotus_obs_note_consumer_locus(void *self) {
@@ -1517,23 +1743,42 @@ void lotus_obs_note_consumer_locus(void *self) {
  * here and consumed there. */
 uint64_t lotus_obs_record_publish_payload(const char *subject,
                                           const void *payload,
-                                          uint64_t size) {
+                                          uint64_t size,
+                                          int raw_struct) {
   if ((!lotus_obs_recording && !lotus_replay_active) || !subject)
     return 0;
   if (!obs_on()) return 0;
   int ingress = g_obs_tls_redispatch; /* peek only */
-  uint64_t cid = t_consumer_id ? t_consumer_id : 999;
-  uint64_t pub_id = ((cid & 0xFFu) << 36)
-      | (++t_pub_seq & 0xFFFFFFFFFULL);
+  if (t_consumer_id == 0) obs_rec_claim(); /* unique anon id */
+  uint64_t cid = t_consumer_id;
+  /* cid:12 | seq:32 (44 bits total — fits BUS_CONSUME/ENQ w1's
+   * pub field). 12 bits cover main/pool/pinned/anonymous id
+   * ranges without truncation (review finding 8). */
+  uint64_t pub_id = ((cid & 0xFFFu) << 32)
+      | (++t_pub_seq & 0xFFFFFFFFULL);
   /* Under replay the identity is re-derived (same threads, same
    * per-thread order → same ids) so dequeues can be matched to the
    * recorded consume order; nothing is written anywhere. */
   if (!lotus_obs_recording) return pub_id;
-  uint32_t topic = 0;
-  obs_topic_slot_t *t = obs_topic_slot(subject, 0);
-  if (t) topic = (uint32_t)t->id;
-  obs_rec_blob_push(OBS_REC_TAG_PAYLOAD, topic, pub_id,
-                    ingress ? 1u : 0u, payload, size);
+  /* Topic identity in the ARTIFACT must survive a re-run: manifest
+   * ids are registration-order, and two racing publishers register
+   * their topics in either order — caught by the racing-replay
+   * test comparing per-run ids. Use a stable subject hash. */
+  uint32_t topic = 2166136261u;
+  for (const char *q = subject; *q; q++) {
+    topic ^= (uint8_t)*q;
+    topic *= 16777619u;
+  }
+  /* flags: bit 0 = external ingress (wire re-dispatch); bit 1 =
+   * raw in-process struct bytes — an ABI snapshot (pointers for
+   * String/Bytes fields, padding, ASLR-dependent), NOT a portable
+   * encoding. Consumers must not byte-compare or decode flagged
+   * payloads; canonical per-topic recording codecs are the staged
+   * fix (review finding 9). Wire captures are canonical bytes and
+   * carry no flag. */
+  uint64_t flags = (ingress ? 1u : 0u) | (raw_struct ? 2u : 0u);
+  obs_rec_blob_push(OBS_REC_TAG_PAYLOAD, topic, pub_id, flags,
+                    payload, size);
   return pub_id;
 }
 
@@ -1544,26 +1789,30 @@ void lotus_obs_record_enqueue(uint64_t pub_id, void *subscriber_self) {
   if (!lotus_obs_recording || !pub_id) return;
   if (!obs_on()) return;
   uint32_t locus = subscriber_self ? obs_inst_id_of(subscriber_self) : 0;
-  obs_emit(EK_BUS_ENQ, 0, 0,
-           (((uint64_t)locus & 0xFFFFFu) << 44)
-               | (pub_id & 0xFFFFFFFFFFFULL));
+  obs_rec_emit(REC_EV_ENQ,
+               (((uint64_t)locus & 0xFFFFFu) << 44)
+                   | (pub_id & 0xFFFFFFFFFFFULL));
 }
 
 /* GH #296 Phase 3: journal a nondeterministic input read. The
  * value blob rides the capture list keyed (jkind, consumer, seq);
  * the ring record is the interleaving marker. */
-void lotus_obs_journal_bytes(uint32_t jkind, const void *p, uint64_t n) {
+void lotus_obs_journal_bytes(uint32_t jkind, uint32_t arghash,
+                             const void *p, uint64_t n) {
   if (!lotus_obs_recording) return;
   if (!obs_on()) return;
-  uint64_t cid = t_consumer_id ? t_consumer_id : 999;
-  uint64_t seq = ++t_journal_seq;
+  if (t_consumer_id == 0) obs_rec_claim();
+  uint64_t cid = t_consumer_id;
+  uint64_t seq = ((uint64_t)arghash << 32)
+      | (++t_journal_seq & 0xFFFFFFFFULL);
   obs_rec_blob_push(OBS_REC_TAG_JOURNAL, jkind, cid, seq, p, n);
-  obs_emit(EK_JOURNAL, 0, 0,
-           ((uint64_t)jkind << 56) | (seq & 0xFFFFFFFFFFFFFFULL));
+  obs_rec_emit(REC_EV_JOURNAL,
+               ((uint64_t)jkind << 56) | (seq & 0xFFFFFFFFFFFFFFULL));
 }
 
-void lotus_obs_journal_i64(uint32_t jkind, int64_t v) {
-  lotus_obs_journal_bytes(jkind, &v, 8);
+void lotus_obs_journal_i64(uint32_t jkind, uint32_t arghash,
+                           int64_t v) {
+  lotus_obs_journal_bytes(jkind, arghash, &v, 8);
 }
 
 /* binding_obs_id: cached on the remote entry by the caller (the

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -421,6 +421,8 @@ static _Atomic int g_rec_ring_next = 0;
 static __thread int t_rec_ring = -2; /* -2 = unassigned */
 static _Atomic uint64_t g_rec_priv_cursor[64];
 
+static void obs_rec_claim(void);
+
 static obs_rec_blob_t *_Atomic g_rec_blob_head = NULL;
 static _Atomic uint64_t g_rec_blob_bytes = 0;
 #define OBS_REC_BLOB_BUDGET (64ull << 20)
@@ -1477,6 +1479,16 @@ static void obs_emit_raw(uint64_t w0, uint64_t w1) {
     }
     t_ring = r;
     RD[r].tag_b = (uint32_t)(uintptr_t)pthread_self();
+    /* v0.3: file-side map public ring → stable consumer id, so the
+     * comparator can align PUBLIC streams across runs (ring claim
+     * order races). Never touches the segment. Field contract
+     * (matches both Rust readers): a = ring, b = subtype,
+     * c = consumer. */
+    if (lotus_obs_recording) {
+      obs_rec_claim();
+      obs_rec_blob_push(OBS_REC_TAG_META, (uint32_t)r,
+                        OBS_REC_META_PUBRING, t_consumer_id, NULL, 0);
+    }
   }
   /* GH #296 recording disposition: overwrite-oldest becomes
    * block-the-producer. The ring is effectively a bounded SPSC
@@ -1785,8 +1797,10 @@ static obs_topic_slot_t *obs_topic_slot(const char *subject,
          * the comparator can align PUBLIC bus streams across runs
          * (manifest ids are registration order, which races). */
         if (lotus_obs_recording) {
-          obs_rec_blob_push(OBS_REC_TAG_META, OBS_REC_META_TOPIC,
-                            (uint64_t)id, 0,
+          /* a = topic id, b = subtype, c = 0 (field contract as at
+           * the pubring push). */
+          obs_rec_blob_push(OBS_REC_TAG_META, (uint32_t)id,
+                            OBS_REC_META_TOPIC, 0,
                             subject, strlen(subject) + 1);
         }
       }

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -1372,6 +1372,18 @@ __attribute__((constructor)) static void obs_live_ctor(void) {
       _exit(64);
     }
   }
+  /* Round 4, finding 1: recording must initialize EAGERLY. Lazy
+   * creation waited for the first probe, so a probe-free program
+   * exited successfully with NO recording — and a stale artifact
+   * already at the path silently impersonated the run that was
+   * just requested. obs_on() under recording creates the file
+   * (replacing anything at the path), spawns the drain, and
+   * registers the finalizer — or fails the run. Identity stamps
+   * arrive later from the prelude; finalize-time restamping
+   * already covers that ordering. */
+  if (lotus_obs_recording || lotus_replay_active) {
+    (void)obs_on();
+  }
 }
 
 /* Enable check + lazy init. Fast path after first call: one

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -74,6 +74,36 @@
 #define EK_LOCUS_BIRTH 5
 #define EK_LOCUS_DISSOLVE 6
 #define EK_RESTART 7
+/* GH #296 Phase 1 (recording mode only — never emitted under plain
+ * LOTUS_OBS=1, so a pre-addendum consumer attached to an observed
+ * process never sees it): a dequeue-driven handler invoke on the
+ * consuming thread. BUS_DELIVER is enqueue-time by design (§5); this
+ * record is the CONSUMPTION event replay reconstructs order from.
+ * Pairing rule: per queue, the k-th BUS_CONSUME corresponds to the
+ * k-th queued delivery (FIFO per single consumer thread). Synchronous
+ * direct-dispatch flavors have no consume record — their handler runs
+ * at the BUS_DELIVER position on the same ring, which IS the
+ * consumption point. w1 packs locus:20 (subscriber) | pub_id:44
+ * (the delivery's deterministic identity — see the v0.2 note);
+ * id = 0. */
+#define EK_BUS_CONSUME 8
+/* GH #296 Phase 2 (recording mode only): one record per QUEUED
+ * delivery at enqueue, on the publishing thread's ring —
+ * w1 = locus:20 (subscriber) | pub_id:44. Pairs the eventual
+ * BUS_CONSUME (same pub_id) with the publish whose payload blob
+ * carries the bytes. */
+#define EK_BUS_ENQ 9
+/* GH #296 Phase 3 (recording mode only): a journaled input read
+ * (time/entropy/env) happened on this thread —
+ * w1 = jkind:8 << 56 | per-thread journal seq:56. The VALUE lives
+ * in a tag-2 blob in the recording file; this ring record is the
+ * interleaving marker. */
+#define EK_JOURNAL 11
+/* GH #296 (recording mode only): first record of every claimed
+ * ring — w1 = the claiming thread's stable consumer id, so a
+ * reader can attribute per-ring streams across runs (pthread ids
+ * don't survive a re-run; these do). */
+#define EK_CONSUMER 12
 #define EK_DROP_MARK 14
 
 /* manifest kinds */
@@ -238,6 +268,449 @@ static __thread uint64_t t_epoch_ns = 0;  /* ring epoch anchor */
 #define OBS_EPOCH_EVERY 1024
 static __thread uint32_t t_since_epoch = 0;
 
+/* ---- lossless recording mode (GH #296 Phase 1) ------------------
+ *
+ * LOTUS_OBS_RECORD=<path> opts a run into recording: every ring
+ * record is drained to <path> by an in-process thread, and the
+ * emission disposition changes from overwrite-oldest to
+ * BLOCK-THE-PRODUCER — a live observer prefers losing records to
+ * stalling the observed program; a recording that drops a record is
+ * a replay that diverges silently, so it must never drop (RFC #296
+ * delta 1). Concretely:
+ *
+ *   - a producer whose ring is full against the drain cursor waits
+ *     for the drain instead of overwriting;
+ *   - a thread that cannot get a ring at all FAILS THE RUN loudly
+ *     (recording defaults to the 64-ring maximum, so this means
+ *     >64 emitting threads);
+ *   - a drain-side write error fails the run, never truncates
+ *     silently.
+ *
+ * Cost contract: `g_obs_recording` is process-constant from the
+ * same constructor that resolves `lotus_obs_live`, so the unset
+ * default is one predictable branch on the paths that already pay
+ * one for observation — the LOTUS_OBS-unset lowering stays
+ * instruction-identical. Recording-on hot cost is one relaxed
+ * cursor load + compare per record while the ring has room.
+ *
+ * File format v0.1 (PRE-STABLE — the recording artifact proper is
+ * RFC #296 Phase 2): 64-byte header, then 24-byte entries
+ * (u32 ring, u32 reserved, u64 w0, u64 w1) in drain order (per-ring
+ * order preserved; cross-ring interleaving meaningless), then a
+ * 16-byte trailer whose presence marks a clean finalize. */
+int lotus_obs_recording = 0; /* read (weak) from lotus_arena.c */
+/* Defined (with its story) next to obs_gate; obs_create pre-arms
+ * it under recording. Tentative declaration so it's visible here. */
+static _Atomic uint32_t g_last_observed;
+static char g_rec_path[512];
+static FILE *g_rec_file = NULL;
+static pthread_t g_rec_thread;
+static int g_rec_thread_started = 0;
+static _Atomic int g_rec_stop = 0;
+static _Atomic uint64_t g_rec_cursor[64]; /* per-ring drained head */
+static uint64_t g_rec_written = 0;        /* drain-thread-owned */
+static __thread uint64_t t_consume_seq = 0;
+
+#define OBS_REC_MAGIC 0x30434552454C4148ULL /* "HALEREC0" */
+#define OBS_REC_END 0x30444E45454C4148ULL   /* "HALEEND0" */
+
+/* ---- format v0.2: tagged entry stream (GH #296 Phase 2/3) ------
+ *
+ * The v0.1 stream was homogeneous 24-byte ring records. v0.2 tags
+ * every entry so payload blobs and journal values ride the same
+ * file (still PRE-STABLE — the self-describing artifact is a later
+ * phase):
+ *
+ *   tag 0 (ring):    u32 tag, u32 ring, u64 w0, u64 w1        (24B)
+ *   tag 1 (payload): u32 tag, u32 topic_id, u64 pub_id,
+ *                    u64 flags (bit 0 = external ingress),
+ *                    u64 size, size bytes padded to 8
+ *   tag 2 (journal): u32 tag, u32 jkind, u64 consumer_id,
+ *                    u64 seq, u64 size, size bytes padded to 8
+ *
+ * Identity. pub_id = consumer_id:8 << 36 | per-thread publish
+ * seq:36 — deterministic across runs (a re-executed publisher
+ * thread re-derives the same ids in the same order), which is what
+ * lets a replay match a re-executed delivery to its recorded
+ * consume without any global coordination. 0 = unidentified
+ * (structural cells: run starts, cross-pool creates — matched by
+ * per-queue count, not id).
+ *
+ * Consumer identity. Stable across runs, unlike pthread ids:
+ * main = 1, cooperative pool workers = 16 + registration index,
+ * pinned locus threads = 64 + obs instance id, recording drain and
+ * heartbeat never claim one. Stamped as each ring's first record
+ * (EK_CONSUMER) and carried in journal entries. */
+#define OBS_REC_TAG_RING 0u
+#define OBS_REC_TAG_PAYLOAD 1u
+#define OBS_REC_TAG_JOURNAL 2u
+
+/* journal kinds — one per interposed runtime read */
+#define JK_TIME_NOW 1u
+#define JK_TIME_MONO_NS 2u
+#define JK_RAND_NEXT_INT 3u
+#define JK_OS_GETRANDOM 4u
+#define JK_ENV_VAR 5u
+#define JK_ENV_VAR_EXISTS 6u
+#define JK_ENV_ARG 7u
+#define JK_ENV_ARGS_COUNT 8u
+
+static __thread uint64_t t_consumer_id = 0; /* 0 = unassigned */
+static __thread uint64_t t_pub_seq = 0;
+static __thread uint64_t t_journal_seq = 0;
+
+/* Capture side-channel: payload + journal blobs travel from the
+ * emitting thread to the drain on an MPSC push list (atomic
+ * exchange head), bounded by a byte budget — a producer over
+ * budget BLOCKS (the recording disposition), never drops. */
+typedef struct obs_rec_blob {
+  struct obs_rec_blob *next;
+  uint32_t tag;      /* OBS_REC_TAG_PAYLOAD / _JOURNAL */
+  uint32_t a;        /* topic_id / jkind */
+  uint64_t b;        /* pub_id / consumer_id */
+  uint64_t c;        /* flags / seq */
+  uint64_t size;
+  /* bytes follow */
+} obs_rec_blob_t;
+static obs_rec_blob_t *_Atomic g_rec_blob_head = NULL;
+static _Atomic uint64_t g_rec_blob_bytes = 0;
+#define OBS_REC_BLOB_BUDGET (64ull << 20)
+
+static void obs_rec_blob_push(uint32_t tag, uint32_t a, uint64_t b,
+                              uint64_t c, const void *bytes,
+                              uint64_t size) {
+  while (atomic_load_explicit(&g_rec_blob_bytes, memory_order_relaxed)
+         > OBS_REC_BLOB_BUDGET) {
+    if (atomic_load_explicit(&g_rec_stop, memory_order_relaxed)) return;
+    struct timespec ts = {0, 50 * 1000};
+    nanosleep(&ts, NULL);
+  }
+  obs_rec_blob_t *n = malloc(sizeof(obs_rec_blob_t) + size);
+  if (!n) return; /* OOM under recording: the drain detects the
+                   * gap at replay-match time, not silently here */
+  n->tag = tag; n->a = a; n->b = b; n->c = c; n->size = size;
+  if (size && bytes) memcpy(n + 1, bytes, size);
+  atomic_fetch_add_explicit(&g_rec_blob_bytes,
+                            sizeof(obs_rec_blob_t) + size,
+                            memory_order_relaxed);
+  obs_rec_blob_t *old = atomic_load_explicit(&g_rec_blob_head,
+                                             memory_order_relaxed);
+  do {
+    n->next = old;
+  } while (!atomic_compare_exchange_weak_explicit(
+      &g_rec_blob_head, &old, n, memory_order_release,
+      memory_order_relaxed));
+}
+
+typedef struct {
+  uint64_t magic;
+  uint16_t maj, min;
+  uint32_t header_len; /* 64 */
+  uint32_t pid, ring_count, ring_slots, ts_shift;
+  uint64_t started_mono_ns, started_wall_ns;
+  uint64_t model_hash;
+  uint8_t reserved[8];
+} obs_rec_hdr_t;
+_Static_assert(sizeof(obs_rec_hdr_t) == 64, "recording header is 64B");
+
+typedef struct {
+  uint32_t tag; /* OBS_REC_TAG_RING */
+  uint32_t ring;
+  uint64_t w0, w1;
+} obs_rec_entry_t;
+_Static_assert(sizeof(obs_rec_entry_t) == 24, "recording entry is 24B");
+
+/* Stable per-thread consumer identity (see the v0.2 note above).
+ * The main thread is stamped in the same pre-main constructor
+ * that resolves the flags; workers and pinned threads are stamped
+ * by the arena at thread start. */
+void lotus_obs_note_consumer(uint64_t id) { t_consumer_id = id; }
+uint64_t lotus_obs_consumer_id(void) { return t_consumer_id; }
+
+/* ---- replay (GH #296, LOTUS_REPLAY=<path>) ----------------------
+ *
+ * Loads a v0.2 recording and serves it back: journal values
+ * (time/entropy/env) FIFO per (consumer, jkind), the per-consumer
+ * consume order for Phase-4 enforcement, payload blobs for
+ * ingress/diff. Serving degrades, never refuses (RFC #296 Q6): a
+ * miss falls back to the live read and counts as a divergence,
+ * summarized on stderr at teardown.
+ *
+ * LOTUS_REPLAY implies observation: consumer identity, instance
+ * ids, and the pub_id assignment all ride the obs machinery, so a
+ * replayed run creates the segment exactly as a recorded one does.
+ * The file mapping is kept for process life — served strings are
+ * pointers into it. */
+int lotus_replay_active = 0;
+static char g_replay_path[512];
+static const uint8_t *g_rp_base; /* mmap'd recording */
+static size_t g_rp_len;
+static uint64_t g_replay_at = 0; /* LOTUS_REPLAY_AT: stop at Nth consume */
+
+#define RP_MAX_CONSUMERS 96
+#define RP_MAX_JK 9
+
+typedef struct { const uint8_t *p; uint64_t size; } rp_blob_ref_t;
+typedef struct {
+  rp_blob_ref_t *items;
+  uint32_t len, cap, cursor;
+} rp_queue_t;
+typedef struct {
+  uint64_t consumer;
+  rp_queue_t journal[RP_MAX_JK];   /* per jkind */
+  uint64_t *consume;               /* recorded pub_id order */
+  uint32_t consume_len, consume_cap, consume_cursor;
+} rp_consumer_t;
+static rp_consumer_t g_rp_consumers[RP_MAX_CONSUMERS];
+static int g_rp_consumer_count = 0;
+static _Atomic uint64_t g_rp_divergences[RP_MAX_JK];
+static _Atomic uint64_t g_rp_consume_count = 0;
+typedef struct { uint64_t pub_id; uint32_t topic; uint32_t flags;
+                 rp_blob_ref_t bytes; } rp_payload_t;
+static rp_payload_t *g_rp_payloads = NULL;
+static uint32_t g_rp_payload_len = 0, g_rp_payload_cap = 0;
+
+/* Creation happens ONLY during rp_load (single-threaded, pre-main);
+ * at runtime every caller is lookup-only — the table is immutable
+ * and per-consumer cursors are touched only by their own thread,
+ * so no lock is needed anywhere. */
+static rp_consumer_t *rp_consumer_create(uint64_t cid) {
+  for (int i = 0; i < g_rp_consumer_count; i++) {
+    if (g_rp_consumers[i].consumer == cid) return &g_rp_consumers[i];
+  }
+  if (g_rp_consumer_count >= RP_MAX_CONSUMERS) return NULL;
+  rp_consumer_t *c = &g_rp_consumers[g_rp_consumer_count++];
+  memset(c, 0, sizeof *c);
+  c->consumer = cid;
+  return c;
+}
+static rp_consumer_t *rp_consumer(uint64_t cid) {
+  for (int i = 0; i < g_rp_consumer_count; i++) {
+    if (g_rp_consumers[i].consumer == cid) return &g_rp_consumers[i];
+  }
+  return NULL;
+}
+
+static void rp_queue_push(rp_queue_t *q, const uint8_t *p, uint64_t n) {
+  if (q->len == q->cap) {
+    q->cap = q->cap ? q->cap * 2 : 16;
+    q->items = realloc(q->items, q->cap * sizeof(rp_blob_ref_t));
+  }
+  q->items[q->len].p = p;
+  q->items[q->len].size = n;
+  q->len++;
+}
+
+static uint64_t rp_ring_consumer[64]; /* ring idx → consumer id */
+
+static void rp_load(void) {
+  FILE *f = fopen(g_replay_path, "rb");
+  if (!f) {
+    fprintf(stderr, "hale: LOTUS_REPLAY could not open `%s`: %s\n",
+            g_replay_path, strerror(errno));
+    _exit(66);
+  }
+  fseek(f, 0, SEEK_END);
+  long fl = ftell(f);
+  fclose(f);
+  int fd = open(g_replay_path, O_RDONLY);
+  if (fd < 0 || fl < 80) {
+    fprintf(stderr, "hale: LOTUS_REPLAY `%s` is not a recording\n",
+            g_replay_path);
+    _exit(66);
+  }
+  g_rp_len = (size_t)fl;
+  g_rp_base = mmap(NULL, g_rp_len, PROT_READ, MAP_PRIVATE, fd, 0);
+  close(fd);
+  if (g_rp_base == MAP_FAILED) {
+    fprintf(stderr, "hale: LOTUS_REPLAY mmap failed: %s\n",
+            strerror(errno));
+    _exit(66);
+  }
+  const obs_rec_hdr_t *h = (const obs_rec_hdr_t *)g_rp_base;
+  if (h->magic != OBS_REC_MAGIC || h->maj != 0 || h->min < 2) {
+    fprintf(stderr,
+            "hale: LOTUS_REPLAY `%s`: not a v0.2+ recording "
+            "(magic/version mismatch)\n",
+            g_replay_path);
+    _exit(66);
+  }
+  size_t end = g_rp_len;
+  if (end >= 16 &&
+      *(const uint64_t *)(g_rp_base + end - 16) == OBS_REC_END) {
+    end -= 16;
+  } else {
+    fprintf(stderr,
+            "hale: LOTUS_REPLAY `%s`: no clean-finalize trailer — "
+            "the recording is truncated; refusing to replay a "
+            "partial history (re-record, or accept divergence by "
+            "trimming the file yourself)\n",
+            g_replay_path);
+    _exit(66);
+  }
+  memset(rp_ring_consumer, 0, sizeof rp_ring_consumer);
+  size_t off = h->header_len;
+  while (off + 8 <= end) {
+    uint32_t tag = *(const uint32_t *)(g_rp_base + off);
+    uint32_t a = *(const uint32_t *)(g_rp_base + off + 4);
+    if (tag == OBS_REC_TAG_RING) {
+      if (off + 24 > end) break;
+      uint64_t w0 = *(const uint64_t *)(g_rp_base + off + 8);
+      uint64_t w1 = *(const uint64_t *)(g_rp_base + off + 16);
+      uint32_t ring = a;
+      uint32_t ekind = (uint32_t)((w0 >> 20) & 0x1F);
+      if (ekind == EK_CONSUMER && ring < 64) {
+        rp_ring_consumer[ring] = w1;
+      } else if (ekind == EK_BUS_CONSUME && ring < 64) {
+        rp_consumer_t *c = rp_consumer_create(rp_ring_consumer[ring]);
+        if (c) {
+          if (c->consume_len == c->consume_cap) {
+            c->consume_cap = c->consume_cap ? c->consume_cap * 2 : 64;
+            c->consume = realloc(
+                c->consume, c->consume_cap * sizeof(uint64_t));
+          }
+          c->consume[c->consume_len++] = w1 & 0xFFFFFFFFFFFULL;
+        }
+      }
+      off += 24;
+    } else if (tag == OBS_REC_TAG_PAYLOAD || tag == OBS_REC_TAG_JOURNAL) {
+      if (off + 32 > end) break;
+      uint64_t b = *(const uint64_t *)(g_rp_base + off + 8);
+      uint64_t cfield = *(const uint64_t *)(g_rp_base + off + 16);
+      uint64_t size = *(const uint64_t *)(g_rp_base + off + 24);
+      const uint8_t *bytes = g_rp_base + off + 32;
+      uint64_t padded = (size + 7) & ~7ull;
+      if (off + 32 + padded > end) break;
+      if (tag == OBS_REC_TAG_JOURNAL) {
+        /* a = jkind, b = consumer, cfield = seq (order = file order
+         * per consumer, which the drain preserved) */
+        (void)cfield;
+        if (a < RP_MAX_JK) {
+          rp_consumer_t *c = rp_consumer_create(b);
+          if (c) rp_queue_push(&c->journal[a], bytes, size);
+        }
+      } else {
+        if (g_rp_payload_len == g_rp_payload_cap) {
+          g_rp_payload_cap =
+              g_rp_payload_cap ? g_rp_payload_cap * 2 : 64;
+          g_rp_payloads = realloc(
+              g_rp_payloads, g_rp_payload_cap * sizeof(rp_payload_t));
+        }
+        rp_payload_t *pl = &g_rp_payloads[g_rp_payload_len++];
+        pl->pub_id = b;
+        pl->topic = a;
+        pl->flags = (uint32_t)cfield;
+        pl->bytes.p = bytes;
+        pl->bytes.size = size;
+      }
+      off += 32 + padded;
+    } else {
+      fprintf(stderr,
+              "hale: LOTUS_REPLAY `%s`: unknown entry tag %u at "
+              "offset %zu — recording from a newer hale?\n",
+              g_replay_path, tag, off);
+      _exit(66);
+    }
+  }
+}
+
+int lotus_replay_serve_i64(uint32_t jkind, int64_t *out) {
+  if (!lotus_replay_active || jkind >= RP_MAX_JK) return 0;
+  rp_consumer_t *c = rp_consumer(t_consumer_id ? t_consumer_id : 999);
+  if (!c) return 0;
+  rp_queue_t *q = &c->journal[jkind];
+  if (q->cursor >= q->len || q->items[q->cursor].size != 8) {
+    atomic_fetch_add_explicit(&g_rp_divergences[jkind], 1,
+                              memory_order_relaxed);
+    return 0;
+  }
+  memcpy(out, q->items[q->cursor].p, 8);
+  q->cursor++;
+  return 1;
+}
+
+const void *lotus_replay_serve_blob(uint32_t jkind, uint64_t *out_n) {
+  if (!lotus_replay_active || jkind >= RP_MAX_JK) return NULL;
+  rp_consumer_t *c = rp_consumer(t_consumer_id ? t_consumer_id : 999);
+  if (!c) return NULL;
+  rp_queue_t *q = &c->journal[jkind];
+  if (q->cursor >= q->len) {
+    atomic_fetch_add_explicit(&g_rp_divergences[jkind], 1,
+                              memory_order_relaxed);
+    return NULL;
+  }
+  *out_n = q->items[q->cursor].size;
+  return q->items[q->cursor++].p;
+}
+
+/* Phase 4: the calling thread's next expected delivery identity.
+ * Returns 1 with *out = pub_id (0 = a structural cell) when the
+ * recorded stream has one left; 0 = stream exhausted (no
+ * constraint — consume freely). */
+int lotus_replay_expected_consume(uint64_t *out) {
+  if (!lotus_replay_active) return 0;
+  rp_consumer_t *c = rp_consumer(t_consumer_id ? t_consumer_id : 999);
+  if (!c || c->consume_cursor >= c->consume_len) return 0;
+  *out = c->consume[c->consume_cursor];
+  return 1;
+}
+
+/* Called at every dequeue-driven handler invoke under replay:
+ * advances this consumer's recorded stream and drives
+ * LOTUS_REPLAY_AT (stop at the Nth consume process-wide, SIGSTOP
+ * so a debugger can attach). */
+void lotus_replay_note_consume(void) {
+  if (!lotus_replay_active) return;
+  rp_consumer_t *c = rp_consumer(t_consumer_id ? t_consumer_id : 999);
+  if (c && c->consume_cursor < c->consume_len) c->consume_cursor++;
+  uint64_t n = atomic_fetch_add_explicit(&g_rp_consume_count, 1,
+                                         memory_order_relaxed) + 1;
+  if (g_replay_at && n == g_replay_at) {
+    fprintf(stderr,
+            "hale replay: stopped at consume #%llu (pid %d) — "
+            "attach a debugger, then SIGCONT\n",
+            (unsigned long long)n, (int)getpid());
+    fflush(NULL);
+    raise(SIGSTOP);
+  }
+}
+
+/* Teardown summary: replay honesty is the divergence report. */
+static void rp_report(void) {
+  if (!lotus_replay_active) return;
+  static const char *jk_names[RP_MAX_JK] = {
+    "?", "time.now", "time.monotonic", "rand.next_int",
+    "os.getrandom", "env.var", "env.var_exists", "env.arg",
+    "env.args_count" };
+  uint64_t total = 0;
+  for (int i = 0; i < RP_MAX_JK; i++)
+    total += atomic_load(&g_rp_divergences[i]);
+  if (total == 0) {
+    fprintf(stderr,
+            "hale replay: journal served fully — 0 divergences, "
+            "%llu consumes\n",
+            (unsigned long long)atomic_load(&g_rp_consume_count));
+    return;
+  }
+  fprintf(stderr,
+          "hale replay: %llu journal divergences (reads past the "
+          "recorded history fell back live):\n",
+          (unsigned long long)total);
+  for (int i = 0; i < RP_MAX_JK; i++) {
+    uint64_t d = atomic_load(&g_rp_divergences[i]);
+    if (d) fprintf(stderr, "  %-16s %llu\n", jk_names[i],
+                   (unsigned long long)d);
+  }
+}
+
+/* Pinned-locus threads: identity = 64 + the locus's obs instance
+ * id (registered by the SPAWNING thread before the pinned thread
+ * runs — handoff-2 ordering), deterministic when the spawn order
+ * is. Called unconditionally from the synthesized __pinned_main
+ * prologue; thread start is a cold path and this no-ops when
+ * observation is off. */
+void lotus_obs_note_consumer_locus(void *self);
+
 static uint64_t obs_mono_ns(void) {
   struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
   return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
@@ -252,6 +725,30 @@ static size_t obs_page_up(size_t n) {
 
 void lotus_obs_teardown(void) {
   if (!g_seg) return;
+  /* GH #296: finalize the recording BEFORE the lock and the unmap —
+   * the drain reads the segment, and a producer blocked on a full
+   * ring is waiting for the drain's cursor. Setting g_rec_stop
+   * releases blocked producers (their wait loop checks it); the
+   * drain does one final full sweep after observing the flag, so
+   * every record published before this point reaches the file. The
+   * trailer is the clean-finalize marker: a reader that doesn't
+   * find it holds a truncated recording and must say so. */
+  if (g_rec_thread_started) {
+    atomic_store(&g_rec_stop, 1);
+    pthread_join(g_rec_thread, NULL);
+    g_rec_thread_started = 0;
+    if (g_rec_file) {
+      uint64_t trailer[2] = { OBS_REC_END, g_rec_written };
+      if (fwrite(trailer, sizeof trailer, 1, g_rec_file) != 1 ||
+          fflush(g_rec_file) != 0) {
+        fprintf(stderr,
+                "hale: LOTUS_OBS_RECORD finalize failed: %s\n",
+                strerror(errno));
+      }
+      fclose(g_rec_file);
+      g_rec_file = NULL;
+    }
+  }
   /* Serialize against the P18 heartbeat: it probes the segment
    * under g_obs_lock, so taking the lock here means the unmap
    * never races a heartbeat mid-deref. */
@@ -282,6 +779,7 @@ void lotus_obs_teardown(void) {
  * It claims one SPSC ring slot for its replay emissions (TLS ring
  * assignment), which the default of 8 rings accommodates. */
 static int obs_gate(void);
+static void *obs_record_drain_main(void *arg);
 static void *obs_heartbeat_main(void *arg) {
   (void)arg;
   for (;;) {
@@ -441,6 +939,48 @@ static int obs_create(int64_t rings, int64_t slots) {
     g_obs_origin = o ? o : (uint16_t)0xFFFFu;
   }
   atexit(lotus_obs_teardown);
+  /* GH #296: recording setup, fail-closed at every step. The file
+   * opens (and its header lands) before any record can be emitted;
+   * the drain thread is joinable so teardown can finalize. The
+   * recording counts as an attached observer — ring emission is on
+   * from the first probe without anyone mmapping the segment. */
+  if (lotus_obs_recording) {
+    g_rec_file = fopen(g_rec_path, "wb");
+    if (!g_rec_file) {
+      fprintf(stderr,
+              "hale: LOTUS_OBS_RECORD could not open `%s`: %s\n",
+              g_rec_path, strerror(errno));
+      fflush(NULL);
+      _exit(74);
+    }
+    setvbuf(g_rec_file, NULL, _IOFBF, 1 << 20);
+    obs_rec_hdr_t rh = { .magic = OBS_REC_MAGIC, .maj = 0, .min = 2,
+      .header_len = sizeof(obs_rec_hdr_t), .pid = (uint32_t)getpid(),
+      .ring_count = (uint32_t)rings, .ring_slots = (uint32_t)slots,
+      .ts_shift = 4, .started_mono_ns = H->started_mono_ns,
+      .started_wall_ns = H->started_wall_ns,
+      .model_hash = g_obs_model_hash, .reserved = {0} };
+    if (fwrite(&rh, sizeof rh, 1, g_rec_file) != 1) {
+      fprintf(stderr, "hale: LOTUS_OBS_RECORD header write failed\n");
+      fflush(NULL);
+      _exit(74);
+    }
+    atomic_store(&C->observer_count, 1u);
+    /* Pre-arm the 0→1 edge detector: the recording observes from
+     * record zero, so there are no pre-attach births to replay —
+     * and without this, the FIRST birth probe (which registers
+     * itself, then gates) would trip the edge and re-emit itself:
+     * a duplicate LOCUS_BIRTH as the recording's opening record. */
+    atomic_store_explicit(&g_last_observed, 1u, memory_order_relaxed);
+    if (pthread_create(&g_rec_thread, NULL, obs_record_drain_main,
+                       NULL) != 0) {
+      fprintf(stderr,
+              "hale: LOTUS_OBS_RECORD drain thread failed to start\n");
+      fflush(NULL);
+      _exit(74);
+    }
+    g_rec_thread_started = 1;
+  }
   /* P18: spawn the replay heartbeat (detached; see
    * obs_heartbeat_main). Best-effort — a failed spawn degrades to
    * the old probe-driven replay, never blocks obs creation. */
@@ -482,6 +1022,45 @@ int lotus_obs_live = 0;
 __attribute__((constructor)) static void obs_live_ctor(void) {
   const char *e = getenv("LOTUS_OBS");
   if (e && e[0] == '1') lotus_obs_live = 1;
+  /* GH #296: LOTUS_OBS_RECORD implies observation — the recording
+   * IS an observer. Resolved here for the same P19 reason as
+   * lotus_obs_live: both flags must be process-constant before any
+   * user code (including fn main's body) can snapshot them. */
+  /* The constructor runs on the main thread: stamp its stable
+   * consumer identity here so the first ring it claims carries it. */
+  t_consumer_id = 1;
+  /* GH #296: replay. Implies observation (identity machinery rides
+   * it); loads the recording eagerly so the first read is served. */
+  const char *rp = getenv("LOTUS_REPLAY");
+  if (rp && rp[0]) {
+    size_t n = strlen(rp);
+    if (n >= sizeof g_replay_path) {
+      fprintf(stderr, "hale: LOTUS_REPLAY path too long\n");
+      _exit(64);
+    }
+    memcpy(g_replay_path, rp, n + 1);
+    const char *at = getenv("LOTUS_REPLAY_AT");
+    if (at && at[0]) g_replay_at = (uint64_t)atoll(at);
+    rp_load();
+    lotus_replay_active = 1;
+    lotus_obs_live = 1;
+    atexit(rp_report);
+  }
+  const char *rec = getenv("LOTUS_OBS_RECORD");
+  if (rec && rec[0]) {
+    size_t n = strlen(rec);
+    if (n < sizeof g_rec_path) {
+      memcpy(g_rec_path, rec, n + 1);
+      lotus_obs_recording = 1;
+      lotus_obs_live = 1;
+    } else {
+      fprintf(stderr,
+              "hale: LOTUS_OBS_RECORD path exceeds %zu bytes; "
+              "recording refused\n",
+              sizeof g_rec_path - 1);
+      _exit(64);
+    }
+  }
 }
 
 /* Enable check + lazy init. Fast path after first call: one
@@ -494,14 +1073,26 @@ static int obs_on(void) {
   st = atomic_load(&g_obs_state);
   if (st == 0) {
     const char *e = getenv("LOTUS_OBS");
-    if (e && e[0] == '1') {
+    if ((e && e[0] == '1') || lotus_obs_recording ||
+        lotus_replay_active) {
       const char *rs = getenv("LOTUS_OBS_RINGS");
       const char *ss = getenv("LOTUS_OBS_SLOTS");
-      int64_t rings = rs ? atoll(rs) : 8;
+      /* Recording defaults to the ring maximum: a thread that
+       * cannot get a ring fails a recorded run (never drops), so
+       * make that as rare as the 64-ring ceiling allows. */
+      int64_t rings = rs ? atoll(rs) : (lotus_obs_recording ? 64 : 8);
       int64_t slots = ss ? atoll(ss) : 4096;
-      if (rings < 1 || rings > 64) rings = 8;
+      if (rings < 1 || rings > 64) rings = lotus_obs_recording ? 64 : 8;
       if (slots < 64 || (slots & (slots - 1))) slots = 4096;
       st = obs_create(rings, slots) ? 2 : 1;
+      if (st != 2 && lotus_obs_recording) {
+        fprintf(stderr,
+                "hale: LOTUS_OBS_RECORD was set but the observation "
+                "segment could not be created; failing the run "
+                "rather than running unrecorded\n");
+        fflush(NULL);
+        _exit(74);
+      }
     } else {
       st = 1;
     }
@@ -594,16 +1185,143 @@ static void obs_emit_raw(uint64_t w0, uint64_t w1) {
   if (t_ring == -1) {
     int r = atomic_fetch_add(&g_ring_next, 1);
     if ((uint32_t)r >= H->ring_count) {
+      /* GH #296: under recording this thread's records would
+       * silently vanish forever (the -2 disposition), which is
+       * exactly what a recording must never do. Block-or-fail:
+       * there is no ring left to block on, so fail the run. */
+      if (lotus_obs_recording) {
+        fprintf(stderr,
+                "hale: LOTUS_OBS_RECORD needs one observation ring "
+                "per emitting thread and all %u are taken; raise "
+                "LOTUS_OBS_RINGS (max 64) or reduce thread count — "
+                "a recording that drops records is not a recording\n",
+                H->ring_count);
+        fflush(NULL);
+        _exit(70);
+      }
       t_ring = -2;
       atomic_fetch_add_explicit(&CNT[0].c[0], 1, memory_order_relaxed);
       return;
     }
     t_ring = r;
     RD[r].tag_b = (uint32_t)(uintptr_t)pthread_self();
+    /* GH #296: under recording, a ring's first record names its
+     * claiming thread's stable consumer id (pthread ids don't
+     * survive a re-run; these do). 1000+r = anonymous thread. */
+    if (lotus_obs_recording) {
+      uint64_t cid = t_consumer_id ? t_consumer_id : 1000u + (uint64_t)r;
+      lotus_spsc_emit(g_seg, &RD[r], H->ring_slots,
+                      (int64_t)((uint64_t)EK_CONSUMER << 20),
+                      (int64_t)cid);
+    }
+  }
+  /* GH #296 recording disposition: overwrite-oldest becomes
+   * block-the-producer. The ring is effectively a bounded SPSC
+   * queue against the drain cursor: writing record `head` clobbers
+   * slot `head - ring_slots`, so wait until the drain has consumed
+   * past it. One relaxed-load compare when the ring has room;
+   * 50µs naps when it doesn't (recording is a debugging mode — the
+   * stall is the contract, RFC #296 delta 1). g_rec_stop releases
+   * waiters at teardown so nobody blocks on a drain that exited. */
+  if (lotus_obs_recording) {
+    uint64_t head = RD[t_ring].head; /* producer-owned */
+    while (head - atomic_load_explicit(&g_rec_cursor[t_ring],
+                                       memory_order_acquire)
+           >= (uint64_t)H->ring_slots) {
+      if (atomic_load_explicit(&g_rec_stop, memory_order_relaxed))
+        break;
+      struct timespec ts = {0, 50 * 1000};
+      nanosleep(&ts, NULL);
+    }
   }
   lotus_spsc_emit(g_seg, &RD[t_ring], H->ring_slots, (int64_t)w0,
                   (int64_t)w1);
   atomic_fetch_add_explicit(&CNT[0].c[2], 1, memory_order_relaxed);
+}
+
+static void obs_rec_write_failed(void) {
+  fprintf(stderr,
+          "hale: LOTUS_OBS_RECORD write to `%s` failed: %s — "
+          "failing the run rather than truncating silently\n",
+          g_rec_path, strerror(errno));
+  fflush(NULL);
+  _exit(74);
+}
+
+/* GH #296: the recording drain. Sweeps every ring oldest-first,
+ * appends raw records to the file, publishes per-ring cursors that
+ * blocked producers wait on. Reads are safe without the seqlock
+ * snapshot: a slot below an acquire-loaded head is fully written
+ * (release-ordered by lotus_spsc_emit), and it cannot be
+ * overwritten because its producer blocks until the cursor passes
+ * the slot being reclaimed. Exit: one final full sweep after
+ * g_rec_stop, so everything published before teardown lands. */
+static void *obs_record_drain_main(void *arg) {
+  (void)arg;
+  for (;;) {
+    int stop = atomic_load_explicit(&g_rec_stop, memory_order_acquire);
+    int wrote = 0;
+    for (uint32_t r = 0; r < H->ring_count; r++) {
+      uint64_t cur =
+          atomic_load_explicit(&g_rec_cursor[r], memory_order_relaxed);
+      uint64_t head =
+          atomic_load_explicit(&RD[r].head, memory_order_acquire);
+      while (cur < head) {
+        const uint64_t *slot = (const uint64_t *)((const char *)g_seg
+            + RD[r].data_off
+            + (cur & ((uint64_t)H->ring_slots - 1)) * 16u);
+        obs_rec_entry_t ent = { .tag = OBS_REC_TAG_RING, .ring = r,
+                                .w0 = slot[0], .w1 = slot[1] };
+        if (fwrite(&ent, sizeof ent, 1, g_rec_file) != 1) {
+          obs_rec_write_failed();
+        }
+        g_rec_written++;
+        cur++;
+        wrote = 1;
+      }
+      atomic_store_explicit(&g_rec_cursor[r], cur,
+                            memory_order_release);
+    }
+    /* Blobs (payloads + journal values): pop the MPSC list. The
+     * exchange yields newest-first; reverse to restore push order
+     * (each pushing thread's own order survives the reversal). */
+    obs_rec_blob_t *lifo = atomic_exchange_explicit(
+        &g_rec_blob_head, NULL, memory_order_acquire);
+    obs_rec_blob_t *fifo = NULL;
+    while (lifo) {
+      obs_rec_blob_t *nx = lifo->next;
+      lifo->next = fifo;
+      fifo = lifo;
+      lifo = nx;
+    }
+    while (fifo) {
+      obs_rec_blob_t *b = fifo;
+      fifo = fifo->next;
+      uint32_t hdr32[2] = { b->tag, b->a };
+      uint64_t hdr64[3] = { b->b, b->c, b->size };
+      uint64_t pad = (8 - (b->size & 7)) & 7;
+      static const uint8_t zeros[8] = {0};
+      if (fwrite(hdr32, sizeof hdr32, 1, g_rec_file) != 1 ||
+          fwrite(hdr64, sizeof hdr64, 1, g_rec_file) != 1 ||
+          (b->size &&
+           fwrite(b + 1, b->size, 1, g_rec_file) != 1) ||
+          (pad && fwrite(zeros, pad, 1, g_rec_file) != 1)) {
+        obs_rec_write_failed();
+      }
+      atomic_fetch_sub_explicit(&g_rec_blob_bytes,
+                                sizeof(obs_rec_blob_t) + b->size,
+                                memory_order_relaxed);
+      free(b);
+      g_rec_written++;
+      wrote = 1;
+    }
+    if (stop) break;
+    if (!wrote) {
+      struct timespec ts = {0, 200 * 1000};
+      nanosleep(&ts, NULL);
+    }
+  }
+  return NULL;
 }
 
 static void obs_emit(uint32_t ekind, uint32_t id, uint32_t size_class,
@@ -759,6 +1477,93 @@ void lotus_obs_bus_deliver(const char *subject, void *subscriber_self,
            obs_size_class(payload_bytes),
            (((uint64_t)locus & 0xFFFFFu) << 44)
                | ((seq ? seq - 1 : 0) & 0xFFFFFFFFFFFULL));
+}
+
+/* GH #296 Phase 1: the consumption event. Emitted by the arena's
+ * dequeue-driven dispatch paths (main-queue drain, coop-pool drain,
+ * mailbox drain, async coro start) right before the handler runs, on
+ * the CONSUMING thread — so its ring position is the per-consumer
+ * delivery order, which is the thing a replay reconstructs and which
+ * enqueue-time BUS_DELIVER records cannot give (they land on the
+ * publisher's ring in publisher order). Recording mode only: call
+ * sites gate on lotus_obs_recording, and the fn re-checks so a
+ * mis-gated caller cannot leak protocol-addendum records into a
+ * plain observer's stream. */
+void lotus_obs_record_consume(void *subscriber_self, uint64_t pub_id) {
+  if (!lotus_obs_recording) return;
+  if (!obs_on()) return;
+  (void)obs_gate();
+  (void)t_consume_seq; /* order = ring position since v0.2 */
+  uint32_t locus = subscriber_self ? obs_inst_id_of(subscriber_self) : 0;
+  obs_emit(EK_BUS_CONSUME, 0, 0,
+           (((uint64_t)locus & 0xFFFFFu) << 44)
+               | (pub_id & 0xFFFFFFFFFFFULL));
+}
+
+void lotus_obs_note_consumer_locus(void *self) {
+  if (!lotus_obs_live || !self) return;
+  if (!obs_on()) return;
+  uint32_t id = obs_inst_id_of(self);
+  if (id) t_consumer_id = 64 + (uint64_t)id;
+}
+
+/* GH #296 Phase 2: capture a publish's payload once, on the
+ * publishing thread, returning its deterministic identity —
+ * pub_id = consumer_id:8 << 36 | per-thread seq:36. A re-executed
+ * publisher thread re-derives the same ids in the same order,
+ * which is what lets a replay match deliveries without global
+ * coordination. Must be called BEFORE lotus_obs_bus_publish at
+ * the same site: the redispatch mark (external ingress) is peeked
+ * here and consumed there. */
+uint64_t lotus_obs_record_publish_payload(const char *subject,
+                                          const void *payload,
+                                          uint64_t size) {
+  if ((!lotus_obs_recording && !lotus_replay_active) || !subject)
+    return 0;
+  if (!obs_on()) return 0;
+  int ingress = g_obs_tls_redispatch; /* peek only */
+  uint64_t cid = t_consumer_id ? t_consumer_id : 999;
+  uint64_t pub_id = ((cid & 0xFFu) << 36)
+      | (++t_pub_seq & 0xFFFFFFFFFULL);
+  /* Under replay the identity is re-derived (same threads, same
+   * per-thread order → same ids) so dequeues can be matched to the
+   * recorded consume order; nothing is written anywhere. */
+  if (!lotus_obs_recording) return pub_id;
+  uint32_t topic = 0;
+  obs_topic_slot_t *t = obs_topic_slot(subject, 0);
+  if (t) topic = (uint32_t)t->id;
+  obs_rec_blob_push(OBS_REC_TAG_PAYLOAD, topic, pub_id,
+                    ingress ? 1u : 0u, payload, size);
+  return pub_id;
+}
+
+/* GH #296 Phase 2: one record per QUEUED target at enqueue, on
+ * the publishing thread's ring. pub_id 0 (unidentified structural
+ * cell, or not recording) emits nothing. */
+void lotus_obs_record_enqueue(uint64_t pub_id, void *subscriber_self) {
+  if (!lotus_obs_recording || !pub_id) return;
+  if (!obs_on()) return;
+  uint32_t locus = subscriber_self ? obs_inst_id_of(subscriber_self) : 0;
+  obs_emit(EK_BUS_ENQ, 0, 0,
+           (((uint64_t)locus & 0xFFFFFu) << 44)
+               | (pub_id & 0xFFFFFFFFFFFULL));
+}
+
+/* GH #296 Phase 3: journal a nondeterministic input read. The
+ * value blob rides the capture list keyed (jkind, consumer, seq);
+ * the ring record is the interleaving marker. */
+void lotus_obs_journal_bytes(uint32_t jkind, const void *p, uint64_t n) {
+  if (!lotus_obs_recording) return;
+  if (!obs_on()) return;
+  uint64_t cid = t_consumer_id ? t_consumer_id : 999;
+  uint64_t seq = ++t_journal_seq;
+  obs_rec_blob_push(OBS_REC_TAG_JOURNAL, jkind, cid, seq, p, n);
+  obs_emit(EK_JOURNAL, 0, 0,
+           ((uint64_t)jkind << 56) | (seq & 0xFFFFFFFFFFFFFFULL));
+}
+
+void lotus_obs_journal_i64(uint32_t jkind, int64_t v) {
+  lotus_obs_journal_bytes(jkind, &v, 8);
 }
 
 /* binding_obs_id: cached on the remote entry by the caller (the

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -1372,15 +1372,21 @@ __attribute__((constructor)) static void obs_live_ctor(void) {
       _exit(64);
     }
   }
-  /* Round 4, finding 1: recording must initialize EAGERLY. Lazy
-   * creation waited for the first probe, so a probe-free program
-   * exited successfully with NO recording — and a stale artifact
-   * already at the path silently impersonated the run that was
-   * just requested. obs_on() under recording creates the file
-   * (replacing anything at the path), spawns the drain, and
-   * registers the finalizer — or fails the run. Identity stamps
-   * arrive later from the prelude; finalize-time restamping
-   * already covers that ordering. */
+}
+
+/* Round 4/5: recording must initialize EAGERLY (a probe-free
+ * program must still produce a recording, replacing anything at
+ * the path) — but NOT from the C constructor: segment creation
+ * snapshots the model identity into the shared header, and at
+ * constructor time the prelude has not stamped it yet, so a
+ * ctor-driven init published a live segment claiming to be
+ * unstamped for its whole life (round 5 — regressing the
+ * obs_model_hash contract iris reads). The generated prelude calls
+ * this immediately AFTER the identity setters: still before any
+ * user code or probe, so probe-free programs are covered and the
+ * segment is born with its immutable header complete. The .halerec
+ * artifact additionally re-stamps at finalize. */
+void lotus_obs_eager_init(void) {
   if (lotus_obs_recording || lotus_replay_active) {
     (void)obs_on();
   }

--- a/crates/hale-codegen/src/bus/dispatch.rs
+++ b/crates/hale-codegen/src/bus/dispatch.rs
@@ -1245,6 +1245,20 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
                     // target, enqueue-time-equivalent (the direct
                     // call IS the delivery).
                     let obs_live = self.obs_live_check()?;
+                    // Round 3: the publish's seq token flows to every
+                    // deliver probe through a stack slot (the probes
+                    // live in separate conditional blocks; mem2reg
+                    // promotes it).
+                    let obs_tok_slot = self.alloca_in_entry(
+                        self.context.i64_type().into(),
+                        "bus.direct.obs.tok",
+                    )?;
+                    self.builder
+                        .build_store(
+                            obs_tok_slot,
+                            self.context.i64_type().const_zero(),
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                     {
                         let ptr_t =
                             self.context.ptr_type(AddressSpace::default());
@@ -1266,12 +1280,14 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
                             .module
                             .get_function("lotus_obs_bus_publish")
                             .expect("lotus_obs_bus_publish declared");
+
                         let pub_self: inkwell::values::BasicValueEnum = self
                             .current_self
                             .as_ref()
                             .map(|cs| cs.self_ptr.into())
                             .unwrap_or_else(|| ptr_t.const_null().into());
-                        self.builder
+                        let obs_tok = self
+                            .builder
                             .build_call(
                                 obs_pub_fn,
                                 &[
@@ -1281,6 +1297,12 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
                                 ],
                                 "bus.direct.obs.pub.call",
                             )
+                            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                            .try_as_basic_value()
+                            .left()
+                            .expect("publish probe returns a token");
+                        self.builder
+                            .build_store(obs_tok_slot, obs_tok)
                             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                         self.builder
                             .build_unconditional_branch(pub_cont_bb)
@@ -1387,6 +1409,14 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
                             .module
                             .get_function("lotus_obs_bus_deliver")
                             .expect("lotus_obs_bus_deliver declared");
+                        let tok_loaded = self
+                            .builder
+                            .build_load(
+                                self.context.i64_type(),
+                                obs_tok_slot,
+                                "bus.direct.obs.tok.load",
+                            )
+                            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                         self.builder
                             .build_call(
                                 obs_dlv_fn,
@@ -1394,6 +1424,7 @@ impl<'ctx, 'p> BusDispatch<'ctx> for Cx<'ctx, 'p> {
                                     subj_val.into(),
                                     sp.into(),
                                     payload_size_iv.into(),
+                                    tok_loaded.into(),
                                 ],
                                 "bus.direct.obs.dlv.call",
                             )

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -8963,6 +8963,22 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     )
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
             }
+            // GH #296 round 5: eager recording/replay init, AFTER
+            // the identity setters — segment creation snapshots
+            // them into the shared header, and a constructor-driven
+            // init published a live segment with model_hash 0 for
+            // its whole life. Still before any user code or probe,
+            // so probe-free programs record. No-op when neither
+            // LOTUS_OBS_RECORD nor LOTUS_REPLAY is set.
+            {
+                let eager_fn = self
+                    .module
+                    .get_function("lotus_obs_eager_init")
+                    .expect("lotus_obs_eager_init declared");
+                self.builder
+                    .build_call(eager_fn, &[], "obs.eager_init")
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            }
         }
         if !self.is_wasm {
             let load_cfg_fn = self

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -587,11 +587,13 @@ pub struct BuildOptions {
     /// typechecks; harness callers leave it None and the header
     /// field reads 0 (unstamped).
     pub model_hash: Option<u64>,
-    /// GH #296: executable identity (compiler version + source
-    /// bytes) for recording-header stamping; `hale replay` admits
-    /// exact builds on this, with shape_hash as the structural
-    /// compatibility check only.
-    pub exec_digest: Option<u64>,
+    /// GH #296: build-manifest identity for recording-header
+    /// stamping — a framed SHA-256 (4×u64) over the toolchain
+    /// source hash, compiler version, build options, and every
+    /// source path + length + contents. `hale replay` admits exact
+    /// builds on this; shape_hash is the structural compatibility
+    /// check only.
+    pub exec_digest: Option<[u64; 4]>,
 }
 
 /// The per-build source table for DWARF emission: each entry is one
@@ -4015,7 +4017,7 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// P26: the build-time model identity to stamp into the obs
     /// segment header (None = harness build, header reads 0).
     pub(crate) model_hash: Option<u64>,
-    pub(crate) exec_digest: Option<u64>,
+    pub(crate) exec_digest: Option<[u64; 4]>,
     /// Replica keys (2026-08-12): the replica index the NEXT locus
     /// instantiation carries — set by the Phase-1c fan-out loop for
     /// replicas 1..K, absent (= replica 0) everywhere else. Consumed
@@ -8932,13 +8934,20 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     .get_function("lotus_obs_exec_digest_set")
                     .expect("lotus_obs_exec_digest_set declared");
                 let i64_t = self.context.i64_type();
-                self.builder
-                    .build_call(
-                        set_fn,
-                        &[i64_t.const_int(d, false).into()],
-                        "obs.exec_digest",
-                    )
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                for (i, part) in d.iter().enumerate() {
+                    self.builder
+                        .build_call(
+                            set_fn,
+                            &[
+                                i64_t.const_int(i as u64, false).into(),
+                                i64_t.const_int(*part, false).into(),
+                            ],
+                            "obs.exec_digest",
+                        )
+                        .map_err(|e| {
+                            CodegenError::LlvmEmit(e.to_string())
+                        })?;
+                }
             }
             if let Some(h) = self.model_hash {
                 let set_fn = self

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -15280,13 +15280,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 .module
                 .get_function("lotus_obs_bus_publish")
                 .expect("lotus_obs_bus_publish declared");
-            self.builder
+            let obs_tok = self
+                .builder
                 .build_call(
                     obs_pub_fn,
                     &[subj_val.into(), pub_self.into(), payload_size_iv.into()],
                     "publish.direct.obs.pub",
                 )
-                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                .try_as_basic_value()
+                .left()
+                .expect("lotus_obs_bus_publish returns a seq token");
             let obs_dlv_fn = self
                 .module
                 .get_function("lotus_obs_bus_deliver")
@@ -15294,7 +15298,12 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             self.builder
                 .build_call(
                     obs_dlv_fn,
-                    &[subj_val.into(), sub_self.into(), payload_size_iv.into()],
+                    &[
+                        subj_val.into(),
+                        sub_self.into(),
+                        payload_size_iv.into(),
+                        obs_tok.into(),
+                    ],
                     "publish.direct.obs.dlv",
                 )
                 .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -587,6 +587,11 @@ pub struct BuildOptions {
     /// typechecks; harness callers leave it None and the header
     /// field reads 0 (unstamped).
     pub model_hash: Option<u64>,
+    /// GH #296: executable identity (compiler version + source
+    /// bytes) for recording-header stamping; `hale replay` admits
+    /// exact builds on this, with shape_hash as the structural
+    /// compatibility check only.
+    pub exec_digest: Option<u64>,
 }
 
 /// The per-build source table for DWARF emission: each entry is one
@@ -1387,6 +1392,7 @@ pub fn build_executable_with_options(
         returned_bindings: compute_returned_bindings(&merged),
         assign_moved_bindings: compute_assign_moved_bindings(&merged),
         model_hash: options.model_hash,
+            exec_digest: options.exec_digest,
         replica_index_for_next_locus_instantiation: None,
         current_instantiation_replica_index: 0,
         suppress_fresh_temp: false,
@@ -4009,6 +4015,7 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// P26: the build-time model identity to stamp into the obs
     /// segment header (None = harness build, header reads 0).
     pub(crate) model_hash: Option<u64>,
+    pub(crate) exec_digest: Option<u64>,
     /// Replica keys (2026-08-12): the replica index the NEXT locus
     /// instantiation carries — set by the Phase-1c fan-out loop for
     /// replicas 1..K, absent (= replica 0) everywhere else. Consumed
@@ -8919,6 +8926,20 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             // the prelude, so the value is in place before any
             // probe lazily creates the segment. Harness builds
             // (None) skip the call and the header reads 0.
+            if let Some(d) = self.exec_digest {
+                let set_fn = self
+                    .module
+                    .get_function("lotus_obs_exec_digest_set")
+                    .expect("lotus_obs_exec_digest_set declared");
+                let i64_t = self.context.i64_type();
+                self.builder
+                    .build_call(
+                        set_fn,
+                        &[i64_t.const_int(d, false).into()],
+                        "obs.exec_digest",
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            }
             if let Some(h) = self.model_hash {
                 let set_fn = self
                     .module

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -3275,6 +3275,23 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
             self.di_begin_function();
             let thread_self =
                 thread_main.get_nth_param(0).unwrap().into_pointer_value();
+            // GH #296: stamp this thread's stable consumer identity
+            // (64 + obs instance id) for record/replay attribution.
+            // Thread start is cold; the callee no-ops when obs is
+            // off, so no gate is needed here.
+            {
+                let note_fn = self
+                    .module
+                    .get_function("lotus_obs_note_consumer_locus")
+                    .expect("lotus_obs_note_consumer_locus declared");
+                self.builder
+                    .build_call(
+                        note_fn,
+                        &[thread_self.into()],
+                        "obs.note_consumer",
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            }
             // 2026-05-23: stash this locus's mailbox in
             // TLS so time::sleep / yield inside birth() and run()
             // can drain it without going through the post-run

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1205,6 +1205,16 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 .fn_type(&[i64_t2.into(), i64_t2.into()], false),
             None,
         );
+        // GH #296 round 5: eager observation-plane init, called from
+        // the prelude AFTER the identity setters (segment creation
+        // snapshots them into the shared header). No-ops unless
+        // recording/replay is active.
+        // declare void @lotus_obs_eager_init()
+        self.module.add_function(
+            "lotus_obs_eager_init",
+            self.context.void_type().fn_type(&[], false),
+            None,
+        );
         // GH #296: stable consumer identity for a pinned locus's
         // thread, called once from the __pinned_main prologue
         // (cold path; no-ops when observation is off).

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1183,13 +1183,14 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 .fn_type(&[i64_t2.into()], false),
             None,
         );
-        // GH #296: executable identity for recording headers.
-        // declare void @lotus_obs_exec_digest_set(i64 digest)
+        // GH #296: build-manifest identity for recording headers,
+        // stamped as four u64 parts of a framed SHA-256.
+        // declare void @lotus_obs_exec_digest_set(i64 part, i64 v)
         self.module.add_function(
             "lotus_obs_exec_digest_set",
             self.context
                 .void_type()
-                .fn_type(&[i64_t2.into()], false),
+                .fn_type(&[i64_t2.into(), i64_t2.into()], false),
             None,
         );
         // GH #296: stable consumer identity for a pinned locus's

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1183,6 +1183,15 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 .fn_type(&[i64_t2.into()], false),
             None,
         );
+        // GH #296: executable identity for recording headers.
+        // declare void @lotus_obs_exec_digest_set(i64 digest)
+        self.module.add_function(
+            "lotus_obs_exec_digest_set",
+            self.context
+                .void_type()
+                .fn_type(&[i64_t2.into()], false),
+            None,
+        );
         // GH #296: stable consumer identity for a pinned locus's
         // thread, called once from the __pinned_main prologue
         // (cold path; no-ops when observation is off).

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1131,13 +1131,20 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // iris handoff-5 P17: the baked direct-dispatch loop emits
         // the publish/deliver probes itself (the one flavor with no
         // C dispatch fn to host them).
-        // declare void @lotus_obs_bus_publish(ptr subject, ptr self, i64 bytes)
-        // declare void @lotus_obs_bus_deliver(ptr subject, ptr self, i64 bytes)
+        // declare i64 @lotus_obs_bus_publish(ptr subject, ptr self, i64 bytes)
+        //   — returns the assigned seq + 1 (a TOKEN; 0 = nothing
+        //     recorded), which every deliver probe for this publish
+        //     must receive so deliveries name their exact publish
+        //     (GH #296 review round 3: the reload-high-water
+        //     approximation misattributed racing same-subject
+        //     deliveries).
+        // declare void @lotus_obs_bus_deliver(ptr subject, ptr self,
+        //                                     i64 bytes, i64 seq_token)
         {
             let i64_t = self.context.i64_type();
             self.module.add_function(
                 "lotus_obs_bus_publish",
-                self.context.void_type().fn_type(
+                i64_t.fn_type(
                     &[ptr_t.into(), ptr_t.into(), i64_t.into()],
                     false,
                 ),
@@ -1146,7 +1153,12 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             self.module.add_function(
                 "lotus_obs_bus_deliver",
                 self.context.void_type().fn_type(
-                    &[ptr_t.into(), ptr_t.into(), i64_t.into()],
+                    &[
+                        ptr_t.into(),
+                        ptr_t.into(),
+                        i64_t.into(),
+                        i64_t.into(),
+                    ],
                     false,
                 ),
                 None,

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1183,6 +1183,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 .fn_type(&[i64_t2.into()], false),
             None,
         );
+        // GH #296: stable consumer identity for a pinned locus's
+        // thread, called once from the __pinned_main prologue
+        // (cold path; no-ops when observation is off).
+        // declare void @lotus_obs_note_consumer_locus(ptr self)
+        self.module.add_function(
+            "lotus_obs_note_consumer_locus",
+            self.context
+                .void_type()
+                .fn_type(&[ptr_t.into()], false),
+            None,
+        );
         self.module.add_function(
             "lotus_obs_locus_dissolve",
             self.context
@@ -3237,6 +3248,15 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         self.module.add_function(
             "lotus_time_now_seconds",
             time_now_seconds_ty,
+            None,
+        );
+        // GH #296 Phase 3: monotonic reads route through a named
+        // primitive so record/replay can interpose (they used to
+        // be inline clock_gettime IR — uninterposable).
+        // declare i64 @lotus_time_monotonic_ns()
+        self.module.add_function(
+            "lotus_time_monotonic_ns",
+            i64_t.fn_type(&[], false),
             None,
         );
         // declare ptr @lotus_time_from_unix(i64 n)

--- a/crates/hale-codegen/src/stdlib/time.rs
+++ b/crates/hale-codegen/src/stdlib/time.rs
@@ -64,10 +64,17 @@ impl<'ctx, 'p> TimeStdlib<'ctx> for Cx<'ctx, 'p> {
         Ok((value, CodegenTy::Int))
     }
 
-    /// Lower `time::monotonic()` to `clock_gettime(CLOCK_MONOTONIC,
-    /// &ts)` followed by `ts.tv_sec * 1_000_000_000 + ts.tv_nsec`.
+    /// Lower `time::monotonic()` to `lotus_time_monotonic_ns()`.
     /// Result is a `Duration` (i64 nanoseconds since an
     /// unspecified reference).
+    ///
+    /// GH #296 Phase 3: this used to inline
+    /// `clock_gettime(CLOCK_MONOTONIC)` IR directly — no symbol,
+    /// so nothing a recording journal or a replay could interpose
+    /// on. Two of the three TIME-classified reads were invisible
+    /// to record/replay while `now()` (already a named primitive)
+    /// was covered. Same rationale that made `now` a symbol; the
+    /// call costs the same as the libc call it replaces.
     fn lower_time_monotonic(
         &mut self,
         args: &[Expr],
@@ -78,50 +85,18 @@ impl<'ctx, 'p> TimeStdlib<'ctx> for Cx<'ctx, 'p> {
                 args.len()
             )));
         }
-        let i32_t = self.context.i32_type();
-        let i64_t = self.context.i64_type();
-        let ts_t = self.timespec_type();
-
-        let ts = self.alloca_in_entry(ts_t.into(), "ts")?;
-        let cgt = self
+        let mono = self
             .module
-            .get_function("clock_gettime")
-            .expect("clock_gettime declared");
-        // CLOCK_MONOTONIC = 1 on Linux.
-        let clock_id = i32_t.const_int(1, false);
-        self.builder
-            .build_call(cgt, &[clock_id.into(), ts.into()], "cgt.ret")
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-        // Ignore the return value best-effort; CLOCK_MONOTONIC
-        // shouldn't fail. tv_sec * 1e9 + tv_nsec.
-        let sec_ptr = self
-            .builder
-            .build_struct_gep(ts_t, ts, 0, "ts.sec.ptr")
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-        let nsec_ptr = self
-            .builder
-            .build_struct_gep(ts_t, ts, 1, "ts.nsec.ptr")
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-        let sec = self
-            .builder
-            .build_load(i64_t, sec_ptr, "ts.sec")
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
-            .into_int_value();
-        let nsec = self
-            .builder
-            .build_load(i64_t, nsec_ptr, "ts.nsec")
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
-            .into_int_value();
-        let billion = i64_t.const_int(1_000_000_000, false);
-        let sec_ns = self
-            .builder
-            .build_int_mul(sec, billion, "sec.ns")
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            .get_function("lotus_time_monotonic_ns")
+            .expect("lotus_time_monotonic_ns declared");
         let total = self
             .builder
-            .build_int_add(sec_ns, nsec, "now.ns")
-            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-        Ok((total.into(), CodegenTy::Duration))
+            .build_call(mono, &[], "now.ns")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+            .try_as_basic_value()
+            .left()
+            .expect("lotus_time_monotonic_ns returns i64");
+        Ok((total, CodegenTy::Duration))
     }
 
     /// C7 (pond follow-up): lower `std::time::now() -> Int` to a

--- a/crates/hale-codegen/tests/replay_determinism.rs
+++ b/crates/hale-codegen/tests/replay_determinism.rs
@@ -133,7 +133,10 @@ fn topic_names(seg: &[u8]) -> std::collections::HashMap<u32, String> {
         if seg[e + 28] != 0 {
             continue; // not a topic row
         }
-        let id = read_u32(seg, e);
+        // obs_me_t: shape_hash u64, aux_b u64, THEN id at +16
+        // (review: reading offset 0 took the low bits of
+        // shape_hash and every lookup fell back to <unknown-N>).
+        let id = read_u32(seg, e + 16);
         let name_off = read_u32(seg, e + 20) as usize;
         let name_len =
             seg[e + 24] as usize | ((seg[e + 25] as usize) << 8);

--- a/crates/hale-codegen/tests/replay_determinism.rs
+++ b/crates/hale-codegen/tests/replay_determinism.rs
@@ -1,0 +1,266 @@
+//! RFC #296 Phase 0 — single-pool execution is deterministic by
+//! construction. This test converts that implementation accident
+//! into a stated, pinned guarantee.
+//!
+//! The claim (spec/testing.md § Determinism): a program whose loci
+//! all run on the main cooperative scheduler — no `placement`, no
+//! extra pools — produces the same publishes and the same
+//! deliveries in the same order on every run, given the same
+//! inputs. The cooperative pool is a single consumer thread by
+//! construction (spec/runtime.md — the invariant devirtualization
+//! rests on), so the delivery order not only exists, it cannot
+//! vary.
+//!
+//! Pinning method: run the same multi-locus cascade program several
+//! times under LOTUS_OBS=1 with an attached observer, and compare
+//! the complete ordered sequence of BUS_PUBLISH / BUS_DELIVER
+//! records across runs. Record timestamps differ run to run; the
+//! (subject, kind, locus, seq) tuple sequence must not.
+//!
+//! This is deliberately an obs-record test in Rust (not a
+//! `*_test.hl`): the assertion is about the runtime's event stream,
+//! which spec/testing.md files under compiler/runtime output.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+#[path = "support/obs.rs"]
+mod obs;
+use obs::{obs_bus_locus, read_u32, read_u64};
+
+fn build(name: &str, src: &str) -> PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(&format!("hale_test_replay_{}", name));
+    build_executable(&program, &bin).expect("build");
+    bin
+}
+
+/// A single-pool cascade: seeds fan out into a re-publishing locus
+/// and two sinks, one of which subscribes to both stages. No
+/// placement, no pools — everything on the main scheduler. No
+/// time/entropy dependence in any handler (the one sleep runs
+/// before the burst, purely so the test can attach its observer).
+const CASCADE: &str = r#"
+    type Seed { n: Int = 0; }
+    type Derived { n: Int = 0; }
+
+    locus Fan {
+        params { seen: Int = 0; }
+        bus {
+            subscribe "det.seed" as on_seed of type Seed;
+            publish "det.derived" of type Derived;
+        }
+        fn on_seed(s: Seed) {
+            self.seen = self.seen + 1;
+            "det.derived" <- Derived { n: s.n * 2 };
+            "det.derived" <- Derived { n: s.n * 2 + 1 };
+        }
+    }
+
+    locus SinkA {
+        params { total: Int = 0; }
+        bus { subscribe "det.derived" as on_d of type Derived; }
+        fn on_d(d: Derived) { self.total = self.total + d.n; }
+    }
+
+    locus SinkB {
+        params { count: Int = 0; }
+        bus {
+            subscribe "det.seed" as on_s of type Seed;
+            subscribe "det.derived" as on_d of type Derived;
+        }
+        fn on_s(s: Seed) { self.count = self.count + 1; }
+        fn on_d(d: Derived) { self.count = self.count + 1; }
+    }
+
+    main locus App {
+        params {
+            f: Fan = Fan { };
+            a: SinkA = SinkA { };
+            b: SinkB = SinkB { };
+        }
+        bus { publish "det.seed" of type Seed; }
+        run() {
+            std::time::sleep(600ms);
+            let mut i = 0;
+            while i < 32 {
+                "det.seed" <- Seed { n: i };
+                i = i + 1;
+            }
+        }
+    }
+
+    fn main() { App { }; }
+"#;
+
+/// Publishes: 32 seeds + 64 derived. Deliveries: seeds → Fan +
+/// SinkB (64), derived → SinkA + SinkB (128).
+const EXPECT_PUBLISH: usize = 32 + 64;
+const EXPECT_DELIVER: usize = 64 + 128;
+
+const EKIND_BUS_PUBLISH: u32 = 1;
+const EKIND_BUS_DELIVER: u32 = 2;
+
+/// One observed bus event, with everything nondeterministic
+/// (timestamps) stripped: subject name instead of the per-run
+/// manifest id, event kind, attributed locus, per-publisher seq.
+#[derive(PartialEq, Eq, Debug, Clone)]
+struct BusEvent {
+    subject: String,
+    ekind: u32,
+    locus: u32,
+    seq: u64,
+}
+
+/// Map manifest topic ids (registration-order, per-run) back to
+/// subject names so run-to-run comparison does not depend on
+/// registration order being stable — that stability is part of
+/// what determinism buys, but the sequence comparison should not
+/// assume the thing it is proving.
+fn topic_names(seg: &[u8]) -> std::collections::HashMap<u32, String> {
+    let manifest_off = read_u64(seg, 0x40) as usize;
+    let entry_count = read_u32(seg, manifest_off) as usize;
+    let pool_off = read_u32(seg, manifest_off + 8) as usize;
+    let entries = manifest_off + 16;
+    let mut out = std::collections::HashMap::new();
+    for i in 0..entry_count {
+        let e = entries + i * 32;
+        if seg[e + 28] != 0 {
+            continue; // not a topic row
+        }
+        let id = read_u32(seg, e);
+        let name_off = read_u32(seg, e + 20) as usize;
+        let name_len =
+            seg[e + 24] as usize | ((seg[e + 25] as usize) << 8);
+        let name = &seg[manifest_off + pool_off + name_off
+            ..manifest_off + pool_off + name_off + name_len];
+        out.insert(id, String::from_utf8_lossy(name).into_owned());
+    }
+    out
+}
+
+/// The complete ordered bus-event sequence of one run, and the
+/// number of rings that carried bus records.
+fn one_run(bin: &PathBuf) -> (Vec<BusEvent>, usize) {
+    let mut child = Command::new(bin)
+        .env("LOTUS_OBS", "1")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    let pid = child.id();
+
+    // Attach before the publish burst (which starts at t+600ms):
+    // poll for the lazily-created segment, then bump
+    // observer_count so ring emission is on for every record.
+    let mut attached = false;
+    for _ in 0..40 {
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        if std::fs::metadata(format!("/dev/shm/hale-obs-{}", pid)).is_ok() {
+            obs::attach_observer(pid);
+            attached = true;
+            break;
+        }
+    }
+    if !attached {
+        let _ = child.kill();
+        panic!("obs segment for pid {} never appeared", pid);
+    }
+    // Leaked mapping stays valid past emitter exit (POSIX shm).
+    let seg = obs::map_shm(pid).expect("map obs segment");
+    let out = child.wait_with_output().expect("wait");
+    assert!(out.status.success(), "cascade exited nonzero");
+
+    let names = topic_names(seg);
+    let rings_off = read_u64(seg, 0x68) as usize;
+    let ring_count = read_u32(seg, 0x1C) as usize;
+    let ring_slots = read_u32(seg, 0x20) as usize;
+
+    let mut events = Vec::new();
+    let mut rings_with_bus = 0usize;
+    for r in 0..ring_count {
+        let rdesc = rings_off + r * 64;
+        let data_off = read_u64(seg, rdesc) as usize;
+        let head = read_u64(seg, rdesc + 8) as usize;
+        let dropped = read_u64(seg, rdesc + 16);
+        assert_eq!(dropped, 0, "ring {} dropped records", r);
+        assert!(
+            head <= ring_slots,
+            "ring {} wrapped ({} records into {} slots) — the \
+             sequence is no longer complete and the comparison \
+             would be vacuous",
+            r,
+            head,
+            ring_slots
+        );
+        let before = events.len();
+        for i in 0..head {
+            let slot = data_off + (i & (ring_slots - 1)) * 16;
+            let w0 = read_u64(seg, slot);
+            let w1 = read_u64(seg, slot + 8);
+            let id = (w0 & 0xFFFFF) as u32;
+            let ekind = ((w0 >> 20) & 0x1F) as u32;
+            if ekind != EKIND_BUS_PUBLISH && ekind != EKIND_BUS_DELIVER {
+                continue;
+            }
+            events.push(BusEvent {
+                subject: names
+                    .get(&id)
+                    .cloned()
+                    .unwrap_or_else(|| format!("<unknown-{}>", id)),
+                ekind,
+                locus: obs_bus_locus(w1),
+                seq: w1 & 0xFFF_FFFF_FFFF, // seq:44 low
+            });
+        }
+        if events.len() > before {
+            rings_with_bus += 1;
+        }
+    }
+    (events, rings_with_bus)
+}
+
+#[test]
+fn single_pool_bus_order_is_identical_across_runs() {
+    let bin = build("phase0", CASCADE);
+
+    let (baseline, baseline_rings) = one_run(&bin);
+
+    // Negative control for the comparison itself (the P20 lesson:
+    // a recorder that captured nothing passes any equality check).
+    // The event counts must match the program's static shape.
+    let publishes =
+        baseline.iter().filter(|e| e.ekind == EKIND_BUS_PUBLISH).count();
+    let delivers =
+        baseline.iter().filter(|e| e.ekind == EKIND_BUS_DELIVER).count();
+    assert_eq!(publishes, EXPECT_PUBLISH, "publish records incomplete");
+    assert_eq!(delivers, EXPECT_DELIVER, "deliver records incomplete");
+
+    // Single-pool: one consumer thread, so one ring carries the
+    // entire bus stream. This is the structural fact the ordering
+    // guarantee stands on — if it breaks, the claim breaks.
+    assert_eq!(
+        baseline_rings, 1,
+        "expected the whole bus stream on the main thread's ring"
+    );
+
+    for run in 1..3 {
+        let (events, rings) = one_run(&bin);
+        assert_eq!(rings, 1);
+        assert_eq!(
+            events, baseline,
+            "run {} diverged from run 0 — single-pool execution \
+             is documented deterministic (spec/testing.md § \
+             Determinism); a divergence here is a runtime bug, \
+             not a flaky test",
+            run
+        );
+    }
+
+    let _ = std::fs::remove_file(&bin);
+}

--- a/crates/hale-codegen/tests/replay_recording.rs
+++ b/crates/hale-codegen/tests/replay_recording.rs
@@ -7,8 +7,8 @@
 //!      oldest; every record published before teardown reaches the
 //!      file, verified by exact counts under wrap pressure
 //!      (LOTUS_OBS_SLOTS far below the record volume).
-//!   2. **Per-consumer order.** Queued deliveries get an
-//!      `EK_BUS_CONSUME` (8) record on the consuming thread at
+//!   2. **Per-consumer order.** Queued deliveries get a consume
+//!      record (private recorder namespace) on the consuming thread at
 //!      handler invoke — the order replay reconstructs. Enqueue-time
 //!      BUS_DELIVER can't give it (it lands on the publisher's
 //!      ring).
@@ -35,7 +35,17 @@ use obs::{obs_bus_locus, rec_id_ekind};
 
 const EK_BUS_PUBLISH: u32 = 1;
 const EK_BUS_DELIVER: u32 = 2;
-const EK_BUS_CONSUME: u32 = 8;
+/// Recorder events ride PRIVATE rings (high bit set on the file
+/// entry's ring field) in their own namespace — never iris ekinds.
+const REC_EV_CONSUME: u32 = 2;
+const PRIV_RING: u32 = 0x8000_0000;
+
+fn is_consume(ring: u32, w0: u64) -> bool {
+    ring & PRIV_RING != 0 && ((w0 >> 20) & 0x1F) as u32 == REC_EV_CONSUME
+}
+fn is_public_bus(ring: u32, w0: u64, want: u32) -> bool {
+    ring & PRIV_RING == 0 && ((w0 >> 20) & 0x1F) as u32 == want
+}
 
 fn build(name: &str, src: &str) -> PathBuf {
     let program = hale_syntax::parse_source(src).expect("parse");
@@ -183,6 +193,12 @@ fn recording_is_lossless_under_wrap_pressure() {
         "trailer count disagrees with the entries on disk"
     );
     assert_eq!(r.ring_slots, 64);
+    // Every capture here is an in-process struct (raw flag, bit 1),
+    // none ingress.
+    assert!(
+        r.payloads.iter().all(|p| p.flags & 2 != 0 && p.flags & 1 == 0),
+        "struct captures must carry the raw-ABI flag"
+    );
     // Phase 2: one payload blob per QUEUED publish (the 32 seeds —
     // App's publishes route through the arena fanout). Fan's 64
     // derived publishes take the synchronous intra-tree desugar,
@@ -190,20 +206,17 @@ fn recording_is_lossless_under_wrap_pressure() {
     // same-thread call cannot carry external input, and replay
     // re-derives its payloads by re-execution. None marked ingress.
     assert_eq!(r.payloads.len(), 32, "queued-publish payloads lost");
-    assert!(
-        r.payloads.iter().all(|p| p.flags & 1 == 0),
-        "internal publish marked as external ingress"
-    );
+
 
     let publishes = r
         .entries
         .iter()
-        .filter(|(_, w0, _)| rec_id_ekind(*w0).1 == EK_BUS_PUBLISH)
+        .filter(|(ring, w0, _)| is_public_bus(*ring, *w0, EK_BUS_PUBLISH))
         .count();
     let delivers = r
         .entries
         .iter()
-        .filter(|(_, w0, _)| rec_id_ekind(*w0).1 == EK_BUS_DELIVER)
+        .filter(|(ring, w0, _)| is_public_bus(*ring, *w0, EK_BUS_DELIVER))
         .count();
     assert_eq!(publishes, CASCADE_PUBLISH, "publish records lost");
     assert_eq!(delivers, CASCADE_DELIVER, "deliver records lost");
@@ -224,7 +237,7 @@ fn queued_deliveries_get_consume_records_in_consumer_order() {
     let consumes: Vec<_> = r
         .entries
         .iter()
-        .filter(|(_, w0, _)| rec_id_ekind(*w0).1 == EK_BUS_CONSUME)
+        .filter(|(ring, w0, _)| is_consume(*ring, *w0))
         .collect();
     assert_eq!(
         consumes.len(),
@@ -246,7 +259,7 @@ fn queued_deliveries_get_consume_records_in_consumer_order() {
         );
         let pub_id = *w1 & 0xFFF_FFFF_FFFF;
         assert_ne!(pub_id, 0, "queued delivery lost its identity");
-        let seq = pub_id & 0xF_FFFF_FFFF; // low 36 = per-thread seq
+        let seq = pub_id & 0xFFFF_FFFF; // low 32 = per-thread seq
         assert_eq!(
             seq,
             last_seq + 1,
@@ -265,7 +278,7 @@ fn queued_deliveries_get_consume_records_in_consumer_order() {
     let delivers = r
         .entries
         .iter()
-        .filter(|(_, w0, _)| rec_id_ekind(*w0).1 == EK_BUS_DELIVER)
+        .filter(|(ring, w0, _)| is_public_bus(*ring, *w0, EK_BUS_DELIVER))
         .count();
     assert_eq!(delivers, 50, "deliver records lost");
 
@@ -291,13 +304,14 @@ fn two_recordings_of_a_single_pool_program_are_identical() {
             .expect("parse recording")
             .entries
             .iter()
-            .filter_map(|(_, w0, w1)| {
+            .filter_map(|(ring, w0, w1)| {
                 let (id, ekind) = rec_id_ekind(*w0);
-                if ekind == EK_BUS_PUBLISH
-                    || ekind == EK_BUS_DELIVER
-                    || ekind == EK_BUS_CONSUME
+                if is_public_bus(*ring, *w0, EK_BUS_PUBLISH)
+                    || is_public_bus(*ring, *w0, EK_BUS_DELIVER)
                 {
                     Some((id, ekind, *w1))
+                } else if is_consume(*ring, *w0) {
+                    Some((id, 100 + ekind, *w1))
                 } else {
                     None
                 }
@@ -312,7 +326,7 @@ fn two_recordings_of_a_single_pool_program_are_identical() {
     // which the a == b below holds it to).
     let consumes = a
         .iter()
-        .filter(|(_, ekind, _)| *ekind == EK_BUS_CONSUME)
+        .filter(|(_, ekind, _)| *ekind == 100 + REC_EV_CONSUME)
         .count();
     assert_eq!(
         a.len(),
@@ -353,10 +367,13 @@ fn plain_observation_never_emits_consume_records() {
     let seg = obs::map_shm(pid).expect("map segment");
     let out = child.wait_with_output().expect("wait");
     assert!(out.status.success());
-    let consumes = obs::records(seg, EK_BUS_CONSUME);
+    // ekind 8 in the PUBLIC segment is iris SUPERV_TRANS; the
+    // recorder must never emit anything of its own there (its
+    // events live on private rings that exist only in the file).
+    let stray = obs::records(seg, 8);
     assert!(
-        consumes.is_empty(),
-        "consume records leaked into a non-recording stream"
+        stray.is_empty(),
+        "recorder bookkeeping leaked into the public protocol stream"
     );
     // ...while the deliveries themselves demonstrably happened
     // (the vacuity guard for the assertion above).

--- a/crates/hale-codegen/tests/replay_recording.rs
+++ b/crates/hale-codegen/tests/replay_recording.rs
@@ -298,49 +298,64 @@ fn two_recordings_of_a_single_pool_program_are_identical() {
     run_recorded(&bin, &rec_a, &[]);
     run_recorded(&bin, &rec_b, &[]);
 
-    // Compare the bus-event sequences (publish/deliver/consume),
-    // stripped of timestamps. All bus records of a single-pool
-    // program sit on the main thread's ring, and the drain
-    // preserves per-ring order, so the filtered file order is the
-    // execution order.
-    let strip = |p: &PathBuf| -> Vec<(u32, u32, u64)> {
-        obs::read_recording(p)
-            .expect("parse recording")
-            .entries
-            .iter()
-            .filter_map(|(ring, w0, w1)| {
-                let (id, ekind) = rec_id_ekind(*w0);
-                if is_public_bus(*ring, *w0, EK_BUS_PUBLISH)
-                    || is_public_bus(*ring, *w0, EK_BUS_DELIVER)
-                {
-                    Some((id, ekind, *w1))
-                } else if is_consume(*ring, *w0) {
-                    Some((id, 100 + ekind, *w1))
-                } else {
-                    None
-                }
-            })
-            .collect()
+    // Round 3, finding 4: the drain preserves order WITHIN each
+    // ring, not between the public and private rings — their
+    // relative file positions depend on where the asynchronous
+    // drain divided its sweeps. Compare the streams the artifact
+    // actually orders, independently: the public bus stream (one
+    // ring in a single-pool program) and the private consume
+    // stream. A unified semantic order, if ever wanted, must be a
+    // recorded ordinal, not inferred drain interleaving.
+    struct Streams {
+        public_bus: Vec<(u32, u32, u64)>,
+        consume: Vec<(u64, u64)>,
+    }
+    let strip = |p: &PathBuf| -> Streams {
+        let r = obs::read_recording(p).expect("parse recording");
+        Streams {
+            public_bus: r
+                .entries
+                .iter()
+                .filter_map(|(ring, w0, w1)| {
+                    let (id, ekind) = rec_id_ekind(*w0);
+                    if is_public_bus(*ring, *w0, EK_BUS_PUBLISH)
+                        || is_public_bus(*ring, *w0, EK_BUS_DELIVER)
+                    {
+                        Some((id, ekind, *w1))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            consume: r
+                .entries
+                .iter()
+                .filter_map(|(ring, w0, w1)| {
+                    if is_consume(*ring, *w0) {
+                        Some((*w0 & 0xFFFFF, *w1))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        }
     };
     let a = strip(&rec_a);
     let b = strip(&rec_b);
-    // Every publish and delivery, plus one consume per QUEUED
-    // delivery (how many are queued vs synchronous-direct is the
-    // dispatch planner's business — but it must be deterministic,
-    // which the a == b below holds it to).
-    let consumes = a
-        .iter()
-        .filter(|(_, ekind, _)| *ekind == 100 + REC_EV_CONSUME)
-        .count();
     assert_eq!(
-        a.len(),
-        CASCADE_PUBLISH + CASCADE_DELIVER + consumes,
+        a.public_bus.len(),
+        CASCADE_PUBLISH + CASCADE_DELIVER,
         "recording incomplete"
     );
     assert_eq!(
-        a, b,
-        "two recordings of a single-pool program diverged — \
-         spec/testing.md § Determinism is violated"
+        a.public_bus, b.public_bus,
+        "two recordings of a single-pool program diverged on the \
+         public bus stream — spec/testing.md § Determinism is \
+         violated"
+    );
+    assert_eq!(
+        a.consume, b.consume,
+        "two recordings diverged on the consume stream"
     );
 
     let _ = std::fs::remove_file(&bin);

--- a/crates/hale-codegen/tests/replay_recording.rs
+++ b/crates/hale-codegen/tests/replay_recording.rs
@@ -31,7 +31,7 @@ mod harness;
 
 #[path = "support/obs.rs"]
 mod obs;
-use obs::{obs_bus_locus, rec_id_ekind};
+use obs::rec_id_ekind;
 
 const EK_BUS_PUBLISH: u32 = 1;
 const EK_BUS_DELIVER: u32 = 2;
@@ -189,15 +189,20 @@ fn recording_is_lossless_under_wrap_pressure() {
     assert!(r.clean, "no trailer — the recording did not finalize");
     assert_eq!(
         r.trailer_count,
-        (r.entries.len() + r.payloads.len() + r.journal.len()) as u64,
+        (r.entries.len() + r.payloads.len() + r.journal.len()
+            + r.meta_entries) as u64,
         "trailer count disagrees with the entries on disk"
     );
     assert_eq!(r.ring_slots, 64);
-    // Every capture here is an in-process struct (raw flag, bit 1),
-    // none ingress.
+    // Every capture here is an in-process struct: raw flag set, no
+    // ingress, and METADATA ONLY on disk — an ABI snapshot would
+    // carry heap pointers and padding (review round 2, finding 8).
     assert!(
-        r.payloads.iter().all(|p| p.flags & 2 != 0 && p.flags & 1 == 0),
-        "struct captures must carry the raw-ABI flag"
+        r.payloads.iter().all(|p| p.flags & 2 != 0
+            && p.flags & 1 == 0
+            && p.bytes.is_empty()
+            && p.raw_size > 0),
+        "raw struct captures must be metadata-only"
     );
     // Phase 2: one payload blob per QUEUED publish (the 32 seeds —
     // App's publishes route through the arena fanout). Fan's 64
@@ -246,20 +251,19 @@ fn queued_deliveries_get_consume_records_in_consumer_order() {
          stamp exactly one consume record"
     );
 
-    // All on one ring (the single consumer thread), carrying the
-    // publisher's deterministic pub_ids in gapless per-publisher
-    // order — that sequence IS the per-consumer delivery order
-    // replay serves back.
+    // All on one ring (the single consumer thread), carrying full
+    // 64-bit message ids (consumer:16 | seq:48) in gapless
+    // per-publisher order, with the TARGET locus in w0's id field —
+    // the (locus, msg_id) pair is the delivery identity.
     let ring0 = consumes[0].0;
     let mut last_seq = 0u64;
-    for (ring, _, w1) in consumes.iter() {
+    for (ring, w0, w1) in consumes.iter() {
         assert_eq!(
             *ring, ring0,
             "consume records spread across rings — not one consumer"
         );
-        let pub_id = *w1 & 0xFFF_FFFF_FFFF;
-        assert_ne!(pub_id, 0, "queued delivery lost its identity");
-        let seq = pub_id & 0xFFFF_FFFF; // low 32 = per-thread seq
+        assert_ne!(*w1, 0, "queued delivery lost its identity");
+        let seq = *w1 & 0xFFFF_FFFF_FFFF; // low 48 = per-thread seq
         assert_eq!(
             seq,
             last_seq + 1,
@@ -268,9 +272,9 @@ fn queued_deliveries_get_consume_records_in_consumer_order() {
         );
         last_seq = seq;
         assert_ne!(
-            obs_bus_locus(*w1),
+            (*w0 & 0xFFFFF) as u32,
             0,
-            "consume record lost its subscriber attribution"
+            "consume record lost its target-locus identity"
         );
     }
 

--- a/crates/hale-codegen/tests/replay_recording.rs
+++ b/crates/hale-codegen/tests/replay_recording.rs
@@ -1,0 +1,397 @@
+//! RFC #296 Phase 1 — lossless recording mode (`LOTUS_OBS_RECORD`).
+//!
+//! What Phase 1 promises, and what these tests hold it to:
+//!
+//!   1. **Never drop.** Under recording, ring emission blocks the
+//!      producer against the drain cursor instead of overwriting
+//!      oldest; every record published before teardown reaches the
+//!      file, verified by exact counts under wrap pressure
+//!      (LOTUS_OBS_SLOTS far below the record volume).
+//!   2. **Per-consumer order.** Queued deliveries get an
+//!      `EK_BUS_CONSUME` (8) record on the consuming thread at
+//!      handler invoke — the order replay reconstructs. Enqueue-time
+//!      BUS_DELIVER can't give it (it lands on the publisher's
+//!      ring).
+//!   3. **Opt-in only.** Without LOTUS_OBS_RECORD there is no file,
+//!      no consume record, and no disposition change — plain
+//!      LOTUS_OBS observation streams are byte-compatible with
+//!      pre-recording consumers.
+//!
+//! The counts are exact equalities, never `> 0` — the P20 lesson
+//! from the RFC thread: a recorder that captured nothing passes any
+//! vacuous check the first time a probe goes dark.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+#[path = "support/obs.rs"]
+mod obs;
+use obs::{obs_bus_locus, rec_id_ekind};
+
+const EK_BUS_PUBLISH: u32 = 1;
+const EK_BUS_DELIVER: u32 = 2;
+const EK_BUS_CONSUME: u32 = 8;
+
+fn build(name: &str, src: &str) -> PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(&format!("hale_test_rec_{}", name));
+    build_executable(&program, &bin).expect("build");
+    bin
+}
+
+fn rec_path(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "hale_rec_{}_{}.halerec",
+        std::process::id(),
+        name
+    ));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+/// Same single-pool cascade as replay_determinism.rs, minus the
+/// attach-window sleep: a recording is an observer from the first
+/// probe, so nothing needs to attach. 32 seeds → 96 publishes,
+/// 192 deliveries, all synchronous direct dispatch on the main
+/// thread.
+const CASCADE: &str = r#"
+    type Seed { n: Int = 0; }
+    type Derived { n: Int = 0; }
+
+    locus Fan {
+        params { seen: Int = 0; }
+        bus {
+            subscribe "det.seed" as on_seed of type Seed;
+            publish "det.derived" of type Derived;
+        }
+        fn on_seed(s: Seed) {
+            self.seen = self.seen + 1;
+            "det.derived" <- Derived { n: s.n * 2 };
+            "det.derived" <- Derived { n: s.n * 2 + 1 };
+        }
+    }
+
+    locus SinkA {
+        params { total: Int = 0; }
+        bus { subscribe "det.derived" as on_d of type Derived; }
+        fn on_d(d: Derived) { self.total = self.total + d.n; }
+    }
+
+    locus SinkB {
+        params { count: Int = 0; }
+        bus {
+            subscribe "det.seed" as on_s of type Seed;
+            subscribe "det.derived" as on_d of type Derived;
+        }
+        fn on_s(s: Seed) { self.count = self.count + 1; }
+        fn on_d(d: Derived) { self.count = self.count + 1; }
+    }
+
+    main locus App {
+        params {
+            f: Fan = Fan { };
+            a: SinkA = SinkA { };
+            b: SinkB = SinkB { };
+        }
+        bus { publish "det.seed" of type Seed; }
+        run() {
+            let mut i = 0;
+            while i < 32 {
+                "det.seed" <- Seed { n: i };
+                i = i + 1;
+            }
+        }
+    }
+
+    fn main() { App { }; }
+"#;
+
+const CASCADE_PUBLISH: usize = 32 + 64;
+const CASCADE_DELIVER: usize = 64 + 128;
+
+/// A pinned publisher bursting into a main-tree subscriber: every
+/// delivery crosses a thread boundary into the main bus queue, so
+/// every one is dequeue-driven — 50 consume records on the
+/// consumer's ring.
+const PINNED_PUB: &str = r#"
+    type Tick { n: Int = 0; }
+
+    locus Sink {
+        params { seen: Int = 0; }
+        bus { subscribe "rec.tick" as on_t of type Tick; }
+        fn on_t(t: Tick) { self.seen = self.seen + 1; }
+    }
+
+    locus Pub {
+        bus { publish "rec.tick" of type Tick; }
+        run() {
+            std::time::sleep(400ms);
+            let mut i = 0;
+            while i < 50 {
+                "rec.tick" <- Tick { n: i };
+                i = i + 1;
+            }
+        }
+    }
+
+    main locus App {
+        params { s: Sink = Sink { }; p: Pub = Pub { }; }
+        placement { p: pinned(core = 0); }
+        run() { std::time::sleep(1300ms); }
+    }
+
+    fn main() { App { }; }
+"#;
+
+fn run_recorded(bin: &PathBuf, rec: &PathBuf, extra: &[(&str, &str)]) {
+    let mut cmd = Command::new(bin);
+    cmd.env("LOTUS_OBS_RECORD", rec)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped());
+    for (k, v) in extra {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("run recorded");
+    assert!(
+        out.status.success(),
+        "recorded run exited nonzero: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn recording_is_lossless_under_wrap_pressure() {
+    let bin = build("lossless", CASCADE);
+    let rec = rec_path("lossless");
+
+    // 64-slot rings against ~300 records from one thread: without
+    // the blocking disposition the ring wraps five times and the
+    // oldest records are gone. The file must still hold every one.
+    run_recorded(&bin, &rec, &[("LOTUS_OBS_SLOTS", "64")]);
+
+    let r = obs::read_recording(&rec).expect("parse recording");
+    assert!(r.clean, "no trailer — the recording did not finalize");
+    assert_eq!(
+        r.trailer_count,
+        (r.entries.len() + r.payloads.len() + r.journal.len()) as u64,
+        "trailer count disagrees with the entries on disk"
+    );
+    assert_eq!(r.ring_slots, 64);
+    // Phase 2: one payload blob per QUEUED publish (the 32 seeds —
+    // App's publishes route through the arena fanout). Fan's 64
+    // derived publishes take the synchronous intra-tree desugar,
+    // which deliberately captures nothing: a closed-world
+    // same-thread call cannot carry external input, and replay
+    // re-derives its payloads by re-execution. None marked ingress.
+    assert_eq!(r.payloads.len(), 32, "queued-publish payloads lost");
+    assert!(
+        r.payloads.iter().all(|p| p.flags & 1 == 0),
+        "internal publish marked as external ingress"
+    );
+
+    let publishes = r
+        .entries
+        .iter()
+        .filter(|(_, w0, _)| rec_id_ekind(*w0).1 == EK_BUS_PUBLISH)
+        .count();
+    let delivers = r
+        .entries
+        .iter()
+        .filter(|(_, w0, _)| rec_id_ekind(*w0).1 == EK_BUS_DELIVER)
+        .count();
+    assert_eq!(publishes, CASCADE_PUBLISH, "publish records lost");
+    assert_eq!(delivers, CASCADE_DELIVER, "deliver records lost");
+
+    let _ = std::fs::remove_file(&bin);
+    let _ = std::fs::remove_file(&rec);
+}
+
+#[test]
+fn queued_deliveries_get_consume_records_in_consumer_order() {
+    let bin = build("consume", PINNED_PUB);
+    let rec = rec_path("consume");
+    run_recorded(&bin, &rec, &[]);
+
+    let r = obs::read_recording(&rec).expect("parse recording");
+    assert!(r.clean, "no trailer — the recording did not finalize");
+
+    let consumes: Vec<_> = r
+        .entries
+        .iter()
+        .filter(|(_, w0, _)| rec_id_ekind(*w0).1 == EK_BUS_CONSUME)
+        .collect();
+    assert_eq!(
+        consumes.len(),
+        50,
+        "every cross-thread delivery is dequeue-driven and must \
+         stamp exactly one consume record"
+    );
+
+    // All on one ring (the single consumer thread), carrying the
+    // publisher's deterministic pub_ids in gapless per-publisher
+    // order — that sequence IS the per-consumer delivery order
+    // replay serves back.
+    let ring0 = consumes[0].0;
+    let mut last_seq = 0u64;
+    for (ring, _, w1) in consumes.iter() {
+        assert_eq!(
+            *ring, ring0,
+            "consume records spread across rings — not one consumer"
+        );
+        let pub_id = *w1 & 0xFFF_FFFF_FFFF;
+        assert_ne!(pub_id, 0, "queued delivery lost its identity");
+        let seq = pub_id & 0xF_FFFF_FFFF; // low 36 = per-thread seq
+        assert_eq!(
+            seq,
+            last_seq + 1,
+            "one publisher, FIFO queue: consume order must be \
+             the gapless publish order"
+        );
+        last_seq = seq;
+        assert_ne!(
+            obs_bus_locus(*w1),
+            0,
+            "consume record lost its subscriber attribution"
+        );
+    }
+
+    // The queued deliveries themselves are also all present.
+    let delivers = r
+        .entries
+        .iter()
+        .filter(|(_, w0, _)| rec_id_ekind(*w0).1 == EK_BUS_DELIVER)
+        .count();
+    assert_eq!(delivers, 50, "deliver records lost");
+
+    let _ = std::fs::remove_file(&bin);
+    let _ = std::fs::remove_file(&rec);
+}
+
+#[test]
+fn two_recordings_of_a_single_pool_program_are_identical() {
+    let bin = build("determ", CASCADE);
+    let rec_a = rec_path("determ_a");
+    let rec_b = rec_path("determ_b");
+    run_recorded(&bin, &rec_a, &[]);
+    run_recorded(&bin, &rec_b, &[]);
+
+    // Compare the bus-event sequences (publish/deliver/consume),
+    // stripped of timestamps. All bus records of a single-pool
+    // program sit on the main thread's ring, and the drain
+    // preserves per-ring order, so the filtered file order is the
+    // execution order.
+    let strip = |p: &PathBuf| -> Vec<(u32, u32, u64)> {
+        obs::read_recording(p)
+            .expect("parse recording")
+            .entries
+            .iter()
+            .filter_map(|(_, w0, w1)| {
+                let (id, ekind) = rec_id_ekind(*w0);
+                if ekind == EK_BUS_PUBLISH
+                    || ekind == EK_BUS_DELIVER
+                    || ekind == EK_BUS_CONSUME
+                {
+                    Some((id, ekind, *w1))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    };
+    let a = strip(&rec_a);
+    let b = strip(&rec_b);
+    // Every publish and delivery, plus one consume per QUEUED
+    // delivery (how many are queued vs synchronous-direct is the
+    // dispatch planner's business — but it must be deterministic,
+    // which the a == b below holds it to).
+    let consumes = a
+        .iter()
+        .filter(|(_, ekind, _)| *ekind == EK_BUS_CONSUME)
+        .count();
+    assert_eq!(
+        a.len(),
+        CASCADE_PUBLISH + CASCADE_DELIVER + consumes,
+        "recording incomplete"
+    );
+    assert_eq!(
+        a, b,
+        "two recordings of a single-pool program diverged — \
+         spec/testing.md § Determinism is violated"
+    );
+
+    let _ = std::fs::remove_file(&bin);
+    let _ = std::fs::remove_file(&rec_a);
+    let _ = std::fs::remove_file(&rec_b);
+}
+
+#[test]
+fn plain_observation_never_emits_consume_records() {
+    // The negative control for opt-in: LOTUS_OBS=1 without
+    // LOTUS_OBS_RECORD must produce a stream a pre-addendum
+    // consumer can read — ekind 8 must not appear.
+    let bin = build("optin", PINNED_PUB);
+    let child = Command::new(&bin)
+        .env("LOTUS_OBS", "1")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    let pid = child.id();
+    for _ in 0..40 {
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        if std::fs::metadata(format!("/dev/shm/hale-obs-{}", pid)).is_ok() {
+            obs::attach_observer(pid);
+            break;
+        }
+    }
+    let seg = obs::map_shm(pid).expect("map segment");
+    let out = child.wait_with_output().expect("wait");
+    assert!(out.status.success());
+    let consumes = obs::records(seg, EK_BUS_CONSUME);
+    assert!(
+        consumes.is_empty(),
+        "consume records leaked into a non-recording stream"
+    );
+    // ...while the deliveries themselves demonstrably happened
+    // (the vacuity guard for the assertion above).
+    let delivers = obs::records(seg, EK_BUS_DELIVER);
+    assert!(!delivers.is_empty(), "no deliveries — vacuous control");
+    let _ = std::fs::remove_file(&bin);
+}
+
+#[test]
+fn ring_exhaustion_fails_a_recorded_run_loudly() {
+    // One ring, two emitting threads (main + the pinned publisher):
+    // the second thread cannot get a ring, and a recording must
+    // never silently drop a thread's records — the run fails with
+    // the documented diagnostic instead.
+    let bin = build("exhaust", PINNED_PUB);
+    let rec = rec_path("exhaust");
+    let out = Command::new(&bin)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .env("LOTUS_OBS_RINGS", "1")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .expect("run");
+    assert_eq!(
+        out.status.code(),
+        Some(70),
+        "expected the ring-exhaustion failure, got: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("LOTUS_OBS_RECORD") && stderr.contains("LOTUS_OBS_RINGS"),
+        "diagnostic must name the knob that fixes it:\n{}",
+        stderr
+    );
+    let _ = std::fs::remove_file(&bin);
+    let _ = std::fs::remove_file(&rec);
+}

--- a/crates/hale-codegen/tests/support/obs.rs
+++ b/crates/hale-codegen/tests/support/obs.rs
@@ -224,3 +224,130 @@ pub fn binding_cells(seg: &[u8], subject: &[u8]) -> Option<[u64; 8]> {
     }
     None
 }
+
+/* ---- GH #296 recording file (format v0.2, PRE-STABLE) ---------- */
+
+/// One drained ring record: (ring index, w0, w1).
+pub type RecEntry = (u32, u64, u64);
+
+/// A captured publish payload.
+pub struct RecPayload {
+    pub topic_id: u32,
+    pub pub_id: u64,
+    /// bit 0 = external ingress (wire re-dispatch)
+    pub flags: u64,
+    pub bytes: Vec<u8>,
+}
+
+/// A journaled input read.
+pub struct RecJournal {
+    pub jkind: u32,
+    pub consumer: u64,
+    pub seq: u64,
+    pub bytes: Vec<u8>,
+}
+
+pub struct Recording {
+    pub ring_count: u32,
+    pub ring_slots: u32,
+    pub model_hash: u64,
+    pub entries: Vec<RecEntry>,
+    pub payloads: Vec<RecPayload>,
+    pub journal: Vec<RecJournal>,
+    /// Trailer present — the run finalized cleanly. A recording
+    /// without it is truncated and must be treated as such.
+    pub clean: bool,
+    pub trailer_count: u64,
+}
+
+pub const REC_MAGIC: u64 = 0x30434552454C4148; // "HALEREC0"
+pub const REC_END: u64 = 0x30444E45454C4148; // "HALEEND0"
+
+/// Parse a LOTUS_OBS_RECORD file (v0.2): 64B header, then tagged
+/// entries — tag 0 ring record (24B), tag 1 payload blob, tag 2
+/// journal blob (both 32B header + padded bytes) — then a 16B
+/// trailer counting every entry.
+pub fn read_recording(path: &std::path::Path) -> Option<Recording> {
+    let buf = std::fs::read(path).ok()?;
+    if buf.len() < 64 || read_u64(&buf, 0) != REC_MAGIC {
+        return None;
+    }
+    let header_len = read_u32(&buf, 12) as usize;
+    let ring_count = read_u32(&buf, 20);
+    let ring_slots = read_u32(&buf, 24);
+    let model_hash = read_u64(&buf, 48);
+    let mut end = buf.len();
+    let mut clean = false;
+    let mut trailer_count = 0u64;
+    if end >= header_len + 16 && read_u64(&buf, end - 16) == REC_END {
+        trailer_count = read_u64(&buf, end - 8);
+        clean = true;
+        end -= 16;
+    }
+    let mut entries = Vec::new();
+    let mut payloads = Vec::new();
+    let mut journal = Vec::new();
+    let mut off = header_len;
+    while off + 8 <= end {
+        let tag = read_u32(&buf, off);
+        let a = read_u32(&buf, off + 4);
+        match tag {
+            0 => {
+                if off + 24 > end {
+                    break;
+                }
+                entries.push((
+                    a,
+                    read_u64(&buf, off + 8),
+                    read_u64(&buf, off + 16),
+                ));
+                off += 24;
+            }
+            1 | 2 => {
+                if off + 32 > end {
+                    break;
+                }
+                let b = read_u64(&buf, off + 8);
+                let c = read_u64(&buf, off + 16);
+                let size = read_u64(&buf, off + 24) as usize;
+                let padded = (size + 7) & !7;
+                if off + 32 + padded > end {
+                    break;
+                }
+                let bytes = buf[off + 32..off + 32 + size].to_vec();
+                if tag == 1 {
+                    payloads.push(RecPayload {
+                        topic_id: a,
+                        pub_id: b,
+                        flags: c,
+                        bytes,
+                    });
+                } else {
+                    journal.push(RecJournal {
+                        jkind: a,
+                        consumer: b,
+                        seq: c,
+                        bytes,
+                    });
+                }
+                off += 32 + padded;
+            }
+            _ => break, // unknown tag: stop rather than misparse
+        }
+    }
+    Some(Recording {
+        ring_count,
+        ring_slots,
+        model_hash,
+        entries,
+        payloads,
+        journal,
+        clean,
+        trailer_count,
+    })
+}
+
+/// Decode an entry's w0 into (id, ekind).
+pub fn rec_id_ekind(w0: u64) -> (u32, u32) {
+    ((w0 & 0xFFFFF) as u32, ((w0 >> 20) & 0x1F) as u32)
+}

--- a/crates/hale-codegen/tests/support/obs.rs
+++ b/crates/hale-codegen/tests/support/obs.rs
@@ -277,11 +277,11 @@ pub fn read_recording(path: &std::path::Path) -> Option<Recording> {
     let ring_slots = read_u32(&buf, 24);
     let model_hash = read_u64(&buf, 48);
     let mut end = buf.len();
-    let mut clean = false;
+    let mut has_trailer = false;
     let mut trailer_count = 0u64;
     if end >= header_len + 16 && read_u64(&buf, end - 16) == REC_END {
         trailer_count = read_u64(&buf, end - 8);
-        clean = true;
+        has_trailer = true;
         end -= 16;
     }
     let mut entries = Vec::new();
@@ -335,6 +335,12 @@ pub fn read_recording(path: &std::path::Path) -> Option<Recording> {
             _ => break, // unknown tag: stop rather than misparse
         }
     }
+    // Clean = the ENTIRE artifact validated: exact end at the
+    // trailer, trailer count matching parsed entries.
+    let clean = has_trailer
+        && off == end
+        && trailer_count
+            == (entries.len() + payloads.len() + journal.len()) as u64;
     Some(Recording {
         ring_count,
         ring_slots,

--- a/crates/hale-codegen/tests/support/obs.rs
+++ b/crates/hale-codegen/tests/support/obs.rs
@@ -225,26 +225,29 @@ pub fn binding_cells(seg: &[u8], subject: &[u8]) -> Option<[u64; 8]> {
     None
 }
 
-/* ---- GH #296 recording file (format v0.2, PRE-STABLE) ---------- */
+/* ---- GH #296 recording file (format v0.3, PRE-STABLE) ---------- */
 
 /// One drained ring record: (ring index, w0, w1).
 pub type RecEntry = (u32, u64, u64);
 
-/// A captured publish payload.
+/// A captured publish payload. flags bit 0 = external ingress;
+/// bit 1 = raw in-process struct (metadata only: no bytes stored,
+/// declared size in `raw_size`).
 pub struct RecPayload {
     pub topic_id: u32,
     pub pub_id: u64,
-    /// bit 0 = external ingress (wire re-dispatch)
     pub flags: u64,
+    pub raw_size: u64,
     pub bytes: Vec<u8>,
 }
 
-/// A journaled input read.
+/// A journaled input read (exact framed args + result).
 pub struct RecJournal {
     pub jkind: u32,
     pub consumer: u64,
-    pub seq: u64,
-    pub bytes: Vec<u8>,
+    pub withheld: bool,
+    pub args: Vec<u8>,
+    pub result: Vec<u8>,
 }
 
 pub struct Recording {
@@ -254,6 +257,7 @@ pub struct Recording {
     pub entries: Vec<RecEntry>,
     pub payloads: Vec<RecPayload>,
     pub journal: Vec<RecJournal>,
+    pub meta_entries: usize,
     /// Trailer present — the run finalized cleanly. A recording
     /// without it is truncated and must be treated as such.
     pub clean: bool,
@@ -263,16 +267,19 @@ pub struct Recording {
 pub const REC_MAGIC: u64 = 0x30434552454C4148; // "HALEREC0"
 pub const REC_END: u64 = 0x30444E45454C4148; // "HALEEND0"
 
-/// Parse a LOTUS_OBS_RECORD file (v0.2): 64B header, then tagged
-/// entries — tag 0 ring record (24B), tag 1 payload blob, tag 2
-/// journal blob (both 32B header + padded bytes) — then a 16B
-/// trailer counting every entry.
+/// Parse a LOTUS_OBS_RECORD file (v0.3): 96B header, then tagged
+/// entries — tag 0 ring record (24B); tags 1/2/3 payload/journal/
+/// meta blobs (32B header + padded bytes) — then a 16B trailer
+/// counting every entry.
 pub fn read_recording(path: &std::path::Path) -> Option<Recording> {
     let buf = std::fs::read(path).ok()?;
-    if buf.len() < 64 || read_u64(&buf, 0) != REC_MAGIC {
+    if buf.len() < 112 || read_u64(&buf, 0) != REC_MAGIC {
         return None;
     }
     let header_len = read_u32(&buf, 12) as usize;
+    if header_len != 96 {
+        return None;
+    }
     let ring_count = read_u32(&buf, 20);
     let ring_slots = read_u32(&buf, 24);
     let model_hash = read_u64(&buf, 48);
@@ -287,6 +294,7 @@ pub fn read_recording(path: &std::path::Path) -> Option<Recording> {
     let mut entries = Vec::new();
     let mut payloads = Vec::new();
     let mut journal = Vec::new();
+    let mut meta_entries = 0usize;
     let mut off = header_len;
     while off + 8 <= end {
         let tag = read_u32(&buf, off);
@@ -303,7 +311,7 @@ pub fn read_recording(path: &std::path::Path) -> Option<Recording> {
                 ));
                 off += 24;
             }
-            1 | 2 => {
+            1 | 2 | 3 => {
                 if off + 32 > end {
                     break;
                 }
@@ -316,19 +324,31 @@ pub fn read_recording(path: &std::path::Path) -> Option<Recording> {
                 }
                 let bytes = buf[off + 32..off + 32 + size].to_vec();
                 if tag == 1 {
+                    let raw = c & 2 != 0;
                     payloads.push(RecPayload {
                         topic_id: a,
                         pub_id: b,
-                        flags: c,
+                        flags: c & 0xFFFF_FFFF,
+                        raw_size: if raw { c >> 32 } else { size as u64 },
                         bytes,
                     });
-                } else {
+                } else if tag == 2 {
+                    if size < 4 {
+                        break;
+                    }
+                    let args_len = read_u32(&bytes, 0) as usize;
+                    if args_len + 4 > size {
+                        break;
+                    }
                     journal.push(RecJournal {
                         jkind: a,
                         consumer: b,
-                        seq: c,
-                        bytes,
+                        withheld: c >> 63 != 0,
+                        args: bytes[4..4 + args_len].to_vec(),
+                        result: bytes[4 + args_len..].to_vec(),
                     });
+                } else {
+                    meta_entries += 1;
                 }
                 off += 32 + padded;
             }
@@ -340,7 +360,8 @@ pub fn read_recording(path: &std::path::Path) -> Option<Recording> {
     let clean = has_trailer
         && off == end
         && trailer_count
-            == (entries.len() + payloads.len() + journal.len()) as u64;
+            == (entries.len() + payloads.len() + journal.len()
+                + meta_entries) as u64;
     Some(Recording {
         ring_count,
         ring_slots,
@@ -348,6 +369,7 @@ pub fn read_recording(path: &std::path::Path) -> Option<Recording> {
         entries,
         payloads,
         journal,
+        meta_entries,
         clean,
         trailer_count,
     })

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -1784,6 +1784,15 @@ pub fn effect_manifest_with_inference(
                     walk_infer(&md.items, &inner, add);
                 }
                 TopDecl::Locus(l) => {
+                    // Round 4, finding 2: the summary KEY must be
+                    // qualified like the display name — an
+                    // unqualified key let `inner::Worker::run` find
+                    // an unrelated top-level `Worker::run`'s summary
+                    // and inherit its (possibly pure) effects. The
+                    // qualified key misses until the summarizer
+                    // descends into modules, which fails closed as
+                    // `unclassified`.
+                    let locus_key = format!("{}{}", prefix, l.name.name);
                     for m in &l.members {
                         match m {
                             LocusMember::Fn(fd) => add(
@@ -1792,7 +1801,7 @@ pub fn effect_manifest_with_inference(
                                     prefix, l.name.name, fd.name.name
                                 ),
                                 FnKey::method(
-                                    l.name.name.clone(),
+                                    locus_key.clone(),
                                     fd.name.name.clone(),
                                 ),
                             in_module,
@@ -1815,7 +1824,7 @@ pub fn effect_manifest_with_inference(
                                         prefix, l.name.name, phase
                                     ),
                                     FnKey::method(
-                                        l.name.name.clone(),
+                                        locus_key.clone(),
                                         phase.to_string(),
                                     ),
                                     in_module,

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -1663,23 +1663,46 @@ pub fn effect_manifest(programs: &[&Program]) -> Vec<EffectManifestRow> {
             inferred: Vec::new(),
         });
     };
-    for p in programs {
-        for item in &p.items {
+    // GH #296 review round 3: modules nest top declarations
+    // arbitrarily deep, and a module-contained fn or locus whose
+    // effects never reached a manifest row was invisible to both
+    // the committed-baseline diff and `hale replay`'s safety
+    // admission — the same fail-open shape twice.
+    fn walk_items(
+        items: &[TopDecl],
+        prefix: &str,
+        push: &mut dyn FnMut(String, &hale_syntax::ast::FnDecl),
+    ) {
+        for item in items {
             match item {
-                TopDecl::Fn(fd) => push(fd.name.name.clone(), fd),
+                TopDecl::Fn(fd) => push(
+                    format!("{}{}", prefix, fd.name.name),
+                    fd,
+                ),
                 TopDecl::Locus(l) => {
                     for m in &l.members {
                         if let LocusMember::Fn(fd) = m {
                             push(
-                                format!("{}::{}", l.name.name, fd.name.name),
+                                format!(
+                                    "{}{}::{}",
+                                    prefix, l.name.name, fd.name.name
+                                ),
                                 fd,
                             );
                         }
                     }
                 }
+                TopDecl::Module(md) => {
+                    let inner =
+                        format!("{}{}::", prefix, md.name.name);
+                    walk_items(&md.items, &inner, push);
+                }
                 _ => {}
             }
         }
+    }
+    for p in programs {
+        walk_items(&p.items, "", &mut push);
     }
     rows.sort_by(|a, b| a.func.cmp(&b.func));
     rows
@@ -1700,11 +1723,22 @@ pub fn effect_manifest_with_inference(
         .map(|r| (r.func.clone(), r))
         .collect();
     let mut rows: Vec<EffectManifestRow> = Vec::new();
-    let mut add = |name: String, key: FnKey| {
-        let inferred = crate::frontier::render_effects_named(
-            crate::frontier::infer_effects(&summary, &key, &ffi),
-            &names,
-        );
+    let mut add = |name: String, key: FnKey, in_module: bool| {
+        // Round 3 (GH #296): the callgraph summarizer does not yet
+        // descend into inline modules, and a missing summary key
+        // infers PURE — which turned a module-contained subprocess
+        // call invisible. Inside a module, an unresolvable key is
+        // rendered `unclassified` ("may do anything"): fail closed,
+        // and scoped so non-module rows are untouched.
+        let inferred = if in_module && !summary.fns.contains_key(&key)
+        {
+            vec!["unclassified".to_string()]
+        } else {
+            crate::frontier::render_effects_named(
+                crate::frontier::infer_effects(&summary, &key, &ffi),
+                &names,
+            )
+        };
         let mut row = declared.get(&name).cloned().unwrap_or(
             EffectManifestRow {
                 func: name.clone(),
@@ -1727,22 +1761,41 @@ pub fn effect_manifest_with_inference(
         }
         rows.push(row);
     };
-    for p in programs {
-        for item in &p.items {
+    // Round 3 (GH #296): recurse through modules — a
+    // module-contained fn or lifecycle body absent from these rows
+    // was invisible to both the baseline diff and replay's safety
+    // admission. A module fn whose summary key misses resolves to
+    // `unclassified`, which is the fail-closed answer.
+    fn walk_infer(
+        items: &[TopDecl],
+        prefix: &str,
+        add: &mut dyn FnMut(String, FnKey, bool),
+    ) {
+        let in_module = !prefix.is_empty();
+        for item in items {
             match item {
                 TopDecl::Fn(fd) => {
-                    let n = fd.name.name.clone();
-                    add(n.clone(), FnKey::free_fn(n));
+                    let n = format!("{}{}", prefix, fd.name.name);
+                    add(n.clone(), FnKey::free_fn(n), in_module);
+                }
+                TopDecl::Module(md) => {
+                    let inner =
+                        format!("{}{}::", prefix, md.name.name);
+                    walk_infer(&md.items, &inner, add);
                 }
                 TopDecl::Locus(l) => {
                     for m in &l.members {
                         match m {
                             LocusMember::Fn(fd) => add(
-                                format!("{}::{}", l.name.name, fd.name.name),
+                                format!(
+                                    "{}{}::{}",
+                                    prefix, l.name.name, fd.name.name
+                                ),
                                 FnKey::method(
                                     l.name.name.clone(),
                                     fd.name.name.clone(),
                                 ),
+                            in_module,
                             ),
                             // Lifecycle hooks belong in the
                             // fingerprint too. Leaving them out made
@@ -1757,11 +1810,15 @@ pub fn effect_manifest_with_inference(
                             LocusMember::Lifecycle(lc) => {
                                 let phase = lifecycle_name(lc.kind);
                                 add(
-                                    format!("{}::{}", l.name.name, phase),
+                                    format!(
+                                        "{}{}::{}",
+                                        prefix, l.name.name, phase
+                                    ),
                                     FnKey::method(
                                         l.name.name.clone(),
                                         phase.to_string(),
                                     ),
+                                    in_module,
                                 )
                             }
                             _ => {}
@@ -1771,6 +1828,9 @@ pub fn effect_manifest_with_inference(
                 _ => {}
             }
         }
+    }
+    for p in programs {
+        walk_infer(&p.items, "", &mut add);
     }
     rows.sort_by(|a, b| a.func.cmp(&b.func));
     rows

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -58,6 +58,7 @@
 - [Binding C](./systems/binding-c.md)
 - [WebAssembly & the browser](./systems/webassembly.md)
 - [Operations & debugging](./systems/operations.md)
+- [Record & replay](./systems/replay.md)
 - [Modes](./systems/modes.md)
 
 ---

--- a/docs/src/everyday/testing.md
+++ b/docs/src/everyday/testing.md
@@ -51,6 +51,16 @@ hale test --json        # machine-readable results (one record per file)
 it, reporting which passed and which failed. It's the same binary that
 `hale build` produces — there's no separate test runtime.
 
+One property comes free with that binary: **a test whose loci all
+run on the main scheduler is deterministic.** No `placement`, no
+extra pools — then every publish and every delivery happens in the
+same order on every run, by construction (one pool is one consumer
+thread; handlers run to completion). A flaky single-pool test is
+never the scheduler's fault: look for a real input — time, entropy,
+environment, the network — feeding the assertion instead. If you
+want the compiler to prove there isn't one, mark the code under
+test [`@deterministic`](../effects.md).
+
 ## Testing what runs over time
 
 The assertions above check *values*. For a long-running locus, the

--- a/docs/src/systems/operations.md
+++ b/docs/src/systems/operations.md
@@ -275,17 +275,23 @@ hale replay run.halerec app.hl --diff          # + report first divergence
 hale replay run.halerec app.hl --at 4120       # SIGSTOP at consume #4120
 ```
 
-`hale replay` re-runs the same program (it recompiles and checks
-the recording's `model_hash` against it — a recording from a
-different model is rejected, and a truncated one refused), serving
+`hale replay` re-runs the same program (it recompiles and admits
+the recording by **executable identity** — compiler version +
+source bytes — with the model's `shape_hash` as a secondary check;
+a mismatched, unstamped, or truncated recording is refused),
+serving
 journaled inputs back and re-consuming each consumer's deliveries
 in the recorded order — two racing pinned publishers replay in
 exactly the interleaving that was recorded. Replay *degrades*
 rather than refuses: a read or delivery past the recorded history
-falls back live and is counted, and the divergence summary prints
-at exit. Not yet replayable: `where async_io` pools (refused
-loudly) and live external ingress — socket/adapter input
-re-executes against the real world in this version. Single-pool
+falls back live and is counted, the divergence summary prints at
+exit, and any divergence fails `--diff`. **Replay is refused by
+default for programs whose effects reach `syscall`/`ffi`** — a
+re-execution repeats real side effects (sends, writes, spawns), so
+that requires an explicit `--allow-live-effects`. Not yet
+replayable: `where async_io` pools (refused loudly) and live
+external ingress — socket/adapter input re-executes against the
+real world in this version. Single-pool
 runs are deterministic by construction even without replay; see
 the [testing chapter](../everyday/testing.md).
 

--- a/docs/src/systems/operations.md
+++ b/docs/src/systems/operations.md
@@ -269,31 +269,16 @@ file format is pre-stable (GH #296).
 **Replaying one.**
 
 ```sh
-LOTUS_OBS_RECORD=run.halerec hale run app.hl   # record
-hale replay run.halerec app.hl                 # re-execute it
-hale replay run.halerec app.hl --diff          # + report first divergence
-hale replay run.halerec app.hl --at 4120       # SIGSTOP at consume #4120
+hale replay run.halerec app.hl            # re-execute it
+hale replay run.halerec app.hl --diff     # + compare, fail on any divergence
+hale replay run.halerec app.hl --at 65:12 # SIGSTOP at consumer 65's 12th consume
 ```
 
-`hale replay` re-runs the same program (it recompiles and admits
-the recording by **executable identity** — compiler version +
-source bytes — with the model's `shape_hash` as a secondary check;
-a mismatched, unstamped, or truncated recording is refused),
-serving
-journaled inputs back and re-consuming each consumer's deliveries
-in the recorded order — two racing pinned publishers replay in
-exactly the interleaving that was recorded. Replay *degrades*
-rather than refuses: a read or delivery past the recorded history
-falls back live and is counted, the divergence summary prints at
-exit, and any divergence fails `--diff`. **Replay is refused by
-default for programs whose effects reach `syscall`/`ffi`** — a
-re-execution repeats real side effects (sends, writes, spawns), so
-that requires an explicit `--allow-live-effects`. Not yet
-replayable: `where async_io` pools (refused loudly) and live
-external ingress — socket/adapter input re-executes against the
-real world in this version. Single-pool
-runs are deterministic by construction even without replay; see
-the [testing chapter](../everyday/testing.md).
+The full story — admission by executable identity, the
+safe-by-default effect gate (`--allow-live-effects`), env-value
+redaction (`LOTUS_OBS_RECORD_ENV`), the coverage boundary, and
+what the comparator actually compares — has its own chapter:
+[Record & replay](./replay.md).
 
 ## Debugging with the native toolchain
 

--- a/docs/src/systems/operations.md
+++ b/docs/src/systems/operations.md
@@ -252,6 +252,43 @@ understands the header. (A non-framed unicast transport carries
 no seq and falls back to a local delivery count even with the
 wire enabled.)
 
+**Recording a run.** `LOTUS_OBS_RECORD=<path>` turns the sampler
+into a flight recorder: every observation record is drained to
+`<path>`, and the disposition flips from "drop rather than stall"
+to "stall rather than drop" — a full ring blocks its producer
+until the drain catches up, and a run that *couldn't* record
+everything fails loudly instead of producing a silently
+incomplete file. It implies `LOTUS_OBS=1` and needs no observer
+attached. The recording captures each consumer's actual handler
+order, every queued publish's payload, and a journal of the
+nondeterministic reads (`std::time`, `std::rand`,
+`std::os::getrandom`, `std::env`). Recording changes your
+program's timing by design; don't leave it on in production. The
+file format is pre-stable (GH #296).
+
+**Replaying one.**
+
+```sh
+LOTUS_OBS_RECORD=run.halerec hale run app.hl   # record
+hale replay run.halerec app.hl                 # re-execute it
+hale replay run.halerec app.hl --diff          # + report first divergence
+hale replay run.halerec app.hl --at 4120       # SIGSTOP at consume #4120
+```
+
+`hale replay` re-runs the same program (it recompiles and checks
+the recording's `model_hash` against it — a recording from a
+different model is rejected, and a truncated one refused), serving
+journaled inputs back and re-consuming each consumer's deliveries
+in the recorded order — two racing pinned publishers replay in
+exactly the interleaving that was recorded. Replay *degrades*
+rather than refuses: a read or delivery past the recorded history
+falls back live and is counted, and the divergence summary prints
+at exit. Not yet replayable: `where async_io` pools (refused
+loudly) and live external ingress — socket/adapter input
+re-executes against the real world in this version. Single-pool
+runs are deterministic by construction even without replay; see
+the [testing chapter](../everyday/testing.md).
+
 ## Debugging with the native toolchain
 
 Hale binaries carry full DWARF by default (zero runtime cost):

--- a/docs/src/systems/replay.md
+++ b/docs/src/systems/replay.md
@@ -1,0 +1,143 @@
+# Record & replay
+
+"Reproduce the incident exactly" is worth more to someone running a
+system than any counter you can print. Hale's substrate is unusually
+close to being able to promise it: a cooperative pool is one
+consumer thread by construction, messages are copies, and every
+delivery already passes an observation probe. Record & replay is
+those ingredients combined — a flight recorder over the observation
+plane, and a `hale replay` command that re-executes what it
+captured.
+
+The claim, stated exactly: **re-run a recorded execution and get
+the same schedule and the same journaled inputs, with an explicit,
+checked coverage boundary.** What sits outside that boundary —
+live sockets, files, subprocesses — is refused by default rather
+than silently re-executed. This chapter walks the whole surface;
+the normative contract is `spec/runtime.md` § *Lossless recording
+mode* and § *Replay*.
+
+## Recording a run
+
+```sh
+LOTUS_OBS_RECORD=run.halerec hale run app.hl
+```
+
+Recording turns the observation plane's sampler disposition into a
+flight recorder's. A live observer prefers losing records to
+stalling the observed program; a recorder makes the opposite trade,
+because a dropped record is a replay that diverges silently:
+
+- a producer whose ring is full **blocks** until the in-process
+  drain catches up, instead of overwriting the oldest record;
+- a thread that cannot get a ring, a capture allocation failure, a
+  write failure, or a finalize failure **fails the run** — never a
+  silent gap;
+- the file ends with a clean-finalize trailer, and a recording is
+  admitted for replay only when the *entire* artifact validates —
+  exact parse to the trailer, matching entry count.
+
+The recording needs no observer attached and works from the first
+probe. It captures four things:
+
+1. **The schedule.** Every queued delivery gets a consume record on
+   the consuming thread at handler invoke, carrying the delivery's
+   identity — (target locus, message id), where the message id is
+   deterministic per publisher thread. Per consumer, that stream
+   *is* the order the handlers ran in.
+2. **The public bus stream.** Publishes and deliveries as the iris
+   protocol already emits them, with file-side identity maps so the
+   comparator can align them across runs. Synchronous
+   direct-dispatch traffic — the devirtualized flavor most
+   intra-app traffic compiles to — is visible here.
+3. **Payloads.** Wire-encoded payloads verbatim; raw in-process
+   structs as *metadata only* (an ABI snapshot would carry heap
+   pointers and padding while being useless for comparison).
+4. **The input journal.** Every user-facing nondeterministic read —
+   `std::time::now`, `std::time::monotonic[_ns]`,
+   `std::rand::next_int`, `std::os::getrandom`, the `std::env`
+   surface — with its exact encoded arguments, per consumer.
+
+**Secrets:** env *values* are withheld from recordings by default —
+names, existence, and lengths are captured; the value itself
+requires `LOTUS_OBS_RECORD_ENV=full`, and the artifact header
+records which policy applied. A withheld read replays as a named
+divergence, never as a substituted value.
+
+Recording changes your program's timing by design; don't leave it
+on in production.
+
+## Replaying one
+
+```sh
+hale replay run.halerec app.hl            # re-execute it
+hale replay run.halerec app.hl --diff     # + compare, fail on any divergence
+hale replay run.halerec app.hl --at 4120  # SIGSTOP at consume #4120
+hale replay run.halerec app.hl --at 65:12 # ...at consumer 65's 12th consume
+```
+
+`hale replay` recompiles the program through the same pipeline as
+`hale run`, then admits the recording — strongest check first:
+
+- **Safety, before anything else.** Re-execution repeats real side
+  effects, so a program whose effect frontier reaches `syscall`,
+  `ffi`, `unclassified`, or any transport-bound `bindings` block is
+  refused with the residue named, unless you pass
+  `--allow-live-effects`. This is deliberately coarse (a lone
+  `sleep` trips it); over-refusing is the safe direction.
+- **Executable identity.** The recording carries a framed SHA-256
+  over the full compiler/runtime/stdlib source tree, the compiler
+  version, build options, and every application source's path,
+  length, and contents. A structurally compatible model with a
+  changed function body is *not* the same executable — it is
+  rejected, with `--allow-unverified-model` as the explicit
+  override for unstamped or divergent-build recordings.
+- **Artifact integrity.** The child re-reads the same validated
+  file object (an inherited descriptor, no path re-resolution
+  window), snapshots the bytes into private memory, and
+  independently re-validates the whole structure.
+
+During re-execution the runtime serves journaled reads back per
+consumer — refusing to serve an entry whose kind or arguments
+differ from the caller's — and re-consumes each consumer's queued
+deliveries in the recorded order, holding early arrivals in a
+per-consumer buffer. **Replay degrades, never refuses**: a read or
+delivery past the recorded history falls back live and is counted,
+and the divergence summary (journal misses, order holds, unconsumed
+or unexpected deliveries) prints at exit. Under `--diff`, *any* of
+those fails the comparison, alongside a bidirectional comparison of
+consume streams, public bus streams, payloads, and journals.
+
+Two pinned publishers racing into one sink replay in exactly the
+interleaving that was recorded — that is the per-consumer order
+enforcement working, and it is pinned by tests that run the race
+repeatedly.
+
+## The coverage boundary, honestly
+
+- **Per consumer, not global.** Each consumer reproduces its own
+  recorded order; cross-consumer wall-clock alignment is not a
+  replay property (and is exactly what the recording never
+  promised).
+- **External ingress re-executes live.** Socket and adapter input
+  is captured in the artifact (flagged as ingress) but not yet
+  injected — a replayed server talks to the real world, which is
+  half of why the safety gate exists. Ingress injection is the
+  fleet-replay milestone.
+- **`where async_io` pools refuse replay** loudly; their coroutine
+  interleaving is a later milestone.
+- **The artifact format is pre-stable** while the remaining phases
+  (fleet replay, replay-under-a-different-plan, durability grades)
+  land.
+
+## Determinism without the recorder
+
+A program whose loci all run on the main scheduler is deterministic
+by construction — same publishes, same deliveries, same order,
+given the same inputs. That is a stated guarantee
+(`spec/testing.md` § Determinism), which means a flaky single-pool
+test is never the scheduler's fault: look for a real input feeding
+the assertion, or mark the code under test
+[`@deterministic`](../effects.md) and let the compiler prove there
+isn't one. The recorder exists for everything that guarantee
+doesn't cover.

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1633,11 +1633,15 @@ input, and re-execution re-derives its payloads.
 
 **Input journal (Phase 3).** Under recording, every user-facing
 nondeterministic read is journaled per consumer as ONE unified
-stream carrying the read's kind AND an argument hash — replay
-refuses to serve an entry whose kind or arguments differ from the
-caller's, so a changed env name, rand bound, or read length is
-the first *named* divergence, never a silently substituted
-plausible value. The interposed set:
+stream carrying the read's kind and its **exact encoded
+arguments** (length-framed; replay memcmps them — hashes proved
+collision-prone), so a changed env name, arg index, rand bound,
+or read length is the first *named* divergence, never a silently
+substituted value. **Env values are withheld by default**: names,
+existence, and lengths are recorded; the value itself requires
+`LOTUS_OBS_RECORD_ENV=full`, the artifact header says which
+policy applied, and a withheld read replays as a named withheld
+divergence. The interposed set:
 `std::time::now`, `std::time::monotonic[_ns]` (now a named
 primitive, `lotus_time_monotonic_ns` — it used to be inline
 `clock_gettime` IR that nothing could interpose),
@@ -1646,25 +1650,41 @@ seed-replay unsound across threads), `std::os::getrandom`, and
 the `std::env` surface. Internal runtime clocks and config
 `getenv`s are deliberately not journaled.
 
-**File format v0.2 (PRE-STABLE).** 64-byte header (magic
+**File format v0.3 (PRE-STABLE).** 96-byte header (magic
 `HALEREC0`, version, pid, ring geometry, epoch anchors,
-`model_hash`), tagged entries — tag 0: 24-byte ring record; tag
-1: payload blob; tag 2: journal blob (32-byte header + bytes
-padded to 8) — and a 16-byte trailer (`HALEEND0` + entry count)
-whose presence marks a clean finalize.
+`model_hash`, a 32-byte framed-SHA-256 `exec_digest`, and policy
+flags), tagged entries — tag 0: 24-byte ring record; tags 1/2/3:
+payload / journal / meta blobs (32-byte header + bytes padded to
+8; meta carries the run-stable topic and public-ring identity
+maps) — and a 16-byte trailer (`HALEEND0` + entry count). A
+recording is *clean* only when the ENTIRE artifact validates:
+exact parse to the trailer position and a matching entry count,
+enforced by the CLI reader and independently by the runtime
+loader (one open + fstat + private mmap, checked arithmetic,
+per-kind value shapes) — trailer magic at EOF alone proves
+nothing. Identity fields are re-stamped at finalize (a prelude
+binding registration can probe — creating the header — before
+the stamps run).
 
 **Replay (`hale replay <recording> <program.hl>`).** Admission,
-strongest check first: the recording's `exec_digest` (compiler
-version + every source byte, stamped at build) must match the
-recompiled program exactly — `shape_hash` alone is structural
-compatibility and admits behaviorally different bodies, so it is
-the secondary check only. An unstamped recording is refused
-without `--allow-unverified-model`. **Safe by default:** replay
-re-executes real side effects, so a program whose effect frontier
-reaches `syscall`/`ffi` beyond the journaled read set is refused
-without an explicit `--allow-live-effects` (coarse by the class
-granularity — over-refusal is the safe direction; per-primitive
-replay classes are the staged refinement). `LOTUS_REPLAY=<path>`
+strongest check first: the recording's `exec_digest` — a framed
+SHA-256 over the toolchain source hash (compiler + runtime +
+stdlib implementation, via the stale-CLI build hash), the CLI
+version, build options, and every source file's full path,
+length, and contents — must match the recompiled program exactly;
+`shape_hash` is structural compatibility only, the secondary
+check. An unstamped recording is refused without
+`--allow-unverified-model`. Stated residue: the digest cannot see
+the LLVM/libc toolchain outside the hale binary; a post-link
+binary digest is the staged stronger form. **Safe by default:**
+replay re-executes real side effects, so the typed effect rows
+gate admission and fail CLOSED on `syscall`, `ffi`,
+`unclassified` ("may do anything"), and any transport-bound
+`bindings` block (the user-level effect of a bound publish is
+`publish`; the send is generated deployment machinery) — all
+refused without an explicit `--allow-live-effects` (coarse by
+class granularity — over-refusal is the safe direction;
+per-primitive replay classes are the staged refinement). `LOTUS_REPLAY=<path>`
 then serves journaled reads back per consumer in recorded order;
 a read past (or mismatching) the recorded history falls back live
 and is counted — **replay degrades, never refuses** (RFC Q6) —
@@ -1678,19 +1698,20 @@ order, with a bounded hold (1s) after which the oldest held cell
 is released and the miss counted, so a genuinely divergent replay
 reports rather than deadlocks. `where async_io` pools refuse
 replay loudly (their coro interleaving is a later milestone).
-The CLI compiles the program through the same pipeline as
-`hale run`, then admits the recording by `model_hash` — a
-recording made from a different model is rejected, never
-misreplayed; a truncated recording (no trailer) is refused.
-`--diff` records the replay and compares bidirectionally: consume
-streams per consumer, payloads both ways (topic + flags + bytes;
-raw-struct payloads by size), and the journal streams — plus the
-runtime verdict above. `--at N` stops (SIGSTOP) at the Nth consume
-process-wide (meaningful for one consumer); `--at consumer:N` is
-the stable multi-consumer form. A recording is admitted only when
-the ENTIRE artifact validates: exact parse to the trailer and a
-matching entry count, not trailer magic at EOF alone. Replay
-implies observation (identity rides the obs machinery).
+`--diff` records the replay (under the original's env policy) and
+compares bidirectionally: per-consumer queued consume streams
+(target locus + msg_id), per-consumer PUBLIC bus streams aligned
+by subject and stable consumer id via the meta maps — which is
+what makes synchronous direct dispatch visible — payloads both
+ways (topic, flags, bytes; raw metadata by declared size), and
+per-consumer journal streams (kind, exact args, withheld state,
+value; grouped per consumer because the drain interleaves
+concurrent threads' entries in incidental order). Any runtime
+divergence fails `--diff` through the verdict. `--at <n>` stops
+(SIGSTOP) at the nth consume process-wide (meaningful for one
+consumer); `--at <consumer-id>:<ordinal>` is the stable
+multi-consumer form. Replay implies observation (identity rides
+the obs machinery).
 
 Two honest limits, stated rather than implied: the recorded
 interleaving is reproduced per consumer, not globally — cross-

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1556,6 +1556,118 @@ v0.11.20):
   with the P15 negative marking. Per-subscriber BUS_DELIVER and
   the topic registration are unchanged.
 
+### Lossless recording mode (GH #296 Phase 1)
+
+`LOTUS_OBS_RECORD=<path>` opts a run into **recording**: the
+observation plane stops being a sampler and becomes a flight
+recorder. Implies `LOTUS_OBS=1`; the recording counts as an
+attached observer, so ring emission is on from the first probe
+with nothing mmapping the segment. Opt-in on the same terms as
+everything else here — unset, the lowering and the wire are
+byte-for-byte the unobserved build (the flag resolves in the same
+constructor as `lotus_obs_live` and gates behind it everywhere).
+
+Three deltas from observer mode, all in the service of one rule —
+**a recording never drops** (a dropped record is a replay that
+diverges silently):
+
+- **Overwrite-oldest becomes block-the-producer.** An in-process
+  drain thread appends every ring record to `<path>` and
+  publishes per-ring cursors; a producer whose ring is full
+  against the cursor waits (50µs naps) instead of clobbering the
+  oldest slot. Recording-on hot cost while the ring has room is
+  one relaxed load + compare per record. A live observer prefers
+  losing records to stalling the program; a recorder makes the
+  opposite trade, and the stall is the contract.
+- **A thread that cannot get a ring fails the run** (exit 70,
+  diagnostic names `LOTUS_OBS_RINGS`) instead of going silently
+  dark forever (the `-2` disposition observer mode keeps).
+  Recording defaults `LOTUS_OBS_RINGS` to the 64 maximum, so this
+  means more than 64 emitting threads. Block or fail — never drop.
+- **A drain-side write failure fails the run** (exit 74) rather
+  than truncating silently. The file ends with a trailer written
+  at teardown after a final full sweep; a reader that does not
+  find the trailer holds a truncated recording and must say so.
+
+**`BUS_CONSUME` (ekind 8, recording mode only).** `BUS_DELIVER`
+is enqueue-time by design and lands on the *publisher's* ring —
+correct for fanout accounting, structurally unable to say in what
+order a consumer actually ran its handlers. Under recording, every
+dequeue-driven handler invoke (main-queue drain, coop-pool drain,
+pinned mailbox drain, async coro start) stamps a consume record on
+the *consuming* thread right before the handler runs:
+`w1 = locus:20 (subscriber) | pub_id:44` (the delivery's identity —
+see Phase 2 below). Its ring position is the per-consumer delivery
+order — the thing a replay serves back. Pairing rule: per queue,
+the k-th consume is the k-th queued delivery (one consumer thread
+per queue, FIFO). The synchronous direct-dispatch flavors
+deliberately emit no consume record: their handler runs at the
+`BUS_DELIVER` position on the same ring, which *is* the
+consumption point. Never emitted under plain `LOTUS_OBS=1`, so
+pre-addendum consumers never see an unknown ekind.
+
+**Delivery identity (Phase 2).** Every queued delivery carries a
+deterministic `pub_id = consumer_id:8 | per-publisher-thread
+seq:36`, re-derivable by a re-executed run without global
+coordination (a publisher thread re-derives its own ids in its
+own order). Consumer ids are stable across runs, unlike pthread
+ids: main = 1, cooperative pool workers = 16 + registration
+index, pinned locus threads = 64 + obs instance id; each ring's
+first record under recording is `EK_CONSUMER` (12) naming its
+claimant. Payload bytes are captured once per queued publish
+(flagged when they arrived as external wire ingress — the
+redispatch mark); the synchronous direct-dispatch flavors
+deliberately capture nothing, since a closed-world same-thread
+call cannot carry external input and re-execution re-derives its
+payloads. `BUS_ENQ` (9) records each queued target at enqueue;
+`BUS_CONSUME` carries `locus:20 | pub_id:44`.
+
+**Input journal (Phase 3).** Under recording, every user-facing
+nondeterministic read is journaled per (consumer, kind):
+`std::time::now`, `std::time::monotonic[_ns]` (now a named
+primitive, `lotus_time_monotonic_ns` — it used to be inline
+`clock_gettime` IR that nothing could interpose),
+`std::rand::next_int` (per call — the global RNG's mutex makes
+seed-replay unsound across threads), `std::os::getrandom`, and
+the `std::env` surface. Internal runtime clocks and config
+`getenv`s are deliberately not journaled.
+
+**File format v0.2 (PRE-STABLE).** 64-byte header (magic
+`HALEREC0`, version, pid, ring geometry, epoch anchors,
+`model_hash`), tagged entries — tag 0: 24-byte ring record; tag
+1: payload blob; tag 2: journal blob (32-byte header + bytes
+padded to 8) — and a 16-byte trailer (`HALEEND0` + entry count)
+whose presence marks a clean finalize.
+
+**Replay (`hale replay <recording> <program.hl>`).**
+`LOTUS_REPLAY=<path>` re-executes against a recording: journaled
+reads are served back per consumer in recorded order; a read past
+the recorded history falls back live and is counted — **replay
+degrades, never refuses** (RFC Q6) — with a divergence summary on
+stderr at exit. Each consumer's queued deliveries are re-consumed
+in the RECORDED order (Phase 4): dequeued cells that arrive ahead
+of their recorded turn are held per-consumer and released in
+order, with a bounded hold (1s) after which the oldest held cell
+is released and the miss counted, so a genuinely divergent replay
+reports rather than deadlocks. `where async_io` pools refuse
+replay loudly (their coro interleaving is a later milestone).
+The CLI compiles the program through the same pipeline as
+`hale run`, then admits the recording by `model_hash` — a
+recording made from a different model is rejected, never
+misreplayed; a truncated recording (no trailer) is refused.
+`--diff` records the replay and reports the first per-consumer
+divergence (consume streams, then payload bytes); `--at N` stops
+the process (SIGSTOP) at the Nth consume for debugger attach.
+Replay implies observation (identity rides the obs machinery).
+
+Two honest limits, stated rather than implied: the recorded
+interleaving is reproduced per consumer, not globally — cross-
+consumer wall-clock alignment is not a replay property; and
+external ingress (sockets, adapters) re-executes LIVE in v1 —
+captured ingress payloads exist in the recording (flagged), but
+injection is the fleet-replay milestone (Phase 5, with #262's
+plan admission for Phase 6's replay-under-a-different-plan).
+
 ### Time
 
 - **Monotonic + wall-clock.** `time::now()` and
@@ -2177,8 +2289,11 @@ Erlang.
   supports module-level hot reload. Lotus's perspective
   hot-reload is more granular and addresses most of the use
   case; full code hot-reload may not be needed.
-- **Determinism mode for tests.** Discussed in `testing.md`;
-  runtime needs to support deterministic scheduling when
-  requested. The cooperative scheduler makes this easier than
-  M:N would have — single-scheduler test mode is fully
-  deterministic by construction.
+- **Determinism mode for tests.** Resolved for the single-pool
+  case: no mode is needed, because single-pool execution is
+  deterministic by construction, and that is now a stated,
+  pinned guarantee rather than an accident — see
+  `spec/testing.md` § Determinism. What remains open is
+  deterministic *re-execution* of multi-pool programs, which is
+  the record/replay track (GH #296) — reproducing a recorded
+  per-consumer order, never constraining live scheduling.

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1589,41 +1589,55 @@ diverges silently):
   at teardown after a final full sweep; a reader that does not
   find the trailer holds a truncated recording and must say so.
 
-**`BUS_CONSUME` (ekind 8, recording mode only).** `BUS_DELIVER`
+**Consume records (private recorder namespace).** `BUS_DELIVER`
 is enqueue-time by design and lands on the *publisher's* ring —
 correct for fanout accounting, structurally unable to say in what
 order a consumer actually ran its handlers. Under recording, every
 dequeue-driven handler invoke (main-queue drain, coop-pool drain,
 pinned mailbox drain, async coro start) stamps a consume record on
 the *consuming* thread right before the handler runs:
-`w1 = locus:20 (subscriber) | pub_id:44` (the delivery's identity —
-see Phase 2 below). Its ring position is the per-consumer delivery
-order — the thing a replay serves back. Pairing rule: per queue,
-the k-th consume is the k-th queued delivery (one consumer thread
-per queue, FIFO). The synchronous direct-dispatch flavors
-deliberately emit no consume record: their handler runs at the
-`BUS_DELIVER` position on the same ring, which *is* the
-consumption point. Never emitted under plain `LOTUS_OBS=1`, so
-pre-addendum consumers never see an unknown ekind.
+`w1 = locus:20 (subscriber) | pub_id:44`. Its ring position is the
+per-consumer delivery order — the thing a replay serves back.
+Pairing rule: per queue, the k-th consume is the k-th queued
+delivery. The synchronous direct-dispatch flavors deliberately emit
+no consume record: their handler runs at the `BUS_DELIVER`
+position, which *is* the consumption point.
+
+Recorder events (`CONSUMER`/`CONSUME`/`ENQ`/`JOURNAL`) live on
+**process-private per-thread rings** in their own event namespace,
+never in the public observation segment: iris protocol ekinds
+8/9/11/12 mean SUPERV_TRANS/PLACEMENT/BINDING_UP/BINDING_DOWN, and
+an observer attaching to a recording process must never decode
+recorder bookkeeping as lifecycle transitions. In the recording
+file, private-ring entries carry the high bit in their ring field,
+so the two namespaces can never be confused.
 
 **Delivery identity (Phase 2).** Every queued delivery carries a
-deterministic `pub_id = consumer_id:8 | per-publisher-thread
-seq:36`, re-derivable by a re-executed run without global
-coordination (a publisher thread re-derives its own ids in its
-own order). Consumer ids are stable across runs, unlike pthread
+deterministic `pub_id = consumer_id:12 | per-publisher-thread
+seq:32`, re-derivable by a re-executed run without global
+coordination. Consumer ids are stable across runs, unlike pthread
 ids: main = 1, cooperative pool workers = 16 + registration
-index, pinned locus threads = 64 + obs instance id; each ring's
-first record under recording is `EK_CONSUMER` (12) naming its
-claimant. Payload bytes are captured once per queued publish
-(flagged when they arrived as external wire ingress — the
-redispatch mark); the synchronous direct-dispatch flavors
-deliberately capture nothing, since a closed-world same-thread
-call cannot carry external input and re-execution re-derives its
-payloads. `BUS_ENQ` (9) records each queued target at enqueue;
-`BUS_CONSUME` carries `locus:20 | pub_id:44`.
+index, pinned locus threads = 64 + obs instance id; threads with
+no stable identity (ingress readers) get run-unique anonymous
+ids, never a shared fallback. Payload bytes are captured once per
+queued publish under a **stable subject hash** (manifest topic
+ids are registration-order and racing publishers register in
+either order). Flags: bit 0 = external wire ingress; bit 1 = raw
+in-process struct bytes — an ABI snapshot (String/Bytes fields
+are pointers, padding is uninitialized) that consumers must
+compare by size only; canonical per-topic recording codecs are
+the staged fix. Wire captures are canonical bytes, unflagged.
+The synchronous direct-dispatch flavors deliberately capture
+nothing: a closed-world same-thread call cannot carry external
+input, and re-execution re-derives its payloads.
 
 **Input journal (Phase 3).** Under recording, every user-facing
-nondeterministic read is journaled per (consumer, kind):
+nondeterministic read is journaled per consumer as ONE unified
+stream carrying the read's kind AND an argument hash — replay
+refuses to serve an entry whose kind or arguments differ from the
+caller's, so a changed env name, rand bound, or read length is
+the first *named* divergence, never a silently substituted
+plausible value. The interposed set:
 `std::time::now`, `std::time::monotonic[_ns]` (now a named
 primitive, `lotus_time_monotonic_ns` — it used to be inline
 `clock_gettime` IR that nothing could interpose),
@@ -1639,12 +1653,25 @@ the `std::env` surface. Internal runtime clocks and config
 padded to 8) — and a 16-byte trailer (`HALEEND0` + entry count)
 whose presence marks a clean finalize.
 
-**Replay (`hale replay <recording> <program.hl>`).**
-`LOTUS_REPLAY=<path>` re-executes against a recording: journaled
-reads are served back per consumer in recorded order; a read past
-the recorded history falls back live and is counted — **replay
-degrades, never refuses** (RFC Q6) — with a divergence summary on
-stderr at exit. Each consumer's queued deliveries are re-consumed
+**Replay (`hale replay <recording> <program.hl>`).** Admission,
+strongest check first: the recording's `exec_digest` (compiler
+version + every source byte, stamped at build) must match the
+recompiled program exactly — `shape_hash` alone is structural
+compatibility and admits behaviorally different bodies, so it is
+the secondary check only. An unstamped recording is refused
+without `--allow-unverified-model`. **Safe by default:** replay
+re-executes real side effects, so a program whose effect frontier
+reaches `syscall`/`ffi` beyond the journaled read set is refused
+without an explicit `--allow-live-effects` (coarse by the class
+granularity — over-refusal is the safe direction; per-primitive
+replay classes are the staged refinement). `LOTUS_REPLAY=<path>`
+then serves journaled reads back per consumer in recorded order;
+a read past (or mismatching) the recorded history falls back live
+and is counted — **replay degrades, never refuses** (RFC Q6) —
+with a divergence summary at exit and a machine-readable verdict
+(`LOTUS_REPLAY_STATUS`) the CLI consumes: journal misses, order
+holds, unconsumed journal entries, and unconsumed deliveries all
+count, and any of them fails `--diff`. Each consumer's queued deliveries are re-consumed
 in the RECORDED order (Phase 4): dequeued cells that arrive ahead
 of their recorded turn are held per-consumer and released in
 order, with a bounded hold (1s) after which the oldest held cell
@@ -1655,10 +1682,15 @@ The CLI compiles the program through the same pipeline as
 `hale run`, then admits the recording by `model_hash` — a
 recording made from a different model is rejected, never
 misreplayed; a truncated recording (no trailer) is refused.
-`--diff` records the replay and reports the first per-consumer
-divergence (consume streams, then payload bytes); `--at N` stops
-the process (SIGSTOP) at the Nth consume for debugger attach.
-Replay implies observation (identity rides the obs machinery).
+`--diff` records the replay and compares bidirectionally: consume
+streams per consumer, payloads both ways (topic + flags + bytes;
+raw-struct payloads by size), and the journal streams — plus the
+runtime verdict above. `--at N` stops (SIGSTOP) at the Nth consume
+process-wide (meaningful for one consumer); `--at consumer:N` is
+the stable multi-consumer form. A recording is admitted only when
+the ENTIRE artifact validates: exact parse to the trailer and a
+matching entry count, not trailer magic at EOF alone. Replay
+implies observation (identity rides the obs machinery).
 
 Two honest limits, stated rather than implied: the recorded
 interleaving is reproduced per consumer, not globally — cross-

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1595,8 +1595,9 @@ correct for fanout accounting, structurally unable to say in what
 order a consumer actually ran its handlers. Under recording, every
 dequeue-driven handler invoke (main-queue drain, coop-pool drain,
 pinned mailbox drain, async coro start) stamps a consume record on
-the *consuming* thread right before the handler runs:
-`w1 = locus:20 (subscriber) | pub_id:44`. Its ring position is the
+the *consuming* thread right before the handler runs, carrying the
+delivery identity: the target locus in the record's id field and
+the full 64-bit `msg_id` in `w1`. Its ring position is the
 per-consumer delivery order — the thing a replay serves back.
 Pairing rule: per queue, the k-th consume is the k-th queued
 delivery. The synchronous direct-dispatch flavors deliberately emit

--- a/spec/testing.md
+++ b/spec/testing.md
@@ -350,6 +350,38 @@ observation records.
 | `bench_iter(n, f)` | not shipped |
 | `hale test` CLI runner | shipped — discovery→compile→run→report driver over `*_test.hl` (`-run`, `--json`) |
 
+## Determinism
+
+**Single-pool execution is deterministic.** A program whose loci
+all run on the main cooperative scheduler — no `placement`
+pinning, no additional pools — produces the same publishes and
+the same deliveries in the same order on every run, given the
+same inputs. This is a guarantee, not an observation: one pool
+is one consumer thread by construction (`spec/runtime.md`
+§ Scheduler — the same invariant dispatch devirtualization rests
+on), handlers run to completion, and the main-thread bus queue
+drains FIFO, so there is no scheduling freedom for an order to
+vary within.
+
+"Given the same inputs" is load-bearing: time, entropy,
+environment, FFI returns, and socket reads are inputs, and a
+program that consumes them may compute differently even though
+its scheduling cannot reorder. Whether a body reaches those
+inputs is a compile-time question — `@deterministic`
+(`spec/verification.md` § Effect assertions) asserts it, and
+`frontier::infer_effects` answers it without any annotation.
+
+Pinned: `crates/hale-codegen/tests/replay_determinism.rs`
+compares the complete ordered `BUS_PUBLISH`/`BUS_DELIVER` record
+sequence of a multi-locus cascade across repeated runs. A
+divergence there is a runtime bug, never a flaky test.
+
+Multi-pool programs get no ordering guarantee across pools
+today: each pool's single consumer thread has a well-defined
+per-consumer delivery order, but the interleaving between pools
+is OS scheduling. Recording that per-consumer order (and
+replaying it) is the record/replay track — GH #296.
+
 ## Property-based testing
 
 Reserved as a future extension. The language's strong
@@ -378,11 +410,13 @@ Actions annotations, etc.) are downstream conversions.
    neither attributes nor magic-name conventions yet. Decision
    pending; probably an attribute (`@bench fn ...`) added to
    the grammar in v0.2.
-2. **Determinism.** For benchmarks, the runtime should be
-   isolatable (no GC pauses to confound; we don't have GC, so
-   that's free). Does the runtime need deterministic
-   scheduling for benchmark consistency? Probably yes for some
-   benchmark classes; opt-in.
+2. **Determinism.** ~~Does the runtime need deterministic
+   scheduling for benchmark consistency?~~ Resolved for the
+   single-pool case: it already has it, by construction — see
+   § Determinism above. Deterministic *re-execution* of
+   multi-pool programs is the record/replay track (GH #296);
+   forcing deterministic scheduling in production is an explicit
+   non-goal there.
 3. **External-language toolchain access.** `hale bench
    -compare` needs `go`, `rustc`, `erlc`, etc. on PATH.
    Documenting this clearly is dev-experience work.

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -1293,7 +1293,13 @@ assume the others in a build:
   annotations cannot: a handler that quietly starts doing filesystem
   I/O shows up as `+ Api::emit … does={syscall,publish,alloc}` in
   review even though no annotation changed. Regenerate deliberately
-  with the dump flag when the change is intended.
+  with the dump flag when the change is intended. Rows recurse
+  through `module` declarations (GH #296 review: a module-contained
+  fn absent from the rows was invisible to both this gate and
+  `hale replay`'s safety admission); an inline-module fn the
+  callgraph summarizer cannot yet resolve renders `does={unclassified}`
+  — fail-closed, and scoped to modules so non-module manifests are
+  unchanged.
 - **Corpus-wide conformance** (GH #265 step 7). Beyond the per-test
   runtime oracle, a sweep over the whole in-tree `.hl` corpus asserts
   three properties everywhere real code lives: no reachable stdlib


### PR DESCRIPTION
Phases 0–4 of #296 plus the CLI. The shipped claim, scoped per review: **re-run a recorded execution and get the same schedule and the same journaled inputs, with an explicit, checked coverage boundary.** External ingress and non-journaled I/O re-execute live and are gated behind `--allow-live-effects`; the full "same outputs" promise arrives with the staged artifact/executor layers (see the review thread).

Hardened by a full review round (2cf0e1a): recorder events on process-private rings (no iris ekind reuse), admission by executable identity (`exec_digest`), safe-by-default effect gating, atomic capture budgeting with fail-closed write paths, whole-artifact validation, bidirectional diff driven by a machine-readable runtime verdict, per-call journal argument identity, widened `pub_id`, and ABI-snapshot payload flagging.

```sh
LOTUS_OBS_RECORD=run.halerec hale run app.hl   # record
hale replay run.halerec app.hl --diff          # re-execute; report first divergence
hale replay run.halerec app.hl --at 4120       # SIGSTOP at consume #4120, attach a debugger
```

## Phase 0 — the determinism guarantee

Single-pool execution was deterministic by accident; it is now deterministic by contract. `spec/testing.md` § Determinism states it, both former "determinism mode" open questions resolve against it, and `replay_determinism.rs` pins it by comparing the complete ordered BUS record stream across repeated runs — with exact-count vacuity guards, per the negative-control discipline from #298.

## Phase 1 — a recording that never drops

`LOTUS_OBS_RECORD=<path>` flips the observation plane's disposition from *drop rather than stall* to *stall rather than drop*: an in-process drain appends every ring record to the file, a producer whose ring is full **blocks** against the drain cursor, a thread that cannot get a ring **fails the run** (exit 70, names `LOTUS_OBS_RINGS`; recording defaults to the 64-ring max first), and a drain write error fails the run (exit 74). A trailer marks clean finalize — a reader that doesn't find it holds a truncated recording and says so.

## Phase 2 — identity and payloads (format v0.3)

Every queued delivery carries `msg_id = consumer_id:16 | per-publisher-thread seq:48` (full width, loudly range-guarded) — deterministic across runs because a re-executed publisher thread re-derives its own ids in its own order, no global coordination. The delivery identity proper is **(target locus, msg_id)** — the consume record carries the target, so two subscribers of one publish on one consumer are distinguishable and the enforcement gate matches both. Consumer ids are stable where pthread ids are not: main = 1, pool workers = 16 + registration index, pinned threads = 64 + obs instance id (stamped from the synthesized `__pinned_main` prologue; anonymous ingress threads get run-unique ids from a disjoint range). Wire captures store canonical bytes; raw in-process structs store **metadata only** (an ABI snapshot would carry pointers, padding, and secret-derived bytes). Public bus records are aligned across runs by file-side identity maps (topic id → subject, public ring → consumer), and the publish probe returns its assigned sequence as a token every deliver probe receives — deliveries name their exact publish even under same-subject races and nested republish. Synchronous direct dispatch captures no payloads, but its public publish/deliver records are compared by `--diff`.

## Phase 3 — the input journal

`std::time::now`, `std::time::monotonic[_ns]`, `std::rand::next_int`, `std::os::getrandom`, and the `std::env` surface journal per consumer under recording and serve back under `LOTUS_REPLAY`. Two findings from building it: **`monotonic`/`monotonic_ns` lowered as inline `clock_gettime` IR** — no symbol, nothing a journal could interpose — so they now route through a named primitive (`lotus_time_monotonic_ns`), the same rationale that made `now` a symbol; and per-call journaling of `rand::next_int` is the only sound choice, because the global RNG's mutex makes seed-replay diverge under any thread interleaving.

A read past the recorded history falls back live and is counted — **replay degrades, never refuses** (the RFC's Q6 preference) — with a divergence summary on stderr at exit.

## Phase 4 — recorded-order enforcement

Each consumer (cooperative pool worker, pinned mailbox, main queue) re-consumes its queued deliveries in the recorded order: early arrivals are held in a per-consumer buffer and released in order, with a bounded (1s) hold after which the oldest held cell is released and the miss counted — a genuinely divergent replay reports rather than deadlocks. `where async_io` pools refuse replay loudly (their coro interleaving is a later milestone). The end-to-end pin: two pinned publishers racing 40+40 deliveries into one sink, replayed twice, both reproducing the recorded interleaving exactly — a coin flip per delivery without enforcement.

## Admission

`hale replay` compiles through the same pipeline as `hale run` and admits by identity, strongest first: a framed SHA-256 `exec_digest` over the full toolchain source tree (parser, analyses, codegen, every runtime TU, stdlib, the replay CLI — via the build-script digest), rustc version, git commit, build options, and every application source's logical path + length + contents. `shape_hash` is the secondary structural check; unstamped recordings need `--allow-unverified-model`; a truncated or internally corrupt artifact is refused by whole-artifact validation (exact trailer position + entry count) in both the CLI reader and the runtime loader, which snapshots the inherited, validated fd's bytes into anonymous memory before serving. Safety admission runs first and fails closed on `syscall`, `ffi`, `unclassified`, and transport-bound `bindings` — recursing through modules — without `--allow-live-effects`. The journal serves per-consumer with exact argument matching; env values are redacted by default (`LOTUS_OBS_RECORD_ENV=full` opts in).

## Cost contract

Unchanged where it matters: the recording and replay flags resolve in the same pre-main constructor as `lotus_obs_live` (the P19 hoist-soundness pattern) and every new site gates behind the existing branch discipline — env unset stays one predictable branch on paths that already paid one.

## Not in this PR, staged in spec + CHANGELOG

Ingress injection + fleet replay (Phase 5 — captured ingress payloads are in the recording, flagged; injection needs `LOTUS_OBS_WIRE` fleet identity), replay-under-a-different-plan (Phase 6, blocked on #262's plan admission), and async_io replay.

## Tests

2560 passed, 0 failed workspace-wide (+9 new: determinism pin, 5 recording-mode tests including losslessness under forced wrap pressure and the ring-exhaustion failure, 3 CLI end-to-end including the racing-interleaving reproduction and both admission rejections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)