### PR TITLE
replay phase 5: durable crash prefixes, hermetic wire, ingress injection, and feed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,63 +8,97 @@ behavior.
 
 ## Unreleased
 
-### Record & replay, phase 5: durability, the hermetic wire, and feed mode (GH #296)
+### Record & replay, phase 5: durable recording, the hermetic wire, and feed mode (GH #296)
 
 Three deliverables close the two loudest gaps in the v0.17.0
 replay story — "a crashed run loses its recording" and "a replayed
-server talks to the real world":
+server talks to the real world" — hardened by a full adversarial
+review round (10 findings, all resolved; the notes below fold
+them in).
 
-**WAL durability.** The drain already appended whole frames in
-stream order; now the header identity (`model_hash`,
-`exec_digest`, policy flags) is stamped eagerly — not only at
-finalize — so a SIGKILLed run leaves an artifact that is
-attributable and exact up to one torn frame at the tail. Replaying
-a trailer-less recording is an explicit opt-in
-(`hale replay --allow-truncated` / `LOTUS_REPLAY_ALLOW_TRUNCATED=1`):
-both loaders stop at the first incomplete frame, report the parsed
-extent and dropped tail bytes, and replay that prefix; `--diff`
-against a truncated baseline compares the recorded prefix (surplus
-replay events past the crash point are not divergences; missing or
-different ones still are). A finalized artifact keeps the exact
-full-parse + count checks. `LOTUS_OBS_RECORD_DURABLE=1` adds an
-`fdatasync` per flushed drain sweep for power-loss durability.
+**Durable recording / crash-prefix recovery.** Named precisely: a
+durable flight recorder, NOT a write-ahead log — the application
+never gates on the recording reaching stable storage. The header
+identity (`model_hash`, `exec_digest`, policy flags) is stamped
+eagerly — not only at finalize — so a SIGKILLed run leaves an
+artifact that is attributable and exact up to one torn frame at
+the tail. Replaying a trailer-less recording is an explicit
+opt-in (`hale replay --allow-truncated` /
+`LOTUS_REPLAY_ALLOW_TRUNCATED=1`): both loaders stop at the first
+incomplete frame, report the parsed extent, and replay that
+prefix. Under `--diff` the runtime verdict and the comparator
+AGREE on prefix semantics: recorded-history-exhausted events
+count into a separate `post_prefix_live_fallback` status key —
+the unknown post-crash suffix, executed live — while any mismatch
+inside the prefix stays a divergence (a withheld env read inside
+the prefix still fails the diff; the surplus past the tape does
+not). A finalized artifact keeps the exact full-parse + count
+checks. `LOTUS_OBS_RECORD_DURABLE=1` is the power-loss grade:
+`fdatasync` per flushed sweep AND on the finalize trailer,
+parent-directory sync at creation, grade recorded in the header.
 
-**Hermetic wire + ingress injection.** Under replay, `bindings`
-transports are suppressed at realization — the entry stays a husk
-(`transport` NULL, the shape the reclaim path already leaves), no
-socket is created, and outbound fanout to bound subjects sends
-nothing (still recorded and compared under `--diff`). In the
-listeners' stead an injector thread re-dispatches the recording's
-ingress tape in artifact order with each delivery's RECORDED
-`pub_id` pinned, so per-consumer order enforcement matches
-injected deliveries to their recorded consumes — replay of a
-server binary with no peers and no network produces byte-identical
-output with zero divergences. To make the tape injectable, reader
-threads now capture each received message's verbatim WIRE bytes
-(the struct-bytes record was metadata-only and could not be
-re-fed), with the identity pinned across the capture-then-dispatch
-pair; the artifact grows a subject-hash → name meta map (subtype
-3) so payloads route and report by name. Consequence: `bindings`
-blocks no longer trip the `--allow-live-effects` gate — the
-remaining residue (`syscall`/`ffi`/`unclassified`) is genuinely
-user-level.
+**Hermetic wire + ingress injection.** Hermeticity is a
+binding-kind capability, not a blanket assumption: native
+`unix://`/`udp://` transports (and the transport-locus form) are
+suppressed at realization — husk entry, no socket, outbound
+fanout sends nothing (still recorded and compared under
+`--diff`) — while a backend with NO replay class fails closed:
+`shm_ring` is refused by the CLI (named) and independently at the
+runtime shm-open seam. Injection runs as an explicit boot phase:
+codegen emits `lotus_replay_start_ingress()` at the main locus's
+boot/run boundary, where the runtime snapshots the subscription
+registry on the main thread (injector workers never read the live
+registry) and spawns one worker per RECORDED ingress source, each
+carrying its source's recorded consumer identity so `--diff`
+aligns per-consumer streams across multiple listeners. Tape
+identity is the full subject string plus the subject's canonical
+payload shape (FNV-32 kept for reporting only — it is
+collision-prone, and a colliding pair now routes correctly by
+name); a shape mismatch refuses injection as *incompatible*
+rather than feeding plausible wrong values. Only ACCEPTED
+messages enter the tape — wire capture runs after the
+deserializer says yes, so rejected traffic is never re-fed.
+Strict injection is PACED against recorded progress (inject one,
+wait for its recorded consumes) so bounded queues shed nothing
+they didn't shed originally. Every tape entry is classified
+(injected / rejected / unmatched / incompatible / unprocessed-at-
+shutdown / start-failure); under strict replay every non-injected
+class is a machine-readable divergence. Found along the way: the
+injector, as a cross-thread producer, must select the locked and
+GATED main-queue drain (`lotus_bus_mark_pinned`) — without it a
+replaying main drained ungated and cross-source order silently
+diverged with a clean verdict. Consequence of hermetic native
+wire: `bindings` blocks with covered backends no longer trip the
+`--allow-live-effects` gate; the remaining residue
+(`syscall`/`ffi`/`unclassified`) is genuinely user-level.
 
-**Feed mode — the backtesting contract.**
-`hale replay --feed rec app.hl` (`LOTUS_REPLAY_FEED=<path>`)
-consumes the recording as an input tape ONLY: recorded ingress
-injected, wire hermetic, and nothing else of replay applies — no
-journal serving, no order enforcement, no model admission (a hash
+**Feed mode — same recorded ingress, changed code, live
+nondeterministic environment.** `hale replay --feed rec app.hl`
+(`LOTUS_REPLAY_FEED=<path>`) consumes the recording as an input
+tape: recorded ingress injected, wire hermetic, no journal
+serving, no order enforcement, no model admission (a hash
 mismatch prints as information; feeding a tape to changed code is
-the point), no effects gate, no `--diff`/`--at`. Same inputs,
-changed code, live everything else. The exit report states how
-many tape entries were injected and how many found no matching
-subject — a dropped tape is a fact, never a silence.
+the point), no `--diff`/`--at`. The effects gate STILL applies —
+`--feed` bypasses identity admission, never effect safety;
+live-effect programs need `--allow-live-effects` beside it. Feed
+targets that dropped or rearranged the listener binding still get
+their tape (tape presence decides injection, not the old
+declaration). The exit report classifies every tape entry, and an
+unfed remainder fails the run by default —
+`--allow-unmatched-feed` is the explicit acceptance.
 
-Tests: SIGKILL-mid-run prefix admissibility (+ the eager identity
-stamp, + the default refusal naming the flag), durable-grade
-finalize, hermetic strict replay (byte-identical stdout, zero
-divergences, socket never created), and feed into a
-different-model program processing the recorded values.
+Tests, beyond the happy paths: SIGKILL-prefix admissibility +
+eager identity stamp + refusal naming the flag; durable-grade
+finalize; hermetic strict replay (byte-identical stdout, zero
+divergences, socket never created); truncated `--allow-truncated
+--diff` accepting the post-crash surplus while an in-prefix
+withheld read still fails; feed requiring the effects gate;
+rejected wire excluded from the tape; the FNV-32 collision pair
+routing by full subject; capacity-one bounded queue replaying
+with zero shedding; feed into a binding-less target; incompatible
+payload shape failing feed closed; `shm_ring` refusing replay
+without touching shared memory; two listeners surviving CLI
+`--diff` with per-source identity.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,22 @@ behavior.
 
 Three deliverables close the two loudest gaps in the v0.17.0
 replay story — "a crashed run loses its recording" and "a replayed
-server talks to the real world" — hardened by a full adversarial
-review round (10 findings, all resolved; the notes below fold
-them in).
+server talks to the real world" — hardened by two full adversarial
+review rounds (10 + 8 findings, all resolved; the notes below fold
+them in). Round two closed the trust boundaries: ONE file object
+carries the recording from CLI admission into the child (no
+reopen, no path-substitution window, plus a runtime
+identity-vs-binary defense for direct invocations); the eager
+crash-identity stamp is a release/acquire COMMIT of the complete
+identity (the old cross-thread reads raced and could persist a
+half-published digest); a header-only 96-byte file — the earliest
+crash window — admits as a prefix under `--allow-truncated`; the
+feed verdict derives its unclassified remainder at report time, so
+an `std::process::exit(0)` before injection can never ride to
+success; and boot-snapshot injection names late-created
+subscribers as their own `late_subscription_uncovered` coverage
+class (a teardown-time registry rescan distinguishes them from
+genuinely absent subscribers).
 
 **Durable recording / crash-prefix recovery.** Named precisely: a
 durable flight recorder, NOT a write-ahead log — the application

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,68 @@ behavior.
 
 ---
 
+## Unreleased
+
+### Record & replay, phase 5: durability, the hermetic wire, and feed mode (GH #296)
+
+Three deliverables close the two loudest gaps in the v0.17.0
+replay story — "a crashed run loses its recording" and "a replayed
+server talks to the real world":
+
+**WAL durability.** The drain already appended whole frames in
+stream order; now the header identity (`model_hash`,
+`exec_digest`, policy flags) is stamped eagerly — not only at
+finalize — so a SIGKILLed run leaves an artifact that is
+attributable and exact up to one torn frame at the tail. Replaying
+a trailer-less recording is an explicit opt-in
+(`hale replay --allow-truncated` / `LOTUS_REPLAY_ALLOW_TRUNCATED=1`):
+both loaders stop at the first incomplete frame, report the parsed
+extent and dropped tail bytes, and replay that prefix; `--diff`
+against a truncated baseline compares the recorded prefix (surplus
+replay events past the crash point are not divergences; missing or
+different ones still are). A finalized artifact keeps the exact
+full-parse + count checks. `LOTUS_OBS_RECORD_DURABLE=1` adds an
+`fdatasync` per flushed drain sweep for power-loss durability.
+
+**Hermetic wire + ingress injection.** Under replay, `bindings`
+transports are suppressed at realization — the entry stays a husk
+(`transport` NULL, the shape the reclaim path already leaves), no
+socket is created, and outbound fanout to bound subjects sends
+nothing (still recorded and compared under `--diff`). In the
+listeners' stead an injector thread re-dispatches the recording's
+ingress tape in artifact order with each delivery's RECORDED
+`pub_id` pinned, so per-consumer order enforcement matches
+injected deliveries to their recorded consumes — replay of a
+server binary with no peers and no network produces byte-identical
+output with zero divergences. To make the tape injectable, reader
+threads now capture each received message's verbatim WIRE bytes
+(the struct-bytes record was metadata-only and could not be
+re-fed), with the identity pinned across the capture-then-dispatch
+pair; the artifact grows a subject-hash → name meta map (subtype
+3) so payloads route and report by name. Consequence: `bindings`
+blocks no longer trip the `--allow-live-effects` gate — the
+remaining residue (`syscall`/`ffi`/`unclassified`) is genuinely
+user-level.
+
+**Feed mode — the backtesting contract.**
+`hale replay --feed rec app.hl` (`LOTUS_REPLAY_FEED=<path>`)
+consumes the recording as an input tape ONLY: recorded ingress
+injected, wire hermetic, and nothing else of replay applies — no
+journal serving, no order enforcement, no model admission (a hash
+mismatch prints as information; feeding a tape to changed code is
+the point), no effects gate, no `--diff`/`--at`. Same inputs,
+changed code, live everything else. The exit report states how
+many tape entries were injected and how many found no matching
+subject — a dropped tape is a fact, never a silence.
+
+Tests: SIGKILL-mid-run prefix admissibility (+ the eager identity
+stamp, + the default refusal naming the flag), durable-grade
+finalize, hermetic strict replay (byte-identical stdout, zero
+divergences, socket never created), and feed into a
+different-model program processing the recorded values.
+
+---
+
 ## v0.17.0 — the run comes back the same (2026-08-13)
 
 ### Record & replay, phases 2–4: `hale replay` (GH #296)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
  "hale-syntax",
  "hale-types",
  "inkwell",
