### PR TITLE
feat(cli): hale topology graph — deterministic visuals from the artifact (#476 Track A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ behavior.
 
 ## Unreleased
 
+### `hale topology graph` - deterministic visuals from the artifact (GH #476 Track A)
+
+A committed `--dump-topology` artifact can now be rendered:
+`hale topology graph <artifact> [--view system|code|bus|claim|residue]
+[--format svg|mermaid|dot] [--claim NAME] [--config file.json] [-o out]`.
+An ARTIFACT CLIENT by construction - it reads exactly the JSON a third
+party reads, never Hale source, and has no dependency on the future
+canonical-model crate (its input adapter swaps later without changing
+output). Deterministic by design: fixed character-cell text metrics
+(no font measurement - byte-stable across machines), stable IDs from
+artifact names, no timestamps; rendering twice is byte-identical and
+moving source lines does not move a pixel (spans change, the model
+shape does not - pinned by test). The claim view highlights the named
+claim's groups and states its verdict on a card; the residue view
+renders unresolved holes as first-class nodes, and every other view
+notes them on a card rather than omitting them. Experimental surface
+pre-1.0. Pinned by `topology_graph_cli.rs` (7 tests incl. checked-in
+mermaid/SVG goldens for a pinned fixture); docs claims chapter gains
+the rendering section.
+
 ### Listen-binding ingest no longer loses messages at the edges (GH #468)
 
 Three defects, one delivery contract. The issue's two observed

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -32,6 +32,7 @@ mod mcp;
 mod pkg;
 mod replay;
 mod sign;
+mod topology_graph;
 
 fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
@@ -152,6 +153,15 @@ fn main() -> ExitCode {
         return run_fleet(&rest);
     }
 
+    // GH #476 Track A: `hale topology graph <artifact>` — deterministic
+    // visuals from a committed topology artifact. Like `fleet`, an
+    // artifact CLIENT: reads exactly what a third party reads, never
+    // Hale source. Experimental surface pre-1.0.
+    if cmd == "topology" {
+        let rest: Vec<String> = args.iter().skip(2).cloned().collect();
+        return topology_graph::run_topology(&rest);
+    }
+
     // `bench` is discovery-driven like `test`: *_bench.hl files,
     // bench_* fns, self-calibrating harness.
     if cmd == "bench" {
@@ -211,6 +221,7 @@ fn usage() {
     eprintln!("        [--dump-effects-manifest] [--json] [--workspace]");
     eprintln!("        (`hale check --help` for all)");
     eprintln!("    hale verify <file.hl | dir>   check + FAIL on any advisory (discipline gate)");
+    eprintln!("    hale topology graph <artifact> render a --dump-topology artifact (svg|mermaid|dot; experimental)");
     eprintln!("    hale run   <file.hl | dir>    compile + run as a native binary");
     eprintln!("    hale build <file.hl | dir>    parse + typecheck + emit native binary");
     eprintln!("    hale replay <rec> <file.hl>   re-run a LOTUS_OBS_RECORD recording");

--- a/crates/hale-cli/src/topology_graph.rs
+++ b/crates/hale-cli/src/topology_graph.rs
@@ -295,6 +295,130 @@ impl Artifact {
             art.v["shape_hash"].is_string(),
             "shape_hash must be a string",
         )?;
+        // Row-level validation: every row this adapter reads must
+        // carry its required fields with the required types. A
+        // malformed row is an ERROR naming its location — never a
+        // silently dropped edge rendering as a false absence. (The
+        // digest is an unkeyed tripwire, not an authenticator; row
+        // shape is checked on its own.)
+        let str_fields = |section: &str, fields: &[&str]| -> Result<(), String> {
+            let rows = art.v[section.split('.').next().unwrap()].clone();
+            let rows = if let Some(rel) = section.strip_prefix("relations.") {
+                art.v["relations"][rel].clone()
+            } else {
+                rows
+            };
+            for (i, row) in
+                rows.as_array().into_iter().flatten().enumerate()
+            {
+                for f in fields {
+                    if !row[*f].is_string() {
+                        return Err(format!(
+                            "{}: malformed artifact — {}[{}].{} must \
+                             be a string",
+                            path.display(),
+                            section,
+                            i,
+                            f
+                        ));
+                    }
+                }
+            }
+            Ok(())
+        };
+        str_fields("relations.calls", &["from", "to"])?;
+        str_fields("relations.calls_via_stdlib", &["from", "to"])?;
+        str_fields("relations.publishes", &["fn", "subject"])?;
+        str_fields(
+            "relations.subscribes",
+            &["subject", "locus", "handler"],
+        )?;
+        str_fields(
+            "topics",
+            &["name", "subject", "shape", "payload_hash"],
+        )?;
+        str_fields("claims", &["name", "form", "result"])?;
+        for (i, row) in art.v["unknowns"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .enumerate()
+        {
+            let reasons_ok = row["reasons"]
+                .as_array()
+                .map(|a| a.iter().all(|x| x.is_string()))
+                .unwrap_or(false);
+            if !row["fn"].is_string() || !reasons_ok {
+                return Err(format!(
+                    "{}: malformed artifact — unknowns[{}] needs a \
+                     string `fn` and string `reasons`",
+                    path.display(),
+                    i
+                ));
+            }
+        }
+        for sort in ["loci", "fns"] {
+            for (i, x) in art.v["sorts"][sort]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .enumerate()
+            {
+                if !x.is_string() {
+                    return Err(format!(
+                        "{}: malformed artifact — sorts.{}[{}] must be \
+                         a string",
+                        path.display(),
+                        sort,
+                        i
+                    ));
+                }
+            }
+        }
+        for (name, members) in
+            art.v["groups"].as_object().into_iter().flatten()
+        {
+            let ok = members
+                .as_array()
+                .map(|a| a.iter().all(|x| x.is_string()))
+                .unwrap_or(false);
+            if !ok {
+                return Err(format!(
+                    "{}: malformed artifact — groups.{} must be an \
+                     array of strings",
+                    path.display(),
+                    name
+                ));
+            }
+        }
+        for (name, row) in
+            art.v["phases"].as_object().into_iter().flatten()
+        {
+            if !row["phase"].is_string() || !row["kind"].is_string() {
+                return Err(format!(
+                    "{}: malformed artifact — phases.{} needs string \
+                     `phase` and `kind`",
+                    path.display(),
+                    name
+                ));
+            }
+        }
+        for (name, effects) in
+            art.v["effects"].as_object().into_iter().flatten()
+        {
+            let ok = effects
+                .as_array()
+                .map(|a| a.iter().all(|x| x.is_string()))
+                .unwrap_or(false);
+            if !ok {
+                return Err(format!(
+                    "{}: malformed artifact — effects.{} must be an \
+                     array of strings",
+                    path.display(),
+                    name
+                ));
+            }
+        }
         Ok(art)
     }
 

--- a/crates/hale-cli/src/topology_graph.rs
+++ b/crates/hale-cli/src/topology_graph.rs
@@ -112,26 +112,17 @@ pub fn run_topology(rest: &[String]) -> ExitCode {
             return ExitCode::from(1);
         }
     };
-    let v: Value = match serde_json::from_str(&raw) {
-        Ok(v) => v,
+    // Admission, in the fleet loader's order: integrity BEFORE
+    // meaning, meaning before rendering. The renderer does NOT
+    // require a clean verdict (violations are worth drawing), but it
+    // refuses artifacts it cannot trust or cannot correctly read.
+    let art = match Artifact::admit(&path, &raw) {
+        Ok(a) => a,
         Err(e) => {
-            eprintln!("{} is not a JSON topology artifact: {}", path.display(), e);
+            eprintln!("{}", e);
             return ExitCode::from(1);
         }
     };
-    let art = Artifact { v };
-    // Version adapter: this renderer understands the 1.x artifact
-    // family. A future major schema gets a new adapter, not silent
-    // misreading.
-    let schema = art.schema();
-    if !schema.starts_with("1.") && schema != "1" {
-        eprintln!(
-            "unsupported topology artifact schema `{}` (this renderer \
-             understands 1.x)",
-            schema
-        );
-        return ExitCode::from(1);
-    }
 
     let config = match config_path {
         None => RenderConfig::default(),
@@ -203,6 +194,110 @@ struct Artifact {
 }
 
 impl Artifact {
+    /// Admission: (1) whole-body `artifact_digest` verifies — a
+    /// hand-edited claims/topics section is refused, not rendered
+    /// under a stale identity; (2) `semantics` matches this build —
+    /// rows that share a shape but mean different things are not
+    /// renderable; (3) the schema minor is one this adapter's field
+    /// set actually covers (`topics` landed in 1.2, `verdict` in
+    /// 1.4 — older 1.x artifacts would silently render as having
+    /// neither); higher minors are accepted per the artifact's
+    /// additive-minor contract; (4) the sections this adapter reads
+    /// are present with the right JSON types — absence is an error,
+    /// never an empty graph.
+    fn admit(
+        path: &std::path::Path,
+        raw: &str,
+    ) -> Result<Artifact, String> {
+        match hale_types::topology::verify_artifact_digest(raw) {
+            Some(true) => {}
+            Some(false) => {
+                return Err(format!(
+                    "{}: artifact_digest does not match its contents — \
+                     refusing to render an edited or corrupted artifact",
+                    path.display()
+                ))
+            }
+            None => {
+                return Err(format!(
+                    "{}: no artifact_digest (predates schema 1.3) — an \
+                     unverifiable artifact is not renderable; re-dump \
+                     with a current compiler",
+                    path.display()
+                ))
+            }
+        }
+        let v: Value = serde_json::from_str(raw)
+            .map_err(|e| format!("{}: not a JSON artifact: {}", path.display(), e))?;
+        let sem = v["semantics"].as_u64();
+        if sem != Some(hale_types::topology::MODEL_SEMANTICS as u64) {
+            return Err(format!(
+                "{}: model semantics {} — this build speaks {}; the rows \
+                 may share a shape and mean different things",
+                path.display(),
+                sem.map(|s| s.to_string()).unwrap_or_else(|| "absent".into()),
+                hale_types::topology::MODEL_SEMANTICS
+            ));
+        }
+        let art = Artifact { v };
+        let schema = art.schema();
+        let minor: Option<u32> = schema
+            .strip_prefix("1.")
+            .and_then(|m| m.parse().ok());
+        match minor {
+            Some(m) if m >= 4 => {}
+            _ => {
+                return Err(format!(
+                    "{}: unsupported topology artifact schema `{}` — this \
+                     renderer's adapter covers 1.4+ (topics landed in \
+                     1.2, verdict in 1.4; an older artifact would render \
+                     misleadingly incomplete)",
+                    path.display(),
+                    schema
+                ))
+            }
+        }
+        // Structural presence: every section this adapter reads.
+        let need = |ok: bool, what: &str| -> Result<(), String> {
+            if ok {
+                Ok(())
+            } else {
+                Err(format!(
+                    "{}: malformed artifact — {} (digest verified, so \
+                     this is a schema drift, not corruption)",
+                    path.display(),
+                    what
+                ))
+            }
+        };
+        need(
+            art.v["sorts"]["loci"].is_array(),
+            "sorts.loci must be an array",
+        )?;
+        need(
+            art.v["sorts"]["fns"].is_array(),
+            "sorts.fns must be an array",
+        )?;
+        for rel in ["calls", "calls_via_stdlib", "publishes", "subscribes"] {
+            need(
+                art.v["relations"][rel].is_array(),
+                &format!("relations.{} must be an array", rel),
+            )?;
+        }
+        need(art.v["topics"].is_array(), "topics must be an array")?;
+        need(art.v["claims"].is_array(), "claims must be an array")?;
+        need(art.v["unknowns"].is_array(), "unknowns must be an array")?;
+        need(art.v["groups"].is_object(), "groups must be an object")?;
+        need(art.v["phases"].is_object(), "phases must be an object")?;
+        need(art.v["effects"].is_object(), "effects must be an object")?;
+        need(art.v["verdict"].is_string(), "verdict must be a string")?;
+        need(
+            art.v["shape_hash"].is_string(),
+            "shape_hash must be a string",
+        )?;
+        Ok(art)
+    }
+
     fn schema(&self) -> String {
         match &self.v["schema"] {
             Value::String(s) => s.clone(),
@@ -474,12 +569,22 @@ struct RenderGraph {
     cards: Vec<Card>,
 }
 
-fn locus_of(fn_full: &str) -> Option<&str> {
-    fn_full.split_once("::").map(|(l, _)| l)
-}
-
-fn short_fn(fn_full: &str) -> &str {
-    fn_full.split_once("::").map(|(_, f)| f).unwrap_or(fn_full)
+/// The owning locus of a function by LONGEST declared-locus
+/// prefix. Author spellings may contain seed aliases
+/// (`p::Store::get` is method `get` on imported locus `p::Store`),
+/// so membership is never inferred from the first `::` — only a
+/// declared locus name followed by `::` claims a function. No
+/// declared prefix ⇒ free function, even when the spelling is
+/// qualified (`p::helper`).
+fn owner_of<'a>(loci: &'a [String], fn_full: &str) -> Option<&'a str> {
+    loci.iter()
+        .filter(|l| {
+            fn_full.len() > l.len() + 2
+                && fn_full.starts_with(l.as_str())
+                && fn_full[l.len()..].starts_with("::")
+        })
+        .max_by_key(|l| l.len())
+        .map(|l| l.as_str())
 }
 
 const FREE_FNS: &str = "(free functions)";
@@ -491,7 +596,9 @@ fn build_graph(
 ) -> Result<RenderGraph, String> {
     let loci = art.loci();
     let fns = art.fns();
-    let topics = art.topics();
+    let declared_topics = art.topics();
+    let publishes = art.publishes();
+    let subscribes = art.subscribes();
     let with_chips = view != "bus";
 
     // Which fns appear as lines. bus view: only endpoint fns.
@@ -499,23 +606,23 @@ fn build_graph(
         if view != "bus" {
             return true;
         }
-        art.publishes().iter().any(|(pf, _)| pf == f)
-            || art
-                .subscribes()
+        publishes.iter().any(|(pf, _)| pf == f)
+            || subscribes
                 .iter()
                 .any(|(_, l, h)| format!("{}::{}", l, h) == *f)
     };
 
-    // Locus boxes with fn lines (sorted fn order inside each box).
+    // Locus boxes with fn lines, membership by longest declared
+    // prefix; everything unclaimed is free.
     let mut boxes: Vec<LocusBox> = Vec::new();
     for locus in &loci {
         let lines: Vec<FnLine> = fns
             .iter()
-            .filter(|f| locus_of(f) == Some(locus.as_str()))
+            .filter(|f| owner_of(&loci, f) == Some(locus.as_str()))
             .filter(|f| keep_fn(f))
             .map(|f| FnLine {
                 full: f.clone(),
-                label: fn_label(art, f, with_chips),
+                label: fn_label(art, f, &f[locus.len() + 2..], with_chips),
                 highlight: false,
             })
             .collect();
@@ -527,11 +634,11 @@ fn build_graph(
     }
     let free: Vec<FnLine> = fns
         .iter()
-        .filter(|f| locus_of(f).is_none())
+        .filter(|f| owner_of(&loci, f).is_none())
         .filter(|f| keep_fn(f))
         .map(|f| FnLine {
             full: f.clone(),
-            label: fn_label(art, f, with_chips),
+            label: fn_label(art, f, f, with_chips),
             highlight: false,
         })
         .collect();
@@ -542,40 +649,66 @@ fn build_graph(
             highlight: false,
         });
     }
-    // A box with no lines still renders (a locus with no visible fns).
-    boxes.retain(|b| !b.lines.is_empty() || b.name != FREE_FNS);
 
-    // Topic nodes (not in the code view).
+    // Bus nodes: the UNION of subjects referenced by publish and
+    // subscribe rows, plus declared topics. Literal and wildcard
+    // subjects have no declared-topic row but are real endpoints —
+    // they get a visible node, enriched with wire/payload identity
+    // only when a declaration exists.
     let topic_nodes: Vec<TopicNode> = if view == "code" {
         Vec::new()
     } else {
-        topics
-            .iter()
-            .map(|t| TopicNode {
-                name: t.name.clone(),
-                sub: format!(
-                    "{} · payload {}",
-                    t.subject,
-                    t.payload_hash.chars().take(8).collect::<String>()
-                ),
-                highlight: false,
+        let mut names: std::collections::BTreeSet<String> =
+            std::collections::BTreeSet::new();
+        for (_, t) in &publishes {
+            names.insert(t.clone());
+        }
+        for (t, _, _) in &subscribes {
+            names.insert(t.clone());
+        }
+        for t in &declared_topics {
+            names.insert(t.name.clone());
+        }
+        names
+            .into_iter()
+            .map(|name| {
+                let sub = match declared_topics
+                    .iter()
+                    .find(|t| t.name == name)
+                {
+                    Some(t) => format!(
+                        "{} · payload {}",
+                        t.subject,
+                        t.payload_hash.chars().take(8).collect::<String>()
+                    ),
+                    None if name.contains('*') => {
+                        "(pattern subject)".to_string()
+                    }
+                    None => "(literal subject)".to_string(),
+                };
+                TopicNode {
+                    name,
+                    sub,
+                    highlight: false,
+                }
             })
             .collect()
     };
+    let mut topic_nodes = topic_nodes;
 
     // Edges.
     let mut edges: Vec<Edge> = Vec::new();
     if view != "code" {
-        for (f, topic) in art.publishes() {
+        for (f, topic) in &publishes {
             edges.push(Edge {
-                from: f,
+                from: f.clone(),
                 to: format!("topic:{}", topic),
                 kind: EdgeKind::Publish,
                 label: "publish".to_string(),
                 highlight: false,
             });
         }
-        for (topic, locus, handler) in art.subscribes() {
+        for (topic, locus, handler) in &subscribes {
             edges.push(Edge {
                 from: format!("topic:{}", topic),
                 to: format!("{}::{}", locus, handler),
@@ -606,8 +739,9 @@ fn build_graph(
         }
     }
 
-    // Unknown residue nodes (residue view renders them; other views
-    // note them in a card so they are never silently absent).
+    // Unknown residue nodes (residue view renders them; every other
+    // view — claim included — notes them in a card, so residue is
+    // never invisible).
     let unknown_rows = art.unknowns();
     let mut unknowns: Vec<UnknownNode> = Vec::new();
     if view == "residue" {
@@ -627,7 +761,8 @@ fn build_graph(
         }
     }
 
-    // Cards.
+    // Cards + view-specific decoration. NO early returns: the
+    // residue card at the bottom must reach every non-residue view.
     let mut cards: Vec<Card> = Vec::new();
     match view {
         "residue" => {
@@ -668,10 +803,11 @@ fn build_graph(
                 lines: vec![form.clone()],
                 tone,
             });
-            // Highlight every group member and topic the claim's
-            // rendered form names. (The artifact carries the claim as
-            // normalized text; structured ClaimIr rows are the Track B
-            // upgrade — this stays presentation-side.)
+            // Highlight every group member (loci AND free fns) and
+            // topic the claim's rendered form names. (The artifact
+            // carries the claim as normalized text; structured
+            // ClaimIr rows are the Track B upgrade — this stays
+            // presentation-side.)
             let mut hl: Vec<String> = Vec::new();
             for (gname, members) in art.groups() {
                 if form_mentions(&form, &gname) {
@@ -687,16 +823,17 @@ fn build_graph(
                 if hl.iter().any(|h| h == &b.name) {
                     b.highlight = true;
                 }
+                for line in &mut b.lines {
+                    if hl.iter().any(|h| h == &line.full) {
+                        line.highlight = true;
+                    }
+                }
             }
-            let mut tnodes = topic_nodes.clone();
-            for t in &mut tnodes {
+            for t in &mut topic_nodes {
                 if form_mentions(&form, &t.name) {
                     t.highlight = true;
                 }
             }
-            return finish_graph(
-                art, view, boxes, tnodes, unknowns, edges, cards,
-            );
         }
         _ => {}
     }
@@ -711,23 +848,11 @@ fn build_graph(
         });
     }
 
-    finish_graph(art, view, boxes, topic_nodes, unknowns, edges, cards)
-}
-
-fn finish_graph(
-    art: &Artifact,
-    view: &str,
-    boxes: Vec<LocusBox>,
-    topics: Vec<TopicNode>,
-    unknowns: Vec<UnknownNode>,
-    edges: Vec<Edge>,
-    cards: Vec<Card>,
-) -> Result<RenderGraph, String> {
     Ok(RenderGraph {
         title: format!("topology · {} view", view),
         footer: art.footer(),
         boxes,
-        topics,
+        topics: topic_nodes,
         unknowns,
         edges,
         cards,
@@ -756,8 +881,12 @@ fn is_ident(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_'
 }
 
-fn fn_label(art: &Artifact, f: &str, with_chips: bool) -> String {
-    let mut label = short_fn(f).to_string();
+/// `short` is the display name inside the owning box (the full name
+/// with the owner's longest-prefix stripped — computed by the
+/// caller, which knows the owner; a free fn keeps its full author
+/// spelling, alias-qualified or not).
+fn fn_label(art: &Artifact, f: &str, short: &str, with_chips: bool) -> String {
+    let mut label = short.to_string();
     if !with_chips {
         return label;
     }
@@ -819,12 +948,27 @@ impl RenderConfig {
         }
         if !self.focus.is_empty() {
             // Keep focused boxes/topics plus anything sharing an edge
-            // with a focused endpoint.
+            // with a focused endpoint. Ownership comes from the built
+            // boxes (longest-prefix membership), never re-derived
+            // from name shape.
+            let fn_owner: std::collections::BTreeMap<String, String> = g
+                .boxes
+                .iter()
+                .flat_map(|b| {
+                    b.lines
+                        .iter()
+                        .map(|l| (l.full.clone(), b.name.clone()))
+                        .collect::<Vec<_>>()
+                })
+                .collect();
             let anchor_owner = |anchor: &str| -> String {
                 if let Some(t) = anchor.strip_prefix("topic:") {
                     t.to_string()
                 } else {
-                    locus_of(anchor).unwrap_or(FREE_FNS).to_string()
+                    fn_owner
+                        .get(anchor)
+                        .cloned()
+                        .unwrap_or_else(|| FREE_FNS.to_string())
                 }
             };
             let mut keep: Vec<String> = self.focus.clone();
@@ -900,13 +1044,23 @@ impl RenderConfig {
 // Mermaid
 // ---------------------------------------------------------------
 
-fn mm_id(name: &str) -> String {
-    let mut s = String::with_capacity(name.len());
-    for c in name.chars() {
-        if c.is_ascii_alphanumeric() {
-            s.push(c);
+/// Injective Mermaid node ID: a kind prefix (functions `n_`, topics
+/// `t_`, unknowns `u_`, subgraphs `g_`) plus bytewise hex-escaping
+/// of every non-alphanumeric byte (`_` included — `A::B` →
+/// `n_A_3a_3aB`, `A__B` → `n_A_5f_5fB`). Distinct entities can
+/// never collapse onto one Mermaid node, and the cross-sort prefix
+/// prevents a function literally named `t_X` from colliding with
+/// topic `X`.
+fn mm_id(kind: &str, name: &str) -> String {
+    let mut s = String::with_capacity(name.len() + 4);
+    s.push_str(kind);
+    s.push('_');
+    for b in name.bytes() {
+        if b.is_ascii_alphanumeric() {
+            s.push(b as char);
         } else {
             s.push('_');
+            s.push_str(&format!("{:02x}", b));
         }
     }
     s
@@ -927,13 +1081,13 @@ fn render_mermaid(g: &RenderGraph) -> String {
     for b in &g.boxes {
         out.push_str(&format!(
             "  subgraph {}[\"{}\"]\n",
-            mm_id(&b.name),
+            mm_id("g", &b.name),
             mm_escape(&b.name)
         ));
         for l in &b.lines {
             out.push_str(&format!(
                 "    {}[\"{}\"]\n",
-                mm_id(&l.full),
+                mm_id("n", &l.full),
                 mm_escape(&l.label)
             ));
         }
@@ -941,8 +1095,8 @@ fn render_mermaid(g: &RenderGraph) -> String {
     }
     for t in &g.topics {
         out.push_str(&format!(
-            "  topic_{}([\"{}<br/>{}\"])\n",
-            mm_id(&t.name),
+            "  {}([\"{}<br/>{}\"])\n",
+            mm_id("t", &t.name),
             mm_escape(&t.name),
             mm_escape(&t.sub)
         ));
@@ -950,15 +1104,17 @@ fn render_mermaid(g: &RenderGraph) -> String {
     for u in &g.unknowns {
         out.push_str(&format!(
             "  {}[/\"{}\"/]\n",
-            mm_id(&u.id),
+            mm_id("u", &u.id),
             mm_escape(&u.label)
         ));
     }
     let anchor = |a: &str| -> String {
         if let Some(t) = a.strip_prefix("topic:") {
-            format!("topic_{}", mm_id(t))
+            mm_id("t", t)
+        } else if a.starts_with("unknown:") {
+            mm_id("u", a)
         } else {
-            mm_id(a)
+            mm_id("n", a)
         }
     };
     for e in &g.edges {
@@ -980,13 +1136,13 @@ fn render_mermaid(g: &RenderGraph) -> String {
     for b in &g.boxes {
         for l in &b.lines {
             if l.highlight || b.highlight {
-                hl_nodes.push(mm_id(&l.full));
+                hl_nodes.push(mm_id("n", &l.full));
             }
         }
     }
     for t in &g.topics {
         if t.highlight {
-            hl_nodes.push(format!("topic_{}", mm_id(&t.name)));
+            hl_nodes.push(mm_id("t", &t.name));
         }
     }
     if !hl_nodes.is_empty() {

--- a/crates/hale-cli/src/topology_graph.rs
+++ b/crates/hale-cli/src/topology_graph.rs
@@ -764,6 +764,9 @@ enum EdgeKind {
     Publish,
     Subscribe,
     Hole,
+    /// A known-dead uninhabited-interface dispatch: neutral, NOT
+    /// residue — the call relation stays exact.
+    Dead,
 }
 
 #[derive(Clone)]
@@ -791,6 +794,9 @@ struct TopicNode {
 struct UnknownNode {
     id: String, // "unknown:<fn>" — the edge from its fn carries the anchor
     label: String,
+    /// True for dead uninhabited dispatches (rendered neutrally,
+    /// never counted as unresolved).
+    dead: bool,
 }
 
 #[derive(Clone)]
@@ -814,6 +820,7 @@ enum CardTone {
     Ok,
     Bad,
     Warn,
+    Info,
 }
 
 struct RenderGraph {
@@ -996,23 +1003,67 @@ fn build_graph(
         }
     }
 
-    // Unknown residue nodes (residue view renders them; every other
-    // view — claim included — notes them in a card, so residue is
-    // never invisible).
+    // Unknown residue nodes. The artifact's unknowns section holds
+    // two DIFFERENT things (its own documented distinction): genuine
+    // unresolved residue, and `uninhabited_interface_call:*` rows,
+    // which are known-DEAD closed-world dispatches retained only so
+    // a later conformer changes the shape hash — the call relation
+    // stays exact. Rendering them as "unresolved" would show a
+    // clean application as incomplete, so they are partitioned:
+    // dead sites render neutrally and never join unresolved counts.
+    let is_dead =
+        |r: &String| r.starts_with("uninhabited_interface_call:");
     let unknown_rows = art.unknowns();
+    let mut genuine: Vec<(String, Vec<String>)> = Vec::new();
+    let mut dead: Vec<(String, Vec<String>)> = Vec::new();
+    for (f, reasons) in &unknown_rows {
+        let (d, g): (Vec<String>, Vec<String>) =
+            reasons.iter().cloned().partition(&is_dead);
+        if !g.is_empty() {
+            genuine.push((f.clone(), g));
+        }
+        if !d.is_empty() {
+            dead.push((f.clone(), d));
+        }
+    }
     let mut unknowns: Vec<UnknownNode> = Vec::new();
     if view == "residue" {
-        for (f, reasons) in &unknown_rows {
+        for (f, reasons) in &genuine {
             let id = format!("unknown:{}", f);
             unknowns.push(UnknownNode {
                 id: id.clone(),
                 label: reasons.join("; "),
+                dead: false,
             });
             edges.push(Edge {
                 from: f.clone(),
                 to: id,
                 kind: EdgeKind::Hole,
                 label: "unresolved".to_string(),
+                highlight: false,
+            });
+        }
+        for (f, reasons) in &dead {
+            let id = format!("unknown:dead:{}", f);
+            unknowns.push(UnknownNode {
+                id: id.clone(),
+                label: reasons
+                    .iter()
+                    .map(|r| {
+                        r.replace(
+                            "uninhabited_interface_call:",
+                            "dead dispatch: ",
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("; "),
+                dead: true,
+            });
+            edges.push(Edge {
+                from: f.clone(),
+                to: id,
+                kind: EdgeKind::Dead,
+                label: "dead (uninhabited)".to_string(),
                 highlight: false,
             });
         }
@@ -1023,7 +1074,7 @@ fn build_graph(
     let mut cards: Vec<Card> = Vec::new();
     match view {
         "residue" => {
-            if unknown_rows.is_empty() {
+            if genuine.is_empty() {
                 cards.push(Card {
                     title: "no unresolved residue".to_string(),
                     lines: vec![
@@ -1094,14 +1145,37 @@ fn build_graph(
         }
         _ => {}
     }
-    if view != "residue" && !unknown_rows.is_empty() {
+    if view != "residue" && !genuine.is_empty() {
         cards.push(Card {
-            title: format!("{} unresolved", unknown_rows.len()),
-            lines: unknown_rows
+            title: format!("{} unresolved", genuine.len()),
+            lines: genuine
                 .iter()
                 .map(|(f, r)| format!("{}: {}", f, r.join("; ")))
                 .collect(),
             tone: CardTone::Warn,
+        });
+    }
+    if !dead.is_empty() {
+        cards.push(Card {
+            title: format!(
+                "{} dead dispatch{}",
+                dead.len(),
+                if dead.len() == 1 { "" } else { "es" }
+            ),
+            lines: dead
+                .iter()
+                .map(|(f, r)| {
+                    format!(
+                        "{}: {} — uninhabited; call relation stays exact",
+                        f,
+                        r.join("; ").replace(
+                            "uninhabited_interface_call:",
+                            ""
+                        )
+                    )
+                })
+                .collect(),
+            tone: CardTone::Info,
         });
     }
 
@@ -1378,7 +1452,7 @@ fn render_mermaid(g: &RenderGraph) -> String {
         let arrow = match e.kind {
             EdgeKind::Publish | EdgeKind::Call => "-->",
             EdgeKind::Subscribe | EdgeKind::CallViaStdlib => "-.->",
-            EdgeKind::Hole => "-.->",
+            EdgeKind::Hole | EdgeKind::Dead => "-.->",
         };
         out.push_str(&format!(
             "  {} {}|{}| {}\n",
@@ -1481,7 +1555,7 @@ fn render_dot(g: &RenderGraph) -> String {
             EdgeKind::Subscribe => "dashed",
             EdgeKind::Call => "solid",
             EdgeKind::CallViaStdlib => "dashed",
-            EdgeKind::Hole => "dotted",
+            EdgeKind::Hole | EdgeKind::Dead => "dotted",
         };
         out.push_str(&format!(
             "  \"{}\" -> \"{}\" [label=\"{}\", style={}{}];\n",
@@ -1708,6 +1782,7 @@ fn render_svg(g: &RenderGraph) -> String {
                 ("#718096", " stroke-dasharray=\"6,4\"")
             }
             EdgeKind::Hole => ("#c53030", " stroke-dasharray=\"2,3\""),
+            EdgeKind::Dead => ("#718096", " stroke-dasharray=\"2,3\""),
         };
         let (color, width_attr) = if e.highlight {
             ("#d69e2e", " stroke-width=\"2.5\"")
@@ -1839,18 +1914,25 @@ fn render_svg(g: &RenderGraph) -> String {
         ));
     }
 
-    // Unknown nodes.
+    // Unknown nodes: red for genuine residue, neutral grey for
+    // known-dead dispatches.
     for (u, (_, p)) in g.unknowns.iter().zip(&unk_pos) {
+        let (fill, stroke) = if u.dead {
+            ("#f7fafc", "#718096")
+        } else {
+            ("#fff5f5", "#c53030")
+        };
         s.push_str(&format!(
             "<rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" rx=\"4\" \
-             fill=\"#fff5f5\" stroke=\"#c53030\" stroke-width=\"1.5\" \
+             fill=\"{}\" stroke=\"{}\" stroke-width=\"1.5\" \
              stroke-dasharray=\"4,3\"/>\n",
-            p.x, p.y, p.w, p.h
+            p.x, p.y, p.w, p.h, fill, stroke
         ));
         s.push_str(&format!(
-            "<text x=\"{}\" y=\"{}\" fill=\"#c53030\">{}</text>\n",
+            "<text x=\"{}\" y=\"{}\" fill=\"{}\">{}</text>\n",
             p.x + PAD,
             p.y + LINE_H - 4,
+            stroke,
             xml_escape(&u.label)
         ));
     }
@@ -1861,6 +1943,7 @@ fn render_svg(g: &RenderGraph) -> String {
             CardTone::Ok => ("#2f855a", "#f0fff4", "#22543d"),
             CardTone::Bad => ("#c53030", "#fff5f5", "#742a2a"),
             CardTone::Warn => ("#b7791f", "#fffff0", "#744210"),
+            CardTone::Info => ("#4a5568", "#f7fafc", "#2d3748"),
         };
         s.push_str(&format!(
             "<rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" rx=\"6\" \

--- a/crates/hale-cli/src/topology_graph.rs
+++ b/crates/hale-cli/src/topology_graph.rs
@@ -1,0 +1,1477 @@
+//! GH #476 Track A — deterministic renderer over topology artifacts.
+//!
+//! `hale topology graph <artifact> [--view V] [--format F] [...]`
+//!
+//! This is an **artifact client**: it reads exactly the JSON a third
+//! party reads (`--dump-topology` output), never touches Hale source,
+//! and has no dependency on the future `hale-model` crate. Its input
+//! adapter can later switch from artifact rows to the canonical
+//! `ApplicationModel` without changing render configs or output.
+//!
+//! `RenderGraph` below is deliberately presentational and disposable —
+//! it is NOT the canonical model, carries no semantic authority, and
+//! may be replaced without migration guarantees.
+//!
+//! Determinism rules (the point of the tool — outputs are
+//! regression-tested snapshots, and slide decks are generated from
+//! them):
+//!   - node identity derives from artifact names, never allocation or
+//!     iteration order; every collection is sorted before rendering;
+//!   - fixed character-cell text metrics (no font measurement — text
+//!     extents are `len * CHAR_W`, so output is byte-stable across
+//!     machines regardless of installed fonts);
+//!   - no timestamps, no absolute paths, no machine identity;
+//!   - the SVG layout is a simple layered two-column arrangement
+//!     computed with integer arithmetic only.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use serde_json::Value;
+
+const CHAR_W: i64 = 8; // fixed glyph advance for font-size 13 monospace
+const LINE_H: i64 = 18;
+const PAD: i64 = 10;
+const BOX_GAP: i64 = 24;
+const COL_GAP: i64 = 140;
+
+pub fn run_topology(rest: &[String]) -> ExitCode {
+    if rest.first().map(String::as_str) != Some("graph") {
+        usage();
+        return ExitCode::from(2);
+    }
+    let mut artifact_path: Option<PathBuf> = None;
+    let mut view = "system".to_string();
+    let mut format = "svg".to_string();
+    let mut out_path: Option<PathBuf> = None;
+    let mut claim: Option<String> = None;
+    let mut config_path: Option<PathBuf> = None;
+
+    let mut it = rest[1..].iter().peekable();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--view" => match it.next() {
+                Some(v) => view = v.clone(),
+                None => return flag_err("--view needs a value"),
+            },
+            "--format" => match it.next() {
+                Some(v) => format = v.clone(),
+                None => return flag_err("--format needs a value"),
+            },
+            "-o" | "--output" => match it.next() {
+                Some(v) => out_path = Some(PathBuf::from(v)),
+                None => return flag_err("-o needs a path"),
+            },
+            "--claim" => match it.next() {
+                Some(v) => claim = Some(v.clone()),
+                None => return flag_err("--claim needs a name"),
+            },
+            "--config" => match it.next() {
+                Some(v) => config_path = Some(PathBuf::from(v)),
+                None => return flag_err("--config needs a path"),
+            },
+            other if other.starts_with('-') => {
+                eprintln!("unknown flag: {}", other);
+                usage();
+                return ExitCode::from(2);
+            }
+            other => {
+                if artifact_path.is_some() {
+                    eprintln!("unexpected extra argument: {}", other);
+                    usage();
+                    return ExitCode::from(2);
+                }
+                artifact_path = Some(PathBuf::from(other));
+            }
+        }
+    }
+    let Some(path) = artifact_path else {
+        usage();
+        return ExitCode::from(2);
+    };
+    if !matches!(view.as_str(), "system" | "code" | "bus" | "claim" | "residue") {
+        eprintln!(
+            "unknown view `{}` (expect system|code|bus|claim|residue)",
+            view
+        );
+        return ExitCode::from(2);
+    }
+    if !matches!(format.as_str(), "svg" | "mermaid" | "dot") {
+        eprintln!("unknown format `{}` (expect svg|mermaid|dot)", format);
+        return ExitCode::from(2);
+    }
+    if view == "claim" && claim.is_none() {
+        eprintln!("--view claim requires --claim <name>");
+        return ExitCode::from(2);
+    }
+
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("cannot read {}: {}", path.display(), e);
+            return ExitCode::from(1);
+        }
+    };
+    let v: Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{} is not a JSON topology artifact: {}", path.display(), e);
+            return ExitCode::from(1);
+        }
+    };
+    let art = Artifact { v };
+    // Version adapter: this renderer understands the 1.x artifact
+    // family. A future major schema gets a new adapter, not silent
+    // misreading.
+    let schema = art.schema();
+    if !schema.starts_with("1.") && schema != "1" {
+        eprintln!(
+            "unsupported topology artifact schema `{}` (this renderer \
+             understands 1.x)",
+            schema
+        );
+        return ExitCode::from(1);
+    }
+
+    let config = match config_path {
+        None => RenderConfig::default(),
+        Some(p) => match RenderConfig::load(&p) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("bad --config {}: {}", p.display(), e);
+                return ExitCode::from(1);
+            }
+        },
+    };
+
+    let mut graph = match build_graph(&art, &view, claim.as_deref()) {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("{}", e);
+            return ExitCode::from(1);
+        }
+    };
+    config.apply(&mut graph);
+
+    let output = match format.as_str() {
+        "mermaid" => render_mermaid(&graph),
+        "dot" => render_dot(&graph),
+        _ => render_svg(&graph),
+    };
+    match out_path {
+        None => {
+            print!("{}", output);
+            ExitCode::SUCCESS
+        }
+        Some(p) => match std::fs::write(&p, output) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("cannot write {}: {}", p.display(), e);
+                ExitCode::from(1)
+            }
+        },
+    }
+}
+
+fn usage() {
+    eprintln!(
+        "usage: hale topology graph <artifact.json>\n\
+         \x20   [--view system|code|bus|claim|residue]   (default: system)\n\
+         \x20   [--format svg|mermaid|dot]               (default: svg)\n\
+         \x20   [--claim <name>]                         (required for --view claim)\n\
+         \x20   [--config <render-config.json>]\n\
+         \x20   [-o <path>]                              (default: stdout)\n\
+         \n\
+         Renders a `--dump-topology` artifact deterministically. An\n\
+         artifact client: reads only the committed JSON, never source.\n\
+         Experimental surface (pre-1.0)."
+    );
+}
+
+fn flag_err(msg: &str) -> ExitCode {
+    eprintln!("{}", msg);
+    usage();
+    ExitCode::from(2)
+}
+
+// ---------------------------------------------------------------
+// Artifact accessors (schema 1.x)
+// ---------------------------------------------------------------
+
+struct Artifact {
+    v: Value,
+}
+
+impl Artifact {
+    fn schema(&self) -> String {
+        match &self.v["schema"] {
+            Value::String(s) => s.clone(),
+            Value::Number(n) => n.to_string(),
+            _ => String::new(),
+        }
+    }
+    fn str_list(&self, path: &[&str]) -> Vec<String> {
+        let mut cur = &self.v;
+        for p in path {
+            cur = &cur[*p];
+        }
+        let mut out: Vec<String> = cur
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|x| x.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
+        out.sort();
+        out
+    }
+    fn rows(&self, path: &[&str]) -> Vec<&Value> {
+        let mut cur = &self.v;
+        for p in path {
+            cur = &cur[*p];
+        }
+        cur.as_array().map(|a| a.iter().collect()).unwrap_or_default()
+    }
+    fn loci(&self) -> Vec<String> {
+        self.str_list(&["sorts", "loci"])
+    }
+    fn fns(&self) -> Vec<String> {
+        self.str_list(&["sorts", "fns"])
+    }
+    fn topics(&self) -> Vec<TopicRow> {
+        let mut t: Vec<TopicRow> = self
+            .rows(&["topics"])
+            .iter()
+            .filter_map(|r| {
+                Some(TopicRow {
+                    name: r["name"].as_str()?.to_string(),
+                    subject: r["subject"].as_str().unwrap_or("").to_string(),
+                    payload_hash: r["payload_hash"]
+                        .as_str()
+                        .unwrap_or("")
+                        .to_string(),
+                })
+            })
+            .collect();
+        t.sort_by(|a, b| a.name.cmp(&b.name));
+        t
+    }
+    fn publishes(&self) -> Vec<(String, String)> {
+        let mut p: Vec<(String, String)> = self
+            .rows(&["relations", "publishes"])
+            .iter()
+            .filter_map(|r| {
+                Some((
+                    r["fn"].as_str()?.to_string(),
+                    r["subject"].as_str()?.to_string(),
+                ))
+            })
+            .collect();
+        p.sort();
+        p
+    }
+    /// (topic, locus, handler)
+    fn subscribes(&self) -> Vec<(String, String, String)> {
+        let mut s: Vec<(String, String, String)> = self
+            .rows(&["relations", "subscribes"])
+            .iter()
+            .filter_map(|r| {
+                Some((
+                    r["subject"].as_str()?.to_string(),
+                    r["locus"].as_str()?.to_string(),
+                    r["handler"].as_str()?.to_string(),
+                ))
+            })
+            .collect();
+        s.sort();
+        s
+    }
+    fn calls(&self, via_stdlib: bool) -> Vec<(String, String)> {
+        let key = if via_stdlib { "calls_via_stdlib" } else { "calls" };
+        let mut c: Vec<(String, String)> = self
+            .rows(&["relations", key])
+            .iter()
+            .filter_map(|r| {
+                Some((
+                    r["from"].as_str()?.to_string(),
+                    r["to"].as_str()?.to_string(),
+                ))
+            })
+            .collect();
+        c.sort();
+        c
+    }
+    fn groups(&self) -> Vec<(String, Vec<String>)> {
+        let mut g: Vec<(String, Vec<String>)> = self.v["groups"]
+            .as_object()
+            .map(|o| {
+                o.iter()
+                    .map(|(k, v)| {
+                        let mut members: Vec<String> = v
+                            .as_array()
+                            .map(|a| {
+                                a.iter()
+                                    .filter_map(|x| {
+                                        x.as_str().map(str::to_string)
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        members.sort();
+                        (k.clone(), members)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        g.sort();
+        g
+    }
+    fn phase_of(&self, f: &str) -> Option<(String, String)> {
+        let p = &self.v["phases"][f];
+        Some((
+            p["phase"].as_str()?.to_string(),
+            p["kind"].as_str()?.to_string(),
+        ))
+    }
+    fn effects_of(&self, f: &str) -> Vec<String> {
+        // Effect ORDER inside a fn's row is semantic in the artifact
+        // (declaration order); keep it, don't sort.
+        self.v["effects"][f]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|x| x.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+    /// (fn, reasons)
+    fn unknowns(&self) -> Vec<(String, Vec<String>)> {
+        let mut u: Vec<(String, Vec<String>)> = self
+            .rows(&["unknowns"])
+            .iter()
+            .filter_map(|r| {
+                let mut reasons: Vec<String> = r["reasons"]
+                    .as_array()
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|x| x.as_str().map(str::to_string))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                reasons.sort();
+                Some((r["fn"].as_str()?.to_string(), reasons))
+            })
+            .collect();
+        u.sort();
+        u
+    }
+    /// (name, form, result)
+    fn claims(&self) -> Vec<(String, String, String)> {
+        let mut c: Vec<(String, String, String)> = self
+            .rows(&["claims"])
+            .iter()
+            .filter_map(|r| {
+                Some((
+                    r["name"].as_str()?.to_string(),
+                    r["form"].as_str().unwrap_or("").to_string(),
+                    r["result"].as_str().unwrap_or("").to_string(),
+                ))
+            })
+            .collect();
+        c.sort();
+        c
+    }
+    fn footer(&self) -> String {
+        let shape = self.v["shape_hash"].as_str().unwrap_or("?");
+        let verdict = self.v["verdict"].as_str().unwrap_or("?");
+        format!(
+            "schema {} · shape {} · verdict {}",
+            self.schema(),
+            shape,
+            verdict
+        )
+    }
+}
+
+struct TopicRow {
+    name: String,
+    subject: String,
+    payload_hash: String,
+}
+
+// ---------------------------------------------------------------
+// RenderGraph — presentational only
+// ---------------------------------------------------------------
+
+#[derive(Clone, PartialEq)]
+enum EdgeKind {
+    Call,
+    CallViaStdlib,
+    Publish,
+    Subscribe,
+    Hole,
+}
+
+#[derive(Clone)]
+struct FnLine {
+    full: String,  // "Locus::fn" or bare fn — the anchor identity
+    label: String, // rendered text (short name + chips)
+    highlight: bool,
+}
+
+#[derive(Clone)]
+struct LocusBox {
+    name: String, // locus name, or "(free functions)"
+    lines: Vec<FnLine>,
+    highlight: bool,
+}
+
+#[derive(Clone)]
+struct TopicNode {
+    name: String,
+    sub: String, // "subject · payload abcd1234"
+    highlight: bool,
+}
+
+#[derive(Clone)]
+struct UnknownNode {
+    id: String, // "unknown:<fn>" — the edge from its fn carries the anchor
+    label: String,
+}
+
+#[derive(Clone)]
+struct Edge {
+    from: String, // anchor id: fn full name, "topic:<name>", "unknown:<fn>"
+    to: String,
+    kind: EdgeKind,
+    label: String,
+    highlight: bool,
+}
+
+#[derive(Clone)]
+struct Card {
+    title: String,
+    lines: Vec<String>,
+    tone: CardTone,
+}
+
+#[derive(Clone, PartialEq)]
+enum CardTone {
+    Ok,
+    Bad,
+    Warn,
+}
+
+struct RenderGraph {
+    title: String,
+    footer: String,
+    boxes: Vec<LocusBox>,
+    topics: Vec<TopicNode>,
+    unknowns: Vec<UnknownNode>,
+    edges: Vec<Edge>,
+    cards: Vec<Card>,
+}
+
+fn locus_of(fn_full: &str) -> Option<&str> {
+    fn_full.split_once("::").map(|(l, _)| l)
+}
+
+fn short_fn(fn_full: &str) -> &str {
+    fn_full.split_once("::").map(|(_, f)| f).unwrap_or(fn_full)
+}
+
+const FREE_FNS: &str = "(free functions)";
+
+fn build_graph(
+    art: &Artifact,
+    view: &str,
+    claim: Option<&str>,
+) -> Result<RenderGraph, String> {
+    let loci = art.loci();
+    let fns = art.fns();
+    let topics = art.topics();
+    let with_chips = view != "bus";
+
+    // Which fns appear as lines. bus view: only endpoint fns.
+    let keep_fn = |f: &String| -> bool {
+        if view != "bus" {
+            return true;
+        }
+        art.publishes().iter().any(|(pf, _)| pf == f)
+            || art
+                .subscribes()
+                .iter()
+                .any(|(_, l, h)| format!("{}::{}", l, h) == *f)
+    };
+
+    // Locus boxes with fn lines (sorted fn order inside each box).
+    let mut boxes: Vec<LocusBox> = Vec::new();
+    for locus in &loci {
+        let lines: Vec<FnLine> = fns
+            .iter()
+            .filter(|f| locus_of(f) == Some(locus.as_str()))
+            .filter(|f| keep_fn(f))
+            .map(|f| FnLine {
+                full: f.clone(),
+                label: fn_label(art, f, with_chips),
+                highlight: false,
+            })
+            .collect();
+        boxes.push(LocusBox {
+            name: locus.clone(),
+            lines,
+            highlight: false,
+        });
+    }
+    let free: Vec<FnLine> = fns
+        .iter()
+        .filter(|f| locus_of(f).is_none())
+        .filter(|f| keep_fn(f))
+        .map(|f| FnLine {
+            full: f.clone(),
+            label: fn_label(art, f, with_chips),
+            highlight: false,
+        })
+        .collect();
+    if !free.is_empty() {
+        boxes.push(LocusBox {
+            name: FREE_FNS.to_string(),
+            lines: free,
+            highlight: false,
+        });
+    }
+    // A box with no lines still renders (a locus with no visible fns).
+    boxes.retain(|b| !b.lines.is_empty() || b.name != FREE_FNS);
+
+    // Topic nodes (not in the code view).
+    let topic_nodes: Vec<TopicNode> = if view == "code" {
+        Vec::new()
+    } else {
+        topics
+            .iter()
+            .map(|t| TopicNode {
+                name: t.name.clone(),
+                sub: format!(
+                    "{} · payload {}",
+                    t.subject,
+                    t.payload_hash.chars().take(8).collect::<String>()
+                ),
+                highlight: false,
+            })
+            .collect()
+    };
+
+    // Edges.
+    let mut edges: Vec<Edge> = Vec::new();
+    if view != "code" {
+        for (f, topic) in art.publishes() {
+            edges.push(Edge {
+                from: f,
+                to: format!("topic:{}", topic),
+                kind: EdgeKind::Publish,
+                label: "publish".to_string(),
+                highlight: false,
+            });
+        }
+        for (topic, locus, handler) in art.subscribes() {
+            edges.push(Edge {
+                from: format!("topic:{}", topic),
+                to: format!("{}::{}", locus, handler),
+                kind: EdgeKind::Subscribe,
+                label: "subscribe".to_string(),
+                highlight: false,
+            });
+        }
+    }
+    if view != "bus" {
+        for (from, to) in art.calls(false) {
+            edges.push(Edge {
+                from,
+                to,
+                kind: EdgeKind::Call,
+                label: "calls".to_string(),
+                highlight: false,
+            });
+        }
+        for (from, to) in art.calls(true) {
+            edges.push(Edge {
+                from,
+                to,
+                kind: EdgeKind::CallViaStdlib,
+                label: "calls (via stdlib)".to_string(),
+                highlight: false,
+            });
+        }
+    }
+
+    // Unknown residue nodes (residue view renders them; other views
+    // note them in a card so they are never silently absent).
+    let unknown_rows = art.unknowns();
+    let mut unknowns: Vec<UnknownNode> = Vec::new();
+    if view == "residue" {
+        for (f, reasons) in &unknown_rows {
+            let id = format!("unknown:{}", f);
+            unknowns.push(UnknownNode {
+                id: id.clone(),
+                label: reasons.join("; "),
+            });
+            edges.push(Edge {
+                from: f.clone(),
+                to: id,
+                kind: EdgeKind::Hole,
+                label: "unresolved".to_string(),
+                highlight: false,
+            });
+        }
+    }
+
+    // Cards.
+    let mut cards: Vec<Card> = Vec::new();
+    match view {
+        "residue" => {
+            if unknown_rows.is_empty() {
+                cards.push(Card {
+                    title: "no unresolved residue".to_string(),
+                    lines: vec![
+                        "every relation in this artifact is exact".to_string()
+                    ],
+                    tone: CardTone::Ok,
+                });
+            }
+        }
+        "claim" => {
+            let name = claim.expect("checked in run_topology");
+            let Some((cname, form, result)) =
+                art.claims().into_iter().find(|(n, _, _)| n == name)
+            else {
+                let known: Vec<String> =
+                    art.claims().into_iter().map(|(n, _, _)| n).collect();
+                return Err(format!(
+                    "claim `{}` is not in this artifact (has: {})",
+                    name,
+                    if known.is_empty() {
+                        "none".to_string()
+                    } else {
+                        known.join(", ")
+                    }
+                ));
+            };
+            let tone = match result.as_str() {
+                "holds" => CardTone::Ok,
+                "violated" => CardTone::Bad,
+                _ => CardTone::Warn,
+            };
+            cards.push(Card {
+                title: format!("claim {} — {}", cname, result),
+                lines: vec![form.clone()],
+                tone,
+            });
+            // Highlight every group member and topic the claim's
+            // rendered form names. (The artifact carries the claim as
+            // normalized text; structured ClaimIr rows are the Track B
+            // upgrade — this stays presentation-side.)
+            let mut hl: Vec<String> = Vec::new();
+            for (gname, members) in art.groups() {
+                if form_mentions(&form, &gname) {
+                    hl.extend(members);
+                }
+            }
+            for l in &loci {
+                if form_mentions(&form, l) {
+                    hl.push(l.clone());
+                }
+            }
+            for b in &mut boxes {
+                if hl.iter().any(|h| h == &b.name) {
+                    b.highlight = true;
+                }
+            }
+            let mut tnodes = topic_nodes.clone();
+            for t in &mut tnodes {
+                if form_mentions(&form, &t.name) {
+                    t.highlight = true;
+                }
+            }
+            return finish_graph(
+                art, view, boxes, tnodes, unknowns, edges, cards,
+            );
+        }
+        _ => {}
+    }
+    if view != "residue" && !unknown_rows.is_empty() {
+        cards.push(Card {
+            title: format!("{} unresolved", unknown_rows.len()),
+            lines: unknown_rows
+                .iter()
+                .map(|(f, r)| format!("{}: {}", f, r.join("; ")))
+                .collect(),
+            tone: CardTone::Warn,
+        });
+    }
+
+    finish_graph(art, view, boxes, topic_nodes, unknowns, edges, cards)
+}
+
+fn finish_graph(
+    art: &Artifact,
+    view: &str,
+    boxes: Vec<LocusBox>,
+    topics: Vec<TopicNode>,
+    unknowns: Vec<UnknownNode>,
+    edges: Vec<Edge>,
+    cards: Vec<Card>,
+) -> Result<RenderGraph, String> {
+    Ok(RenderGraph {
+        title: format!("topology · {} view", view),
+        footer: art.footer(),
+        boxes,
+        topics,
+        unknowns,
+        edges,
+        cards,
+    })
+}
+
+/// Word-boundary mention check over the claim's normalized form, so
+/// group `stores` doesn't light up locus `Store` by prefix accident.
+fn form_mentions(form: &str, name: &str) -> bool {
+    let bytes = form.as_bytes();
+    let mut start = 0;
+    while let Some(pos) = form[start..].find(name) {
+        let a = start + pos;
+        let b = a + name.len();
+        let left_ok = a == 0 || !is_ident(bytes[a - 1]);
+        let right_ok = b >= bytes.len() || !is_ident(bytes[b]);
+        if left_ok && right_ok {
+            return true;
+        }
+        start = a + 1;
+    }
+    false
+}
+
+fn is_ident(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+fn fn_label(art: &Artifact, f: &str, with_chips: bool) -> String {
+    let mut label = short_fn(f).to_string();
+    if !with_chips {
+        return label;
+    }
+    if let Some((_, kind)) = art.phase_of(f) {
+        if kind == "hook" {
+            label.push_str("  [hook]");
+        }
+    }
+    let effects = art.effects_of(f);
+    if !effects.is_empty() {
+        label.push_str("  {");
+        label.push_str(&effects.join(","));
+        label.push('}');
+    }
+    label
+}
+
+// ---------------------------------------------------------------
+// Render config — presentation data, not semantics
+// ---------------------------------------------------------------
+
+#[derive(Default)]
+struct RenderConfig {
+    title: Option<String>,
+    highlight: Vec<String>,
+    hide: Vec<String>,
+    focus: Vec<String>,
+}
+
+impl RenderConfig {
+    fn load(path: &PathBuf) -> Result<RenderConfig, String> {
+        let raw = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+        let v: Value = serde_json::from_str(&raw).map_err(|e| e.to_string())?;
+        let list = |k: &str| -> Vec<String> {
+            v[k].as_array()
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|x| x.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        Ok(RenderConfig {
+            title: v["title"].as_str().map(str::to_string),
+            highlight: list("highlight"),
+            hide: list("hide"),
+            focus: list("focus"),
+        })
+    }
+
+    fn apply(&self, g: &mut RenderGraph) {
+        if let Some(t) = &self.title {
+            g.title = t.clone();
+        }
+        let named = |name: &str, list: &[String]| list.iter().any(|x| x == name);
+        if !self.hide.is_empty() {
+            g.boxes.retain(|b| !named(&b.name, &self.hide));
+            g.topics.retain(|t| !named(&t.name, &self.hide));
+        }
+        if !self.focus.is_empty() {
+            // Keep focused boxes/topics plus anything sharing an edge
+            // with a focused endpoint.
+            let anchor_owner = |anchor: &str| -> String {
+                if let Some(t) = anchor.strip_prefix("topic:") {
+                    t.to_string()
+                } else {
+                    locus_of(anchor).unwrap_or(FREE_FNS).to_string()
+                }
+            };
+            let mut keep: Vec<String> = self.focus.clone();
+            for e in &g.edges {
+                let fo = anchor_owner(&e.from);
+                let to = anchor_owner(&e.to);
+                if named(&fo, &self.focus) || named(&to, &self.focus) {
+                    keep.push(fo);
+                    keep.push(to);
+                }
+            }
+            g.boxes.retain(|b| named(&b.name, &keep));
+            g.topics.retain(|t| named(&t.name, &keep));
+        }
+        for b in &mut g.boxes {
+            if named(&b.name, &self.highlight) {
+                b.highlight = true;
+            }
+            for l in &mut b.lines {
+                if named(&l.full, &self.highlight) {
+                    l.highlight = true;
+                }
+            }
+        }
+        for t in &mut g.topics {
+            if named(&t.name, &self.highlight) {
+                t.highlight = true;
+            }
+        }
+        // Drop edges whose endpoints were hidden/defocused.
+        let boxes = &g.boxes;
+        let topics = &g.topics;
+        let unknowns = &g.unknowns;
+        let has_anchor = |a: &str| -> bool {
+            if let Some(t) = a.strip_prefix("topic:") {
+                return topics.iter().any(|x| x.name == t);
+            }
+            if a.starts_with("unknown:") {
+                return unknowns.iter().any(|u| u.id == a);
+            }
+            boxes
+                .iter()
+                .any(|b| b.lines.iter().any(|l| l.full == a))
+        };
+        g.edges.retain(|e| has_anchor(&e.from) && has_anchor(&e.to));
+        // Highlighted endpoints light their edges.
+        let hl_anchor: Vec<String> = g
+            .boxes
+            .iter()
+            .flat_map(|b| {
+                b.lines
+                    .iter()
+                    .filter(|l| l.highlight || b.highlight)
+                    .map(|l| l.full.clone())
+                    .collect::<Vec<_>>()
+            })
+            .chain(
+                g.topics
+                    .iter()
+                    .filter(|t| t.highlight)
+                    .map(|t| format!("topic:{}", t.name)),
+            )
+            .collect();
+        for e in &mut g.edges {
+            if hl_anchor.iter().any(|a| a == &e.from || a == &e.to) {
+                e.highlight = true;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------
+// Mermaid
+// ---------------------------------------------------------------
+
+fn mm_id(name: &str) -> String {
+    let mut s = String::with_capacity(name.len());
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() {
+            s.push(c);
+        } else {
+            s.push('_');
+        }
+    }
+    s
+}
+
+fn mm_escape(s: &str) -> String {
+    s.replace('"', "&quot;")
+}
+
+fn render_mermaid(g: &RenderGraph) -> String {
+    let mut out = String::new();
+    out.push_str("flowchart LR\n");
+    out.push_str(&format!(
+        "  %% {} — {}\n",
+        mm_escape(&g.title),
+        mm_escape(&g.footer)
+    ));
+    for b in &g.boxes {
+        out.push_str(&format!(
+            "  subgraph {}[\"{}\"]\n",
+            mm_id(&b.name),
+            mm_escape(&b.name)
+        ));
+        for l in &b.lines {
+            out.push_str(&format!(
+                "    {}[\"{}\"]\n",
+                mm_id(&l.full),
+                mm_escape(&l.label)
+            ));
+        }
+        out.push_str("  end\n");
+    }
+    for t in &g.topics {
+        out.push_str(&format!(
+            "  topic_{}([\"{}<br/>{}\"])\n",
+            mm_id(&t.name),
+            mm_escape(&t.name),
+            mm_escape(&t.sub)
+        ));
+    }
+    for u in &g.unknowns {
+        out.push_str(&format!(
+            "  {}[/\"{}\"/]\n",
+            mm_id(&u.id),
+            mm_escape(&u.label)
+        ));
+    }
+    let anchor = |a: &str| -> String {
+        if let Some(t) = a.strip_prefix("topic:") {
+            format!("topic_{}", mm_id(t))
+        } else {
+            mm_id(a)
+        }
+    };
+    for e in &g.edges {
+        let arrow = match e.kind {
+            EdgeKind::Publish | EdgeKind::Call => "-->",
+            EdgeKind::Subscribe | EdgeKind::CallViaStdlib => "-.->",
+            EdgeKind::Hole => "-.->",
+        };
+        out.push_str(&format!(
+            "  {} {}|{}| {}\n",
+            anchor(&e.from),
+            arrow,
+            mm_escape(&e.label),
+            anchor(&e.to)
+        ));
+    }
+    // Highlight classes.
+    let mut hl_nodes: Vec<String> = Vec::new();
+    for b in &g.boxes {
+        for l in &b.lines {
+            if l.highlight || b.highlight {
+                hl_nodes.push(mm_id(&l.full));
+            }
+        }
+    }
+    for t in &g.topics {
+        if t.highlight {
+            hl_nodes.push(format!("topic_{}", mm_id(&t.name)));
+        }
+    }
+    if !hl_nodes.is_empty() {
+        out.push_str("  classDef hl stroke:#d69e2e,stroke-width:3px\n");
+        out.push_str(&format!("  class {} hl\n", hl_nodes.join(",")));
+    }
+    for c in &g.cards {
+        out.push_str(&format!(
+            "  %% card: {} | {}\n",
+            mm_escape(&c.title),
+            mm_escape(&c.lines.join(" | "))
+        ));
+    }
+    out
+}
+
+// ---------------------------------------------------------------
+// DOT
+// ---------------------------------------------------------------
+
+fn render_dot(g: &RenderGraph) -> String {
+    let mut out = String::new();
+    out.push_str("digraph topology {\n");
+    out.push_str("  rankdir=LR;\n  fontname=\"monospace\";\n");
+    out.push_str("  node [fontname=\"monospace\", shape=box];\n");
+    out.push_str(&format!(
+        "  label=\"{} — {}\";\n",
+        dot_escape(&g.title),
+        dot_escape(&g.footer)
+    ));
+    for (i, b) in g.boxes.iter().enumerate() {
+        out.push_str(&format!(
+            "  subgraph cluster_{} {{\n    label=\"{}\";\n{}",
+            i,
+            dot_escape(&b.name),
+            if b.highlight {
+                "    color=\"#d69e2e\"; penwidth=2;\n"
+            } else {
+                ""
+            }
+        ));
+        for l in &b.lines {
+            out.push_str(&format!(
+                "    \"{}\" [label=\"{}\"{}];\n",
+                dot_escape(&l.full),
+                dot_escape(&l.label),
+                if l.highlight {
+                    ", color=\"#d69e2e\", penwidth=2"
+                } else {
+                    ""
+                }
+            ));
+        }
+        out.push_str("  }\n");
+    }
+    for t in &g.topics {
+        out.push_str(&format!(
+            "  \"topic:{}\" [label=\"{}\\n{}\", shape=ellipse{}];\n",
+            dot_escape(&t.name),
+            dot_escape(&t.name),
+            dot_escape(&t.sub),
+            if t.highlight {
+                ", color=\"#d69e2e\", penwidth=2"
+            } else {
+                ""
+            }
+        ));
+    }
+    for u in &g.unknowns {
+        out.push_str(&format!(
+            "  \"{}\" [label=\"{}\", shape=diamond, color=\"#c53030\"];\n",
+            dot_escape(&u.id),
+            dot_escape(&u.label)
+        ));
+    }
+    for e in &g.edges {
+        let style = match e.kind {
+            EdgeKind::Publish => "solid",
+            EdgeKind::Subscribe => "dashed",
+            EdgeKind::Call => "solid",
+            EdgeKind::CallViaStdlib => "dashed",
+            EdgeKind::Hole => "dotted",
+        };
+        out.push_str(&format!(
+            "  \"{}\" -> \"{}\" [label=\"{}\", style={}{}];\n",
+            dot_escape(&e.from),
+            dot_escape(&e.to),
+            dot_escape(&e.label),
+            style,
+            if e.highlight {
+                ", color=\"#d69e2e\", penwidth=2"
+            } else {
+                ""
+            }
+        ));
+    }
+    out.push_str("}\n");
+    out
+}
+
+fn dot_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+// ---------------------------------------------------------------
+// SVG — fixed-metrics layered layout
+// ---------------------------------------------------------------
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+fn text_w(s: &str) -> i64 {
+    s.chars().count() as i64 * CHAR_W
+}
+
+struct Placed {
+    x: i64,
+    y: i64,
+    w: i64,
+    h: i64,
+}
+
+fn render_svg(g: &RenderGraph) -> String {
+    // ---- layout: left column of locus boxes, right column of
+    // topics, further-right column of unknown nodes, cards top-right.
+    let title_h = 2 * LINE_H + PAD;
+
+    // Left column: uniform width from the widest content line.
+    let mut left_w: i64 = text_w("(free functions)");
+    for b in &g.boxes {
+        left_w = left_w.max(text_w(&b.name) + 2 * PAD);
+        for l in &b.lines {
+            left_w = left_w.max(text_w(&l.label) + 3 * PAD);
+        }
+    }
+    // Call edges between left-column boxes route through a left
+    // gutter; size it from the widest call label so nothing clips.
+    let call_labels_w = g
+        .edges
+        .iter()
+        .filter(|e| {
+            matches!(e.kind, EdgeKind::Call | EdgeKind::CallViaStdlib)
+        })
+        .map(|e| text_w(&e.label))
+        .max()
+        .unwrap_or(0);
+    let gutter = if call_labels_w > 0 {
+        call_labels_w + 3 * PAD
+    } else {
+        0
+    };
+    let mut y = title_h + BOX_GAP;
+    let x0 = PAD * 2 + gutter;
+    let mut box_pos: Vec<Placed> = Vec::new();
+    let mut fn_anchor: Vec<(String, i64, i64, i64)> = Vec::new(); // (full, right-x, left-x, y-center)
+    for b in &g.boxes {
+        let h = LINE_H + (b.lines.len() as i64) * LINE_H + PAD;
+        box_pos.push(Placed {
+            x: x0,
+            y,
+            w: left_w,
+            h,
+        });
+        for (i, l) in b.lines.iter().enumerate() {
+            let cy = y + LINE_H + (i as i64) * LINE_H + LINE_H / 2;
+            fn_anchor.push((l.full.clone(), x0 + left_w, x0, cy));
+        }
+        y += h + BOX_GAP;
+    }
+    let left_bottom = y;
+
+    // Topic column.
+    let mut topic_w: i64 = 0;
+    for t in &g.topics {
+        topic_w = topic_w.max(text_w(&t.name).max(text_w(&t.sub)) + 2 * PAD);
+    }
+    let tx = x0 + left_w + COL_GAP;
+    let mut ty = title_h + BOX_GAP;
+    let mut topic_pos: Vec<(String, Placed)> = Vec::new();
+    for t in &g.topics {
+        let h = 2 * LINE_H + PAD;
+        topic_pos.push((
+            t.name.clone(),
+            Placed {
+                x: tx,
+                y: ty,
+                w: topic_w,
+                h,
+            },
+        ));
+        ty += h + BOX_GAP;
+    }
+
+    // Unknown column.
+    let mut unk_w: i64 = 0;
+    for u in &g.unknowns {
+        unk_w = unk_w.max(text_w(&u.label) + 2 * PAD);
+    }
+    let ux = if g.topics.is_empty() {
+        x0 + left_w + COL_GAP
+    } else {
+        tx + topic_w + COL_GAP
+    };
+    let mut uy = title_h + BOX_GAP;
+    let mut unk_pos: Vec<(String, Placed)> = Vec::new();
+    for u in &g.unknowns {
+        let h = LINE_H + PAD;
+        unk_pos.push((
+            u.id.clone(),
+            Placed {
+                x: ux,
+                y: uy,
+                w: unk_w,
+                h,
+            },
+        ));
+        uy += h + BOX_GAP;
+    }
+
+    // Cards under the rightmost column.
+    let mut card_w: i64 = 0;
+    for c in &g.cards {
+        card_w = card_w.max(text_w(&c.title) + 2 * PAD);
+        for l in &c.lines {
+            card_w = card_w.max(text_w(l) + 2 * PAD);
+        }
+    }
+    let cx = if !g.unknowns.is_empty() {
+        ux
+    } else if !g.topics.is_empty() {
+        tx + topic_w + COL_GAP
+    } else {
+        x0 + left_w + COL_GAP
+    };
+    let mut cy0 = [ty, uy, title_h + BOX_GAP]
+        .iter()
+        .copied()
+        .max()
+        .unwrap_or(title_h);
+    let mut card_pos: Vec<Placed> = Vec::new();
+    // Cards stack in their own column top-down.
+    let mut ccy = title_h + BOX_GAP;
+    if !g.unknowns.is_empty() || !g.topics.is_empty() {
+        ccy = cy0;
+    }
+    for c in &g.cards {
+        let h = LINE_H + (c.lines.len() as i64) * LINE_H + PAD;
+        card_pos.push(Placed {
+            x: cx,
+            y: ccy,
+            w: card_w.max(topic_w),
+            h,
+        });
+        ccy += h + BOX_GAP;
+    }
+    cy0 = ccy;
+
+    let width =
+        (cx + card_w.max(topic_w).max(unk_w) + 2 * PAD).max(x0 + left_w + 2 * PAD);
+    let height = left_bottom.max(ty).max(cy0).max(uy) + 2 * LINE_H;
+
+    // ---- emit
+    let mut s = String::new();
+    s.push_str(&format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{w}\" \
+         height=\"{h}\" viewBox=\"0 0 {w} {h}\" font-family=\"monospace\" \
+         font-size=\"13\">\n",
+        w = width,
+        h = height
+    ));
+    s.push_str(&format!(
+        "<rect x=\"0\" y=\"0\" width=\"{}\" height=\"{}\" fill=\"#ffffff\"/>\n",
+        width, height
+    ));
+    s.push_str(&format!(
+        "<text x=\"{}\" y=\"{}\" font-size=\"15\" font-weight=\"bold\" \
+         fill=\"#1a202c\">{}</text>\n",
+        x0,
+        LINE_H,
+        xml_escape(&g.title)
+    ));
+    s.push_str(&format!(
+        "<text x=\"{}\" y=\"{}\" fill=\"#718096\">{}</text>\n",
+        x0,
+        2 * LINE_H,
+        xml_escape(&g.footer)
+    ));
+
+    // Edges first (under boxes).
+    let find_fn = |a: &str| fn_anchor.iter().find(|(f, _, _, _)| f == a);
+    let find_topic = |a: &str| {
+        a.strip_prefix("topic:")
+            .and_then(|t| topic_pos.iter().find(|(n, _)| n == t))
+    };
+    let find_unk = |a: &str| unk_pos.iter().find(|(n, _)| n == a);
+    for e in &g.edges {
+        let (color, dash) = match e.kind {
+            EdgeKind::Publish => ("#2f855a", ""),
+            EdgeKind::Subscribe => ("#6b46c1", " stroke-dasharray=\"6,4\""),
+            EdgeKind::Call => ("#4a5568", ""),
+            EdgeKind::CallViaStdlib => {
+                ("#718096", " stroke-dasharray=\"6,4\"")
+            }
+            EdgeKind::Hole => ("#c53030", " stroke-dasharray=\"2,3\""),
+        };
+        let (color, width_attr) = if e.highlight {
+            ("#d69e2e", " stroke-width=\"2.5\"")
+        } else {
+            (color, " stroke-width=\"1.5\"")
+        };
+        // Resolve endpoints to (x, y) pairs.
+        let seg: Option<((i64, i64), (i64, i64), bool)> = match (
+            find_fn(&e.from),
+            find_topic(&e.from),
+            find_fn(&e.to),
+            find_topic(&e.to),
+            find_unk(&e.to),
+        ) {
+            // fn -> topic (publish)
+            (Some((_, rx, _, fy)), _, _, Some((_, p)), _) => {
+                Some(((*rx, *fy), (p.x, p.y + p.h / 2), false))
+            }
+            // topic -> fn (subscribe): arrow back into the left column
+            (_, Some((_, p)), Some((_, rx, _, fy)), _, _) => {
+                Some(((p.x, p.y + p.h / 2), (*rx, *fy), false))
+            }
+            // fn -> unknown
+            (Some((_, rx, _, fy)), _, _, _, Some((_, p))) => {
+                Some(((*rx, *fy), (p.x, p.y + p.h / 2), false))
+            }
+            // fn -> fn (call): bulge left of the column
+            (Some((_, _, lx, fy)), _, Some((_, _, lx2, ty2)), _, _) => {
+                Some(((*lx, *fy), (*lx2, *ty2), true))
+            }
+            _ => None,
+        };
+        let Some(((x1, y1), (x2, y2), bulge_left)) = seg else {
+            continue;
+        };
+        let bulge = (gutter - PAD).max(40);
+        let (c1x, c2x) = if bulge_left {
+            (x1 - bulge, x2 - bulge)
+        } else {
+            (x1 + (x2 - x1) / 2, x1 + (x2 - x1) / 2)
+        };
+        s.push_str(&format!(
+            "<path d=\"M {x1} {y1} C {c1x} {y1}, {c2x} {y2}, {x2} {y2}\" \
+             fill=\"none\" stroke=\"{color}\"{width_attr}{dash}/>\n"
+        ));
+        // Arrowhead: small triangle at the destination, pointing +x
+        // (or -x for the leftward bulge return).
+        let dir = if bulge_left || x2 >= x1 { 1 } else { -1 };
+        s.push_str(&format!(
+            "<path d=\"M {x2} {y2} l {} {} l 0 {} z\" fill=\"{color}\"/>\n",
+            -7 * dir,
+            -4,
+            8
+        ));
+        // Edge label. Midpoints of opposing publish/subscribe pairs
+        // collide, so each kind anchors at a different fraction of
+        // the chord; call labels sit in the left gutter.
+        let (mx, my) = if bulge_left {
+            let bx = x1.min(x2) - bulge;
+            (bx.max(PAD), (y1 + y2) / 2 - 4)
+        } else {
+            let frac_num: i64 = match e.kind {
+                EdgeKind::Publish => 30,
+                EdgeKind::Subscribe => 70,
+                _ => 50,
+            };
+            let lx = x1 + (x2 - x1) * frac_num / 100
+                - text_w(&e.label) / 2;
+            let ly = y1 + (y2 - y1) * frac_num / 100 - 6;
+            (lx, ly)
+        };
+        s.push_str(&format!(
+            "<text x=\"{}\" y=\"{}\" font-size=\"11\" fill=\"{}\">{}</text>\n",
+            mx,
+            my,
+            color,
+            xml_escape(&e.label)
+        ));
+    }
+
+    // Locus boxes.
+    for (b, p) in g.boxes.iter().zip(&box_pos) {
+        let stroke = if b.highlight { "#d69e2e" } else { "#4a5568" };
+        let sw = if b.highlight { 2.5 } else { 1.5 };
+        s.push_str(&format!(
+            "<rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" rx=\"6\" \
+             fill=\"#f7fafc\" stroke=\"{}\" stroke-width=\"{}\"/>\n",
+            p.x, p.y, p.w, p.h, stroke, sw
+        ));
+        s.push_str(&format!(
+            "<text x=\"{}\" y=\"{}\" font-weight=\"bold\" fill=\"#1a202c\">{}</text>\n",
+            p.x + PAD,
+            p.y + LINE_H - 4,
+            xml_escape(&b.name)
+        ));
+        for (i, l) in b.lines.iter().enumerate() {
+            let ly = p.y + LINE_H + (i as i64) * LINE_H + LINE_H - 5;
+            let fill = if l.highlight { "#b7791f" } else { "#2d3748" };
+            s.push_str(&format!(
+                "<text x=\"{}\" y=\"{}\" fill=\"{}\">{}</text>\n",
+                p.x + 2 * PAD,
+                ly,
+                fill,
+                xml_escape(&l.label)
+            ));
+        }
+    }
+
+    // Topic nodes.
+    for (t, (_, p)) in g.topics.iter().zip(&topic_pos) {
+        let stroke = if t.highlight { "#d69e2e" } else { "#2b6cb0" };
+        let sw = if t.highlight { 2.5 } else { 1.5 };
+        s.push_str(&format!(
+            "<rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" rx=\"14\" \
+             fill=\"#ebf8ff\" stroke=\"{}\" stroke-width=\"{}\"/>\n",
+            p.x, p.y, p.w, p.h, stroke, sw
+        ));
+        s.push_str(&format!(
+            "<text x=\"{}\" y=\"{}\" font-weight=\"bold\" fill=\"#2b6cb0\">{}</text>\n",
+            p.x + PAD,
+            p.y + LINE_H - 4,
+            xml_escape(&t.name)
+        ));
+        s.push_str(&format!(
+            "<text x=\"{}\" y=\"{}\" font-size=\"11\" fill=\"#4a5568\">{}</text>\n",
+            p.x + PAD,
+            p.y + 2 * LINE_H - 6,
+            xml_escape(&t.sub)
+        ));
+    }
+
+    // Unknown nodes.
+    for (u, (_, p)) in g.unknowns.iter().zip(&unk_pos) {
+        s.push_str(&format!(
+            "<rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" rx=\"4\" \
+             fill=\"#fff5f5\" stroke=\"#c53030\" stroke-width=\"1.5\" \
+             stroke-dasharray=\"4,3\"/>\n",
+            p.x, p.y, p.w, p.h
+        ));
+        s.push_str(&format!(
+            "<text x=\"{}\" y=\"{}\" fill=\"#c53030\">{}</text>\n",
+            p.x + PAD,
+            p.y + LINE_H - 4,
+            xml_escape(&u.label)
+        ));
+    }
+
+    // Cards.
+    for (c, p) in g.cards.iter().zip(&card_pos) {
+        let (stroke, fill, tfill) = match c.tone {
+            CardTone::Ok => ("#2f855a", "#f0fff4", "#22543d"),
+            CardTone::Bad => ("#c53030", "#fff5f5", "#742a2a"),
+            CardTone::Warn => ("#b7791f", "#fffff0", "#744210"),
+        };
+        s.push_str(&format!(
+            "<rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" rx=\"6\" \
+             fill=\"{}\" stroke=\"{}\" stroke-width=\"1.5\"/>\n",
+            p.x, p.y, p.w, p.h, fill, stroke
+        ));
+        s.push_str(&format!(
+            "<text x=\"{}\" y=\"{}\" font-weight=\"bold\" fill=\"{}\">{}</text>\n",
+            p.x + PAD,
+            p.y + LINE_H - 4,
+            tfill,
+            xml_escape(&c.title)
+        ));
+        for (i, l) in c.lines.iter().enumerate() {
+            s.push_str(&format!(
+                "<text x=\"{}\" y=\"{}\" font-size=\"12\" fill=\"{}\">{}</text>\n",
+                p.x + PAD,
+                p.y + LINE_H + (i as i64 + 1) * LINE_H - 8,
+                tfill,
+                xml_escape(l)
+            ));
+        }
+    }
+
+    s.push_str("</svg>\n");
+    s
+}

--- a/crates/hale-cli/src/topology_graph.rs
+++ b/crates/hale-cli/src/topology_graph.rs
@@ -419,6 +419,139 @@ impl Artifact {
                 ));
             }
         }
+        // Referential integrity: every function/locus a row names
+        // must exist in the sorts. A well-typed row referencing a
+        // ghost endpoint would otherwise build an edge the anchored
+        // -edge filter then silently deletes — a false absence
+        // instead of a refusal.
+        let fn_set: std::collections::BTreeSet<&str> = art.v["sorts"]
+            ["fns"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|x| x.as_str())
+            .collect();
+        let locus_set: std::collections::BTreeSet<&str> = art.v["sorts"]
+            ["loci"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|x| x.as_str())
+            .collect();
+        let ghost = |section: &str, i: usize, field: &str, who: &str| {
+            format!(
+                "{}: referentially invalid artifact — {}[{}].{} names \
+                 `{}`, which is not in the sorts",
+                path.display(),
+                section,
+                i,
+                field,
+                who
+            )
+        };
+        for rel in ["calls", "calls_via_stdlib"] {
+            for (i, row) in art.v["relations"][rel]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .enumerate()
+            {
+                for field in ["from", "to"] {
+                    let who = row[field].as_str().unwrap_or("");
+                    if !fn_set.contains(who) {
+                        return Err(ghost(
+                            &format!("relations.{}", rel),
+                            i,
+                            field,
+                            who,
+                        ));
+                    }
+                }
+            }
+        }
+        for (i, row) in art.v["relations"]["publishes"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .enumerate()
+        {
+            let who = row["fn"].as_str().unwrap_or("");
+            if !fn_set.contains(who) {
+                return Err(ghost("relations.publishes", i, "fn", who));
+            }
+        }
+        for (i, row) in art.v["relations"]["subscribes"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .enumerate()
+        {
+            let locus = row["locus"].as_str().unwrap_or("");
+            if !locus_set.contains(locus) {
+                return Err(ghost(
+                    "relations.subscribes",
+                    i,
+                    "locus",
+                    locus,
+                ));
+            }
+            let handler = format!(
+                "{}::{}",
+                locus,
+                row["handler"].as_str().unwrap_or("")
+            );
+            if !fn_set.contains(handler.as_str()) {
+                return Err(ghost(
+                    "relations.subscribes",
+                    i,
+                    "handler",
+                    &handler,
+                ));
+            }
+        }
+        for (i, row) in
+            art.v["unknowns"].as_array().into_iter().flatten().enumerate()
+        {
+            let who = row["fn"].as_str().unwrap_or("");
+            if !fn_set.contains(who) {
+                return Err(ghost("unknowns", i, "fn", who));
+            }
+        }
+        for key in ["phases", "effects"] {
+            for (name, _) in
+                art.v[key].as_object().into_iter().flatten()
+            {
+                if !fn_set.contains(name.as_str()) {
+                    return Err(format!(
+                        "{}: referentially invalid artifact — {}.{} is \
+                         not in sorts.fns",
+                        path.display(),
+                        key,
+                        name
+                    ));
+                }
+            }
+        }
+        for (gname, members) in
+            art.v["groups"].as_object().into_iter().flatten()
+        {
+            for (i, mv) in
+                members.as_array().into_iter().flatten().enumerate()
+            {
+                let m = mv.as_str().unwrap_or("");
+                if !locus_set.contains(m) && !fn_set.contains(m) {
+                    return Err(format!(
+                        "{}: referentially invalid artifact — \
+                         groups.{}[{}] names `{}`, which is neither a \
+                         locus nor a fn",
+                        path.display(),
+                        gname,
+                        i,
+                        m
+                    ));
+                }
+            }
+        }
         Ok(art)
     }
 

--- a/crates/hale-cli/tests/fixtures/topology/golden-claim.mmd
+++ b/crates/hale-cli/tests/fixtures/topology/golden-claim.mmd
@@ -1,0 +1,27 @@
+flowchart LR
+  %% topology · claim view — schema 1.10 · shape 9e25ca5ffbf88ac3 · verdict clean
+  subgraph App["App"]
+    App__run["run  [hook]  {publish,alloc}"]
+  end
+  subgraph Store["Store"]
+    Store__on_c["on_c"]
+  end
+  subgraph Worker["Worker"]
+    Worker__on_r["on_r  {unclassified}"]
+  end
+  subgraph _free_functions_["(free functions)"]
+    call_it["call_it  {unclassified}"]
+    double["double"]
+    main["main  {alloc}"]
+  end
+  topic_Cmds(["Cmds<br/>ctl.cmd · payload 828a7a8d"])
+  topic_Readings(["Readings<br/>sense.reading · payload fb9fb455"])
+  App__run -->|publish| topic_Readings
+  Worker__on_r -->|publish| topic_Cmds
+  topic_Cmds -.->|subscribe| Store__on_c
+  topic_Readings -.->|subscribe| Worker__on_r
+  Store__on_c -->|calls| double
+  Worker__on_r -->|calls| call_it
+  classDef hl stroke:#d69e2e,stroke-width:3px
+  class Store__on_c,Worker__on_r hl
+  %% card: claim apart — holds | forbid reaches(stores, workers) via { calls }

--- a/crates/hale-cli/tests/fixtures/topology/golden-claim.mmd
+++ b/crates/hale-cli/tests/fixtures/topology/golden-claim.mmd
@@ -1,27 +1,28 @@
 flowchart LR
   %% topology · claim view — schema 1.10 · shape 9e25ca5ffbf88ac3 · verdict clean
-  subgraph App["App"]
-    App__run["run  [hook]  {publish,alloc}"]
+  subgraph g_App["App"]
+    n_App_3a_3arun["run  [hook]  {publish,alloc}"]
   end
-  subgraph Store["Store"]
-    Store__on_c["on_c"]
+  subgraph g_Store["Store"]
+    n_Store_3a_3aon_5fc["on_c"]
   end
-  subgraph Worker["Worker"]
-    Worker__on_r["on_r  {unclassified}"]
+  subgraph g_Worker["Worker"]
+    n_Worker_3a_3aon_5fr["on_r  {unclassified}"]
   end
-  subgraph _free_functions_["(free functions)"]
-    call_it["call_it  {unclassified}"]
-    double["double"]
-    main["main  {alloc}"]
+  subgraph g__28free_20functions_29["(free functions)"]
+    n_call_5fit["call_it  {unclassified}"]
+    n_double["double"]
+    n_main["main  {alloc}"]
   end
-  topic_Cmds(["Cmds<br/>ctl.cmd · payload 828a7a8d"])
-  topic_Readings(["Readings<br/>sense.reading · payload fb9fb455"])
-  App__run -->|publish| topic_Readings
-  Worker__on_r -->|publish| topic_Cmds
-  topic_Cmds -.->|subscribe| Store__on_c
-  topic_Readings -.->|subscribe| Worker__on_r
-  Store__on_c -->|calls| double
-  Worker__on_r -->|calls| call_it
+  t_Cmds(["Cmds<br/>ctl.cmd · payload 828a7a8d"])
+  t_Readings(["Readings<br/>sense.reading · payload fb9fb455"])
+  n_App_3a_3arun -->|publish| t_Readings
+  n_Worker_3a_3aon_5fr -->|publish| t_Cmds
+  t_Cmds -.->|subscribe| n_Store_3a_3aon_5fc
+  t_Readings -.->|subscribe| n_Worker_3a_3aon_5fr
+  n_Store_3a_3aon_5fc -->|calls| n_double
+  n_Worker_3a_3aon_5fr -->|calls| n_call_5fit
   classDef hl stroke:#d69e2e,stroke-width:3px
-  class Store__on_c,Worker__on_r hl
+  class n_Store_3a_3aon_5fc,n_Worker_3a_3aon_5fr hl
   %% card: claim apart — holds | forbid reaches(stores, workers) via { calls }
+  %% card: 1 unresolved | call_it: indirect_call

--- a/crates/hale-cli/tests/fixtures/topology/golden-system.mmd
+++ b/crates/hale-cli/tests/fixtures/topology/golden-system.mmd
@@ -1,0 +1,25 @@
+flowchart LR
+  %% topology · system view — schema 1.10 · shape 9e25ca5ffbf88ac3 · verdict clean
+  subgraph App["App"]
+    App__run["run  [hook]  {publish,alloc}"]
+  end
+  subgraph Store["Store"]
+    Store__on_c["on_c"]
+  end
+  subgraph Worker["Worker"]
+    Worker__on_r["on_r  {unclassified}"]
+  end
+  subgraph _free_functions_["(free functions)"]
+    call_it["call_it  {unclassified}"]
+    double["double"]
+    main["main  {alloc}"]
+  end
+  topic_Cmds(["Cmds<br/>ctl.cmd · payload 828a7a8d"])
+  topic_Readings(["Readings<br/>sense.reading · payload fb9fb455"])
+  App__run -->|publish| topic_Readings
+  Worker__on_r -->|publish| topic_Cmds
+  topic_Cmds -.->|subscribe| Store__on_c
+  topic_Readings -.->|subscribe| Worker__on_r
+  Store__on_c -->|calls| double
+  Worker__on_r -->|calls| call_it
+  %% card: 1 unresolved | call_it: indirect_call

--- a/crates/hale-cli/tests/fixtures/topology/golden-system.mmd
+++ b/crates/hale-cli/tests/fixtures/topology/golden-system.mmd
@@ -1,25 +1,25 @@
 flowchart LR
   %% topology · system view — schema 1.10 · shape 9e25ca5ffbf88ac3 · verdict clean
-  subgraph App["App"]
-    App__run["run  [hook]  {publish,alloc}"]
+  subgraph g_App["App"]
+    n_App_3a_3arun["run  [hook]  {publish,alloc}"]
   end
-  subgraph Store["Store"]
-    Store__on_c["on_c"]
+  subgraph g_Store["Store"]
+    n_Store_3a_3aon_5fc["on_c"]
   end
-  subgraph Worker["Worker"]
-    Worker__on_r["on_r  {unclassified}"]
+  subgraph g_Worker["Worker"]
+    n_Worker_3a_3aon_5fr["on_r  {unclassified}"]
   end
-  subgraph _free_functions_["(free functions)"]
-    call_it["call_it  {unclassified}"]
-    double["double"]
-    main["main  {alloc}"]
+  subgraph g__28free_20functions_29["(free functions)"]
+    n_call_5fit["call_it  {unclassified}"]
+    n_double["double"]
+    n_main["main  {alloc}"]
   end
-  topic_Cmds(["Cmds<br/>ctl.cmd · payload 828a7a8d"])
-  topic_Readings(["Readings<br/>sense.reading · payload fb9fb455"])
-  App__run -->|publish| topic_Readings
-  Worker__on_r -->|publish| topic_Cmds
-  topic_Cmds -.->|subscribe| Store__on_c
-  topic_Readings -.->|subscribe| Worker__on_r
-  Store__on_c -->|calls| double
-  Worker__on_r -->|calls| call_it
+  t_Cmds(["Cmds<br/>ctl.cmd · payload 828a7a8d"])
+  t_Readings(["Readings<br/>sense.reading · payload fb9fb455"])
+  n_App_3a_3arun -->|publish| t_Readings
+  n_Worker_3a_3aon_5fr -->|publish| t_Cmds
+  t_Cmds -.->|subscribe| n_Store_3a_3aon_5fc
+  t_Readings -.->|subscribe| n_Worker_3a_3aon_5fr
+  n_Store_3a_3aon_5fc -->|calls| n_double
+  n_Worker_3a_3aon_5fr -->|calls| n_call_5fit
   %% card: 1 unresolved | call_it: indirect_call

--- a/crates/hale-cli/tests/fixtures/topology/golden-system.svg
+++ b/crates/hale-cli/tests/fixtures/topology/golden-system.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1196" height="422" viewBox="0 0 1196 422" font-family="monospace" font-size="13">
+<rect x="0" y="0" width="1196" height="422" fill="#ffffff"/>
+<text x="90" y="18" font-size="15" font-weight="bold" fill="#1a202c">topology · system view</text>
+<text x="90" y="36" fill="#718096">schema 1.10 · shape 9e25ca5ffbf88ac3 · verdict clean</text>
+<path d="M 344 97 C 414 97, 414 163, 484 163" fill="none" stroke="#2f855a" stroke-width="1.5"/>
+<path d="M 484 163 l -7 -4 l 0 8 z" fill="#2f855a"/>
+<text x="358" y="110" font-size="11" fill="#2f855a">publish</text>
+<path d="M 344 237 C 414 237, 414 93, 484 93" fill="none" stroke="#2f855a" stroke-width="1.5"/>
+<path d="M 484 93 l -7 -4 l 0 8 z" fill="#2f855a"/>
+<text x="358" y="188" font-size="11" fill="#2f855a">publish</text>
+<path d="M 484 93 C 414 93, 414 167, 344 167" fill="none" stroke="#6b46c1" stroke-width="1.5" stroke-dasharray="6,4"/>
+<path d="M 344 167 l 7 -4 l 0 8 z" fill="#6b46c1"/>
+<text x="350" y="138" font-size="11" fill="#6b46c1">subscribe</text>
+<path d="M 484 163 C 414 163, 414 237, 344 237" fill="none" stroke="#6b46c1" stroke-width="1.5" stroke-dasharray="6,4"/>
+<path d="M 344 237 l 7 -4 l 0 8 z" fill="#6b46c1"/>
+<text x="350" y="208" font-size="11" fill="#6b46c1">subscribe</text>
+<path d="M 90 167 C 30 167, 30 325, 90 325" fill="none" stroke="#4a5568" stroke-width="1.5"/>
+<path d="M 90 325 l -7 -4 l 0 8 z" fill="#4a5568"/>
+<text x="30" y="242" font-size="11" fill="#4a5568">calls</text>
+<path d="M 90 237 C 30 237, 30 307, 90 307" fill="none" stroke="#4a5568" stroke-width="1.5"/>
+<path d="M 90 307 l -7 -4 l 0 8 z" fill="#4a5568"/>
+<text x="30" y="268" font-size="11" fill="#4a5568">calls</text>
+<rect x="90" y="70" width="254" height="46" rx="6" fill="#f7fafc" stroke="#4a5568" stroke-width="1.5"/>
+<text x="100" y="84" font-weight="bold" fill="#1a202c">App</text>
+<text x="110" y="101" fill="#2d3748">run  [hook]  {publish,alloc}</text>
+<rect x="90" y="140" width="254" height="46" rx="6" fill="#f7fafc" stroke="#4a5568" stroke-width="1.5"/>
+<text x="100" y="154" font-weight="bold" fill="#1a202c">Store</text>
+<text x="110" y="171" fill="#2d3748">on_c</text>
+<rect x="90" y="210" width="254" height="46" rx="6" fill="#f7fafc" stroke="#4a5568" stroke-width="1.5"/>
+<text x="100" y="224" font-weight="bold" fill="#1a202c">Worker</text>
+<text x="110" y="241" fill="#2d3748">on_r  {unclassified}</text>
+<rect x="90" y="280" width="254" height="82" rx="6" fill="#f7fafc" stroke="#4a5568" stroke-width="1.5"/>
+<text x="100" y="294" font-weight="bold" fill="#1a202c">(free functions)</text>
+<text x="110" y="311" fill="#2d3748">call_it  {unclassified}</text>
+<text x="110" y="329" fill="#2d3748">double</text>
+<text x="110" y="347" fill="#2d3748">main  {alloc}</text>
+<rect x="484" y="70" width="276" height="46" rx="14" fill="#ebf8ff" stroke="#2b6cb0" stroke-width="1.5"/>
+<text x="494" y="84" font-weight="bold" fill="#2b6cb0">Cmds</text>
+<text x="494" y="100" font-size="11" fill="#4a5568">ctl.cmd · payload 828a7a8d</text>
+<rect x="484" y="140" width="276" height="46" rx="14" fill="#ebf8ff" stroke="#2b6cb0" stroke-width="1.5"/>
+<text x="494" y="154" font-weight="bold" fill="#2b6cb0">Readings</text>
+<text x="494" y="170" font-size="11" fill="#4a5568">sense.reading · payload fb9fb455</text>
+<rect x="900" y="210" width="276" height="46" rx="6" fill="#fffff0" stroke="#b7791f" stroke-width="1.5"/>
+<text x="910" y="224" font-weight="bold" fill="#744210">1 unresolved</text>
+<text x="910" y="238" font-size="12" fill="#744210">call_it: indirect_call</text>
+</svg>

--- a/crates/hale-cli/tests/fixtures/topology/pipeline.hl
+++ b/crates/hale-cli/tests/fixtures/topology/pipeline.hl
@@ -1,0 +1,42 @@
+// The pinned renderer fixture: two loci, two topics, a keyed
+// subscription, a cross-locus call, one indirect call (the model
+// hole), a group, and two claims — every view has something to show.
+type Reading { sensor: Int = 0; v: Int = 0; }
+type Cmd { op: Int = 0; }
+topic Readings { payload: Reading; subject: "sense.reading"; keyed_by sensor; }
+topic Cmds { payload: Cmd; subject: "ctl.cmd"; }
+
+fn double(v: Int) -> Int { return v * 2; }
+
+fn call_it(f: fn (Int) -> Int, v: Int) -> Int {
+    return f(v);
+}
+
+locus Worker {
+    params { seen: Int = 0; }
+    bus { subscribe Readings as on_r where key == replica; publish Cmds; }
+    fn on_r(r: Reading) {
+        self.seen = self.seen + 1;
+        if r.v > 100 { Cmds <- Cmd { op: call_it(double, r.v) }; }
+    }
+}
+
+locus Store {
+    params { total: Int = 0; }
+    bus { subscribe Cmds as on_c; }
+    fn on_c(c: Cmd) { self.total = self.total + double(c.op); }
+}
+
+group stores = { Store };
+group workers = { Worker };
+
+main locus App {
+    params { w: Worker = Worker { }; s: Store = Store { }; }
+    bus { publish Readings; }
+    claims {
+        apart: forbid reaches(stores, workers) via { calls };
+        one_writer: count publishers(topic Readings) <= 1;
+    }
+    run() { Readings <- Reading { sensor: 1, v: 10 }; }
+}
+fn main() { App { }; }

--- a/crates/hale-cli/tests/fixtures/topology/slide-focus.json
+++ b/crates/hale-cli/tests/fixtures/topology/slide-focus.json
@@ -1,0 +1,5 @@
+{
+  "title": "sensor pipeline — worker focus",
+  "focus": ["Worker"],
+  "highlight": ["Worker"]
+}

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -173,11 +173,25 @@ fn claim_view_highlights_the_named_groups_and_states_the_result() {
     // group members' fn nodes carry the highlight class, and the
     // card states the verdict.
     assert!(mmd.contains("class ") && mmd.contains(" hl"));
-    assert!(mmd.contains("Store__on_c"), "stores member highlighted");
-    assert!(mmd.contains("Worker__on_r"), "workers member highlighted");
+    assert!(
+        mmd.contains("n_Store_3a_3aon_5fc"),
+        "stores member highlighted"
+    );
+    assert!(
+        mmd.contains("n_Worker_3a_3aon_5fr"),
+        "workers member highlighted"
+    );
     assert!(
         mmd.contains("claim apart — holds"),
         "card carries name + verdict:\n{}",
+        mmd
+    );
+    // P2 (review round 1): the claim view must NOT hide residue —
+    // the pinned fixture has an indirect_call hole, and the very
+    // view most likely to become a proof slide says so.
+    assert!(
+        mmd.contains("1 unresolved"),
+        "claim view carries the residue card:\n{}",
         mmd
     );
 
@@ -234,15 +248,10 @@ fn render_config_focuses_and_highlights_without_new_semantics() {
             fixture("slide-focus.json").to_str().unwrap(),
         ],
     );
-    // Focus keeps Worker plus its edge-neighbors (App publishes the
-    // topic Worker subscribes; the free fns Worker calls)...
-    assert!(mmd.contains("Worker__on_r"));
-    assert!(mmd.contains("topic_Readings"), "subscribed topic kept");
-    // ...and drops the unconnected-to-Worker Store subscription side
-    // only if Store shares no edge with Worker's anchors. Store
-    // subscribes Cmds which Worker publishes — via the topic they ARE
-    // neighbors, so Store stays. The one guaranteed drop: nothing.
-    // What MUST hold: the config title replaced the default.
+    // Focus keeps Worker plus its edge-neighbors...
+    assert!(mmd.contains("n_Worker_3a_3aon_5fr"));
+    assert!(mmd.contains("t_Readings"), "subscribed topic kept");
+    // ...and the config title replaced the default.
     assert!(
         mmd.contains("sensor pipeline — worker focus"),
         "config title applied:\n{}",
@@ -296,5 +305,303 @@ fn bad_inputs_fail_closed() {
             .unwrap();
         assert!(!out.status.success(), "must refuse: {:?}", args);
     }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// -----------------------------------------------------------------
+// Review round 1 — adapter and identity coverage.
+// -----------------------------------------------------------------
+
+/// FNV-1a 64 (the artifact's own tripwire algorithm) — used to craft
+/// a digest-valid artifact with hostile CONTENT, so the admission
+/// checks past the digest can be exercised.
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in bytes {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+/// Re-stamp a (possibly edited) artifact with a fresh valid digest,
+/// mirroring the emitter's trailer format.
+fn restamp_digest(body_without_trailer: &str) -> String {
+    format!(
+        "{},\n  \"artifact_digest\": \"{:016x}\"\n}}\n",
+        body_without_trailer,
+        fnv1a64(body_without_trailer.as_bytes())
+    )
+}
+
+fn strip_trailer(artifact: &str) -> String {
+    let key = ",\n  \"artifact_digest\": \"";
+    let i = artifact.rfind(key).expect("artifact has a digest trailer");
+    artifact[..i].to_string()
+}
+
+#[test]
+fn tampered_or_unverifiable_artifacts_are_refused() {
+    let dir = workdir("admission");
+    let artifact = dump_artifact(&dir, &fixture("pipeline.hl"));
+    let raw = std::fs::read_to_string(&artifact).unwrap();
+
+    // 1. Hand-edited claims section under the ORIGINAL digest: the
+    //    exact attack the review named — refused as tampered.
+    let edited = raw.replace("\"result\": \"holds\"", "\"result\": \"violated\"");
+    assert_ne!(raw, edited, "test premise: the edit landed");
+    let tampered = dir.join("tampered.topology");
+    std::fs::write(&tampered, &edited).unwrap();
+    let out = hale().arg("topology").arg("graph").arg(&tampered).output().unwrap();
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("artifact_digest"),
+        "refusal names the digest"
+    );
+
+    // 2. No digest at all (pre-1.3 artifact): refused as unverifiable.
+    let undigested = dir.join("undigested.topology");
+    std::fs::write(&undigested, strip_trailer(&raw) + "\n}\n").unwrap();
+    let out = hale().arg("topology").arg("graph").arg(&undigested).output().unwrap();
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("artifact_digest"),
+        "refusal names the missing digest"
+    );
+
+    // 3. Valid digest, WRONG SEMANTICS: rows may mean different
+    //    things; refused past the integrity gate.
+    let body = strip_trailer(&raw).replace("\"semantics\": 1", "\"semantics\": 999");
+    let wrong_sem = dir.join("semantics.topology");
+    std::fs::write(&wrong_sem, restamp_digest(&body)).unwrap();
+    let out = hale().arg("topology").arg("graph").arg(&wrong_sem).output().unwrap();
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("semantics"),
+        "refusal names the semantics mismatch: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // 4. Valid digest, unsupported OLD schema minor (pre-topics /
+    //    pre-verdict): refused rather than rendered misleadingly
+    //    empty.
+    let body = strip_trailer(&raw).replace("\"schema\": \"1.10\"", "\"schema\": \"1.3\"");
+    let old_schema = dir.join("oldschema.topology");
+    std::fs::write(&old_schema, restamp_digest(&body)).unwrap();
+    let out = hale().arg("topology").arg("graph").arg(&old_schema).output().unwrap();
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("schema"),
+        "refusal names the unsupported schema"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Imported locus methods (`p::Store::get`) and imported free fns
+/// (`p::helper`) must land in the right boxes — membership by
+/// longest declared-locus prefix, never by the first `::`.
+#[test]
+fn imported_members_keep_their_owners() {
+    let dir = workdir("xseed");
+    let app = dir.join("app");
+    let lib = dir.join("lib/kv");
+    std::fs::create_dir_all(&app).unwrap();
+    std::fs::create_dir_all(&lib).unwrap();
+    std::fs::write(dir.join("hale.toml"), "name = \"xseed-graph\"\n").unwrap();
+    std::fs::write(
+        lib.join("kv.hl"),
+        r#"
+type Pair { k: Int = 0; v: Int = 0; }
+locus Store {
+    params { total: Int = 0; }
+    fn get(k: Int) -> Int { return self.total + k; }
+}
+fn helper(v: Int) -> Int { return v + 1; }
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        app.join("main.hl"),
+        r#"
+import "lib/kv" as p;
+main locus App {
+    params { s: p::Store = p::Store { }; }
+    run() {
+        let a = self.s.get(1);
+        let b = p::helper(a);
+        println(b);
+    }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let artifact = dir.join("x.topology");
+    let out = hale()
+        .arg("check")
+        .arg(&app)
+        .arg(format!("--dump-topology={}", artifact.display()))
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "cross-seed fixture must check: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let mmd = render(&artifact, &["--format", "mermaid"]);
+    // The imported locus box exists and OWNS its method (the method
+    // node appears inside the subgraph, labeled by its short name).
+    assert!(
+        mmd.contains("subgraph g_p_3a_3aStore"),
+        "imported locus box exists:\n{}",
+        mmd
+    );
+    assert!(
+        mmd.contains("n_p_3a_3aStore_3a_3aget[\"get"),
+        "imported method placed in its locus, short-labeled:\n{}",
+        mmd
+    );
+    // The imported free fn is rendered as free — present, not
+    // orphaned into a phantom `p` locus.
+    assert!(
+        mmd.contains("n_p_3a_3ahelper"),
+        "imported free fn is rendered:\n{}",
+        mmd
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Literal and wildcard bus subjects have no declared-topic row but
+/// are real endpoints: they need visible nodes and edges in every
+/// format.
+#[test]
+fn literal_and_wildcard_subjects_render() {
+    let dir = workdir("litsubj");
+    let src = dir.join("lit.hl");
+    std::fs::write(
+        &src,
+        r#"
+type Event { n: Int = 0; }
+locus Audit {
+    params { seen: Int = 0; }
+    bus { subscribe "orders.**" as on_any of type Event; }
+    fn on_any(e: Event) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { a: Audit = Audit { }; }
+    bus { publish "orders.created" of type Event; }
+    run() { "orders.created" <- Event { n: 1 }; }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let artifact = dir.join("lit.topology");
+    let out = hale()
+        .arg("check")
+        .arg(&src)
+        .arg(format!("--dump-topology={}", artifact.display()))
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "literal-subject fixture must check: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    for format in ["mermaid", "dot", "svg"] {
+        let rendered = render(&artifact, &["--format", format]);
+        assert!(
+            rendered.contains("orders.created"),
+            "{}: literal subject node present:\n{}",
+            format,
+            rendered
+        );
+        assert!(
+            rendered.contains("orders.**"),
+            "{}: wildcard subject node present:\n{}",
+            format,
+            rendered
+        );
+        assert!(
+            rendered.contains("publish") && rendered.contains("subscribe"),
+            "{}: both bus edges survive:\n{}",
+            format,
+            rendered
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The Mermaid-ID collision canary: `A::B` (method), `A__B` (free
+/// fn), and a fn named like a prefixed topic must all get distinct
+/// injective IDs.
+#[test]
+fn mermaid_ids_are_injective() {
+    let dir = workdir("collide");
+    let src = dir.join("collide.hl");
+    std::fs::write(
+        &src,
+        r#"
+fn A__B(v: Int) -> Int { return v; }
+locus A {
+    fn B(v: Int) -> Int { return v + 1; }
+}
+main locus App {
+    params { a: A = A { }; }
+    run() { println(self.a.B(A__B(1))); }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let artifact = dir.join("collide.topology");
+    let out = hale()
+        .arg("check")
+        .arg(&src)
+        .arg(format!("--dump-topology={}", artifact.display()))
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "collision fixture must check: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let mmd = render(&artifact, &["--format", "mermaid"]);
+    // Method A::B → n_A_3a_3aB; free fn A__B → n_A_5f_5fB. Distinct.
+    assert!(mmd.contains("n_A_3a_3aB"), "method id present:\n{}", mmd);
+    assert!(mmd.contains("n_A_5f_5fB"), "free fn id present:\n{}", mmd);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Focus must actually DROP non-neighbors: focusing Store keeps its
+/// subscribed topic (Cmds) and drops App and Readings, which share
+/// no edge with a focused endpoint.
+#[test]
+fn focus_drops_non_neighbors() {
+    let dir = workdir("focusdrop");
+    let artifact = dump_artifact(&dir, &fixture("pipeline.hl"));
+    let cfg = dir.join("focus-store.json");
+    std::fs::write(&cfg, r#"{ "focus": ["Store"] }"#).unwrap();
+    let mmd = render(
+        &artifact,
+        &["--format", "mermaid", "--config", cfg.to_str().unwrap()],
+    );
+    assert!(mmd.contains("g_Store"), "focused box kept:\n{}", mmd);
+    assert!(
+        mmd.contains("t_Cmds"),
+        "edge-neighbor topic kept:\n{}",
+        mmd
+    );
+    assert!(
+        !mmd.contains("g_App"),
+        "App shares no edge with Store — dropped:\n{}",
+        mmd
+    );
+    assert!(
+        !mmd.contains("t_Readings"),
+        "Readings shares no edge with Store — dropped:\n{}",
+        mmd
+    );
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -653,3 +653,47 @@ fn malformed_rows_are_refused_not_dropped() {
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Round 3: a digest-valid, well-TYPED row naming a ghost endpoint
+/// must be refused — the anchored-edge filter would otherwise
+/// silently delete the edge, a false absence again.
+#[test]
+fn referentially_invalid_rows_are_refused() {
+    let dir = workdir("ghost");
+    let artifact = dump_artifact(&dir, &fixture("pipeline.hl"));
+    let raw = std::fs::read_to_string(&artifact).unwrap();
+
+    // Ghost call endpoint.
+    let body = strip_trailer(&raw).replace(
+        "{\"from\": \"Worker::on_r\", \"to\": \"call_it\"}",
+        "{\"from\": \"Ghost::run\", \"to\": \"call_it\"}",
+    );
+    assert!(body.contains("Ghost::run"), "test premise: edit landed");
+    let bad = dir.join("ghostcall.topology");
+    std::fs::write(&bad, restamp_digest(&body)).unwrap();
+    let out = hale().arg("topology").arg("graph").arg(&bad).output().unwrap();
+    assert!(!out.status.success(), "ghost call endpoint must refuse");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("Ghost::run") && err.contains("not in the sorts"),
+        "refusal names the ghost: {}",
+        err
+    );
+
+    // Ghost subscription locus.
+    let body = strip_trailer(&raw).replace(
+        "{\"subject\": \"Cmds\", \"locus\": \"Store\", \"handler\": \"on_c\"}",
+        "{\"subject\": \"Cmds\", \"locus\": \"Phantom\", \"handler\": \"on_c\"}",
+    );
+    assert!(body.contains("Phantom"), "test premise: edit landed");
+    let bad2 = dir.join("ghostsub.topology");
+    std::fs::write(&bad2, restamp_digest(&body)).unwrap();
+    let out = hale().arg("topology").arg("graph").arg(&bad2).output().unwrap();
+    assert!(!out.status.success(), "ghost subscription locus must refuse");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("Phantom"),
+        "refusal names the phantom locus"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -697,3 +697,78 @@ fn referentially_invalid_rows_are_refused() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Round 4 (shared P1): `uninhabited_interface_call:*` rows are
+/// known-DEAD closed-world dispatches, not residue — the artifact's
+/// own documented distinction. They must render neutrally, never
+/// join the unresolved count, and a clean-but-for-dead-sites
+/// application must not be visualized as incomplete.
+#[test]
+fn dead_dispatches_are_not_rendered_as_unresolved() {
+    let dir = workdir("dead");
+    let artifact = dump_artifact(&dir, &fixture("pipeline.hl"));
+    let raw = std::fs::read_to_string(&artifact).unwrap();
+
+    // Add a dead-dispatch row alongside the genuine indirect_call.
+    let body = strip_trailer(&raw).replace(
+        "{\"fn\": \"call_it\", \"reasons\": [\"indirect_call\"]}",
+        "{\"fn\": \"call_it\", \"reasons\": [\"indirect_call\"]}, \
+         {\"fn\": \"double\", \"reasons\": [\"uninhabited_interface_call:Notifier.notify\"]}",
+    );
+    let mixed = dir.join("dead.topology");
+    std::fs::write(&mixed, restamp_digest(&body)).unwrap();
+
+    // System view: the unresolved count stays 1 (the genuine hole);
+    // the dead site gets its own neutral card stating exactness.
+    let mmd = render(&mixed, &["--format", "mermaid"]);
+    assert!(
+        mmd.contains("1 unresolved"),
+        "dead dispatch must not inflate the unresolved count:\n{}",
+        mmd
+    );
+    assert!(
+        mmd.contains("1 dead dispatch")
+            && mmd.contains("call relation stays exact"),
+        "dead dispatch gets its own neutral card:\n{}",
+        mmd
+    );
+
+    // Residue view: both render, distinctly — the dead site as a
+    // dead dispatch, not an unresolved hole.
+    let svg = render(&mixed, &["--view", "residue"]);
+    assert!(svg.contains("indirect_call"), "genuine hole rendered");
+    assert!(
+        svg.contains("dead dispatch: Notifier.notify")
+            && svg.contains("dead (uninhabited)"),
+        "dead site rendered neutrally:\n{}",
+        svg
+    );
+    // The neutral grey, not the residue red, styles the dead node.
+    assert!(
+        svg.contains("#718096"),
+        "dead node uses the neutral palette"
+    );
+
+    // A DEAD-ONLY artifact renders as exact: no unresolved card at
+    // all, and the residue view says so.
+    let body = strip_trailer(&raw).replace(
+        "{\"fn\": \"call_it\", \"reasons\": [\"indirect_call\"]}",
+        "{\"fn\": \"call_it\", \"reasons\": [\"uninhabited_interface_call:Notifier.notify\"]}",
+    );
+    let deadonly = dir.join("deadonly.topology");
+    std::fs::write(&deadonly, restamp_digest(&body)).unwrap();
+    let mmd = render(&deadonly, &["--format", "mermaid"]);
+    assert!(
+        !mmd.contains("unresolved"),
+        "a dead-only application is not incomplete:\n{}",
+        mmd
+    );
+    let residue = render(&deadonly, &["--view", "residue", "--format", "mermaid"]);
+    assert!(
+        residue.contains("no unresolved residue"),
+        "residue view states exactness over dead-only unknowns:\n{}",
+        residue
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -605,3 +605,51 @@ fn focus_drops_non_neighbors() {
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Round 2: a digest-valid artifact with a MALFORMED relation row
+/// (numeric `from`) must be refused naming the row — never rendered
+/// with the edge silently absent. The digest is a tripwire, not an
+/// authenticator; row shape is validated on its own.
+#[test]
+fn malformed_rows_are_refused_not_dropped() {
+    let dir = workdir("badrow");
+    let artifact = dump_artifact(&dir, &fixture("pipeline.hl"));
+    let raw = std::fs::read_to_string(&artifact).unwrap();
+
+    // Corrupt one call row's `from` into a number, restamp so the
+    // digest is valid — the exact fail-open the review demonstrated.
+    let body = strip_trailer(&raw).replace(
+        "{\"from\": \"Worker::on_r\", \"to\": \"call_it\"}",
+        "{\"from\": 7, \"to\": \"call_it\"}",
+    );
+    assert!(body.contains("\"from\": 7"), "test premise: the edit landed");
+    let bad = dir.join("badrow.topology");
+    std::fs::write(&bad, restamp_digest(&body)).unwrap();
+    let out = hale().arg("topology").arg("graph").arg(&bad).output().unwrap();
+    assert!(
+        !out.status.success(),
+        "malformed row must refuse, not render a false absence"
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("relations.calls[") && err.contains(".from"),
+        "refusal names the row and field: {}",
+        err
+    );
+
+    // Same for a malformed unknowns row: residue must never be
+    // silently droppable either.
+    let body = strip_trailer(&raw).replace(
+        "{\"fn\": \"call_it\", \"reasons\": [\"indirect_call\"]}",
+        "{\"fn\": \"call_it\", \"reasons\": \"indirect_call\"}",
+    );
+    let bad2 = dir.join("badunknown.topology");
+    std::fs::write(&bad2, restamp_digest(&body)).unwrap();
+    let out = hale().arg("topology").arg("graph").arg(&bad2).output().unwrap();
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("unknowns[0]"),
+        "refusal names the unknowns row"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -1,0 +1,300 @@
+//! GH #476 Track A — the deterministic topology renderer.
+//!
+//! What these tests hold the tool to (the plan's acceptance criteria):
+//!   1. **Artifact client only.** The renderer consumes a committed
+//!      `--dump-topology` artifact; it never reads Hale source.
+//!   2. **Byte-determinism.** Rendering the same artifact twice is
+//!      byte-identical, for every format.
+//!   3. **Source-motion invariance.** Moving source lines (a leading
+//!      comment) changes provenance spans and the file digest but not
+//!      the model shape — the rendered output must be byte-identical.
+//!      (This is what makes slide decks stable across edits.)
+//!   4. **Golden snapshots.** A pinned fixture renders to checked-in
+//!      goldens, so presentation output is regression-tested against
+//!      the compiler. A golden change is a reviewable diff, never
+//!      silent drift.
+//!   5. **Views carry their semantics**: claim view highlights the
+//!      groups the claim names and states the result; residue view
+//!      renders unknowns visibly rather than omitting them.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn hale() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_hale"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/topology")
+        .join(name)
+}
+
+fn workdir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "hale_topograph_{}_{}",
+        std::process::id(),
+        tag
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+/// Dump the fixture's artifact into `dir` and return its path.
+fn dump_artifact(dir: &Path, source: &Path) -> PathBuf {
+    let artifact = dir.join("app.hale.topology");
+    let out = hale()
+        .arg("check")
+        .arg(source)
+        .arg(format!("--dump-topology={}", artifact.display()))
+        .output()
+        .expect("hale check --dump-topology");
+    assert!(
+        out.status.success(),
+        "fixture must typecheck: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    artifact
+}
+
+fn render(artifact: &Path, extra: &[&str]) -> String {
+    let out = hale()
+        .arg("topology")
+        .arg("graph")
+        .arg(artifact)
+        .args(extra)
+        .output()
+        .expect("hale topology graph");
+    assert!(
+        out.status.success(),
+        "render failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).expect("utf8 output")
+}
+
+#[test]
+fn rendering_is_byte_deterministic_in_every_format() {
+    let dir = workdir("determ");
+    let artifact = dump_artifact(&dir, &fixture("pipeline.hl"));
+    for format in ["svg", "mermaid", "dot"] {
+        let a = render(&artifact, &["--format", format]);
+        let b = render(&artifact, &["--format", format]);
+        assert_eq!(a, b, "{} output must be byte-identical", format);
+        assert!(!a.is_empty());
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn source_motion_does_not_change_the_render() {
+    let dir = workdir("motion");
+    let original = std::fs::read_to_string(fixture("pipeline.hl")).unwrap();
+
+    let src_a = dir.join("a.hl");
+    std::fs::write(&src_a, &original).unwrap();
+    let art_a = dump_artifact(&dir, &src_a);
+    let svg_a = render(&art_a, &[]);
+
+    // Shift every span: three comment lines up top. Provenance and
+    // the source digest change; the model shape must not — and the
+    // render consumes only the model, so it must be byte-identical.
+    let src_b = dir.join("b.hl");
+    std::fs::write(
+        &src_b,
+        format!("// moved\n// by three\n// comment lines\n{}", original),
+    )
+    .unwrap();
+    let art_b = dir.join("b.hale.topology");
+    let out = hale()
+        .arg("check")
+        .arg(&src_b)
+        .arg(format!("--dump-topology={}", art_b.display()))
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    assert_ne!(
+        std::fs::read(&art_a).unwrap(),
+        std::fs::read(&art_b).unwrap(),
+        "test premise: the artifacts DO differ (spans + digest moved)"
+    );
+    let svg_b = render(&art_b, &[]);
+    assert_eq!(
+        svg_a, svg_b,
+        "source motion must not move a single pixel of the render"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pinned_fixture_matches_the_checked_in_goldens() {
+    let dir = workdir("golden");
+    let artifact = dump_artifact(&dir, &fixture("pipeline.hl"));
+
+    let system_mmd = render(&artifact, &["--format", "mermaid"]);
+    let golden_mmd =
+        std::fs::read_to_string(fixture("golden-system.mmd")).unwrap();
+    assert_eq!(
+        system_mmd, golden_mmd,
+        "system mermaid drifted from the golden — if the change is \
+         intended, regenerate tests/fixtures/topology/golden-system.mmd"
+    );
+
+    let system_svg = render(&artifact, &["--format", "svg"]);
+    let golden_svg =
+        std::fs::read_to_string(fixture("golden-system.svg")).unwrap();
+    assert_eq!(
+        system_svg, golden_svg,
+        "system SVG drifted from the golden — if the change is \
+         intended, regenerate tests/fixtures/topology/golden-system.svg"
+    );
+
+    let claim_mmd = render(
+        &artifact,
+        &["--view", "claim", "--claim", "apart", "--format", "mermaid"],
+    );
+    let golden_claim =
+        std::fs::read_to_string(fixture("golden-claim.mmd")).unwrap();
+    assert_eq!(claim_mmd, golden_claim, "claim mermaid drifted");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn claim_view_highlights_the_named_groups_and_states_the_result() {
+    let dir = workdir("claim");
+    let artifact = dump_artifact(&dir, &fixture("pipeline.hl"));
+    let mmd = render(
+        &artifact,
+        &["--view", "claim", "--claim", "apart", "--format", "mermaid"],
+    );
+    // `apart: forbid reaches(stores, workers) via { calls }` — both
+    // group members' fn nodes carry the highlight class, and the
+    // card states the verdict.
+    assert!(mmd.contains("class ") && mmd.contains(" hl"));
+    assert!(mmd.contains("Store__on_c"), "stores member highlighted");
+    assert!(mmd.contains("Worker__on_r"), "workers member highlighted");
+    assert!(
+        mmd.contains("claim apart — holds"),
+        "card carries name + verdict:\n{}",
+        mmd
+    );
+
+    // An unknown claim name refuses loudly and lists what exists.
+    let out = hale()
+        .arg("topology")
+        .arg("graph")
+        .arg(&artifact)
+        .args(["--view", "claim", "--claim", "nope"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("nope") && err.contains("apart"),
+        "refusal names the missing claim and the available ones: {}",
+        err
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn residue_view_renders_unknowns_visibly() {
+    let dir = workdir("residue");
+    let artifact = dump_artifact(&dir, &fixture("pipeline.hl"));
+    let mmd = render(&artifact, &["--view", "residue", "--format", "mermaid"]);
+    assert!(
+        mmd.contains("indirect_call"),
+        "the fn-pointer hole must be a rendered node:\n{}",
+        mmd
+    );
+    assert!(mmd.contains("unresolved"), "hole edge labeled");
+
+    // Other views never silently omit residue: it surfaces as a card.
+    let sys = render(&artifact, &["--format", "mermaid"]);
+    assert!(
+        sys.contains("unresolved") || sys.contains("card: 1 unresolved"),
+        "system view notes the residue:\n{}",
+        sys
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn render_config_focuses_and_highlights_without_new_semantics() {
+    let dir = workdir("config");
+    let artifact = dump_artifact(&dir, &fixture("pipeline.hl"));
+    let mmd = render(
+        &artifact,
+        &[
+            "--format",
+            "mermaid",
+            "--config",
+            fixture("slide-focus.json").to_str().unwrap(),
+        ],
+    );
+    // Focus keeps Worker plus its edge-neighbors (App publishes the
+    // topic Worker subscribes; the free fns Worker calls)...
+    assert!(mmd.contains("Worker__on_r"));
+    assert!(mmd.contains("topic_Readings"), "subscribed topic kept");
+    // ...and drops the unconnected-to-Worker Store subscription side
+    // only if Store shares no edge with Worker's anchors. Store
+    // subscribes Cmds which Worker publishes — via the topic they ARE
+    // neighbors, so Store stays. The one guaranteed drop: nothing.
+    // What MUST hold: the config title replaced the default.
+    assert!(
+        mmd.contains("sensor pipeline — worker focus"),
+        "config title applied:\n{}",
+        mmd
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn bad_inputs_fail_closed() {
+    let dir = workdir("bad");
+    // Not JSON.
+    let not_json = dir.join("nope.topology");
+    std::fs::write(&not_json, "hello").unwrap();
+    let out = hale()
+        .arg("topology")
+        .arg("graph")
+        .arg(&not_json)
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+
+    // Unsupported schema family.
+    let future = dir.join("future.topology");
+    std::fs::write(&future, r#"{"schema": "9.0", "sorts": {}}"#).unwrap();
+    let out = hale()
+        .arg("topology")
+        .arg("graph")
+        .arg(&future)
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("schema"),
+        "refusal names the schema"
+    );
+
+    // Unknown view / format / missing --claim.
+    for args in [
+        vec!["--view", "sideways"],
+        vec!["--format", "png"],
+        vec!["--view", "claim"],
+    ] {
+        let real = dump_artifact(&dir, &fixture("pipeline.hl"));
+        let out = hale()
+            .arg("topology")
+            .arg("graph")
+            .arg(&real)
+            .args(&args)
+            .output()
+            .unwrap();
+        assert!(!out.status.success(), "must refuse: {:?}", args);
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -821,6 +821,34 @@ Dumping does **not** change what the command means: a program whose
 claims fail still exits non-zero with its witnesses, it just prints
 the artifact on the way.
 
+### Rendering the artifact
+
+A committed artifact can be drawn (experimental surface, pre-1.0):
+
+```text
+hale topology graph .hale.topology                          # SVG to stdout
+hale topology graph .hale.topology --format mermaid
+hale topology graph .hale.topology --view claim --claim apart -o claim.svg
+```
+
+Views: `system` (loci, functions with phase/effect chips, topics,
+publish/subscribe/call edges), `code` (functions and calls only),
+`bus` (endpoints only), `claim` (system view with the named claim's
+groups highlighted and its verdict on a card), `residue` (unresolved
+holes rendered as first-class nodes — never silently omitted; other
+views note them on a card). A `--config file.json` can retitle,
+`focus`, `hide`, or `highlight` — presentation choices only, never
+new semantics.
+
+The renderer is an **artifact client**: it reads exactly the JSON a
+third party reads, never your source, and its output is
+deterministic by construction — fixed text metrics (no font
+measurement), stable IDs derived from artifact names, no
+timestamps. Rendering the same artifact twice is byte-identical,
+and *moving source lines doesn't move a pixel* (provenance spans
+change; the model shape doesn't) — which is what makes generated
+diagrams safe to commit and regression-test.
+
 ### One verdict vocabulary
 
 Bundle claims and fn-grained certificates (`@effects`, `@budget`,

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -840,6 +840,13 @@ views note them on a card). A `--config file.json` can retitle,
 `focus`, `hide`, or `highlight` — presentation choices only, never
 new semantics.
 
+The renderer admits before it draws, in the fleet loader's order:
+the whole-body `artifact_digest` must verify (a hand-edited
+artifact is refused, not rendered under a stale identity), the
+model `semantics` must match the build, and the schema minor must
+be one the adapter actually covers (1.4+). It does *not* require a
+clean verdict — violations are worth drawing.
+
 The renderer is an **artifact client**: it reads exactly the JSON a
 third party reads, never your source, and its output is
 deterministic by construction — fixed text metrics (no font


### PR DESCRIPTION
The Track A deliverable from #476: render a committed `--dump-topology` artifact into SVG / Mermaid / DOT, deterministically.

```text
hale topology graph .hale.topology                          # SVG to stdout
hale topology graph .hale.topology --view claim --claim apart -o claim.svg
hale topology graph .hale.topology --format mermaid
```

**An artifact client by construction.** It reads exactly the JSON a third party reads, never Hale source, and has no dependency on the future `hale-model` crate — the input adapter later swaps from artifact rows to `ApplicationModel` without changing render configs or output. `RenderGraph` is deliberately presentational and disposable; it carries no semantic authority.

**Views**: `system` (loci with phase/effect-chipped fns, topics with subject + payload identity, publish/subscribe/call edges), `code`, `bus`, `claim` (highlights the groups the claim's normalized form names, verdict on a card), `residue` (unresolved holes as first-class nodes — and every *other* view notes residue on a card rather than omitting it: unknowns are never invisible). `--config` JSON can retitle/focus/hide/highlight — presentation only, never new semantics.

**Determinism is the product**: fixed character-cell text metrics (no font measurement → byte-stable across machines and installed fonts), stable IDs from artifact names, sorted collections, integer-only layout, no timestamps. The two tests that matter most:

- **byte-determinism** in every format, and
- **source-motion invariance**: a leading comment shifts provenance spans and the file digest (the artifacts demonstrably differ — premise-checked) but the render is *byte-identical*. That's what makes generated slide decks safe to commit and regression-test.

Plus checked-in mermaid + SVG goldens for a pinned fixture (drift becomes a reviewable diff, never silent), claim-view highlight/verdict assertions with unknown-claim refusal listing what exists, residue visibility in residue *and* non-residue views, and fail-closed handling of non-JSON input, unsupported schema families (this is a 1.x adapter), unknown views/formats, and missing `--claim`. 7/7 locally; `hale fmt --check` clean; docs claims chapter gains a "Rendering the artifact" section.

Sample renders (from the pinned fixture): system view shows the two loci + free-fns box, keyed topics with payload identity, publish (green) / subscribe (violet dashed) / call (gutter-routed) edges; claim view paints `stores`/`workers` members gold with the `forbid reaches` verdict card; residue view attaches the `indirect_call` hole to `call_it` in red.

Experimental surface pre-1.0, marked as such in usage and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)