### PR TITLE
types: stdlib values get their real nominal types — closes the fail-open Ty::Unknown class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ behavior.
 
 ## Unreleased
 
+### Stdlib values get their real types - the fail-open `Ty::Unknown` class is closed (GH #470)
+
+Found via a downstream server whose responses curl rejected: a
+middleware locus with the wrong `after` arity typechecked and the
+Router's interface fat-pointer call corrupted the HTTP response
+in-memory (garbage status integer, dangling header, the request's
+method and path bleeding into the output). Root cause: stdlib
+qualified paths resolved to `Ty::Unknown`, which is bidirectionally
+compatible - so `router.use(badMw)` performed no signature lookup,
+no interface-satisfaction check, and codegen coerced blindly. Even
+`let x: Int = router;` and `std::log::TotallyFakeSink {}` (a
+nonexistent name) typechecked.
+
+The fix is the one the sealed-loci injection (GH #436) deferred:
+the ENTIRE Hale-source stdlib surface - loci, types, interfaces,
+free fns - is now registered into the checker's top scope
+(signatures only; stdlib bodies are never added to the checked
+bundle, so no diagnostics can land on stdlib source). `std::...`
+type expressions and struct/locus literals resolve through
+PATH_RENAMES to their nominal symbols and validate for real:
+literal fields are checked, methods resolve against true
+signatures, interface coercions run the structural verifier, and a
+`std::` literal that matches nothing is a hard error. Diagnostics
+render the public spelling (`std::http::Middleware`, not the
+mangled name). Rust-implemented builtins keep their historical
+tolerance (their path-call names were already validated by the
+stdlib surface registry).
+
+Measured blast radius: the whole fixture corpus and workspace pass
+untouched except two tests that pinned the old permissiveness -
+one of which was an invalid fixture the tolerance had been hiding
+(a call to a Router method that does not exist). Ergonomics
+follow-through: `std::http::Request` gained defaults for
+`version`/`headers`/`body` so the documented hand-built-Request
+pattern stays one line. Canaries: the wrong-arity middleware, the
+`Int = router` absurdity, and the typo'd-literal case are all
+compile errors now.
+
 ### Record & replay, phase 5: durable recording, the hermetic wire, and feed mode (GH #296)
 
 Three deliverables close the two loudest gaps in the v0.17.0
@@ -114,7 +152,6 @@ without touching shared memory; two listeners surviving CLI
 `--diff` with per-source identity.
 
 ---
-
 ## v0.17.0 — the run comes back the same (2026-08-13)
 
 ### Record & replay, phases 2–4: `hale replay` (GH #296)

--- a/crates/hale-cli/tests/topology_v2.rs
+++ b/crates/hale-cli/tests/topology_v2.rs
@@ -146,7 +146,7 @@ locus Gate {
 }
 fn main() {
     let r = std::http::Router { };
-    r.get("/", Hello { });
+    r.add("GET", "/", Hello { });
     let req = std::http::Request { method: "GET", path: "/", body: "" };
     println(Gate { }.probe(r, req));
 }

--- a/crates/hale-stdlib/hl/file.hl
+++ b/crates/hale-stdlib/hl/file.hl
@@ -64,6 +64,40 @@ locus __StdIoFileFile {
         // "never spawned" default is safe.
         std::io::file::__close(self.fd);
     }
+
+    // GH #470: the handle operations are REAL locus members (the
+    // io_tcp.hl Stream style), so both the (now-nominal) checker
+    // and codegen's fallible-member machinery see one declaration.
+    // The free-fn spellings below delegate here, keeping the
+    // std::io::file::write_line(f, ...) path-call form working.
+
+    /// Read one '\n'-terminated line (newline stripped); "" at EOF.
+    fn read_line() -> String {
+        return std::io::file::__read_line(self.fd);
+    }
+
+    /// True once a read has hit end-of-file.
+    fn at_eof() -> Bool {
+        return std::io::file::__at_eof(self.fd);
+    }
+
+    /// Write raw bytes at the current position.
+    fn write_bytes(b: Bytes) -> () fallible(IoError) {
+        std::io::file::__write_bytes(self.fd, b) or raise;
+    }
+
+    /// Write a line (newline appended).
+    fn write_line(line: String) -> () fallible(IoError) {
+        let body = std::bytes::concat(
+            std::bytes::from_string(line),
+            std::bytes::from_string("\n"));
+        std::io::file::__write_bytes(self.fd, body) or raise;
+    }
+
+    /// Reposition the read/write cursor (absolute byte offset).
+    fn seek(offset: Int) -> () fallible(IoError) {
+        std::io::file::__seek(self.fd, offset) or raise;
+    }
 }
 
 // Open `path` with the given mode. Returns a fully-constructed
@@ -93,14 +127,14 @@ fn __std_io_file_open(path: String, mode_str: String)
 /// Read one line (newline stripped). Empty String at EOF —
 /// disambiguate with `at_eof(f)`.
 fn __std_io_file_read_line(f: std::io::file::File) -> String {
-    return std::io::file::__read_line(f.fd);
+    return f.read_line();
 }
 
 // True when the file has no more bytes to read. Drives
 // while-loops over file contents.
 /// True once a read has hit end-of-file.
 fn __std_io_file_at_eof(f: std::io::file::File) -> Bool {
-    return std::io::file::__at_eof(f.fd);
+    return f.at_eof();
 }
 
 // Write all bytes to the file. Position advances by len(bytes).
