### PR TITLE
docs: retire "Say less. Spell more." from the introduction epigraph

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -3,7 +3,7 @@
 **A concurrent systems language with a GC-free runtime — typed
 message-bus concurrency, data-race-free by design.**
 
-*Say less. Spell more.*
+*Write the system, not the lore.*
 
 Most languages pick a level and live there. Python and
 JavaScript sit high — fast to write, far from the metal. Go


### PR DESCRIPTION
One line: the epigraph is being saved to become a future article's title, and the book now opens on the same sentence as the reskinned homepage — *Write the system, not the lore.*

(hale-lang.org syncs `docs/src` at deploy time, so this propagates to the site's `/docs` landing on its next deploy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)