### PR TITLE
replay phase 6: `where async_io` pools replay their recorded schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,20 @@ the clock:
   never deadlock; a dry or pre-phase-6 tape hands the pool back to
   the live drain.
 
-Hardened by a review round: the artifact carries an
+Hardened by two review rounds. Round two closed the degradation
+and compatibility paths: a skipped START retires its birth ordinal
+AND its consume slot (one missing delivery no longer cascades into
+wrong resume pairings — steps naming a retired slot skip
+immediately); the dry-tape flag is set BEFORE the ready-head/held
+flushes so post-tape work is always classified; the CLI comparator
+carries the artifact's async-capability bit and skips schedule
+comparison for pre-phase-6 artifacts (matching the runtime's
+coverage note instead of contradicting it); the one-shot warning
+is atomic; the test module is Linux-gated; and the public
+`hale replay --diff` path is exercised end to end (exact match,
+mutated-step failure, and old-artifact compatibility).
+
+Round one: the artifact carries an
 async-capable header bit, the dry-tape states are named instead of
 silent (pre-phase-6 artifact → one-shot coverage note; truncated
 tape → stated coverage boundary; a finalized tape running dry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,39 @@ pattern stays one line. Canaries: the wrong-arity middleware, the
 `Int = router` absurdity, and the typo'd-literal case are all
 compile errors now.
 
+### Record & replay, phase 6: `where async_io` pools replay (GH #296)
+
+The last refusing surface joins the replay story. The
+nondeterminism of an async pool is its drain's SCHEDULING — which
+cell starts when, which parked coro resumes when (epoll readiness
+order), when a timed park expires relative to both. Recording now
+stamps every such decision on the pool worker's private ring as a
+step stream (`ASYNC_START`/`ASYNC_RESUME`/`ASYNC_EXPIRE`; coros
+named by birth ordinal, stable across runs because start order is
+enforced), and replay DRIVES the drain from that stream instead of
+the clock:
+
+- START steps reuse the phase-4 cell gate unchanged (start order
+  is consume order; the async live path now gates too, closing the
+  never-reached gap the old refusal hid);
+- RESUME steps wait for the named coro's readiness — early-ready
+  coros park aside until their recorded turn;
+- EXPIRE steps resume immediately with the timed-out sentinel: the
+  recording proves the deadline fired here, so replayed sleeps
+  fast-forward rather than re-waiting wall-clock time;
+- an unsatisfiable step counts an `async-schedule` divergence
+  (new status-file key, new summary row) and is skipped — degrade,
+  never deadlock; a dry or pre-phase-6 tape hands the pool back to
+  the live drain.
+
+Boundary, stated: the schedule replays; the data of unjournaled
+I/O still re-executes live (syscall-class, gated), and bindings
+ingress arrives via the phase-5 injector. Tests: a staggered
+two-locus async pool records and replays byte-identically with
+zero divergences, finishes faster than its recorded sleeps (proof
+the tape, not timers, drove it), and two replays of one recording
+agree with each other.
+
 ### Record & replay, phase 5: durable recording, the hermetic wire, and feed mode (GH #296)
 
 Three deliverables close the two loudest gaps in the v0.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,13 +71,25 @@ the clock:
   never deadlock; a dry or pre-phase-6 tape hands the pool back to
   the live drain.
 
+Hardened by a review round: the artifact carries an
+async-capable header bit, the dry-tape states are named instead of
+silent (pre-phase-6 artifact → one-shot coverage note; truncated
+tape → stated coverage boundary; a finalized tape running dry
+under continued async work → `async_post_tape` divergences, with
+schedule steps left unconsumed at exit as
+`unconsumed_async_steps`), and `--diff` compares the per-consumer
+async step streams bidirectionally like every other stream.
+
 Boundary, stated: the schedule replays; the data of unjournaled
 I/O still re-executes live (syscall-class, gated), and bindings
 ingress arrives via the phase-5 injector. Tests: a staggered
 two-locus async pool records and replays byte-identically with
-zero divergences, finishes faster than its recorded sleeps (proof
-the tape, not timers, drove it), and two replays of one recording
-agree with each other.
+zero divergences; a 2.5-second recorded park replays in a fraction
+of its own measured recorded wall time (the fast-forward PROOF —
+the old bound was satisfiable live); readiness arriving in the
+OPPOSITE order of the recorded resumes is held on ready_head and
+replayed in tape order across a mixed START/RESUME/EXPIRE stream;
+and two replays of one recording agree with each other.
 
 ### Record & replay, phase 5: durable recording, the hermetic wire, and feed mode (GH #296)
 

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -5447,6 +5447,13 @@ fn run_replay(args: &[String]) -> ExitCode {
     let _ = std::fs::remove_file(&status_path);
 
     if let Some(v) = &verify_path {
+        if !rec.async_schedule_capable {
+            eprintln!(
+                "hale replay: note — this recording predates \
+                 async-schedule support; schedule comparison is \
+                 skipped (coverage limitation, not a divergence)"
+            );
+        }
         if runtime_divergences > 0 {
             eprintln!(
                 "replay DIVERGED: {} runtime divergences (see the \

--- a/crates/hale-cli/src/replay.rs
+++ b/crates/hale-cli/src/replay.rs
@@ -96,6 +96,12 @@ pub struct Recording {
     /// journal streams: "byte-identical output" alone is weaker
     /// than "the asynchronous schedule matched".
     pub async_steps: Vec<(u64, Vec<(u32, u64)>)>,
+    /// Header flag bit 2 (review round 2, finding 3): whether the
+    /// RECORDING runtime knew how to record async schedules. "No
+    /// schedule was recorded" and "the recorded schedule was empty"
+    /// are different facts — the comparator must not treat an
+    /// old artifact's absence as an asserted empty schedule.
+    pub async_schedule_capable: bool,
 }
 
 pub fn parse(path: &Path) -> Result<Recording, String> {
@@ -151,6 +157,7 @@ pub fn parse_file(file: &std::fs::File, path: &Path) -> Result<Recording, String
         *part = u64_at(&buf, 56 + i * 8);
     }
     let env_redacted = u64_at(&buf, 88) & 1 != 0;
+    let async_schedule_capable = u64_at(&buf, 88) & 4 != 0;
 
     let mut end = buf.len();
     let has_trailer =
@@ -392,6 +399,7 @@ pub fn parse_file(file: &std::fs::File, path: &Path) -> Result<Recording, String
         consume_streams: consume,
         public_streams: public,
         async_steps,
+        async_schedule_capable,
     })
 }
 
@@ -481,13 +489,19 @@ pub fn diff(
     ) {
         return Some(d);
     }
-    if let Some(d) = stream_diff(
-        "async schedule step",
-        &original.async_steps,
-        &replayed.async_steps,
-        prefix_only,
-    ) {
-        return Some(d);
+    // Review round 2 (phase 6, finding 3): only compare schedules
+    // the original could have asserted. An old artifact runs async
+    // pools live — a stated coverage limitation, not a divergence —
+    // and the runtime says the same (the two must not contradict).
+    if original.async_schedule_capable {
+        if let Some(d) = stream_diff(
+            "async schedule step",
+            &original.async_steps,
+            &replayed.async_steps,
+            prefix_only,
+        ) {
+            return Some(d);
+        }
     }
 
     // Payloads, bidirectionally.

--- a/crates/hale-cli/src/replay.rs
+++ b/crates/hale-cli/src/replay.rs
@@ -25,6 +25,10 @@ pub const REC_END: u64 = 0x30444E45454C4148; // "HALEEND0"
 // carries PRIV_RING) — disjoint from iris protocol ekinds.
 const REC_EV_CONSUMER: u32 = 1;
 const REC_EV_CONSUME: u32 = 2;
+// GH #296 phase 6: the async drain's recorded scheduling steps.
+const REC_EV_ASYNC_START: u32 = 5;
+const REC_EV_ASYNC_RESUME: u32 = 6;
+const REC_EV_ASYNC_EXPIRE: u32 = 7;
 const PRIV_RING: u32 = 0x8000_0000;
 
 // Public iris ekinds the comparator aligns across runs.
@@ -86,6 +90,12 @@ pub struct Recording {
     /// deliver), subject-aligned — this is what makes synchronous
     /// direct dispatch visible to `--diff`.
     pub public_streams: Vec<(u64, Vec<PubEvent>)>,
+    /// Per consumer id: the async drain's scheduling-step stream
+    /// (phase 6) — (kind, value) in emission order. Compared
+    /// bidirectionally by `--diff`, exactly like the consume and
+    /// journal streams: "byte-identical output" alone is weaker
+    /// than "the asynchronous schedule matched".
+    pub async_steps: Vec<(u64, Vec<(u32, u64)>)>,
 }
 
 pub fn parse(path: &Path) -> Result<Recording, String> {
@@ -154,6 +164,7 @@ pub fn parse_file(file: &std::fs::File, path: &Path) -> Result<Recording, String
     let mut pub_ring_consumer: BTreeMap<u32, u64> = BTreeMap::new();
     let mut topic_names: BTreeMap<u32, String> = BTreeMap::new();
     let mut consume: Vec<(u64, Vec<(u32, u64)>)> = Vec::new();
+    let mut async_steps: Vec<(u64, Vec<(u32, u64)>)> = Vec::new();
     // Public records buffered raw (ring, w0, w1) and resolved into
     // streams at the end, once the meta maps are complete.
     let mut public_raw: Vec<(u32, u64, u64)> = Vec::new();
@@ -186,6 +197,19 @@ pub fn parse_file(file: &std::fs::File, path: &Path) -> Result<Recording, String
                     }
                     if ekind == REC_EV_CONSUMER {
                         priv_ring_consumer[pr] = w1;
+                    } else if ekind == REC_EV_ASYNC_START
+                        || ekind == REC_EV_ASYNC_RESUME
+                        || ekind == REC_EV_ASYNC_EXPIRE
+                    {
+                        let cid = priv_ring_consumer[pr];
+                        match async_steps
+                            .iter_mut()
+                            .find(|(c, _)| *c == cid)
+                        {
+                            Some((_, v)) => v.push((ekind, w1)),
+                            None => async_steps
+                                .push((cid, vec![(ekind, w1)])),
+                        }
                     } else if ekind == REC_EV_CONSUME {
                         let cid = priv_ring_consumer[pr];
                         let locus = (w0 & 0xFFFFF) as u32;
@@ -367,6 +391,7 @@ pub fn parse_file(file: &std::fs::File, path: &Path) -> Result<Recording, String
         journal,
         consume_streams: consume,
         public_streams: public,
+        async_steps,
     })
 }
 
@@ -452,6 +477,14 @@ pub fn diff(
         "public bus event",
         &original.public_streams,
         &replayed.public_streams,
+        prefix_only,
+    ) {
+        return Some(d);
+    }
+    if let Some(d) = stream_diff(
+        "async schedule step",
+        &original.async_steps,
+        &replayed.async_steps,
         prefix_only,
     ) {
         return Some(d);

--- a/crates/hale-cli/tests/replay_cli.rs
+++ b/crates/hale-cli/tests/replay_cli.rs
@@ -1336,3 +1336,224 @@ fn main() { App { }; }
     }
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+// ---- phase 6 review-round canaries (async schedule × CLI) ----------
+
+#[cfg(target_os = "linux")]
+const ASYNC_PROG: &str = r#"
+type Job { n: Int = 0; }
+type Poke { n: Int = 0; }
+locus Slow {
+    bus { subscribe "cd.job" as on_j of type Job; }
+    fn on_j(j: Job) {
+        std::time::sleep(20ms);
+        println("slow=", j.n);
+    }
+}
+locus Fast {
+    bus { subscribe "cd.poke" as on_p of type Poke; }
+    fn on_p(p: Poke) {
+        std::time::sleep(6ms);
+        println("fast=", p.n);
+    }
+}
+main locus App {
+    params { s: Slow = Slow { }; f: Fast = Fast { }; }
+    placement {
+        s: cooperative(pool = io) where async_io;
+        f: cooperative(pool = io) where async_io;
+    }
+    bus {
+        publish "cd.job" of type Job;
+        publish "cd.poke" of type Poke;
+    }
+    run() {
+        let mut i = 0;
+        while i < 3 {
+            "cd.job" <- Job { n: i };
+            "cd.poke" <- Poke { n: i };
+            i = i + 1;
+        }
+        std::time::sleep(400ms);
+    }
+}
+fn main() { App { }; }
+"#;
+
+/// Walk a recording's frames, calling `f` on each 24-byte tag-0
+/// entry offset; returns (header_len, end_before_trailer).
+#[cfg(target_os = "linux")]
+fn walk_ring_entries(buf: &[u8], mut f: impl FnMut(usize)) -> (usize, usize) {
+    let hlen = u32::from_le_bytes(buf[12..16].try_into().unwrap()) as usize;
+    let mut end = buf.len();
+    if &buf[end - 16..end - 8] == b"HALEEND0" {
+        end -= 16;
+    }
+    let mut off = hlen;
+    while off + 8 <= end {
+        let tag = u32::from_le_bytes(buf[off..off + 4].try_into().unwrap());
+        if tag == 0 {
+            f(off);
+            off += 24;
+        } else {
+            let size = u64::from_le_bytes(
+                buf[off + 24..off + 32].try_into().unwrap(),
+            ) as usize;
+            off += 32 + ((size + 7) & !7);
+        }
+    }
+    (hlen, end)
+}
+
+/// The public `hale replay --diff` path must certify the async
+/// schedule end to end (review round 2, finding 6).
+#[cfg(target_os = "linux")]
+#[test]
+fn async_schedule_matches_under_cli_diff() {
+    let dir = workdir("asyncdiff");
+    let prog = dir.join("as.hl");
+    std::fs::write(&prog, ASYNC_PROG).unwrap();
+    let rec = record(&dir, &prog);
+    let out = hale()
+        .arg("replay")
+        .arg(&rec)
+        .arg(&prog)
+        .arg("--diff")
+        .arg("--allow-live-effects")
+        .output()
+        .expect("replay --diff");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success() && stdout.contains("replay matches"),
+        "stdout:{}\nstderr:{}",
+        stdout,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// ...and a mutated schedule step must fail it: flipping one
+/// recorded RESUME/EXPIRE ordinal makes that step unsatisfiable.
+#[cfg(target_os = "linux")]
+#[test]
+fn mutated_async_step_fails_cli_diff() {
+    let dir = workdir("asyncmut");
+    let prog = dir.join("as.hl");
+    std::fs::write(&prog, ASYNC_PROG).unwrap();
+    let rec = record(&dir, &prog);
+    let mut buf = std::fs::read(&rec).unwrap();
+    let mut flip_at = None;
+    walk_ring_entries(&buf.clone(), |off| {
+        if flip_at.is_some() {
+            return;
+        }
+        let ring =
+            u32::from_le_bytes(buf[off + 4..off + 8].try_into().unwrap());
+        let w0 =
+            u64::from_le_bytes(buf[off + 8..off + 16].try_into().unwrap());
+        let ekind = ((w0 >> 20) & 0x1F) as u32;
+        if ring & 0x8000_0000 != 0 && (ekind == 6 || ekind == 7) {
+            flip_at = Some(off + 16);
+        }
+    });
+    let at = flip_at.expect("no RESUME/EXPIRE step found to mutate");
+    buf[at] ^= 1; // flip the low bit of the step's ordinal (w1)
+    let bad = dir.join("mut.halerec");
+    std::fs::write(&bad, &buf).unwrap();
+    let out = hale()
+        .arg("replay")
+        .arg(&bad)
+        .arg(&prog)
+        .arg("--diff")
+        .arg("--allow-live-effects")
+        .output()
+        .expect("replay mutated");
+    assert!(
+        !out.status.success(),
+        "a mutated schedule step must fail --diff:\nstdout:{}\nstderr:{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A pre-phase-6 artifact (no async-capability bit, no schedule
+/// events) must NOT fail --diff merely because the verify run emits
+/// schedule steps — the runtime calls it a coverage limitation and
+/// the comparator must agree (review round 2, finding 3).
+#[cfg(target_os = "linux")]
+#[test]
+fn pre_phase6_artifact_diff_skips_schedule_comparison() {
+    let dir = workdir("asyncold");
+    let prog = dir.join("as.hl");
+    std::fs::write(&prog, ASYNC_PROG).unwrap();
+    let rec = record(&dir, &prog);
+    let buf = std::fs::read(&rec).unwrap();
+
+    // Rebuild the artifact as a pre-phase-6 runtime would have
+    // written it: drop the ASYNC_* private events, fix the trailer
+    // count, clear capability bit 2.
+    let (hlen, end) = walk_ring_entries(&buf, |_| {});
+    let mut out_bytes: Vec<u8> = buf[..hlen].to_vec();
+    let mut removed = 0u64;
+    let mut off = hlen;
+    while off + 8 <= end {
+        let tag = u32::from_le_bytes(buf[off..off + 4].try_into().unwrap());
+        if tag == 0 {
+            let ring = u32::from_le_bytes(
+                buf[off + 4..off + 8].try_into().unwrap(),
+            );
+            let w0 = u64::from_le_bytes(
+                buf[off + 8..off + 16].try_into().unwrap(),
+            );
+            let ekind = ((w0 >> 20) & 0x1F) as u32;
+            if ring & 0x8000_0000 != 0 && (5..=7).contains(&ekind) {
+                removed += 1;
+            } else {
+                out_bytes.extend_from_slice(&buf[off..off + 24]);
+            }
+            off += 24;
+        } else {
+            let size = u64::from_le_bytes(
+                buf[off + 24..off + 32].try_into().unwrap(),
+            ) as usize;
+            let padded = 32 + ((size + 7) & !7);
+            out_bytes.extend_from_slice(&buf[off..off + padded]);
+            off += padded;
+        }
+    }
+    assert!(removed > 0, "the recording should contain async steps");
+    // clear capability bit 2 in the header flags (offset 88)
+    let flags = u64::from_le_bytes(out_bytes[88..96].try_into().unwrap());
+    out_bytes[88..96].copy_from_slice(&(flags & !4u64).to_le_bytes());
+    // trailer: magic + corrected entry count
+    let old_count =
+        u64::from_le_bytes(buf[buf.len() - 8..].try_into().unwrap());
+    out_bytes.extend_from_slice(b"HALEEND0");
+    out_bytes.extend_from_slice(&(old_count - removed).to_le_bytes());
+
+    let old = dir.join("old.halerec");
+    std::fs::write(&old, &out_bytes).unwrap();
+    let out = hale()
+        .arg("replay")
+        .arg(&old)
+        .arg(&prog)
+        .arg("--diff")
+        .arg("--allow-live-effects")
+        .output()
+        .expect("replay old artifact");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "an old artifact must not fail --diff on schedule steps:\n{}\n{}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stderr.contains("predates async-schedule support"),
+        "both layers must state the coverage limitation:\n{}",
+        stderr
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -6452,6 +6452,7 @@ int lotus_replay_async_step_peek(uint32_t *kind, uint64_t *val)
     __attribute__((weak));
 void lotus_replay_async_step_advance(void) __attribute__((weak));
 void lotus_replay_note_async_divergence(void) __attribute__((weak));
+void lotus_replay_skip_consume(void) __attribute__((weak));
 void lotus_replay_note_async_post_tape(void) __attribute__((weak));
 int lotus_replay_async_capable(void) __attribute__((weak));
 int lotus_replay_is_truncated(void) __attribute__((weak));
@@ -7676,6 +7677,19 @@ typedef struct lotus_coop_pool {
      * async work from here on is a named coverage class, never a
      * silent fallback. */
     int               rp_tape_dry;
+    /* Review round 2 (phase 6, finding 1): the ordinal domain
+     * belongs to the RECORDED START slots, not to "whichever cell
+     * happened to start" — a skipped slot must retire its ordinal
+     * or every later coroutine shifts into earlier recorded
+     * identities and one divergence cascades into wrong resume
+     * pairings. */
+    uint64_t          rp_start_ord;
+    /* Retired START slots (finding 1): a RESUME/EXPIRE naming a
+     * retired ordinal can never be satisfied — skip it immediately
+     * instead of burning a full hold on a known-dead identity.
+     * Bitmap covers the first 256 slots; later ones fall back to
+     * the bounded hold. */
+    uint64_t          rp_retired[4];
 #endif
     /* Pool affinity (2026-08-12): a core set stashed by codegen
      * before start_all spawns the worker; applied right after
@@ -7793,6 +7807,11 @@ lotus_coop_pool_t *lotus_coop_pool_register(const char *name) {
     p->ready_head       = NULL;
     p->coro_birth_seq   = 0;
     p->rp_tape_dry      = 0;
+    p->rp_start_ord     = 0;
+    p->rp_retired[0]    = 0;
+    p->rp_retired[1]    = 0;
+    p->rp_retired[2]    = 0;
+    p->rp_retired[3]    = 0;
 #endif
     /* Truncated copy — the bound is LOTUS_COOP_POOL_MAX-name's-
      * worth and pool names are conventionally short. Anything
@@ -8376,9 +8395,11 @@ static void lotus_async_note_live_action(lotus_coop_pool_t *p) {
     if (!(lotus_replay_note_consume && lotus_replay_active)) return;
     if (!p->rp_tape_dry) return;
     if (lotus_replay_async_capable && !lotus_replay_async_capable()) {
-        static int warned = 0;
-        if (!warned) {
-            warned = 1;
+        /* Concurrent pool workers reach this — the suppression flag
+         * must be atomic (review round 2, finding 4). */
+        static _Atomic int warned = 0;
+        if (!atomic_exchange_explicit(&warned, 1,
+                                      memory_order_relaxed)) {
             fprintf(stderr,
                     "hale replay: recording predates async-schedule "
                     "support — async pools run live (coverage "
@@ -8397,7 +8418,8 @@ static void lotus_async_note_live_action(lotus_coop_pool_t *p) {
  * cells identically. Numbers the start (birth ordinal) and records
  * the START step. */
 static int lotus_async_start_cell(lotus_coop_pool_t *p,
-                                  lotus_bus_cell_t *cell_copy) {
+                                  lotus_bus_cell_t *cell_copy,
+                                  uint64_t ord) {
     /* Wire cell from a cross-thread publisher: deserialize into the
      * subscriber's arena here, on this pool's worker (bug 3,
      * downstream handoff 2026-07-15). Completes before the coro is
@@ -8409,7 +8431,9 @@ static int lotus_async_start_cell(lotus_coop_pool_t *p,
             ? cell_copy->payload_heap
             : (void *)cell_copy->payload_inline;
     }
-    uint64_t ord = p->coro_birth_seq++;
+    /* Keep the live counter monotone past any replay-assigned slot
+     * ordinal so post-tape live starts stay in a disjoint range. */
+    if (p->coro_birth_seq <= ord) p->coro_birth_seq = ord + 1;
     lotus_async_rec_step(LOTUS_REC_ASYNC_START, cell_copy->rec_pub_id);
     /* Heap payload outlives the cell on the dispatch path; we copy
      * the pointer into the coro so the thunk can read it. The free
@@ -8509,18 +8533,26 @@ static int lotus_coop_pool_drain_one_async_replay(lotus_coop_pool_t *p) {
     uint32_t kind;
     uint64_t val;
     if (!lotus_replay_async_step_peek(&kind, &val)) {
+        /* Review round 2, finding 2: the tape is dry the moment the
+         * peek says so — BEFORE the flushes below, or the flushed
+         * actions escape post-tape classification and a finalized
+         * replay can do unrecorded async work with a clean verdict. */
+        p->rp_tape_dry = 1;
         /* Dry tape: flush replay-held state so the live drain
          * (which knows nothing of it) starts clean. One item per
          * call keeps the worker loop's shutdown checks frequent. */
         if (p->ready_head) {
             lotus_coro_t *c = p->ready_head;
             p->ready_head = c->next;
+            lotus_async_note_live_action(p);
             lotus_async_resume_coro(p, c, 0);
             return 1;
         }
         lotus_bus_cell_t held;
         if (lotus_rp_pending_pop_oldest(&held)) {
-            return lotus_async_start_cell(p, &held);
+            lotus_async_note_live_action(p);
+            return lotus_async_start_cell(p, &held,
+                                          p->coro_birth_seq);
         }
         return -1;
     }
@@ -8556,7 +8588,10 @@ static int lotus_coop_pool_drain_one_async_replay(lotus_coop_pool_t *p) {
         if (kind == LOTUS_REC_ASYNC_START) {
             /* Drain what's available through the phase-4 gate until
              * the expected cell dispatches; non-matching cells are
-             * held by the gate. */
+             * held by the gate. The slot's ordinal is assigned only
+             * to the MATCHING cell (finding 1) — a degraded release
+             * of some other held cell under this slot would pair
+             * later RESUME/EXPIRE steps with the wrong coroutine. */
             lotus_bus_cell_t cell;
             for (;;) {
                 int got = lotus_mpsc_ring_try_dequeue(&p->ring, &cell);
@@ -8573,14 +8608,35 @@ static int lotus_coop_pool_drain_one_async_replay(lotus_coop_pool_t *p) {
                 if (!got) break;
                 if (!lotus_replay_gate_cell(&cell)) continue;
                 lotus_replay_async_step_advance();
-                return lotus_async_start_cell(p, &cell);
+                return lotus_async_start_cell(p, &cell,
+                                              p->rp_start_ord++);
             }
-            if (t_rp_pending_len > 0 && lotus_replay_gate_idle(&cell)) {
+            /* The expected cell may already sit in the hold buffer
+             * (pushed while some earlier slot was being served). */
+            uint64_t exp_msg;
+            uint32_t exp_locus;
+            if (lotus_replay_expected_consume &&
+                lotus_replay_expected_consume(&exp_msg, &exp_locus) &&
+                lotus_rp_pending_take(exp_msg, exp_locus, &cell)) {
                 lotus_replay_async_step_advance();
-                return lotus_async_start_cell(p, &cell);
+                return lotus_async_start_cell(p, &cell,
+                                              p->rp_start_ord++);
             }
         } else if (kind == LOTUS_REC_ASYNC_RESUME ||
                    kind == LOTUS_REC_ASYNC_EXPIRE) {
+            /* A step naming a RETIRED slot can never be satisfied —
+             * count and move on without burning the hold. */
+            if (val < 256 &&
+                (p->rp_retired[val >> 6] & (1ull << (val & 63)))) {
+                if (lotus_replay_note_async_divergence)
+                    lotus_replay_note_async_divergence();
+                lotus_replay_async_step_advance();
+                if (!lotus_replay_async_step_peek(&kind, &val)) {
+                    return 1; /* dry next call */
+                }
+                hold_start = lotus_rp_now_ns();
+                continue;
+            }
             lotus_coro_t *c = lotus_async_take_ord(&p->ready_head, val);
             if (!c && kind == LOTUS_REC_ASYNC_EXPIRE) {
                 /* Expiry needs no readiness — the recording proves
@@ -8598,6 +8654,21 @@ static int lotus_coop_pool_drain_one_async_replay(lotus_coop_pool_t *p) {
         if (lotus_rp_now_ns() - hold_start > LOTUS_REPLAY_HOLD_NS) {
             if (lotus_replay_note_async_divergence) {
                 lotus_replay_note_async_divergence();
+            }
+            /* A skipped START still owns its ordinal AND its
+             * consume slot — retire both, so later coroutines keep
+             * their recorded identities and later STARTs still
+             * match their own cells (finding 1: without this, one
+             * missing delivery cascades in ordinal-space AND in
+             * consume-space). */
+            if (kind == LOTUS_REC_ASYNC_START) {
+                uint64_t retired = p->rp_start_ord++;
+                if (retired < 256) {
+                    p->rp_retired[retired >> 6] |=
+                        1ull << (retired & 63);
+                }
+                if (lotus_replay_skip_consume)
+                    lotus_replay_skip_consume();
             }
             lotus_replay_async_step_advance();
             if (!lotus_replay_async_step_peek(&kind, &val)) {
@@ -8861,7 +8932,9 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
          * too) — release per the classic idle discipline. */
         if (replaying && t_rp_pending_len > 0 &&
             lotus_replay_gate_idle(&cell_copy)) {
-            return lotus_async_start_cell(p, &cell_copy);
+            lotus_async_note_live_action(p);
+            return lotus_async_start_cell(p, &cell_copy,
+                                          p->coro_birth_seq);
         }
         /* Spurious — the peek raced a concurrent state change, or the cell
          * was already consumed. Loop. */
@@ -8871,7 +8944,7 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
      * pool and mailbox drains. */
     if (replaying && !lotus_replay_gate_cell(&cell_copy)) return 1;
     lotus_async_note_live_action(p);
-    return lotus_async_start_cell(p, &cell_copy);
+    return lotus_async_start_cell(p, &cell_copy, p->coro_birth_seq);
 }
 #else /* !LOTUS_HAVE_ASYNC_IO — macOS / other BSDs */
 /* Async_io is unsupported on this platform. `where async_io` is rejected

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -6445,6 +6445,13 @@ void lotus_replay_note_injector_start_failure(void)
     __attribute__((weak));
 void lotus_replay_note_binding_suppressed(void)
     __attribute__((weak));
+/* GH #296 phase 6: async_io scheduling-step stream (lotus_obs.c). */
+void lotus_obs_record_async_step(uint32_t ev, uint64_t val)
+    __attribute__((weak));
+int lotus_replay_async_step_peek(uint32_t *kind, uint64_t *val)
+    __attribute__((weak));
+void lotus_replay_async_step_advance(void) __attribute__((weak));
+void lotus_replay_note_async_divergence(void) __attribute__((weak));
 extern int lotus_replay_feed __attribute__((weak));
 /* iris handoff-12 P22: the per-binding backpressure cells
  * (PROTOCOL §6: 3 queue_depth gauge, 4 send_block_ns, 5 retries).
@@ -7556,6 +7563,10 @@ typedef struct lotus_coro {
     /* GH #296: the delivery's recording identity, copied from the
      * cell at coro creation; consumed by the thunk's consume stamp. */
     uint64_t          rec_pub_id;
+    /* GH #296 phase 6: birth ordinal on this pool — the index of
+     * the START step that created it, which is the identity the
+     * recorded RESUME/EXPIRE steps carry across runs. */
+    uint64_t          birth_ord;
     /* Per-coro snapshot of the `lotus_current_caller_arena` TLS
      * (downstream handoff 2026-07-15, item 3). That TLS decides where
      * stdlib primitives (recv result blobs, str builders, …) allocate,
@@ -7651,6 +7662,13 @@ typedef struct lotus_coop_pool {
      * teardown. `free_count` is the current list length. */
     lotus_coro_t     *free_head;
     int               free_count;
+    /* GH #296 phase 6 (replay): coros whose fd went ready while the
+     * replay drain was waiting for an EARLIER recorded step — fd
+     * deregistered, detached from parked_head, resumed when their
+     * step comes up. `coro_birth_seq` numbers cell starts in both
+     * modes so RESUME/EXPIRE records name their coro across runs. */
+    lotus_coro_t     *ready_head;
+    uint64_t          coro_birth_seq;
 #endif
     /* Pool affinity (2026-08-12): a core set stashed by codegen
      * before start_all spawns the worker; applied right after
@@ -7765,6 +7783,8 @@ lotus_coop_pool_t *lotus_coop_pool_register(const char *name) {
     p->parked_head      = NULL;
     p->free_head        = NULL;
     p->free_count       = 0;
+    p->ready_head       = NULL;
+    p->coro_birth_seq   = 0;
 #endif
     /* Truncated copy — the bound is LOTUS_COOP_POOL_MAX-name's-
      * worth and pool names are conventionally short. Anything
@@ -8050,18 +8070,10 @@ lotus_coop_pool_t *lotus_coop_pool_current(void) {
 int lotus_coop_pool_enable_async_io(lotus_coop_pool_t *p) {
     if (!p) return -1;
     if (p->async_io_enabled) return 0;
-    /* GH #296: the async drain multiplexes coros whose park/resume
-     * interleaving is epoll-driven — per-consumer order enforcement
-     * for it is a later milestone. Refuse loudly rather than replay
-     * wrongly. */
-    if (lotus_replay_note_consume && lotus_replay_active) {
-        fprintf(stderr,
-                "hale replay: `where async_io` pools are not "
-                "replayable yet (GH #296 Phase 4 covers classic "
-                "pools, mailboxes, and the main queue)\n");
-        fflush(NULL);
-        _exit(65);
-    }
+    /* GH #296 phase 6: async pools replay — the drain is driven by
+     * the recording's scheduling-step stream (see
+     * lotus_coop_pool_drain_one_async_replay below), so the old
+     * loud refusal is gone. */
     int fd = epoll_create1(EPOLL_CLOEXEC);
     if (fd < 0) {
         return -1;
@@ -8301,6 +8313,294 @@ int64_t lotus_time_sleep_park_try(int64_t ns) {
     return 1;
 }
 
+/* ---- GH #296 phase 6: async_io replay ---------------------------
+ *
+ * The nondeterminism of an async_io pool is its drain's SCHEDULING:
+ * which cell starts when, which parked coro resumes when (epoll
+ * readiness order), and when a timed park expires relative to both.
+ * Under recording, each of those decisions is stamped on the pool
+ * worker's private ring (REC_EV_ASYNC_START/RESUME/EXPIRE, with
+ * coros named by birth ordinal — the index of the START that
+ * created them). Under replay, the drain below is driven by that
+ * recorded step stream instead of by the clock:
+ *
+ *   - START steps reuse the classic phase-4 cell gate (identity =
+ *     target locus + msg_id via the consume stream, hold buffer,
+ *     bounded-hold degrade) — start order IS consume order;
+ *   - RESUME steps wait for the named coro's fd readiness;
+ *     readiness that arrives for a LATER step parks the coro on
+ *     `ready_head` until its turn;
+ *   - EXPIRE steps resume the named coro with the timed-out
+ *     sentinel IMMEDIATELY — the recording already proves the
+ *     deadline fired at this point in the sequence, so replay does
+ *     not re-wait wall-clock time (sleeps fast-forward);
+ *   - a step unsatisfiable within the phase-4 hold bound counts an
+ *     async-schedule divergence and is skipped — replay degrades,
+ *     never refuses and never deadlocks;
+ *   - a dry tape (recording ended, or a pre-phase-6 recording)
+ *     hands the pool back to the live drain, which still gates
+ *     cell starts while the consume stream lasts.
+ *
+ * What this does NOT reproduce: the DATA of unjournaled I/O. A coro
+ * resumed at its recorded turn re-executes its recv against the
+ * live world (syscall-class — gated by --allow-live-effects);
+ * bindings ingress arrives via the phase-5b injector instead of
+ * sockets. The schedule replays; foreign bytes stay foreign. */
+#define LOTUS_REC_ASYNC_START 5u
+#define LOTUS_REC_ASYNC_RESUME 6u
+#define LOTUS_REC_ASYNC_EXPIRE 7u
+
+static inline void lotus_async_rec_step(uint32_t ev, uint64_t val) {
+    if (lotus_obs_record_async_step && lotus_obs_live &&
+        lotus_obs_recording) {
+        lotus_obs_record_async_step(ev, val);
+    }
+}
+
+/* Start one dequeued cell on a fresh coro stack — the tail of the
+ * live drain, shared with the replay drain so both modes start
+ * cells identically. Numbers the start (birth ordinal) and records
+ * the START step. */
+static int lotus_async_start_cell(lotus_coop_pool_t *p,
+                                  lotus_bus_cell_t *cell_copy) {
+    /* Wire cell from a cross-thread publisher: deserialize into the
+     * subscriber's arena here, on this pool's worker (bug 3,
+     * downstream handoff 2026-07-15). Completes before the coro is
+     * created, so the TLS struct buffer can't be aliased by a park. */
+    if (!lotus_bus_cell_materialize(cell_copy)) return 1;
+    void *payload_ptr = NULL;
+    if (cell_copy->payload_size > 0) {
+        payload_ptr = cell_copy->payload_heap
+            ? cell_copy->payload_heap
+            : (void *)cell_copy->payload_inline;
+    }
+    uint64_t ord = p->coro_birth_seq++;
+    lotus_async_rec_step(LOTUS_REC_ASYNC_START, cell_copy->rec_pub_id);
+    /* Heap payload outlives the cell on the dispatch path; we copy
+     * the pointer into the coro so the thunk can read it. The free
+     * happens after the coro returns (parked or not). For Slice 1
+     * we conservatively leak heap payloads on coro-park because
+     * the coro retains the pointer until it resumes-and-completes.
+     * Tighten in Slice 3 when blocking I/O is wired up and the
+     * leak shape becomes observable. */
+    lotus_coro_t *c =
+        lotus_coro_alloc(p, cell_copy->handler, cell_copy->self_ptr,
+                         payload_ptr);
+    if (c) {
+        c->rec_pub_id = cell_copy->rec_pub_id;
+        c->birth_ord = ord;
+    }
+    if (!c) {
+        /* OOM on coro alloc — fall back to direct invocation. The
+         * handler runs on the worker's stack; if it parks via
+         * `park_on_fd`, the call returns -1 (no current coro). */
+        lotus_bus_note_consume(cell_copy->self_ptr,
+                               cell_copy->rec_pub_id);
+        ((lotus_handler_fn)cell_copy->handler)(
+            cell_copy->self_ptr, payload_ptr);
+        if (cell_copy->payload_heap) free(cell_copy->payload_heap);
+        if (cell_copy->payload_region)
+            lotus_arena_destroy(cell_copy->payload_region);
+        return 1;
+    }
+    g_current_coro_tls = c;
+    swapcontext(&p->drain_ctx, &c->ctx);
+    g_current_coro_tls = NULL;
+    lotus_current_caller_arena = NULL;   /* drain baseline */
+    if (c->done) {
+        if (cell_copy->payload_heap) free(cell_copy->payload_heap);
+        if (cell_copy->payload_region)
+            lotus_arena_destroy(cell_copy->payload_region);
+        lotus_coro_release(p, c);
+    }
+    /* If c is not done (it parked), the cell's payload_heap and
+     * payload_region are retained by the coro and freed when it
+     * resumes-and-completes (Slice 3 wiring). */
+    return 1;
+}
+
+static lotus_coro_t *lotus_async_take_ord(lotus_coro_t **head,
+                                          uint64_t ord) {
+    lotus_coro_t **pp = head;
+    while (*pp) {
+        if ((*pp)->birth_ord == ord) {
+            lotus_coro_t *c = *pp;
+            *pp = c->next;
+            c->next = NULL;
+            return c;
+        }
+        pp = &(*pp)->next;
+    }
+    return NULL;
+}
+
+/* Resume one coro under replay control (also used to flush
+ * ready-held coros when the tape runs dry). Deregisters a still-
+ * registered fd, stamps the step for the verify recording, swaps. */
+static void lotus_async_resume_coro(lotus_coop_pool_t *p,
+                                    lotus_coro_t *c, int timed_out) {
+    if (c->parked_fd >= 0) {
+        (void)epoll_ctl(p->epoll_fd, EPOLL_CTL_DEL, c->parked_fd, NULL);
+        c->parked_fd = -1;
+    }
+    c->next = NULL;
+    c->park_timed_out = timed_out;
+    lotus_async_rec_step(timed_out ? LOTUS_REC_ASYNC_EXPIRE
+                                   : LOTUS_REC_ASYNC_RESUME,
+                         c->birth_ord);
+    g_current_coro_tls = c;
+    swapcontext(&p->drain_ctx, &c->ctx);
+    g_current_coro_tls = NULL;
+    lotus_current_caller_arena = NULL;
+    if (c->done) lotus_coro_release(p, c);
+}
+
+/* Oldest held cell, unconditionally — used when the tape is dry
+ * (no expected-consume constraint remains; free consumption). */
+static int lotus_rp_pending_pop_oldest(lotus_bus_cell_t *out) {
+    if (t_rp_pending_len == 0) return 0;
+    *out = t_rp_pending[0];
+    memmove(&t_rp_pending[0], &t_rp_pending[1],
+            (t_rp_pending_len - 1) * sizeof(lotus_bus_cell_t));
+    t_rp_pending_len--;
+    return 1;
+}
+
+/* The replay-driven drain. Returns like the live drain (0 =
+ * shutdown-and-empty, 1 = advanced), plus -1 = the recorded step
+ * tape is dry — caller falls through to the live drain. */
+static int lotus_coop_pool_drain_one_async_replay(lotus_coop_pool_t *p) {
+    struct epoll_event events[16];
+    uint32_t kind;
+    uint64_t val;
+    if (!lotus_replay_async_step_peek(&kind, &val)) {
+        /* Dry tape: flush replay-held state so the live drain
+         * (which knows nothing of it) starts clean. One item per
+         * call keeps the worker loop's shutdown checks frequent. */
+        if (p->ready_head) {
+            lotus_coro_t *c = p->ready_head;
+            p->ready_head = c->next;
+            lotus_async_resume_coro(p, c, 0);
+            return 1;
+        }
+        lotus_bus_cell_t held;
+        if (lotus_rp_pending_pop_oldest(&held)) {
+            return lotus_async_start_cell(p, &held);
+        }
+        return -1;
+    }
+    int64_t hold_start = lotus_rp_now_ns();
+    for (;;) {
+        int cell_pending = lotus_mpsc_ring_peek_nonempty(&p->ring)
+                           || (p->overflow_head != NULL);
+        int shutdown_set = atomic_load_explicit(&p->shutdown,
+                                                memory_order_seq_cst);
+        if (shutdown_set && !cell_pending && t_rp_pending_len == 0) {
+            /* Same abandon discipline as the live drain, extended
+             * to ready-held coros. */
+            lotus_coro_t *c = p->parked_head;
+            while (c) {
+                lotus_coro_t *next = c->next;
+                if (c->parked_fd >= 0) {
+                    (void)epoll_ctl(p->epoll_fd, EPOLL_CTL_DEL,
+                                    c->parked_fd, NULL);
+                }
+                lotus_coro_free(c);
+                c = next;
+            }
+            p->parked_head = NULL;
+            c = p->ready_head;
+            while (c) {
+                lotus_coro_t *next = c->next;
+                lotus_coro_free(c);
+                c = next;
+            }
+            p->ready_head = NULL;
+            return 0;
+        }
+        if (kind == LOTUS_REC_ASYNC_START) {
+            /* Drain what's available through the phase-4 gate until
+             * the expected cell dispatches; non-matching cells are
+             * held by the gate. */
+            lotus_bus_cell_t cell;
+            for (;;) {
+                int got = lotus_mpsc_ring_try_dequeue(&p->ring, &cell);
+                if (got) {
+                    lotus_coop_pool_wake_producers(p);
+                } else if (p->overflow_head) {
+                    lotus_coop_overflow_t *node = p->overflow_head;
+                    p->overflow_head = node->next;
+                    if (!p->overflow_head) p->overflow_tail = NULL;
+                    cell = node->cell;
+                    free(node);
+                    got = 1;
+                }
+                if (!got) break;
+                if (!lotus_replay_gate_cell(&cell)) continue;
+                lotus_replay_async_step_advance();
+                return lotus_async_start_cell(p, &cell);
+            }
+            if (t_rp_pending_len > 0 && lotus_replay_gate_idle(&cell)) {
+                lotus_replay_async_step_advance();
+                return lotus_async_start_cell(p, &cell);
+            }
+        } else if (kind == LOTUS_REC_ASYNC_RESUME ||
+                   kind == LOTUS_REC_ASYNC_EXPIRE) {
+            lotus_coro_t *c = lotus_async_take_ord(&p->ready_head, val);
+            if (!c && kind == LOTUS_REC_ASYNC_EXPIRE) {
+                /* Expiry needs no readiness — the recording proves
+                 * the deadline fired here. Resume immediately. */
+                c = lotus_async_take_ord(&p->parked_head, val);
+            }
+            if (c) {
+                lotus_replay_async_step_advance();
+                lotus_async_resume_coro(
+                    p, c, kind == LOTUS_REC_ASYNC_EXPIRE);
+                return 1;
+            }
+        }
+        /* Step not yet satisfiable. Bounded hold, then degrade. */
+        if (lotus_rp_now_ns() - hold_start > LOTUS_REPLAY_HOLD_NS) {
+            if (lotus_replay_note_async_divergence) {
+                lotus_replay_note_async_divergence();
+            }
+            lotus_replay_async_step_advance();
+            if (!lotus_replay_async_step_peek(&kind, &val)) {
+                return 1; /* dry now; next call flushes + hands over */
+            }
+            hold_start = lotus_rp_now_ns();
+            continue;
+        }
+        /* Wait for the world to move: readiness harvested here may
+         * satisfy this step or a later one (ready_head). The wake
+         * eventfd covers cross-pool enqueues. */
+        int n = epoll_wait(p->epoll_fd, events, 16, 10);
+        if (n < 0) {
+            if (errno != EINTR) return 0;
+            n = 0;
+        }
+        for (int i = 0; i < n; i++) {
+            if (events[i].data.ptr == p) {
+                if (p->wake_fd >= 0) {
+                    uint64_t v;
+                    (void)read(p->wake_fd, &v, sizeof(v));
+                }
+                continue;
+            }
+            lotus_coro_t *rc = (lotus_coro_t *)events[i].data.ptr;
+            if (!rc) continue;
+            (void)epoll_ctl(p->epoll_fd, EPOLL_CTL_DEL, rc->parked_fd,
+                            NULL);
+            lotus_coro_t **pp = &p->parked_head;
+            while (*pp && *pp != rc) pp = &(*pp)->next;
+            if (*pp == rc) *pp = rc->next;
+            rc->parked_fd = -1;
+            rc->next = p->ready_head;
+            p->ready_head = rc;
+        }
+    }
+}
+
 /* F.35 Slice 1: async-aware drain. Runs in the pool worker thread.
  * Each iteration:
  *   1. epoll_wait if there are parked coros (with timeout 0 if the
@@ -8314,6 +8614,14 @@ int64_t lotus_time_sleep_park_try(int64_t ns) {
  * Returns 0 on shutdown-with-empty-queue-and-no-parked; 1 after a
  * cell or wakeup advanced state (caller loops). */
 static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
+    int replaying = lotus_replay_note_consume && lotus_replay_active;
+    /* GH #296 phase 6: a replaying pool is schedule-driven by the
+     * recording until its step tape runs dry (-1), then falls
+     * through to the live drain below. */
+    if (replaying && lotus_replay_async_step_peek) {
+        int r = lotus_coop_pool_drain_one_async_replay(p);
+        if (r >= 0) return r;
+    }
     /* Phase-1b: the cell SOURCE is now the lock-free ring (+ the consumer-
      * local overflow list); the park stays epoll_wait and the wake stays
      * the wake eventfd — NO cond handshake on this path (eventfd is level-
@@ -8392,6 +8700,13 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
                     timeout_ms = (int)ms;
                 }
             }
+            /* GH #296 phase 6: cells held out of recorded order
+             * (post-tape gate) release on a timeout, so never park
+             * unbounded while any are held. */
+            if (replaying && t_rp_pending_len > 0 &&
+                (timeout_ms < 0 || timeout_ms > 100)) {
+                timeout_ms = 100;
+            }
         }
         struct epoll_event events[16];
         int n = epoll_wait(p->epoll_fd, events, 16, timeout_ms);
@@ -8424,6 +8739,9 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
             if (*pp == c) *pp = c->next;
             c->next      = NULL;
             c->parked_fd = -1;
+            /* GH #296 phase 6: the scheduling decision IS the
+             * nondeterminism on this pool — record it. */
+            lotus_async_rec_step(LOTUS_REC_ASYNC_RESUME, c->birth_ord);
             /* Resume the coro. Returns here when it parks again or
              * the handler returns. */
             g_current_coro_tls = c;
@@ -8468,6 +8786,8 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
             expired->next           = NULL;
             expired->parked_fd      = -1;
             expired->park_timed_out = 1;
+            lotus_async_rec_step(LOTUS_REC_ASYNC_EXPIRE,
+                                 expired->birth_ord);
             g_current_coro_tls = expired;
             swapcontext(&p->drain_ctx, &expired->ctx);
             g_current_coro_tls = NULL;
@@ -8498,58 +8818,21 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
         got = 1;
     }
     if (!got) {
+        /* GH #296 phase 6: cells can be HELD out of order here (the
+         * post-tape live fallback and old-recording replays gate
+         * too) — release per the classic idle discipline. */
+        if (replaying && t_rp_pending_len > 0 &&
+            lotus_replay_gate_idle(&cell_copy)) {
+            return lotus_async_start_cell(p, &cell_copy);
+        }
         /* Spurious — the peek raced a concurrent state change, or the cell
          * was already consumed. Loop. */
         return 1;
     }
-    /* Wire cell from a cross-thread publisher: deserialize into the
-     * subscriber's arena here, on this pool's worker (bug 3,
-     * downstream handoff 2026-07-15). Completes before the coro is
-     * created, so the TLS struct buffer can't be aliased by a park. */
-    if (!lotus_bus_cell_materialize(&cell_copy)) return 1;
-    void *payload_ptr = NULL;
-    if (cell_copy.payload_size > 0) {
-        payload_ptr = cell_copy.payload_heap
-            ? cell_copy.payload_heap
-            : (void *)cell_copy.payload_inline;
-    }
-    /* Heap payload outlives the cell on the dispatch path; we copy
-     * the pointer into the coro so the thunk can read it. The free
-     * happens after the coro returns (parked or not). For Slice 1
-     * we conservatively leak heap payloads on coro-park because
-     * the coro retains the pointer until it resumes-and-completes.
-     * Tighten in Slice 3 when blocking I/O is wired up and the
-     * leak shape becomes observable. */
-    lotus_coro_t *c =
-        lotus_coro_alloc(p, cell_copy.handler, cell_copy.self_ptr, payload_ptr);
-    if (c) c->rec_pub_id = cell_copy.rec_pub_id;
-    if (!c) {
-        /* OOM on coro alloc — fall back to direct invocation. The
-         * handler runs on the worker's stack; if it parks via
-         * `park_on_fd`, the call returns -1 (no current coro). */
-        lotus_bus_note_consume(cell_copy.self_ptr,
-                               cell_copy.rec_pub_id);
-        ((lotus_handler_fn)cell_copy.handler)(
-            cell_copy.self_ptr, payload_ptr);
-        if (cell_copy.payload_heap) free(cell_copy.payload_heap);
-        if (cell_copy.payload_region)
-            lotus_arena_destroy(cell_copy.payload_region);
-        return 1;
-    }
-    g_current_coro_tls = c;
-    swapcontext(&p->drain_ctx, &c->ctx);
-    g_current_coro_tls = NULL;
-    lotus_current_caller_arena = NULL;   /* drain baseline — see above */
-    if (c->done) {
-        if (cell_copy.payload_heap) free(cell_copy.payload_heap);
-        if (cell_copy.payload_region)
-            lotus_arena_destroy(cell_copy.payload_region);
-        lotus_coro_release(p, c);
-    }
-    /* If c is not done (it parked), the cell's payload_heap and
-     * payload_region are retained by the coro and freed when it
-     * resumes-and-completes (Slice 3 wiring). */
-    return 1;
+    /* GH #296 phase 6: same per-consumer order gate as the classic
+     * pool and mailbox drains. */
+    if (replaying && !lotus_replay_gate_cell(&cell_copy)) return 1;
+    return lotus_async_start_cell(p, &cell_copy);
 }
 #else /* !LOTUS_HAVE_ASYNC_IO — macOS / other BSDs */
 /* Async_io is unsupported on this platform. `where async_io` is rejected

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -6452,6 +6452,9 @@ int lotus_replay_async_step_peek(uint32_t *kind, uint64_t *val)
     __attribute__((weak));
 void lotus_replay_async_step_advance(void) __attribute__((weak));
 void lotus_replay_note_async_divergence(void) __attribute__((weak));
+void lotus_replay_note_async_post_tape(void) __attribute__((weak));
+int lotus_replay_async_capable(void) __attribute__((weak));
+int lotus_replay_is_truncated(void) __attribute__((weak));
 extern int lotus_replay_feed __attribute__((weak));
 /* iris handoff-12 P22: the per-binding backpressure cells
  * (PROTOCOL §6: 3 queue_depth gauge, 4 send_block_ns, 5 retries).
@@ -7669,6 +7672,10 @@ typedef struct lotus_coop_pool {
      * modes so RESUME/EXPIRE records name their coro across runs. */
     lotus_coro_t     *ready_head;
     uint64_t          coro_birth_seq;
+    /* Review round (phase 6): the tape ran dry on this pool — live
+     * async work from here on is a named coverage class, never a
+     * silent fallback. */
+    int               rp_tape_dry;
 #endif
     /* Pool affinity (2026-08-12): a core set stashed by codegen
      * before start_all spawns the worker; applied right after
@@ -7785,6 +7792,7 @@ lotus_coop_pool_t *lotus_coop_pool_register(const char *name) {
     p->free_count       = 0;
     p->ready_head       = NULL;
     p->coro_birth_seq   = 0;
+    p->rp_tape_dry      = 0;
 #endif
     /* Truncated copy — the bound is LOTUS_COOP_POOL_MAX-name's-
      * worth and pool names are conventionally short. Anything
@@ -8357,6 +8365,33 @@ static inline void lotus_async_rec_step(uint32_t ev, uint64_t val) {
     }
 }
 
+/* Review round (phase 6): live async work after this pool's tape
+ * ran dry. Three states, none silent: a pre-phase-6 artifact gets
+ * a one-shot coverage note (nothing recorded to enforce); a
+ * truncated tape's remainder is the stated coverage boundary
+ * (rp_report says so); a dry tape on a FINALIZED capable artifact
+ * means the re-execution did more async work than the recording —
+ * each such action counts as an async-post-tape divergence. */
+static void lotus_async_note_live_action(lotus_coop_pool_t *p) {
+    if (!(lotus_replay_note_consume && lotus_replay_active)) return;
+    if (!p->rp_tape_dry) return;
+    if (lotus_replay_async_capable && !lotus_replay_async_capable()) {
+        static int warned = 0;
+        if (!warned) {
+            warned = 1;
+            fprintf(stderr,
+                    "hale replay: recording predates async-schedule "
+                    "support — async pools run live (coverage "
+                    "note)\n");
+        }
+        return;
+    }
+    if (lotus_replay_is_truncated && lotus_replay_is_truncated())
+        return;
+    if (lotus_replay_note_async_post_tape)
+        lotus_replay_note_async_post_tape();
+}
+
 /* Start one dequeued cell on a fresh coro stack — the tail of the
  * live drain, shared with the replay drain so both modes start
  * cells identically. Numbers the start (birth ordinal) and records
@@ -8621,6 +8656,7 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
     if (replaying && lotus_replay_async_step_peek) {
         int r = lotus_coop_pool_drain_one_async_replay(p);
         if (r >= 0) return r;
+        p->rp_tape_dry = 1;
     }
     /* Phase-1b: the cell SOURCE is now the lock-free ring (+ the consumer-
      * local overflow list); the park stays epoll_wait and the wake stays
@@ -8739,6 +8775,7 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
             if (*pp == c) *pp = c->next;
             c->next      = NULL;
             c->parked_fd = -1;
+            lotus_async_note_live_action(p);
             /* GH #296 phase 6: the scheduling decision IS the
              * nondeterminism on this pool — record it. */
             lotus_async_rec_step(LOTUS_REC_ASYNC_RESUME, c->birth_ord);
@@ -8786,6 +8823,7 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
             expired->next           = NULL;
             expired->parked_fd      = -1;
             expired->park_timed_out = 1;
+            lotus_async_note_live_action(p);
             lotus_async_rec_step(LOTUS_REC_ASYNC_EXPIRE,
                                  expired->birth_ord);
             g_current_coro_tls = expired;
@@ -8832,6 +8870,7 @@ static int lotus_coop_pool_drain_one_async(lotus_coop_pool_t *p) {
     /* GH #296 phase 6: same per-consumer order gate as the classic
      * pool and mailbox drains. */
     if (replaying && !lotus_replay_gate_cell(&cell_copy)) return 1;
+    lotus_async_note_live_action(p);
     return lotus_async_start_cell(p, &cell_copy);
 }
 #else /* !LOTUS_HAVE_ASYNC_IO — macOS / other BSDs */

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -2716,6 +2716,21 @@ void lotus_replay_async_step_advance(void) {
   rp_consumer_t *c = rp_consumer(t_consumer_id);
   if (c && c->step_cursor < c->step_len) c->step_cursor++;
 }
+/* Review round 2 (phase 6, finding 1): a skipped START slot owns
+ * exactly one recorded consume — advance past it, or the consume
+ * expectation stays pinned on the never-arriving delivery and every
+ * later START mismatches (the cascade in consume-space). The skip
+ * is already reported as an async-schedule divergence; the entry is
+ * deliberately NOT left to double-count as unconsumed. */
+void lotus_replay_skip_consume(void) {
+  rp_consumer_t *c = rp_consumer(t_consumer_id);
+  if (c && atomic_load_explicit(&c->consume_cursor,
+                                memory_order_relaxed) <
+               c->consume_len) {
+    atomic_fetch_add_explicit(&c->consume_cursor, 1,
+                              memory_order_release);
+  }
+}
 
 void lotus_obs_record_consume(void *subscriber_self, uint64_t pub_id) {
   if (!lotus_obs_recording) return;

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -575,6 +575,7 @@ static char g_replay_path[512];
 static const uint8_t *g_rp_base; /* mmap'd recording */
 static int g_rp_truncated = 0; /* accepted without a finalize trailer */
 static uint64_t g_rp_hdr_model = 0;
+static uint64_t g_rp_hdr_flags = 0;
 static uint64_t g_rp_dropped_tail = 0;
 /* phase 5 (truncated prefix): recorded-history-exhausted events on
  * an accepted truncated tape are the unknown post-crash suffix,
@@ -679,8 +680,10 @@ static _Atomic uint64_t g_rp_bindings_suppressed = 0;
  * collide in a verify recording. */
 static uint64_t g_rp_anon_floor = 0;
 /* phase 6: async-schedule steps that could not be satisfied from
- * the tape (skipped via the bounded-hold degrade). */
+ * the tape (skipped via the bounded-hold degrade), and live async
+ * work performed after a non-truncated tape ran dry. */
 static _Atomic uint64_t g_rp_async_divergences = 0;
+static _Atomic uint64_t g_rp_async_post_tape = 0;
 
 /* Creation happens ONLY during rp_load (single-threaded, pre-main);
  * at runtime every caller is lookup-only — the table is immutable
@@ -780,6 +783,7 @@ static void rp_load(void) {
     rp_fail("unexpected header length");
   }
   g_rp_hdr_model = h->model_hash;
+  g_rp_hdr_flags = h->flags;
   size_t end = g_rp_len;
   uint64_t trailer_count = 0;
   if (end >= sizeof(obs_rec_hdr_t) + 16 &&
@@ -1414,6 +1418,11 @@ static void rp_report(void) {
       uint64_t jd = 0;
       for (int i = 0; i < RP_MAX_JK; i++)
         jd += atomic_load(&g_rp_divergences[i]);
+      uint64_t sf_steps = 0;
+      for (int ci = 0; ci < g_rp_consumer_count; ci++) {
+        sf_steps += g_rp_consumers[ci].step_len -
+                    g_rp_consumers[ci].step_cursor;
+      }
       fprintf(sf,
               "journal_divergences=%llu\norder_divergences=%llu\n"
               "unconsumed_journal=%llu\nunconsumed_deliveries=%llu\n"
@@ -1422,6 +1431,7 @@ static void rp_report(void) {
               "late_subscription_uncovered=%llu\n"
               "ingress_incompatible=%llu\ningress_unprocessed=%llu\n"
               "injector_start_failure=%llu\nasync_schedule=%llu\n"
+              "unconsumed_async_steps=%llu\nasync_post_tape=%llu\n"
               "post_prefix_live_fallback=%llu\nconsumes=%llu\n",
               (unsigned long long)jd, (unsigned long long)order_div,
               (unsigned long long)unconsumed_journal,
@@ -1435,6 +1445,11 @@ static void rp_report(void) {
               (unsigned long long)atomic_load(
                   &g_rp_injector_start_failure),
               (unsigned long long)atomic_load(&g_rp_async_divergences),
+              (unsigned long long)(g_rp_truncated ? 0 : sf_steps),
+              (unsigned long long)(g_rp_truncated
+                                       ? 0
+                                       : atomic_load(
+                                             &g_rp_async_post_tape)),
               (unsigned long long)atomic_load(&g_rp_post_prefix),
               (unsigned long long)atomic_load(&g_rp_consume_count));
       fclose(sf);
@@ -1451,8 +1466,19 @@ static void rp_report(void) {
                      atomic_load(&g_rp_ing_unprocessed) +
                      atomic_load(&g_rp_injector_start_failure);
   uint64_t async_div = atomic_load(&g_rp_async_divergences);
+  uint64_t async_post = atomic_load(&g_rp_async_post_tape);
+  uint64_t unconsumed_steps = 0;
+  for (int ci = 0; ci < g_rp_consumer_count; ci++) {
+    rp_consumer_t *cc = &g_rp_consumers[ci];
+    unconsumed_steps += cc->step_len - cc->step_cursor;
+  }
+  /* Truncated tape: remaining steps and post-tape work are the
+   * expected coverage boundary, not divergences. */
+  uint64_t async_div_total =
+      g_rp_truncated ? 0 : async_post + unconsumed_steps;
   uint64_t total = order_div + unconsumed_journal
-      + unconsumed_deliveries + unexpected + ing_div + async_div;
+      + unconsumed_deliveries + unexpected + ing_div + async_div
+      + async_div_total;
   for (int i = 0; i < RP_MAX_JK; i++)
     total += atomic_load(&g_rp_divergences[i]);
   if (g_rp_truncated) {
@@ -1503,6 +1529,12 @@ static void rp_report(void) {
   if (async_div)
     fprintf(stderr, "  %-22s %llu\n", "async-schedule",
             (unsigned long long)async_div);
+  if (!g_rp_truncated && unconsumed_steps)
+    fprintf(stderr, "  %-22s %llu\n", "unconsumed-async-steps",
+            (unsigned long long)unconsumed_steps);
+  if (!g_rp_truncated && async_post)
+    fprintf(stderr, "  %-22s %llu\n", "async-post-tape",
+            (unsigned long long)async_post);
   if (unconsumed_journal)
     fprintf(stderr, "  %-22s %llu\n", "unconsumed-journal",
             (unsigned long long)unconsumed_journal);
@@ -1558,7 +1590,11 @@ void lotus_obs_teardown(void) {
                             g_obs_exec_digest[0], g_obs_exec_digest[1],
                             g_obs_exec_digest[2], g_obs_exec_digest[3],
                             (g_rec_env_full ? 0u : 1u) |
-                                (g_rec_durable ? 2u : 0u) };
+                                (g_rec_durable ? 2u : 0u) |
+                                /* bit 2: async-schedule capable —
+                                 * this runtime records the drain's
+                                 * scheduling steps (phase 6). */
+                                4u };
       if (fseek(g_rec_file, 48, SEEK_SET) != 0 ||
           fwrite(ident, sizeof ident, 1, g_rec_file) != 1 ||
           fseek(g_rec_file, 0, SEEK_END) != 0) {
@@ -1834,7 +1870,8 @@ static int obs_create(int64_t rings, int64_t slots) {
       .model_hash = g_obs_model_hash,
       .exec_digest = { g_obs_exec_digest[0], g_obs_exec_digest[1],
                        g_obs_exec_digest[2], g_obs_exec_digest[3] },
-      .flags = g_rec_env_full ? 0 : 1 };
+      .flags = (g_rec_env_full ? 0u : 1u) | (g_rec_durable ? 2u : 0u)
+               | 4u };
     if (fwrite(&rh, sizeof rh, 1, g_rec_file) != 1) {
       fprintf(stderr, "hale: LOTUS_OBS_RECORD header write failed\n");
       fflush(NULL);
@@ -1993,7 +2030,8 @@ void lotus_obs_eager_init(void) {
     g_obs_ident_committed_vals[3] = g_obs_exec_digest[2];
     g_obs_ident_committed_vals[4] = g_obs_exec_digest[3];
     g_obs_ident_committed_vals[5] =
-        (g_rec_env_full ? 0u : 1u) | (g_rec_durable ? 2u : 0u);
+        (g_rec_env_full ? 0u : 1u) | (g_rec_durable ? 2u : 0u) |
+        /* bit 2: async-schedule capable (phase 6). */ 4u;
     atomic_store_explicit(&g_obs_ident_committed, 1,
                           memory_order_release);
   }
@@ -2649,6 +2687,19 @@ void lotus_replay_note_async_divergence(void) {
   atomic_fetch_add_explicit(&g_rp_async_divergences, 1,
                             memory_order_relaxed);
 }
+/* Review round (phase 6): the dry-tape coverage classes must not
+ * collapse into "run live silently". */
+void lotus_replay_note_async_post_tape(void) {
+  atomic_fetch_add_explicit(&g_rp_async_post_tape, 1,
+                            memory_order_relaxed);
+}
+/* Did the RECORDING runtime know how to record async schedules?
+ * (header flag bit 2). Absent = a pre-phase-6 artifact: async
+ * pools run live as a stated coverage note, not a divergence. */
+int lotus_replay_async_capable(void) {
+  return (g_rp_hdr_flags & 4u) != 0;
+}
+int lotus_replay_is_truncated(void) { return g_rp_truncated; }
 
 /* The calling pool-worker's next recorded scheduling step. 0 =
  * stream exhausted (or none recorded) — the drain falls back to

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -110,6 +110,15 @@
 #define REC_EV_CONSUME 2
 #define REC_EV_ENQ 3
 #define REC_EV_JOURNAL 4
+/* GH #296 phase 6 (async_io replay): the async drain's scheduling
+ * decisions, recorded per pool-worker as a step stream so replay
+ * can drive the same interleaving. START marks a cell start (w1 =
+ * pub_id; its position also assigns the coro's birth ordinal);
+ * RESUME marks an epoll-readiness resume and EXPIRE a timed-park
+ * expiry resume (w1 = the resumed coro's birth ordinal). */
+#define REC_EV_ASYNC_START 5
+#define REC_EV_ASYNC_RESUME 6
+#define REC_EV_ASYNC_EXPIRE 7
 #define OBS_REC_PRIV_RING 0x80000000u
 
 /* manifest kinds */
@@ -606,6 +615,12 @@ typedef struct {
    * ingress pacing check (review round: injection must be bounded
    * by recorded progress, which lives in these cursors). */
   _Atomic uint32_t consume_cursor;
+  /* phase 6: the async drain's recorded scheduling steps (kind =
+   * REC_EV_ASYNC_*, val = pub_id for START / birth ordinal for
+   * RESUME|EXPIRE), in emission order. Empty for non-async
+   * consumers and for pre-phase-6 recordings. */
+  struct { uint32_t kind; uint64_t val; } *steps;
+  uint32_t step_len, step_cap, step_cursor;
 } rp_consumer_t;
 static rp_consumer_t g_rp_consumers[RP_MAX_CONSUMERS];
 static int g_rp_consumer_count = 0;
@@ -663,6 +678,9 @@ static _Atomic uint64_t g_rp_bindings_suppressed = 0;
  * process start above the recorded range so the two can never
  * collide in a verify recording. */
 static uint64_t g_rp_anon_floor = 0;
+/* phase 6: async-schedule steps that could not be satisfied from
+ * the tape (skipped via the bounded-hold degrade). */
+static _Atomic uint64_t g_rp_async_divergences = 0;
 
 /* Creation happens ONLY during rp_load (single-threaded, pre-main);
  * at runtime every caller is lookup-only — the table is immutable
@@ -804,6 +822,22 @@ static void rp_load(void) {
         if (pr >= 64) rp_fail("private ring index out of range");
         if (ekind == REC_EV_CONSUMER) {
           rp_ring_consumer[pr] = w1;
+        } else if (ekind == REC_EV_ASYNC_START ||
+                   ekind == REC_EV_ASYNC_RESUME ||
+                   ekind == REC_EV_ASYNC_EXPIRE) {
+          rp_consumer_t *c = rp_consumer_create(rp_ring_consumer[pr]);
+          if (c) {
+            if (c->step_len == c->step_cap) {
+              c->step_cap = c->step_cap ? c->step_cap * 2 : 64;
+              void *g = realloc(c->steps,
+                                c->step_cap * sizeof(*c->steps));
+              if (!g) rp_fail("out of memory");
+              c->steps = g;
+            }
+            c->steps[c->step_len].kind = ekind;
+            c->steps[c->step_len].val = w1;
+            c->step_len++;
+          }
         } else if (ekind == REC_EV_CONSUME) {
           rp_consumer_t *c =
               rp_consumer_create(rp_ring_consumer[pr]);
@@ -1387,7 +1421,7 @@ static void rp_report(void) {
               "ingress_rejected=%llu\ningress_unmatched=%llu\n"
               "late_subscription_uncovered=%llu\n"
               "ingress_incompatible=%llu\ningress_unprocessed=%llu\n"
-              "injector_start_failure=%llu\n"
+              "injector_start_failure=%llu\nasync_schedule=%llu\n"
               "post_prefix_live_fallback=%llu\nconsumes=%llu\n",
               (unsigned long long)jd, (unsigned long long)order_div,
               (unsigned long long)unconsumed_journal,
@@ -1400,6 +1434,7 @@ static void rp_report(void) {
               (unsigned long long)atomic_load(&g_rp_ing_unprocessed),
               (unsigned long long)atomic_load(
                   &g_rp_injector_start_failure),
+              (unsigned long long)atomic_load(&g_rp_async_divergences),
               (unsigned long long)atomic_load(&g_rp_post_prefix),
               (unsigned long long)atomic_load(&g_rp_consume_count));
       fclose(sf);
@@ -1415,8 +1450,9 @@ static void rp_report(void) {
                      atomic_load(&g_rp_ing_incompatible) +
                      atomic_load(&g_rp_ing_unprocessed) +
                      atomic_load(&g_rp_injector_start_failure);
+  uint64_t async_div = atomic_load(&g_rp_async_divergences);
   uint64_t total = order_div + unconsumed_journal
-      + unconsumed_deliveries + unexpected + ing_div;
+      + unconsumed_deliveries + unexpected + ing_div + async_div;
   for (int i = 0; i < RP_MAX_JK; i++)
     total += atomic_load(&g_rp_divergences[i]);
   if (g_rp_truncated) {
@@ -1464,6 +1500,9 @@ static void rp_report(void) {
   if (ing_div)
     fprintf(stderr, "  %-22s %llu\n", "ingress",
             (unsigned long long)ing_div);
+  if (async_div)
+    fprintf(stderr, "  %-22s %llu\n", "async-schedule",
+            (unsigned long long)async_div);
   if (unconsumed_journal)
     fprintf(stderr, "  %-22s %llu\n", "unconsumed-journal",
             (unsigned long long)unconsumed_journal);
@@ -2596,6 +2635,37 @@ void lotus_obs_bus_deliver(const char *subject, void *subscriber_self,
  * sites gate on lotus_obs_recording, and the fn re-checks so a
  * mis-gated caller cannot leak protocol-addendum records into a
  * plain observer's stream. */
+/* GH #296 phase 6: one async-drain scheduling step, on the pool
+ * worker's private ring (ev = REC_EV_ASYNC_*). Recording only —
+ * which includes the verify recording a --diff replay runs. */
+void lotus_obs_record_async_step(uint32_t ev, uint64_t val) {
+  if (!lotus_obs_recording) return;
+  if (!obs_on()) return;
+  if (t_consumer_id == 0) obs_rec_claim();
+  obs_rec_emit2(ev, 0, val);
+}
+
+void lotus_replay_note_async_divergence(void) {
+  atomic_fetch_add_explicit(&g_rp_async_divergences, 1,
+                            memory_order_relaxed);
+}
+
+/* The calling pool-worker's next recorded scheduling step. 0 =
+ * stream exhausted (or none recorded) — the drain falls back to
+ * live scheduling, per degrade-never-refuse. */
+int lotus_replay_async_step_peek(uint32_t *kind, uint64_t *val) {
+  if (!lotus_replay_active) return 0;
+  rp_consumer_t *c = rp_consumer(t_consumer_id);
+  if (!c || c->step_cursor >= c->step_len) return 0;
+  *kind = c->steps[c->step_cursor].kind;
+  *val = c->steps[c->step_cursor].val;
+  return 1;
+}
+void lotus_replay_async_step_advance(void) {
+  rp_consumer_t *c = rp_consumer(t_consumer_id);
+  if (c && c->step_cursor < c->step_len) c->step_cursor++;
+}
+
 void lotus_obs_record_consume(void *subscriber_self, uint64_t pub_id) {
   if (!lotus_obs_recording) return;
   if (!obs_on()) return;

--- a/crates/hale-codegen/tests/replay_asyncio.rs
+++ b/crates/hale-codegen/tests/replay_asyncio.rs
@@ -19,6 +19,11 @@
 //!      depend on timing; replay must reproduce the recorded
 //!      interleaving from the tape, not re-derive it from timers.
 
+// async_io is Linux-only (epoll/eventfd); the type checker rejects
+// `where async_io` on other platforms, so these integration tests
+// must not compile-and-run there (review round 2, finding 5).
+#![cfg(target_os = "linux")]
+
 use std::process::Command;
 use std::time::Instant;
 
@@ -446,6 +451,138 @@ fn readiness_resumes_follow_the_tape_not_arrival_order() {
     assert!(err.contains("0 divergences"), "stderr:\n{}", err);
 
     let _ = std::fs::remove_file(&ready);
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&bin);
+}
+
+/// Finding 1's cascade canary: a START whose cell never arrives in
+/// replay must RETIRE its birth ordinal, not hand it to the next
+/// coroutine — otherwise every later RESUME/EXPIRE pairs with the
+/// wrong coroutine and one divergence cascades. A's publisher is
+/// gated on a LIVE filesystem read (unjournaled, so replay sees the
+/// replay-time world): the flag file exists at record, and is
+/// deleted before replay — A never publishes, B must keep its own
+/// recorded identity.
+#[test]
+fn skipped_start_retires_its_ordinal_without_cascade() {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let flag = format!(
+        "{}/hale-296-cascade-{}-{}.flag",
+        std::env::temp_dir().display(),
+        std::process::id(),
+        nanos
+    );
+    let src = format!(
+        r#"
+        type TA {{ n: Int = 0; }}
+        type TB {{ n: Int = 0; }}
+        locus Gate {{
+            bus {{ publish "oc.a" of type TA; }}
+            run() {{
+                let mut waited = 0;
+                while waited < 40 {{
+                    if std::io::fs::file_exists("{flag}") {{
+                        "oc.a" <- TA {{ n: 7 }};
+                        return;
+                    }}
+                    std::time::sleep(20ms);
+                    waited = waited + 1;
+                }}
+            }}
+        }}
+        locus SubA {{
+            bus {{ subscribe "oc.a" as on_a of type TA; }}
+            fn on_a(t: TA) {{
+                std::time::sleep(30ms);
+                println("a=", t.n);
+            }}
+        }}
+        locus SubB {{
+            bus {{ subscribe "oc.b" as on_b of type TB; }}
+            fn on_b(t: TB) {{
+                std::time::sleep(10ms);
+                println("b=", t.n);
+            }}
+        }}
+        main locus App {{
+            params {{
+                sa: SubA = SubA {{ }};
+                sb: SubB = SubB {{ }};
+                g:  Gate = Gate {{ }};
+            }}
+            placement {{
+                sa: cooperative(pool = io) where async_io;
+                sb: cooperative(pool = io) where async_io;
+                g:  pinned(core = 0);
+            }}
+            bus {{ publish "oc.b" of type TB; }}
+            run() {{
+                std::time::sleep(300ms);
+                "oc.b" <- TB {{ n: 42 }};
+                std::time::sleep(1500ms);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#
+    );
+    let bin = build("cascade", &src);
+    let rec = rec_path("cascade");
+
+    // Record WITH the flag present: A publishes, both handlers run.
+    std::fs::write(&flag, "on").unwrap();
+    let recorded = Command::new(&bin)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .output()
+        .expect("recorded run");
+    assert!(
+        recorded.status.success(),
+        "recorded run failed: {}",
+        String::from_utf8_lossy(&recorded.stderr)
+    );
+    let recorded_stdout =
+        String::from_utf8_lossy(&recorded.stdout).into_owned();
+    assert!(
+        recorded_stdout.contains("a=7")
+            && recorded_stdout.contains("b=42"),
+        "recorded run incomplete:\n{}",
+        recorded_stdout
+    );
+
+    // Replay WITHOUT the flag: A's publish never happens. Its START
+    // slot must time out, count, and RETIRE ordinal 0 — B keeps
+    // ordinal 1 and its EXPIRE resumes the right coroutine.
+    let _ = std::fs::remove_file(&flag);
+    let replayed = Command::new(&bin)
+        .env("LOTUS_REPLAY", &rec)
+        .output()
+        .expect("replay without the flag");
+    let out = String::from_utf8_lossy(&replayed.stdout);
+    let err = String::from_utf8_lossy(&replayed.stderr);
+    assert!(
+        replayed.status.success(),
+        "degraded replay must complete; stderr:\n{}",
+        err
+    );
+    assert!(
+        out.contains("b=42"),
+        "B must still run correctly under its own identity:\n{}\n{}",
+        out,
+        err
+    );
+    assert!(
+        !out.contains("a="),
+        "A never arrived — nothing may impersonate it:\n{}",
+        out
+    );
+    assert!(
+        err.contains("divergences from the recorded history"),
+        "the skipped slot must be reported, never silent:\n{}",
+        err
+    );
+
     let _ = std::fs::remove_file(&rec);
     let _ = std::fs::remove_file(&bin);
 }

--- a/crates/hale-codegen/tests/replay_asyncio.rs
+++ b/crates/hale-codegen/tests/replay_asyncio.rs
@@ -127,12 +127,10 @@ fn async_pool_schedule_records_and_replays_exactly() {
         recorded_stdout
     );
 
-    let t0 = Instant::now();
     let replayed = Command::new(&bin)
         .env("LOTUS_REPLAY", &rec)
         .output()
         .expect("replayed run");
-    let replay_wall = t0.elapsed();
     let err = String::from_utf8_lossy(&replayed.stderr);
     assert!(
         replayed.status.success(),
@@ -158,17 +156,6 @@ fn async_pool_schedule_records_and_replays_exactly() {
         "expected a divergence-free async replay; stderr:\n{}",
         err
     );
-    // 3. Expiries were tape-driven, not re-timed: the recorded run
-    //    holds a 700ms settle sleep on main plus the staggered
-    //    handler sleeps; a replay that re-waited them cannot finish
-    //    this fast. (Generous bound — the point is "did not
-    //    re-sleep", not a benchmark.)
-    assert!(
-        replay_wall.as_millis() < 3000,
-        "replay took {}ms — schedule should be tape-driven",
-        replay_wall.as_millis()
-    );
-
     let _ = std::fs::remove_file(&rec);
     let _ = std::fs::remove_file(&bin);
 }
@@ -199,6 +186,266 @@ fn two_replays_of_one_async_recording_are_identical() {
         "two replays of one recording must agree with each other"
     );
 
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&bin);
+}
+
+/// The REAL fast-forward proof (review round: the old three-second
+/// bound was satisfiable by a fully live re-execution). The recorded
+/// run holds a 2.5s coro park; the recorded wall time proves it. A
+/// replay that re-waited that park cannot finish under the bound
+/// asserted here — only a tape-driven EXPIRE can.
+#[test]
+fn expiry_fast_forwards_from_the_tape() {
+    const LONG_PARK: &str = r#"
+        type Job { n: Int = 0; }
+        locus Slow {
+            params { seen: Int = 0; }
+            bus { subscribe "ff.job" as on_j of type Job; }
+            fn on_j(j: Job) {
+                std::time::sleep(2500ms);
+                self.seen = self.seen + 1;
+                println("done=", j.n);
+            }
+        }
+        main locus App {
+            params { s: Slow = Slow { }; }
+            placement { s: cooperative(pool = io) where async_io; }
+            bus { publish "ff.job" of type Job; }
+            run() {
+                "ff.job" <- Job { n: 7 };
+                let mut waited = 0;
+                while self.s.seen < 1 {
+                    std::time::sleep(50ms);
+                    waited = waited + 1;
+                    if waited > 200 { std::process::exit(3); }
+                }
+            }
+        }
+        fn main() { App { }; }
+    "#;
+    let bin = build("ffwd", LONG_PARK);
+    let rec = rec_path("ffwd");
+
+    let t0 = Instant::now();
+    let recorded = Command::new(&bin)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .output()
+        .expect("recorded run");
+    let record_wall = t0.elapsed();
+    assert!(
+        recorded.status.success(),
+        "recorded run failed: {}",
+        String::from_utf8_lossy(&recorded.stderr)
+    );
+    // The park is real: the recorded run cannot beat its own sleep.
+    assert!(
+        record_wall.as_millis() >= 2400,
+        "recorded run finished in {}ms — the park never happened",
+        record_wall.as_millis()
+    );
+
+    let t1 = Instant::now();
+    let replayed = Command::new(&bin)
+        .env("LOTUS_REPLAY", &rec)
+        .output()
+        .expect("replayed run");
+    let replay_wall = t1.elapsed();
+    let err = String::from_utf8_lossy(&replayed.stderr);
+    assert!(replayed.status.success(), "stderr:\n{}", err);
+    assert_eq!(
+        String::from_utf8_lossy(&replayed.stdout),
+        String::from_utf8_lossy(&recorded.stdout)
+    );
+    assert!(err.contains("0 divergences"), "stderr:\n{}", err);
+    // Strictly below the recorded park: only a tape-driven EXPIRE
+    // gets here. (Margin for loaded machines; the recorded lower
+    // bound above is what makes this a proof rather than a vibe.)
+    assert!(
+        replay_wall.as_millis() < 1500,
+        "replay took {}ms against a {}ms recorded park — the \
+         schedule was re-timed, not tape-driven",
+        replay_wall.as_millis(),
+        record_wall.as_millis()
+    );
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&bin);
+}
+
+/// The RESUME path, adversarially: two coros parked on real fds, a
+/// third on a timer — READINESS ARRIVES IN THE OPPOSITE ORDER of
+/// the recorded resumes, and replay must hold the early-ready coro
+/// on ready_head until its recorded turn. Mixed decision stream:
+/// STARTs (three cells), RESUMEs (two fd parks), EXPIRE (the timer).
+#[test]
+fn readiness_resumes_follow_the_tape_not_arrival_order() {
+    use std::io::Write;
+    use std::net::{TcpListener, TcpStream};
+
+    let (port_a, port_b) = {
+        let a = TcpListener::bind("127.0.0.1:0").unwrap();
+        let b = TcpListener::bind("127.0.0.1:0").unwrap();
+        let (pa, pb) = (
+            a.local_addr().unwrap().port(),
+            b.local_addr().unwrap().port(),
+        );
+        drop(a);
+        drop(b);
+        (pa, pb)
+    };
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let ready = format!(
+        "{}/hale-296-resume-{}-{}.ready",
+        std::env::temp_dir().display(),
+        std::process::id(),
+        nanos
+    );
+    let src = format!(
+        r#"
+        type Kick {{ n: Int = 0; }}
+        fn handle_a(s: std::io::tcp::Stream) {{
+            let b = std::bytes::BytesBuilder {{ }};
+            let got = std::io::tcp::recv_into(s.conn_fd, b, 64);
+            println("ra=", got);
+        }}
+        fn handle_b(s: std::io::tcp::Stream) {{
+            let b = std::bytes::BytesBuilder {{ }};
+            let got = std::io::tcp::recv_into(s.conn_fd, b, 64);
+            println("rb=", got);
+        }}
+        locus Timer {{
+            bus {{ subscribe "rs.kick" as on_k of type Kick; }}
+            fn on_k(k: Kick) {{
+                std::time::sleep(300ms);
+                println("timer=", k.n);
+            }}
+        }}
+        main locus App {{
+            params {{
+                t: Timer = Timer {{ }};
+                la: std::io::tcp::Listener = std::io::tcp::Listener {{
+                    host:          "127.0.0.1",
+                    port:          {port_a},
+                    max_accepts:   1,
+                    on_connection: handle_a,
+                }};
+                lb: std::io::tcp::Listener = std::io::tcp::Listener {{
+                    host:          "127.0.0.1",
+                    port:          {port_b},
+                    max_accepts:   1,
+                    on_connection: handle_b,
+                }};
+            }}
+            placement {{
+                t:  cooperative(pool = io) where async_io;
+                la: cooperative(pool = io) where async_io;
+                lb: cooperative(pool = io) where async_io;
+            }}
+            bus {{ publish "rs.kick" of type Kick; }}
+            run() {{
+                std::io::fs::write_file("{ready}", "ready") or discard;
+                "rs.kick" <- Kick {{ n: 1 }};
+                std::time::sleep(1800ms);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#
+    );
+    let bin = build("resume", &src);
+    let rec = rec_path("resume");
+
+    let wait_ready = |ready: &str| {
+        let deadline = std::time::Instant::now()
+            + std::time::Duration::from_secs(20);
+        while !std::path::Path::new(ready).exists() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "program never reached run()"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    };
+    // drive(sends_a_first): connect A then B (accept order fixed),
+    // then deliver DATA in the given order.
+    let drive = |a_first: bool| {
+        wait_ready(&ready);
+        let mut ca =
+            TcpStream::connect(("127.0.0.1", port_a)).expect("a");
+        let mut cb =
+            TcpStream::connect(("127.0.0.1", port_b)).expect("b");
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        let (first, second): (&mut TcpStream, &mut TcpStream) =
+            if a_first {
+                (&mut ca, &mut cb)
+            } else {
+                (&mut cb, &mut ca)
+            };
+        first.write_all(b"hello").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(250));
+        second.write_all(b"hello").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        (ca, cb) // keep the peers open past the reads
+    };
+
+    // Record: A's data first — recorded resume order is A, B.
+    let _ = std::fs::remove_file(&ready);
+    let mut child = Command::new(&bin)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn recorded");
+    let _peers = drive(true);
+    let recorded = child.wait_with_output().expect("recorded exit");
+    assert!(
+        recorded.status.success(),
+        "recorded run failed: {}",
+        String::from_utf8_lossy(&recorded.stderr)
+    );
+    let recorded_stdout =
+        String::from_utf8_lossy(&recorded.stdout).into_owned();
+    assert!(
+        recorded_stdout.contains("ra=5")
+            && recorded_stdout.contains("rb=5")
+            && recorded_stdout.contains("timer=1"),
+        "recorded run incomplete:\n{}",
+        recorded_stdout
+    );
+    let a_pos = recorded_stdout.find("ra=").unwrap();
+    let b_pos = recorded_stdout.find("rb=").unwrap();
+    assert!(
+        a_pos < b_pos,
+        "premise: the recording resumed A before B\n{}",
+        recorded_stdout
+    );
+
+    // Replay: B's data arrives FIRST. B's readiness is early — the
+    // drain must hold it on ready_head and resume A at its recorded
+    // turn. stdout must be byte-identical to the recording.
+    let _ = std::fs::remove_file(&ready);
+    let mut child = Command::new(&bin)
+        .env("LOTUS_REPLAY", &rec)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn replay");
+    let _peers = drive(false);
+    let replayed = child.wait_with_output().expect("replay exit");
+    let err = String::from_utf8_lossy(&replayed.stderr);
+    assert!(replayed.status.success(), "stderr:\n{}", err);
+    assert_eq!(
+        String::from_utf8_lossy(&replayed.stdout),
+        recorded_stdout,
+        "reversed readiness must not reorder the replay;\nstderr:\n{}",
+        err
+    );
+    assert!(err.contains("0 divergences"), "stderr:\n{}", err);
+
+    let _ = std::fs::remove_file(&ready);
     let _ = std::fs::remove_file(&rec);
     let _ = std::fs::remove_file(&bin);
 }

--- a/crates/hale-codegen/tests/replay_asyncio.rs
+++ b/crates/hale-codegen/tests/replay_asyncio.rs
@@ -1,0 +1,204 @@
+//! GH #296 phase 6 — `where async_io` pools record and REPLAY.
+//!
+//! The nondeterminism of an async pool is its drain's scheduling:
+//! cell starts, epoll-readiness resumes, timed-park expiries. Under
+//! recording each decision lands on the worker's private ring as a
+//! step (START/RESUME/EXPIRE); under replay the drain is driven by
+//! that stream instead of the clock. What these tests hold that to:
+//!
+//!   1. **The recording carries the schedule.** An async pool with
+//!      two loci whose handlers park on different sleep durations
+//!      records a step stream (the loud pre-phase-6 refusal is gone).
+//!   2. **Replay reproduces it, divergence-free.** The same binary
+//!      replayed produces byte-identical stdout and reports ZERO
+//!      divergences — expiry steps resume in recorded order without
+//!      re-waiting wall-clock time, so the replay also finishes
+//!      FASTER than the recorded run's sleeps would allow.
+//!   3. **Interleaved expiries are order-enforced, not re-timed.**
+//!      Deliberately staggered sleeps make the recorded interleaving
+//!      depend on timing; replay must reproduce the recorded
+//!      interleaving from the tape, not re-derive it from timers.
+
+use std::process::Command;
+use std::time::Instant;
+
+use hale_codegen::{build_executable_with_options, BuildOptions};
+
+#[path = "support/harness.rs"]
+mod harness;
+
+fn build(name: &str, src: &str) -> std::path::PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut programs = std::collections::BTreeMap::new();
+    programs.insert(name.to_string(), &program);
+    let bundle = hale_types::Bundle::new(programs);
+    let model_hash = hale_types::topology::model_shape_hash(&bundle);
+    let bin = harness::unique_bin(&format!("hale_test_rpasync_{}", name));
+    let options = BuildOptions {
+        model_hash: Some(model_hash),
+        ..BuildOptions::default()
+    };
+    build_executable_with_options(&program, &bin, &[], &options)
+        .expect("build");
+    bin
+}
+
+fn rec_path(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "hale_rpasync_{}_{}.halerec",
+        std::process::id(),
+        name
+    ));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+/// Two subscribers on ONE async_io pool, parking on deliberately
+/// staggered sleeps: the printed interleaving of `slow=`/`fast=`
+/// lines is decided by expiry scheduling, not program order.
+const STAGGERED: &str = r#"
+    type Job { n: Int = 0; }
+    type Poke { n: Int = 0; }
+
+    locus Slow {
+        bus { subscribe "as.job" as on_j of type Job; }
+        fn on_j(j: Job) {
+            std::time::sleep(35ms);
+            println("slow=", j.n);
+        }
+    }
+
+    locus Fast {
+        bus { subscribe "as.poke" as on_p of type Poke; }
+        fn on_p(p: Poke) {
+            std::time::sleep(6ms);
+            println("fast=", p.n);
+        }
+    }
+
+    main locus App {
+        params { s: Slow = Slow { }; f: Fast = Fast { }; }
+        placement {
+            s: cooperative(pool = io) where async_io;
+            f: cooperative(pool = io) where async_io;
+        }
+        bus {
+            publish "as.job" of type Job;
+            publish "as.poke" of type Poke;
+        }
+        run() {
+            let mut i = 0;
+            while i < 6 {
+                "as.job" <- Job { n: i };
+                "as.poke" <- Poke { n: i };
+                i = i + 1;
+            }
+            std::time::sleep(700ms);
+            println("done");
+        }
+    }
+
+    fn main() { App { }; }
+"#;
+
+#[test]
+fn async_pool_schedule_records_and_replays_exactly() {
+    let bin = build("staggered", STAGGERED);
+    let rec = rec_path("staggered");
+
+    let recorded = Command::new(&bin)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .output()
+        .expect("recorded run");
+    assert!(
+        recorded.status.success(),
+        "recorded run failed: {}",
+        String::from_utf8_lossy(&recorded.stderr)
+    );
+    let recorded_stdout =
+        String::from_utf8_lossy(&recorded.stdout).into_owned();
+    // Sanity: both handler families actually ran on the async pool.
+    assert!(
+        recorded_stdout.contains("slow=5")
+            && recorded_stdout.contains("fast=5")
+            && recorded_stdout.contains("done"),
+        "recorded run incomplete:\n{}",
+        recorded_stdout
+    );
+
+    let t0 = Instant::now();
+    let replayed = Command::new(&bin)
+        .env("LOTUS_REPLAY", &rec)
+        .output()
+        .expect("replayed run");
+    let replay_wall = t0.elapsed();
+    let err = String::from_utf8_lossy(&replayed.stderr);
+    assert!(
+        replayed.status.success(),
+        "replay failed; stderr:\n{}",
+        err
+    );
+    // 1. The pre-phase-6 refusal is gone.
+    assert!(
+        !err.contains("not replayable"),
+        "async_io pools must no longer refuse replay; stderr:\n{}",
+        err
+    );
+    // 2. Byte-identical schedule-dependent output.
+    assert_eq!(
+        String::from_utf8_lossy(&replayed.stdout),
+        recorded_stdout,
+        "replayed interleaving differs from the recording's"
+    );
+    // ...with zero divergences: every step was satisfied from the
+    // tape, never from the degrade path.
+    assert!(
+        err.contains("0 divergences"),
+        "expected a divergence-free async replay; stderr:\n{}",
+        err
+    );
+    // 3. Expiries were tape-driven, not re-timed: the recorded run
+    //    holds a 700ms settle sleep on main plus the staggered
+    //    handler sleeps; a replay that re-waited them cannot finish
+    //    this fast. (Generous bound — the point is "did not
+    //    re-sleep", not a benchmark.)
+    assert!(
+        replay_wall.as_millis() < 3000,
+        "replay took {}ms — schedule should be tape-driven",
+        replay_wall.as_millis()
+    );
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&bin);
+}
+
+#[test]
+fn two_replays_of_one_async_recording_are_identical() {
+    let bin = build("twice", STAGGERED);
+    let rec = rec_path("twice");
+
+    let recorded = Command::new(&bin)
+        .env("LOTUS_OBS_RECORD", &rec)
+        .output()
+        .expect("recorded run");
+    assert!(recorded.status.success());
+
+    let a = Command::new(&bin)
+        .env("LOTUS_REPLAY", &rec)
+        .output()
+        .expect("replay a");
+    let b = Command::new(&bin)
+        .env("LOTUS_REPLAY", &rec)
+        .output()
+        .expect("replay b");
+    assert!(a.status.success() && b.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&a.stdout),
+        String::from_utf8_lossy(&b.stdout),
+        "two replays of one recording must agree with each other"
+    );
+
+    let _ = std::fs::remove_file(&rec);
+    let _ = std::fs::remove_file(&bin);
+}

--- a/docs/src/systems/replay.md
+++ b/docs/src/systems/replay.md
@@ -192,8 +192,12 @@ silence.
   them), and adapter loci re-execute their own protocol logic.
   Fleet-scale replay — multiple binaries against one composed
   tape — is the next milestone.
-- **`where async_io` pools refuse replay** loudly; their coroutine
-  interleaving is a later milestone.
+- **`where async_io` pools replay their recorded schedule.** The
+  drain's decisions — cell starts, readiness resumes, timed-park
+  expiries — are recorded as a per-worker step stream and drive the
+  replayed drain instead of the clock (recorded sleeps
+  fast-forward). What replays is the *schedule*: the data of
+  unjournaled I/O still re-executes live (and is gated).
 - **The artifact format is pre-stable** while the remaining phases
   (fleet replay, replay-under-a-different-plan, durability grades)
   land.

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1754,7 +1754,14 @@ with the timed-out sentinel immediately — the recording already
 proves the deadline fired at this point in the sequence, so
 replayed sleeps fast-forward rather than re-waiting. A step
 unsatisfiable within the hold bound counts an `async-schedule`
-divergence and is skipped (degrade, never deadlock).
+divergence and is skipped (degrade, never deadlock) — and a
+skipped START **retires** both its birth ordinal and its consume
+slot (review round 2: ordinals belong to the recorded START slots,
+not to whichever cell happened to start next — without retirement
+one missing delivery shifts every later coroutine into an earlier
+recorded identity, and the pinned consume expectation makes every
+later START mismatch; with it, later steps that name a retired
+slot skip immediately and the divergence stays local).
 
 **Coverage, named (review round).** A dry tape hands the pool back
 to the live drain — never silently. The artifact carries a

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1754,10 +1754,23 @@ with the timed-out sentinel immediately — the recording already
 proves the deadline fired at this point in the sequence, so
 replayed sleeps fast-forward rather than re-waiting. A step
 unsatisfiable within the hold bound counts an `async-schedule`
-divergence and is skipped (degrade, never deadlock); a dry tape —
-the recording ended, or predates phase 6 — hands the pool back to
-the live drain, which still gates cell starts while the consume
-stream lasts. Boundary, stated: the SCHEDULE replays; the DATA of
+divergence and is skipped (degrade, never deadlock).
+
+**Coverage, named (review round).** A dry tape hands the pool back
+to the live drain — never silently. The artifact carries a
+capability bit (header flag 4: this runtime records async
+schedules); the states are distinct and reviewable: a pre-phase-6
+artifact gets a one-shot coverage note ("recording predates
+async-schedule support"); a truncated tape's remaining schedule is
+the stated coverage boundary (excluded from the divergence
+totals); a FINALIZED capable artifact whose tape runs dry while
+the re-execution keeps doing async work counts each such action as
+`async_post_tape`, and schedule steps left unconsumed at exit
+count as `unconsumed_async_steps` — both machine-readable status
+keys and divergence rows. `--diff` compares the per-consumer async
+step streams (kind, value) bidirectionally, exactly like the
+consume and journal streams — "byte-identical output" alone is
+weaker than "the schedule matched". Boundary, stated: the SCHEDULE replays; the DATA of
 unjournaled I/O does not — a coro resumed at its recorded turn
 re-executes its recv against the live world (syscall-class, gated),
 and bindings ingress arrives via the Phase-5 injector.

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1736,8 +1736,31 @@ in the RECORDED order (Phase 4): dequeued cells that arrive ahead
 of their recorded turn are held per-consumer and released in
 order, with a bounded hold (1s) after which the oldest held cell
 is released and the miss counted, so a genuinely divergent replay
-reports rather than deadlocks. `where async_io` pools refuse
-replay loudly (their coro interleaving is a later milestone).
+reports rather than deadlocks.
+
+**Async pools replay (Phase 6).** The nondeterminism of a `where
+async_io` pool is its drain's SCHEDULING: which cell starts when,
+which parked coro resumes when (epoll readiness order), and when a
+timed park expires relative to both. Under recording, every such
+decision is stamped on the pool worker's private ring as a step
+(`ASYNC_START`/`ASYNC_RESUME`/`ASYNC_EXPIRE`; coros are named by
+birth ordinal — the index of the START that created them, stable
+across runs because start order is enforced). Under replay the
+drain is DRIVEN by that stream instead of the clock: START steps
+reuse the phase-4 cell gate (start order is consume order); RESUME
+steps wait for the named coro's readiness, parking early-ready
+coros aside until their turn; EXPIRE steps resume the named coro
+with the timed-out sentinel immediately — the recording already
+proves the deadline fired at this point in the sequence, so
+replayed sleeps fast-forward rather than re-waiting. A step
+unsatisfiable within the hold bound counts an `async-schedule`
+divergence and is skipped (degrade, never deadlock); a dry tape —
+the recording ended, or predates phase 6 — hands the pool back to
+the live drain, which still gates cell starts while the consume
+stream lasts. Boundary, stated: the SCHEDULE replays; the DATA of
+unjournaled I/O does not — a coro resumed at its recorded turn
+re-executes its recv against the live world (syscall-class, gated),
+and bindings ingress arrives via the Phase-5 injector.
 
 **Hermetic wire + ingress injection (Phase 5).** Hermeticity is
 a **binding-kind capability, not a blanket assumption**: the


### PR DESCRIPTION
Successor to #467 (auto-closed when its stacked base branch merged as #466 and was deleted; this branch is the identical content rebased onto main). Both review rounds are addressed — the point-by-point responses live on #467, and the body there describes exactly this head.

Summary: async pools record their drain's scheduling decisions (START/RESUME/EXPIRE per pool worker, coroutines named by recorded START-slot ordinal) and replay drives the drain from that stream. Skipped slots retire their ordinal AND consume slot (no cascade), dry-tape states are named (`async_post_tape`, `unconsumed_async_steps`, capability bit for pre-phase-6 artifacts), `--diff` compares the schedule streams bidirectionally, and the proof surface is adversarial: a 2.5s recorded park replaying far below its own recorded wall time, readiness delivered in the opposite order of the recorded resumes, and a suppressed-START cascade canary. Linux-gated tests; three CLI `--diff` integration canaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)