@@ -109,7 +143,7 @@ fn __std_io_file_at_eof(f: std::io::file::File) -> Bool {
 /// Write raw bytes at the current position.
 fn __std_io_file_write_bytes(f: std::io::file::File, b: Bytes)
     -> () fallible(IoError) {
-        std::io::file::__write_bytes(f.fd, b) or raise;
+        f.write_bytes(b) or raise;
     }
 
 // Write a String followed by a '\n'. Convenience wrapper over
@@ -117,10 +151,7 @@ fn __std_io_file_write_bytes(f: std::io::file::File, b: Bytes)
 /// Write a line (newline appended).
 fn __std_io_file_write_line(f: std::io::file::File, line: String)
     -> () fallible(IoError) {
-        let body = std::bytes::concat(
-            std::bytes::from_string(line),
-            std::bytes::from_string("\n"));
-        std::io::file::__write_bytes(f.fd, body) or raise;
+        f.write_line(line) or raise;
     }
 
 // Seek to absolute byte offset. Position negative or beyond
@@ -130,5 +161,5 @@ fn __std_io_file_write_line(f: std::io::file::File, line: String)
 /// 1 = from current, 2 = from end.
 fn __std_io_file_seek(f: std::io::file::File, offset: Int)
     -> () fallible(IoError) {
-        std::io::file::__seek(f.fd, offset) or raise;
+        f.seek(offset) or raise;
     }

--- a/crates/hale-stdlib/hl/http.hl
+++ b/crates/hale-stdlib/hl/http.hl
@@ -41,9 +41,14 @@
 type __StdHttpRequest {
     method: String;
     path: String;
-    version: String;
-    headers: String;
-    body: String;
+    /// Defaults let a hand-built Request (unit tests, Router
+    /// dispatch probes — the documented parse_request-adjacent
+    /// pattern) spell only what it means: method + path (+ body).
+    /// GH #470 made literal fields checked for real; these
+    /// defaults keep that check ergonomic rather than pedantic.
+    version: String = "HTTP/1.1";
+    headers: String = "";
+    body: String = "";
     /// The live connection fd (Upgrade/takeover surface,
     /// 2026-07-19). Populated by the Server's per-connection
     /// loop before dispatch; -1 when the Request was built by

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -10856,6 +10856,82 @@ impl<'a> Checker<'a> {
                             .iter()
                             .map(|s| s.name.as_str())
                             .collect();
+                        // GH #470: a std:: path that renames to a
+                        // REGISTERED Hale-source free fn checks
+                        // against its real signature — full
+                        // fidelity: arity, param types, nominal
+                        // return, fallibility. The surface table
+                        // below stays authoritative only for the
+                        // Rust-implemented builtins it was built
+                        // for. (Before this, `std::io::file::open`
+                        // checked against the table's stale fd-era
+                        // row — `-> Int` — so the DOCUMENTED File
+                        // handle pattern could not typecheck.)
+                        if let Some(mangled) =
+                            crate::stdlib_bodies::mangled_locus_name(
+                                &segs,
+                            )
+                        {
+                            if let Some(TopSymbol::Fn(f)) =
+                                self.top.lookup(mangled).cloned()
+                            {
+                                let min = f
+                                    .min_params
+                                    .unwrap_or(f.params.len());
+                                if args.len() < min
+                                    || args.len() > f.params.len()
+                                {
+                                    self.diags.push(Diag::ty(
+                                        qn.span,
+                                        format!(
+                                            "`{}` takes {} argument{}, \
+                                             got {}",
+                                            segs.join("::"),
+                                            f.params.len(),
+                                            if f.params.len() == 1 {
+                                                ""
+                                            } else {
+                                                "s"
+                                            },
+                                            args.len()
+                                        ),
+                                    ));
+                                }
+                                for (i, a) in args.iter().enumerate() {
+                                    let got =
+                                        self.check_expr_addressed(a);
+                                    if let Some((_, want)) =
+                                        f.params.get(i)
+                                    {
+                                        if !want.assignable_from(&got) {
+                                            self.diags.push(Diag::ty(
+                                                a.span(),
+                                                format!(
+                                                    "`{}` argument {}: \
+                                                     expected `{}`, \
+                                                     got `{}`",
+                                                    segs.join("::"),
+                                                    i + 1,
+                                                    want.display(),
+                                                    got.display()
+                                                ),
+                                            ));
+                                        }
+                                    }
+                                }
+                                return match &f.fallible {
+                                    Some(payload) => Ty::Fallible {
+                                        success: Box::new(
+                                            f.ret.clone(),
+                                        ),
+                                        payload: Box::new(
+                                            payload.clone(),
+                                        ),
+                                    },
+                                    None => f.ret.clone(),
+                                };
+                            }
+                        }
                         if let Some(msg) =
                             crate::stdlib_surface::unknown_fn_error(&segs)
                         {
@@ -11669,6 +11745,72 @@ impl<'a> Checker<'a> {
                         // statically. GH #241: with a nearest-
                         // name suggestion drawn from the
                         // receiver's fields + methods.
+                        // GH #470: stdlib handle-method sugar.
+                        // `f.write_line(x)` on a handle typed
+                        // `std::io::file::File` is codegen-dispatched
+                        // to the handle namespace's free fn
+                        // (`__std_io_file_write_line(f, x)`). Mirror
+                        // that here: reverse-map the receiver's
+                        // mangled name to its public path, swap the
+                        // type leaf for the member name, resolve
+                        // through the same renames, and type the
+                        // member as a bound fn (receiver = arg 0,
+                        // checked for compatibility). Without this,
+                        // making handles nominal would have turned
+                        // the documented handle patterns into false
+                        // "no field" errors.
+                        if let Ty::Named(tn) = &rt {
+                            if let Some(pub_path) = hale_stdlib::PATH_RENAMES
+                                .iter()
+                                .find(|(_, m)| *m == tn.as_str())
+                                .map(|(p, _)| *p)
+                            {
+                                let mut segs: Vec<&str> = pub_path.to_vec();
+                                if let Some(last) = segs.last_mut() {
+                                    *last = name.name.as_str();
+                                }
+                                if let Some(m2) =
+                                    crate::stdlib_bodies::mangled_locus_name(
+                                        &segs,
+                                    )
+                                {
+                                    if let Some(TopSymbol::Fn(f)) =
+                                        self.top.lookup(m2).cloned()
+                                    {
+                                        let recv_ok = f
+                                            .params
+                                            .first()
+                                            .map(|(_, t)| {
+                                                t.assignable_from(&rt)
+                                            })
+                                            .unwrap_or(false);
+                                        if recv_ok {
+                                            let tail: Vec<Ty> = f
+                                                .params
+                                                .iter()
+                                                .skip(1)
+                                                .map(|(_, t)| t.clone())
+                                                .collect();
+                                            let ret = match &f.fallible {
+                                                Some(p) => Ty::Fallible {
+                                                    success: Box::new(
+                                                        f.ret.clone(),
+                                                    ),
+                                                    payload: Box::new(
+                                                        p.clone(),
+                                                    ),
+                                                },
+                                                None => f.ret.clone(),
+                                            };
+                                            return Ty::Function {
+                                                params: tail,
+                                                ret: Box::new(ret),
+                                            };
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         if !matches!(rt, Ty::Unknown) {
                             let mut candidates: Vec<String> = Vec::new();
                             if let Ty::Named(tn) = &rt {
@@ -11825,8 +11967,35 @@ impl<'a> Checker<'a> {
                                 .iter()
                                 .map(|s| s.name.as_str())
                                 .collect();
-                            crate::stdlib_surface::signature_for(&segs)
+                            // GH #470: a path renaming to a
+                            // REGISTERED Hale-source fn is an
+                            // ordinary fn call — the Call arm typed
+                            // it with its real (possibly Fallible)
+                            // signature, and the generic unwrap
+                            // below handles it. The surface table's
+                            // dual-mode or_types are only for the
+                            // Rust builtins (its `open` row was the
+                            // stale fd era and OVERRODE the real
+                            // File return here).
+                            let renamed_registered =
+                                crate::stdlib_bodies::mangled_locus_name(
+                                    &segs,
+                                )
+                                .map(|m| {
+                                    matches!(
+                                        self.top.lookup(m),
+                                        Some(TopSymbol::Fn(_))
+                                    )
+                                })
+                                .unwrap_or(false);
+                            if renamed_registered {
+                                None
+                            } else {
+                                crate::stdlib_surface::signature_for(
+                                    &segs,
+                                )
                                 .and_then(|sig| sig.or_types())
+                            }
                         }
                         _ => None,
                     },

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -15,10 +15,15 @@
 //!   in milestone 2 — just that something is there).
 //! - `self.field`: resolves against enclosing locus's params.
 //!
-//! Names referenced via paths the bundle can't see (stdlib,
-//! `time::sleep`, `println`) resolve to `Ty::Unknown`, which
-//! is bidirectionally compatible — milestone 2 does not error
-//! on these. Milestone 3 will tighten.
+//! Names referenced via paths the bundle can't see resolve to
+//! `Ty::Unknown`, which is bidirectionally compatible. GH #470
+//! tightened the STDLIB half of that tolerance: the Hale-source
+//! stdlib surface is registered into the top scope (signatures
+//! only — its bodies are never checked here), so `std::…` type
+//! exprs, literals, fields, methods, and interface coercions
+//! check for real, and a `std::` literal that resolves nowhere is
+//! an error. Rust-implemented builtins keep the tolerance (their
+//! path-call NAMES are validated by `stdlib_surface`).
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -12382,10 +12387,8 @@ impl<'a> Checker<'a> {
         inits: &[StructInit],
         span: Span,
     ) -> Ty {
+        let mut stdlib_resolved: Option<String> = None;
         if path.segments.len() != 1 {
-            for init in inits {
-                let _ = self.check_expr(&init.value);
-            }
             // Resolve an imported qualified literal (`mat::Grid { }`)
             // to the merged symbol codegen lowers it to, so field and
             // method access on the RESULT is checked against the real
@@ -12393,17 +12396,19 @@ impl<'a> Checker<'a> {
             // the gap that let `mat::Grid { }.make(x)` (no such method;
             // `make` is a free fn) pass `check` and die in codegen.
             //
-            // Only the result TYPE is resolved. The inits are not
-            // re-validated against the imported params, so any literal
-            // `check` accepted before (as Unknown) still typechecks —
-            // this only adds checking downstream of the literal, never
-            // new errors on the literal itself. Empty renames (every
-            // single-seed bundle) fall straight through to Unknown.
+            // Only the result TYPE is resolved for IMPORTS. The inits
+            // are not re-validated against the imported params, so any
+            // literal `check` accepted before (as Unknown) still
+            // typechecks. Empty renames (every single-seed bundle)
+            // skip straight past this.
             let key: Vec<String> =
                 path.segments.iter().map(|s| s.name.clone()).collect();
             if let Some((_, mangled)) =
                 self.import_renames.iter().find(|(p, _)| *p == key)
             {
+                for init in inits {
+                    let _ = self.check_expr(&init.value);
+                }
                 if matches!(
                     self.top.lookup(mangled),
                     Some(
@@ -12414,10 +12419,58 @@ impl<'a> Checker<'a> {
                 ) {
                     return Ty::Named(mangled.clone());
                 }
+                return Ty::Unknown;
             }
-            return Ty::Unknown;
+            // GH #470: a STDLIB qualified literal resolves through
+            // PATH_RENAMES to the mangled symbol the Hale-source
+            // stdlib declares (now registered in the top scope), and
+            // then falls through to FULL literal validation below —
+            // fields checked, interface coercions enforced. The old
+            // `Ty::Unknown` tolerance here was fail-open all the way
+            // to runtime memory corruption (a wrong-arity middleware
+            // coerced to `std::http::Middleware` unchecked).
+            let segs: Vec<&str> =
+                path.segments.iter().map(|s| s.name.as_str()).collect();
+            if let Some(m) = crate::stdlib_bodies::mangled_locus_name(&segs)
+            {
+                if self.top.lookup(m).is_some() {
+                    stdlib_resolved = Some(m.to_string());
+                } else {
+                    // Renamed but not Hale-source-declared (a
+                    // Rust-implemented handle, e.g.
+                    // std::io::tcp::Listener): keep the historical
+                    // tolerance — a Named with no symbol behind it
+                    // would trade fail-open for false errors.
+                    for init in inits {
+                        let _ = self.check_expr(&init.value);
+                    }
+                    return Ty::Unknown;
+                }
+            } else if segs.first() == Some(&"std") {
+                // GH #470: a std:: literal that matches nothing in
+                // the rename table is a typo, not an Unknown —
+                // `std::log::TotallyFakeSink {}` used to typecheck.
+                self.diags.push(Diag::ty(
+                    span,
+                    format!(
+                        "unknown stdlib type `{}` in struct/locus \
+                         literal",
+                        key.join("::")
+                    ),
+                ));
+                for init in inits {
+                    let _ = self.check_expr(&init.value);
+                }
+                return Ty::Unknown;
+            } else {
+                for init in inits {
+                    let _ = self.check_expr(&init.value);
+                }
+                return Ty::Unknown;
+            }
         }
-        let name = &path.segments[0].name;
+        let name: &String =
+            stdlib_resolved.as_ref().unwrap_or(&path.segments[0].name);
         // M3 stage 3 tranche 2 (2026-07-02): mangled generic
         // monomorph literal (`Box_Int { ... }`). Resolve the
         // `Base_Tok[_Tok...]` shape against a generic type

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -153,6 +153,15 @@ pub fn check_bundle_opts(
 ) -> Vec<Diag> {
     let (top, mut diags) = resolve::build_top_scope(bundle);
     diags.extend(check::check_bundle(bundle, &top, allow_unowned_subscriber));
+    // GH #470: diagnostics speak the user's spelling at EVERY
+    // consumer — CLI, LSP, library callers, tests — not just the
+    // CLI, which used to be the only layer applying the stdlib
+    // demangle. A message naming `__StdHttpMiddleware` points at a
+    // symbol that appears nowhere in the author's source. (The
+    // CLI's own demangle pass additionally rewrites cross-seed
+    // import renames, which only it knows; re-rewriting an
+    // already-public stdlib name there is a no-op.)
+    stdlib_bodies::demangle_imports(&mut diags, &[]);
     diags
 }
 

--- a/crates/hale-types/src/resolve.rs
+++ b/crates/hale-types/src/resolve.rs
@@ -69,16 +69,38 @@ pub fn build_top_scope(bundle: &Bundle<'_>) -> (TopScope, Vec<Diag>) {
             .entry("BusUnmatchedKey".to_string())
             .or_insert(Span::new(0, 0));
     }
-    // GH #436: pre-register the `@sealed` Hale-source stdlib loci, so
-    // a user's `params { s: std::secret::Signer = … }` resolves to
-    // the mangled name that stdlib source declares rather than to
-    // `Ty::Unknown`. This must land BEFORE the register pass below —
-    // that is where user type-exprs resolve.
-    for it in sealed_stdlib_loci() {
-        if let TopDecl::Locus(l) = it {
-            known_names
-                .entry(l.name.name.clone())
-                .or_insert(l.name.span);
+    // GH #470: pre-register the ENTIRE Hale-source stdlib surface —
+    // loci, types, interfaces, enums, free fns — so a user's
+    // `std::http::Router {}` / `ctx: std::http::Context` resolves to
+    // the mangled nominal symbol the stdlib source declares rather
+    // than to `Ty::Unknown`. The Unknown tolerance was fail-open all
+    // the way to runtime memory corruption: a locus with a
+    // wrong-arity method coerced to a stdlib interface unchecked
+    // (`router.use(m)`) and the fat-pointer call scrambled the
+    // frame. Registration is signatures-only — stdlib BODIES are
+    // never added to the checked bundle, so this cannot produce
+    // diagnostics against stdlib source itself. (Supersedes the
+    // GH #436 sealed-only injection, which was this fix restricted
+    // to the loci that could not wait for it.) Must land BEFORE the
+    // register pass below — that is where user type-exprs resolve.
+    for it in stdlib_top_decls() {
+        match it {
+            TopDecl::Locus(l) => {
+                known_names
+                    .entry(l.name.name.clone())
+                    .or_insert(l.name.span);
+            }
+            TopDecl::Type(t) => {
+                known_names
+                    .entry(t.name.name.clone())
+                    .or_insert(t.name.span);
+            }
+            TopDecl::Interface(i) => {
+                known_names
+                    .entry(i.name.name.clone())
+                    .or_insert(i.name.span);
+            }
+            _ => {}
         }
     }
 
@@ -106,14 +128,22 @@ pub fn build_top_scope(bundle: &Bundle<'_>) -> (TopScope, Vec<Diag>) {
         );
     }
 
-    for it in sealed_stdlib_loci() {
-        register_top_decls(
-            std::slice::from_ref(it),
-            &known_names,
-            &topics_resolved,
-            &mut scope,
-            &mut diags,
-        );
+    // GH #470: register the full stdlib surface. Diagnostics from
+    // this pass are swallowed — the stdlib is not the user's code to
+    // fix, and an internal signature that fails to resolve simply
+    // degrades that symbol to the old Unknown tolerance instead of
+    // erroring someone else's build.
+    {
+        let mut stdlib_diags: Vec<Diag> = Vec::new();
+        for it in stdlib_top_decls() {
+            register_top_decls(
+                std::slice::from_ref(it),
+                &known_names,
+                &topics_resolved,
+                &mut scope,
+                &mut stdlib_diags,
+            );
+        }
     }
 
     // v1.x-FORM-1 PR3b: inject the form-specific stdlib type
@@ -491,29 +521,22 @@ fn finalize_topic_chain(
     }
 }
 
-/// GH #436: the `@sealed` loci declared in the Hale-source stdlib.
+/// GH #470: every top declaration in the Hale-source stdlib.
 ///
-/// Deliberately ONLY the sealed ones. Every multi-segment stdlib path
-/// (`std::io::tcp::Stream`, `std::http::Server`, …) resolves to
-/// `Ty::Unknown` today, and making them all `Named` would switch on
-/// field-existence and method arity/fallibility checking across the
-/// whole stdlib surface at once — a real improvement, and one that can
-/// newly reject programs that compile today. That is its own change
-/// with its own measurement.
-///
-/// Sealing cannot wait for it, because it fails OPEN without it.
-/// `@sealed` keys off the receiver's resolved type, so a sealed stdlib
-/// locus reached through a qualified path had readable params —
-/// verified before this fix: `self.signer.key` returned real key bytes
-/// and `hale check` passed it.
-///
-/// Restricting the injection to sealed loci puts the blast radius at
-/// exactly the types that could not otherwise be protected.
-fn sealed_stdlib_loci() -> impl Iterator<Item = &'static TopDecl> {
+/// This is the "its own change with its own measurement" the GH #436
+/// sealed-only note promised: the whole surface is registered, so
+/// field-existence, method arity, and interface-satisfaction checking
+/// apply across it. The measurement happened - the fixture corpus and
+/// full workspace pass untouched except for two tests that pinned the
+/// old permissiveness (one of which was a genuinely invalid fixture
+/// the tolerance had been hiding: a call to a Router method that does
+/// not exist). What forced the timing was fail-open UB: a locus with
+/// a wrong-arity method coerced to `std::http::Middleware` unchecked,
+/// and the interface fat-pointer call corrupted the frame.
+fn stdlib_top_decls() -> impl Iterator<Item = &'static TopDecl> {
     crate::stdlib_bodies::program()
         .into_iter()
         .flat_map(|p| p.items.iter())
-        .filter(|it| matches!(it, TopDecl::Locus(l) if l.sealed))
 }
 
 fn register_top_decls(

--- a/crates/hale-types/src/stdlib_bodies.rs
+++ b/crates/hale-types/src/stdlib_bodies.rs
@@ -88,6 +88,13 @@ pub fn demangle_imports(
     // MANGLED name — `__StdSecretSigner::sign` — a symbol that
     // appears nowhere in the author's program. Claims witnesses hit
     // this the moment `secret_use` became findable.
+    // Only genuinely MANGLED spellings are rewritten. Some stdlib
+    // renames alias a BARE name (`ParseError`, `IoError` — the
+    // injected error types); substring-replacing those corrupts any
+    // message that legitimately contains the word ("MyParseError" →
+    // "Mystd::str::ParseError"). A `__` prefix is what makes a name
+    // unspeakable in user source, and unspeakable names are the
+    // entire reason this pass exists.
     let mut table: Vec<(&str, String)> = import_renames
         .iter()
         .map(|(segs, mangled)| (mangled.as_str(), segs.join("::")))
@@ -96,6 +103,7 @@ pub fn demangle_imports(
                 .iter()
                 .map(|(segs, mangled)| (*mangled, segs.join("::"))),
         )
+        .filter(|(mangled, _)| mangled.starts_with("__"))
         .collect();
     table.sort_by_key(|(m, _)| std::cmp::Reverse(m.len()));
     for d in diags.iter_mut() {

--- a/crates/hale-types/tests/std_secret.rs
+++ b/crates/hale-types/tests/std_secret.rs
@@ -118,12 +118,13 @@ fn a_fingerprint_is_publishable_and_the_value_is_not() {
 }
 
 #[test]
-fn only_sealed_stdlib_loci_gained_a_resolved_type() {
-    // The resolver injection is deliberately narrow: making EVERY
-    // qualified stdlib path resolve would switch on field-existence
-    // and arity checking across the whole stdlib surface at once.
-    // An unsealed stdlib locus must still behave exactly as before —
-    // permissive, because its type is still `Unknown`.
+fn every_stdlib_locus_gained_a_resolved_type() {
+    // GH #470 inverted the old sealed-only narrowing: the ENTIRE
+    // Hale-source stdlib surface is registered, so field-existence
+    // and arity checking apply across it. The Unknown tolerance
+    // this test used to pin was fail-open all the way to runtime
+    // memory corruption (a wrong-arity middleware coerced to
+    // `std::http::Middleware` unchecked).
     let src = "
         locus L {
             params { n: Int = 0; }
@@ -134,9 +135,56 @@ fn only_sealed_stdlib_loci_gained_a_resolved_type() {
         main locus App { params { l: L = L { }; } }
         fn main() { App { }; }
     ";
+    let errs = errors(src);
     assert!(
-        errors(src).is_empty(),
-        "unsealed stdlib paths must stay permissive: {:?}",
-        errors(src)
+        errs.iter().any(|d| d.contains("no_such_field_at_all")),
+        "a bogus field on a stdlib handle must now be an error: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn wrong_arity_interface_impl_is_refused_at_the_stdlib_call_site() {
+    // The #470 canary itself: the middleware contract is
+    // `after(ctx, resp) -> Response`; a one-arg `after` used to
+    // typecheck through the Unknown receiver and corrupt memory at
+    // the fat-pointer call.
+    let src = "
+        locus BadMw {
+            fn before(ctx: std::http::Context) -> std::http::Context {
+                return ctx;
+            }
+            fn after(ctx: std::http::Context) -> std::http::Context {
+                return ctx;
+            }
+        }
+        fn main() {
+            let router = std::http::Router {};
+            router.use(BadMw {});
+        }
+    ";
+    let errs = errors(src);
+    assert!(
+        errs.iter().any(|d| {
+            d.contains("after") && d.contains("arity")
+        }),
+        "the wrong-arity middleware must be refused: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn nonexistent_stdlib_paths_are_errors_not_unknowns() {
+    // `std::log::TotallyFakeSink {}` used to typecheck silently.
+    let src = "
+        fn main() {
+            std::log::TotallyFakeSink {};
+        }
+    ";
+    let errs = errors(src);
+    assert!(
+        errs.iter().any(|d| d.contains("unknown stdlib type")),
+        "a typo'd stdlib literal must be an error: {:?}",
+        errs
     );
 }

--- a/crates/hale-types/tests/stdlib_nominal.rs
+++ b/crates/hale-types/tests/stdlib_nominal.rs
@@ -1,0 +1,300 @@
+//! GH #470: stdlib values carry their real nominal types.
+//!
+//! The change has two failure directions and both need pins:
+//!
+//!   - fail-open (the bug): a wrong-arity method coerced to a stdlib
+//!     interface unchecked and corrupted memory at the fat-pointer
+//!     call — the negative pins here keep that impossible;
+//!   - false errors (the risk of the fix): the tightened checker
+//!     rejecting CORRECT stdlib use — the positive pins here (and
+//!     `tests/hale/router_middleware_test.hl`, which also RUNS the
+//!     accepted program) keep the acceptance surface honest.
+//!
+//! Plus one consistency canary: the literal path keeps a tolerant
+//! branch for renamed-but-not-Hale-declared handles. Today that
+//! branch is DEAD (every `__Std` rename target is declared in the
+//! `.hl` stdlib); the canary makes adding a rename without a
+//! declaration a conscious act rather than a silent regression to
+//! the old permissiveness.
+
+use hale_syntax::parse_source;
+
+fn errors(src: &str) -> Vec<String> {
+    let program = parse_source(src).expect("parse");
+    hale_types::check_program(&program)
+        .into_iter()
+        .filter(|d| d.is_error())
+        .map(|d| d.message)
+        .collect()
+}
+
+const GOOD_MW: &str = "
+    locus GoodMw {
+        fn before(ctx: std::http::Context) -> std::http::Context {
+            return ctx;
+        }
+        fn after(ctx: std::http::Context, resp: std::http::Response) -> std::http::Response {
+            return resp;
+        }
+    }
+";
+
+const BAD_MW: &str = "
+    locus BadMw {
+        fn before(ctx: std::http::Context) -> std::http::Context {
+            return ctx;
+        }
+        fn after(ctx: std::http::Context) -> std::http::Context {
+            return ctx;
+        }
+    }
+";
+
+#[test]
+fn the_correct_middleware_contract_is_accepted() {
+    let src = format!(
+        "{GOOD_MW}
+        fn main() {{
+            let r = std::http::Router {{}};
+            r.use(GoodMw {{}});
+        }}"
+    );
+    assert!(
+        errors(&src).is_empty(),
+        "the tightened checker must not reject the CORRECT contract: {:?}",
+        errors(&src)
+    );
+}
+
+#[test]
+fn the_wrong_arity_middleware_is_refused_with_the_public_spelling() {
+    let src = format!(
+        "{BAD_MW}
+        fn main() {{
+            let r = std::http::Router {{}};
+            r.use(BadMw {{}});
+        }}"
+    );
+    let errs = errors(&src);
+    assert!(
+        errs.iter()
+            .any(|m| m.contains("after") && m.contains("arity")),
+        "wrong-arity `after` must be refused: {:?}",
+        errs
+    );
+    // The diagnostic must speak the user's spelling — a mangled
+    // `__StdHttpMiddleware` appears nowhere in their source.
+    assert!(
+        errs.iter().any(|m| m.contains("std::http::Middleware")),
+        "the refusal must name the PUBLIC interface spelling: {:?}",
+        errs
+    );
+}
+
+#[test]
+fn stdlib_interfaces_in_user_signatures_coerce_and_refuse() {
+    // A USER fn taking a stdlib interface: the same structural
+    // verification applies at the user call site.
+    let ok = format!(
+        "{GOOD_MW}
+        fn take(m: std::http::Middleware) {{ }}
+        fn main() {{ take(GoodMw {{}}); }}"
+    );
+    assert!(
+        errors(&ok).is_empty(),
+        "a satisfying locus must coerce at a user fn site: {:?}",
+        errors(&ok)
+    );
+    let bad = format!(
+        "{BAD_MW}
+        fn take(m: std::http::Middleware) {{ }}
+        fn main() {{ take(BadMw {{}}); }}"
+    );
+    assert!(
+        errors(&bad)
+            .iter()
+            .any(|m| m.contains("after") && m.contains("arity")),
+        "a non-satisfying locus must be refused at a user fn site: {:?}",
+        errors(&bad)
+    );
+}
+
+#[test]
+fn stdlib_method_calls_check_name_and_arity() {
+    // The tolerance that hid an invalid workspace fixture for
+    // months: `Router.get` does not exist (the method is `add`).
+    let unknown = "
+        fn main() {
+            let r = std::http::Router {};
+            r.get(\"/\");
+        }
+    ";
+    assert!(
+        !errors(unknown).is_empty(),
+        "a nonexistent stdlib method must be an error"
+    );
+    let wrong_arity = "
+        fn main() {
+            let r = std::http::Router {};
+            r.add(\"GET\", \"/\");
+        }
+    ";
+    assert!(
+        !errors(wrong_arity).is_empty(),
+        "a wrong-arity stdlib method call must be an error"
+    );
+}
+
+#[test]
+fn stdlib_type_annotations_are_real_types() {
+    let ok = "
+        fn main() {
+            let r: std::http::Router = std::http::Router {};
+        }
+    ";
+    assert!(
+        errors(ok).is_empty(),
+        "a stdlib literal must satisfy its own annotation: {:?}",
+        errors(ok)
+    );
+    let bad = "
+        fn main() {
+            let x: Int = std::http::Router {};
+        }
+    ";
+    assert!(
+        errors(bad)
+            .iter()
+            .any(|m| m.contains("std::http::Router")),
+        "the mismatch must name the stdlib type publicly: {:?}",
+        errors(bad)
+    );
+}
+
+#[test]
+fn non_stdlib_qualified_literals_keep_the_historical_tolerance() {
+    // Only `std::` roots gained the unknown-name error; other
+    // qualified literals (cross-seed shapes with no renames in a
+    // single-seed check) stay permissive exactly as before.
+    let src = "
+        fn main() {
+            somelib::Widget {};
+        }
+    ";
+    assert!(
+        errors(src).is_empty(),
+        "non-std qualified literals must stay permissive: {:?}",
+        errors(src)
+    );
+}
+
+#[test]
+fn every_renamed_std_target_is_declared_or_consciously_exempt() {
+    // The literal path keeps a tolerant branch for a rename whose
+    // target has no Hale-source declaration (a Rust-implemented
+    // handle). That branch is UNREACHABLE today; a rename added
+    // without a declaration would silently reopen the old
+    // permissive typing for that name. Make it a decision instead.
+    const EXEMPT: &[&str] = &[];
+    let program = hale_syntax::parse_source(hale_stdlib::AP_SOURCE)
+        .expect("the bundled stdlib source must parse");
+    let mut declared = std::collections::BTreeSet::new();
+    for item in &program.items {
+        match item {
+            hale_syntax::ast::TopDecl::Locus(l) => {
+                declared.insert(l.name.name.clone());
+            }
+            hale_syntax::ast::TopDecl::Type(t) => {
+                declared.insert(t.name.name.clone());
+            }
+            hale_syntax::ast::TopDecl::Interface(i) => {
+                declared.insert(i.name.name.clone());
+            }
+            _ => {}
+        }
+    }
+    let mut undeclared: Vec<String> = Vec::new();
+    for (path, target) in hale_stdlib::PATH_RENAMES {
+        if target.starts_with("__Std")
+            && !declared.contains(*target)
+            && !EXEMPT.contains(target)
+        {
+            undeclared.push(format!("{} -> {}", path.join("::"), target));
+        }
+    }
+    assert!(
+        undeclared.is_empty(),
+        "renamed __Std targets with no .hl declaration (add the \
+         declaration, or add to EXEMPT with a comment explaining \
+         why permissive typing is intended): {:?}",
+        undeclared
+    );
+}
+
+#[test]
+fn fallible_handle_methods_are_enforced_at_check_time() {
+    // The checker twin of codegen's must-address backstop (PR
+    // #217): with handles nominal, a bare fallible handle method
+    // is a CHECK error, not a codegen surprise.
+    let bare = "
+        fn work() -> Int fallible(IoError) {
+            let f = std::io::file::open(\"/tmp/x\", \"w\") or raise;
+            f.write_line(\"hi\");
+            return 1;
+        }
+        fn main() { let n = work() or 0; }
+    ";
+    assert!(
+        errors(bare)
+            .iter()
+            .any(|m| m.contains("not addressed")),
+        "a bare fallible handle method must be refused: {:?}",
+        errors(bare)
+    );
+    let addressed = "
+        fn work() -> Int fallible(IoError) {
+            let f = std::io::file::open(\"/tmp/x\", \"w\") or raise;
+            f.write_line(\"hi\") or raise;
+            let line = f.read_line();
+            return len(line);
+        }
+        fn main() { let n = work() or 0; }
+    ";
+    assert!(
+        errors(addressed).is_empty(),
+        "the documented File pattern must typecheck: {:?}",
+        errors(addressed)
+    );
+}
+
+#[test]
+fn renamed_stdlib_fns_check_against_their_real_signatures() {
+    // The surface table's stale fd-era `open -> Int` row used to
+    // win; the registered Hale-source wrapper is authoritative now.
+    let wrong_arity = "
+        fn work() -> Int fallible(IoError) {
+            let f = std::io::file::open(\"/tmp/x\") or raise;
+            return 1;
+        }
+        fn main() { let n = work() or 0; }
+    ";
+    assert!(
+        !errors(wrong_arity).is_empty(),
+        "open takes (path, mode) — one arg must be refused"
+    );
+    let nominal_return = "
+        fn work() -> Int fallible(IoError) {
+            let f = std::io::file::open(\"/tmp/x\", \"w\") or raise;
+            let b: Bool = f;
+            return 1;
+        }
+        fn main() { let n = work() or 0; }
+    ";
+    assert!(
+        errors(nominal_return)
+            .iter()
+            .any(|m| m.contains("std::io::file::File")),
+        "open's success type is the File handle, named publicly: {:?}",
+        errors(nominal_return)
+    );
+}

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -920,8 +920,9 @@ Type-check rules:
    type, and names the topic-as-parameter-type mistake
    (`fn on_h(msg: Hello)` where `Hello` is the topic)
    specifically. Payloads that resolve `Unknown` — cross-seed
-   topics, stdlib paths — stay permissive by the milestone-2
-   rule.)
+   topics — stay permissive by the milestone-2 rule; stdlib
+   paths resolve to their real nominal types since GH #470 and
+   are checked like any user type.)
 2. The send-expression's type at a topic-ref `<-` site must match
    `Topic.payload`.
 3. The `of type T` clause is forbidden on topic-ref subscribe /

--- a/spec/stdlib.md
+++ b/spec/stdlib.md
@@ -14,9 +14,15 @@ let contents = std::io::fs::read_file("config.toml");
 std::io::tcp::Listener { host: "127.0.0.1", port: 8080 };
 ```
 
-The parser tokenizes `::` as a path separator and the type checker
-punts namespaced paths to `Ty::Unknown`; the codegen layer
-resolves `std::*` paths against a hardcoded namespace dispatcher.
+The parser tokenizes `::` as a path separator. The type checker
+resolves `std::*` paths that name Hale-source stdlib declarations
+to their real nominal types (GH #470 — literals, fields, methods,
+and interface coercions check like user code, and a `std::`
+literal that matches nothing is an error); remaining namespaced
+paths (Rust-implemented builtins) type permissively, with their
+path-call names validated against the stdlib surface registry.
+The codegen layer resolves `std::*` paths against a hardcoded
+namespace dispatcher.
 
 There is **no general module system** at v1 — no `use`
 statements, no user-defined modules, no multi-file `.hl`

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -950,12 +950,16 @@ enters the program and there is no construction site at which the
 caller held it. `std::secret::Credential` is the same discipline for a
 token or password, with a `fingerprint()` that is safe to log.
 
-Sealing keys off the receiver's resolved type, so a qualified path
-naming a **sealed** Hale-source stdlib locus resolves to the mangled
-name that source declares. Other qualified paths resolve to
-`Ty::Unknown`: resolving them all would turn on field-existence and
-method arity checking across the whole stdlib surface at once, which
-is a separate change.
+Sealing keys off the receiver's resolved type. Since GH #470 every
+qualified path naming a Hale-source stdlib declaration resolves to
+the mangled name that source declares — the whole surface, not only
+sealed loci — so field-existence, method arity, and
+interface-satisfaction checking apply to stdlib-typed values exactly
+as to user types (the old `Ty::Unknown` tolerance was fail-open:
+a wrong-arity method coerced to a stdlib interface unchecked and
+corrupted memory at the fat-pointer call). Rust-implemented builtin
+handles keep the permissive typing; their path-call names are
+validated by the stdlib surface registry.
 
 **The recommended shape**, a pattern rather than an enforced contract:
 an ordinary function prepares a request from public data and returns a

--- a/tests/hale/file_handle_test.hl
+++ b/tests/hale/file_handle_test.hl
@@ -1,0 +1,23 @@
+// GH #470: the documented File handle pattern, END TO END. Before
+// the nominal-types change this could not even typecheck (the
+// surface table's stale fd-era row typed `open` as -> Int), and
+// before file.hl's handle ops became real locus members it could
+// not lower (codegen's fallible-member machinery had no member to
+// find). This test is the proof both layers now agree.
+
+fn roundtrip(path: String) -> String fallible(IoError) {
+    let w = std::io::file::open(path, "w") or raise;
+    w.write_line("alpha") or raise;
+    w.write_line("beta") or raise;
+    let r = std::io::file::open(path, "r") or raise;
+    // read_line keeps the trailing newline; trim for comparison.
+    let first = std::str::trim(r.read_line());
+    let second = std::str::trim(r.read_line());
+    std::test::assert(len(second) > 0, "read progressed");
+    return first + "|" + second;
+}
+
+fn main() {
+    let got = roundtrip("/tmp/hale_470_file_test.txt") or "FAILED";
+    std::test::assert_eq_str(got, "alpha|beta", "write then read back through the handle");
+}

--- a/tests/hale/router_middleware_test.hl
+++ b/tests/hale/router_middleware_test.hl
@@ -1,0 +1,51 @@
+// GH #470 keystone POSITIVE test: the correct middleware contract —
+// `before(ctx) -> Context`, `after(ctx, resp) -> Response` — must
+// typecheck AND behave through the whole promoted Router battery:
+// stdlib literals validated for real, interface coercion at the
+// `use`/`add` call sites, hand-built Request with the new
+// version/headers/body defaults, and the onion order observable in
+// the dispatched Response. (The wrong-arity variant is pinned as a
+// compile ERROR in crates/hale-types/tests/stdlib_nominal.rs; this
+// file is the proof the tightened checker still accepts the code it
+// should.) No sockets: Router.dispatch is exercised directly.
+
+locus Stamp {
+    fn before(ctx: std::http::Context) -> std::http::Context {
+        return ctx;
+    }
+    fn after(ctx: std::http::Context, resp: std::http::Response) -> std::http::Response {
+        return std::http::Response {
+            status: resp.status,
+            body: resp.body + "+after",
+        };
+    }
+}
+
+locus Hello {
+    fn handle(ctx: std::http::Context) -> std::http::Response {
+        return std::http::Response {
+            status: 201,
+            body: "hi:" + ctx.req.path,
+        };
+    }
+}
+
+fn main() {
+    let r = std::http::Router { };
+    r.use(Stamp { });
+    r.add("GET", "/greet", Hello { });
+
+    // Request defaults (GH #470 follow-through): only what the test
+    // means — method, path, body.
+    let req = std::http::Request { method: "GET", path: "/greet", body: "" };
+    let resp = r.dispatch(req);
+
+    std::test::assert_eq_int(resp.status, 201, "handler status survives the onion");
+    std::test::assert_eq_str(resp.body, "hi:/greet+after", "before->handle->after ran in onion order");
+
+    // A miss routes to the default 404 — the not-found path is part
+    // of the same dispatch surface.
+    let missing = std::http::Request { method: "GET", path: "/nope", body: "" };
+    let notfound = r.dispatch(missing);
+    std::test::assert_eq_int(notfound.status, 404, "unrouted path lands on not_found");
+}


### PR DESCRIPTION
Fixes #470 — the real fix, not the backstop.

## What was fail-open

Stdlib qualified paths resolved to `Ty::Unknown`, which is bidirectionally compatible — so `router.use(badMw)` performed no signature lookup and no interface-satisfaction check, and codegen coerced the locus to the interface fat pointer blindly. The downstream symptom that surfaced it: a middleware with `after(ctx) -> Context` (contract: `after(ctx, resp) -> Response`) compiled clean and the ABI-mismatched call corrupted the HTTP response in memory. `let x: Int = router;` typechecked. `std::log::TotallyFakeSink {}` — a nonexistent name — typechecked.

## The fix

The one the GH #436 sealed-only injection explicitly deferred ("its own change with its own measurement"):

- **The entire Hale-source stdlib surface registers into the checker's top scope** — signatures only; stdlib bodies are never added to the checked bundle, and registration diagnostics are swallowed, so no diagnostic can land on stdlib source.
- **Stdlib qualified literals resolve through `PATH_RENAMES` and validate fully** — fields checked against real params, methods against real signatures, interface coercions through the structural verifier (at literal-init sites and call sites). A `std::` literal matching nothing is a hard error; a renamed-but-Rust-implemented handle keeps the historical tolerance rather than trading fail-open for false errors. Builtin free-fn calls were already name-validated by `stdlib_surface` and are unchanged.
- **Diagnostics render public spellings** (`std::http::Middleware`, not `__StdHttpMiddleware`) via the existing demangle pass:

```
type error: locus `Passthru` method `after` arity does not match interface `std::http::Middleware`: expected 2 arg(s), locus has 1
type error: let `x`: expected `Int`, got `std::http::Router`
type error: unknown stdlib type `std::log::TotallyFakeSink` in struct/locus literal
```

## The measurement (as the deferral demanded)

Whole fixture corpus: clean. Full workspace: 2569/2569 after updating exactly two tests that pinned the old permissiveness — and one of those was **an invalid fixture the tolerance had been hiding**: `topology_v2` called `Router.get(...)`, a method that does not exist (now `add`). The `std_secret` sealed-only pin is inverted to assert the new contract, and the #470 canaries are permanent: wrong-arity middleware refused at the call site, bogus stdlib-handle field refused, typo'd literal refused.

Ergonomics follow-through: `std::http::Request` gains defaults for `version`/`headers`/`body`, keeping the documented hand-built-Request pattern (`Request { method, path, body }`) one line now that literal fields are checked for real.

Spec (semantics/verification/stdlib), the checker preamble, and the resolve rationale updated in the same change. The downstream program that surfaced the bug typechecks and serves correctly against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)