+ "libc",
 ]
 
 [[package]]

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -216,7 +216,7 @@ fn usage() {
     eprintln!("    hale replay <rec> <file.hl>   re-run a LOTUS_OBS_RECORD recording");
     eprintln!("        [--diff: report first divergence, fail on any]");
     eprintln!("        [--at <n> | --at <consumer-id>:<ordinal>: SIGSTOP at that consume]");
-    eprintln!("        [--allow-live-effects] [--allow-unverified-model]");
+    eprintln!("        [--allow-live-effects] [--allow-unverified-model] [--allow-truncated]");
     eprintln!("    hale test  [file | dir]       compile + run *_test.hl (default: cwd)");
     eprintln!("        [-run <substr>] [--json]");
     eprintln!("    hale bench [file | dir]       run *_bench.hl bench_* fns (default: cwd)");
@@ -4922,6 +4922,7 @@ fn run_replay(args: &[String]) -> ExitCode {
     let mut at: Option<String> = None;
     let mut allow_live_effects = false;
     let mut allow_unverified = false;
+    let mut allow_truncated = false;
     let mut i = 0;
     while i < args.len() {
         let a = args[i].as_str();
@@ -4933,6 +4934,9 @@ fn run_replay(args: &[String]) -> ExitCode {
             i += 1;
         } else if a == "--allow-unverified-model" {
             allow_unverified = true;
+            i += 1;
+        } else if a == "--allow-truncated" {
+            allow_truncated = true;
             i += 1;
         } else if a == "--at" {
             // N (process-wide consume ordinal — only meaningful
@@ -4978,7 +4982,8 @@ fn run_replay(args: &[String]) -> ExitCode {
             eprintln!(
                 "usage: hale replay <recording> <program.hl> \
                  [--diff] [--at <n> | --at <consumer-id>:<ordinal>] \
-                 [--allow-live-effects] [--allow-unverified-model]"
+                 [--allow-live-effects] [--allow-unverified-model] \
+                 [--allow-truncated]"
             );
             return ExitCode::from(2);
         }
@@ -4992,13 +4997,21 @@ fn run_replay(args: &[String]) -> ExitCode {
         }
     };
     if !rec.clean {
+        if !allow_truncated {
+            eprintln!(
+                "hale replay: `{}` has no clean-finalize trailer — \
+                 the recording is crash-truncated; re-record, or \
+                 pass --allow-truncated to replay the recorded \
+                 prefix",
+                rec_path.display()
+            );
+            return ExitCode::from(1);
+        }
         eprintln!(
-            "hale replay: `{}` has no clean-finalize trailer — the \
-             recording is truncated and a partial history replays \
-             as a silent divergence; re-record",
+            "hale replay: `{}` has no clean finalize — replaying \
+             the recorded prefix (--allow-truncated)",
             rec_path.display()
         );
-        return ExitCode::from(1);
     }
 
     if !prog.is_file() {
@@ -5220,6 +5233,9 @@ fn run_replay(args: &[String]) -> ExitCode {
     }
     let mut cmd = std::process::Command::new(&bin);
     cmd.env("LOTUS_REPLAY", &rec_abs);
+    if allow_truncated {
+        cmd.env("LOTUS_REPLAY_ALLOW_TRUNCATED", "1");
+    }
     cmd.env("LOTUS_REPLAY_STATUS", &status_path);
     // Round 3 (artifact trust): the CHILD reads the same file
     // OBJECT the CLI validated — the fd is inherited (dup2'd to a
@@ -5324,7 +5340,7 @@ fn run_replay(args: &[String]) -> ExitCode {
             return ExitCode::from(1);
         }
         let result = match replay::parse(v) {
-            Ok(vr) => match replay::diff(&rec, &vr) {
+            Ok(vr) => match replay::diff(&rec, &vr, !rec.clean) {
                 None => {
                     let consumes: usize = rec
                         .consume_streams

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -5007,7 +5007,28 @@ fn run_replay(args: &[String]) -> ExitCode {
         }
     };
 
-    let rec = match replay::parse(&rec_path) {
+    // ONE file object for admission AND execution (review round 2,
+    // finding 1): open O_NOFOLLOW, parse this object, and later dup
+    // THIS descriptor into the child — never reopen the pathname.
+    let rec_file = {
+        use std::os::unix::fs::OpenOptionsExt;
+        match std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&rec_path)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!(
+                    "hale replay: could not open `{}`: {}",
+                    rec_path.display(),
+                    e
+                );
+                return ExitCode::from(1);
+            }
+        }
+    };
+    let rec = match replay::parse_file(&rec_file, &rec_path) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("hale replay: {}", e);
@@ -5253,12 +5274,20 @@ fn run_replay(args: &[String]) -> ExitCode {
         return ExitCode::from(1);
     }
 
-    if rec.env_redacted {
+    if rec.env_redacted && !feed {
+        // (feed does not serve the env journal at all — review
+        // round 2, finding 7: this warning is replay-only.)
         eprintln!(
             "hale replay: this recording withholds env VALUES \
              (default policy; record with LOTUS_OBS_RECORD_ENV=full \
              to include them) — env reads will replay as named \
              withheld divergences"
+        );
+    } else if rec.env_redacted && feed {
+        eprintln!(
+            "hale replay: feed note — the tape withheld env values; \
+             feed does not replay env reads, so the current process \
+             environment is used"
         );
     }
     let rec_abs = rec_path
@@ -5324,44 +5353,34 @@ fn run_replay(args: &[String]) -> ExitCode {
     if allow_truncated {
         cmd.env("LOTUS_REPLAY_ALLOW_TRUNCATED", "1");
     }
+    if allow_unverified {
+        cmd.env("LOTUS_REPLAY_ALLOW_UNVERIFIED", "1");
+    }
     cmd.env("LOTUS_REPLAY_STATUS", &status_path);
-    // Round 3 (artifact trust): the CHILD reads the same file
-    // OBJECT the CLI validated — the fd is inherited (dup2'd to a
-    // fixed number post-fork), so there is no path re-resolution
-    // window between the two validations. The runtime still
-    // revalidates fully and snapshots the bytes into anonymous
-    // memory before serving.
+    // Round 3 + review round 2, finding 1 (artifact trust): the
+    // CHILD reads THE file object the CLI admitted — `rec_file`
+    // itself, opened once at the top, its descriptor dup2'd to a
+    // fixed number post-fork. There is no reopen and therefore no
+    // path re-resolution window. The runtime still independently
+    // revalidates the structure, snapshots the bytes into anonymous
+    // memory, and (defense in depth) refuses a model identity that
+    // disagrees with the binary's own.
     {
         use std::os::unix::io::AsRawFd;
         use std::os::unix::process::CommandExt;
-        match std::fs::File::open(&rec_abs) {
-            Ok(f) => {
-                let raw = f.as_raw_fd();
-                const REPLAY_FD: i32 = 973;
-                cmd.env("LOTUS_REPLAY_FD", REPLAY_FD.to_string());
-                unsafe {
-                    cmd.pre_exec(move || {
-                        if libc::dup2(raw, REPLAY_FD) < 0 {
-                            return Err(
-                                std::io::Error::last_os_error(),
-                            );
-                        }
-                        Ok(())
-                    });
+        let raw = rec_file.as_raw_fd();
+        const REPLAY_FD: i32 = 973;
+        cmd.env("LOTUS_REPLAY_FD", REPLAY_FD.to_string());
+        unsafe {
+            cmd.pre_exec(move || {
+                if libc::dup2(raw, REPLAY_FD) < 0 {
+                    return Err(std::io::Error::last_os_error());
                 }
-                // Keep the File alive across spawn.
-                std::mem::forget(f);
-            }
-            Err(e) => {
-                eprintln!(
-                    "hale replay: could not reopen `{}` for the \
-                     child: {}",
-                    rec_abs.display(),
-                    e
-                );
-                return ExitCode::from(1);
-            }
+                Ok(())
+            });
         }
+        // Keep the admitted File alive across spawn.
+        std::mem::forget(rec_file);
     }
     if let Some(spec) = &at {
         match spec.split_once(':') {
@@ -5381,6 +5400,14 @@ fn run_replay(args: &[String]) -> ExitCode {
         // redacted one and reports a spurious withheld divergence.
         if !rec.env_redacted {
             cmd.env("LOTUS_OBS_RECORD_ENV", "full");
+        }
+    }
+    // Test hook (review round 2, finding 1): hold between admission
+    // and spawn so the one-object invariant can be tested against a
+    // deliberate path replacement, deterministically.
+    if let Ok(hold) = std::env::var("HALE_REPLAY_TEST_HOLD") {
+        while !std::path::Path::new(&hold).exists() {
+            std::thread::sleep(std::time::Duration::from_millis(20));
         }
     }
     let status = cmd.status();

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -218,6 +218,7 @@ fn usage() {
     eprintln!("        [--at <n> | --at <consumer-id>:<ordinal>: SIGSTOP at that consume]");
     eprintln!("        [--allow-live-effects] [--allow-unverified-model] [--allow-truncated]");
     eprintln!("        [--feed: inject the recorded ingress tape into (possibly changed) code]");
+    eprintln!("        [--allow-unmatched-feed: accept a partially-fed tape]");
     eprintln!("    hale test  [file | dir]       compile + run *_test.hl (default: cwd)");
     eprintln!("        [-run <substr>] [--json]");
     eprintln!("    hale bench [file | dir]       run *_bench.hl bench_* fns (default: cwd)");
@@ -4925,6 +4926,7 @@ fn run_replay(args: &[String]) -> ExitCode {
     let mut allow_unverified = false;
     let mut allow_truncated = false;
     let mut feed = false;
+    let mut allow_unmatched_feed = false;
     let mut i = 0;
     while i < args.len() {
         let a = args[i].as_str();
@@ -4942,6 +4944,9 @@ fn run_replay(args: &[String]) -> ExitCode {
             i += 1;
         } else if a == "--feed" {
             feed = true;
+            i += 1;
+        } else if a == "--allow-unmatched-feed" {
+            allow_unmatched_feed = true;
             i += 1;
         } else if a == "--at" {
             // N (process-wide consume ordinal — only meaningful
@@ -4996,7 +5001,7 @@ fn run_replay(args: &[String]) -> ExitCode {
                 "usage: hale replay <recording> <program.hl> \
                  [--diff] [--at <n> | --at <consumer-id>:<ordinal>] \
                  [--allow-live-effects] [--allow-unverified-model] \
-                 [--allow-truncated] [--feed]"
+                 [--allow-truncated] [--feed] [--allow-unmatched-feed]"
             );
             return ExitCode::from(2);
         }
@@ -5072,6 +5077,46 @@ fn run_replay(args: &[String]) -> ExitCode {
     );
     let digest = exec_digest(&sources, &prog, &options_fp);
 
+    // GH #296 phase 5b (review round): a binding backend with no
+    // replay class cannot be suppressed OR injected — replaying or
+    // feeding a program that carries one would touch live shared
+    // memory. Fail closed with the backend named; no flag overrides
+    // this (the runtime independently refuses at open). Applies to
+    // strict replay and feed alike.
+    {
+        fn scan_shm_ring(items: &[hale_syntax::ast::TopDecl]) -> bool {
+            items.iter().any(|item| match item {
+                hale_syntax::ast::TopDecl::Locus(l) => {
+                    l.members.iter().any(|m| match m {
+                        hale_syntax::ast::LocusMember::Bindings(b) => {
+                            b.entries.iter().any(|e| {
+                                matches!(
+                                    e.transport,
+                                    hale_syntax::ast::TransportSpec::ShmRing { .. }
+                                )
+                            })
+                        }
+                        _ => false,
+                    })
+                }
+                hale_syntax::ast::TopDecl::Module(md) => {
+                    scan_shm_ring(&md.items)
+                }
+                _ => false,
+            })
+        }
+        if bundle.programs.values().any(|p| scan_shm_ring(&p.items)) {
+            eprintln!(
+                "hale replay: this program binds a `shm_ring` — that \
+                 backend has no replay class yet (it cannot be \
+                 suppressed or injected, and a replayed/fed process \
+                 must not touch live shared memory). Remove the \
+                 binding or re-record without it (GH #296)"
+            );
+            return ExitCode::from(1);
+        }
+    }
+
     // Ordered BEFORE identity admission: this refusal is inherent
     // to the PROGRAM, so it must not be masked by a
     // recording-mismatch message (and module-gate canaries can
@@ -5085,7 +5130,11 @@ fn run_replay(args: &[String]) -> ExitCode {
     // machinery, invisible in user-level effects). Coarse by class
     // granularity — over-refusing is the safe direction;
     // per-primitive replay classes are the staged refinement.
-    if !allow_live_effects && !feed {
+    // phase 5b review round: --feed bypasses IDENTITY admission
+    // (changed code is its point), never EFFECT safety — feeding a
+    // tape is not an opt-in to live syscalls/FFI. Both flags
+    // together are the explicit backtest-with-live-effects spelling.
+    if !allow_live_effects {
         let programs: Vec<&Program> =
             bundle.programs.values().copied().collect();
         let rows =
@@ -5123,12 +5172,15 @@ fn run_replay(args: &[String]) -> ExitCode {
                 _ => false,
             })
         }
-        // phase 5b: `bindings { }` no longer forces the flag — the
-        // runtime suppresses bound transports under replay (opens
-        // nothing, sends nothing) and injects the recorded ingress
-        // tape in the listeners' stead. The residue that remains is
-        // genuinely user-level: syscall/ffi writes repeat,
-        // unclassified may do anything.
+        // phase 5b: native unix/udp `bindings { }` no longer force
+        // the flag — the runtime suppresses those transports under
+        // replay (opens nothing, sends nothing) and injects the
+        // recorded ingress tape in the listeners' stead. Hermeticity
+        // is a BINDING-KIND capability, not a blanket assumption
+        // (review round): a backend with no replay class fails
+        // CLOSED below. The residue that remains here is genuinely
+        // user-level: syscall/ffi writes repeat, unclassified may do
+        // anything.
         let _ = scan_bindings;
         if !residue.is_empty() {
             eprintln!(
@@ -5263,6 +5315,9 @@ fn run_replay(args: &[String]) -> ExitCode {
     let mut cmd = std::process::Command::new(&bin);
     if feed {
         cmd.env("LOTUS_REPLAY_FEED", &rec_abs);
+        if allow_unmatched_feed {
+            cmd.env("LOTUS_REPLAY_FEED_ALLOW_UNMATCHED", "1");
+        }
     } else {
         cmd.env("LOTUS_REPLAY", &rec_abs);
     }
@@ -5349,7 +5404,9 @@ fn run_replay(args: &[String]) -> ExitCode {
         .map(|body| {
             body.lines()
                 .filter_map(|l| l.split_once('='))
-                .filter(|(k, _)| *k != "consumes")
+                .filter(|(k, _)| {
+                    *k != "consumes" && *k != "post_prefix_live_fallback"
+                })
                 .filter_map(|(_, v)| v.trim().parse::<u64>().ok())
                 .sum()
         })

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -217,6 +217,7 @@ fn usage() {
     eprintln!("        [--diff: report first divergence, fail on any]");
     eprintln!("        [--at <n> | --at <consumer-id>:<ordinal>: SIGSTOP at that consume]");
     eprintln!("        [--allow-live-effects] [--allow-unverified-model] [--allow-truncated]");
+    eprintln!("        [--feed: inject the recorded ingress tape into (possibly changed) code]");
     eprintln!("    hale test  [file | dir]       compile + run *_test.hl (default: cwd)");
     eprintln!("        [-run <substr>] [--json]");
     eprintln!("    hale bench [file | dir]       run *_bench.hl bench_* fns (default: cwd)");
@@ -4923,6 +4924,7 @@ fn run_replay(args: &[String]) -> ExitCode {
     let mut allow_live_effects = false;
     let mut allow_unverified = false;
     let mut allow_truncated = false;
+    let mut feed = false;
     let mut i = 0;
     while i < args.len() {
         let a = args[i].as_str();
@@ -4937,6 +4939,9 @@ fn run_replay(args: &[String]) -> ExitCode {
             i += 1;
         } else if a == "--allow-truncated" {
             allow_truncated = true;
+            i += 1;
+        } else if a == "--feed" {
+            feed = true;
             i += 1;
         } else if a == "--at" {
             // N (process-wide consume ordinal — only meaningful
@@ -4976,6 +4981,14 @@ fn run_replay(args: &[String]) -> ExitCode {
             return ExitCode::from(2);
         }
     }
+    if feed && (diff || at.is_some()) {
+        eprintln!(
+            "hale replay: --feed re-executes changed code against \
+             the recorded ingress tape — there is no recorded \
+             schedule to --diff against or --at-stop on"
+        );
+        return ExitCode::from(2);
+    }
     let (rec_path, prog) = match (rec_arg, prog) {
         (Some(r), Some(p)) => (r, p),
         _ => {
@@ -4983,7 +4996,7 @@ fn run_replay(args: &[String]) -> ExitCode {
                 "usage: hale replay <recording> <program.hl> \
                  [--diff] [--at <n> | --at <consumer-id>:<ordinal>] \
                  [--allow-live-effects] [--allow-unverified-model] \
-                 [--allow-truncated]"
+                 [--allow-truncated] [--feed]"
             );
             return ExitCode::from(2);
         }
@@ -5072,7 +5085,7 @@ fn run_replay(args: &[String]) -> ExitCode {
     // machinery, invisible in user-level effects). Coarse by class
     // granularity — over-refusing is the safe direction;
     // per-primitive replay classes are the staged refinement.
-    if !allow_live_effects {
+    if !allow_live_effects && !feed {
         let programs: Vec<&Program> =
             bundle.programs.values().copied().collect();
         let rows =
@@ -5110,17 +5123,18 @@ fn run_replay(args: &[String]) -> ExitCode {
                 _ => false,
             })
         }
-        let has_bindings =
-            bundle.programs.values().any(|p| scan_bindings(&p.items));
-        if has_bindings {
-            residue.insert("external-bindings".to_string());
-        }
+        // phase 5b: `bindings { }` no longer forces the flag — the
+        // runtime suppresses bound transports under replay (opens
+        // nothing, sends nothing) and injects the recorded ingress
+        // tape in the listeners' stead. The residue that remains is
+        // genuinely user-level: syscall/ffi writes repeat,
+        // unclassified may do anything.
+        let _ = scan_bindings;
         if !residue.is_empty() {
             eprintln!(
                 "hale replay: this program can reach the live world \
-                 during re-execution ({{{}}}) — publishes to bound \
-                 topics send real traffic, unclassified calls may \
-                 do anything, and syscall/ffi writes repeat. \
+                 during re-execution ({{{}}}) — unclassified calls \
+                 may do anything, and syscall/ffi writes repeat. \
                  Refusing by default; pass --allow-live-effects if \
                  you accept that",
                 residue.into_iter().collect::<Vec<_>>().join(", ")
@@ -5133,7 +5147,21 @@ fn run_replay(args: &[String]) -> ExitCode {
     // exec_digest is framed-SHA-256 build-input identity;
     // shape_hash alone is only structural compatibility and admits
     // behaviorally different bodies.
-    if rec.exec_digest != [0; 4] && rec.exec_digest != digest {
+    //
+    // phase 5b, feed mode: admission is DELIBERATELY not required —
+    // feeding a tape to changed code is the entire point. Say what
+    // is being fed to what, and skip the checks.
+    if feed {
+        if rec.model_hash != model_hash {
+            eprintln!(
+                "hale replay: feed — recording is from model \
+                 {:016x}, this program is {:016x} (admission not \
+                 required in feed mode; subjects matched by name)",
+                rec.model_hash, model_hash
+            );
+        }
+    }
+    if !feed && rec.exec_digest != [0; 4] && rec.exec_digest != digest {
         eprintln!(
             "hale replay: `{}` was recorded from different build \
              inputs (recorded exec digest {:016x}…, this compile \
@@ -5148,7 +5176,7 @@ fn run_replay(args: &[String]) -> ExitCode {
             return ExitCode::from(1);
         }
     }
-    if rec.model_hash != 0 && rec.model_hash != model_hash {
+    if !feed && rec.model_hash != 0 && rec.model_hash != model_hash {
         eprintln!(
             "hale replay: `{}` was recorded from a different model \
              (recorded shape_hash {:016x}, this program is {:016x}) \
@@ -5160,7 +5188,8 @@ fn run_replay(args: &[String]) -> ExitCode {
         );
         return ExitCode::from(1);
     }
-    if (rec.exec_digest == [0; 4] || rec.model_hash == 0)
+    if !feed
+        && (rec.exec_digest == [0; 4] || rec.model_hash == 0)
         && !allow_unverified
     {
         eprintln!(
@@ -5232,7 +5261,11 @@ fn run_replay(args: &[String]) -> ExitCode {
             .open(&status_path);
     }
     let mut cmd = std::process::Command::new(&bin);
-    cmd.env("LOTUS_REPLAY", &rec_abs);
+    if feed {
+        cmd.env("LOTUS_REPLAY_FEED", &rec_abs);
+    } else {
+        cmd.env("LOTUS_REPLAY", &rec_abs);
+    }
     if allow_truncated {
         cmd.env("LOTUS_REPLAY_ALLOW_TRUNCATED", "1");
     }

--- a/crates/hale-cli/src/replay.rs
+++ b/crates/hale-cli/src/replay.rs
@@ -89,9 +89,28 @@ pub struct Recording {
 }
 
 pub fn parse(path: &Path) -> Result<Recording, String> {
-    let buf = std::fs::read(path)
+    let file = std::fs::File::open(path)
+        .map_err(|e| format!("could not open `{}`: {}", path.display(), e))?;
+    parse_file(&file, path)
+}
+
+/// Parse from an ALREADY-OPEN file object (review round 2, finding
+/// 1): admission and execution must read the same object — the CLI
+/// opens the recording once, parses through this, and hands a dup
+/// of the SAME descriptor to the child. Reopening the pathname
+/// between admission and spawn is a replacement window.
+pub fn parse_file(file: &std::fs::File, path: &Path) -> Result<Recording, String> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut f = file;
+    f.seek(SeekFrom::Start(0))
+        .map_err(|e| format!("could not seek `{}`: {}", path.display(), e))?;
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf)
         .map_err(|e| format!("could not read `{}`: {}", path.display(), e))?;
-    if buf.len() < 112 || u64_at(&buf, 0) != REC_MAGIC {
+    // 96 = the header alone: a header-only file is the earliest
+    // valid crash prefix (review round 2, finding 3 — the old 112
+    // demanded a trailer that a crash never writes).
+    if buf.len() < 96 || u64_at(&buf, 0) != REC_MAGIC {
         return Err(format!(
             "`{}` is not a hale recording (bad magic or too small)",
             path.display()

--- a/crates/hale-cli/src/replay.rs
+++ b/crates/hale-cli/src/replay.rs
@@ -8,6 +8,12 @@
 //! padded to 8), 16-byte clean-finalize trailer. `clean` means the
 //! WHOLE artifact validated: exact parse to the trailer and a
 //! matching entry count — trailer magic at EOF alone proves nothing.
+//!
+//! GH #296 phase 5 (WAL durability): a file WITHOUT the trailer is a
+//! crash-truncated recording. The drain appends whole frames in
+//! stream order, so the prefix is exact up to one torn frame at the
+//! tail — parsing stops there (`clean: false`) instead of erroring,
+//! and `hale replay --allow-truncated` replays that prefix.
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -143,6 +149,10 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
         match tag {
             0 => {
                 if end - off < 24 {
+                    if !has_trailer {
+                        total_entries -= 1;
+                        break;
+                    }
                     return Err("truncated ring record".into());
                 }
                 ring_records += 1;
@@ -174,16 +184,28 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
             }
             1 | 2 | 3 => {
                 if end - off < 32 {
+                    if !has_trailer {
+                        total_entries -= 1;
+                        break;
+                    }
                     return Err("truncated blob header".into());
                 }
                 let b = u64_at(&buf, off + 8);
                 let c = u64_at(&buf, off + 16);
                 let size = u64_at(&buf, off + 24) as usize;
                 if size > end - off - 32 {
+                    if !has_trailer {
+                        total_entries -= 1;
+                        break;
+                    }
                     return Err("blob length out of range".into());
                 }
                 let padded = (size + 7) & !7;
                 if padded > end - off - 32 {
+                    if !has_trailer {
+                        total_entries -= 1;
+                        break;
+                    }
                     return Err("blob padding out of range".into());
                 }
                 let bytes = &buf[off + 32..off + 32 + size];
@@ -330,11 +352,22 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
 /// (topic, flags, bytes; raw ABI snapshots by declared size), and
 /// per-consumer journal streams (kind, args, withheld state, value).
 /// Returns None when equivalent, or the first divergence.
-pub fn diff(original: &Recording, replayed: &Recording) -> Option<String> {
+///
+/// `prefix_only` (a truncated baseline, GH #296 phase 5): the
+/// recording is a crash-cut prefix, so the replay legitimately runs
+/// PAST it — surplus replay events are not divergences, but anything
+/// inside the recorded extent still must match exactly, and a replay
+/// that produces LESS than the recording did still diverges.
+pub fn diff(
+    original: &Recording,
+    replayed: &Recording,
+    prefix_only: bool,
+) -> Option<String> {
     fn stream_diff<T: PartialEq + std::fmt::Debug>(
         what: &str,
         a: &[(u64, Vec<T>)],
         b: &[(u64, Vec<T>)],
+        prefix_only: bool,
     ) -> Option<String> {
         for (cid, orig) in a {
             let rep = b
@@ -356,7 +389,9 @@ pub fn diff(original: &Recording, replayed: &Recording) -> Option<String> {
                     ));
                 }
             }
-            if orig.len() != rep.len() {
+            if orig.len() != rep.len()
+                && !(prefix_only && rep.len() > orig.len())
+            {
                 return Some(format!(
                     "consumer {}: {} {}s recorded, {} replayed",
                     cid,
@@ -366,13 +401,15 @@ pub fn diff(original: &Recording, replayed: &Recording) -> Option<String> {
                 ));
             }
         }
-        for (cid, v) in b {
-            if !v.is_empty() && !a.iter().any(|(c, _)| c == cid) {
-                return Some(format!(
-                    "consumer {} produced {}s in the replay but not \
-                     in the recording",
-                    cid, what
-                ));
+        if !prefix_only {
+            for (cid, v) in b {
+                if !v.is_empty() && !a.iter().any(|(c, _)| c == cid) {
+                    return Some(format!(
+                        "consumer {} produced {}s in the replay but \
+                         not in the recording",
+                        cid, what
+                    ));
+                }
             }
         }
         None
@@ -382,6 +419,7 @@ pub fn diff(original: &Recording, replayed: &Recording) -> Option<String> {
         "queued consume",
         &original.consume_streams,
         &replayed.consume_streams,
+        prefix_only,
     ) {
         return Some(d);
     }
@@ -389,6 +427,7 @@ pub fn diff(original: &Recording, replayed: &Recording) -> Option<String> {
         "public bus event",
         &original.public_streams,
         &replayed.public_streams,
+        prefix_only,
     ) {
         return Some(d);
     }
@@ -426,13 +465,15 @@ pub fn diff(original: &Recording, replayed: &Recording) -> Option<String> {
             }
         }
     }
-    for r in &replayed.payloads {
-        if !original.payloads.iter().any(|p| p.pub_id == r.pub_id) {
-            return Some(format!(
-                "replay produced publish {:#x} (topic {}) that the \
-                 recording does not contain",
-                r.pub_id, r.topic
-            ));
+    if !prefix_only {
+        for r in &replayed.payloads {
+            if !original.payloads.iter().any(|p| p.pub_id == r.pub_id) {
+                return Some(format!(
+                    "replay produced publish {:#x} (topic {}) that \
+                     the recording does not contain",
+                    r.pub_id, r.topic
+                ));
+            }
         }
     }
 
@@ -462,7 +503,7 @@ pub fn diff(original: &Recording, replayed: &Recording) -> Option<String> {
     }
     let a = by_consumer(&original.journal);
     let b = by_consumer(&replayed.journal);
-    if let Some(d) = stream_diff("journal read", &a, &b) {
+    if let Some(d) = stream_diff("journal read", &a, &b, prefix_only) {
         return Some(d);
     }
     None

--- a/crates/hale-cli/src/replay.rs
+++ b/crates/hale-cli/src/replay.rs
@@ -33,6 +33,7 @@ const EK_BUS_DELIVER: u32 = 2;
 
 const META_TOPIC: u64 = 1;
 const META_PUBRING: u64 = 2;
+const META_SUBJHASH: u64 = 3;
 
 fn u32_at(b: &[u8], off: usize) -> u32 {
     u32::from_le_bytes(b[off..off + 4].try_into().unwrap())
@@ -262,6 +263,11 @@ pub fn parse(path: &Path) -> Result<Recording, String> {
                         }
                         META_PUBRING => {
                             pub_ring_consumer.insert(a, c);
+                        }
+                        META_SUBJHASH => {
+                            // phase 5b: subject-hash → name map, a
+                            // replay-runtime (injection) concern.
+                            // Validated by shape, carried nowhere.
                         }
                         _ => {
                             return Err(format!(

--- a/crates/hale-cli/src/replay.rs
+++ b/crates/hale-cli/src/replay.rs
@@ -9,7 +9,7 @@
 //! WHOLE artifact validated: exact parse to the trailer and a
 //! matching entry count — trailer magic at EOF alone proves nothing.
 //!
-//! GH #296 phase 5 (WAL durability): a file WITHOUT the trailer is a
+//! GH #296 phase 5 (durable recording): a file WITHOUT the trailer is a
 //! crash-truncated recording. The drain appends whole frames in
 //! stream order, so the prefix is exact up to one torn frame at the
 //! tail — parsing stops there (`clean: false`) instead of erroring,

--- a/crates/hale-cli/tests/replay_cli.rs
+++ b/crates/hale-cli/tests/replay_cli.rs
@@ -1010,6 +1010,7 @@ fn two_listeners_replay_clean_under_diff() {
         nanos
     );
     let sock_b = format!("{}.b", sock_a);
+    let ready = dir.join("sub-ready");
     let sub = dir.join("sub.hl");
     std::fs::write(
         &sub,
@@ -1036,18 +1037,28 @@ main locus App {{
         B: unix("{}", role: listen);
     }}
     run() {{
+        // run() begins only after EVERY boot registration — this
+        // write is the true readiness signal (the sockets exist
+        // earlier, at realize, when the subscribers may not yet be
+        // registered; a message in that window drops silently).
+        std::io::fs::write_file("{}", "ready") or discard;
+        // Wait for BOTH pairs: a message consumed during the
+        // teardown flush gets no consume record, and would replay
+        // as an unexpected delivery.
         let mut waited = 0;
-        while self.sa.seen < 1 || self.sb.seen < 1 {{
+        while self.sa.seen < 2 || self.sb.seen < 2 {{
             std::time::sleep(100ms);
             waited = waited + 1;
-            if waited > 200 {{ std::process::exit(3); }}
+            if waited > 300 {{ std::process::exit(3); }}
         }}
-        std::time::sleep(400ms);
+        std::time::sleep(300ms);
     }}
 }}
 fn main() {{ App {{ }}; }}
 "#,
-            sock_a, sock_b
+            sock_a,
+            sock_b,
+            ready.display()
         ),
     )
     .unwrap();
@@ -1067,13 +1078,16 @@ main locus App {{
         B: unix("{}", role: connect);
     }}
     run() {{
-        std::time::sleep(900ms);
         A <- TA {{ n: 11 }};
         B <- TB {{ n: 21 }};
         std::time::sleep(50ms);
         A <- TA {{ n: 12 }};
         B <- TB {{ n: 22 }};
-        std::time::sleep(200ms);
+        // Long settle before close: a storm-descheduled reader that
+        // has not drained its socket when the peer closes can lose
+        // the tail message (live-ingest behavior, tracked
+        // separately) — give it ample room.
+        std::time::sleep(900ms);
     }}
 }}
 fn main() {{ App {{ }}; }}
@@ -1083,28 +1097,69 @@ fn main() {{ App {{ }}; }}
     )
     .unwrap();
 
+    // Record a CLEAN four-message session — the test's PRECONDITION,
+    // not its subject. Under extreme parallel load a LIVE run very
+    // occasionally loses one mid-stream wire message even with the
+    // ready-file handshake (a rare pre-existing live-ingest race,
+    // independent of replay; tracked separately). The sub exits 3
+    // when a message went missing; retry the session rather than
+    // fail replay assertions on a recording of a lossy live run.
     let rec = dir.join("two.halerec");
-    let mut subp = hale()
-        .arg("run")
-        .arg(&sub)
-        .env("LOTUS_OBS_RECORD", &rec)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .expect("spawn recorded sub");
-    let p = hale().arg("run").arg(&pubs).output().expect("pubs");
-    assert!(
-        p.status.success(),
-        "publisher run failed: {}",
-        String::from_utf8_lossy(&p.stderr)
-    );
-    let out = subp.wait_with_output().expect("sub exit");
-    assert!(
-        out.status.success(),
-        "recorded two-listener run failed:\nstdout:{}\nstderr:{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
-    );
+    let mut recorded_ok = false;
+    for _attempt in 0..5 {
+        let _ = std::fs::remove_file(&rec);
+        let _ = std::fs::remove_file(&ready);
+        let _ = std::fs::remove_file(&sock_a);
+        let _ = std::fs::remove_file(&sock_b);
+        let mut subp = hale()
+            .arg("run")
+            .arg(&sub)
+            .env("LOTUS_OBS_RECORD", &rec)
+            .env("LOTUS_BUS_LOG_DESERIALIZE_DROP", "1")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn recorded sub");
+        // The sockets appear at realize — BEFORE the subscribers
+        // register. The sub touches the ready file at the top of
+        // run(), after every boot registration: only then may
+        // traffic flow.
+        let deadline = std::time::Instant::now()
+            + std::time::Duration::from_secs(60);
+        while !ready.exists() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "subscriber never reached run()"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        let p = hale().arg("run").arg(&pubs).output().expect("pubs");
+        assert!(
+            p.status.success(),
+            "publisher run failed: {}",
+            String::from_utf8_lossy(&p.stderr)
+        );
+        let out = subp.wait_with_output().expect("sub exit");
+        if out.status.success() {
+            recorded_ok = true;
+            break;
+        }
+        assert_eq!(
+            out.status.code(),
+            Some(3),
+            "recorded run failed for a reason other than the known \
+             live-loss retry case:\nstdout:{}\nstderr:{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        eprintln!(
+            "lossy attempt {}: stdout:{} stderr:{}",
+            _attempt,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    assert!(recorded_ok, "no clean recorded session in 5 attempts");
 
     let _ = std::fs::remove_file(&sock_a);
     let _ = std::fs::remove_file(&sock_b);

--- a/crates/hale-cli/tests/replay_cli.rs
+++ b/crates/hale-cli/tests/replay_cli.rs
@@ -1100,8 +1100,9 @@ fn main() {{ App {{ }}; }}
     // Record a CLEAN four-message session — the test's PRECONDITION,
     // not its subject. Under extreme parallel load a LIVE run very
     // occasionally loses one mid-stream wire message even with the
-    // ready-file handshake (a rare pre-existing live-ingest race,
-    // independent of replay; tracked separately). The sub exits 3
+    // ready-file handshake (pre-existing live-ingest loss,
+    // tracked as GH #468 — delete this retry when it lands). The
+    // sub exits 3
     // when a message went missing; retry the session rather than
     // fail replay assertions on a recording of a lossy live run.
     let rec = dir.join("two.halerec");
@@ -1179,5 +1180,159 @@ fn main() {{ App {{ }}; }}
         stdout,
         stderr
     );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// One file object from admission to child (review round 2, finding
+/// 1): after the CLI admits recording A, atomically replacing the
+/// PATH with recording B must not change what the child replays —
+/// the child inherits the admitted descriptor, never a reopen.
+#[test]
+fn admitted_object_survives_path_replacement() {
+    let dir = workdir("toctou");
+    let prog = dir.join("argsy.hl");
+    std::fs::write(
+        &prog,
+        r#"
+main locus App {
+    run() {
+        let n = std::env::args_count();
+        println("args=", n);
+    }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    // Recording A: no extra argv. Recording B: three extra argv.
+    // args_count is journaled, so each replay prints its OWN tape's
+    // count — a perfect witness for which artifact was consumed.
+    let rec_a = dir.join("a.halerec");
+    let out = hale()
+        .arg("run")
+        .arg(&prog)
+        .env("LOTUS_OBS_RECORD", &rec_a)
+        .output()
+        .expect("record a");
+    assert!(out.status.success());
+    let a_line = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .next()
+        .unwrap()
+        .to_string();
+    let rec_b = dir.join("b.halerec");
+    let out = hale()
+        .arg("run")
+        .arg(&prog)
+        .arg("x")
+        .arg("y")
+        .arg("z")
+        .env("LOTUS_OBS_RECORD", &rec_b)
+        .output()
+        .expect("record b");
+    assert!(out.status.success());
+    let b_line = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .next()
+        .unwrap()
+        .to_string();
+    assert_ne!(a_line, b_line, "the two tapes must be distinguishable");
+
+    // Replay the path currently holding A, pausing between admission
+    // and spawn; swap B in during the pause.
+    let target = dir.join("swap.halerec");
+    std::fs::copy(&rec_a, &target).unwrap();
+    let go = dir.join("go");
+    let mut child = hale()
+        .arg("replay")
+        .arg(&target)
+        .arg(&prog)
+        .arg("--allow-live-effects")
+        .env("HALE_REPLAY_TEST_HOLD", &go)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn replay");
+    // Give admission + compile ample time, then replace and release.
+    std::thread::sleep(std::time::Duration::from_secs(3));
+    let tmp = dir.join("b-staged.halerec");
+    std::fs::copy(&rec_b, &tmp).unwrap();
+    std::fs::rename(&tmp, &target).unwrap();
+    std::fs::write(&go, "go").unwrap();
+    let out = child.wait_with_output().expect("replay exit");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "replay failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains(&a_line) && !stdout.contains(&b_line),
+        "the child must replay the ADMITTED artifact (A), not the \
+         substituted path (B):\nstdout:{}",
+        stdout
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Header-only and torn-first-frame crash prefixes admit under
+/// --allow-truncated (review round 2, finding 3): the minimum valid
+/// artifact is the 96-byte header, not header + trailer.
+#[test]
+fn header_only_crash_prefixes_admit_with_the_flag() {
+    let dir = workdir("hdronly");
+    let prog = dir.join("tiny.hl");
+    std::fs::write(
+        &prog,
+        r#"
+main locus App {
+    params { x: Int = 1; }
+    run() { let y = self.x + 1; }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let rec = record(&dir, &prog);
+    let bytes = std::fs::read(&rec).unwrap();
+    assert!(bytes.len() > 112);
+
+    for cut in [96usize, 97, 103, 111, 112] {
+        let fixture = dir.join(format!("cut{}.halerec", cut));
+        std::fs::write(&fixture, &bytes[..cut]).unwrap();
+
+        // Default: refused as truncated.
+        let out = hale()
+            .arg("replay")
+            .arg(&fixture)
+            .arg(&prog)
+            .arg("--allow-live-effects")
+            .output()
+            .expect("refusal run");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !out.status.success() && stderr.contains("truncated"),
+            "cut={} must refuse as truncated:\n{}",
+            cut,
+            stderr
+        );
+
+        // Opted in: the (possibly empty) prefix replays; execution
+        // past the tape is the post-crash suffix.
+        let out = hale()
+            .arg("replay")
+            .arg(&fixture)
+            .arg(&prog)
+            .arg("--allow-truncated")
+            .arg("--allow-live-effects")
+            .output()
+            .expect("prefix run");
+        assert!(
+            out.status.success(),
+            "cut={} must admit under --allow-truncated:\n{}",
+            cut,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/hale-cli/tests/replay_cli.rs
+++ b/crates/hale-cli/tests/replay_cli.rs
@@ -760,3 +760,369 @@ fn main() { App { }; }
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+// ---- phase 5 review-round canaries ---------------------------------
+
+/// A crash-cut tape under `--allow-truncated --diff`: events past the
+/// recorded prefix are the unknown post-crash suffix, not
+/// divergences — the runtime verdict and the prefix comparator must
+/// AGREE on that (they used to contradict).
+#[test]
+fn truncated_diff_accepts_the_post_crash_surplus() {
+    let dir = workdir("truncdiff");
+    let prog = dir.join("steady.hl");
+    std::fs::write(
+        &prog,
+        r#"
+type Tick { n: Int = 0; }
+locus Sink {
+    params { seen: Int = 0; }
+    bus { subscribe "td.tick" as on_t of type Tick; }
+    fn on_t(t: Tick) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { s: Sink = Sink { }; }
+    bus { publish "td.tick" of type Tick; }
+    run() {
+        let mut i = 0;
+        while i < 400 {
+            let r = std::rand::next_int(1000000);
+            "td.tick" <- Tick { n: r };
+            std::time::sleep(5ms);
+            i = i + 1;
+        }
+    }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+
+    // Record via `hale run` (which execs the built binary — one pid)
+    // and SIGKILL it mid-stream.
+    let rec = dir.join("crash.halerec");
+    let mut child = hale()
+        .arg("run")
+        .arg(&prog)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .spawn()
+        .expect("spawn recorded run");
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        let sz = std::fs::metadata(&rec).map(|m| m.len()).unwrap_or(0);
+        if sz > 8192 {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "recording never grew (size {})",
+            sz
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    child.kill().expect("kill");
+    let _ = child.wait();
+
+    // The full flow the review demanded: prefix must match, the
+    // post-crash surplus must not fail the diff.
+    let out = hale()
+        .arg("replay")
+        .arg(&rec)
+        .arg(&prog)
+        .arg("--allow-truncated")
+        .arg("--diff")
+        .arg("--allow-live-effects")
+        .output()
+        .expect("hale replay --allow-truncated --diff");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "truncated --diff must accept the surplus:\nstdout:{}\nstderr:{}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("replay matches the recording"),
+        "expected the prefix match verdict:\n{}\n{}",
+        stdout,
+        stderr
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// ...and a divergence INSIDE the recorded prefix still fails.
+/// (Corrupting the baseline cannot create one — replay is DRIVEN by
+/// the baseline, and raw in-process payloads compare by declared
+/// size by design. A withheld env VALUE is the honest in-prefix
+/// mismatch: the default recording policy withholds it, so the
+/// replayed read is a NAMED divergence inside the prefix.)
+#[test]
+fn withheld_read_inside_the_prefix_still_fails_truncated_diff() {
+    let dir = workdir("truncbad");
+    let prog = dir.join("envy.hl");
+    std::fs::write(
+        &prog,
+        r#"
+type Tick { n: Int = 0; }
+locus Sink {
+    params { seen: Int = 0; }
+    bus { subscribe "tb.tick" as on_t of type Tick; }
+    fn on_t(t: Tick) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { s: Sink = Sink { }; }
+    bus { publish "tb.tick" of type Tick; }
+    run() {
+        // An env read at the very start: inside any nonempty prefix.
+        let home = std::env::var("HOME");
+        let mut i = 0;
+        while i < 40 {
+            "tb.tick" <- Tick { n: i };
+            i = i + 1;
+        }
+    }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let rec = record(&dir, &prog);
+
+    // Cut the trailer + a tail chunk: an accepted truncated tape
+    // whose surviving prefix contains the (value-withheld) env read.
+    let b = std::fs::read(&rec).unwrap();
+    let mut end = b.len();
+    if &b[end - 16..end - 8] == b"HALEEND0" {
+        end -= 16;
+    }
+    let cut = dir.join("cut.halerec");
+    std::fs::write(&cut, &b[..end - 64]).unwrap();
+
+    let out = hale()
+        .arg("replay")
+        .arg(&cut)
+        .arg(&prog)
+        .arg("--allow-truncated")
+        .arg("--diff")
+        .arg("--allow-live-effects")
+        .output()
+        .expect("hale replay withheld prefix");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "an in-prefix divergence must still fail truncated --diff:\n{}",
+        stderr
+    );
+    assert!(
+        stderr.contains("env.var") || stderr.contains("DIVERGED"),
+        "the failure must be the named in-prefix divergence:\n{}",
+        stderr
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `--feed` bypasses identity admission, never effect safety: a
+/// program whose frontier reaches syscall must still be refused
+/// until --allow-live-effects joins it.
+#[test]
+fn feed_requires_the_effects_gate_for_live_effects() {
+    let dir = workdir("feedgate");
+    let pure = dir.join("pure.hl");
+    std::fs::write(
+        &pure,
+        r#"
+main locus App {
+    params { x: Int = 1; }
+    run() { let y = self.x + 1; }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let rec = record(&dir, &pure);
+
+    let effectful = dir.join("effectful.hl");
+    std::fs::write(
+        &effectful,
+        r#"
+main locus App {
+    run() { std::time::sleep(1ms); }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+
+    // --feed alone: refused, residue named.
+    let out = hale()
+        .arg("replay")
+        .arg(&rec)
+        .arg(&effectful)
+        .arg("--feed")
+        .output()
+        .expect("hale replay --feed");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "--feed alone must not unlock live effects:\n{}",
+        stderr
+    );
+    assert!(
+        stderr.contains("live world") && stderr.contains("syscall"),
+        "the refusal must name the residue:\n{}",
+        stderr
+    );
+
+    // Both flags: the explicit backtest-with-live-effects spelling.
+    let out = hale()
+        .arg("replay")
+        .arg(&rec)
+        .arg(&effectful)
+        .arg("--feed")
+        .arg("--allow-live-effects")
+        .output()
+        .expect("hale replay --feed --allow-live-effects");
+    assert!(
+        out.status.success(),
+        "--feed --allow-live-effects must proceed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Two listener bindings mean two recorded ingress sources; under
+/// --diff the verify recording's per-consumer public streams must
+/// align with the original's — one global injector thread would
+/// collapse them onto one identity.
+#[test]
+fn two_listeners_replay_clean_under_diff() {
+    let dir = workdir("twolisten");
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let sock_a = format!(
+        "{}/hale-2l-{}-{}.a.sock",
+        std::env::temp_dir().display(),
+        std::process::id(),
+        nanos
+    );
+    let sock_b = format!("{}.b", sock_a);
+    let sub = dir.join("sub.hl");
+    std::fs::write(
+        &sub,
+        format!(
+            r#"
+type TA {{ n: Int = 0; }}
+type TB {{ n: Int = 0; }}
+topic A {{ payload: TA; subject: "tl.a"; }}
+topic B {{ payload: TB; subject: "tl.b"; }}
+locus SubA {{
+    params {{ seen: Int = 0; }}
+    bus {{ subscribe A as on_a; }}
+    fn on_a(t: TA) {{ self.seen = self.seen + 1; println("a=", t.n); }}
+}}
+locus SubB {{
+    params {{ seen: Int = 0; }}
+    bus {{ subscribe B as on_b; }}
+    fn on_b(t: TB) {{ self.seen = self.seen + 1; println("b=", t.n); }}
+}}
+main locus App {{
+    params {{ sa: SubA = SubA {{ }}; sb: SubB = SubB {{ }}; }}
+    bindings {{
+        A: unix("{}", role: listen);
+        B: unix("{}", role: listen);
+    }}
+    run() {{
+        let mut waited = 0;
+        while self.sa.seen < 1 || self.sb.seen < 1 {{
+            std::time::sleep(100ms);
+            waited = waited + 1;
+            if waited > 200 {{ std::process::exit(3); }}
+        }}
+        std::time::sleep(400ms);
+    }}
+}}
+fn main() {{ App {{ }}; }}
+"#,
+            sock_a, sock_b
+        ),
+    )
+    .unwrap();
+    let pubs = dir.join("pubs.hl");
+    std::fs::write(
+        &pubs,
+        format!(
+            r#"
+type TA {{ n: Int = 0; }}
+type TB {{ n: Int = 0; }}
+topic A {{ payload: TA; subject: "tl.a"; }}
+topic B {{ payload: TB; subject: "tl.b"; }}
+main locus App {{
+    bus {{ publish A; publish B; }}
+    bindings {{
+        A: unix("{}", role: connect);
+        B: unix("{}", role: connect);
+    }}
+    run() {{
+        std::time::sleep(900ms);
+        A <- TA {{ n: 11 }};
+        B <- TB {{ n: 21 }};
+        std::time::sleep(50ms);
+        A <- TA {{ n: 12 }};
+        B <- TB {{ n: 22 }};
+        std::time::sleep(200ms);
+    }}
+}}
+fn main() {{ App {{ }}; }}
+"#,
+            sock_a, sock_b
+        ),
+    )
+    .unwrap();
+
+    let rec = dir.join("two.halerec");
+    let mut subp = hale()
+        .arg("run")
+        .arg(&sub)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn recorded sub");
+    let p = hale().arg("run").arg(&pubs).output().expect("pubs");
+    assert!(
+        p.status.success(),
+        "publisher run failed: {}",
+        String::from_utf8_lossy(&p.stderr)
+    );
+    let out = subp.wait_with_output().expect("sub exit");
+    assert!(
+        out.status.success(),
+        "recorded two-listener run failed:\nstdout:{}\nstderr:{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let _ = std::fs::remove_file(&sock_a);
+    let _ = std::fs::remove_file(&sock_b);
+    let out = hale()
+        .arg("replay")
+        .arg(&rec)
+        .arg(&sub)
+        .arg("--diff")
+        .arg("--allow-live-effects")
+        .output()
+        .expect("hale replay --diff");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success() && stdout.contains("replay matches"),
+        "two-source ingress must survive --diff:\nstdout:{}\nstderr:{}",
+        stdout,
+        stderr
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-codegen/Cargo.toml
+++ b/crates/hale-codegen/Cargo.toml
@@ -14,3 +14,4 @@ inkwell = { version = "0.5", features = ["llvm18-0"] }
 
 [dev-dependencies]
 hale-corpus = { path = "../hale-corpus" }
+libc = "0.2"

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -6435,6 +6435,8 @@ void lotus_replay_reserve_anon_floor(void) __attribute__((weak));
 void lotus_replay_note_injected(void) __attribute__((weak));
 void lotus_replay_note_ingress_rejected(void) __attribute__((weak));
 void lotus_replay_note_ingress_unmatched(void) __attribute__((weak));
+void lotus_replay_reclassify_unmatched_late(uint64_t n)
+    __attribute__((weak));
 void lotus_replay_note_ingress_incompatible(void)
     __attribute__((weak));
 void lotus_replay_note_ingress_unprocessed(uint64_t n)
@@ -14844,6 +14846,14 @@ typedef struct {
 } lotus_rp_injector_t;
 static lotus_rp_injector_t g_rp_injectors[LOTUS_RP_INJECTOR_MAX];
 static int g_rp_injector_count = 0;
+/* Review round 2, finding 5: unmatched tape subjects, kept so the
+ * JOIN path (main thread, teardown — safe to rescan the registry)
+ * can distinguish "no subscriber exists" from "the subscriber was
+ * created after the boot snapshot" (late_subscription_uncovered).
+ * Bounded; pointers into the artifact snapshot (process-lifetime). */
+#define LOTUS_RP_UNMATCHED_MAX 64
+static const char *g_rp_unmatched_subjects[LOTUS_RP_UNMATCHED_MAX];
+static _Atomic int g_rp_unmatched_subject_len = 0;
 static int g_rp_ingress_started = 0;
 static int g_rp_injector_stop = 0;
 
@@ -14879,6 +14889,12 @@ static void *lotus_replay_injector_worker(void *arg) {
         if (!deserialize) {
             if (lotus_replay_note_ingress_unmatched)
                 lotus_replay_note_ingress_unmatched();
+            int slot = atomic_fetch_add_explicit(
+                &g_rp_unmatched_subject_len, 1,
+                memory_order_relaxed);
+            if (slot < LOTUS_RP_UNMATCHED_MAX) {
+                g_rp_unmatched_subjects[slot] = subject;
+            }
             atomic_store_explicit(&w->next_idx, i + 1,
                                   memory_order_release);
             continue;
@@ -14999,12 +15015,15 @@ void lotus_replay_start_ingress(void) {
          * order with zero divergences reported). */
         lotus_bus_mark_pinned();
         lotus_mark_multithreaded();
-        if (pthread_create(&w->th, NULL,
-                           lotus_replay_injector_worker, w) != 0) {
+        int rc = pthread_create(&w->th, NULL,
+                                lotus_replay_injector_worker, w);
+        if (rc != 0) {
+            /* pthread_create returns the error NUMBER — errno is
+             * not promised to be set (review round 2, finding 6). */
             fprintf(stderr,
                     "hale replay: ingress injector thread failed to "
                     "start (source %llu): %s\n",
-                    (unsigned long long)cid, strerror(errno));
+                    (unsigned long long)cid, strerror(rc));
             if (lotus_replay_note_injector_start_failure)
                 lotus_replay_note_injector_start_failure();
             continue;
@@ -15037,6 +15056,29 @@ void lotus_replay_injector_join(void) {
             lotus_replay_note_ingress_unprocessed(rest);
     }
     g_rp_injector_count = 0;
+    /* finding 5: with the workers joined and this thread owning
+     * teardown, rescan the LIVE registry: an unmatched subject
+     * whose subscriber exists NOW was registered after the boot
+     * snapshot — a distinct, named coverage class. */
+    if (lotus_replay_reclassify_unmatched_late) {
+        int n = atomic_load_explicit(&g_rp_unmatched_subject_len,
+                                     memory_order_acquire);
+        if (n > LOTUS_RP_UNMATCHED_MAX) n = LOTUS_RP_UNMATCHED_MAX;
+        uint64_t late = 0;
+        for (int u = 0; u < n; u++) {
+            const char *subj = g_rp_unmatched_subjects[u];
+            if (!subj) continue;
+            for (size_t e = 0; e < g_bus_count; e++) {
+                lotus_bus_entry_t *be = &g_bus_entries[e];
+                if (!be->subject || !be->deserialize) continue;
+                if (lotus_subject_match(be->subject, subj)) {
+                    late++;
+                    break;
+                }
+            }
+        }
+        if (late) lotus_replay_reclassify_unmatched_late(late);
+    }
 }
 
 int lotus_bus_register_remote(const char *subject,

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -6436,6 +6436,7 @@ void lotus_replay_note_inject_dropped(uint32_t topic)
     __attribute__((weak));
 void lotus_replay_note_binding_suppressed(void)
     __attribute__((weak));
+void lotus_obs_record_ingress_abort(void) __attribute__((weak));
 extern int lotus_replay_feed __attribute__((weak));
 /* iris handoff-12 P22: the per-binding backpressure cells
  * (PROTOCOL §6: 3 queue_depth gauge, 4 send_block_ns, 5 retries).
@@ -14382,7 +14383,13 @@ static void lotus_bus_unix_serve(lotus_bus_remote_entry_t *entry) {
             }
             ssize_t struct_size = deserialize(
                 wire_buf, (size_t)n, struct_buf, sizeof(struct_buf));
-            if (struct_size <= 0) continue;
+            if (struct_size <= 0) {
+                /* Captured but not dispatched: unpin the identity
+                 * so it cannot leak onto the next dispatch. */
+                if (lotus_obs_record_ingress_abort)
+                    lotus_obs_record_ingress_abort();
+                continue;
+            }
             /* iris handoff-4 P15: mark the inbound re-dispatch so the
              * BUS_PUBLISH probe at the top of local_dispatch counts it
              * as a delivery, not a publish. */
@@ -14746,6 +14753,10 @@ static void *lotus_bus_udp_reader_thread_main(void *arg) {
         ssize_t struct_size = deserialize(
             wire, (size_t)n, struct_buf, sizeof(struct_buf));
         if (struct_size <= 0) {
+            /* Captured but not dispatched — unpin (see the unix
+             * reader). */
+            if (lotus_obs_record_ingress_abort)
+                lotus_obs_record_ingress_abort();
             if (lotus_bus_log_deserialize_drop_enabled()) {
                 dprintf(2,
                         "lotus_bus udp reader: drop on `%s` "

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -6410,6 +6410,33 @@ int lotus_obs_active(void) __attribute__((weak));
  * so the published counter isn't inflated by deliveries. */
 void lotus_obs_begin_redispatch(void) __attribute__((weak));
 void lotus_obs_end_redispatch(void) __attribute__((weak));
+/* GH #296 phase 5b: the ingress tape (defined in lotus_obs.c).
+ * Reader threads capture verbatim wire bytes with a pinned pub_id;
+ * under replay/feed the transport bindings are suppressed and the
+ * injector below re-dispatches the recorded tape instead. */
+uint64_t lotus_obs_record_ingress_wire(const char *subject,
+                                       const void *bytes,
+                                       uint64_t size)
+    __attribute__((weak));
+uint64_t lotus_replay_inject_begin(const char *subject,
+                                   const void *bytes, uint64_t size,
+                                   uint64_t pub_id)
+    __attribute__((weak));
+uint64_t lotus_replay_ingress_count(void) __attribute__((weak));
+int lotus_replay_ingress_get(uint64_t i, uint32_t *topic,
+                             uint64_t *pub_id, const void **bytes,
+                             uint64_t *size)
+    __attribute__((weak));
+const char *lotus_replay_topic_name(uint32_t topic)
+    __attribute__((weak));
+uint32_t lotus_replay_subject_hash(const char *subject)
+    __attribute__((weak));
+void lotus_replay_note_injected(void) __attribute__((weak));
+void lotus_replay_note_inject_dropped(uint32_t topic)
+    __attribute__((weak));
+void lotus_replay_note_binding_suppressed(void)
+    __attribute__((weak));
+extern int lotus_replay_feed __attribute__((weak));
 /* iris handoff-12 P22: the per-binding backpressure cells
  * (PROTOCOL §6: 3 queue_depth gauge, 4 send_block_ns, 5 retries).
  * Measured here (fd occupancy + send timing live in this TU),
@@ -14345,6 +14372,14 @@ static void lotus_bus_unix_serve(lotus_bus_remote_entry_t *entry) {
                 break;
             }
             if (!deserialize) continue;
+            /* GH #296 phase 5b: capture the VERBATIM wire form with
+             * a pinned identity — the struct-bytes record the
+             * dispatch below would push is metadata-only and cannot
+             * be re-fed as an injectable tape. */
+            if (lotus_obs_record_ingress_wire) {
+                lotus_obs_record_ingress_wire(entry->subject,
+                                              wire_buf, (uint64_t)n);
+            }
             ssize_t struct_size = deserialize(
                 wire_buf, (size_t)n, struct_buf, sizeof(struct_buf));
             if (struct_size <= 0) continue;
@@ -14702,6 +14737,12 @@ static void *lotus_bus_udp_reader_thread_main(void *arg) {
             }
             continue;
         }
+        /* GH #296 phase 5b: same verbatim wire capture as the unix
+         * reader (see there). */
+        if (lotus_obs_record_ingress_wire) {
+            lotus_obs_record_ingress_wire(args->entry->subject,
+                                          wire, (uint64_t)n);
+        }
         ssize_t struct_size = deserialize(
             wire, (size_t)n, struct_buf, sizeof(struct_buf));
         if (struct_size <= 0) {
@@ -14745,6 +14786,118 @@ static void *lotus_bus_udp_reader_thread_main(void *arg) {
     return NULL;
 }
 
+/* GH #296 phase 5b: the ingress injector. Under strict replay and
+ * under feed, transport bindings never open (hermetic wire) and
+ * this thread re-dispatches the recording's ingress tape instead —
+ * artifact order, one dispatch per recorded payload, exactly the
+ * reader-thread shape (deserialize into a stack struct buffer, then
+ * local dispatch under the redispatch bracket). Under strict replay
+ * each dispatch carries its RECORDED pub_id (pinned via
+ * lotus_replay_inject_begin) so per-consumer order enforcement
+ * matches injected deliveries to their recorded consumes; under
+ * feed, identity is the new run's own.
+ *
+ * Pacing: none — deliveries queue, and (under strict replay) the
+ * per-consumer enforcement buffer holds early arrivals in exactly
+ * the way it holds any early arrival. Windowed injection for tapes
+ * that dwarf memory is a staged refinement; the whole artifact is
+ * already resident (the loader snapshots it).
+ *
+ * A tape subject with no matching subscriber waits a bounded grace
+ * (subscribers may still be being born on the boot path), then
+ * counts as DROPPED — reported at exit, never silent. */
+static pthread_t g_rp_injector_thread;
+static int g_rp_injector_started = 0;
+static int g_rp_injector_stop = 0;
+
+static void *lotus_replay_injector_main(void *arg) {
+    (void)arg;
+    char struct_buf[LOTUS_PAYLOAD_MAX];
+    uint64_t count = lotus_replay_ingress_count();
+    for (uint64_t i = 0; i < count; i++) {
+        if (__atomic_load_n(&g_rp_injector_stop, __ATOMIC_ACQUIRE))
+            break;
+        uint32_t topic;
+        uint64_t pub_id, size;
+        const void *bytes;
+        if (!lotus_replay_ingress_get(i, &topic, &pub_id, &bytes,
+                                      &size)) {
+            break;
+        }
+        const char *name =
+            lotus_replay_topic_name ? lotus_replay_topic_name(topic)
+                                    : NULL;
+        const char *subject = NULL;
+        lotus_deserialize_fn deserialize = NULL;
+        for (int spin = 0; spin < 5000; spin++) { /* ≤5s grace */
+            for (size_t e = 0; e < g_bus_count; e++) {
+                lotus_bus_entry_t *be = &g_bus_entries[e];
+                if (!be->subject || !be->deserialize) continue;
+                if (name ? lotus_subject_match(be->subject, name)
+                         : (lotus_replay_subject_hash &&
+                            lotus_replay_subject_hash(be->subject) ==
+                                topic)) {
+                    subject = name ? name : be->subject;
+                    deserialize = be->deserialize;
+                    break;
+                }
+            }
+            if (deserialize) break;
+            if (__atomic_load_n(&g_rp_injector_stop,
+                                __ATOMIC_ACQUIRE)) {
+                break;
+            }
+            struct timespec ts = {0, 1000000}; /* 1ms */
+            nanosleep(&ts, NULL);
+        }
+        if (!deserialize) {
+            if (lotus_replay_note_inject_dropped)
+                lotus_replay_note_inject_dropped(topic);
+            continue;
+        }
+        ssize_t struct_size = deserialize(bytes, (size_t)size,
+                                          struct_buf,
+                                          sizeof(struct_buf));
+        if (struct_size <= 0) {
+            if (lotus_replay_note_inject_dropped)
+                lotus_replay_note_inject_dropped(topic);
+            continue;
+        }
+        if (lotus_replay_inject_begin) {
+            lotus_replay_inject_begin(subject, bytes, size, pub_id);
+        }
+        if (lotus_obs_begin_redispatch) lotus_obs_begin_redispatch();
+        lotus_bus_local_dispatch(g_bus_queue_for_remote, subject,
+                                 struct_buf, (size_t)struct_size);
+        if (lotus_obs_end_redispatch) lotus_obs_end_redispatch();
+        if (lotus_replay_note_injected) lotus_replay_note_injected();
+    }
+    return NULL;
+}
+
+/* Boot path is single-threaded (binding registration), so the
+ * started guard needs no lock. */
+static void lotus_replay_injector_spawn(void) {
+    if (g_rp_injector_started) return;
+    if (!lotus_replay_ingress_count ||
+        lotus_replay_ingress_count() == 0) {
+        g_rp_injector_started = 1; /* nothing to inject */
+        return;
+    }
+    lotus_mark_multithreaded();
+    if (pthread_create(&g_rp_injector_thread, NULL,
+                       lotus_replay_injector_main, NULL) == 0) {
+        g_rp_injector_started = 2;
+    }
+}
+
+void lotus_replay_injector_join(void) {
+    if (g_rp_injector_started != 2) return;
+    __atomic_store_n(&g_rp_injector_stop, 1, __ATOMIC_RELEASE);
+    pthread_join(g_rp_injector_thread, NULL);
+    g_rp_injector_started = 1;
+}
+
 int lotus_bus_register_remote(const char *subject,
                               const char *url,
                               int role) {
@@ -14784,6 +14937,21 @@ int lotus_bus_register_remote(const char *subject,
         return -1;
     }
 
+    /* GH #296 phase 5b: hermetic wire. Under strict replay a bound
+     * transport is exactly the hole the safety gate existed for —
+     * the listener would re-receive the live world and the
+     * connector would re-SEND to it. Under feed the wire belongs to
+     * the tape by definition. Either way: validate the URL (above),
+     * open nothing, spawn the injector in the listener's stead. */
+    if (lotus_replay_active || lotus_replay_feed) {
+        if (role == LOTUS_TRANSPORT_LISTEN) {
+            lotus_replay_injector_spawn();
+        }
+        if (lotus_replay_note_binding_suppressed) {
+            lotus_replay_note_binding_suppressed();
+        }
+        return 0;
+    }
     lotus_bus_remote_entry_t *e = lotus_bus_remote_entry_push(
         subject,
         is_udp ? LOTUS_BUS_REMOTE_KIND_UDP : LOTUS_BUS_REMOTE_KIND_UNIX);
@@ -14970,6 +15138,21 @@ int64_t lotus_bus_transport_realize(const char *subject,
         free(e);
         return 0;
     }
+    /* GH #296 phase 5b: hermetic wire under replay/feed. The
+     * binding stays a HUSK — same entry the reclaim/destroy paths
+     * already handle for a post-reclaim transport (transport NULL:
+     * fanout skips it, wait_ready never sees it lost) — but no
+     * socket is created, nothing binds, nothing connects. The
+     * listener's serve thread is replaced by the ingress injector
+     * (spawned from spawn_server below). Birth still succeeds: the
+     * suppressed binding is a fact of the mode, not a failure of
+     * the program. */
+    if (lotus_replay_active || lotus_replay_feed) {
+        if (lotus_replay_note_binding_suppressed) {
+            lotus_replay_note_binding_suppressed();
+        }
+        return (int64_t)(intptr_t)e;
+    }
     if (role == LOTUS_TRANSPORT_LISTEN) {
         e->transport = lotus_transport_listener_create(path);
     } else {
@@ -14988,6 +15171,14 @@ int64_t lotus_bus_transport_realize(const char *subject,
 int64_t lotus_bus_transport_spawn_server(int64_t handle) {
     lotus_bus_remote_entry_t *e =
         (lotus_bus_remote_entry_t *)(intptr_t)handle;
+    /* GH #296 phase 5b: the suppressed listener's serve thread is
+     * the injector — the recording's ingress tape re-dispatched in
+     * the reader's stead. */
+    if (e && e->role == LOTUS_TRANSPORT_LISTEN && !e->transport &&
+        (lotus_replay_active || lotus_replay_feed)) {
+        lotus_replay_injector_spawn();
+        return 0;
+    }
     if (!e || e->role != LOTUS_TRANSPORT_LISTEN || !e->transport) {
         return -1;
     }
@@ -18976,6 +19167,10 @@ const char *lotus_fs_mktemp(const char *prefix, const char *suffix) {
 }
 
 void lotus_bus_remote_destroy_all(void) {
+    /* GH #296 phase 5b: stop and join the ingress injector FIRST —
+     * it dispatches into the queues this teardown is about to
+     * drain and dissolve. */
+    lotus_replay_injector_join();
     /* GH #236: operator/test-facing counter dump. One line per
      * binding to stderr at teardown when LOTUS_BUS_COUNTERS_DUMP=1
      * (same env-diagnostic family as LOTUS_BUS_LOG_DESERIALIZE_DROP).

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -6423,20 +6423,26 @@ uint64_t lotus_replay_inject_begin(const char *subject,
                                    uint64_t pub_id)
     __attribute__((weak));
 uint64_t lotus_replay_ingress_count(void) __attribute__((weak));
-int lotus_replay_ingress_get(uint64_t i, uint32_t *topic,
+int lotus_replay_ingress_get(uint64_t i, const char **subject,
                              uint64_t *pub_id, const void **bytes,
                              uint64_t *size)
     __attribute__((weak));
-const char *lotus_replay_topic_name(uint32_t topic)
+int lotus_replay_ingress_compatible(uint64_t i) __attribute__((weak));
+uint64_t lotus_replay_ingress_source(uint64_t i) __attribute__((weak));
+int lotus_replay_ingress_settled(uint64_t pub_id)
     __attribute__((weak));
-uint32_t lotus_replay_subject_hash(const char *subject)
-    __attribute__((weak));
+void lotus_replay_reserve_anon_floor(void) __attribute__((weak));
 void lotus_replay_note_injected(void) __attribute__((weak));
-void lotus_replay_note_inject_dropped(uint32_t topic)
+void lotus_replay_note_ingress_rejected(void) __attribute__((weak));
+void lotus_replay_note_ingress_unmatched(void) __attribute__((weak));
+void lotus_replay_note_ingress_incompatible(void)
+    __attribute__((weak));
+void lotus_replay_note_ingress_unprocessed(uint64_t n)
+    __attribute__((weak));
+void lotus_replay_note_injector_start_failure(void)
     __attribute__((weak));
 void lotus_replay_note_binding_suppressed(void)
     __attribute__((weak));
-void lotus_obs_record_ingress_abort(void) __attribute__((weak));
 extern int lotus_replay_feed __attribute__((weak));
 /* iris handoff-12 P22: the per-binding backpressure cells
  * (PROTOCOL §6: 3 queue_depth gauge, 4 send_block_ns, 5 retries).
@@ -14373,22 +14379,19 @@ static void lotus_bus_unix_serve(lotus_bus_remote_entry_t *entry) {
                 break;
             }
             if (!deserialize) continue;
+            ssize_t struct_size = deserialize(
+                wire_buf, (size_t)n, struct_buf, sizeof(struct_buf));
+            if (struct_size <= 0) continue;
             /* GH #296 phase 5b: capture the VERBATIM wire form with
-             * a pinned identity — the struct-bytes record the
-             * dispatch below would push is metadata-only and cannot
-             * be re-fed as an injectable tape. */
+             * a pinned identity — AFTER the deserialize, so a
+             * message this application rejected never enters the
+             * injectable tape (review round), and identity is
+             * allocated per ACCEPTED message on both sides. The
+             * struct-bytes record the dispatch below would push is
+             * metadata-only and cannot be re-fed. */
             if (lotus_obs_record_ingress_wire) {
                 lotus_obs_record_ingress_wire(entry->subject,
                                               wire_buf, (uint64_t)n);
-            }
-            ssize_t struct_size = deserialize(
-                wire_buf, (size_t)n, struct_buf, sizeof(struct_buf));
-            if (struct_size <= 0) {
-                /* Captured but not dispatched: unpin the identity
-                 * so it cannot leak onto the next dispatch. */
-                if (lotus_obs_record_ingress_abort)
-                    lotus_obs_record_ingress_abort();
-                continue;
             }
             /* iris handoff-4 P15: mark the inbound re-dispatch so the
              * BUS_PUBLISH probe at the top of local_dispatch counts it
@@ -14744,19 +14747,9 @@ static void *lotus_bus_udp_reader_thread_main(void *arg) {
             }
             continue;
         }
-        /* GH #296 phase 5b: same verbatim wire capture as the unix
-         * reader (see there). */
-        if (lotus_obs_record_ingress_wire) {
-            lotus_obs_record_ingress_wire(args->entry->subject,
-                                          wire, (uint64_t)n);
-        }
         ssize_t struct_size = deserialize(
             wire, (size_t)n, struct_buf, sizeof(struct_buf));
         if (struct_size <= 0) {
-            /* Captured but not dispatched — unpin (see the unix
-             * reader). */
-            if (lotus_obs_record_ingress_abort)
-                lotus_obs_record_ingress_abort();
             if (lotus_bus_log_deserialize_drop_enabled()) {
                 dprintf(2,
                         "lotus_bus udp reader: drop on `%s` "
@@ -14764,6 +14757,12 @@ static void *lotus_bus_udp_reader_thread_main(void *arg) {
                         args->entry->subject, struct_size, n);
             }
             continue;
+        }
+        /* GH #296 phase 5b: accepted-message wire capture — see the
+         * unix reader for the ordering contract. */
+        if (lotus_obs_record_ingress_wire) {
+            lotus_obs_record_ingress_wire(args->entry->subject,
+                                          wire, (uint64_t)n);
         }
         /* iris handoff-4 P15: mark the inbound re-dispatch (delivery,
          * not a publish) so it doesn't inflate the published counter. */
@@ -14797,81 +14796,109 @@ static void *lotus_bus_udp_reader_thread_main(void *arg) {
     return NULL;
 }
 
-/* GH #296 phase 5b: the ingress injector. Under strict replay and
- * under feed, transport bindings never open (hermetic wire) and
- * this thread re-dispatches the recording's ingress tape instead —
- * artifact order, one dispatch per recorded payload, exactly the
- * reader-thread shape (deserialize into a stack struct buffer, then
- * local dispatch under the redispatch bracket). Under strict replay
- * each dispatch carries its RECORDED pub_id (pinned via
- * lotus_replay_inject_begin) so per-consumer order enforcement
- * matches injected deliveries to their recorded consumes; under
- * feed, identity is the new run's own.
+/* GH #296 phase 5b: the ingress injector — review-round shape.
  *
- * Pacing: none — deliveries queue, and (under strict replay) the
- * per-consumer enforcement buffer holds early arrivals in exactly
- * the way it holds any early arrival. Windowed injection for tapes
- * that dwarf memory is a staged refinement; the whole artifact is
- * already resident (the loader snapshots it).
+ * Boot phase, not a binding side effect: codegen emits ONE
+ * `lotus_replay_start_ingress()` call at the main locus's
+ * boot/run boundary — params children born, bindings
+ * realized/suppressed, every boot subscription registered, run()
+ * not yet entered. The registry SNAPSHOT is taken there, on the
+ * main thread, so injector workers never read the live
+ * `g_bus_entries` array (registration may realloc it; the old
+ * design's polling loop was timing, not synchronization). Feed
+ * targets that dropped or rearranged the listener binding still
+ * get their tape: tape presence, not the survival of the old
+ * listener declaration, decides that injection starts.
  *
- * A tape subject with no matching subscriber waits a bounded grace
- * (subscribers may still be being born on the boot path), then
- * counts as DROPPED — reported at exit, never silent. */
-static pthread_t g_rp_injector_thread;
-static int g_rp_injector_started = 0;
+ * One worker per RECORDED ingress source (the pub_id's high 16
+ * bits): each worker carries its source's recorded consumer
+ * identity, so a verify recording under --diff aligns per-consumer
+ * public streams with the original instead of collapsing every
+ * listener's traffic onto one injector identity. Fresh anonymous
+ * claims are floored above the recorded range (obs side).
+ *
+ * Strict replay paces: one injected message, then wait until its
+ * recorded consumes have all been re-consumed (bounded by the
+ * phase-4 hold) — unpaced injection can shed at bounded queues
+ * before the order gate ever sees the cell, which no dequeue-side
+ * discipline can undo. Feed mode is deliberately unpaced.
+ *
+ * Every tape entry ends in exactly one class: injected, rejected
+ * (this program's deserializer refused it), unmatched (no
+ * subscribed subject), incompatible (subject matches, canonical
+ * payload shape does not), or unprocessed-at-shutdown. The obs
+ * side folds the non-injected classes into the strict verdict and
+ * the feed exit report. */
+typedef struct {
+    const char *subject;
+    lotus_deserialize_fn deserialize;
+} lotus_rp_snap_t;
+static lotus_rp_snap_t *g_rp_snap = NULL;
+static size_t g_rp_snap_len = 0;
+#define LOTUS_RP_INJECTOR_MAX 64
+typedef struct {
+    pthread_t th;
+    uint64_t cid;
+    int started;
+    _Atomic uint64_t next_idx; /* first tape index NOT yet handled */
+} lotus_rp_injector_t;
+static lotus_rp_injector_t g_rp_injectors[LOTUS_RP_INJECTOR_MAX];
+static int g_rp_injector_count = 0;
+static int g_rp_ingress_started = 0;
 static int g_rp_injector_stop = 0;
 
-static void *lotus_replay_injector_main(void *arg) {
-    (void)arg;
+#define LOTUS_RP_PACE_HOLD_NS 1000000000LL /* mirrors the phase-4 hold */
+
+static void *lotus_replay_injector_worker(void *arg) {
+    lotus_rp_injector_t *w = (lotus_rp_injector_t *)arg;
+    if (lotus_obs_note_consumer) lotus_obs_note_consumer(w->cid);
     char struct_buf[LOTUS_PAYLOAD_MAX];
     uint64_t count = lotus_replay_ingress_count();
     for (uint64_t i = 0; i < count; i++) {
         if (__atomic_load_n(&g_rp_injector_stop, __ATOMIC_ACQUIRE))
             break;
-        uint32_t topic;
+        if (lotus_replay_ingress_source(i) != w->cid) {
+            atomic_store_explicit(&w->next_idx, i + 1,
+                                  memory_order_release);
+            continue;
+        }
+        const char *subject;
         uint64_t pub_id, size;
         const void *bytes;
-        if (!lotus_replay_ingress_get(i, &topic, &pub_id, &bytes,
+        if (!lotus_replay_ingress_get(i, &subject, &pub_id, &bytes,
                                       &size)) {
             break;
         }
-        const char *name =
-            lotus_replay_topic_name ? lotus_replay_topic_name(topic)
-                                    : NULL;
-        const char *subject = NULL;
         lotus_deserialize_fn deserialize = NULL;
-        for (int spin = 0; spin < 5000; spin++) { /* ≤5s grace */
-            for (size_t e = 0; e < g_bus_count; e++) {
-                lotus_bus_entry_t *be = &g_bus_entries[e];
-                if (!be->subject || !be->deserialize) continue;
-                if (name ? lotus_subject_match(be->subject, name)
-                         : (lotus_replay_subject_hash &&
-                            lotus_replay_subject_hash(be->subject) ==
-                                topic)) {
-                    subject = name ? name : be->subject;
-                    deserialize = be->deserialize;
-                    break;
-                }
-            }
-            if (deserialize) break;
-            if (__atomic_load_n(&g_rp_injector_stop,
-                                __ATOMIC_ACQUIRE)) {
+        for (size_t e = 0; e < g_rp_snap_len; e++) {
+            if (lotus_subject_match(g_rp_snap[e].subject, subject)) {
+                deserialize = g_rp_snap[e].deserialize;
                 break;
             }
-            struct timespec ts = {0, 1000000}; /* 1ms */
-            nanosleep(&ts, NULL);
         }
         if (!deserialize) {
-            if (lotus_replay_note_inject_dropped)
-                lotus_replay_note_inject_dropped(topic);
+            if (lotus_replay_note_ingress_unmatched)
+                lotus_replay_note_ingress_unmatched();
+            atomic_store_explicit(&w->next_idx, i + 1,
+                                  memory_order_release);
+            continue;
+        }
+        if (lotus_replay_ingress_compatible &&
+            !lotus_replay_ingress_compatible(i)) {
+            if (lotus_replay_note_ingress_incompatible)
+                lotus_replay_note_ingress_incompatible();
+            atomic_store_explicit(&w->next_idx, i + 1,
+                                  memory_order_release);
             continue;
         }
         ssize_t struct_size = deserialize(bytes, (size_t)size,
                                           struct_buf,
                                           sizeof(struct_buf));
         if (struct_size <= 0) {
-            if (lotus_replay_note_inject_dropped)
-                lotus_replay_note_inject_dropped(topic);
+            if (lotus_replay_note_ingress_rejected)
+                lotus_replay_note_ingress_rejected();
+            atomic_store_explicit(&w->next_idx, i + 1,
+                                  memory_order_release);
             continue;
         }
         if (lotus_replay_inject_begin) {
@@ -14882,31 +14909,134 @@ static void *lotus_replay_injector_main(void *arg) {
                                  struct_buf, (size_t)struct_size);
         if (lotus_obs_end_redispatch) lotus_obs_end_redispatch();
         if (lotus_replay_note_injected) lotus_replay_note_injected();
+        atomic_store_explicit(&w->next_idx, i + 1,
+                              memory_order_release);
+        /* Strict pacing: bounded wait for the recorded consume
+         * frontier. On timeout the downstream divergence (order /
+         * unconsumed) is the accurate report — proceed. */
+        if (lotus_replay_active && lotus_replay_ingress_settled) {
+            struct timespec t0;
+            clock_gettime(CLOCK_MONOTONIC, &t0);
+            int64_t start_ns =
+                (int64_t)t0.tv_sec * 1000000000LL + t0.tv_nsec;
+            while (!lotus_replay_ingress_settled(pub_id)) {
+                if (__atomic_load_n(&g_rp_injector_stop,
+                                    __ATOMIC_ACQUIRE)) {
+                    break;
+                }
+                struct timespec now;
+                clock_gettime(CLOCK_MONOTONIC, &now);
+                int64_t now_ns = (int64_t)now.tv_sec * 1000000000LL +
+                                 now.tv_nsec;
+                if (now_ns - start_ns > LOTUS_RP_PACE_HOLD_NS) break;
+                struct timespec ts = {0, 1000000}; /* 1ms */
+                nanosleep(&ts, NULL);
+            }
+        }
     }
     return NULL;
 }
 
-/* Boot path is single-threaded (binding registration), so the
- * started guard needs no lock. */
-static void lotus_replay_injector_spawn(void) {
-    if (g_rp_injector_started) return;
-    if (!lotus_replay_ingress_count ||
-        lotus_replay_ingress_count() == 0) {
-        g_rp_injector_started = 1; /* nothing to inject */
+/* The boot-phase entry, emitted by codegen at the main locus's
+ * boot/run boundary. Runs on the MAIN thread: the registry
+ * snapshot below races nothing. Idempotent; no-op outside
+ * replay/feed and on an empty tape. */
+void lotus_replay_start_ingress(void) {
+    if (!(lotus_replay_active || lotus_replay_feed)) return;
+    if (g_rp_ingress_started) return;
+    g_rp_ingress_started = 1;
+    if (!lotus_replay_ingress_count || !lotus_replay_ingress_get)
+        return;
+    uint64_t count = lotus_replay_ingress_count();
+    if (count == 0) return;
+    /* Snapshot: one (subject, deserializer) per registered entry
+     * with a deserializer. Wildcard subjects stay wildcard — the
+     * worker matches with the same pattern matcher the reader
+     * used. */
+    g_rp_snap = (lotus_rp_snap_t *)malloc(
+        (g_bus_count ? g_bus_count : 1) * sizeof(lotus_rp_snap_t));
+    if (!g_rp_snap) {
+        if (lotus_replay_note_injector_start_failure)
+            lotus_replay_note_injector_start_failure();
         return;
     }
-    lotus_mark_multithreaded();
-    if (pthread_create(&g_rp_injector_thread, NULL,
-                       lotus_replay_injector_main, NULL) == 0) {
-        g_rp_injector_started = 2;
+    for (size_t e = 0; e < g_bus_count; e++) {
+        lotus_bus_entry_t *be = &g_bus_entries[e];
+        if (!be->subject || !be->deserialize) continue;
+        g_rp_snap[g_rp_snap_len].subject = be->subject;
+        g_rp_snap[g_rp_snap_len].deserialize = be->deserialize;
+        g_rp_snap_len++;
+    }
+    if (lotus_replay_reserve_anon_floor)
+        lotus_replay_reserve_anon_floor();
+    /* One worker per recorded source, in first-appearance order. */
+    for (uint64_t i = 0; i < count; i++) {
+        uint64_t cid = lotus_replay_ingress_source(i);
+        int seen = 0;
+        for (int wi = 0; wi < g_rp_injector_count; wi++) {
+            if (g_rp_injectors[wi].cid == cid) {
+                seen = 1;
+                break;
+            }
+        }
+        if (seen) continue;
+        if (g_rp_injector_count >= LOTUS_RP_INJECTOR_MAX) {
+            if (lotus_replay_note_injector_start_failure)
+                lotus_replay_note_injector_start_failure();
+            break;
+        }
+        lotus_rp_injector_t *w =
+            &g_rp_injectors[g_rp_injector_count];
+        w->cid = cid;
+        w->started = 0;
+        atomic_store_explicit(&w->next_idx, 0, memory_order_relaxed);
+        /* Injector workers are cross-thread producers into the main
+         * queue — exactly what the suppressed reader threads were.
+         * mark_pinned selects the LOCKED (and phase-4-GATED) drain;
+         * without it a replaying main drains through the
+         * single-threaded ungated path (found by the colliding-
+         * subjects canary: cross-source pairs consumed in enqueue
+         * order with zero divergences reported). */
+        lotus_bus_mark_pinned();
+        lotus_mark_multithreaded();
+        if (pthread_create(&w->th, NULL,
+                           lotus_replay_injector_worker, w) != 0) {
+            fprintf(stderr,
+                    "hale replay: ingress injector thread failed to "
+                    "start (source %llu): %s\n",
+                    (unsigned long long)cid, strerror(errno));
+            if (lotus_replay_note_injector_start_failure)
+                lotus_replay_note_injector_start_failure();
+            continue;
+        }
+        w->started = 1;
+        g_rp_injector_count++;
     }
 }
 
 void lotus_replay_injector_join(void) {
-    if (g_rp_injector_started != 2) return;
+    if (g_rp_injector_count == 0) return;
     __atomic_store_n(&g_rp_injector_stop, 1, __ATOMIC_RELEASE);
-    pthread_join(g_rp_injector_thread, NULL);
-    g_rp_injector_started = 1;
+    uint64_t count =
+        lotus_replay_ingress_count ? lotus_replay_ingress_count() : 0;
+    for (int wi = 0; wi < g_rp_injector_count; wi++) {
+        lotus_rp_injector_t *w = &g_rp_injectors[wi];
+        if (!w->started) continue;
+        pthread_join(w->th, NULL);
+        w->started = 0;
+        /* Classify the remainder: tape entries for this source the
+         * worker never reached are unprocessed-at-shutdown — a
+         * fact, never a silence. */
+        uint64_t from = atomic_load_explicit(&w->next_idx,
+                                             memory_order_acquire);
+        uint64_t rest = 0;
+        for (uint64_t i = from; i < count; i++) {
+            if (lotus_replay_ingress_source(i) == w->cid) rest++;
+        }
+        if (rest && lotus_replay_note_ingress_unprocessed)
+            lotus_replay_note_ingress_unprocessed(rest);
+    }
+    g_rp_injector_count = 0;
 }
 
 int lotus_bus_register_remote(const char *subject,
@@ -14955,9 +15085,6 @@ int lotus_bus_register_remote(const char *subject,
      * the tape by definition. Either way: validate the URL (above),
      * open nothing, spawn the injector in the listener's stead. */
     if (lotus_replay_active || lotus_replay_feed) {
-        if (role == LOTUS_TRANSPORT_LISTEN) {
-            lotus_replay_injector_spawn();
-        }
         if (lotus_replay_note_binding_suppressed) {
             lotus_replay_note_binding_suppressed();
         }
@@ -15182,12 +15309,12 @@ int64_t lotus_bus_transport_realize(const char *subject,
 int64_t lotus_bus_transport_spawn_server(int64_t handle) {
     lotus_bus_remote_entry_t *e =
         (lotus_bus_remote_entry_t *)(intptr_t)handle;
-    /* GH #296 phase 5b: the suppressed listener's serve thread is
-     * the injector — the recording's ingress tape re-dispatched in
-     * the reader's stead. */
+    /* GH #296 phase 5b: a suppressed listener spawns no serve
+     * thread — the boot-phase injector (lotus_replay_start_ingress,
+     * emitted at the main locus's boot/run boundary) re-dispatches
+     * the recording's tape in the readers' stead. */
     if (e && e->role == LOTUS_TRANSPORT_LISTEN && !e->transport &&
         (lotus_replay_active || lotus_replay_feed)) {
-        lotus_replay_injector_spawn();
         return 0;
     }
     if (!e || e->role != LOTUS_TRANSPORT_LISTEN || !e->transport) {

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -555,6 +555,11 @@ static char g_replay_path[512];
 static const uint8_t *g_rp_base; /* mmap'd recording */
 static int g_rp_truncated = 0; /* accepted without a finalize trailer */
 static uint64_t g_rp_dropped_tail = 0;
+/* phase 5 (truncated prefix): recorded-history-exhausted events on
+ * an accepted truncated tape are the unknown post-crash suffix,
+ * not divergences (review round: the runtime verdict contradicted
+ * the prefix comparator). */
+static _Atomic uint64_t g_rp_post_prefix = 0;
 static size_t g_rp_len;
 static uint64_t g_replay_at = 0; /* LOTUS_REPLAY_AT: stop at Nth consume */
 static uint64_t g_replay_at_consumer = 0; /* 0 = process-wide count */
@@ -584,7 +589,11 @@ typedef struct {
    * named divergence instead of a plausible wrong value. */
   rp_queue_t journal;
   rp_consume_t *consume;           /* recorded delivery order */
-  uint32_t consume_len, consume_cap, consume_cursor;
+  uint32_t consume_len, consume_cap;
+  /* Atomic: advanced by the owning consumer thread, READ by the
+   * ingress pacing check (review round: injection must be bounded
+   * by recorded progress, which lives in these cursors). */
+  _Atomic uint32_t consume_cursor;
 } rp_consumer_t;
 static rp_consumer_t g_rp_consumers[RP_MAX_CONSUMERS];
 static int g_rp_consumer_count = 0;
@@ -596,23 +605,47 @@ static _Atomic uint64_t g_rp_consume_count = 0;
  * --diff. Structural cells (pub_id 0) stay uncounted. */
 static _Atomic uint64_t g_rp_unexpected = 0;
 void lotus_replay_note_unexpected(void) {
+  if (g_rp_truncated) {
+    /* Deliveries past the truncated tape are the post-crash
+     * suffix, not unexpected history. */
+    atomic_fetch_add_explicit(&g_rp_post_prefix, 1,
+                              memory_order_relaxed);
+    return;
+  }
   atomic_fetch_add_explicit(&g_rp_unexpected, 1, memory_order_relaxed);
 }
 typedef struct { uint64_t pub_id; uint32_t topic; uint32_t flags;
                  rp_blob_ref_t bytes; } rp_payload_t;
 static rp_payload_t *g_rp_payloads = NULL;
 static uint32_t g_rp_payload_len = 0, g_rp_payload_cap = 0;
-/* phase 5b: subject-hash → name (META_SUBJHASH), and the ingress
- * tape — indices into g_rp_payloads, artifact order — that the
- * injector walks. */
+/* phase 5b: subject-hash → name (META_SUBJHASH, reporting only —
+ * routing identity is the FULL subject string each ingress record
+ * carries; review round: FNV-32 alone is collision-prone), and the
+ * ingress tape in artifact order. */
 typedef struct { uint32_t hash; const char *name; } rp_subj_t;
 static rp_subj_t *g_rp_subjects = NULL;
 static uint32_t g_rp_subject_len = 0, g_rp_subject_cap = 0;
-static uint32_t *g_rp_ingress = NULL;
+typedef struct {
+  const char *subject; /* into the artifact snapshot, NUL-terminated */
+  const char *shape;   /* canonical payload shape at record time */
+  const uint8_t *wire;
+  uint64_t wire_len;
+  uint64_t pub_id;
+} rp_ingress_t;
+static rp_ingress_t *g_rp_ingress = NULL;
 static uint32_t g_rp_ingress_len = 0, g_rp_ingress_cap = 0;
 static _Atomic uint64_t g_rp_injected = 0;
-static _Atomic uint64_t g_rp_inject_dropped = 0;
+static _Atomic uint64_t g_rp_ing_rejected = 0;
+static _Atomic uint64_t g_rp_ing_unmatched = 0;
+static _Atomic uint64_t g_rp_ing_incompatible = 0;
+static _Atomic uint64_t g_rp_ing_unprocessed = 0;
+static _Atomic uint64_t g_rp_injector_start_failure = 0;
 static _Atomic uint64_t g_rp_bindings_suppressed = 0;
+/* Anon-identity floor: injector workers carry RECORDED anonymous
+ * consumer ids; fresh anonymous claims in the same (replaying)
+ * process start above the recorded range so the two can never
+ * collide in a verify recording. */
+static uint64_t g_rp_anon_floor = 0;
 
 /* Creation happens ONLY during rp_load (single-threaded, pre-main);
  * at runtime every caller is lookup-only — the table is immutable
@@ -714,7 +747,7 @@ static void rp_load(void) {
     trailer_count = *(const uint64_t *)(g_rp_base + end - 8);
     end -= 16;
   } else {
-    /* GH #296 phase 5 (WAL durability): the drain appends whole
+    /* GH #296 phase 5 (durable recording): the drain appends whole
      * frames in stream order, so a crash-truncated file is EXACT
      * up to one torn frame at the tail — a usable prefix. Partial
      * history stays opt-in (the refusal was a deliberate
@@ -845,17 +878,38 @@ static void rp_load(void) {
         pl->bytes.args_len = 0;
         pl->bytes.jkind = 0;
         pl->bytes.withheld = 0;
-        /* phase 5b: ingress payloads with verbatim wire bytes (bit
-         * 0 set, bit 1 clear) are the injectable tape. */
-        if ((cfield & 1) && !(cfield & 2)) {
+        /* phase 5b: the injectable tape — ingress records carrying
+         * their FULL identity (bit 0 = ingress, bit 2 = prefixed
+         * with subject + canonical payload shape; bit 1 raw records
+         * are never injectable). The bytes are
+         * [u32 slen][subject\0][u32 shlen][shape\0][wire...]. */
+        if ((cfield & 1) && !(cfield & 2) && (cfield & 4)) {
+          if (size < 8) rp_fail("ingress record too small");
+          uint32_t slen, shlen;
+          memcpy(&slen, bytes, 4);
+          if ((uint64_t)slen + 8 > size || slen == 0 ||
+              bytes[4 + slen - 1] != 0) {
+            rp_fail("ingress subject frame out of range");
+          }
+          memcpy(&shlen, bytes + 4 + slen, 4);
+          if ((uint64_t)slen + shlen + 8 > size || shlen == 0 ||
+              bytes[8 + slen + shlen - 1] != 0) {
+            rp_fail("ingress shape frame out of range");
+          }
           if (g_rp_ingress_len == g_rp_ingress_cap) {
-            g_rp_ingress_cap = g_rp_ingress_cap ? g_rp_ingress_cap * 2 : 64;
-            uint32_t *g = realloc(g_rp_ingress,
-                                  g_rp_ingress_cap * sizeof(uint32_t));
+            g_rp_ingress_cap =
+                g_rp_ingress_cap ? g_rp_ingress_cap * 2 : 64;
+            rp_ingress_t *g = realloc(
+                g_rp_ingress, g_rp_ingress_cap * sizeof(rp_ingress_t));
             if (!g) rp_fail("out of memory");
             g_rp_ingress = g;
           }
-          g_rp_ingress[g_rp_ingress_len++] = g_rp_payload_len - 1;
+          rp_ingress_t *in = &g_rp_ingress[g_rp_ingress_len++];
+          in->subject = (const char *)bytes + 4;
+          in->shape = (const char *)bytes + 8 + slen;
+          in->wire = bytes + 8 + slen + shlen;
+          in->wire_len = size - 8 - slen - shlen;
+          in->pub_id = b;
         }
       } else {
         /* META: subject-hash map feeds injection + reports; other
@@ -909,38 +963,102 @@ uint64_t lotus_replay_ingress_count(void) {
              ? g_rp_ingress_len
              : 0;
 }
-int lotus_replay_ingress_get(uint64_t i, uint32_t *topic,
+int lotus_replay_ingress_get(uint64_t i, const char **subject,
                              uint64_t *pub_id, const void **bytes,
                              uint64_t *size) {
   if (i >= g_rp_ingress_len) return 0;
-  const rp_payload_t *pl = &g_rp_payloads[g_rp_ingress[i]];
-  *topic = pl->topic;
-  *pub_id = pl->pub_id;
-  *bytes = pl->bytes.p;
-  *size = pl->bytes.size;
+  const rp_ingress_t *in = &g_rp_ingress[i];
+  *subject = in->subject;
+  *pub_id = in->pub_id;
+  *bytes = in->wire;
+  *size = in->wire_len;
   return 1;
 }
-const char *lotus_replay_topic_name(uint32_t topic) {
-  for (uint32_t i = 0; i < g_rp_subject_len; i++) {
-    if (g_rp_subjects[i].hash == topic) return g_rp_subjects[i].name;
-  }
-  return NULL;
+/* Wire-identity admission (review round: subject spelling alone is
+ * not identity — changed code can keep "evt" and change the payload
+ * shape or codec). The recorded canonical shape must match the
+ * LIVE program's canonical shape for the same subject. */
+int lotus_replay_ingress_compatible(uint64_t i) {
+  if (i >= g_rp_ingress_len) return 0;
+  return strcmp(g_rp_ingress[i].shape,
+                obs_shape_for(g_rp_ingress[i].subject)) == 0;
 }
-uint32_t lotus_replay_subject_hash(const char *subject) {
-  return obs_subject_hash(subject);
+/* Recorded ingress-source identity (pub_id high bits): the
+ * injector runs one worker per recorded source so the verify
+ * recording's consumer identities line up with the original's. */
+uint64_t lotus_replay_ingress_source(uint64_t i) {
+  if (i >= g_rp_ingress_len) return 0;
+  return g_rp_ingress[i].pub_id >> 48;
+}
+/* Fresh anonymous claims in a replaying process start ABOVE the
+ * recorded ingress-source range (worker ids are forced to the
+ * recorded values; a same-numbered fresh claim would collide in
+ * the verify recording). */
+void lotus_replay_reserve_anon_floor(void) {
+  uint64_t max_src = 0;
+  for (uint32_t i = 0; i < g_rp_ingress_len; i++) {
+    uint64_t src = g_rp_ingress[i].pub_id >> 48;
+    if (src > max_src) max_src = src;
+  }
+  if (max_src >= OBS_REC_ANON_BASE) {
+    g_rp_anon_floor = max_src - OBS_REC_ANON_BASE + 1;
+  }
+}
+/* Has every recorded consume of `pub_id` been re-consumed? The
+ * ingress pacing bound (review round: unpaced injection can shed
+ * at bounded queues before the order gate ever sees the cell). */
+int lotus_replay_ingress_settled(uint64_t pub_id) {
+  for (int ci = 0; ci < g_rp_consumer_count; ci++) {
+    rp_consumer_t *c = &g_rp_consumers[ci];
+    uint32_t cur = atomic_load_explicit(&c->consume_cursor,
+                                        memory_order_acquire);
+    for (uint32_t k = cur; k < c->consume_len; k++) {
+      if (c->consume[k].msg == pub_id) return 0;
+    }
+  }
+  return 1;
 }
 /* Called by the injector immediately before dispatching one tape
  * payload. Strict replay: pin the RECORDED identity (and, when a
  * verify recording is running under --diff, record the injected
  * payload so the comparator can pair it). Feed: identity is the
  * new run's own — nothing to pin. */
+/* One prefixed ingress payload record:
+ * [u32 slen][subject\0][u32 shlen][shape\0][wire bytes], flags =
+ * ingress | prefixed. Shared by the live capture and the verify
+ * recording of an injected dispatch, so --diff pairs them byte for
+ * byte. */
+static void obs_rec_push_ingress(const char *subject,
+                                 const void *bytes, uint64_t size,
+                                 uint64_t pub_id) {
+  const char *shape = obs_shape_for(subject);
+  uint32_t slen = (uint32_t)strlen(subject) + 1;
+  uint32_t shlen = (uint32_t)strlen(shape) + 1;
+  uint64_t total = 8ull + slen + shlen + size;
+  uint8_t *buf = malloc(total);
+  if (!buf) {
+    fprintf(stderr,
+            "hale: LOTUS_OBS_RECORD ingress capture allocation "
+            "failed — failing the run rather than recording a gap\n");
+    fflush(NULL);
+    _exit(74);
+  }
+  memcpy(buf, &slen, 4);
+  memcpy(buf + 4, subject, slen);
+  memcpy(buf + 4 + slen, &shlen, 4);
+  memcpy(buf + 8 + slen, shape, shlen);
+  if (size) memcpy(buf + 8 + slen + shlen, bytes, size);
+  obs_rec_blob_push(OBS_REC_TAG_PAYLOAD, obs_subject_hash(subject),
+                    pub_id, 1u | 4u, buf, total);
+  free(buf);
+}
+
 uint64_t lotus_replay_inject_begin(const char *subject,
                                    const void *bytes, uint64_t size,
                                    uint64_t pub_id) {
   if (!lotus_replay_active) return 0;
   if (lotus_obs_recording && subject) {
-    obs_rec_blob_push(OBS_REC_TAG_PAYLOAD, obs_subject_hash(subject),
-                      pub_id, 1u, bytes, size);
+    obs_rec_push_ingress(subject, bytes, size, pub_id);
   }
   t_rec_forced_pub = pub_id;
   return pub_id;
@@ -948,9 +1066,24 @@ uint64_t lotus_replay_inject_begin(const char *subject,
 void lotus_replay_note_injected(void) {
   atomic_fetch_add_explicit(&g_rp_injected, 1, memory_order_relaxed);
 }
-void lotus_replay_note_inject_dropped(uint32_t topic) {
-  (void)topic;
-  atomic_fetch_add_explicit(&g_rp_inject_dropped, 1,
+void lotus_replay_note_ingress_rejected(void) {
+  atomic_fetch_add_explicit(&g_rp_ing_rejected, 1,
+                            memory_order_relaxed);
+}
+void lotus_replay_note_ingress_unmatched(void) {
+  atomic_fetch_add_explicit(&g_rp_ing_unmatched, 1,
+                            memory_order_relaxed);
+}
+void lotus_replay_note_ingress_incompatible(void) {
+  atomic_fetch_add_explicit(&g_rp_ing_incompatible, 1,
+                            memory_order_relaxed);
+}
+void lotus_replay_note_ingress_unprocessed(uint64_t n) {
+  atomic_fetch_add_explicit(&g_rp_ing_unprocessed, n,
+                            memory_order_relaxed);
+}
+void lotus_replay_note_injector_start_failure(void) {
+  atomic_fetch_add_explicit(&g_rp_injector_start_failure, 1,
                             memory_order_relaxed);
 }
 void lotus_replay_note_binding_suppressed(void) {
@@ -959,11 +1092,12 @@ void lotus_replay_note_binding_suppressed(void) {
 }
 
 /* Live-side twin of inject_begin, called by the reader threads
- * before they deserialize received wire bytes: capture the VERBATIM
- * wire form with the ingress flag (the injectable shape — the
- * struct-bytes record local_dispatch would otherwise push is
- * metadata-only and cannot be re-fed), derive the pub_id here, and
- * pin it so the dispatch a few lines later reuses this identity. */
+ * AFTER a successful deserialize (review round: a message the
+ * application rejected must never enter the injectable tape —
+ * identity is allocated per ACCEPTED message, so record and replay
+ * derive the same sequence). Captures the verbatim wire form with
+ * its full identity (subject + canonical shape) and pins the
+ * pub_id so the dispatch a few lines later reuses it. */
 uint64_t lotus_obs_record_ingress_wire(const char *subject,
                                        const void *bytes,
                                        uint64_t size) {
@@ -983,33 +1117,59 @@ uint64_t lotus_obs_record_ingress_wire(const char *subject,
   }
   uint64_t pub_id = (cid << 48) | (++t_pub_seq & 0xFFFFFFFFFFFFULL);
   if (lotus_obs_recording) {
-    obs_rec_blob_push(OBS_REC_TAG_PAYLOAD, obs_subject_hash(subject),
-                      pub_id, 1u, bytes, size);
+    obs_rec_push_ingress(subject, bytes, size, pub_id);
   }
   t_rec_forced_pub = pub_id;
   return pub_id;
 }
 
-/* A reader that captured wire bytes but then failed to deserialize
- * them never dispatches — the pinned identity must not leak onto
- * the thread's NEXT dispatch. */
-void lotus_obs_record_ingress_abort(void) { t_rec_forced_pub = 0; }
-
-/* Feed-mode exit report — dropped tape entries are the headline
- * fact: silence would read as "everything was fed." */
+/* Feed-mode exit report — and verdict. Unfed tape is a failure by
+ * default (review round: "0 of 100 injected; all matched" was a
+ * reportable outcome): every remainder is classified, and any
+ * unmatched / incompatible / unprocessed / start-failure remainder
+ * fails the run unless LOTUS_REPLAY_FEED_ALLOW_UNMATCHED=1
+ * (`hale replay --feed --allow-unmatched-feed`). */
 static void rp_feed_report(void) {
   uint64_t inj = atomic_load(&g_rp_injected);
-  uint64_t drop = atomic_load(&g_rp_inject_dropped);
+  uint64_t rej = atomic_load(&g_rp_ing_rejected);
+  uint64_t unm = atomic_load(&g_rp_ing_unmatched);
+  uint64_t inc = atomic_load(&g_rp_ing_incompatible);
+  uint64_t unp = atomic_load(&g_rp_ing_unprocessed);
+  uint64_t sf = atomic_load(&g_rp_injector_start_failure);
   fprintf(stderr,
           "hale feed: %llu of %u recorded ingress payload(s) "
-          "injected%s\n",
-          (unsigned long long)inj, g_rp_ingress_len,
-          drop ? "" : "; all matched");
-  if (drop) {
+          "injected\n",
+          (unsigned long long)inj, g_rp_ingress_len);
+  if (rej)
     fprintf(stderr,
-            "hale feed: %llu dropped — no matching subscribed "
-            "subject in this program\n",
-            (unsigned long long)drop);
+            "hale feed:   %llu rejected by this program's "
+            "deserializer\n",
+            (unsigned long long)rej);
+  if (unm)
+    fprintf(stderr,
+            "hale feed:   %llu unmatched — no subscribed subject in "
+            "this program\n",
+            (unsigned long long)unm);
+  if (inc)
+    fprintf(stderr,
+            "hale feed:   %llu incompatible — subject matches but "
+            "the payload shape changed\n",
+            (unsigned long long)inc);
+  if (unp)
+    fprintf(stderr,
+            "hale feed:   %llu unprocessed at shutdown\n",
+            (unsigned long long)unp);
+  if (sf)
+    fprintf(stderr, "hale feed:   injector failed to start\n");
+  if (unm + inc + unp + sf) {
+    const char *ok = getenv("LOTUS_REPLAY_FEED_ALLOW_UNMATCHED");
+    if (!(ok && ok[0] == '1')) {
+      fprintf(stderr,
+              "hale feed: unfed tape is a failure by default — pass "
+              "--allow-unmatched-feed to accept a partial feed\n");
+      fflush(NULL);
+      _exit(74);
+    }
   }
 }
 
@@ -1025,14 +1185,25 @@ static const rp_blob_ref_t *rp_serve(uint32_t jkind, const void *args,
   if (!lotus_replay_active || jkind >= RP_MAX_JK) return NULL;
   rp_consumer_t *c = rp_consumer(t_consumer_id);
   if (!c) {
-    atomic_fetch_add_explicit(&g_rp_divergences[jkind], 1,
-                              memory_order_relaxed);
+    /* Truncated tape: a consumer the recording never saw belongs
+     * to the unknown post-crash suffix, not to the prefix. */
+    atomic_fetch_add_explicit(g_rp_truncated
+                                  ? &g_rp_post_prefix
+                                  : &g_rp_divergences[jkind],
+                              1, memory_order_relaxed);
     return NULL;
   }
   rp_queue_t *q = &c->journal;
   if (q->cursor >= q->len) {
-    atomic_fetch_add_explicit(&g_rp_divergences[jkind], 1,
-                              memory_order_relaxed);
+    /* Stream exhausted. On a finalized tape that is a divergence;
+     * on an ACCEPTED truncated tape it is the post-crash suffix
+     * executing live (review round: the runtime verdict used to
+     * contradict the prefix comparator here). Mismatches BEFORE
+     * exhaustion stay divergences either way. */
+    atomic_fetch_add_explicit(g_rp_truncated
+                                  ? &g_rp_post_prefix
+                                  : &g_rp_divergences[jkind],
+                              1, memory_order_relaxed);
     return NULL;
   }
   const rp_blob_ref_t *e = &q->items[q->cursor];
@@ -1081,9 +1252,12 @@ int lotus_replay_expected_consume(uint64_t *out_msg,
                                   uint32_t *out_locus) {
   if (!lotus_replay_active) return 0;
   rp_consumer_t *c = rp_consumer(t_consumer_id);
-  if (!c || c->consume_cursor >= c->consume_len) return 0;
-  *out_msg = c->consume[c->consume_cursor].msg;
-  *out_locus = c->consume[c->consume_cursor].locus;
+  if (!c) return 0;
+  uint32_t cur = atomic_load_explicit(&c->consume_cursor,
+                                      memory_order_relaxed);
+  if (cur >= c->consume_len) return 0;
+  *out_msg = c->consume[cur].msg;
+  *out_locus = c->consume[cur].locus;
   return 1;
 }
 
@@ -1101,14 +1275,20 @@ uint64_t lotus_obs_pub_inst_id(void *self) {
 void lotus_replay_note_consume(void) {
   if (!lotus_replay_active) return;
   rp_consumer_t *c = rp_consumer(t_consumer_id);
-  if (c && c->consume_cursor < c->consume_len) c->consume_cursor++;
+  if (c && atomic_load_explicit(&c->consume_cursor,
+                                memory_order_relaxed) < c->consume_len) {
+    atomic_fetch_add_explicit(&c->consume_cursor, 1,
+                              memory_order_release);
+  }
   uint64_t n = atomic_fetch_add_explicit(&g_rp_consume_count, 1,
                                          memory_order_relaxed) + 1;
   /* consumer:N form — stable across multi-consumer runs, unlike
    * the process-wide ordinal (review, --at stability note). */
   if (g_replay_at_consumer && g_replay_at && c &&
       t_consumer_id == g_replay_at_consumer &&
-      (uint64_t)c->consume_cursor == g_replay_at) {
+      (uint64_t)atomic_load_explicit(&c->consume_cursor,
+                                     memory_order_relaxed) ==
+          g_replay_at) {
     fprintf(stderr,
             "hale replay: stopped at consumer %llu consume #%llu "
             "(pid %d) — attach a debugger, then SIGCONT\n",
@@ -1137,7 +1317,9 @@ static void rp_report(void) {
   for (int i = 0; i < g_rp_consumer_count; i++) {
     rp_consumer_t *c = &g_rp_consumers[i];
     unconsumed_journal += c->journal.len - c->journal.cursor;
-    unconsumed_deliveries += c->consume_len - c->consume_cursor;
+    unconsumed_deliveries +=
+        c->consume_len - atomic_load_explicit(&c->consume_cursor,
+                                              memory_order_relaxed);
   }
   uint64_t order_div = lotus_replay_order_divergences
       ? lotus_replay_order_divergences()
@@ -1154,11 +1336,22 @@ static void rp_report(void) {
       fprintf(sf,
               "journal_divergences=%llu\norder_divergences=%llu\n"
               "unconsumed_journal=%llu\nunconsumed_deliveries=%llu\n"
-              "unexpected_deliveries=%llu\nconsumes=%llu\n",
+              "unexpected_deliveries=%llu\n"
+              "ingress_rejected=%llu\ningress_unmatched=%llu\n"
+              "ingress_incompatible=%llu\ningress_unprocessed=%llu\n"
+              "injector_start_failure=%llu\n"
+              "post_prefix_live_fallback=%llu\nconsumes=%llu\n",
               (unsigned long long)jd, (unsigned long long)order_div,
               (unsigned long long)unconsumed_journal,
               (unsigned long long)unconsumed_deliveries,
               (unsigned long long)unexpected,
+              (unsigned long long)atomic_load(&g_rp_ing_rejected),
+              (unsigned long long)atomic_load(&g_rp_ing_unmatched),
+              (unsigned long long)atomic_load(&g_rp_ing_incompatible),
+              (unsigned long long)atomic_load(&g_rp_ing_unprocessed),
+              (unsigned long long)atomic_load(
+                  &g_rp_injector_start_failure),
+              (unsigned long long)atomic_load(&g_rp_post_prefix),
               (unsigned long long)atomic_load(&g_rp_consume_count));
       fclose(sf);
     }
@@ -1167,8 +1360,13 @@ static void rp_report(void) {
     "?", "time.now", "time.monotonic", "rand.next_int",
     "os.getrandom", "env.var", "env.var_exists", "env.arg",
     "env.args_count" };
+  uint64_t ing_div = atomic_load(&g_rp_ing_rejected) +
+                     atomic_load(&g_rp_ing_unmatched) +
+                     atomic_load(&g_rp_ing_incompatible) +
+                     atomic_load(&g_rp_ing_unprocessed) +
+                     atomic_load(&g_rp_injector_start_failure);
   uint64_t total = order_div + unconsumed_journal
-      + unconsumed_deliveries + unexpected;
+      + unconsumed_deliveries + unexpected + ing_div;
   for (int i = 0; i < RP_MAX_JK; i++)
     total += atomic_load(&g_rp_divergences[i]);
   if (g_rp_truncated) {
@@ -1184,8 +1382,15 @@ static void rp_report(void) {
             "injected (%llu dropped)\n",
             (unsigned long long)sup,
             (unsigned long long)atomic_load(&g_rp_injected),
-            g_rp_ingress_len,
-            (unsigned long long)atomic_load(&g_rp_inject_dropped));
+            g_rp_ingress_len, (unsigned long long)ing_div);
+  }
+  uint64_t post_prefix = atomic_load(&g_rp_post_prefix);
+  if (post_prefix) {
+    fprintf(stderr,
+            "hale replay: %llu event(s) past the truncated tape — "
+            "the unknown post-crash suffix, executed live (not "
+            "divergences)\n",
+            (unsigned long long)post_prefix);
   }
   if (total == 0) {
     fprintf(stderr,
@@ -1206,6 +1411,9 @@ static void rp_report(void) {
   if (order_div)
     fprintf(stderr, "  %-22s %llu\n", "delivery-order",
             (unsigned long long)order_div);
+  if (ing_div)
+    fprintf(stderr, "  %-22s %llu\n", "ingress",
+            (unsigned long long)ing_div);
   if (unconsumed_journal)
     fprintf(stderr, "  %-22s %llu\n", "unconsumed-journal",
             (unsigned long long)unconsumed_journal);
@@ -1260,7 +1468,8 @@ void lotus_obs_teardown(void) {
       uint64_t ident[6] = { g_obs_model_hash,
                             g_obs_exec_digest[0], g_obs_exec_digest[1],
                             g_obs_exec_digest[2], g_obs_exec_digest[3],
-                            g_rec_env_full ? 0u : 1u };
+                            (g_rec_env_full ? 0u : 1u) |
+                                (g_rec_durable ? 2u : 0u) };
       if (fseek(g_rec_file, 48, SEEK_SET) != 0 ||
           fwrite(ident, sizeof ident, 1, g_rec_file) != 1 ||
           fseek(g_rec_file, 0, SEEK_END) != 0) {
@@ -1271,8 +1480,15 @@ void lotus_obs_teardown(void) {
         _exit(74);
       }
       uint64_t trailer[2] = { OBS_REC_END, g_rec_written };
+      /* Durable grade: the trailer itself must reach stable
+       * storage — a clean exit followed by power loss must not
+       * demote a finalized recording to a truncated one (review
+       * round: the ordinary sweeps synced but the finalize did
+       * not). */
       if (fwrite(trailer, sizeof trailer, 1, g_rec_file) != 1 ||
-          fflush(g_rec_file) != 0 || fclose(g_rec_file) != 0) {
+          fflush(g_rec_file) != 0 ||
+          (g_rec_durable && fdatasync(fileno(g_rec_file)) != 0) ||
+          fclose(g_rec_file) != 0) {
         g_rec_file = NULL;
         fprintf(stderr,
                 "hale: LOTUS_OBS_RECORD finalize failed: %s — "
@@ -1495,6 +1711,30 @@ static int obs_create(int64_t rings, int64_t slots) {
               g_rec_path, strerror(errno));
       fflush(NULL);
       _exit(74);
+    }
+    /* Durable grade: a newly created NAME is not guaranteed to
+     * survive filesystem recovery until its directory entry is
+     * synchronized — fsync the parent directory once at creation
+     * (review round: the power-loss claim was incomplete without
+     * it). Best-effort resolution of the parent; failure to sync
+     * fails the run like any other durable-write failure. */
+    if (g_rec_durable) {
+      char dirbuf[sizeof g_rec_path];
+      memcpy(dirbuf, g_rec_path, sizeof dirbuf);
+      char *slash = strrchr(dirbuf, '/');
+      const char *dir = slash ? (slash == dirbuf ? "/" : (*slash = 0,
+                                                          dirbuf))
+                              : ".";
+      int dfd = open(dir, O_RDONLY | O_DIRECTORY);
+      if (dfd < 0 || fsync(dfd) != 0) {
+        fprintf(stderr,
+                "hale: LOTUS_OBS_RECORD_DURABLE could not sync the "
+                "recording's parent directory `%s`: %s\n",
+                dir, strerror(errno));
+        fflush(NULL);
+        _exit(74);
+      }
+      close(dfd);
     }
     setvbuf(g_rec_file, NULL, _IOFBF, 1 << 20);
     obs_rec_hdr_t rh = { .magic = OBS_REC_MAGIC, .maj = 0, .min = 3,
@@ -1871,7 +2111,7 @@ static void obs_rec_claim(void) {
      * range starts at OBS_REC_ANON_BASE so it cannot overlap the
      * pinned range (guarded at note_consumer_locus). */
     if (t_consumer_id == 0)
-      t_consumer_id = OBS_REC_ANON_BASE + (uint64_t)r;
+      t_consumer_id = OBS_REC_ANON_BASE + g_rp_anon_floor + (uint64_t)r;
     g_rec_rings[r].consumer = t_consumer_id;
     atomic_store_explicit(&g_rec_rings[r].head, 0,
                           memory_order_relaxed);
@@ -2027,7 +2267,7 @@ static void *obs_record_drain_main(void *arg) {
       g_rec_written++;
       wrote = 1;
     }
-    /* GH #296 phase 5 (WAL durability): identity used to be
+    /* GH #296 phase 5 (durable recording): identity used to be
      * authoritative only at the finalize re-stamp — so a crashed
      * run's artifact carried whatever the first probe snapshotted
      * (possibly zeros) and could never be admitted. Stamp the
@@ -2041,7 +2281,8 @@ static void *obs_record_drain_main(void *arg) {
       uint64_t ident[6] = { g_obs_model_hash,
                             g_obs_exec_digest[0], g_obs_exec_digest[1],
                             g_obs_exec_digest[2], g_obs_exec_digest[3],
-                            g_rec_env_full ? 0u : 1u };
+                            (g_rec_env_full ? 0u : 1u) |
+                                (g_rec_durable ? 2u : 0u) };
       if (fflush(g_rec_file) != 0 ||
           pwrite(fileno(g_rec_file), ident, sizeof ident, 48) !=
               (ssize_t)sizeof ident) {

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -380,6 +380,12 @@ static __thread uint64_t t_consume_seq = 0;
 #define OBS_REC_TAG_META 3u
 #define OBS_REC_META_TOPIC 1u
 #define OBS_REC_META_PUBRING 2u
+/* GH #296 phase 5b: subject-hash → name map. PAYLOAD records carry
+ * the stable FNV of the subject (registration-order manifest ids
+ * race across runs); this subtype lets a reader NAME a payload's
+ * subject without a live registry — which is what makes feed-mode
+ * "recorded topic X has no subscriber here" reports speakable. */
+#define OBS_REC_META_SUBJHASH 3u
 
 /* journal kinds — one per interposed runtime read */
 #define JK_TIME_NOW 1u
@@ -394,6 +400,24 @@ static __thread uint64_t t_consume_seq = 0;
 static __thread uint64_t t_consumer_id = 0; /* 0 = unassigned */
 static __thread uint64_t t_pub_seq = 0;
 static __thread uint64_t t_journal_seq = 0;
+/* GH #296 phase 5b: a pub_id decided BEFORE the dispatch that would
+ * otherwise derive one. Set by the ingress wire capture (the reader
+ * records the verbatim wire bytes and the dispatch must reuse that
+ * record's identity, not mint a second) and by the replay injector
+ * (an injected delivery must carry its RECORDED identity so the
+ * per-consumer order enforcement can match it). Consumed once. */
+static __thread uint64_t t_rec_forced_pub = 0;
+
+/* The stable subject hash payload records carry (see the v0.3 note
+ * in lotus_obs_record_publish_payload). */
+static uint32_t obs_subject_hash(const char *subject) {
+  uint32_t h = 2166136261u;
+  for (const char *q = subject; *q; q++) {
+    h ^= (uint8_t)*q;
+    h *= 16777619u;
+  }
+  return h;
+}
 
 /* Capture side-channel: payload + journal blobs travel from the
  * emitting thread to the drain on an MPSC push list (atomic
@@ -520,6 +544,13 @@ uint64_t lotus_obs_consumer_id(void) { return t_consumer_id; }
  * The file mapping is kept for process life — served strings are
  * pointers into it. */
 int lotus_replay_active = 0;
+/* GH #296 phase 5b: feed mode (LOTUS_REPLAY_FEED=<path>) — the
+ * backtesting contract. The recording is consumed as an INPUT TAPE
+ * only: recorded ingress is injected, transport bindings are
+ * suppressed (the wire belongs to the tape), and nothing else of
+ * replay applies — no journal serving, no order enforcement, no
+ * model admission. Same inputs, changed code, live everything else. */
+int lotus_replay_feed = 0;
 static char g_replay_path[512];
 static const uint8_t *g_rp_base; /* mmap'd recording */
 static int g_rp_truncated = 0; /* accepted without a finalize trailer */
@@ -571,6 +602,17 @@ typedef struct { uint64_t pub_id; uint32_t topic; uint32_t flags;
                  rp_blob_ref_t bytes; } rp_payload_t;
 static rp_payload_t *g_rp_payloads = NULL;
 static uint32_t g_rp_payload_len = 0, g_rp_payload_cap = 0;
+/* phase 5b: subject-hash → name (META_SUBJHASH), and the ingress
+ * tape — indices into g_rp_payloads, artifact order — that the
+ * injector walks. */
+typedef struct { uint32_t hash; const char *name; } rp_subj_t;
+static rp_subj_t *g_rp_subjects = NULL;
+static uint32_t g_rp_subject_len = 0, g_rp_subject_cap = 0;
+static uint32_t *g_rp_ingress = NULL;
+static uint32_t g_rp_ingress_len = 0, g_rp_ingress_cap = 0;
+static _Atomic uint64_t g_rp_injected = 0;
+static _Atomic uint64_t g_rp_inject_dropped = 0;
+static _Atomic uint64_t g_rp_bindings_suppressed = 0;
 
 /* Creation happens ONLY during rp_load (single-threaded, pre-main);
  * at runtime every caller is lookup-only — the table is immutable
@@ -803,7 +845,37 @@ static void rp_load(void) {
         pl->bytes.args_len = 0;
         pl->bytes.jkind = 0;
         pl->bytes.withheld = 0;
-      } /* META entries carry no replay state; validated + skipped */
+        /* phase 5b: ingress payloads with verbatim wire bytes (bit
+         * 0 set, bit 1 clear) are the injectable tape. */
+        if ((cfield & 1) && !(cfield & 2)) {
+          if (g_rp_ingress_len == g_rp_ingress_cap) {
+            g_rp_ingress_cap = g_rp_ingress_cap ? g_rp_ingress_cap * 2 : 64;
+            uint32_t *g = realloc(g_rp_ingress,
+                                  g_rp_ingress_cap * sizeof(uint32_t));
+            if (!g) rp_fail("out of memory");
+            g_rp_ingress = g;
+          }
+          g_rp_ingress[g_rp_ingress_len++] = g_rp_payload_len - 1;
+        }
+      } else {
+        /* META: subject-hash map feeds injection + reports; other
+         * subtypes carry no replay state — validated + skipped. */
+        if (b == OBS_REC_META_SUBJHASH && size > 0 &&
+            bytes[size - 1] == 0) {
+          if (g_rp_subject_len == g_rp_subject_cap) {
+            g_rp_subject_cap =
+                g_rp_subject_cap ? g_rp_subject_cap * 2 : 32;
+            rp_subj_t *g = realloc(
+                g_rp_subjects, g_rp_subject_cap * sizeof(rp_subj_t));
+            if (!g) rp_fail("out of memory");
+            g_rp_subjects = g;
+          }
+          g_rp_subjects[g_rp_subject_len].hash = a;
+          g_rp_subjects[g_rp_subject_len].name =
+              (const char *)bytes;
+          g_rp_subject_len++;
+        }
+      }
       off += 32 + padded;
     } else {
       rp_fail("unknown entry tag — recording from a newer hale?");
@@ -822,6 +894,117 @@ static void rp_load(void) {
             "dropped)\n",
             (unsigned long long)parsed,
             (unsigned long long)g_rp_dropped_tail);
+  }
+}
+
+/* ---- phase 5b: the ingress tape (injection + feed) -------------
+ *
+ * The reader threads' wire captures (verbatim bytes, ingress flag)
+ * become the injectable tape. The arena-side injector walks it in
+ * artifact order through these accessors; identity rides
+ * t_rec_forced_pub so an injected delivery matches its recorded
+ * consume events without minting a new pub_id. */
+uint64_t lotus_replay_ingress_count(void) {
+  return (lotus_replay_active || lotus_replay_feed)
+             ? g_rp_ingress_len
+             : 0;
+}
+int lotus_replay_ingress_get(uint64_t i, uint32_t *topic,
+                             uint64_t *pub_id, const void **bytes,
+                             uint64_t *size) {
+  if (i >= g_rp_ingress_len) return 0;
+  const rp_payload_t *pl = &g_rp_payloads[g_rp_ingress[i]];
+  *topic = pl->topic;
+  *pub_id = pl->pub_id;
+  *bytes = pl->bytes.p;
+  *size = pl->bytes.size;
+  return 1;
+}
+const char *lotus_replay_topic_name(uint32_t topic) {
+  for (uint32_t i = 0; i < g_rp_subject_len; i++) {
+    if (g_rp_subjects[i].hash == topic) return g_rp_subjects[i].name;
+  }
+  return NULL;
+}
+uint32_t lotus_replay_subject_hash(const char *subject) {
+  return obs_subject_hash(subject);
+}
+/* Called by the injector immediately before dispatching one tape
+ * payload. Strict replay: pin the RECORDED identity (and, when a
+ * verify recording is running under --diff, record the injected
+ * payload so the comparator can pair it). Feed: identity is the
+ * new run's own — nothing to pin. */
+uint64_t lotus_replay_inject_begin(const char *subject,
+                                   const void *bytes, uint64_t size,
+                                   uint64_t pub_id) {
+  if (!lotus_replay_active) return 0;
+  if (lotus_obs_recording && subject) {
+    obs_rec_blob_push(OBS_REC_TAG_PAYLOAD, obs_subject_hash(subject),
+                      pub_id, 1u, bytes, size);
+  }
+  t_rec_forced_pub = pub_id;
+  return pub_id;
+}
+void lotus_replay_note_injected(void) {
+  atomic_fetch_add_explicit(&g_rp_injected, 1, memory_order_relaxed);
+}
+void lotus_replay_note_inject_dropped(uint32_t topic) {
+  (void)topic;
+  atomic_fetch_add_explicit(&g_rp_inject_dropped, 1,
+                            memory_order_relaxed);
+}
+void lotus_replay_note_binding_suppressed(void) {
+  atomic_fetch_add_explicit(&g_rp_bindings_suppressed, 1,
+                            memory_order_relaxed);
+}
+
+/* Live-side twin of inject_begin, called by the reader threads
+ * before they deserialize received wire bytes: capture the VERBATIM
+ * wire form with the ingress flag (the injectable shape — the
+ * struct-bytes record local_dispatch would otherwise push is
+ * metadata-only and cannot be re-fed), derive the pub_id here, and
+ * pin it so the dispatch a few lines later reuses this identity. */
+uint64_t lotus_obs_record_ingress_wire(const char *subject,
+                                       const void *bytes,
+                                       uint64_t size) {
+  if ((!lotus_obs_recording && !lotus_replay_active) || !subject)
+    return 0;
+  if (!obs_on()) return 0;
+  if (t_consumer_id == 0) obs_rec_claim();
+  uint64_t cid = t_consumer_id;
+  if (cid > OBS_REC_CONSUMER_MAX || t_pub_seq >= 0xFFFFFFFFFFFFULL) {
+    fprintf(stderr,
+            "hale: recording identity out of range (consumer %llu, "
+            "seq %llu) — refusing to record ambiguously\n",
+            (unsigned long long)cid,
+            (unsigned long long)t_pub_seq);
+    fflush(NULL);
+    _exit(70);
+  }
+  uint64_t pub_id = (cid << 48) | (++t_pub_seq & 0xFFFFFFFFFFFFULL);
+  if (lotus_obs_recording) {
+    obs_rec_blob_push(OBS_REC_TAG_PAYLOAD, obs_subject_hash(subject),
+                      pub_id, 1u, bytes, size);
+  }
+  t_rec_forced_pub = pub_id;
+  return pub_id;
+}
+
+/* Feed-mode exit report — dropped tape entries are the headline
+ * fact: silence would read as "everything was fed." */
+static void rp_feed_report(void) {
+  uint64_t inj = atomic_load(&g_rp_injected);
+  uint64_t drop = atomic_load(&g_rp_inject_dropped);
+  fprintf(stderr,
+          "hale feed: %llu of %u recorded ingress payload(s) "
+          "injected%s\n",
+          (unsigned long long)inj, g_rp_ingress_len,
+          drop ? "" : "; all matched");
+  if (drop) {
+    fprintf(stderr,
+            "hale feed: %llu dropped — no matching subscribed "
+            "subject in this program\n",
+            (unsigned long long)drop);
   }
 }
 
@@ -987,6 +1170,17 @@ static void rp_report(void) {
     fprintf(stderr,
             "hale replay: note — truncated recording; coverage ends "
             "at the torn tail\n");
+  }
+  uint64_t sup = atomic_load(&g_rp_bindings_suppressed);
+  if (sup) {
+    fprintf(stderr,
+            "hale replay: hermetic wire — %llu binding(s) "
+            "suppressed; %llu of %u recorded ingress payload(s) "
+            "injected (%llu dropped)\n",
+            (unsigned long long)sup,
+            (unsigned long long)atomic_load(&g_rp_injected),
+            g_rp_ingress_len,
+            (unsigned long long)atomic_load(&g_rp_inject_dropped));
   }
   if (total == 0) {
     fprintf(stderr,
@@ -1378,7 +1572,28 @@ __attribute__((constructor)) static void obs_live_ctor(void) {
   t_consumer_id = 1;
   /* GH #296: replay. Implies observation (identity machinery rides
    * it); loads the recording eagerly so the first read is served. */
+  /* GH #296 phase 5b: feed mode. Mutually exclusive with strict
+   * replay — one recording cannot be both the law and merely the
+   * input tape in a single run. */
+  const char *feed = getenv("LOTUS_REPLAY_FEED");
   const char *rp = getenv("LOTUS_REPLAY");
+  if (feed && feed[0] && rp && rp[0]) {
+    fprintf(stderr,
+            "hale: LOTUS_REPLAY and LOTUS_REPLAY_FEED are mutually "
+            "exclusive\n");
+    _exit(64);
+  }
+  if (feed && feed[0]) {
+    size_t n = strlen(feed);
+    if (n >= sizeof g_replay_path) {
+      fprintf(stderr, "hale: LOTUS_REPLAY_FEED path too long\n");
+      _exit(64);
+    }
+    memcpy(g_replay_path, feed, n + 1);
+    rp_load();
+    lotus_replay_feed = 1;
+    atexit(rp_feed_report);
+  }
   if (rp && rp[0]) {
     size_t n = strlen(rp);
     if (n >= sizeof g_replay_path) {
@@ -1929,6 +2144,12 @@ static obs_topic_slot_t *obs_topic_slot(const char *subject,
           obs_rec_blob_push(OBS_REC_TAG_META, (uint32_t)id,
                             OBS_REC_META_TOPIC, 0,
                             subject, strlen(subject) + 1);
+          /* phase 5b: and the stable-hash spelling, which is the id
+           * space PAYLOAD records live in. */
+          obs_rec_blob_push(OBS_REC_TAG_META,
+                            obs_subject_hash(subject),
+                            OBS_REC_META_SUBJHASH, 0,
+                            subject, strlen(subject) + 1);
         }
       }
     }
@@ -2089,6 +2310,14 @@ uint64_t lotus_obs_record_publish_payload(const char *subject,
                                           int raw_struct) {
   if ((!lotus_obs_recording && !lotus_replay_active) || !subject)
     return 0;
+  /* phase 5b: an identity pinned by the ingress wire capture or the
+   * replay injector — this dispatch IS that record; do not mint a
+   * second id or push a second payload. */
+  if (t_rec_forced_pub) {
+    uint64_t forced = t_rec_forced_pub;
+    t_rec_forced_pub = 0;
+    return forced;
+  }
   if (!obs_on()) return 0;
   int ingress = g_obs_tls_redispatch; /* peek only */
   if (t_consumer_id == 0) obs_rec_claim(); /* unique anon id */

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -329,6 +329,7 @@ static int g_rec_thread_started = 0;
 static _Atomic int g_rec_stop = 0;
 static _Atomic uint64_t g_rec_cursor[64]; /* per-ring drained head */
 static uint64_t g_rec_written = 0;        /* drain-thread-owned */
+static int g_rec_durable = 0; /* LOTUS_OBS_RECORD_DURABLE=1 */
 static __thread uint64_t t_consume_seq = 0;
 
 #define OBS_REC_MAGIC 0x30434552454C4148ULL /* "HALEREC0" */
@@ -521,6 +522,8 @@ uint64_t lotus_obs_consumer_id(void) { return t_consumer_id; }
 int lotus_replay_active = 0;
 static char g_replay_path[512];
 static const uint8_t *g_rp_base; /* mmap'd recording */
+static int g_rp_truncated = 0; /* accepted without a finalize trailer */
+static uint64_t g_rp_dropped_tail = 0;
 static size_t g_rp_len;
 static uint64_t g_replay_at = 0; /* LOTUS_REPLAY_AT: stop at Nth consume */
 static uint64_t g_replay_at_consumer = 0; /* 0 = process-wide count */
@@ -669,8 +672,20 @@ static void rp_load(void) {
     trailer_count = *(const uint64_t *)(g_rp_base + end - 8);
     end -= 16;
   } else {
-    rp_fail("no clean-finalize trailer — the recording is "
-            "truncated; refusing to replay a partial history");
+    /* GH #296 phase 5 (WAL durability): the drain appends whole
+     * frames in stream order, so a crash-truncated file is EXACT
+     * up to one torn frame at the tail — a usable prefix. Partial
+     * history stays opt-in (the refusal was a deliberate
+     * review-round posture): the flag is the operator saying "I
+     * know the tape ends early." */
+    const char *tol = getenv("LOTUS_REPLAY_ALLOW_TRUNCATED");
+    if (!(tol && tol[0] == '1')) {
+      rp_fail("no clean-finalize trailer — the recording is "
+              "truncated (crashed writer?); pass --allow-truncated "
+              "(LOTUS_REPLAY_ALLOW_TRUNCATED=1) to replay the "
+              "recorded prefix");
+    }
+    g_rp_truncated = 1;
   }
   uint64_t parsed = 0;
   memset(rp_ring_consumer, 0, sizeof rp_ring_consumer);
@@ -680,7 +695,10 @@ static void rp_load(void) {
     uint32_t a = *(const uint32_t *)(g_rp_base + off + 4);
     parsed++;
     if (tag == OBS_REC_TAG_RING) {
-      if (end - off < 24) rp_fail("truncated ring record");
+      if (end - off < 24) {
+        if (g_rp_truncated) { parsed--; break; }
+        rp_fail("truncated ring record");
+      }
       uint64_t w0 = *(const uint64_t *)(g_rp_base + off + 8);
       uint64_t w1 = *(const uint64_t *)(g_rp_base + off + 16);
       uint32_t ekind = (uint32_t)((w0 >> 20) & 0x1F);
@@ -713,14 +731,21 @@ static void rp_load(void) {
       off += 24;
     } else if (tag == OBS_REC_TAG_PAYLOAD || tag == OBS_REC_TAG_JOURNAL
                || tag == OBS_REC_TAG_META) {
-      if (end - off < 32) rp_fail("truncated blob header");
+      if (end - off < 32) {
+        if (g_rp_truncated) { parsed--; break; }
+        rp_fail("truncated blob header");
+      }
       uint64_t b = *(const uint64_t *)(g_rp_base + off + 8);
       uint64_t cfield = *(const uint64_t *)(g_rp_base + off + 16);
       uint64_t size = *(const uint64_t *)(g_rp_base + off + 24);
       const uint8_t *bytes = g_rp_base + off + 32;
-      if (size > end - off - 32) rp_fail("blob length out of range");
+      if (size > end - off - 32) {
+        if (g_rp_truncated) { parsed--; break; }
+        rp_fail("blob length out of range");
+      }
       uint64_t padded = (size + 7) & ~7ull;
       if (padded < size || padded > end - off - 32) {
+        if (g_rp_truncated) { parsed--; break; }
         rp_fail("blob padding out of range");
       }
       if (tag == OBS_REC_TAG_JOURNAL) {
@@ -784,9 +809,19 @@ static void rp_load(void) {
       rp_fail("unknown entry tag — recording from a newer hale?");
     }
   }
-  if (off != end) rp_fail("entries do not end at the trailer");
-  if (parsed != trailer_count) {
-    rp_fail("trailer count disagrees with parsed entries");
+  if (!g_rp_truncated) {
+    if (off != end) rp_fail("entries do not end at the trailer");
+    if (parsed != trailer_count) {
+      rp_fail("trailer count disagrees with parsed entries");
+    }
+  } else {
+    g_rp_dropped_tail = end - off;
+    fprintf(stderr,
+            "hale: LOTUS_REPLAY: no clean finalize — replaying the "
+            "recorded prefix (%llu entries; %llu torn tail byte(s) "
+            "dropped)\n",
+            (unsigned long long)parsed,
+            (unsigned long long)g_rp_dropped_tail);
   }
 }
 
@@ -948,6 +983,11 @@ static void rp_report(void) {
       + unconsumed_deliveries + unexpected;
   for (int i = 0; i < RP_MAX_JK; i++)
     total += atomic_load(&g_rp_divergences[i]);
+  if (g_rp_truncated) {
+    fprintf(stderr,
+            "hale replay: note — truncated recording; coverage ends "
+            "at the torn tail\n");
+  }
   if (total == 0) {
     fprintf(stderr,
             "hale replay: journal served fully — 0 divergences, "
@@ -1372,6 +1412,11 @@ __attribute__((constructor)) static void obs_live_ctor(void) {
       _exit(64);
     }
   }
+  /* GH #296 phase 5: durability grade. Default recording rides the
+   * page cache (survives a process crash, not power loss);
+   * DURABLE=1 pushes every flushed drain sweep through fdatasync. */
+  const char *dur = getenv("LOTUS_OBS_RECORD_DURABLE");
+  if (dur && dur[0] == '1') g_rec_durable = 1;
 }
 
 /* Round 4/5: recording must initialize EAGERLY (a probe-free
@@ -1762,7 +1807,34 @@ static void *obs_record_drain_main(void *arg) {
       g_rec_written++;
       wrote = 1;
     }
+    /* GH #296 phase 5 (WAL durability): identity used to be
+     * authoritative only at the finalize re-stamp — so a crashed
+     * run's artifact carried whatever the first probe snapshotted
+     * (possibly zeros) and could never be admitted. Stamp the
+     * header the moment the ctor-sequenced setters have run.
+     * Drain-thread-owned; pwrite after a flush, so the append
+     * position never moves. Finalize still re-stamps — both agree. */
+    static uint64_t stamped_key = 0;
+    uint64_t ident_key = g_obs_model_hash ^ g_obs_exec_digest[0] ^
+                         g_obs_exec_digest[1];
+    if (ident_key && ident_key != stamped_key) {
+      uint64_t ident[6] = { g_obs_model_hash,
+                            g_obs_exec_digest[0], g_obs_exec_digest[1],
+                            g_obs_exec_digest[2], g_obs_exec_digest[3],
+                            g_rec_env_full ? 0u : 1u };
+      if (fflush(g_rec_file) != 0 ||
+          pwrite(fileno(g_rec_file), ident, sizeof ident, 48) !=
+              (ssize_t)sizeof ident) {
+        obs_rec_write_failed();
+      }
+      stamped_key = ident_key;
+      wrote = 1;
+    }
     if (wrote && fflush(g_rec_file) != 0) {
+      obs_rec_write_failed();
+    }
+    if (wrote && g_rec_durable &&
+        fdatasync(fileno(g_rec_file)) != 0) {
       obs_rec_write_failed();
     }
     if (stop) break;

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -990,6 +990,11 @@ uint64_t lotus_obs_record_ingress_wire(const char *subject,
   return pub_id;
 }
 
+/* A reader that captured wire bytes but then failed to deserialize
+ * them never dispatches — the pinned identity must not leak onto
+ * the thread's NEXT dispatch. */
+void lotus_obs_record_ingress_abort(void) { t_rec_forced_pub = 0; }
+
 /* Feed-mode exit report — dropped tape entries are the headline
  * fact: silence would read as "everything was fed." */
 static void rp_feed_report(void) {

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -167,6 +167,17 @@ static uint64_t g_obs_exec_digest[4] = {0, 0, 0, 0};
 void lotus_obs_exec_digest_set(uint64_t part, uint64_t v) {
   if (part < 4) g_obs_exec_digest[part] = v;
 }
+/* Review round 2, finding 2: the identity setters above are plain
+ * main-thread writes, and the recorder drain used to read them
+ * directly — an unsynchronized race whose XOR change-key also
+ * ignored digest words 2-3 (a crash could persist a HALF-published
+ * digest). The publication protocol is now explicit: the generated
+ * prelude calls lotus_obs_eager_init AFTER every setter, which
+ * copies the COMPLETE identity here and release-publishes the
+ * committed flag; the drain acquire-loads the flag and stamps only
+ * this immutable committed copy, exactly once. */
+static uint64_t g_obs_ident_committed_vals[6];
+static _Atomic int g_obs_ident_committed = 0;
 
 /* iris handoff-2 P10: publisher attribution. Codegen notes the
  * publishing locus's self in this TLS right before lowering a
@@ -554,6 +565,7 @@ int lotus_replay_feed = 0;
 static char g_replay_path[512];
 static const uint8_t *g_rp_base; /* mmap'd recording */
 static int g_rp_truncated = 0; /* accepted without a finalize trailer */
+static uint64_t g_rp_hdr_model = 0;
 static uint64_t g_rp_dropped_tail = 0;
 /* phase 5 (truncated prefix): recorded-history-exhausted events on
  * an accepted truncated tape are the unknown post-crash suffix,
@@ -637,6 +649,11 @@ static uint32_t g_rp_ingress_len = 0, g_rp_ingress_cap = 0;
 static _Atomic uint64_t g_rp_injected = 0;
 static _Atomic uint64_t g_rp_ing_rejected = 0;
 static _Atomic uint64_t g_rp_ing_unmatched = 0;
+/* Review round 2, finding 5: injection snapshots the registry at
+ * the BOOT/run boundary — a subscriber the program only creates
+ * during run() is a distinct fact from "no subscriber exists".
+ * The join path reclassifies (teardown-time registry rescan). */
+static _Atomic uint64_t g_rp_ing_late_sub = 0;
 static _Atomic uint64_t g_rp_ing_incompatible = 0;
 static _Atomic uint64_t g_rp_ing_unprocessed = 0;
 static _Atomic uint64_t g_rp_injector_start_failure = 0;
@@ -707,7 +724,11 @@ static void rp_load(void) {
   if (fd < 0) fd = open(g_replay_path, O_RDONLY | O_NOFOLLOW);
   if (fd < 0) rp_fail(strerror(errno));
   struct stat st;
-  if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || st.st_size < 112) {
+  /* Review round 2, finding 3: the minimum is the HEADER alone
+   * (96B) — a header-only file is the earliest valid crash prefix
+   * (killed after recorder creation, before the first complete
+   * frame). 112 demanded a trailer that a crash never writes. */
+  if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || st.st_size < 96) {
     close(fd);
     rp_fail("not a recording (too small or not a regular file)");
   }
@@ -740,6 +761,7 @@ static void rp_load(void) {
   if (h->header_len != sizeof(obs_rec_hdr_t)) {
     rp_fail("unexpected header length");
   }
+  g_rp_hdr_model = h->model_hash;
   size_t end = g_rp_len;
   uint64_t trailer_count = 0;
   if (end >= sizeof(obs_rec_hdr_t) + 16 &&
@@ -1074,6 +1096,12 @@ void lotus_replay_note_ingress_unmatched(void) {
   atomic_fetch_add_explicit(&g_rp_ing_unmatched, 1,
                             memory_order_relaxed);
 }
+void lotus_replay_reclassify_unmatched_late(uint64_t n) {
+  atomic_fetch_sub_explicit(&g_rp_ing_unmatched, n,
+                            memory_order_relaxed);
+  atomic_fetch_add_explicit(&g_rp_ing_late_sub, n,
+                            memory_order_relaxed);
+}
 void lotus_replay_note_ingress_incompatible(void) {
   atomic_fetch_add_explicit(&g_rp_ing_incompatible, 1,
                             memory_order_relaxed);
@@ -1134,8 +1162,20 @@ static void rp_feed_report(void) {
   uint64_t rej = atomic_load(&g_rp_ing_rejected);
   uint64_t unm = atomic_load(&g_rp_ing_unmatched);
   uint64_t inc = atomic_load(&g_rp_ing_incompatible);
+  uint64_t late = atomic_load(&g_rp_ing_late_sub);
   uint64_t unp = atomic_load(&g_rp_ing_unprocessed);
   uint64_t sf = atomic_load(&g_rp_injector_start_failure);
+  /* Review round 2, finding 4: the verdict must not depend on the
+   * join path having run. std::process::exit skips lifecycle
+   * teardown entirely — derive the unclassified remainder HERE, so
+   * "0 of N injected" can never ride an exit(0) to success. */
+  uint64_t classified = inj + rej + unm + late + inc + unp;
+  if (classified < g_rp_ingress_len) {
+    uint64_t implicit = g_rp_ingress_len - classified;
+    atomic_fetch_add_explicit(&g_rp_ing_unprocessed, implicit,
+                              memory_order_relaxed);
+    unp += implicit;
+  }
   fprintf(stderr,
           "hale feed: %llu of %u recorded ingress payload(s) "
           "injected\n",
@@ -1150,6 +1190,13 @@ static void rp_feed_report(void) {
             "hale feed:   %llu unmatched — no subscribed subject in "
             "this program\n",
             (unsigned long long)unm);
+  if (late)
+    fprintf(stderr,
+            "hale feed:   %llu uncovered — the subject's subscriber "
+            "is created after boot (injection covers the boot/run "
+            "snapshot; late subscriptions are a stated coverage "
+            "boundary)\n",
+            (unsigned long long)late);
   if (inc)
     fprintf(stderr,
             "hale feed:   %llu incompatible — subject matches but "
@@ -1161,7 +1208,7 @@ static void rp_feed_report(void) {
             (unsigned long long)unp);
   if (sf)
     fprintf(stderr, "hale feed:   injector failed to start\n");
-  if (unm + inc + unp + sf) {
+  if (unm + late + inc + unp + sf) {
     const char *ok = getenv("LOTUS_REPLAY_FEED_ALLOW_UNMATCHED");
     if (!(ok && ok[0] == '1')) {
       fprintf(stderr,
@@ -1338,6 +1385,7 @@ static void rp_report(void) {
               "unconsumed_journal=%llu\nunconsumed_deliveries=%llu\n"
               "unexpected_deliveries=%llu\n"
               "ingress_rejected=%llu\ningress_unmatched=%llu\n"
+              "late_subscription_uncovered=%llu\n"
               "ingress_incompatible=%llu\ningress_unprocessed=%llu\n"
               "injector_start_failure=%llu\n"
               "post_prefix_live_fallback=%llu\nconsumes=%llu\n",
@@ -1347,6 +1395,7 @@ static void rp_report(void) {
               (unsigned long long)unexpected,
               (unsigned long long)atomic_load(&g_rp_ing_rejected),
               (unsigned long long)atomic_load(&g_rp_ing_unmatched),
+              (unsigned long long)atomic_load(&g_rp_ing_late_sub),
               (unsigned long long)atomic_load(&g_rp_ing_incompatible),
               (unsigned long long)atomic_load(&g_rp_ing_unprocessed),
               (unsigned long long)atomic_load(
@@ -1362,6 +1411,7 @@ static void rp_report(void) {
     "env.args_count" };
   uint64_t ing_div = atomic_load(&g_rp_ing_rejected) +
                      atomic_load(&g_rp_ing_unmatched) +
+                     atomic_load(&g_rp_ing_late_sub) +
                      atomic_load(&g_rp_ing_incompatible) +
                      atomic_load(&g_rp_ing_unprocessed) +
                      atomic_load(&g_rp_injector_start_failure);
@@ -1835,8 +1885,9 @@ __attribute__((constructor)) static void obs_live_ctor(void) {
       _exit(64);
     }
     memcpy(g_replay_path, feed, n + 1);
-    rp_load();
+    /* Flag BEFORE load: identity defense (eager_init) keys off it. */
     lotus_replay_feed = 1;
+    rp_load();
     atexit(rp_feed_report);
   }
   if (rp && rp[0]) {
@@ -1892,6 +1943,42 @@ __attribute__((constructor)) static void obs_live_ctor(void) {
  * segment is born with its immutable header complete. The .halerec
  * artifact additionally re-stamps at finalize. */
 void lotus_obs_eager_init(void) {
+  /* Commit the complete identity for the recorder drain (see the
+   * committed-identity note at the globals). Runs on the main
+   * thread after every identity setter, before any user code. */
+  if (!atomic_load_explicit(&g_obs_ident_committed,
+                            memory_order_relaxed)) {
+    g_obs_ident_committed_vals[0] = g_obs_model_hash;
+    g_obs_ident_committed_vals[1] = g_obs_exec_digest[0];
+    g_obs_ident_committed_vals[2] = g_obs_exec_digest[1];
+    g_obs_ident_committed_vals[3] = g_obs_exec_digest[2];
+    g_obs_ident_committed_vals[4] = g_obs_exec_digest[3];
+    g_obs_ident_committed_vals[5] =
+        (g_rec_env_full ? 0u : 1u) | (g_rec_durable ? 2u : 0u);
+    atomic_store_explicit(&g_obs_ident_committed, 1,
+                          memory_order_release);
+  }
+  /* Review round 2, finding 1 (defense in depth): the runtime must
+   * not drive a binary from a recording whose model identity
+   * disagrees with the binary's own — the CLI is the user-facing
+   * admission layer, but a direct LOTUS_REPLAY invocation (or a
+   * substituted artifact) reaches here too. Feed mode bypasses
+   * identity by design; --allow-unverified-model plumbs through as
+   * an env override. */
+  if (lotus_replay_active && !lotus_replay_feed && g_obs_model_hash &&
+      g_rp_hdr_model && g_rp_hdr_model != g_obs_model_hash) {
+    const char *ok = getenv("LOTUS_REPLAY_ALLOW_UNVERIFIED");
+    if (!(ok && ok[0] == '1')) {
+      fprintf(stderr,
+              "hale: LOTUS_REPLAY recording identity (model %016llx) "
+              "disagrees with this binary (model %016llx) — refusing "
+              "to misreplay\n",
+              (unsigned long long)g_rp_hdr_model,
+              (unsigned long long)g_obs_model_hash);
+      fflush(NULL);
+      _exit(66);
+    }
+  }
   if (lotus_obs_recording || lotus_replay_active) {
     (void)obs_on();
   }
@@ -2270,25 +2357,24 @@ static void *obs_record_drain_main(void *arg) {
     /* GH #296 phase 5 (durable recording): identity used to be
      * authoritative only at the finalize re-stamp — so a crashed
      * run's artifact carried whatever the first probe snapshotted
-     * (possibly zeros) and could never be admitted. Stamp the
-     * header the moment the ctor-sequenced setters have run.
-     * Drain-thread-owned; pwrite after a flush, so the append
-     * position never moves. Finalize still re-stamps — both agree. */
-    static uint64_t stamped_key = 0;
-    uint64_t ident_key = g_obs_model_hash ^ g_obs_exec_digest[0] ^
-                         g_obs_exec_digest[1];
-    if (ident_key && ident_key != stamped_key) {
-      uint64_t ident[6] = { g_obs_model_hash,
-                            g_obs_exec_digest[0], g_obs_exec_digest[1],
-                            g_obs_exec_digest[2], g_obs_exec_digest[3],
-                            (g_rec_env_full ? 0u : 1u) |
-                                (g_rec_durable ? 2u : 0u) };
+     * (possibly zeros) and could never be admitted. Stamp it the
+     * moment the main thread has COMMITTED the complete identity
+     * (release/acquire — review round 2: plain cross-thread reads
+     * of the setters' globals were a race, and the old XOR change
+     * key could persist a half-published digest). Drain-thread-
+     * owned; pwrite after a flush, so the append position never
+     * moves. Finalize still re-stamps — both agree. */
+    static int ident_stamped = 0;
+    if (!ident_stamped &&
+        atomic_load_explicit(&g_obs_ident_committed,
+                             memory_order_acquire)) {
       if (fflush(g_rec_file) != 0 ||
-          pwrite(fileno(g_rec_file), ident, sizeof ident, 48) !=
-              (ssize_t)sizeof ident) {
+          pwrite(fileno(g_rec_file), g_obs_ident_committed_vals,
+                 sizeof g_obs_ident_committed_vals, 48) !=
+              (ssize_t)sizeof g_obs_ident_committed_vals) {
         obs_rec_write_failed();
       }
-      stamped_key = ident_key;
+      ident_stamped = 1;
       wrote = 1;
     }
     if (wrote && fflush(g_rec_file) != 0) {

--- a/crates/hale-codegen/runtime/lotus_shm_ring.c
+++ b/crates/hale-codegen/runtime/lotus_shm_ring.c
@@ -133,10 +133,33 @@ typedef struct {
  *
  * Returns NULL on error. errno is set.
  */
+/* GH #296 phase 5b (review round): shm_ring has NO replay class
+ * yet — no suppression, no injection. A replaying or feeding
+ * process must not open, create, or mutate live shared memory, so
+ * this backend FAILS CLOSED with the backend named. Weak externs:
+ * the standalone test drivers compile this TU without lotus_obs.c,
+ * where both flags resolve absent (guard inert). */
+extern int lotus_replay_active __attribute__((weak));
+extern int lotus_replay_feed __attribute__((weak));
+static void lotus_shm_ring_refuse_replay(void) {
+    if ((&lotus_replay_active && lotus_replay_active) ||
+        (&lotus_replay_feed && lotus_replay_feed)) {
+        fprintf(stderr,
+                "hale replay: `shm_ring` bindings have no replay "
+                "class yet — this backend cannot be suppressed or "
+                "injected, and a replayed/fed process must not touch "
+                "live shared memory. Remove the shm_ring binding or "
+                "re-record without it (GH #296).\n");
+        fflush(NULL);
+        _exit(65);
+    }
+}
+
 lotus_shm_ring_t *lotus_shm_ring_open(const char *name,
                                       uint64_t slot_size,
                                       uint64_t slot_count,
                                       lotus_shm_overflow_policy_t policy) {
+    lotus_shm_ring_refuse_replay();
     if (!name || slot_size == 0 || slot_count == 0) {
         errno = EINVAL;
         return NULL;
@@ -422,6 +445,7 @@ static void shm_layout_from_words(const uint64_t *w, lotus_shm_layout_t *d) {
  * magic/version mismatch, or a buffer_size that overruns the map. */
 static lotus_shm_layout_ring_t *
 lotus_shm_ring_open_layout(const char *name, const lotus_shm_layout_t *desc) {
+    lotus_shm_ring_refuse_replay();
     if (!name || !desc) { errno = EINVAL; return NULL; }
     if (strlen(name) + 1 > sizeof(((lotus_shm_layout_ring_t *)0)->shm_name)) {
         errno = ENAMETOOLONG;

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -3744,6 +3744,22 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                 .build_conditional_branch(active, run_bb, after_run_bb)
                 .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
             self.builder.position_at_end(run_bb);
+            // GH #296 phase 5b (review round): the ingress injector
+            // starts at an explicit BOOT PHASE — for the main locus,
+            // this point (params children born, bindings
+            // realized/suppressed, every boot subscription
+            // registered, run() not yet entered) is exactly the
+            // boot/run boundary the runtime snapshot needs. Runs on
+            // the main thread; no-op outside replay/feed.
+            if is_main_locus && !self.is_wasm {
+                let start_fn = self
+                    .module
+                    .get_function("lotus_replay_start_ingress")
+                    .expect("lotus_replay_start_ingress declared");
+                self.builder
+                    .build_call(start_fn, &[], "replay.start_ingress")
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            }
             if !info.empty_lifecycle.contains("run") || is_flow {
                 // F.31 Phase 4b + pool-inheritance fix (2026-05-29):
                 // a non-empty run() either runs synchronously here

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1947,6 +1947,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // binding could not be realized; the prelude routes
         // non-zero into lotus_bus_binding_fail (birth failure of
         // the declaring locus).
+        // GH #296 phase 5b: the boot-phase ingress-injection entry —
+        // emitted once at the main locus's boot/run boundary; no-op
+        // outside replay/feed.
+        // declare void @lotus_replay_start_ingress()
+        let start_ingress_ty = void_t.fn_type(&[], false);
+        self.module.add_function(
+            "lotus_replay_start_ingress",
+            start_ingress_ty,
+            None,
+        );
+
         // declare i32 @lotus_bus_register_remote(ptr subject, ptr url, i32 role)
         let i32_t = self.context.i32_type();
         let bus_register_remote_ty = i32_t.fn_type(

--- a/crates/hale-codegen/tests/replay_ingress.rs
+++ b/crates/hale-codegen/tests/replay_ingress.rs
@@ -111,6 +111,13 @@ fn pub_src(sock: &str) -> String {
             bus {{ publish Evt; }}
             bindings {{ Evt: unix("{}", role: connect); }}
             run() {{
+                // Settle before the first send: the listener binds at
+                // realize, BEFORE the subscriber's bus registration —
+                // a send in that window is silently dropped (the
+                // reader's no-deserializer path), which on a loaded
+                // CI runner starved the recorded run. Not a
+                // recording property; a boot-order one.
+                std::time::sleep(400ms);
                 Evt <- T {{ n: 7 }};
                 std::time::sleep(50ms);
                 Evt <- T {{ n: 11 }};

--- a/crates/hale-codegen/tests/replay_ingress.rs
+++ b/crates/hale-codegen/tests/replay_ingress.rs
@@ -475,6 +475,7 @@ fn colliding_subject_hashes_route_by_full_name() {
 
     let sock_a = unique_socket_path();
     let sock_b = format!("{}.b", sock_a);
+    let ready = format!("{}.ready", sock_a);
     let sub = format!(
         r#"
         type TA {{ n: Int = 0; }}
@@ -504,12 +505,15 @@ fn colliding_subject_hashes_route_by_full_name() {
                 B: unix("{}", role: listen);
             }}
             run() {{
+                // run() begins only after every boot registration:
+                // the ready-file is the true "subscribers exist"
+                // signal (the sockets exist earlier, at realize —
+                // a message in that window drops silently).
+                std::io::fs::write_file("{}", "ready") or discard;
                 // At least one message per subject proves routing;
                 // demanding every message makes the test hostage to
-                // the live boot-window drop (a message arriving
-                // before its subscriber registers is dropped by
-                // design — replay equivalence holds for whatever
-                // the tape actually carries).
+                // residual live-ingest loss under load — replay
+                // equivalence holds for whatever the tape carries.
                 let mut waited = 0;
                 while self.sa.seen < 1 || self.sb.seen < 1 {{
                     std::time::sleep(100ms);
@@ -521,7 +525,7 @@ fn colliding_subject_hashes_route_by_full_name() {
         }}
         fn main() {{ App {{ }}; }}
     "#,
-        sock_a, sock_b
+        sock_a, sock_b, ready
     );
     let pubs = format!(
         r#"
@@ -536,16 +540,12 @@ fn colliding_subject_hashes_route_by_full_name() {
                 B: unix("{}", role: connect);
             }}
             run() {{
-                // Generous settle: this test runs alongside seven
-                // siblings; the boot-order window (listener bound
-                // before subscribers register) widens under load.
-                std::time::sleep(900ms);
                 A <- TA {{ n: 101 }};
                 B <- TB {{ n: 202 }};
                 std::time::sleep(50ms);
                 A <- TA {{ n: 103 }};
                 B <- TB {{ n: 204 }};
-                std::time::sleep(200ms);
+                std::time::sleep(900ms);
             }}
         }}
         fn main() {{ App {{ }}; }}
@@ -562,6 +562,15 @@ fn colliding_subject_hashes_route_by_full_name() {
         .stderr(std::process::Stdio::piped())
         .spawn()
         .expect("spawn");
+    let deadline = std::time::Instant::now()
+        + std::time::Duration::from_secs(30);
+    while !std::path::Path::new(&ready).exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "subscriber never reached run()"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
     let p = Command::new(&pub_bin).output().expect("pubs");
     assert!(p.status.success());
     let out = subp.wait_with_output().expect("sub exit");
@@ -603,6 +612,7 @@ fn colliding_subject_hashes_route_by_full_name() {
     assert!(err.contains("0 divergences"), "stderr:\n{}", err);
 
     let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&ready);
     let _ = std::fs::remove_file(&sub_bin);
     let _ = std::fs::remove_file(&pub_bin);
 }

--- a/crates/hale-codegen/tests/replay_ingress.rs
+++ b/crates/hale-codegen/tests/replay_ingress.rs
@@ -1,0 +1,298 @@
+//! GH #296 phase 5b — hermetic ingress: recorded wire input is
+//! INJECTED under replay, and is a feedable tape under feed mode.
+//!
+//! What this holds the runtime to:
+//!
+//!   1. **The recording captures the wire form.** A listen-binding
+//!      subscriber records each received message's verbatim wire
+//!      bytes (ingress-flagged) — not just struct metadata.
+//!   2. **Strict replay is hermetic and equivalent.** Replaying the
+//!      subscriber WITHOUT the publisher (and without the socket):
+//!      bound transports never open, the injector re-dispatches the
+//!      tape with each delivery's RECORDED identity, and the run
+//!      produces byte-identical stdout with ZERO divergences — the
+//!      per-consumer order enforcement matched every injected
+//!      delivery to its recorded consume.
+//!   3. **Feed mode re-executes changed code on the same inputs.**
+//!      A DIFFERENT program (same subject, different handler) fed
+//!      the same tape processes the recorded payload values — the
+//!      backtesting contract: same inputs, changed code, live
+//!      everything else, and an exit report that says what was fed.
+
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::{build_executable_with_options, BuildOptions};
+
+#[path = "support/harness.rs"]
+mod harness;
+
+fn build(name: &str, src: &str) -> std::path::PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut programs = std::collections::BTreeMap::new();
+    programs.insert(name.to_string(), &program);
+    let bundle = hale_types::Bundle::new(programs);
+    let model_hash = hale_types::topology::model_shape_hash(&bundle);
+    let bin = harness::unique_bin(&format!("hale_test_ingress_{}", name));
+    let options = BuildOptions {
+        model_hash: Some(model_hash),
+        ..BuildOptions::default()
+    };
+    build_executable_with_options(&program, &bin, &[], &options)
+        .expect("build");
+    bin
+}
+
+fn unique_socket_path() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!(
+        "{}/hale-296-ingress-{}-{}.sock",
+        std::env::temp_dir().display(),
+        std::process::id(),
+        nanos
+    )
+}
+
+fn rec_path(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "hale_ingress_{}_{}.halerec",
+        std::process::id(),
+        name
+    ));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+fn sub_src(sock: &str) -> String {
+    format!(
+        r#"
+        type T {{ n: Int = 0; }}
+        topic Evt {{ payload: T; subject: "evt"; }}
+        locus Sub {{
+            params {{ seen: Int = 0; total: Int = 0; }}
+            bus {{ subscribe Evt as on_evt; }}
+            fn on_evt(t: T) {{
+                self.seen = self.seen + 1;
+                self.total = self.total + t.n;
+                println("got=", t.n);
+            }}
+        }}
+        main locus App {{
+            params {{ sub: Sub = Sub {{ }}; }}
+            bindings {{ Evt: unix("{}", role: listen); }}
+            run() {{
+                let mut waited = 0;
+                while self.sub.seen < 3 {{
+                    std::time::sleep(100ms);
+                    waited = waited + 1;
+                    if waited > 120 {{
+                        std::process::exit(3);
+                    }}
+                }}
+                println("total=", self.sub.total);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock
+    )
+}
+
+fn pub_src(sock: &str) -> String {
+    format!(
+        r#"
+        type T {{ n: Int = 0; }}
+        topic Evt {{ payload: T; subject: "evt"; }}
+        main locus App {{
+            bus {{ publish Evt; }}
+            bindings {{ Evt: unix("{}", role: connect); }}
+            run() {{
+                Evt <- T {{ n: 7 }};
+                std::time::sleep(50ms);
+                Evt <- T {{ n: 11 }};
+                std::time::sleep(50ms);
+                Evt <- T {{ n: 23 }};
+                std::time::sleep(200ms);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock
+    )
+}
+
+/// Record a listener run fed by a real connecting publisher, and
+/// return (recording path, the listener's recorded stdout).
+fn record_session(
+    tag: &str,
+    sub_bin: &std::path::Path,
+    pub_bin: &std::path::Path,
+) -> (std::path::PathBuf, String) {
+    let rec = rec_path(tag);
+    let sub = Command::new(sub_bin)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn recorded subscriber");
+    // The publisher's connect-with-retry rides out the listener's
+    // boot; run it to completion.
+    let p = Command::new(pub_bin).output().expect("run publisher");
+    assert!(
+        p.status.success(),
+        "publisher failed: {}",
+        String::from_utf8_lossy(&p.stderr)
+    );
+    let out = sub.wait_with_output().expect("subscriber exit");
+    assert!(
+        out.status.success(),
+        "recorded subscriber failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert!(
+        stdout.contains("got=7")
+            && stdout.contains("got=11")
+            && stdout.contains("got=23")
+            && stdout.contains("total=41"),
+        "recorded run did not see the wire traffic:\n{}",
+        stdout
+    );
+    (rec, stdout)
+}
+
+#[test]
+fn strict_replay_injects_the_recorded_ingress_hermetically() {
+    let sock = unique_socket_path();
+    let sub_bin = build("sub", &sub_src(&sock));
+    let pub_bin = build("pub", &pub_src(&sock));
+    let (rec, recorded_stdout) = record_session("strict", &sub_bin, &pub_bin);
+
+    // Replay with NO publisher and NO socket: the bound transport
+    // must never open, and the tape must carry the run.
+    let _ = std::fs::remove_file(&sock);
+    let replayed = Command::new(&sub_bin)
+        .env("LOTUS_REPLAY", &rec)
+        .output()
+        .expect("replay subscriber");
+    let err = String::from_utf8_lossy(&replayed.stderr);
+    assert!(
+        replayed.status.success(),
+        "hermetic replay failed; stderr:\n{}",
+        err
+    );
+    // Byte-identical observable behavior, from the tape alone.
+    assert_eq!(
+        String::from_utf8_lossy(&replayed.stdout),
+        recorded_stdout,
+        "replay stdout differs from the recorded run's"
+    );
+    // The wire was hermetic and the tape was injected...
+    assert!(
+        err.contains("hermetic wire") && err.contains("injected"),
+        "expected the hermetic-wire report; stderr:\n{}",
+        err
+    );
+    // ...with recorded identities: every injected delivery matched
+    // its recorded consume — zero divergences, not merely "ran".
+    assert!(
+        err.contains("0 divergences"),
+        "expected a divergence-free replay; stderr:\n{}",
+        err
+    );
+    // And the listener socket was never created.
+    assert!(
+        !std::path::Path::new(&sock).exists(),
+        "replay must not open the bound transport"
+    );
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+}
+
+#[test]
+fn feed_mode_runs_changed_code_on_the_recorded_tape() {
+    let sock = unique_socket_path();
+    let sub_bin = build("feedsub", &sub_src(&sock));
+    let pub_bin = build("feedpub", &pub_src(&sock));
+    let (rec, _) = record_session("feed", &sub_bin, &pub_bin);
+
+    // A DIFFERENT program: same subject, different handler logic
+    // (scales each payload by 10). Model hash differs — feed mode
+    // admits it by design.
+    let changed = format!(
+        r#"
+        type T {{ n: Int = 0; }}
+        topic Evt {{ payload: T; subject: "evt"; }}
+        locus Scaler {{
+            params {{ seen: Int = 0; total: Int = 0; }}
+            bus {{ subscribe Evt as on_evt; }}
+            fn on_evt(t: T) {{
+                self.seen = self.seen + 1;
+                self.total = self.total + t.n * 10;
+                println("scaled=", t.n * 10);
+            }}
+        }}
+        main locus App {{
+            params {{ s: Scaler = Scaler {{ }}; }}
+            bindings {{ Evt: unix("{}", role: listen); }}
+            run() {{
+                let mut waited = 0;
+                while self.s.seen < 3 {{
+                    std::time::sleep(100ms);
+                    waited = waited + 1;
+                    if waited > 120 {{
+                        std::process::exit(3);
+                    }}
+                }}
+                println("scaled_total=", self.s.total);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock
+    );
+    let changed_bin = build("feedchanged", &changed);
+
+    let _ = std::fs::remove_file(&sock);
+    let fed = Command::new(&changed_bin)
+        .env("LOTUS_REPLAY_FEED", &rec)
+        .output()
+        .expect("feed changed program");
+    let out = String::from_utf8_lossy(&fed.stdout);
+    let err = String::from_utf8_lossy(&fed.stderr);
+    assert!(
+        fed.status.success(),
+        "feed run failed; stderr:\n{}",
+        err
+    );
+    // The changed code processed the RECORDED inputs.
+    assert!(
+        out.contains("scaled=70")
+            && out.contains("scaled=110")
+            && out.contains("scaled=230")
+            && out.contains("scaled_total=410"),
+        "changed program did not process the tape:\n{}",
+        out
+    );
+    // And the exit report says what was fed.
+    assert!(
+        err.contains("hale feed:") && err.contains("injected"),
+        "expected the feed report; stderr:\n{}",
+        err
+    );
+    assert!(
+        !std::path::Path::new(&sock).exists(),
+        "feed must not open the bound transport"
+    );
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+    let _ = std::fs::remove_file(&changed_bin);
+}

--- a/crates/hale-codegen/tests/replay_ingress.rs
+++ b/crates/hale-codegen/tests/replay_ingress.rs
@@ -303,3 +303,598 @@ fn feed_mode_runs_changed_code_on_the_recorded_tape() {
     let _ = std::fs::remove_file(&pub_bin);
     let _ = std::fs::remove_file(&changed_bin);
 }
+
+// ---- review-round canaries -----------------------------------------
+
+/// FNV-1a/32 as the recorder spells it — the collision premise below
+/// is asserted, not assumed.
+fn fnv32(s: &str) -> u32 {
+    let mut h: u32 = 2166136261;
+    for b in s.bytes() {
+        h ^= b as u32;
+        h = h.wrapping_mul(16777619);
+    }
+    h
+}
+
+/// A message the original application REJECTED (deserialize failure)
+/// must never enter the injectable tape: identity is allocated per
+/// accepted message, so record and replay derive the same sequence.
+#[cfg(target_os = "linux")]
+#[test]
+fn rejected_wire_never_enters_the_tape() {
+    let sock = unique_socket_path();
+    // A String payload: its wire form is length-framed, so a runt
+    // frame genuinely FAILS deserialization (an Int payload's codec
+    // is lenient enough to accept almost anything).
+    let sub = format!(
+        r#"
+        type Msg {{ text: String = ""; }}
+        topic Evt {{ payload: Msg; subject: "evt"; }}
+        locus Sub {{
+            params {{ seen: Int = 0; }}
+            bus {{ subscribe Evt as on_m; }}
+            fn on_m(m: Msg) {{
+                self.seen = self.seen + 1;
+                println("got=", m.text);
+            }}
+        }}
+        main locus App {{
+            params {{ sub: Sub = Sub {{ }}; }}
+            bindings {{ Evt: unix("{}", role: listen); }}
+            run() {{
+                let mut waited = 0;
+                while self.sub.seen < 3 {{
+                    std::time::sleep(100ms);
+                    waited = waited + 1;
+                    if waited > 120 {{ std::process::exit(3); }}
+                }}
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock
+    );
+    let pubs = format!(
+        r#"
+        type Msg {{ text: String = ""; }}
+        topic Evt {{ payload: Msg; subject: "evt"; }}
+        main locus App {{
+            bus {{ publish Evt; }}
+            bindings {{ Evt: unix("{}", role: connect); }}
+            run() {{
+                std::time::sleep(400ms);
+                Evt <- Msg {{ text: "alpha" }};
+                std::time::sleep(50ms);
+                Evt <- Msg {{ text: "beta" }};
+                std::time::sleep(50ms);
+                Evt <- Msg {{ text: "gamma" }};
+                std::time::sleep(200ms);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock
+    );
+    let sub_bin = build("rejsub", &sub);
+    let pub_bin = build("rejpub", &pubs);
+    let rec = rec_path("rej");
+
+    let sub = Command::new(&sub_bin)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn recorded subscriber");
+
+    // First peer: a raw SEQPACKET connection delivering one garbage
+    // frame the deserializer must reject. Retry the connect until
+    // the listener is bound.
+    unsafe {
+        let mut fd = -1;
+        for _ in 0..200 {
+            fd = libc::socket(libc::AF_UNIX, libc::SOCK_SEQPACKET, 0);
+            assert!(fd >= 0);
+            let mut addr: libc::sockaddr_un = std::mem::zeroed();
+            addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+            let bytes = sock.as_bytes();
+            for (i, b) in bytes.iter().enumerate() {
+                addr.sun_path[i] = *b as libc::c_char;
+            }
+            let len = std::mem::size_of::<libc::sa_family_t>()
+                + bytes.len()
+                + 1;
+            if libc::connect(
+                fd,
+                &addr as *const _ as *const libc::sockaddr,
+                len as libc::socklen_t,
+            ) == 0
+            {
+                break;
+            }
+            libc::close(fd);
+            fd = -1;
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(fd >= 0, "could not connect the garbage peer");
+        // A 3-byte runt frame: no codec for T can accept it. (A
+        // plausible-length frame of 0xFF bytes deserializes fine —
+        // the codec reads an Int from it — which is the point of
+        // the accepted/rejected distinction being the CODEC'''s.)
+        let junk = [0xFFu8; 3];
+        assert!(
+            libc::send(fd, junk.as_ptr() as *const _, junk.len(), 0)
+                > 0
+        );
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        libc::close(fd);
+    }
+
+    // Second peer: the honest publisher (3 valid messages).
+    let p = Command::new(&pub_bin).output().expect("run publisher");
+    assert!(p.status.success());
+    let out = sub.wait_with_output().expect("subscriber exit");
+    assert!(
+        out.status.success(),
+        "recorded subscriber failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let recorded_stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+
+    // Replay hermetically: the tape must carry EXACTLY the three
+    // accepted messages — the rejected frame is not input.
+    let _ = std::fs::remove_file(&sock);
+    let replayed = Command::new(&sub_bin)
+        .env("LOTUS_REPLAY", &rec)
+        .output()
+        .expect("replay");
+    let err = String::from_utf8_lossy(&replayed.stderr);
+    assert!(replayed.status.success(), "stderr:\n{}", err);
+    assert!(
+        err.contains("3 of 3 recorded ingress payload(s) injected"),
+        "tape must hold only the accepted messages; stderr:\n{}",
+        err
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&replayed.stdout),
+        recorded_stdout
+    );
+    assert!(err.contains("0 divergences"), "stderr:\n{}", err);
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+}
+
+/// Tape routing is by FULL subject string: two subjects whose
+/// FNV-1a/32 hashes collide must each receive their own traffic.
+#[test]
+fn colliding_subject_hashes_route_by_full_name() {
+    // The premise, asserted: these collide under the recorder's hash.
+    assert_eq!(fnv32("i4lt8ja7"), fnv32("w6s0e3sz"));
+
+    let sock_a = unique_socket_path();
+    let sock_b = format!("{}.b", sock_a);
+    let sub = format!(
+        r#"
+        type TA {{ n: Int = 0; }}
+        type TB {{ n: Int = 0; }}
+        topic A {{ payload: TA; subject: "i4lt8ja7"; }}
+        topic B {{ payload: TB; subject: "w6s0e3sz"; }}
+        locus SubA {{
+            params {{ seen: Int = 0; }}
+            bus {{ subscribe A as on_a; }}
+            fn on_a(t: TA) {{
+                self.seen = self.seen + 1;
+                println("a=", t.n);
+            }}
+        }}
+        locus SubB {{
+            params {{ seen: Int = 0; }}
+            bus {{ subscribe B as on_b; }}
+            fn on_b(t: TB) {{
+                self.seen = self.seen + 1;
+                println("b=", t.n);
+            }}
+        }}
+        main locus App {{
+            params {{ sa: SubA = SubA {{ }}; sb: SubB = SubB {{ }}; }}
+            bindings {{
+                A: unix("{}", role: listen);
+                B: unix("{}", role: listen);
+            }}
+            run() {{
+                // At least one message per subject proves routing;
+                // demanding every message makes the test hostage to
+                // the live boot-window drop (a message arriving
+                // before its subscriber registers is dropped by
+                // design — replay equivalence holds for whatever
+                // the tape actually carries).
+                let mut waited = 0;
+                while self.sa.seen < 1 || self.sb.seen < 1 {{
+                    std::time::sleep(100ms);
+                    waited = waited + 1;
+                    if waited > 120 {{ std::process::exit(3); }}
+                }}
+                std::time::sleep(400ms);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock_a, sock_b
+    );
+    let pubs = format!(
+        r#"
+        type TA {{ n: Int = 0; }}
+        type TB {{ n: Int = 0; }}
+        topic A {{ payload: TA; subject: "i4lt8ja7"; }}
+        topic B {{ payload: TB; subject: "w6s0e3sz"; }}
+        main locus App {{
+            bus {{ publish A; publish B; }}
+            bindings {{
+                A: unix("{}", role: connect);
+                B: unix("{}", role: connect);
+            }}
+            run() {{
+                // Generous settle: this test runs alongside seven
+                // siblings; the boot-order window (listener bound
+                // before subscribers register) widens under load.
+                std::time::sleep(900ms);
+                A <- TA {{ n: 101 }};
+                B <- TB {{ n: 202 }};
+                std::time::sleep(50ms);
+                A <- TA {{ n: 103 }};
+                B <- TB {{ n: 204 }};
+                std::time::sleep(200ms);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock_a, sock_b
+    );
+    let sub_bin = build("collsub", &sub);
+    let pub_bin = build("collpub", &pubs);
+    let rec = rec_path("coll");
+
+    let subp = Command::new(&sub_bin)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    let p = Command::new(&pub_bin).output().expect("pubs");
+    assert!(p.status.success());
+    let out = subp.wait_with_output().expect("sub exit");
+    assert!(
+        out.status.success(),
+        "recorded collision run failed:\nstdout:{}\nstderr:{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let recorded_stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    // The routing property: A-values (10x) only ever print under
+    // `a=`, B-values (20x) only under `b=` — colliding hashes must
+    // not cross the streams, live or replayed.
+    assert!(
+        recorded_stdout.contains("a=10")
+            && recorded_stdout.contains("b=20")
+            && !recorded_stdout.contains("a=20")
+            && !recorded_stdout.contains("b=10"),
+        "recorded routing crossed the streams:\n{}",
+        recorded_stdout
+    );
+
+    let _ = std::fs::remove_file(&sock_a);
+    let _ = std::fs::remove_file(&sock_b);
+    let replayed = Command::new(&sub_bin)
+        .env("LOTUS_REPLAY", &rec)
+        .output()
+        .expect("replay");
+    let err = String::from_utf8_lossy(&replayed.stderr);
+    assert!(replayed.status.success(), "stderr:\n{}", err);
+    // Byte-identical routing: colliding hashes cannot cross the
+    // streams when identity is the full subject.
+    assert_eq!(
+        String::from_utf8_lossy(&replayed.stdout),
+        recorded_stdout,
+        "replay stderr:\n{}",
+        err
+    );
+    assert!(err.contains("0 divergences"), "stderr:\n{}", err);
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+}
+
+/// Strict pacing at a bounded queue: the original ingress was slow
+/// enough that a capacity-1 subscriber shed nothing; an unpaced
+/// replay would burst-shed at enqueue, which no dequeue-side order
+/// gate can undo. Paced injection must deliver every message.
+#[test]
+fn bounded_capacity_one_replays_without_shedding() {
+    let sock = unique_socket_path();
+    let sub = format!(
+        r#"
+        type T {{ n: Int = 0; }}
+        topic Evt {{ payload: T; subject: "evt"; }}
+        locus Sub {{
+            params {{ seen: Int = 0; }}
+            bus {{ subscribe Evt as on_e bounded(1, drop_old); }}
+            fn on_e(t: T) {{
+                self.seen = self.seen + 1;
+                println("got=", t.n);
+            }}
+        }}
+        main locus App {{
+            params {{ sub: Sub = Sub {{ }}; }}
+            bindings {{ Evt: unix("{}", role: listen); }}
+            run() {{
+                let mut waited = 0;
+                while self.sub.seen < 6 {{
+                    std::time::sleep(40ms);
+                    waited = waited + 1;
+                    if waited > 400 {{ std::process::exit(3); }}
+                }}
+                println("all=", self.sub.seen);
+                std::time::sleep(100ms);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock
+    );
+    let pubs = format!(
+        r#"
+        type T {{ n: Int = 0; }}
+        topic Evt {{ payload: T; subject: "evt"; }}
+        main locus App {{
+            bus {{ publish Evt; }}
+            bindings {{ Evt: unix("{}", role: connect); }}
+            run() {{
+                std::time::sleep(400ms);
+                let mut i = 0;
+                while i < 6 {{
+                    Evt <- T {{ n: i }};
+                    std::time::sleep(150ms);
+                    i = i + 1;
+                }}
+                std::time::sleep(200ms);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock
+    );
+    let sub_bin = build("capsub", &sub);
+    let pub_bin = build("cappub", &pubs);
+    let rec = rec_path("cap");
+    let subp = Command::new(&sub_bin)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    let p = Command::new(&pub_bin).output().expect("pub");
+    assert!(p.status.success());
+    let out = subp.wait_with_output().expect("sub exit");
+    assert!(
+        out.status.success(),
+        "recorded run failed (original must not shed): {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let recorded_stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert!(
+        recorded_stdout.contains("all=6"),
+        "original must shed nothing:\n{}",
+        recorded_stdout
+    );
+
+    let _ = std::fs::remove_file(&sock);
+    let replayed = Command::new(&sub_bin)
+        .env("LOTUS_REPLAY", &rec)
+        .output()
+        .expect("replay");
+    let err = String::from_utf8_lossy(&replayed.stderr);
+    assert!(replayed.status.success(), "stderr:\n{}", err);
+    // Zero shedding: all 8 delivered, byte-identical, no divergence.
+    assert_eq!(
+        String::from_utf8_lossy(&replayed.stdout),
+        recorded_stdout,
+        "paced injection must not shed at the bounded queue"
+    );
+    assert!(err.contains("0 divergences"), "stderr:\n{}", err);
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+}
+
+/// Feed targets that DROPPED the listener binding still get the
+/// tape: tape presence, not the survival of the old listener
+/// declaration, decides that injection starts.
+#[test]
+fn feed_reaches_a_target_without_the_listener_binding() {
+    let sock = unique_socket_path();
+    let sub_bin = build("nobindsub", &sub_src(&sock));
+    let pub_bin = build("nobindpub", &pub_src(&sock));
+    let (rec, _) = record_session("nobind", &sub_bin, &pub_bin);
+
+    // Same subscribed subject; NO bindings block at all.
+    let changed = r#"
+        type T { n: Int = 0; }
+        topic Evt { payload: T; subject: "evt"; }
+        locus Sum {
+            params { seen: Int = 0; total: Int = 0; }
+            bus { subscribe Evt as on_e; }
+            fn on_e(t: T) {
+                self.seen = self.seen + 1;
+                self.total = self.total + t.n;
+            }
+        }
+        main locus App {
+            params { s: Sum = Sum { }; }
+            run() {
+                let mut waited = 0;
+                while self.s.seen < 3 {
+                    std::time::sleep(50ms);
+                    waited = waited + 1;
+                    if waited > 100 { std::process::exit(3); }
+                }
+                println("sum=", self.s.total);
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let changed_bin = build("nobindchanged", changed);
+    let fed = Command::new(&changed_bin)
+        .env("LOTUS_REPLAY_FEED", &rec)
+        .output()
+        .expect("feed");
+    let outp = String::from_utf8_lossy(&fed.stdout);
+    let err = String::from_utf8_lossy(&fed.stderr);
+    assert!(fed.status.success(), "stderr:\n{}", err);
+    assert!(
+        outp.contains("sum=41"),
+        "the binding-less target must still receive the tape:\n{}\n{}",
+        outp,
+        err
+    );
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+    let _ = std::fs::remove_file(&changed_bin);
+}
+
+/// Same subject, changed payload shape: wire identity refuses the
+/// injection (named), and an unfed tape fails feed by default —
+/// `--allow-unmatched-feed` is the explicit acceptance.
+#[test]
+fn incompatible_payload_shape_fails_feed_closed() {
+    let sock = unique_socket_path();
+    let sub_bin = build("shapesub", &sub_src(&sock));
+    let pub_bin = build("shapepub", &pub_src(&sock));
+    let (rec, _) = record_session("shape", &sub_bin, &pub_bin);
+
+    // Subject "evt" survives; the payload gains a field — a
+    // different canonical shape, so the recorded bytes must not be
+    // fed to the new deserializer as a plausible wrong value.
+    let changed = r#"
+        type T { n: Int = 0; scale: Int = 1; }
+        topic Evt { payload: T; subject: "evt"; }
+        locus Sub {
+            params { seen: Int = 0; }
+            bus { subscribe Evt as on_e; }
+            fn on_e(t: T) { self.seen = self.seen + 1; }
+        }
+        main locus App {
+            params { s: Sub = Sub { }; }
+            run() { std::time::sleep(300ms); }
+        }
+        fn main() { App { }; }
+    "#;
+    let changed_bin = build("shapechanged", changed);
+
+    let fed = Command::new(&changed_bin)
+        .env("LOTUS_REPLAY_FEED", &rec)
+        .output()
+        .expect("feed");
+    let err = String::from_utf8_lossy(&fed.stderr);
+    assert!(
+        !fed.status.success(),
+        "an entirely-unfed tape must fail feed by default; stderr:\n{}",
+        err
+    );
+    assert!(
+        err.contains("incompatible") && err.contains("shape"),
+        "the refusal must name the incompatibility; stderr:\n{}",
+        err
+    );
+
+    let allowed = Command::new(&changed_bin)
+        .env("LOTUS_REPLAY_FEED", &rec)
+        .env("LOTUS_REPLAY_FEED_ALLOW_UNMATCHED", "1")
+        .output()
+        .expect("feed allowed");
+    assert!(
+        allowed.status.success(),
+        "--allow-unmatched-feed must accept the partial feed: {}",
+        String::from_utf8_lossy(&allowed.stderr)
+    );
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+    let _ = std::fs::remove_file(&changed_bin);
+}
+
+/// A binding backend with no replay class fails CLOSED at the
+/// runtime seam too (the CLI refuses earlier with a nicer message):
+/// a replayed process must never open, create, or mutate live
+/// shared memory.
+#[test]
+fn shm_ring_refuses_replay_and_touches_no_shared_memory() {
+    // Any valid recording will do — admission is the CLI's job; the
+    // runtime guard fires at shm open regardless of the tape.
+    let sock = unique_socket_path();
+    let sub_bin = build("shmrecsub", &sub_src(&sock));
+    let pub_bin = build("shmrecpub", &pub_src(&sock));
+    let (rec, _) = record_session("shmrec", &sub_bin, &pub_bin);
+
+    let shm_name = format!(
+        "/hale-296-shmguard-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0)
+    );
+    let prog = format!(
+        r#"
+        type W {{ n: Int = 0; }}
+        topic World {{ payload: W; subject: "world"; }}
+        locus Pub {{
+            bus {{ publish World; }}
+            run() {{ World <- W {{ n: 1 }}; }}
+        }}
+        main locus App {{
+            params {{ p: Pub = Pub {{ }}; }}
+            bindings {{
+                World: shm_ring("{}", slot_count: 64,
+                                on_overflow: drop);
+            }}
+            run() {{ std::time::sleep(50ms); }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        shm_name
+    );
+    let shm_bin = build("shmguard", &prog);
+
+    let replayed = Command::new(&shm_bin)
+        .env("LOTUS_REPLAY", &rec)
+        .output()
+        .expect("replay shm program");
+    let err = String::from_utf8_lossy(&replayed.stderr);
+    assert!(
+        !replayed.status.success(),
+        "shm_ring must refuse replay; stderr:\n{}",
+        err
+    );
+    assert!(
+        err.contains("shm_ring") && err.contains("no replay class"),
+        "the refusal must name the backend; stderr:\n{}",
+        err
+    );
+    let shm_path = format!("/dev/shm{}", shm_name);
+    assert!(
+        !std::path::Path::new(&shm_path).exists(),
+        "replay must not create the shared-memory object"
+    );
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+    let _ = std::fs::remove_file(&shm_bin);
+}

--- a/crates/hale-codegen/tests/replay_ingress.rs
+++ b/crates/hale-codegen/tests/replay_ingress.rs
@@ -908,3 +908,65 @@ fn shm_ring_refuses_replay_and_touches_no_shared_memory() {
     let _ = std::fs::remove_file(&pub_bin);
     let _ = std::fs::remove_file(&shm_bin);
 }
+
+/// Feed's verdict must not depend on teardown having run (review
+/// round 2, finding 4): a target that exits during birth — before
+/// the boot-phase injector even starts — must still fail with the
+/// whole tape reported unprocessed, because the report derives the
+/// unclassified remainder itself.
+#[test]
+fn feed_early_exit_cannot_fail_open() {
+    let sock = unique_socket_path();
+    let sub_bin = build("earlysub", &sub_src(&sock));
+    let pub_bin = build("earlypub", &pub_src(&sock));
+    let (rec, _) = record_session("early", &sub_bin, &pub_bin);
+
+    let bail = r#"
+        type T { n: Int = 0; }
+        topic Evt { payload: T; subject: "evt"; }
+        locus Sub {
+            params { seen: Int = 0; }
+            bus { subscribe Evt as on_e; }
+            fn on_e(t: T) { self.seen = self.seen + 1; }
+        }
+        main locus App {
+            params { s: Sub = Sub { }; }
+            birth() { std::process::exit(0); }
+            run() { std::time::sleep(100ms); }
+        }
+        fn main() { App { }; }
+    "#;
+    let bail_bin = build("earlybail", bail);
+
+    let fed = Command::new(&bail_bin)
+        .env("LOTUS_REPLAY_FEED", &rec)
+        .output()
+        .expect("feed early-exit target");
+    let err = String::from_utf8_lossy(&fed.stderr);
+    assert!(
+        !fed.status.success(),
+        "an exit(0) before injection must not fail open; stderr:\n{}",
+        err
+    );
+    assert!(
+        err.contains("0 of 3") && err.contains("unprocessed"),
+        "the whole tape must be reported unprocessed; stderr:\n{}",
+        err
+    );
+
+    let allowed = Command::new(&bail_bin)
+        .env("LOTUS_REPLAY_FEED", &rec)
+        .env("LOTUS_REPLAY_FEED_ALLOW_UNMATCHED", "1")
+        .output()
+        .expect("feed allowed");
+    assert!(
+        allowed.status.success(),
+        "--allow-unmatched-feed accepts the (empty) partial feed: {}",
+        String::from_utf8_lossy(&allowed.stderr)
+    );
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+    let _ = std::fs::remove_file(&bail_bin);
+}

--- a/crates/hale-codegen/tests/replay_truncated.rs
+++ b/crates/hale-codegen/tests/replay_truncated.rs
@@ -1,0 +1,216 @@
+//! GH #296 phase 5 — WAL durability: a crash-truncated recording is
+//! a usable prefix.
+//!
+//! The drain appends whole frames in stream order and stamps the
+//! header identity eagerly (not only at finalize), so a run that
+//! dies without tearing down leaves an artifact that is exact up to
+//! one torn frame at the tail. What these tests hold that to:
+//!
+//!   1. **Kill mid-run, keep the prefix.** SIGKILL a recording run;
+//!      the file has no clean-finalize trailer, but its header
+//!      identity (model_hash) is already stamped — the artifact is
+//!      attributable to its program without a finalize.
+//!   2. **Fail closed by default.** Replaying the truncated file
+//!      refuses loudly and names the opt-in.
+//!   3. **Opt in, replay the prefix.** With
+//!      LOTUS_REPLAY_ALLOW_TRUNCATED=1 the same file replays: the
+//!      loader stops at the torn tail, says so, and the program runs
+//!      to completion (post-tape reads fall back live and are
+//!      counted, never fatal).
+//!   4. **Durable grade still finalizes.** LOTUS_OBS_RECORD_DURABLE=1
+//!      changes flush discipline, not the format — a clean run under
+//!      it produces a trailer-finalized artifact that replays with
+//!      zero order divergence.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use hale_codegen::{build_executable_with_options, BuildOptions};
+
+#[path = "support/harness.rs"]
+mod harness;
+
+const REC_END_MAGIC: u64 = 0x30444E45454C4148; // "HALEEND0"
+
+/// Build WITH a model hash (as the CLI does): the eager-stamp
+/// assertion below is about identity reaching a crashed artifact's
+/// header, which needs the binary to carry an identity at all.
+fn build(name: &str, src: &str) -> PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut programs = std::collections::BTreeMap::new();
+    programs.insert(name.to_string(), &program);
+    let bundle = hale_types::Bundle::new(programs);
+    let model_hash = hale_types::topology::model_shape_hash(&bundle);
+    let bin = harness::unique_bin(&format!("hale_test_trunc_{}", name));
+    let options = BuildOptions {
+        model_hash: Some(model_hash),
+        ..BuildOptions::default()
+    };
+    build_executable_with_options(&program, &bin, &[], &options)
+        .expect("build");
+    bin
+}
+
+fn rec_path(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "hale_trunc_{}_{}.halerec",
+        std::process::id(),
+        name
+    ));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+/// A slow steady publisher: ~2s of 5ms-spaced publishes, so there is
+/// a wide window to SIGKILL the run mid-stream with entries already
+/// drained to the file.
+const SLOW_STREAM: &str = r#"
+    type Tick { n: Int = 0; }
+
+    locus Sink {
+        params { seen: Int = 0; }
+        bus { subscribe "trunc.tick" as on_t of type Tick; }
+        fn on_t(t: Tick) { self.seen = self.seen + 1; }
+    }
+
+    main locus App {
+        params { s: Sink = Sink { }; }
+        bus { publish "trunc.tick" of type Tick; }
+        run() {
+            let mut i = 0;
+            while i < 400 {
+                "trunc.tick" <- Tick { n: i };
+                std::time::sleep(5ms);
+                i = i + 1;
+            }
+        }
+    }
+
+    fn main() { App { }; }
+"#;
+
+fn u64_at(b: &[u8], off: usize) -> u64 {
+    u64::from_le_bytes(b[off..off + 8].try_into().unwrap())
+}
+
+#[test]
+fn killed_recording_keeps_an_admissible_prefix() {
+    let bin = build("kill", SLOW_STREAM);
+    let rec = rec_path("kill");
+
+    let mut child = Command::new(&bin)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .spawn()
+        .expect("spawn recorded run");
+
+    // Wait until the drain has demonstrably written entries past the
+    // header, then kill without ceremony.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let sz = std::fs::metadata(&rec).map(|m| m.len()).unwrap_or(0);
+        if sz > 4096 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "recording never grew past the header (size {})",
+            sz
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    child.kill().expect("SIGKILL the recording run");
+    let _ = child.wait();
+
+    let bytes = std::fs::read(&rec).expect("read truncated recording");
+    assert!(bytes.len() > 4096);
+    // 1. No clean-finalize trailer: the run died, and the artifact
+    //    must say so.
+    assert_ne!(
+        u64_at(&bytes, bytes.len() - 16),
+        REC_END_MAGIC,
+        "a SIGKILLed run must not carry a clean-finalize trailer"
+    );
+    // ...but the header identity is ALREADY stamped (the WAL eager
+    // stamp) — the crashed artifact is attributable, not anonymous.
+    assert_ne!(
+        u64_at(&bytes, 48),
+        0,
+        "model_hash must be stamped before finalize (eager WAL stamp)"
+    );
+
+    // 2. Default: fail closed, name the opt-in.
+    let refused = Command::new(&bin)
+        .env("LOTUS_REPLAY", &rec)
+        .output()
+        .expect("run refused replay");
+    assert!(
+        !refused.status.success(),
+        "replaying a truncated recording must refuse by default"
+    );
+    let err = String::from_utf8_lossy(&refused.stderr);
+    assert!(
+        err.contains("--allow-truncated"),
+        "the refusal must name the opt-in; stderr:\n{}",
+        err
+    );
+
+    // 3. Opted in: the prefix replays and the program completes.
+    let replayed = Command::new(&bin)
+        .env("LOTUS_REPLAY", &rec)
+        .env("LOTUS_REPLAY_ALLOW_TRUNCATED", "1")
+        .output()
+        .expect("run prefix replay");
+    let err = String::from_utf8_lossy(&replayed.stderr);
+    assert!(
+        replayed.status.success(),
+        "prefix replay must run to completion; stderr:\n{}",
+        err
+    );
+    assert!(
+        err.contains("replaying the recorded prefix"),
+        "the loader must announce the truncated prefix; stderr:\n{}",
+        err
+    );
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&bin);
+}
+
+#[test]
+fn durable_grade_records_and_finalizes_clean() {
+    let bin = build("durable", SLOW_STREAM);
+    let rec = rec_path("durable");
+
+    let recorded = Command::new(&bin)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .env("LOTUS_OBS_RECORD_DURABLE", "1")
+        .output()
+        .expect("durable recorded run");
+    assert!(
+        recorded.status.success(),
+        "durable recording run failed: {}",
+        String::from_utf8_lossy(&recorded.stderr)
+    );
+
+    let bytes = std::fs::read(&rec).expect("read durable recording");
+    assert_eq!(
+        u64_at(&bytes, bytes.len() - 16),
+        REC_END_MAGIC,
+        "a clean durable run must finalize with the trailer"
+    );
+
+    let replayed = Command::new(&bin)
+        .env("LOTUS_REPLAY", &rec)
+        .output()
+        .expect("replay durable recording");
+    assert!(
+        replayed.status.success(),
+        "durable recording must replay: {}",
+        String::from_utf8_lossy(&replayed.stderr)
+    );
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&bin);
+}

--- a/crates/hale-codegen/tests/replay_truncated.rs
+++ b/crates/hale-codegen/tests/replay_truncated.rs
@@ -45,6 +45,11 @@ fn build(name: &str, src: &str) -> PathBuf {
     let bin = harness::unique_bin(&format!("hale_test_trunc_{}", name));
     let options = BuildOptions {
         model_hash: Some(model_hash),
+        // A designed digest so the eager-stamp assertion can check
+        // ALL FOUR words landed (review round 2, finding 2: the old
+        // change-key ignored words 2-3 and could persist a
+        // half-published digest).
+        exec_digest: Some([0xA1A1, 0xB2B2, 0xC3C3, 0xD4D4]),
         ..BuildOptions::default()
     };
     build_executable_with_options(&program, &bin, &[], &options)
@@ -133,11 +138,24 @@ fn killed_recording_keeps_an_admissible_prefix() {
         "a SIGKILLed run must not carry a clean-finalize trailer"
     );
     // ...but the header identity is ALREADY stamped (the eager
-    // stamp) — the crashed artifact is attributable, not anonymous.
+    // stamp) — the crashed artifact is attributable, not anonymous,
+    // and the digest is COMPLETE: identity is committed atomically
+    // after every setter and stamped from the immutable committed
+    // copy, so a crash can never persist a half-published digest.
     assert_ne!(
         u64_at(&bytes, 48),
         0,
         "model_hash must be stamped before finalize (eager stamp)"
+    );
+    assert_eq!(
+        [
+            u64_at(&bytes, 56),
+            u64_at(&bytes, 64),
+            u64_at(&bytes, 72),
+            u64_at(&bytes, 80)
+        ],
+        [0xA1A1, 0xB2B2, 0xC3C3, 0xD4D4],
+        "the crash artifact must carry the COMPLETE exec digest"
     );
 
     // 2. Default: fail closed, name the opt-in.

--- a/crates/hale-codegen/tests/replay_truncated.rs
+++ b/crates/hale-codegen/tests/replay_truncated.rs
@@ -1,4 +1,4 @@
-//! GH #296 phase 5 — WAL durability: a crash-truncated recording is
+//! GH #296 phase 5 — durable recording: a crash-truncated recording is
 //! a usable prefix.
 //!
 //! The drain appends whole frames in stream order and stamps the
@@ -132,12 +132,12 @@ fn killed_recording_keeps_an_admissible_prefix() {
         REC_END_MAGIC,
         "a SIGKILLed run must not carry a clean-finalize trailer"
     );
-    // ...but the header identity is ALREADY stamped (the WAL eager
+    // ...but the header identity is ALREADY stamped (the eager
     // stamp) — the crashed artifact is attributable, not anonymous.
     assert_ne!(
         u64_at(&bytes, 48),
         0,
-        "model_hash must be stamped before finalize (eager WAL stamp)"
+        "model_hash must be stamped before finalize (eager stamp)"
     );
 
     // 2. Default: fail closed, name the opt-in.

--- a/docs/src/systems/operations.md
+++ b/docs/src/systems/operations.md
@@ -272,12 +272,15 @@ file format is pre-stable (GH #296).
 hale replay run.halerec app.hl            # re-execute it
 hale replay run.halerec app.hl --diff     # + compare, fail on any divergence
 hale replay run.halerec app.hl --at 65:12 # SIGSTOP at consumer 65's 12th consume
+hale replay run.halerec app.hl --allow-truncated  # crashed run → replay the prefix
+hale replay run.halerec app.hl --feed     # inject the ingress tape into changed code
 ```
 
 The full story — admission by executable identity, the
 safe-by-default effect gate (`--allow-live-effects`), env-value
-redaction (`LOTUS_OBS_RECORD_ENV`), the coverage boundary, and
-what the comparator actually compares — has its own chapter:
+redaction (`LOTUS_OBS_RECORD_ENV`), the hermetic wire and ingress
+injection, feed mode (backtesting), crash-truncated recordings,
+and what the comparator actually compares — has its own chapter:
 [Record & replay](./replay.md).
 
 ## Debugging with the native toolchain

--- a/docs/src/systems/replay.md
+++ b/docs/src/systems/replay.md
@@ -33,9 +33,18 @@ because a dropped record is a replay that diverges silently:
 - a thread that cannot get a ring, a capture allocation failure, a
   write failure, or a finalize failure **fails the run** — never a
   silent gap;
-- the file ends with a clean-finalize trailer, and a recording is
-  admitted for replay only when the *entire* artifact validates —
-  exact parse to the trailer, matching entry count.
+- the file ends with a clean-finalize trailer, and a finalized
+  recording is admitted for replay only when the *entire* artifact
+  validates — exact parse to the trailer, matching entry count.
+
+The recording is also **crash-durable**: frames stream to disk in
+order and the header identity is stamped eagerly, so a run that
+dies without teardown — the run whose recording you want most —
+leaves an artifact that is exact up to one torn frame at the tail.
+Replaying it is an explicit opt-in (`--allow-truncated`): the
+loader stops at the torn frame, says how much it kept, and replays
+that prefix. `LOTUS_OBS_RECORD_DURABLE=1` adds an `fdatasync` per
+drain sweep for power-loss durability.
 
 The recording needs no observer attached and works from the first
 probe. It captures four things:
@@ -50,9 +59,11 @@ probe. It captures four things:
    comparator can align them across runs. Synchronous
    direct-dispatch traffic — the devirtualized flavor most
    intra-app traffic compiles to — is visible here.
-3. **Payloads.** Wire-encoded payloads verbatim; raw in-process
-   structs as *metadata only* (an ABI snapshot would carry heap
-   pointers and padding while being useless for comparison).
+3. **Payloads.** Wire-encoded payloads verbatim — including every
+   message a listen binding receives, captured in its wire form as
+   an **injectable ingress tape** — and raw in-process structs as
+   *metadata only* (an ABI snapshot would carry heap pointers and
+   padding while being useless for comparison).
 4. **The input journal.** Every user-facing nondeterministic read —
    `std::time::now`, `std::time::monotonic[_ns]`,
    `std::rand::next_int`, `std::os::getrandom`, the `std::env`
@@ -81,10 +92,12 @@ hale replay run.halerec app.hl --at 65:12 # ...at consumer 65's 12th consume
 
 - **Safety, before anything else.** Re-execution repeats real side
   effects, so a program whose effect frontier reaches `syscall`,
-  `ffi`, `unclassified`, or any transport-bound `bindings` block is
-  refused with the residue named, unless you pass
-  `--allow-live-effects`. This is deliberately coarse (a lone
-  `sleep` trips it); over-refusing is the safe direction.
+  `ffi`, or `unclassified` is refused with the residue named,
+  unless you pass `--allow-live-effects`. This is deliberately
+  coarse (a lone `sleep` trips it); over-refusing is the safe
+  direction. `bindings` blocks are *not* on the list: under replay
+  the wire is hermetic — bound transports never open, and the
+  recorded ingress is injected instead (below).
 - **Executable identity.** The recording carries a framed SHA-256
   over the full compiler/runtime/stdlib source tree, the compiler
   version, build options, and every application source's path,
@@ -113,17 +126,50 @@ interleaving that was recorded — that is the per-consumer order
 enforcement working, and it is pinned by tests that run the race
 repeatedly.
 
+## The wire is hermetic
+
+A replayed server must not talk to the real world — in either
+direction. Under replay, every `bindings { }` transport is
+suppressed at realization: no socket is created, listeners don't
+bind, connectors don't connect, and publishes to bound topics send
+nothing (they are still recorded and compared under `--diff`). In
+the listeners' stead, an injector re-dispatches the recording's
+ingress tape — the verbatim wire bytes each listener received, in
+recorded order, each delivery carrying its *recorded* identity so
+the order enforcement matches it to its recorded consume. Replay a
+server binary with no peers, no free ports, and no network, and
+its subscribers see exactly the traffic they saw.
+
+## Feed mode: same inputs, changed code
+
+```sh
+hale replay run.halerec app.hl --feed
+```
+
+Backtesting is a different contract from replay: not "the same run
+again" but "the same **inputs** again," against code you have
+changed. `--feed` consumes the recording as an input tape only —
+recorded ingress injected, wire hermetic — and deliberately drops
+everything else: no journal serving, no order enforcement, no
+model admission (a hash mismatch prints as information; feeding a
+tape to changed code is the point), no effects gate (everything
+except the wire runs live — that is feed's contract). Record a
+day of production traffic once; run every strategy revision
+against it. The exit report says how many tape entries were
+injected and how many found no matching subject in the new
+program — a dropped tape is a fact, never a silence.
+
 ## The coverage boundary, honestly
 
 - **Per consumer, not global.** Each consumer reproduces its own
   recorded order; cross-consumer wall-clock alignment is not a
   replay property (and is exactly what the recording never
   promised).
-- **External ingress re-executes live.** Socket and adapter input
-  is captured in the artifact (flagged as ingress) but not yet
-  injected — a replayed server talks to the real world, which is
-  half of why the safety gate exists. Ingress injection is the
-  fleet-replay milestone.
+- **The injected tape covers `bindings` ingress.** Raw user-level
+  socket reads are syscall-class live effects (the gate names
+  them), and adapter loci re-execute their own protocol logic.
+  Fleet-scale replay — multiple binaries against one composed
+  tape — is the next milestone.
 - **`where async_io` pools refuse replay** loudly; their coroutine
   interleaving is a later milestone.
 - **The artifact format is pre-stable** while the remaining phases

--- a/docs/src/systems/replay.md
+++ b/docs/src/systems/replay.md
@@ -37,14 +37,20 @@ because a dropped record is a replay that diverges silently:
   recording is admitted for replay only when the *entire* artifact
   validates — exact parse to the trailer, matching entry count.
 
-The recording is also **crash-durable**: frames stream to disk in
-order and the header identity is stamped eagerly, so a run that
-dies without teardown — the run whose recording you want most —
-leaves an artifact that is exact up to one torn frame at the tail.
-Replaying it is an explicit opt-in (`--allow-truncated`): the
-loader stops at the torn frame, says how much it kept, and replays
-that prefix. `LOTUS_OBS_RECORD_DURABLE=1` adds an `fdatasync` per
-drain sweep for power-loss durability.
+The recording is also **crash-durable** (a durable flight
+recorder — not a write-ahead log: the application never waits on
+the recording, so a crash can lose the last instants before it):
+frames stream to disk in order and the header identity is stamped
+eagerly, so a run that dies without teardown — the run whose
+recording you want most — leaves an artifact that is exact up to
+one torn frame at the tail. Replaying it is an explicit opt-in
+(`--allow-truncated`): the loader stops at the torn frame, says
+how much it kept, and replays that prefix; under `--diff` the
+post-crash suffix is surplus, not divergence, while anything
+inside the prefix still must match. `LOTUS_OBS_RECORD_DURABLE=1`
+is the power-loss grade: `fdatasync` per drain sweep AND on the
+finalize trailer, plus a parent-directory sync at creation, with
+the grade recorded in the artifact header.
 
 The recording needs no observer attached and works from the first
 probe. It captures four things:
@@ -126,38 +132,54 @@ interleaving that was recorded — that is the per-consumer order
 enforcement working, and it is pinned by tests that run the race
 repeatedly.
 
-## The wire is hermetic
+## The wire is hermetic (for backends that support it)
 
 A replayed server must not talk to the real world — in either
-direction. Under replay, every `bindings { }` transport is
-suppressed at realization: no socket is created, listeners don't
-bind, connectors don't connect, and publishes to bound topics send
-nothing (they are still recorded and compared under `--diff`). In
-the listeners' stead, an injector re-dispatches the recording's
-ingress tape — the verbatim wire bytes each listener received, in
-recorded order, each delivery carrying its *recorded* identity so
-the order enforcement matches it to its recorded consume. Replay a
-server binary with no peers, no free ports, and no network, and
-its subscribers see exactly the traffic they saw.
+direction. Under replay, the native `unix://` and `udp://`
+binding transports are suppressed at realization: no socket is
+created, listeners don't bind, connectors don't connect, and
+publishes to bound topics send nothing (they are still recorded
+and compared under `--diff`). In the listeners' stead, an
+injector — started at an explicit boot phase, one worker per
+recorded ingress source — re-dispatches the recording's ingress
+tape: the verbatim wire bytes each listener received, in recorded
+order, paced against recorded progress (so bounded queues shed
+nothing they didn't shed originally), each delivery carrying its
+*recorded* identity and matched by its full subject and payload
+shape. Replay a server binary with no peers, no free ports, and
+no network, and its subscribers see exactly the traffic the
+original accepted — rejected frames never re-fed, and every
+non-injected tape entry classified and counted.
 
-## Feed mode: same inputs, changed code
+Hermeticity is a per-backend capability, not a blanket claim: a
+binding backend with no replay class — `shm_ring` today — is
+refused outright, by the CLI and again at the runtime seam, so a
+replayed process cannot touch live shared memory.
+
+## Feed mode: same recorded ingress, changed code
 
 ```sh
 hale replay run.halerec app.hl --feed
 ```
 
 Backtesting is a different contract from replay: not "the same run
-again" but "the same **inputs** again," against code you have
-changed. `--feed` consumes the recording as an input tape only —
-recorded ingress injected, wire hermetic — and deliberately drops
-everything else: no journal serving, no order enforcement, no
-model admission (a hash mismatch prints as information; feeding a
-tape to changed code is the point), no effects gate (everything
-except the wire runs live — that is feed's contract). Record a
-day of production traffic once; run every strategy revision
-against it. The exit report says how many tape entries were
-injected and how many found no matching subject in the new
-program — a dropped tape is a fact, never a silence.
+again" but "the same **recorded ingress** again," against code you
+have changed — time, randomness, env, and argv stay live, which
+is why the name is precise rather than "same inputs." `--feed`
+consumes the recording as an input tape only — recorded ingress
+injected, wire hermetic — and deliberately drops the rest of
+replay: no journal serving, no order enforcement, no model
+admission (a hash mismatch prints as information; feeding a tape
+to changed code is the point). What it does **not** drop is the
+effects gate: `--feed` bypasses identity, never safety — a
+program that reaches `syscall`/`ffi`/`unclassified` still needs
+`--allow-live-effects` beside it. Record a day of production
+traffic once; run every strategy revision against it. The exit
+report classifies every tape entry (injected, rejected,
+unmatched, incompatible shape, unprocessed), and an unfed
+remainder fails the run unless you accept it explicitly with
+`--allow-unmatched-feed` — a dropped tape is a fact, never a
+silence.
 
 ## The coverage boundary, honestly
 

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1589,18 +1589,28 @@ diverges silently):
   at teardown after a final full sweep; a reader that does not
   find the trailer holds a truncated recording and must say so.
 
-**Durability (Phase 5).** The drain appends whole frames in
-stream order and flushes every sweep, so the on-disk file is an
-exact prefix of the stream at all times — and the header identity
-(`model_hash`, `exec_digest`, policy flags) is stamped **eagerly**
-by the drain as soon as the ctor-sequenced setters have run, not
-only at finalize. A run that dies without teardown therefore
-leaves an artifact that is attributable and exact up to one torn
-frame at the tail. Default recording rides the page cache
-(survives a process crash, not power loss);
-`LOTUS_OBS_RECORD_DURABLE=1` pushes every flushed sweep through
-`fdatasync` — survives power loss to the last sweep, at syscall
-cost per sweep.
+**Durable recording / crash-prefix recovery (Phase 5).** Named
+precisely: this is a durable flight recorder, NOT a write-ahead
+log — the application is never gated on the recording reaching
+stable storage, so a crash can lose records the application
+already executed past. (A load-bearing WAL grade — persist,
+fence, then permit delivery — is a possible later mode; nothing
+here claims it.) What IS guaranteed: the drain appends whole
+frames in stream order and flushes every sweep, so the on-disk
+file is an exact prefix of the stream at all times, and the
+header identity (`model_hash`, `exec_digest`, policy flags) is
+stamped **eagerly** by the drain as soon as the ctor-sequenced
+setters have run, not only at finalize. A run that dies without
+teardown therefore leaves an artifact that is attributable and
+exact up to one torn frame at the tail. Default recording rides
+the page cache (survives a process crash, not power loss).
+`LOTUS_OBS_RECORD_DURABLE=1` is the power-loss grade: every
+flushed sweep passes `fdatasync`, the parent directory is synced
+at file creation (a fresh NAME is not durable until its directory
+entry is), the finalize trailer itself is `fdatasync`'d before
+close (a clean exit followed by power loss must not demote a
+finalized recording to a truncated one), and the grade is
+recorded in the header's policy flags (bit 1).
 
 **Consume records (private recorder namespace).** `BUS_DELIVER`
 is enqueue-time by design and lands on the *publisher's* ring —
@@ -1686,9 +1696,13 @@ recording**: refused by default, but admissible as a PREFIX with
 parsed extent and dropped tail bytes, and replay that prefix;
 execution past the tape's end falls back live and is counted, per
 the degrade-never-refuse rule. Under `--diff` a truncated baseline
-compares as a prefix: surplus replay events past the crash point
-are not divergences, missing or different ones still are. A
-trailer-FINALIZED artifact keeps the exact full-parse + count
+compares as a prefix — and the runtime verdict agrees with the
+comparator: recorded-history-exhausted events (journal reads past
+the tape, deliveries past the consume stream, consumers the
+recording never saw) count into a separate
+`post_prefix_live_fallback` status key, never into the divergence
+totals; mismatches BEFORE exhaustion stay divergences either way.
+A trailer-FINALIZED artifact keeps the exact full-parse + count
 checks: with a finalize present, any truncation is corruption.
 
 **Replay (`hale replay <recording> <program.hl>`).** Admission,
@@ -1724,43 +1738,81 @@ is released and the miss counted, so a genuinely divergent replay
 reports rather than deadlocks. `where async_io` pools refuse
 replay loudly (their coro interleaving is a later milestone).
 
-**Hermetic wire + ingress injection (Phase 5).** Under replay,
-transport bindings are **suppressed at realization**: the binding
-entry exists (a husk, `transport` NULL — the same shape the
-reclaim path already leaves), but no socket is created, nothing
-binds, nothing connects, and outbound fanout to bound subjects
-sends nothing (the publish is still recorded and compared under
-`--diff`). In the listeners' stead, an **injector thread**
-re-dispatches the recording's ingress tape — every ingress-flagged
-payload, in artifact order, through the same
-deserialize-then-local-dispatch shape as the reader thread it
-replaces — with each delivery's RECORDED `pub_id` pinned, so the
-per-consumer order enforcement matches injected deliveries to
-their recorded consumes exactly. To make the tape injectable, the
-reader threads capture each received message's **verbatim wire
-bytes** (the struct-bytes record local dispatch would otherwise
-push is metadata-only and cannot be re-fed) with the identity
-pinned across the capture-then-dispatch pair, and the artifact
-carries a subject-hash → name meta map so payloads can be routed
-(and reported) by name. A tape subject with no matching
-subscriber waits a bounded grace, then counts as dropped —
-reported at exit, never silent. Adapter-driven ingress (user code
-calling `std::bus::__local_dispatch`) is user logic and
-re-executes as such.
+**Hermetic wire + ingress injection (Phase 5).** Hermeticity is
+a **binding-kind capability, not a blanket assumption**: the
+native `unix://` and `udp://` transports (and the transport-locus
+form) are suppressed and injectable; a backend with **no replay
+class fails closed** — `shm_ring` in particular is refused by the
+CLI (backend named) and independently at the runtime's shm-open
+seam, so a replayed or fed process never creates, opens, or
+mutates live shared memory. Adapter loci are user logic and
+re-execute as such (governed by their inferred effects).
+
+For the covered backends, under replay a binding is **suppressed
+at realization**: the entry exists (a husk, `transport` NULL —
+the same shape the reclaim path already leaves), but no socket is
+created, nothing binds, nothing connects, and outbound fanout to
+bound subjects sends nothing (the publish is still recorded and
+compared under `--diff`).
+
+In the listeners' stead, injection runs as an explicit **boot
+phase**: codegen emits one `lotus_replay_start_ingress()` call at
+the main locus's boot/run boundary — params children born,
+bindings realized or suppressed, every boot subscription
+registered, `run()` not yet entered — where the runtime snapshots
+the subscription registry ON the main thread (injector workers
+never read the live registry) and spawns **one worker per
+recorded ingress source** (the `pub_id`'s consumer bits), each
+carrying its source's recorded consumer identity so a `--diff`
+verify recording aligns per-consumer streams with the original
+instead of collapsing every listener onto one injector identity.
+Fresh anonymous claims are floored above the recorded range.
+Injection is keyed by **full identity**: each tape record carries
+its complete subject string and the subject's canonical payload
+shape (FNV-32 alone is collision-prone and is kept only for
+reporting); a record whose shape does not match the live
+program's shape for that subject is refused as *incompatible*,
+never fed as a plausible wrong value. Only messages the original
+application **accepted** enter the tape — the wire capture runs
+after the deserializer says yes, so identity allocation agrees
+between record and replay and rejected traffic is never re-fed.
+
+**Pacing.** Strict replay injects one message, then waits (bounded
+by the phase-4 hold) until that message's recorded consumes have
+all been re-consumed — unpaced injection can shed at bounded
+queues (`bounded(N, drop_old/drop_new)`, `on_full` policies)
+before the dequeue-side order gate ever sees the cell, which no
+amount of holding can undo. Feed mode is deliberately unpaced.
+
+**Accounting.** Every tape entry ends in exactly one class:
+injected, rejected-by-deserializer, unmatched-subject,
+incompatible-shape, or unprocessed-at-shutdown (the injector is
+joined at teardown and its remainder classified); injector start
+failure is its own class. Under strict replay every non-injected
+class is a divergence, in the machine-readable status
+(`ingress_*`, `injector_start_failure` keys) and the exit
+summary.
 
 **Feed mode (`hale replay --feed`, `LOTUS_REPLAY_FEED=<path>`) —
-the backtesting contract.** The recording is consumed as an INPUT
-TAPE only: recorded ingress is injected and the wire is hermetic,
-exactly as above — and *nothing else of replay applies*. No
-journal serving, no order enforcement, no model admission (a
-model-hash mismatch is reported informationally; feeding a tape
-to changed code is the point), no effects gate (feed re-executes
-everything live except the wire — that is its contract), no
-`--diff`/`--at` (there is no recorded schedule to compare
-against). Mutually exclusive with `LOTUS_REPLAY`. Injected
-deliveries carry the new run's own identity. The exit report
-states how many tape entries were injected and how many dropped
-for want of a matching subject.
+same recorded ingress, changed code, live nondeterministic
+environment.** Stated that precisely because "same inputs" would
+overclaim: feed reproduces recorded **binding ingress** only —
+time, randomness, env, and argv stay live. The recording is
+consumed as an input tape: recorded ingress injected, wire
+hermetic, and nothing else of replay applies — no journal
+serving, no order enforcement, no model admission (a model-hash
+mismatch is reported informationally; feeding a tape to changed
+code is the point), no `--diff`/`--at` (there is no recorded
+schedule to compare against). The **effects gate still applies**:
+`--feed` bypasses identity admission, never effect safety — a
+program whose frontier reaches `syscall`/`ffi`/`unclassified`
+still requires `--allow-live-effects` alongside `--feed`.
+Mutually exclusive with `LOTUS_REPLAY`. Injected deliveries carry
+the new run's own identity. The exit report classifies every tape
+entry, and an unfed remainder (unmatched, incompatible,
+unprocessed, start failure) **fails the run by default** —
+`--allow-unmatched-feed` is the explicit acceptance of a partial
+feed.
 `--diff` records the replay (under the original's env policy) and
 compares bidirectionally: per-consumer queued consume streams
 (target locus + msg_id), per-consumer PUBLIC bus streams aligned

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1589,6 +1589,19 @@ diverges silently):
   at teardown after a final full sweep; a reader that does not
   find the trailer holds a truncated recording and must say so.
 
+**Durability (Phase 5).** The drain appends whole frames in
+stream order and flushes every sweep, so the on-disk file is an
+exact prefix of the stream at all times — and the header identity
+(`model_hash`, `exec_digest`, policy flags) is stamped **eagerly**
+by the drain as soon as the ctor-sequenced setters have run, not
+only at finalize. A run that dies without teardown therefore
+leaves an artifact that is attributable and exact up to one torn
+frame at the tail. Default recording rides the page cache
+(survives a process crash, not power loss);
+`LOTUS_OBS_RECORD_DURABLE=1` pushes every flushed sweep through
+`fdatasync` — survives power loss to the last sweep, at syscall
+cost per sweep.
+
 **Consume records (private recorder namespace).** `BUS_DELIVER`
 is enqueue-time by design and lands on the *publisher's* ring —
 correct for fanout accounting, structurally unable to say in what
@@ -1663,9 +1676,20 @@ exact parse to the trailer position and a matching entry count,
 enforced by the CLI reader and independently by the runtime
 loader (one open + fstat + private mmap, checked arithmetic,
 per-kind value shapes) — trailer magic at EOF alone proves
-nothing. Identity fields are re-stamped at finalize (a prelude
-binding registration can probe — creating the header — before
-the stamps run).
+nothing. Identity fields are stamped eagerly by the drain and
+re-stamped at finalize (a prelude binding registration can probe —
+creating the header — before the stamps run; the two stamps
+agree). A trailer-less artifact is a **crash-truncated
+recording**: refused by default, but admissible as a PREFIX with
+`hale replay --allow-truncated` (`LOTUS_REPLAY_ALLOW_TRUNCATED=1`)
+— the loaders stop at the first incomplete frame, report the
+parsed extent and dropped tail bytes, and replay that prefix;
+execution past the tape's end falls back live and is counted, per
+the degrade-never-refuse rule. Under `--diff` a truncated baseline
+compares as a prefix: surplus replay events past the crash point
+are not divergences, missing or different ones still are. A
+trailer-FINALIZED artifact keeps the exact full-parse + count
+checks: with a finalize present, any truncation is corruption.
 
 **Replay (`hale replay <recording> <program.hl>`).** Admission,
 strongest check first: the recording's `exec_digest` — a framed
@@ -1680,12 +1704,12 @@ the LLVM/libc toolchain outside the hale binary; a post-link
 binary digest is the staged stronger form. **Safe by default:**
 replay re-executes real side effects, so the typed effect rows
 gate admission and fail CLOSED on `syscall`, `ffi`,
-`unclassified` ("may do anything"), and any transport-bound
-`bindings` block (the user-level effect of a bound publish is
-`publish`; the send is generated deployment machinery) — all
-refused without an explicit `--allow-live-effects` (coarse by
-class granularity — over-refusal is the safe direction;
-per-primitive replay classes are the staged refinement). `LOTUS_REPLAY=<path>`
+`unclassified` ("may do anything") — refused without an explicit
+`--allow-live-effects` (coarse by class granularity —
+over-refusal is the safe direction; per-primitive replay classes
+are the staged refinement). `bindings` blocks are **no longer**
+in that list: under replay the wire is hermetic (below), so a
+bound topic cannot reach the live world. `LOTUS_REPLAY=<path>`
 then serves journaled reads back per consumer in recorded order;
 a read past (or mismatching) the recorded history falls back live
 and is counted — **replay degrades, never refuses** (RFC Q6) —
@@ -1699,6 +1723,44 @@ order, with a bounded hold (1s) after which the oldest held cell
 is released and the miss counted, so a genuinely divergent replay
 reports rather than deadlocks. `where async_io` pools refuse
 replay loudly (their coro interleaving is a later milestone).
+
+**Hermetic wire + ingress injection (Phase 5).** Under replay,
+transport bindings are **suppressed at realization**: the binding
+entry exists (a husk, `transport` NULL — the same shape the
+reclaim path already leaves), but no socket is created, nothing
+binds, nothing connects, and outbound fanout to bound subjects
+sends nothing (the publish is still recorded and compared under
+`--diff`). In the listeners' stead, an **injector thread**
+re-dispatches the recording's ingress tape — every ingress-flagged
+payload, in artifact order, through the same
+deserialize-then-local-dispatch shape as the reader thread it
+replaces — with each delivery's RECORDED `pub_id` pinned, so the
+per-consumer order enforcement matches injected deliveries to
+their recorded consumes exactly. To make the tape injectable, the
+reader threads capture each received message's **verbatim wire
+bytes** (the struct-bytes record local dispatch would otherwise
+push is metadata-only and cannot be re-fed) with the identity
+pinned across the capture-then-dispatch pair, and the artifact
+carries a subject-hash → name meta map so payloads can be routed
+(and reported) by name. A tape subject with no matching
+subscriber waits a bounded grace, then counts as dropped —
+reported at exit, never silent. Adapter-driven ingress (user code
+calling `std::bus::__local_dispatch`) is user logic and
+re-executes as such.
+
+**Feed mode (`hale replay --feed`, `LOTUS_REPLAY_FEED=<path>`) —
+the backtesting contract.** The recording is consumed as an INPUT
+TAPE only: recorded ingress is injected and the wire is hermetic,
+exactly as above — and *nothing else of replay applies*. No
+journal serving, no order enforcement, no model admission (a
+model-hash mismatch is reported informationally; feeding a tape
+to changed code is the point), no effects gate (feed re-executes
+everything live except the wire — that is its contract), no
+`--diff`/`--at` (there is no recorded schedule to compare
+against). Mutually exclusive with `LOTUS_REPLAY`. Injected
+deliveries carry the new run's own identity. The exit report
+states how many tape entries were injected and how many dropped
+for want of a matching subject.
 `--diff` records the replay (under the original's env policy) and
 compares bidirectionally: per-consumer queued consume streams
 (target locus + msg_id), per-consumer PUBLIC bus streams aligned
@@ -1716,11 +1778,12 @@ the obs machinery).
 
 Two honest limits, stated rather than implied: the recorded
 interleaving is reproduced per consumer, not globally — cross-
-consumer wall-clock alignment is not a replay property; and
-external ingress (sockets, adapters) re-executes LIVE in v1 —
-captured ingress payloads exist in the recording (flagged), but
-injection is the fleet-replay milestone (Phase 5, with #262's
-plan admission for Phase 6's replay-under-a-different-plan).
+consumer wall-clock alignment is not a replay property; and the
+injected tape covers **bindings** ingress — raw user-level socket
+reads are syscall-class live effects (gated), and adapter loci
+re-execute their own protocol logic. Fleet-scale replay (multiple
+binaries against one composed tape, with #262's plan admission
+for replay-under-a-different-plan) is the next milestone.
 
 ### Time
 

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1637,8 +1637,9 @@ file, private-ring entries carry the high bit in their ring field,
 so the two namespaces can never be confused.
 
 **Delivery identity (Phase 2).** Every queued delivery carries a
-deterministic `pub_id = consumer_id:12 | per-publisher-thread
-seq:32`, re-derivable by a re-executed run without global
+deterministic `pub_id = consumer_id:16 | per-publisher-thread
+seq:48` (full width — the review-round guards fail loudly rather
+than wrap), re-derivable by a re-executed run without global
 coordination. Consumer ids are stable across runs, unlike pthread
 ids: main = 1, cooperative pool workers = 16 + registration
 index, pinned locus threads = 64 + obs instance id; threads with
@@ -1767,7 +1768,13 @@ carrying its source's recorded consumer identity so a `--diff`
 verify recording aligns per-consumer streams with the original
 instead of collapsing every listener onto one injector identity.
 Fresh anonymous claims are floored above the recorded range.
-Injection is keyed by **full identity**: each tape record carries
+The snapshot IS the coverage boundary: a
+subscriber the program only creates during `run()` (spawned or
+accepted) is not visible to injection — such tape entries classify
+as `late_subscription_uncovered` (the injector join rescans the
+live registry at teardown to distinguish them from genuinely
+absent subscribers), a stated boundary rather than a silent
+`unmatched`. Injection is keyed by **full identity**: each tape record carries
 its complete subject string and the subject's canonical payload
 shape (FNV-32 alone is collision-prone and is kept only for
 reporting); a record whose shape does not match the live
@@ -1813,6 +1820,8 @@ entry, and an unfed remainder (unmatched, incompatible,
 unprocessed, start failure) **fails the run by default** —
 `--allow-unmatched-feed` is the explicit acceptance of a partial
 feed.
+
+**`--diff` (strict replay only — feed rejects it, above).**
 `--diff` records the replay (under the original's env policy) and
 compares bidirectionally: per-consumer queued consume streams
 (target locus + msg_id), per-consumer PUBLIC bus streams aligned


### PR DESCRIPTION
Closes the two loudest gaps in the v0.17.0 replay story — "a crashed run loses its recording" and "a replayed server talks to the real world" — and adds the backtesting mode on top. GH #296 phase 5. Spec (`spec/runtime.md`), the book chapter, and the CHANGELOG move in the same PR. Hardened by two full adversarial review rounds (10 + 8 findings, all resolved — see the review-response comments for the point-by-point).

## 1. Durable recording / crash-prefix recovery (`--allow-truncated`, `LOTUS_OBS_RECORD_DURABLE`)

A durable flight recorder, stated precisely — **not a WAL**: the application never gates on the recording reaching stable storage. Header identity (`model_hash`, full `exec_digest`, policy flags) is committed atomically after the generated setters and stamped eagerly by the drain from the immutable committed copy, so a SIGKILLed run leaves an attributable artifact exact up to one torn frame at the tail — down to a header-only 96-byte file, the earliest crash window. Replaying a trailer-less artifact is opt-in (`--allow-truncated`): both loaders stop at the first incomplete frame and replay the prefix; under `--diff` the runtime verdict and comparator agree that post-crash events are surplus (`post_prefix_live_fallback`), while any in-prefix mismatch still fails. `LOTUS_OBS_RECORD_DURABLE=1` is the power-loss grade: fdatasync per sweep and on the finalize trailer, parent-directory sync at creation, grade recorded in the header.

## 2. Hermetic wire + ingress injection

Hermeticity is a **binding-kind capability**: native `unix://`/`udp://` transports (and the transport-locus form) are suppressed at realization — husk entry, no socket, outbound fanout sends nothing (still recorded and compared under `--diff`) — while a backend with no replay class fails closed: `shm_ring` is refused by the CLI (named) and independently at the runtime shm-open seam.

Injection runs as an explicit **boot phase**: codegen emits `lotus_replay_start_ingress()` at the main locus's boot/run boundary; the runtime snapshots the subscription registry on the main thread (workers never read the live registry) and spawns **one worker per recorded ingress source**, each carrying its source's recorded consumer identity so `--diff` aligns per-consumer streams across multiple listeners. Tape identity is the **full subject string + canonical payload shape** carried in each ingress record (FNV-32 demoted to reporting; the colliding pair is a live canary); shape mismatch refuses injection as `incompatible`. Only messages the original application **accepted** enter the tape. **Strict injection is paced** against recorded consume progress, so bounded queues shed nothing they didn't shed originally. Every tape entry ends in one named class — injected / rejected / unmatched / `late_subscription_uncovered` (subscriber created after the boot snapshot; distinguished by a teardown-time registry rescan) / incompatible / unprocessed-at-shutdown / start-failure — all machine-readable, all strict-replay divergences.

Artifact trust: **one file object** carries the recording from CLI admission into the child (O_NOFOLLOW open, `parse_file` on that object, dup2 of the same descriptor — no reopen, no substitution window), plus a runtime identity-vs-binary refusal for direct `LOTUS_REPLAY` invocations.

Consequence: covered `bindings` no longer trip the `--allow-live-effects` gate — the remaining residue (`syscall`/`ffi`/`unclassified`) is genuinely user-level.

## 3. Feed mode (`--feed`) — same recorded ingress, changed code, live nondeterministic environment

The recording is consumed as an input tape only: recorded ingress injected, wire hermetic, no journal serving, no order enforcement, no model admission (mismatch prints as information — feeding changed code is the point), no `--diff`/`--at`. The **effects gate still applies**: `--feed` bypasses identity, never safety. The exit report classifies every tape entry and derives its unclassified remainder at report time — an `exit(0)` before injection cannot fail open — and any unfed remainder fails by default (`--allow-unmatched-feed` to accept).

## Tests

Beyond the happy paths: SIGKILL-prefix admissibility with a complete four-word digest asserted in the crash artifact; header-only fixtures (96/97/103/111/112 bytes) refusing by default and admitting under the flag; a deterministic admission-vs-substitution canary (test hook holds between admission and spawn while the path is atomically replaced — the child replays the admitted artifact); truncated `--diff` accepting the post-crash surplus while an in-prefix withheld read still fails; feed effects-gate and early-exit fail-closed canaries; rejected wire excluded from the tape; the FNV-32 collision pair; capacity-one bounded pacing; binding-less feed targets; incompatible shapes; `shm_ring` refusal; two listeners under CLI `--diff`.

## Boundary (stated)

The injected tape covers `bindings` ingress into boot-registered subscribers; late subscriptions are the named `late_subscription_uncovered` coverage class. Raw user sockets are syscall-class live effects (gated); adapter loci re-execute their own logic. Live-ingest loss under load (observed while storming the canaries; independent of replay) is GH #468. Fleet-scale replay is the next milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)