### PR TITLE
feat(model): hale-model schema crate — canonical semantic model Change 1 (#476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ behavior.
 
 ## Unreleased
 
+### `hale-model` - the canonical semantic model schema (GH #476 Change 1)
+
+The first change of the canonical-model epic: a new source-independent
+crate holding the typed schema and its laws - nothing derives it yet
+(Change 2) and nothing consumes it yet, so there is zero behavior
+change. What Change 1 pins is exactly the set of facts that would be
+expensive to retrofit: typed entity sorts (declaration/instance split
+included) and relation tables with per-row provenance; keyed delivery
+as first-class schema (topic keys, publish key domains, subscription
+predicates incl. `EqReplica`, the may/must-deliver polarity documented
+as law); bounds and loss policy (capacity, shed policies, publish
+dispositions, binding loss behavior) recorded BEFORE any must-arrive
+claim exists to consume them; typed holes that must hide at least one
+relation family; positive capabilities with a validated
+no-contradiction law (a model cannot claim `exact_calls` while a hole
+hides CALLS); `ModelHashKind::TopologyShapeV1` naming the legacy hash
+algorithm so the Change-3 projection cannot ship an unnamed identity;
+and canonical-order validation (an unsorted table is not a model).
+The crate depends on NOTHING - source independence and
+no-serialization-promise are enforced by an architecture canary that
+fails on any dependency line at all. Design note ships as the crate's
+rustdoc; 8 canary tests in `tests/architecture.rs`.
+
 ### `hale topology graph` - deterministic visuals from the artifact (GH #476 Track A)
 
 A committed `--dump-topology` artifact can now be rendered:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "hale-model"
+version = "0.17.0"
+
+[[package]]
 name = "hale-stdlib"
 version = "0.17.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/hale-corpus",
     "crates/hale-syntax",
     "crates/hale-types",
+    "crates/hale-model",
     "crates/hale-codegen",
     "crates/hale-lsp",
     "crates/hale-cli",

--- a/crates/hale-model/Cargo.toml
+++ b/crates/hale-model/Cargo.toml
@@ -1,0 +1,24 @@
+# GH #476 — the canonical semantic model (Change 1: schema skeleton).
+#
+# ARCHITECTURE LAW: this crate is source-independent. It must never
+# depend on `hale-syntax` (or transitively on the AST): the model
+# carries source-neutral provenance records, and `hale-types` maps
+# compiler spans INTO those records while deriving the model. The
+# dependency-direction canary in tests/architecture.rs enforces this
+# at test time; review enforces it at the boundary.
+#
+# Deliberately dependency-free: schema types, invariants, and laws —
+# nothing else. No serde: the external serialization surface is
+# Change 3+ (the legacy topology projection), and promising a wire
+# format from the schema crate would freeze exactly what the epic
+# says must stay evolvable during consolidation.
+
+[package]
+name = "hale-model"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Hale language: canonical typed semantic model (ApplicationModel schema)"
+
+[dependencies]

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -9,15 +9,15 @@
 
 use crate::capability::Capabilities;
 use crate::entity::{
-    Binding, Function, LocusDecl, LocusInstance, PayloadContract, Phase,
-    Seed, Subject, ThreadDomain, Topic,
+    Binding, Function, Group, LocusDecl, LocusInstance, PayloadContract,
+    Phase, Seed, Subject, ThreadDomain, Topic,
 };
 use crate::hole::Hole;
 use crate::ids::{EntityRef, ProvenanceId};
 use crate::provenance::{Provenance, ProvenanceTable};
 use crate::relation::{
-    AffinedTo, Call, DeclaredIn, MemberOf, Owns, PhaseOf, PlacedIn,
-    Publish, Realizes, Subscribe, Supervises, TopicBinding,
+    AffinedTo, Call, DeclaredIn, GroupMember, MemberOf, Owns, PhaseOf,
+    PlacedIn, Publish, Realizes, Subscribe, Supervises, TopicBinding,
 };
 
 /// The meaning of the model's rows. Bumped when a row's
@@ -79,6 +79,7 @@ pub struct Entities {
     pub seeds: Vec<Seed>,
     pub thread_domains: Vec<ThreadDomain>,
     pub bindings: Vec<Binding>,
+    pub groups: Vec<Group>,
 }
 
 #[derive(Clone, Default, Debug)]
@@ -95,6 +96,7 @@ pub struct Relations {
     pub affined_to: Vec<AffinedTo>,
     pub binds: Vec<TopicBinding>,
     pub supervises: Vec<Supervises>,
+    pub group_members: Vec<GroupMember>,
 }
 
 #[derive(Clone, Debug)]
@@ -156,6 +158,11 @@ pub enum ModelError {
     /// Fallback subscription — the policy's required catch is
     /// missing.
     FallbackUncovered { topic: usize },
+    /// The keyed-ness of a publish/subscription disagrees with its
+    /// topic: a key domain on an unkeyed topic (or none on a keyed
+    /// one), or a keyed predicate (`EqLiteral`/`EqReplica`/
+    /// `Fallback`/`Unknown`) filtering an unkeyed topic.
+    KeyContract { table: &'static str, index: usize },
 }
 
 impl ApplicationModel {
@@ -183,6 +190,7 @@ impl ApplicationModel {
     /// | `affined_to`     | (domain)                         |
     /// | `binds`          | (topic, binding)                 |
     /// | `supervises`     | (parent, child, error_type)      |
+    /// | `group_members`  | (group, member)                  |
     /// | `labels`         | (at, label)                      |
     /// | `weights`        | (at, metric)                     |
     /// | `holes`          | (at, kind, reason)               |
@@ -222,6 +230,7 @@ impl ApplicationModel {
             "thread_domains",
             e.thread_domains.iter().map(|d| &d.name),
         )?;
+        check_sorted_keys("groups", e.groups.iter().map(|g| &g.name))?;
         check_sorted_keys(
             "bindings",
             e.bindings
@@ -295,6 +304,9 @@ impl ApplicationModel {
         }
         for (i, d) in e.thread_domains.iter().enumerate() {
             prov("thread_domains", i, d.provenance)?;
+        }
+        for (i, g) in e.groups.iter().enumerate() {
+            prov("groups", i, g.provenance)?;
         }
         for (i, b) in e.bindings.iter().enumerate() {
             if b.subject.index() >= subjects {
@@ -443,19 +455,31 @@ impl ApplicationModel {
                     index: i,
                 });
             }
-            if let crate::keys::KeyDomain::Exact(vals) = &x.key_domain {
+            // Keyed-ness must match the topic, both ways.
+            let topic_keyed =
+                e.topics[x.topic.index()].key.is_some();
+            if topic_keyed != x.key_domain.is_some() {
+                return Err(ModelError::KeyContract {
+                    table: "publishes",
+                    index: i,
+                });
+            }
+            if let Some(crate::keys::KeyDomain::Exact(vals)) =
+                &x.key_domain
+            {
                 check_sorted_keys("publishes.key_domain", vals.iter())
                     .map_err(|_| ModelError::NotCanonical {
                         table: "publishes.key_domain",
                         index: i,
                     })?;
             }
-            if matches!(x.key_domain, crate::keys::KeyDomain::Unknown)
-                && !hole_at(
-                    EntityRef::Function(x.function),
-                    crate::hole::RelationSet::KEY_FILTERS,
-                )
-            {
+            if matches!(
+                x.key_domain,
+                Some(crate::keys::KeyDomain::Unknown)
+            ) && !hole_at(
+                EntityRef::Function(x.function),
+                crate::hole::RelationSet::KEY_FILTERS,
+            ) {
                 return Err(ModelError::UnrepresentedUnknown {
                     table: "publishes",
                     index: i,
@@ -478,6 +502,19 @@ impl ApplicationModel {
             }
             if matches!(x.capacity, crate::keys::Capacity::Bounded(0)) {
                 return Err(ModelError::InvalidBound {
+                    table: "subscribes",
+                    index: i,
+                });
+            }
+            // A keyed predicate needs a keyed topic; unkeyed topics
+            // admit only the plain full-delivery subscription.
+            if e.topics[x.topic.index()].key.is_none()
+                && !matches!(
+                    x.key_predicate,
+                    crate::keys::KeyPredicate::Any
+                )
+            {
+                return Err(ModelError::KeyContract {
                     table: "subscribes",
                     index: i,
                 });
@@ -603,6 +640,21 @@ impl ApplicationModel {
                 });
             }
             prov("supervises", i, x.provenance)?;
+        }
+
+        check_sorted_keys(
+            "group_members",
+            r.group_members.iter().map(|x| (x.group, x.member)),
+        )?;
+        let groups_len = e.groups.len();
+        for (i, x) in r.group_members.iter().enumerate() {
+            if x.group.index() >= groups_len || !ref_ok(&x.member) {
+                return Err(ModelError::DanglingId {
+                    table: "group_members",
+                    index: i,
+                });
+            }
+            prov("group_members", i, x.provenance)?;
         }
 
         // --- labels / weights.

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -16,8 +16,9 @@ use crate::hole::Hole;
 use crate::ids::{EntityRef, ProvenanceId};
 use crate::provenance::{Provenance, ProvenanceTable};
 use crate::relation::{
-    AffinedTo, Call, DeadInterfaceCall, DeclaredIn, GroupMember, MemberOf, Owns, PhaseOf, PlacedIn,
-    Publish, Realizes, Subscribe, Supervises, TopicBinding,
+    AffinedTo, Call, DeadInterfaceCall, DeclaredIn, GroupMember,
+    GroupSelector, MemberOf, Owns, PhaseOf, PlacedIn, Publish, Realizes,
+    SelectorForm, Subscribe, Supervises, TopicBinding,
 };
 
 /// The meaning of the model's rows. Bumped when a row's
@@ -103,6 +104,9 @@ pub struct Relations {
     pub binds: Vec<TopicBinding>,
     pub supervises: Vec<Supervises>,
     pub group_members: Vec<GroupMember>,
+    /// The AUTHORED selector lists (legacy-hash grain), alongside
+    /// the resolved `group_members` (judgment grain).
+    pub group_selectors: Vec<GroupSelector>,
 }
 
 #[derive(Clone, Debug)]
@@ -205,6 +209,7 @@ impl ApplicationModel {
     /// | `binds`          | (topic, binding)                 |
     /// | `supervises`     | (parent, child, error_type)      |
     /// | `group_members`  | (group, member)                  |
+    /// | `group_selectors`| (group, ordinal)                 |
     /// | `labels`         | (at, label)                      |
     /// | `weights`        | (at, metric)                     |
     /// | `holes`          | (at, kind, reason)               |
@@ -696,6 +701,25 @@ impl ApplicationModel {
                 });
             }
             prov("group_members", i, x.provenance)?;
+        }
+        check_sorted_keys(
+            "group_selectors",
+            r.group_selectors.iter().map(|x| (x.group, x.ordinal)),
+        )?;
+        for (i, x) in r.group_selectors.iter().enumerate() {
+            let sel_ok = match &x.selector {
+                SelectorForm::Named { member, .. } => ref_ok(member),
+                SelectorForm::SeedGlob { seed, .. } => {
+                    seed.index() < seeds
+                }
+            };
+            if x.group.index() >= groups_len || !sel_ok {
+                return Err(ModelError::DanglingId {
+                    table: "group_selectors",
+                    index: i,
+                });
+            }
+            prov("group_selectors", i, x.provenance)?;
         }
 
         // --- labels / weights.

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -9,15 +9,16 @@
 
 use crate::capability::Capabilities;
 use crate::entity::{
-    Binding, Function, Group, LocusDecl, LocusInstance, PayloadContract,
-    Phase, Seed, Subject, ThreadDomain, Topic,
+    Binding, Function, Group, InterfaceDecl, LocusDecl, LocusInstance,
+    PayloadContract, Phase, Seed, Subject, ThreadDomain, Topic, TypeDecl,
 };
 use crate::hole::Hole;
 use crate::ids::{EntityRef, ProvenanceId};
 use crate::provenance::{Provenance, ProvenanceTable};
 use crate::relation::{
-    AffinedTo, Call, DeclaredIn, GroupMember, MemberOf, Owns, PhaseOf,
-    PlacedIn, Publish, Realizes, Subscribe, Supervises, TopicBinding,
+    AffinedTo, Call, DeadInterfaceCall, DeclaredIn, GroupMember, MemberOf,
+    Owns, PhaseOf, PlacedIn, Publish, Realizes, Subscribe, Supervises,
+    TopicBinding,
 };
 
 /// The meaning of the model's rows. Bumped when a row's
@@ -80,6 +81,8 @@ pub struct Entities {
     pub thread_domains: Vec<ThreadDomain>,
     pub bindings: Vec<Binding>,
     pub groups: Vec<Group>,
+    pub types: Vec<TypeDecl>,
+    pub interfaces: Vec<InterfaceDecl>,
 }
 
 #[derive(Clone, Default, Debug)]
@@ -90,6 +93,7 @@ pub struct Relations {
     pub realizes: Vec<Realizes>,
     pub owns: Vec<Owns>,
     pub calls: Vec<Call>,
+    pub dead_interface_calls: Vec<DeadInterfaceCall>,
     pub publishes: Vec<Publish>,
     pub subscribes: Vec<Subscribe>,
     pub placed_in: Vec<PlacedIn>,
@@ -163,6 +167,10 @@ pub enum ModelError {
     /// one), or a keyed predicate (`EqLiteral`/`EqReplica`/
     /// `Fallback`/`Unknown`) filtering an unkeyed topic.
     KeyContract { table: &'static str, index: usize },
+    /// A bus row's `declared_topic` names a topic whose subject
+    /// differs from the row's own subject — one endpoint, two
+    /// addresses.
+    DeclaredTopicDisagrees { table: &'static str, index: usize },
 }
 
 impl ApplicationModel {
@@ -184,8 +192,9 @@ impl ApplicationModel {
     /// | `realizes`       | (instance, decl)                 |
     /// | `owns`           | (parent, child)                  |
     /// | `calls`          | (from, to, dispatch, site)       |
-    /// | `publishes`      | (function, topic, site)          |
-    /// | `subscribes`     | (topic, handler, site)           |
+    /// | `publishes`      | (function, subject, site)        |
+    /// | `subscribes`     | (subject, handler, site)         |
+    /// | `dead_interface_calls` | (from, site)               |
     /// | `placed_in`      | (instance)                       |
     /// | `affined_to`     | (domain)                         |
     /// | `binds`          | (topic, binding)                 |
@@ -231,6 +240,11 @@ impl ApplicationModel {
             e.thread_domains.iter().map(|d| &d.name),
         )?;
         check_sorted_keys("groups", e.groups.iter().map(|g| &g.name))?;
+        check_sorted_keys("types", e.types.iter().map(|t| &t.name))?;
+        check_sorted_keys(
+            "interfaces",
+            e.interfaces.iter().map(|t| &t.name),
+        )?;
         check_sorted_keys(
             "bindings",
             e.bindings
@@ -308,6 +322,12 @@ impl ApplicationModel {
         for (i, g) in e.groups.iter().enumerate() {
             prov("groups", i, g.provenance)?;
         }
+        for (i, t) in e.types.iter().enumerate() {
+            prov("types", i, t.provenance)?;
+        }
+        for (i, t) in e.interfaces.iter().enumerate() {
+            prov("interfaces", i, t.provenance)?;
+        }
         for (i, b) in e.bindings.iter().enumerate() {
             if b.subject.index() >= subjects {
                 return Err(ModelError::DanglingId {
@@ -330,6 +350,11 @@ impl ApplicationModel {
                 EntityRef::ThreadDomain(id) => id.index() < domains,
                 EntityRef::Phase(id) => id.index() < phases,
                 EntityRef::Seed(id) => id.index() < seeds,
+                EntityRef::Group(id) => id.index() < e.groups.len(),
+                EntityRef::Type(id) => id.index() < e.types.len(),
+                EntityRef::Interface(id) => {
+                    id.index() < e.interfaces.len()
+                }
             }
         };
         // Does a hole hiding `family` anchor at `at`?
@@ -443,21 +468,51 @@ impl ApplicationModel {
             prov("calls", i, x.provenance)?;
         }
         check_sorted_keys(
+            "dead_interface_calls",
+            r.dead_interface_calls.iter().map(|x| (x.from, x.site)),
+        )?;
+        for (i, x) in r.dead_interface_calls.iter().enumerate() {
+            if x.from.index() >= fns {
+                return Err(ModelError::DanglingId {
+                    table: "dead_interface_calls",
+                    index: i,
+                });
+            }
+            prov("dead_interface_calls", i, x.provenance)?;
+        }
+        check_sorted_keys(
             "publishes",
             r.publishes
                 .iter()
-                .map(|x| (x.function, x.topic, x.site)),
+                .map(|x| (x.function, x.subject, x.site)),
         )?;
         for (i, x) in r.publishes.iter().enumerate() {
-            if x.function.index() >= fns || x.topic.index() >= topics {
+            if x.function.index() >= fns
+                || x.subject.index() >= subjects
+                || x.declared_topic
+                    .map(|t| t.index() >= topics)
+                    .unwrap_or(false)
+            {
                 return Err(ModelError::DanglingId {
                     table: "publishes",
                     index: i,
                 });
             }
-            // Keyed-ness must match the topic, both ways.
-            let topic_keyed =
-                e.topics[x.topic.index()].key.is_some();
+            // A declared topic's subject must agree with the row's.
+            if let Some(t) = x.declared_topic {
+                if e.topics[t.index()].subject != x.subject {
+                    return Err(ModelError::DeclaredTopicDisagrees {
+                        table: "publishes",
+                        index: i,
+                    });
+                }
+            }
+            // Keyed-ness must match the declared topic, both ways;
+            // an undeclared (literal/wildcard) endpoint is unkeyed.
+            let topic_keyed = x
+                .declared_topic
+                .map(|t| e.topics[t.index()].key.is_some())
+                .unwrap_or(false);
             if topic_keyed != x.key_domain.is_some() {
                 return Err(ModelError::KeyContract {
                     table: "publishes",
@@ -491,14 +546,27 @@ impl ApplicationModel {
             "subscribes",
             r.subscribes
                 .iter()
-                .map(|x| (x.topic, x.handler, x.site)),
+                .map(|x| (x.subject, x.handler, x.site)),
         )?;
         for (i, x) in r.subscribes.iter().enumerate() {
-            if x.topic.index() >= topics || x.handler.index() >= fns {
+            if x.subject.index() >= subjects
+                || x.handler.index() >= fns
+                || x.declared_topic
+                    .map(|t| t.index() >= topics)
+                    .unwrap_or(false)
+            {
                 return Err(ModelError::DanglingId {
                     table: "subscribes",
                     index: i,
                 });
+            }
+            if let Some(t) = x.declared_topic {
+                if e.topics[t.index()].subject != x.subject {
+                    return Err(ModelError::DeclaredTopicDisagrees {
+                        table: "subscribes",
+                        index: i,
+                    });
+                }
             }
             if matches!(x.capacity, crate::keys::Capacity::Bounded(0)) {
                 return Err(ModelError::InvalidBound {
@@ -506,9 +574,14 @@ impl ApplicationModel {
                     index: i,
                 });
             }
-            // A keyed predicate needs a keyed topic; unkeyed topics
-            // admit only the plain full-delivery subscription.
-            if e.topics[x.topic.index()].key.is_none()
+            // A keyed predicate needs a keyed declared topic;
+            // unkeyed and undeclared endpoints admit only the plain
+            // full-delivery subscription.
+            let sub_keyed = x
+                .declared_topic
+                .map(|t| e.topics[t.index()].key.is_some())
+                .unwrap_or(false);
+            if !sub_keyed
                 && !matches!(
                     x.key_predicate,
                     crate::keys::KeyPredicate::Any
@@ -540,10 +613,9 @@ impl ApplicationModel {
                 x.key_predicate,
                 crate::keys::KeyPredicate::Fallback
             );
-            let topic_policy = e.topics[x.topic.index()]
-                .key
-                .as_ref()
-                .map(|k| k.on_unmatched);
+            let topic_policy = x.declared_topic.and_then(|t| {
+                e.topics[t.index()].key.as_ref().map(|k| k.on_unmatched)
+            });
             if is_fallback_pred
                 && topic_policy
                     != Some(crate::keys::KeyOnUnmatched::Fallback)
@@ -562,7 +634,7 @@ impl ApplicationModel {
                 .unwrap_or(false);
             if wants_fallback
                 && !r.subscribes.iter().any(|x| {
-                    x.topic.index() == ti
+                    x.declared_topic.map(|t| t.index()) == Some(ti)
                         && matches!(
                             x.key_predicate,
                             crate::keys::KeyPredicate::Fallback

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -1,0 +1,463 @@
+//! The application-horizon root: one checked, closed application.
+//!
+//! Determinism is a law here, not a convention: every table is
+//! canonically sorted and deduplicated, checked by
+//! [`ApplicationModel::validate`]. Canonical iteration is what makes
+//! hashing, artifact projection, diffing, and rendering stable
+//! without forcing hot in-memory operations through ordered maps —
+//! sorting happens once, at the boundary where a model is finished.
+
+use crate::capability::Capabilities;
+use crate::entity::{
+    Binding, Function, LocusDecl, LocusInstance, PayloadContract, Phase,
+    Seed, Subject, ThreadDomain, Topic,
+};
+use crate::hole::Hole;
+use crate::ids::{EntityRef, ProvenanceId};
+use crate::provenance::ProvenanceTable;
+use crate::relation::{
+    AffinedTo, Call, DeclaredIn, MemberOf, Owns, PhaseOf, PlacedIn,
+    Publish, Realizes, Subscribe, Supervises, TopicBinding,
+};
+
+/// The meaning of the model's rows. Bumped when a row's
+/// interpretation changes — a schema addition is not a semantics
+/// bump; a reinterpretation is.
+pub const MODEL_SEMANTICS_V1: u32 = 1;
+
+/// Named hash algorithms over a model. The replay-compatibility law
+/// (crate docs): the first artifact encoder reproduces
+/// `TopologyShapeV1` byte-for-byte over the corpus before any
+/// cutover; richer identities are new *named* variants with a
+/// recording-format transition — the existing `u64` is never
+/// silently reinterpreted. (The projection itself is Change 3;
+/// naming the algorithm is Change 1, so nothing can ship an unnamed
+/// hash in the meantime.)
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ModelHashKind {
+    /// The legacy topology artifact shape hash: FNV-1a 64 over the
+    /// canonical serialized model half, exactly as
+    /// `hale-types::topology` emits it today.
+    TopologyShapeV1,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ModelHeader {
+    pub semantics: u32,
+    /// The application entrypoint (main locus name, or `main`).
+    pub entrypoint: String,
+}
+
+/// A free-form label on an entity (`labels` in the artifact).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct LabelRow {
+    pub at: EntityRef,
+    pub label: String,
+    pub provenance: ProvenanceId,
+}
+
+/// A quantitative fact (loop weights, cost classes) attached to an
+/// entity. Change 1 keeps the metric vocabulary open; the
+/// quantitative-judgment migration (Change 5d) closes it.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct WeightRow {
+    pub at: EntityRef,
+    pub metric: String,
+    pub value: u64,
+    pub provenance: ProvenanceId,
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct Entities {
+    pub functions: Vec<Function>,
+    pub loci: Vec<LocusDecl>,
+    pub locus_instances: Vec<LocusInstance>,
+    pub topics: Vec<Topic>,
+    pub subjects: Vec<Subject>,
+    pub payloads: Vec<PayloadContract>,
+    pub phases: Vec<Phase>,
+    pub seeds: Vec<Seed>,
+    pub thread_domains: Vec<ThreadDomain>,
+    pub bindings: Vec<Binding>,
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct Relations {
+    pub member_of: Vec<MemberOf>,
+    pub phase_of: Vec<PhaseOf>,
+    pub declared_in: Vec<DeclaredIn>,
+    pub realizes: Vec<Realizes>,
+    pub owns: Vec<Owns>,
+    pub calls: Vec<Call>,
+    pub publishes: Vec<Publish>,
+    pub subscribes: Vec<Subscribe>,
+    pub placed_in: Vec<PlacedIn>,
+    pub affined_to: Vec<AffinedTo>,
+    pub binds: Vec<TopicBinding>,
+    pub supervises: Vec<Supervises>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ApplicationModel {
+    pub header: ModelHeader,
+    pub entities: Entities,
+    pub relations: Relations,
+    pub labels: Vec<LabelRow>,
+    pub weights: Vec<WeightRow>,
+    pub holes: Vec<Hole>,
+    pub capabilities: Capabilities,
+    pub provenance: ProvenanceTable,
+}
+
+/// A violated model law. `validate` returns the FIRST violation —
+/// builders fix laws one at a time; consumers treat any error as
+/// "this value is not a model".
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ModelError {
+    /// A table is not canonically sorted + deduplicated. Carries the
+    /// table name and the first offending index.
+    NotCanonical { table: &'static str, index: usize },
+    /// A row references an ID outside its table.
+    DanglingId { table: &'static str, index: usize },
+    /// A row's provenance ID is out of range.
+    DanglingProvenance { table: &'static str, index: usize },
+    /// A hole that hides no relation family is not a hole.
+    EmptyHole { index: usize },
+    /// A capability claims exactness while a hole hides that
+    /// family — the two accounts of completeness drifted.
+    CapabilityContradiction { capability: &'static str },
+}
+
+impl ApplicationModel {
+    /// Check every model law. A value that fails is not a model and
+    /// must not be judged, hashed, projected, or composed.
+    pub fn validate(&self) -> Result<(), ModelError> {
+        let e = &self.entities;
+        let prov_len = self.provenance.records.len();
+
+        // --- canonical order: entity tables sort by canonical name.
+        check_sorted("functions", e.functions.iter().map(|f| &f.name))?;
+        check_sorted("loci", e.loci.iter().map(|l| &l.name))?;
+        check_sorted(
+            "locus_instances",
+            e.locus_instances.iter().map(|i| &i.path),
+        )?;
+        check_sorted("topics", e.topics.iter().map(|t| &t.name))?;
+        check_sorted("subjects", e.subjects.iter().map(|s| &s.pattern))?;
+        check_sorted("phases", e.phases.iter().map(|p| &p.name))?;
+        check_sorted("seeds", e.seeds.iter().map(|s| &s.name))?;
+        check_sorted(
+            "thread_domains",
+            e.thread_domains.iter().map(|d| &d.name),
+        )?;
+
+        // --- ID ranges + provenance for entities.
+        let fns = e.functions.len();
+        let loci = e.loci.len();
+        let insts = e.locus_instances.len();
+        let topics = e.topics.len();
+        let subjects = e.subjects.len();
+        let payloads = e.payloads.len();
+        let phases = e.phases.len();
+        let seeds = e.seeds.len();
+        let domains = e.thread_domains.len();
+        let bindings = e.bindings.len();
+
+        let prov = |table, index, p: ProvenanceId| {
+            if p.index() >= prov_len {
+                Err(ModelError::DanglingProvenance { table, index })
+            } else {
+                Ok(())
+            }
+        };
+        for (i, f) in e.functions.iter().enumerate() {
+            prov("functions", i, f.provenance)?;
+        }
+        for (i, l) in e.loci.iter().enumerate() {
+            prov("loci", i, l.provenance)?;
+        }
+        for (i, inst) in e.locus_instances.iter().enumerate() {
+            if inst.decl.index() >= loci {
+                return Err(ModelError::DanglingId {
+                    table: "locus_instances",
+                    index: i,
+                });
+            }
+            prov("locus_instances", i, inst.provenance)?;
+        }
+        for (i, t) in e.topics.iter().enumerate() {
+            if t.subject.index() >= subjects || t.payload.index() >= payloads
+            {
+                return Err(ModelError::DanglingId {
+                    table: "topics",
+                    index: i,
+                });
+            }
+            prov("topics", i, t.provenance)?;
+        }
+        for (i, s) in e.subjects.iter().enumerate() {
+            prov("subjects", i, s.provenance)?;
+        }
+        for (i, p) in e.payloads.iter().enumerate() {
+            prov("payloads", i, p.provenance)?;
+        }
+        for (i, p) in e.phases.iter().enumerate() {
+            prov("phases", i, p.provenance)?;
+        }
+        for (i, s) in e.seeds.iter().enumerate() {
+            prov("seeds", i, s.provenance)?;
+        }
+        for (i, d) in e.thread_domains.iter().enumerate() {
+            prov("thread_domains", i, d.provenance)?;
+        }
+        for (i, b) in e.bindings.iter().enumerate() {
+            if b.subject.index() >= subjects {
+                return Err(ModelError::DanglingId {
+                    table: "bindings",
+                    index: i,
+                });
+            }
+            prov("bindings", i, b.provenance)?;
+        }
+
+        // --- entity-ref bound check, shared.
+        let ref_ok = |r: &EntityRef| -> bool {
+            match r {
+                EntityRef::Function(id) => id.index() < fns,
+                EntityRef::LocusDecl(id) => id.index() < loci,
+                EntityRef::LocusInstance(id) => id.index() < insts,
+                EntityRef::Topic(id) => id.index() < topics,
+                EntityRef::Subject(id) => id.index() < subjects,
+                EntityRef::Binding(id) => id.index() < bindings,
+                EntityRef::ThreadDomain(id) => id.index() < domains,
+                EntityRef::Phase(id) => id.index() < phases,
+                EntityRef::Seed(id) => id.index() < seeds,
+            }
+        };
+
+        // --- relations: canonical order, ranges, provenance.
+        let r = &self.relations;
+        check_sorted_keys(
+            "member_of",
+            r.member_of.iter().map(|x| (x.function, x.locus)),
+        )?;
+        for (i, x) in r.member_of.iter().enumerate() {
+            if x.function.index() >= fns || x.locus.index() >= loci {
+                return Err(ModelError::DanglingId {
+                    table: "member_of",
+                    index: i,
+                });
+            }
+            prov("member_of", i, x.provenance)?;
+        }
+        check_sorted_keys(
+            "phase_of",
+            r.phase_of.iter().map(|x| (x.function, x.phase)),
+        )?;
+        for (i, x) in r.phase_of.iter().enumerate() {
+            if x.function.index() >= fns || x.phase.index() >= phases {
+                return Err(ModelError::DanglingId {
+                    table: "phase_of",
+                    index: i,
+                });
+            }
+            prov("phase_of", i, x.provenance)?;
+        }
+        for (i, x) in r.declared_in.iter().enumerate() {
+            if !ref_ok(&x.entity) || x.seed.index() >= seeds {
+                return Err(ModelError::DanglingId {
+                    table: "declared_in",
+                    index: i,
+                });
+            }
+            prov("declared_in", i, x.provenance)?;
+        }
+        check_sorted_keys(
+            "realizes",
+            r.realizes.iter().map(|x| (x.instance, x.decl)),
+        )?;
+        for (i, x) in r.realizes.iter().enumerate() {
+            if x.instance.index() >= insts || x.decl.index() >= loci {
+                return Err(ModelError::DanglingId {
+                    table: "realizes",
+                    index: i,
+                });
+            }
+            prov("realizes", i, x.provenance)?;
+        }
+        check_sorted_keys("owns", r.owns.iter().map(|x| (x.parent, x.child)))?;
+        for (i, x) in r.owns.iter().enumerate() {
+            if x.parent.index() >= insts || x.child.index() >= insts {
+                return Err(ModelError::DanglingId {
+                    table: "owns",
+                    index: i,
+                });
+            }
+            prov("owns", i, x.provenance)?;
+        }
+        for (i, x) in r.calls.iter().enumerate() {
+            if x.from.index() >= fns || x.to.index() >= fns {
+                return Err(ModelError::DanglingId {
+                    table: "calls",
+                    index: i,
+                });
+            }
+            prov("calls", i, x.provenance)?;
+        }
+        for (i, x) in r.publishes.iter().enumerate() {
+            if x.function.index() >= fns || x.topic.index() >= topics {
+                return Err(ModelError::DanglingId {
+                    table: "publishes",
+                    index: i,
+                });
+            }
+            prov("publishes", i, x.provenance)?;
+        }
+        for (i, x) in r.subscribes.iter().enumerate() {
+            if x.topic.index() >= topics || x.handler.index() >= fns {
+                return Err(ModelError::DanglingId {
+                    table: "subscribes",
+                    index: i,
+                });
+            }
+            prov("subscribes", i, x.provenance)?;
+        }
+        for (i, x) in r.placed_in.iter().enumerate() {
+            if x.instance.index() >= insts || x.domain.index() >= domains {
+                return Err(ModelError::DanglingId {
+                    table: "placed_in",
+                    index: i,
+                });
+            }
+            prov("placed_in", i, x.provenance)?;
+        }
+        for (i, x) in r.affined_to.iter().enumerate() {
+            if x.domain.index() >= domains {
+                return Err(ModelError::DanglingId {
+                    table: "affined_to",
+                    index: i,
+                });
+            }
+            prov("affined_to", i, x.provenance)?;
+        }
+        for (i, x) in r.binds.iter().enumerate() {
+            if x.topic.index() >= topics || x.binding.index() >= bindings {
+                return Err(ModelError::DanglingId {
+                    table: "binds",
+                    index: i,
+                });
+            }
+            prov("binds", i, x.provenance)?;
+        }
+        for (i, x) in r.supervises.iter().enumerate() {
+            if x.parent.index() >= loci || x.child.index() >= loci {
+                return Err(ModelError::DanglingId {
+                    table: "supervises",
+                    index: i,
+                });
+            }
+            prov("supervises", i, x.provenance)?;
+        }
+
+        // --- labels / weights.
+        for (i, l) in self.labels.iter().enumerate() {
+            if !ref_ok(&l.at) {
+                return Err(ModelError::DanglingId {
+                    table: "labels",
+                    index: i,
+                });
+            }
+            prov("labels", i, l.provenance)?;
+        }
+        for (i, w) in self.weights.iter().enumerate() {
+            if !ref_ok(&w.at) {
+                return Err(ModelError::DanglingId {
+                    table: "weights",
+                    index: i,
+                });
+            }
+            prov("weights", i, w.provenance)?;
+        }
+
+        // --- holes: anchored, non-empty, provenanced.
+        for (i, h) in self.holes.iter().enumerate() {
+            if !ref_ok(&h.at) {
+                return Err(ModelError::DanglingId {
+                    table: "holes",
+                    index: i,
+                });
+            }
+            if h.hides.is_empty() {
+                return Err(ModelError::EmptyHole { index: i });
+            }
+            prov("holes", i, h.provenance)?;
+        }
+
+        // --- capability/hole contradiction: exactness may not be
+        // claimed for a family any hole hides.
+        for (claimed, family) in self.capabilities.vouched_families() {
+            if !claimed {
+                continue;
+            }
+            if self.holes.iter().any(|h| h.hides.intersects(family)) {
+                let capability = match family.0 {
+                    x if x == crate::hole::RelationSet::CALLS.0 => {
+                        "exact_calls"
+                    }
+                    x if x == crate::hole::RelationSet::OWNS.0 => {
+                        "exact_ownership"
+                    }
+                    x if x == crate::hole::RelationSet::PLACED.0 => {
+                        "exact_placement"
+                    }
+                    x if x == crate::hole::RelationSet::ROUTES.0 => {
+                        "exact_routes"
+                    }
+                    x if x == crate::hole::RelationSet::EFFECTS.0 => {
+                        "exact_effects"
+                    }
+                    _ => "exact_bus_endpoints",
+                };
+                return Err(ModelError::CapabilityContradiction {
+                    capability,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+fn check_sorted<'a, I>(table: &'static str, names: I) -> Result<(), ModelError>
+where
+    I: Iterator<Item = &'a String>,
+{
+    let mut prev: Option<&str> = None;
+    for (i, n) in names.enumerate() {
+        if let Some(p) = prev {
+            if p >= n.as_str() {
+                return Err(ModelError::NotCanonical { table, index: i });
+            }
+        }
+        prev = Some(n);
+    }
+    Ok(())
+}
+
+fn check_sorted_keys<K: Ord, I>(
+    table: &'static str,
+    keys: I,
+) -> Result<(), ModelError>
+where
+    I: Iterator<Item = K>,
+{
+    let mut prev: Option<K> = None;
+    for (i, k) in keys.enumerate() {
+        if let Some(p) = &prev {
+            if *p >= k {
+                return Err(ModelError::NotCanonical { table, index: i });
+            }
+        }
+        prev = Some(k);
+    }
+    Ok(())
+}

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -9,16 +9,15 @@
 
 use crate::capability::Capabilities;
 use crate::entity::{
-    Binding, Function, Group, InterfaceDecl, LocusDecl, LocusInstance,
+    Binding, Declaration, Function, Group, InterfaceDecl, LocusDecl, LocusInstance,
     PayloadContract, Phase, Seed, Subject, ThreadDomain, Topic, TypeDecl,
 };
 use crate::hole::Hole;
 use crate::ids::{EntityRef, ProvenanceId};
 use crate::provenance::{Provenance, ProvenanceTable};
 use crate::relation::{
-    AffinedTo, Call, DeadInterfaceCall, DeclaredIn, GroupMember, MemberOf,
-    Owns, PhaseOf, PlacedIn, Publish, Realizes, Subscribe, Supervises,
-    TopicBinding,
+    AffinedTo, Call, DeadInterfaceCall, DeclaredIn, GroupMember, MemberOf, Owns, PhaseOf, PlacedIn,
+    Publish, Realizes, Subscribe, Supervises, TopicBinding,
 };
 
 /// The meaning of the model's rows. Bumped when a row's
@@ -83,6 +82,9 @@ pub struct Entities {
     pub groups: Vec<Group>,
     pub types: Vec<TypeDecl>,
     pub interfaces: Vec<InterfaceDecl>,
+    /// Seed-membership-only declarations (perspective, const, ring
+    /// layout, target) — the rest of the nameable universe.
+    pub declarations: Vec<Declaration>,
 }
 
 #[derive(Clone, Default, Debug)]
@@ -171,6 +173,9 @@ pub enum ModelError {
     /// differs from the row's own subject — one endpoint, two
     /// addresses.
     DeclaredTopicDisagrees { table: &'static str, index: usize },
+    /// A bus row's payload contract differs from its declared
+    /// topic's — one endpoint, two shapes.
+    EndpointPayloadDisagrees { table: &'static str, index: usize },
 }
 
 impl ApplicationModel {
@@ -213,9 +218,7 @@ impl ApplicationModel {
         for (i, rec) in self.provenance.records.iter().enumerate() {
             if let Provenance::Source { source, span } = rec {
                 if source.index() >= src_len || span.0 > span.1 {
-                    return Err(ModelError::InvalidProvenanceRecord {
-                        index: i,
-                    });
+                    return Err(ModelError::InvalidProvenanceRecord { index: i });
                 }
             }
         }
@@ -223,27 +226,19 @@ impl ApplicationModel {
         // --- canonical order: entity tables sort by canonical name.
         check_sorted_keys("functions", e.functions.iter().map(|f| &f.name))?;
         check_sorted_keys("loci", e.loci.iter().map(|l| &l.name))?;
-        check_sorted_keys(
-            "locus_instances",
-            e.locus_instances.iter().map(|i| &i.path),
-        )?;
+        check_sorted_keys("locus_instances", e.locus_instances.iter().map(|i| &i.path))?;
         check_sorted_keys("topics", e.topics.iter().map(|t| &t.name))?;
         check_sorted_keys("subjects", e.subjects.iter().map(|s| &s.pattern))?;
-        check_sorted_keys(
-            "payloads",
-            e.payloads.iter().map(|p| (&p.shape, p.hash)),
-        )?;
+        check_sorted_keys("payloads", e.payloads.iter().map(|p| (&p.shape, p.hash)))?;
         check_sorted_keys("phases", e.phases.iter().map(|p| &p.name))?;
         check_sorted_keys("seeds", e.seeds.iter().map(|s| &s.name))?;
-        check_sorted_keys(
-            "thread_domains",
-            e.thread_domains.iter().map(|d| &d.name),
-        )?;
+        check_sorted_keys("thread_domains", e.thread_domains.iter().map(|d| &d.name))?;
         check_sorted_keys("groups", e.groups.iter().map(|g| &g.name))?;
         check_sorted_keys("types", e.types.iter().map(|t| &t.name))?;
+        check_sorted_keys("interfaces", e.interfaces.iter().map(|t| &t.name))?;
         check_sorted_keys(
-            "interfaces",
-            e.interfaces.iter().map(|t| &t.name),
+            "declarations",
+            e.declarations.iter().map(|d| (&d.name, d.kind)),
         )?;
         check_sorted_keys(
             "bindings",
@@ -287,8 +282,7 @@ impl ApplicationModel {
             prov("locus_instances", i, inst.provenance)?;
         }
         for (i, t) in e.topics.iter().enumerate() {
-            if t.subject.index() >= subjects || t.payload.index() >= payloads
-            {
+            if t.subject.index() >= subjects || t.payload.index() >= payloads {
                 return Err(ModelError::DanglingId {
                     table: "topics",
                     index: i,
@@ -328,6 +322,9 @@ impl ApplicationModel {
         for (i, t) in e.interfaces.iter().enumerate() {
             prov("interfaces", i, t.provenance)?;
         }
+        for (i, d) in e.declarations.iter().enumerate() {
+            prov("declarations", i, d.provenance)?;
+        }
         for (i, b) in e.bindings.iter().enumerate() {
             if b.subject.index() >= subjects {
                 return Err(ModelError::DanglingId {
@@ -352,9 +349,8 @@ impl ApplicationModel {
                 EntityRef::Seed(id) => id.index() < seeds,
                 EntityRef::Group(id) => id.index() < e.groups.len(),
                 EntityRef::Type(id) => id.index() < e.types.len(),
-                EntityRef::Interface(id) => {
-                    id.index() < e.interfaces.len()
-                }
+                EntityRef::Interface(id) => id.index() < e.interfaces.len(),
+                EntityRef::Declaration(id) => id.index() < e.declarations.len(),
             }
         };
         // Does a hole hiding `family` anchor at `at`?
@@ -380,10 +376,7 @@ impl ApplicationModel {
             }
             prov("member_of", i, x.provenance)?;
         }
-        check_sorted_keys(
-            "phase_of",
-            r.phase_of.iter().map(|x| (x.function, x.phase)),
-        )?;
+        check_sorted_keys("phase_of", r.phase_of.iter().map(|x| (x.function, x.phase)))?;
         for (i, x) in r.phase_of.iter().enumerate() {
             if x.function.index() >= fns || x.phase.index() >= phases {
                 return Err(ModelError::DanglingId {
@@ -406,10 +399,7 @@ impl ApplicationModel {
             }
             prov("declared_in", i, x.provenance)?;
         }
-        check_sorted_keys(
-            "realizes",
-            r.realizes.iter().map(|x| (x.instance, x.decl)),
-        )?;
+        check_sorted_keys("realizes", r.realizes.iter().map(|x| (x.instance, x.decl)))?;
         for (i, x) in r.realizes.iter().enumerate() {
             if x.instance.index() >= insts || x.decl.index() >= loci {
                 return Err(ModelError::DanglingId {
@@ -423,23 +413,14 @@ impl ApplicationModel {
         // instance's own `decl` field: one fact, two access paths,
         // provably identical.
         for (i, inst) in e.locus_instances.iter().enumerate() {
-            let mut rows = r
-                .realizes
-                .iter()
-                .filter(|x| x.instance.index() == i);
+            let mut rows = r.realizes.iter().filter(|x| x.instance.index() == i);
             match (rows.next(), rows.next()) {
                 (Some(row), None) => {
                     if row.decl != inst.decl {
-                        return Err(ModelError::RealizesDisagrees {
-                            index: i,
-                        });
+                        return Err(ModelError::RealizesDisagrees { index: i });
                     }
                 }
-                _ => {
-                    return Err(ModelError::RealizesIncomplete {
-                        instance: i,
-                    })
-                }
+                _ => return Err(ModelError::RealizesIncomplete { instance: i }),
             }
         }
         check_sorted_keys("owns", r.owns.iter().map(|x| (x.parent, x.child)))?;
@@ -482,9 +463,7 @@ impl ApplicationModel {
         }
         check_sorted_keys(
             "publishes",
-            r.publishes
-                .iter()
-                .map(|x| (x.function, x.subject, x.site)),
+            r.publishes.iter().map(|x| (x.function, x.subject, x.site)),
         )?;
         for (i, x) in r.publishes.iter().enumerate() {
             if x.function.index() >= fns
@@ -498,10 +477,23 @@ impl ApplicationModel {
                     index: i,
                 });
             }
-            // A declared topic's subject must agree with the row's.
+            if x.payload.index() >= payloads {
+                return Err(ModelError::DanglingId {
+                    table: "publishes",
+                    index: i,
+                });
+            }
+            // A declared topic's subject AND payload must agree
+            // with the row's.
             if let Some(t) = x.declared_topic {
                 if e.topics[t.index()].subject != x.subject {
                     return Err(ModelError::DeclaredTopicDisagrees {
+                        table: "publishes",
+                        index: i,
+                    });
+                }
+                if e.topics[t.index()].payload != x.payload {
+                    return Err(ModelError::EndpointPayloadDisagrees {
                         table: "publishes",
                         index: i,
                     });
@@ -519,22 +511,20 @@ impl ApplicationModel {
                     index: i,
                 });
             }
-            if let Some(crate::keys::KeyDomain::Exact(vals)) =
-                &x.key_domain
-            {
-                check_sorted_keys("publishes.key_domain", vals.iter())
-                    .map_err(|_| ModelError::NotCanonical {
+            if let Some(crate::keys::KeyDomain::Exact(vals)) = &x.key_domain {
+                check_sorted_keys("publishes.key_domain", vals.iter()).map_err(|_| {
+                    ModelError::NotCanonical {
                         table: "publishes.key_domain",
                         index: i,
-                    })?;
+                    }
+                })?;
             }
-            if matches!(
-                x.key_domain,
-                Some(crate::keys::KeyDomain::Unknown)
-            ) && !hole_at(
-                EntityRef::Function(x.function),
-                crate::hole::RelationSet::KEY_FILTERS,
-            ) {
+            if matches!(x.key_domain, Some(crate::keys::KeyDomain::Unknown))
+                && !hole_at(
+                    EntityRef::Function(x.function),
+                    crate::hole::RelationSet::KEY_FILTERS,
+                )
+            {
                 return Err(ModelError::UnrepresentedUnknown {
                     table: "publishes",
                     index: i,
@@ -544,9 +534,7 @@ impl ApplicationModel {
         }
         check_sorted_keys(
             "subscribes",
-            r.subscribes
-                .iter()
-                .map(|x| (x.subject, x.handler, x.site)),
+            r.subscribes.iter().map(|x| (x.subject, x.handler, x.site)),
         )?;
         for (i, x) in r.subscribes.iter().enumerate() {
             if x.subject.index() >= subjects
@@ -560,9 +548,21 @@ impl ApplicationModel {
                     index: i,
                 });
             }
+            if x.payload.index() >= payloads {
+                return Err(ModelError::DanglingId {
+                    table: "subscribes",
+                    index: i,
+                });
+            }
             if let Some(t) = x.declared_topic {
                 if e.topics[t.index()].subject != x.subject {
                     return Err(ModelError::DeclaredTopicDisagrees {
+                        table: "subscribes",
+                        index: i,
+                    });
+                }
+                if e.topics[t.index()].payload != x.payload {
+                    return Err(ModelError::EndpointPayloadDisagrees {
                         table: "subscribes",
                         index: i,
                     });
@@ -581,24 +581,18 @@ impl ApplicationModel {
                 .declared_topic
                 .map(|t| e.topics[t.index()].key.is_some())
                 .unwrap_or(false);
-            if !sub_keyed
-                && !matches!(
-                    x.key_predicate,
-                    crate::keys::KeyPredicate::Any
-                )
-            {
+            if !sub_keyed && !matches!(x.key_predicate, crate::keys::KeyPredicate::Any) {
                 return Err(ModelError::KeyContract {
                     table: "subscribes",
                     index: i,
                 });
             }
-            if matches!(
-                x.key_predicate,
-                crate::keys::KeyPredicate::Unknown
-            ) && !hole_at(
-                EntityRef::Function(x.handler),
-                crate::hole::RelationSet::KEY_FILTERS,
-            ) {
+            if matches!(x.key_predicate, crate::keys::KeyPredicate::Unknown)
+                && !hole_at(
+                    EntityRef::Function(x.handler),
+                    crate::hole::RelationSet::KEY_FILTERS,
+                )
+            {
                 return Err(ModelError::UnrepresentedUnknown {
                     table: "subscribes",
                     index: i,
@@ -609,17 +603,11 @@ impl ApplicationModel {
         // Fallback contract, both directions: `_` only on fallback
         // topics; fallback topics have their catch.
         for (i, x) in r.subscribes.iter().enumerate() {
-            let is_fallback_pred = matches!(
-                x.key_predicate,
-                crate::keys::KeyPredicate::Fallback
-            );
-            let topic_policy = x.declared_topic.and_then(|t| {
-                e.topics[t.index()].key.as_ref().map(|k| k.on_unmatched)
-            });
-            if is_fallback_pred
-                && topic_policy
-                    != Some(crate::keys::KeyOnUnmatched::Fallback)
-            {
+            let is_fallback_pred = matches!(x.key_predicate, crate::keys::KeyPredicate::Fallback);
+            let topic_policy = x
+                .declared_topic
+                .and_then(|t| e.topics[t.index()].key.as_ref().map(|k| k.on_unmatched));
+            if is_fallback_pred && topic_policy != Some(crate::keys::KeyOnUnmatched::Fallback) {
                 return Err(ModelError::IllegalFallback { index: i });
             }
         }
@@ -627,27 +615,18 @@ impl ApplicationModel {
             let wants_fallback = t
                 .key
                 .as_ref()
-                .map(|k| {
-                    k.on_unmatched
-                        == crate::keys::KeyOnUnmatched::Fallback
-                })
+                .map(|k| k.on_unmatched == crate::keys::KeyOnUnmatched::Fallback)
                 .unwrap_or(false);
             if wants_fallback
                 && !r.subscribes.iter().any(|x| {
                     x.declared_topic.map(|t| t.index()) == Some(ti)
-                        && matches!(
-                            x.key_predicate,
-                            crate::keys::KeyPredicate::Fallback
-                        )
+                        && matches!(x.key_predicate, crate::keys::KeyPredicate::Fallback)
                 })
             {
                 return Err(ModelError::FallbackUncovered { topic: ti });
             }
         }
-        check_sorted_keys(
-            "placed_in",
-            r.placed_in.iter().map(|x| x.instance),
-        )?;
+        check_sorted_keys("placed_in", r.placed_in.iter().map(|x| x.instance))?;
         for (i, x) in r.placed_in.iter().enumerate() {
             if x.instance.index() >= insts || x.domain.index() >= domains {
                 return Err(ModelError::DanglingId {
@@ -657,10 +636,7 @@ impl ApplicationModel {
             }
             prov("placed_in", i, x.provenance)?;
         }
-        check_sorted_keys(
-            "affined_to",
-            r.affined_to.iter().map(|x| x.domain),
-        )?;
+        check_sorted_keys("affined_to", r.affined_to.iter().map(|x| x.domain))?;
         for (i, x) in r.affined_to.iter().enumerate() {
             if x.domain.index() >= domains {
                 return Err(ModelError::DanglingId {
@@ -668,18 +644,15 @@ impl ApplicationModel {
                     index: i,
                 });
             }
-            check_sorted_keys("affined_to.cores", x.cores.0.iter()).map_err(
-                |_| ModelError::NotCanonical {
+            check_sorted_keys("affined_to.cores", x.cores.0.iter()).map_err(|_| {
+                ModelError::NotCanonical {
                     table: "affined_to.cores",
                     index: i,
-                },
-            )?;
+                }
+            })?;
             prov("affined_to", i, x.provenance)?;
         }
-        check_sorted_keys(
-            "binds",
-            r.binds.iter().map(|x| (x.topic, x.binding)),
-        )?;
+        check_sorted_keys("binds", r.binds.iter().map(|x| (x.topic, x.binding)))?;
         for (i, x) in r.binds.iter().enumerate() {
             if x.topic.index() >= topics || x.binding.index() >= bindings {
                 return Err(ModelError::DanglingId {
@@ -689,12 +662,8 @@ impl ApplicationModel {
             }
             // The topic's subject and the binding's subject repeat
             // one fact — they must agree.
-            if e.topics[x.topic.index()].subject
-                != e.bindings[x.binding.index()].subject
-            {
-                return Err(ModelError::BindingSubjectDisagrees {
-                    index: i,
-                });
+            if e.topics[x.topic.index()].subject != e.bindings[x.binding.index()].subject {
+                return Err(ModelError::BindingSubjectDisagrees { index: i });
             }
             prov("binds", i, x.provenance)?;
         }
@@ -730,10 +699,7 @@ impl ApplicationModel {
         }
 
         // --- labels / weights.
-        check_sorted_keys(
-            "labels",
-            self.labels.iter().map(|l| (l.at, &l.label)),
-        )?;
+        check_sorted_keys("labels", self.labels.iter().map(|l| (l.at, &l.label)))?;
         for (i, l) in self.labels.iter().enumerate() {
             if !ref_ok(&l.at) {
                 return Err(ModelError::DanglingId {
@@ -743,10 +709,7 @@ impl ApplicationModel {
             }
             prov("labels", i, l.provenance)?;
         }
-        check_sorted_keys(
-            "weights",
-            self.weights.iter().map(|w| (w.at, &w.metric)),
-        )?;
+        check_sorted_keys("weights", self.weights.iter().map(|w| (w.at, &w.metric)))?;
         for (i, w) in self.weights.iter().enumerate() {
             if !ref_ok(&w.at) {
                 return Err(ModelError::DanglingId {
@@ -760,9 +723,7 @@ impl ApplicationModel {
         // --- holes: canonical, anchored, non-empty, provenanced.
         check_sorted_keys(
             "holes",
-            self.holes
-                .iter()
-                .map(|h| (h.at, h.kind.clone(), &h.reason)),
+            self.holes.iter().map(|h| (h.at, h.kind.clone(), &h.reason)),
         )?;
         for (i, h) in self.holes.iter().enumerate() {
             if !ref_ok(&h.at) {
@@ -780,15 +741,12 @@ impl ApplicationModel {
         // --- capability/hole contradiction: exactness may not be
         // claimed for a family any hole hides. Every capability is
         // mapped (an unmapped flag would be unfalsifiable).
-        for (name, claimed, family) in self.capabilities.vouched_families()
-        {
+        for (name, claimed, family) in self.capabilities.vouched_families() {
             if !claimed {
                 continue;
             }
             if self.holes.iter().any(|h| h.hides.intersects(family)) {
-                return Err(ModelError::CapabilityContradiction {
-                    capability: name,
-                });
+                return Err(ModelError::CapabilityContradiction { capability: name });
             }
         }
         Ok(())
@@ -797,10 +755,7 @@ impl ApplicationModel {
 
 /// Strictly-increasing check over a table's canonical keys —
 /// enforces sorted AND deduplicated in one pass.
-fn check_sorted_keys<K: Ord, I>(
-    table: &'static str,
-    keys: I,
-) -> Result<(), ModelError>
+fn check_sorted_keys<K: Ord, I>(table: &'static str, keys: I) -> Result<(), ModelError>
 where
     I: Iterator<Item = K>,
 {

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -14,7 +14,7 @@ use crate::entity::{
 };
 use crate::hole::Hole;
 use crate::ids::{EntityRef, ProvenanceId};
-use crate::provenance::ProvenanceTable;
+use crate::provenance::{Provenance, ProvenanceTable};
 use crate::relation::{
     AffinedTo, Call, DeclaredIn, MemberOf, Owns, PhaseOf, PlacedIn,
     Publish, Realizes, Subscribe, Supervises, TopicBinding,
@@ -114,41 +114,110 @@ pub struct ApplicationModel {
 /// "this value is not a model".
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ModelError {
-    /// A table is not canonically sorted + deduplicated. Carries the
-    /// table name and the first offending index.
+    /// A table (or set-like nested vector) is not canonically
+    /// sorted + deduplicated by its semantic key. Carries the table
+    /// name and the first offending index.
     NotCanonical { table: &'static str, index: usize },
     /// A row references an ID outside its table.
     DanglingId { table: &'static str, index: usize },
     /// A row's provenance ID is out of range.
     DanglingProvenance { table: &'static str, index: usize },
+    /// A provenance record's contents are unresolvable: a dangling
+    /// `SourceId` or an inverted span.
+    InvalidProvenanceRecord { index: usize },
     /// A hole that hides no relation family is not a hole.
     EmptyHole { index: usize },
     /// A capability claims exactness while a hole hides that
     /// family — the two accounts of completeness drifted.
     CapabilityContradiction { capability: &'static str },
+    /// A row carries an inline `Unknown` (key domain / predicate)
+    /// with no typed hole hiding KEY_FILTERS at its anchor — an
+    /// unknown may not hide inside an otherwise resolved row.
+    UnrepresentedUnknown { table: &'static str, index: usize },
+    /// A zero capacity: `Bounded(0)` / a zero topic bound is
+    /// excluded by the settled bounds design (GH #255).
+    InvalidBound { table: &'static str, index: usize },
+    /// A locus instance's `decl` field and its `realizes` row
+    /// disagree — two authorities for one fact drifted.
+    RealizesDisagrees { index: usize },
+    /// A locus instance has no (or more than one) `realizes` row:
+    /// the relational projection is not total.
+    RealizesIncomplete { instance: usize },
+    /// A `binds` row joins a topic and a binding whose subjects
+    /// disagree — the entity attribute and the relation repeat one
+    /// fact and drifted.
+    BindingSubjectDisagrees { index: usize },
 }
 
 impl ApplicationModel {
     /// Check every model law. A value that fails is not a model and
     /// must not be judged, hashed, projected, or composed.
+    ///
+    /// Canonical keys (strictly increasing — sorted AND
+    /// deduplicated; attributes outside the key are merged by the
+    /// builder, never duplicated into extra rows):
+    ///
+    /// | table            | key                              |
+    /// |------------------|----------------------------------|
+    /// | entity tables    | canonical name / path / pattern  |
+    /// | `payloads`       | (shape, hash)                    |
+    /// | `bindings`       | (subject, transport, role)       |
+    /// | `member_of`      | (function, locus)                |
+    /// | `phase_of`       | (function, phase)                |
+    /// | `declared_in`    | (entity, seed)                   |
+    /// | `realizes`       | (instance, decl)                 |
+    /// | `owns`           | (parent, child)                  |
+    /// | `calls`          | (from, to, dispatch)             |
+    /// | `publishes`      | (function, topic)                |
+    /// | `subscribes`     | (topic, handler)                 |
+    /// | `placed_in`      | (instance)                       |
+    /// | `affined_to`     | (domain)                         |
+    /// | `binds`          | (topic, binding)                 |
+    /// | `supervises`     | (parent, child)                  |
+    /// | `labels`         | (at, label)                      |
+    /// | `weights`        | (at, metric)                     |
+    /// | `holes`          | (at, kind, reason)               |
+    /// | nested key sets  | `KeyDomain::Exact`, `CoreSet`    |
     pub fn validate(&self) -> Result<(), ModelError> {
         let e = &self.entities;
         let prov_len = self.provenance.records.len();
 
+        // --- provenance record contents resolve.
+        let src_len = self.provenance.sources.len();
+        for (i, rec) in self.provenance.records.iter().enumerate() {
+            if let Provenance::Source { source, span } = rec {
+                if source.index() >= src_len || span.0 > span.1 {
+                    return Err(ModelError::InvalidProvenanceRecord {
+                        index: i,
+                    });
+                }
+            }
+        }
+
         // --- canonical order: entity tables sort by canonical name.
-        check_sorted("functions", e.functions.iter().map(|f| &f.name))?;
-        check_sorted("loci", e.loci.iter().map(|l| &l.name))?;
-        check_sorted(
+        check_sorted_keys("functions", e.functions.iter().map(|f| &f.name))?;
+        check_sorted_keys("loci", e.loci.iter().map(|l| &l.name))?;
+        check_sorted_keys(
             "locus_instances",
             e.locus_instances.iter().map(|i| &i.path),
         )?;
-        check_sorted("topics", e.topics.iter().map(|t| &t.name))?;
-        check_sorted("subjects", e.subjects.iter().map(|s| &s.pattern))?;
-        check_sorted("phases", e.phases.iter().map(|p| &p.name))?;
-        check_sorted("seeds", e.seeds.iter().map(|s| &s.name))?;
-        check_sorted(
+        check_sorted_keys("topics", e.topics.iter().map(|t| &t.name))?;
+        check_sorted_keys("subjects", e.subjects.iter().map(|s| &s.pattern))?;
+        check_sorted_keys(
+            "payloads",
+            e.payloads.iter().map(|p| (&p.shape, p.hash)),
+        )?;
+        check_sorted_keys("phases", e.phases.iter().map(|p| &p.name))?;
+        check_sorted_keys("seeds", e.seeds.iter().map(|s| &s.name))?;
+        check_sorted_keys(
             "thread_domains",
             e.thread_domains.iter().map(|d| &d.name),
+        )?;
+        check_sorted_keys(
+            "bindings",
+            e.bindings
+                .iter()
+                .map(|b| (b.subject, b.transport.clone(), b.role)),
         )?;
 
         // --- ID ranges + provenance for entities.
@@ -193,6 +262,14 @@ impl ApplicationModel {
                     index: i,
                 });
             }
+            if let Some(b) = &t.bound {
+                if b.capacity == 0 {
+                    return Err(ModelError::InvalidBound {
+                        table: "topics",
+                        index: i,
+                    });
+                }
+            }
             prov("topics", i, t.provenance)?;
         }
         for (i, s) in e.subjects.iter().enumerate() {
@@ -234,8 +311,15 @@ impl ApplicationModel {
                 EntityRef::Seed(id) => id.index() < seeds,
             }
         };
+        // Does a hole hiding `family` anchor at `at`?
+        let hole_at = |at: EntityRef, family: crate::hole::RelationSet| {
+            self.holes
+                .iter()
+                .any(|h| h.at == at && h.hides.intersects(family))
+        };
 
-        // --- relations: canonical order, ranges, provenance.
+        // --- relations: canonical order, ranges, provenance, and
+        // the cross-authority agreement laws.
         let r = &self.relations;
         check_sorted_keys(
             "member_of",
@@ -263,6 +347,10 @@ impl ApplicationModel {
             }
             prov("phase_of", i, x.provenance)?;
         }
+        check_sorted_keys(
+            "declared_in",
+            r.declared_in.iter().map(|x| (x.entity, x.seed)),
+        )?;
         for (i, x) in r.declared_in.iter().enumerate() {
             if !ref_ok(&x.entity) || x.seed.index() >= seeds {
                 return Err(ModelError::DanglingId {
@@ -285,6 +373,29 @@ impl ApplicationModel {
             }
             prov("realizes", i, x.provenance)?;
         }
+        // Realizes totality + uniqueness + agreement with the
+        // instance's own `decl` field: one fact, two access paths,
+        // provably identical.
+        for (i, inst) in e.locus_instances.iter().enumerate() {
+            let mut rows = r
+                .realizes
+                .iter()
+                .filter(|x| x.instance.index() == i);
+            match (rows.next(), rows.next()) {
+                (Some(row), None) => {
+                    if row.decl != inst.decl {
+                        return Err(ModelError::RealizesDisagrees {
+                            index: i,
+                        });
+                    }
+                }
+                _ => {
+                    return Err(ModelError::RealizesIncomplete {
+                        instance: i,
+                    })
+                }
+            }
+        }
         check_sorted_keys("owns", r.owns.iter().map(|x| (x.parent, x.child)))?;
         for (i, x) in r.owns.iter().enumerate() {
             if x.parent.index() >= insts || x.child.index() >= insts {
@@ -295,6 +406,12 @@ impl ApplicationModel {
             }
             prov("owns", i, x.provenance)?;
         }
+        check_sorted_keys(
+            "calls",
+            r.calls
+                .iter()
+                .map(|x| (x.from, x.to, x.dispatch.clone())),
+        )?;
         for (i, x) in r.calls.iter().enumerate() {
             if x.from.index() >= fns || x.to.index() >= fns {
                 return Err(ModelError::DanglingId {
@@ -304,6 +421,10 @@ impl ApplicationModel {
             }
             prov("calls", i, x.provenance)?;
         }
+        check_sorted_keys(
+            "publishes",
+            r.publishes.iter().map(|x| (x.function, x.topic)),
+        )?;
         for (i, x) in r.publishes.iter().enumerate() {
             if x.function.index() >= fns || x.topic.index() >= topics {
                 return Err(ModelError::DanglingId {
@@ -311,8 +432,30 @@ impl ApplicationModel {
                     index: i,
                 });
             }
+            if let crate::keys::KeyDomain::Exact(vals) = &x.key_domain {
+                check_sorted_keys("publishes.key_domain", vals.iter())
+                    .map_err(|_| ModelError::NotCanonical {
+                        table: "publishes.key_domain",
+                        index: i,
+                    })?;
+            }
+            if matches!(x.key_domain, crate::keys::KeyDomain::Unknown)
+                && !hole_at(
+                    EntityRef::Function(x.function),
+                    crate::hole::RelationSet::KEY_FILTERS,
+                )
+            {
+                return Err(ModelError::UnrepresentedUnknown {
+                    table: "publishes",
+                    index: i,
+                });
+            }
             prov("publishes", i, x.provenance)?;
         }
+        check_sorted_keys(
+            "subscribes",
+            r.subscribes.iter().map(|x| (x.topic, x.handler)),
+        )?;
         for (i, x) in r.subscribes.iter().enumerate() {
             if x.topic.index() >= topics || x.handler.index() >= fns {
                 return Err(ModelError::DanglingId {
@@ -320,8 +463,30 @@ impl ApplicationModel {
                     index: i,
                 });
             }
+            if matches!(x.capacity, crate::keys::Capacity::Bounded(0)) {
+                return Err(ModelError::InvalidBound {
+                    table: "subscribes",
+                    index: i,
+                });
+            }
+            if matches!(
+                x.key_predicate,
+                crate::keys::KeyPredicate::Unknown
+            ) && !hole_at(
+                EntityRef::Function(x.handler),
+                crate::hole::RelationSet::KEY_FILTERS,
+            ) {
+                return Err(ModelError::UnrepresentedUnknown {
+                    table: "subscribes",
+                    index: i,
+                });
+            }
             prov("subscribes", i, x.provenance)?;
         }
+        check_sorted_keys(
+            "placed_in",
+            r.placed_in.iter().map(|x| x.instance),
+        )?;
         for (i, x) in r.placed_in.iter().enumerate() {
             if x.instance.index() >= insts || x.domain.index() >= domains {
                 return Err(ModelError::DanglingId {
@@ -331,6 +496,10 @@ impl ApplicationModel {
             }
             prov("placed_in", i, x.provenance)?;
         }
+        check_sorted_keys(
+            "affined_to",
+            r.affined_to.iter().map(|x| x.domain),
+        )?;
         for (i, x) in r.affined_to.iter().enumerate() {
             if x.domain.index() >= domains {
                 return Err(ModelError::DanglingId {
@@ -338,8 +507,18 @@ impl ApplicationModel {
                     index: i,
                 });
             }
+            check_sorted_keys("affined_to.cores", x.cores.0.iter()).map_err(
+                |_| ModelError::NotCanonical {
+                    table: "affined_to.cores",
+                    index: i,
+                },
+            )?;
             prov("affined_to", i, x.provenance)?;
         }
+        check_sorted_keys(
+            "binds",
+            r.binds.iter().map(|x| (x.topic, x.binding)),
+        )?;
         for (i, x) in r.binds.iter().enumerate() {
             if x.topic.index() >= topics || x.binding.index() >= bindings {
                 return Err(ModelError::DanglingId {
@@ -347,8 +526,21 @@ impl ApplicationModel {
                     index: i,
                 });
             }
+            // The topic's subject and the binding's subject repeat
+            // one fact — they must agree.
+            if e.topics[x.topic.index()].subject
+                != e.bindings[x.binding.index()].subject
+            {
+                return Err(ModelError::BindingSubjectDisagrees {
+                    index: i,
+                });
+            }
             prov("binds", i, x.provenance)?;
         }
+        check_sorted_keys(
+            "supervises",
+            r.supervises.iter().map(|x| (x.parent, x.child)),
+        )?;
         for (i, x) in r.supervises.iter().enumerate() {
             if x.parent.index() >= loci || x.child.index() >= loci {
                 return Err(ModelError::DanglingId {
@@ -360,6 +552,10 @@ impl ApplicationModel {
         }
 
         // --- labels / weights.
+        check_sorted_keys(
+            "labels",
+            self.labels.iter().map(|l| (l.at, &l.label)),
+        )?;
         for (i, l) in self.labels.iter().enumerate() {
             if !ref_ok(&l.at) {
                 return Err(ModelError::DanglingId {
@@ -369,6 +565,10 @@ impl ApplicationModel {
             }
             prov("labels", i, l.provenance)?;
         }
+        check_sorted_keys(
+            "weights",
+            self.weights.iter().map(|w| (w.at, &w.metric)),
+        )?;
         for (i, w) in self.weights.iter().enumerate() {
             if !ref_ok(&w.at) {
                 return Err(ModelError::DanglingId {
@@ -379,7 +579,13 @@ impl ApplicationModel {
             prov("weights", i, w.provenance)?;
         }
 
-        // --- holes: anchored, non-empty, provenanced.
+        // --- holes: canonical, anchored, non-empty, provenanced.
+        check_sorted_keys(
+            "holes",
+            self.holes
+                .iter()
+                .map(|h| (h.at, h.kind.clone(), &h.reason)),
+        )?;
         for (i, h) in self.holes.iter().enumerate() {
             if !ref_ok(&h.at) {
                 return Err(ModelError::DanglingId {
@@ -394,32 +600,16 @@ impl ApplicationModel {
         }
 
         // --- capability/hole contradiction: exactness may not be
-        // claimed for a family any hole hides.
-        for (claimed, family) in self.capabilities.vouched_families() {
+        // claimed for a family any hole hides. Every capability is
+        // mapped (an unmapped flag would be unfalsifiable).
+        for (name, claimed, family) in self.capabilities.vouched_families()
+        {
             if !claimed {
                 continue;
             }
             if self.holes.iter().any(|h| h.hides.intersects(family)) {
-                let capability = match family.0 {
-                    x if x == crate::hole::RelationSet::CALLS.0 => {
-                        "exact_calls"
-                    }
-                    x if x == crate::hole::RelationSet::OWNS.0 => {
-                        "exact_ownership"
-                    }
-                    x if x == crate::hole::RelationSet::PLACED.0 => {
-                        "exact_placement"
-                    }
-                    x if x == crate::hole::RelationSet::ROUTES.0 => {
-                        "exact_routes"
-                    }
-                    x if x == crate::hole::RelationSet::EFFECTS.0 => {
-                        "exact_effects"
-                    }
-                    _ => "exact_bus_endpoints",
-                };
                 return Err(ModelError::CapabilityContradiction {
-                    capability,
+                    capability: name,
                 });
             }
         }
@@ -427,22 +617,8 @@ impl ApplicationModel {
     }
 }
 
-fn check_sorted<'a, I>(table: &'static str, names: I) -> Result<(), ModelError>
-where
-    I: Iterator<Item = &'a String>,
-{
-    let mut prev: Option<&str> = None;
-    for (i, n) in names.enumerate() {
-        if let Some(p) = prev {
-            if p >= n.as_str() {
-                return Err(ModelError::NotCanonical { table, index: i });
-            }
-        }
-        prev = Some(n);
-    }
-    Ok(())
-}
-
+/// Strictly-increasing check over a table's canonical keys —
+/// enforces sorted AND deduplicated in one pass.
 fn check_sorted_keys<K: Ord, I>(
     table: &'static str,
     keys: I,

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -147,6 +147,15 @@ pub enum ModelError {
     /// disagree — the entity attribute and the relation repeat one
     /// fact and drifted.
     BindingSubjectDisagrees { index: usize },
+    /// A `where key == _` (Fallback) subscription on a topic whose
+    /// `on_unmatched` policy is not `fallback` — the `_` sentinel
+    /// is legal only on fallback topics (resolve-time law,
+    /// mirrored in the schema).
+    IllegalFallback { index: usize },
+    /// A topic declares `on_unmatched: fallback` but has no
+    /// Fallback subscription — the policy's required catch is
+    /// missing.
+    FallbackUncovered { topic: usize },
 }
 
 impl ApplicationModel {
@@ -167,13 +176,13 @@ impl ApplicationModel {
     /// | `declared_in`    | (entity, seed)                   |
     /// | `realizes`       | (instance, decl)                 |
     /// | `owns`           | (parent, child)                  |
-    /// | `calls`          | (from, to, dispatch)             |
-    /// | `publishes`      | (function, topic)                |
-    /// | `subscribes`     | (topic, handler)                 |
+    /// | `calls`          | (from, to, dispatch, site)       |
+    /// | `publishes`      | (function, topic, site)          |
+    /// | `subscribes`     | (topic, handler, site)           |
     /// | `placed_in`      | (instance)                       |
     /// | `affined_to`     | (domain)                         |
     /// | `binds`          | (topic, binding)                 |
-    /// | `supervises`     | (parent, child)                  |
+    /// | `supervises`     | (parent, child, error_type)      |
     /// | `labels`         | (at, label)                      |
     /// | `weights`        | (at, metric)                     |
     /// | `holes`          | (at, kind, reason)               |
@@ -410,7 +419,7 @@ impl ApplicationModel {
             "calls",
             r.calls
                 .iter()
-                .map(|x| (x.from, x.to, x.dispatch.clone())),
+                .map(|x| (x.from, x.to, x.dispatch.clone(), x.site)),
         )?;
         for (i, x) in r.calls.iter().enumerate() {
             if x.from.index() >= fns || x.to.index() >= fns {
@@ -423,7 +432,9 @@ impl ApplicationModel {
         }
         check_sorted_keys(
             "publishes",
-            r.publishes.iter().map(|x| (x.function, x.topic)),
+            r.publishes
+                .iter()
+                .map(|x| (x.function, x.topic, x.site)),
         )?;
         for (i, x) in r.publishes.iter().enumerate() {
             if x.function.index() >= fns || x.topic.index() >= topics {
@@ -454,7 +465,9 @@ impl ApplicationModel {
         }
         check_sorted_keys(
             "subscribes",
-            r.subscribes.iter().map(|x| (x.topic, x.handler)),
+            r.subscribes
+                .iter()
+                .map(|x| (x.topic, x.handler, x.site)),
         )?;
         for (i, x) in r.subscribes.iter().enumerate() {
             if x.topic.index() >= topics || x.handler.index() >= fns {
@@ -482,6 +495,45 @@ impl ApplicationModel {
                 });
             }
             prov("subscribes", i, x.provenance)?;
+        }
+        // Fallback contract, both directions: `_` only on fallback
+        // topics; fallback topics have their catch.
+        for (i, x) in r.subscribes.iter().enumerate() {
+            let is_fallback_pred = matches!(
+                x.key_predicate,
+                crate::keys::KeyPredicate::Fallback
+            );
+            let topic_policy = e.topics[x.topic.index()]
+                .key
+                .as_ref()
+                .map(|k| k.on_unmatched);
+            if is_fallback_pred
+                && topic_policy
+                    != Some(crate::keys::KeyOnUnmatched::Fallback)
+            {
+                return Err(ModelError::IllegalFallback { index: i });
+            }
+        }
+        for (ti, t) in e.topics.iter().enumerate() {
+            let wants_fallback = t
+                .key
+                .as_ref()
+                .map(|k| {
+                    k.on_unmatched
+                        == crate::keys::KeyOnUnmatched::Fallback
+                })
+                .unwrap_or(false);
+            if wants_fallback
+                && !r.subscribes.iter().any(|x| {
+                    x.topic.index() == ti
+                        && matches!(
+                            x.key_predicate,
+                            crate::keys::KeyPredicate::Fallback
+                        )
+                })
+            {
+                return Err(ModelError::FallbackUncovered { topic: ti });
+            }
         }
         check_sorted_keys(
             "placed_in",
@@ -539,7 +591,9 @@ impl ApplicationModel {
         }
         check_sorted_keys(
             "supervises",
-            r.supervises.iter().map(|x| (x.parent, x.child)),
+            r.supervises
+                .iter()
+                .map(|x| (x.parent, x.child, &x.error_type)),
         )?;
         for (i, x) in r.supervises.iter().enumerate() {
             if x.parent.index() >= loci || x.child.index() >= loci {

--- a/crates/hale-model/src/capability.rs
+++ b/crates/hale-model/src/capability.rs
@@ -30,9 +30,7 @@ impl Capabilities {
     /// flag participates: a capability with no mapped family would
     /// be unfalsifiable, which is exactly the drift this law
     /// exists to prevent.
-    pub fn vouched_families(
-        self,
-    ) -> Vec<(&'static str, bool, RelationSet)> {
+    pub fn vouched_families(self) -> Vec<(&'static str, bool, RelationSet)> {
         vec![
             ("exact_calls", self.exact_calls, RelationSet::CALLS),
             (

--- a/crates/hale-model/src/capability.rs
+++ b/crates/hale-model/src/capability.rs
@@ -26,18 +26,39 @@ pub struct Capabilities {
 
 impl Capabilities {
     /// The relation families each capability vouches for — the
-    /// contradiction check in `validate` walks this mapping.
-    pub fn vouched_families(self) -> Vec<(bool, RelationSet)> {
+    /// contradiction check in `validate` walks this mapping. EVERY
+    /// flag participates: a capability with no mapped family would
+    /// be unfalsifiable, which is exactly the drift this law
+    /// exists to prevent.
+    pub fn vouched_families(
+        self,
+    ) -> Vec<(&'static str, bool, RelationSet)> {
         vec![
-            (self.exact_calls, RelationSet::CALLS),
+            ("exact_calls", self.exact_calls, RelationSet::CALLS),
             (
+                "exact_bus_endpoints",
                 self.exact_bus_endpoints,
                 RelationSet::PUBLISHES.union(RelationSet::SUBSCRIBES),
             ),
-            (self.exact_ownership, RelationSet::OWNS),
-            (self.exact_placement, RelationSet::PLACED),
-            (self.exact_routes, RelationSet::ROUTES),
-            (self.exact_effects, RelationSet::EFFECTS),
+            (
+                "exact_key_filters",
+                self.exact_key_filters,
+                RelationSet::KEY_FILTERS,
+            ),
+            ("exact_ownership", self.exact_ownership, RelationSet::OWNS),
+            ("exact_placement", self.exact_placement, RelationSet::PLACED),
+            ("exact_routes", self.exact_routes, RelationSet::ROUTES),
+            ("exact_effects", self.exact_effects, RelationSet::EFFECTS),
+            (
+                "exact_cardinality",
+                self.exact_cardinality,
+                RelationSet::CARDINALITY,
+            ),
+            (
+                "exact_delivery_guarantees",
+                self.exact_delivery_guarantees,
+                RelationSet::DELIVERY,
+            ),
         ]
     }
 }

--- a/crates/hale-model/src/capability.rs
+++ b/crates/hale-model/src/capability.rs
@@ -1,0 +1,43 @@
+//! Positive completeness — what the model can promise is exact.
+//!
+//! A consumer asks "is this model adequate for my judgment?" by
+//! reading capabilities, never by reverse-engineering the absence of
+//! particular strings. The dual-bookkeeping law: a capability may
+//! not claim exactness while any hole hides that relation family —
+//! [`ApplicationModel::validate`] rejects the contradiction, so the
+//! two accounts cannot drift.
+//!
+//! [`ApplicationModel::validate`]: crate::application::ApplicationModel::validate
+
+use crate::hole::RelationSet;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub struct Capabilities {
+    pub exact_calls: bool,
+    pub exact_bus_endpoints: bool,
+    pub exact_key_filters: bool,
+    pub exact_ownership: bool,
+    pub exact_placement: bool,
+    pub exact_routes: bool,
+    pub exact_effects: bool,
+    pub exact_cardinality: bool,
+    pub exact_delivery_guarantees: bool,
+}
+
+impl Capabilities {
+    /// The relation families each capability vouches for — the
+    /// contradiction check in `validate` walks this mapping.
+    pub fn vouched_families(self) -> Vec<(bool, RelationSet)> {
+        vec![
+            (self.exact_calls, RelationSet::CALLS),
+            (
+                self.exact_bus_endpoints,
+                RelationSet::PUBLISHES.union(RelationSet::SUBSCRIBES),
+            ),
+            (self.exact_ownership, RelationSet::OWNS),
+            (self.exact_placement, RelationSet::PLACED),
+            (self.exact_routes, RelationSet::ROUTES),
+            (self.exact_effects, RelationSet::EFFECTS),
+        ]
+    }
+}

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -95,6 +95,9 @@ pub struct Topic {
     pub payload: PayloadContractId,
     /// `Some` for `keyed_by` topics.
     pub key: Option<TopicKey>,
+    /// `Some` for `bounded(N)` topics — the publisher-facing
+    /// capacity + refusal contract (GH #255's topic-level knob).
+    pub bound: Option<crate::keys::TopicBound>,
     pub provenance: ProvenanceId,
 }
 
@@ -120,7 +123,7 @@ pub struct ThreadDomain {
     pub provenance: ProvenanceId,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum TransportKind {
     Unix,
     Udp,
@@ -129,7 +132,7 @@ pub enum TransportKind {
     Adapter(String),
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum BindingRole {
     Listen,
     Connect,

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -1,0 +1,145 @@
+//! Entity tables — typed sorts, not one homogeneous node kind.
+//!
+//! Sorts live at two strata: the code stratum (functions, locus
+//! *declarations*) and the system stratum (locus *instances*,
+//! bindings, thread domains). The declaration/instance split is what
+//! lets application claims count declarations while fleet claims
+//! count deployed instances without punning — the epic's typed
+//! `CountDomain` distinction starts here.
+//!
+//! Every entity separates **canonical name** (identity) from
+//! **display** spelling (what diagnostics render). Effects are
+//! recorded as label strings at Change 1 — the classification
+//! vocabulary (the #265 lattice) lives upstream and would otherwise
+//! drag a dependency into this crate; the label set is validated
+//! against the upstream lattice at derivation time (Change 2).
+
+use crate::ids::{LocusDeclId, PayloadContractId, ProvenanceId, SubjectId};
+use crate::keys::TopicKey;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FunctionKind {
+    /// A lifecycle hook (birth, run, dissolve, on_failure…).
+    Hook,
+    /// A locus method (including bus handlers).
+    Method,
+    /// A free function.
+    Free,
+    /// A mode body.
+    Mode,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Function {
+    /// Canonical identity, e.g. `Worker::on_r` or `describe`.
+    pub name: String,
+    /// Author-facing spelling when it differs (stdlib publics render
+    /// their `std::…` path, never the mangled name).
+    pub display: String,
+    pub kind: FunctionKind,
+    /// Effect labels in declaration order (order is semantic in the
+    /// existing artifact and is preserved).
+    pub effects: Vec<String>,
+    pub provenance: ProvenanceId,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct LocusDecl {
+    pub name: String,
+    pub display: String,
+    /// `@sealed` confinement (GH #436).
+    pub sealed: bool,
+    pub provenance: ProvenanceId,
+}
+
+/// A statically exact instance in the main arrangement, e.g. the
+/// `App.w` born from `params { w: Worker = Worker { }; }`. Replica
+/// fan-outs contribute one instance per index.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct LocusInstance {
+    /// Canonical instance path, e.g. `App.w` or `App.workers[3]`.
+    pub path: String,
+    pub decl: LocusDeclId,
+    /// `Some(k)` for a `replicas = K` member; feeds `EqReplica`
+    /// coverage in keyed-delivery judgments.
+    pub replica: Option<u32>,
+    pub provenance: ProvenanceId,
+}
+
+/// A wire subject or pattern. Address identity — deliberately a
+/// DIFFERENT sort from the payload contract, even though the current
+/// runtime keeps a fused hash for compatibility (the model derives
+/// that fusion; it does not make it the schema).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Subject {
+    pub pattern: String,
+    /// False when the pattern contains wildcards.
+    pub exact: bool,
+    pub provenance: ProvenanceId,
+}
+
+/// A payload shape contract.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct PayloadContract {
+    /// The canonical shape string (field:kind;… — as the artifact
+    /// serializes today).
+    pub shape: String,
+    pub hash: u64,
+    pub provenance: ProvenanceId,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Topic {
+    pub name: String,
+    pub subject: SubjectId,
+    pub payload: PayloadContractId,
+    /// `Some` for `keyed_by` topics.
+    pub key: Option<TopicKey>,
+    pub provenance: ProvenanceId,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Phase {
+    pub name: String,
+    pub provenance: ProvenanceId,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Seed {
+    pub name: String,
+    pub provenance: ProvenanceId,
+}
+
+/// A thread domain: where code actually runs. Main, a pinned
+/// thread, one cooperative pool's worker, an async-I/O pool — and
+/// (post-#468) a binding's reader thread, which is a real domain
+/// that enqueues cross-thread.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ThreadDomain {
+    pub name: String,
+    pub provenance: ProvenanceId,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum TransportKind {
+    Unix,
+    Udp,
+    ShmRing,
+    /// User-supplied protocol adapter locus (by declaration name).
+    Adapter(String),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BindingRole {
+    Listen,
+    Connect,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Binding {
+    pub subject: SubjectId,
+    pub transport: TransportKind,
+    pub role: BindingRole,
+    pub loss: crate::keys::BindingLossBehavior,
+    pub provenance: ProvenanceId,
+}

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -118,6 +118,26 @@ pub struct Group {
     pub provenance: ProvenanceId,
 }
 
+/// A declared value type. Types are not path vertices — they exist
+/// in the model because the declaration universe must cover the
+/// seed sort exactly (the topology hash covers the full rename
+/// table: loci, fns, types, interfaces, topics, groups), and
+/// because payload contracts and key types name them.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TypeDecl {
+    pub name: String,
+    pub display: String,
+    pub provenance: ProvenanceId,
+}
+
+/// A declared interface (the F.20 structural contract).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct InterfaceDecl {
+    pub name: String,
+    pub display: String,
+    pub provenance: ProvenanceId,
+}
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Phase {
     pub name: String,

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -101,6 +101,23 @@ pub struct Topic {
     pub provenance: ProvenanceId,
 }
 
+/// A declared claim-vocabulary group. Groups are
+/// verification-relevant and shape-hashed in the existing artifact
+/// (claims resolve their selectors through them), so they are model
+/// rows, not a side channel. Membership lives in the
+/// [`GroupMember`] relation.
+///
+/// [`GroupMember`]: crate::relation::GroupMember
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Group {
+    pub name: String,
+    /// Declared `may_be_empty` — an empty group without it is a
+    /// checker error (vacuity fail-closed), so the declared intent
+    /// is a semantic fact selectors need.
+    pub may_be_empty: bool,
+    pub provenance: ProvenanceId,
+}
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Phase {
     pub name: String,

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -138,6 +138,36 @@ pub struct InterfaceDecl {
     pub provenance: ProvenanceId,
 }
 
+/// A declaration kind that participates in seed membership but has
+/// no structural role elsewhere in the model (yet). The
+/// declaration-universe law: every NAMEABLE top-level declaration
+/// (`top_decl_name` in the compiler: locus, perspective, type,
+/// const, fn, interface, topic, ring layout, target, group) is
+/// representable — as a specialized sort where the model needs its
+/// structure, or as an opaque [`Declaration`] row where seed
+/// membership is the only fact. `Module`, `Claims`, and
+/// `Constitution` are deliberately nameless there and are NOT
+/// declarations here either. A new nameable TopDecl variant must
+/// extend one side or the other — the universe canary in
+/// tests/architecture.rs mirrors the compiler's list (this crate
+/// cannot depend on the AST, so the mirror is by test, not type).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum DeclKind {
+    Perspective,
+    Const,
+    RingLayout,
+    Target,
+}
+
+/// An opaque seed-membership-only declaration (see [`DeclKind`]).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Declaration {
+    pub kind: DeclKind,
+    pub name: String,
+    pub display: String,
+    pub provenance: ProvenanceId,
+}
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Phase {
     pub name: String,

--- a/crates/hale-model/src/hole.rs
+++ b/crates/hale-model/src/hole.rs
@@ -28,6 +28,16 @@ impl RelationSet {
     pub const SUPERVISES: RelationSet = RelationSet(1 << 6);
     pub const EFFECTS: RelationSet = RelationSet(1 << 7);
     pub const ROUTES: RelationSet = RelationSet(1 << 8);
+    /// Key-filter knowledge: hidden by unknown key domains or
+    /// predicates. Every inline `KeyDomain::Unknown` /
+    /// `KeyPredicate::Unknown` REQUIRES a hole hiding this family
+    /// (validated) — an unknown may not hide solely inside an
+    /// otherwise resolved row.
+    pub const KEY_FILTERS: RelationSet = RelationSet(1 << 9);
+    /// Cardinality knowledge (instance/publisher/subscriber counts).
+    pub const CARDINALITY: RelationSet = RelationSet(1 << 10);
+    /// Delivery-guarantee knowledge (the must-deliver side).
+    pub const DELIVERY: RelationSet = RelationSet(1 << 11);
 
     pub const fn union(self, other: RelationSet) -> RelationSet {
         RelationSet(self.0 | other.0)
@@ -44,7 +54,7 @@ impl RelationSet {
 }
 
 /// Why the model does not know.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum HoleKind {
     /// A call through a fn pointer / indirect site.
     IndirectCall,

--- a/crates/hale-model/src/hole.rs
+++ b/crates/hale-model/src/hole.rs
@@ -1,0 +1,86 @@
+//! Typed unresolved residue — a model is known facts PLUS an
+//! explicit account of what it does not know.
+//!
+//! The verdict law these feed: a judgment whose relevant projection
+//! can reach a hole that hides a relation family it needs returns
+//! `uncertified`, never `holds`. Holes are rows, not caller policy —
+//! one evaluator cannot treat an unknown as fatal while another
+//! forgets it.
+//!
+//! Composition law (fleet, Change 7): holes never disappear when
+//! models compose.
+
+use crate::ids::{EntityRef, ProvenanceId};
+
+/// The relation families a hole can hide. A tiny fixed bitset —
+/// adding a family is a schema change with review, provenance rules,
+/// and a canary, exactly like adding a relation table.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct RelationSet(pub u32);
+
+impl RelationSet {
+    pub const CALLS: RelationSet = RelationSet(1 << 0);
+    pub const PUBLISHES: RelationSet = RelationSet(1 << 1);
+    pub const SUBSCRIBES: RelationSet = RelationSet(1 << 2);
+    pub const OWNS: RelationSet = RelationSet(1 << 3);
+    pub const PLACED: RelationSet = RelationSet(1 << 4);
+    pub const BINDS: RelationSet = RelationSet(1 << 5);
+    pub const SUPERVISES: RelationSet = RelationSet(1 << 6);
+    pub const EFFECTS: RelationSet = RelationSet(1 << 7);
+    pub const ROUTES: RelationSet = RelationSet(1 << 8);
+
+    pub const fn union(self, other: RelationSet) -> RelationSet {
+        RelationSet(self.0 | other.0)
+    }
+    pub const fn contains(self, other: RelationSet) -> bool {
+        (self.0 & other.0) == other.0
+    }
+    pub const fn intersects(self, other: RelationSet) -> bool {
+        (self.0 & other.0) != 0
+    }
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
+/// Why the model does not know.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum HoleKind {
+    /// A call through a fn pointer / indirect site.
+    IndirectCall,
+    /// A method call on a receiver the summarizer cannot type.
+    UntypedReceiver,
+    /// A publish whose subject is computed at runtime.
+    ComputedSubject,
+    /// A keyed publish/subscription whose key values are unknown
+    /// (the filter is preserved; its coverage is not provable).
+    UnknownKeyDomain,
+    /// An interface dispatch whose conformer set is open.
+    OpenInterface,
+    /// Placement inherited at runtime rather than declared.
+    RuntimeInheritedPlacement,
+    /// An endpoint that appears or disappears dynamically.
+    DynamicEndpoint,
+    /// A declared external boundary with opaque internals.
+    ExternalOpaque,
+    /// An artifact carried semantics this consumer does not
+    /// implement (decode-side honesty: refuse to pretend).
+    UnsupportedArtifactSemantics,
+}
+
+/// One hole: where, why, and — critically — which relation families
+/// it hides from judgments.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Hole {
+    pub at: EntityRef,
+    pub kind: HoleKind,
+    /// Never empty — a hole that hides nothing is not a hole
+    /// (validated; see [`ApplicationModel::validate`]).
+    ///
+    /// [`ApplicationModel::validate`]: crate::application::ApplicationModel::validate
+    pub hides: RelationSet,
+    /// Human-readable reason for witnesses ("call through fn param
+    /// `f`").
+    pub reason: String,
+    pub provenance: ProvenanceId,
+}

--- a/crates/hale-model/src/ids.rs
+++ b/crates/hale-model/src/ids.rs
@@ -73,6 +73,14 @@ table_id!(
     GroupId
 );
 table_id!(
+    /// A declared value type (`type T { ... }`, enums included).
+    TypeDeclId
+);
+table_id!(
+    /// A declared interface.
+    InterfaceDeclId
+);
+table_id!(
     /// A source-neutral origin record in the [`ProvenanceTable`].
     ///
     /// [`ProvenanceTable`]: crate::provenance::ProvenanceTable
@@ -96,4 +104,12 @@ pub enum EntityRef {
     ThreadDomain(ThreadDomainId),
     Phase(PhaseId),
     Seed(SeedId),
+    /// A declared group — seed membership (`declared_in`) covers
+    /// groups, since the seed sort hashes the full rename table.
+    Group(GroupId),
+    /// A declared value type — a seed member even though types are
+    /// not path vertices.
+    Type(TypeDeclId),
+    /// A declared interface.
+    Interface(InterfaceDeclId),
 }

--- a/crates/hale-model/src/ids.rs
+++ b/crates/hale-model/src/ids.rs
@@ -81,6 +81,13 @@ table_id!(
     InterfaceDeclId
 );
 table_id!(
+    /// A seed-membership-only declaration (perspective, const,
+    /// ring layout, target) — see [`Declaration`].
+    ///
+    /// [`Declaration`]: crate::entity::Declaration
+    DeclarationId
+);
+table_id!(
     /// A source-neutral origin record in the [`ProvenanceTable`].
     ///
     /// [`ProvenanceTable`]: crate::provenance::ProvenanceTable
@@ -112,4 +119,7 @@ pub enum EntityRef {
     Type(TypeDeclId),
     /// A declared interface.
     Interface(InterfaceDeclId),
+    /// A seed-membership-only declaration (perspective, const,
+    /// ring layout, target).
+    Declaration(DeclarationId),
 }

--- a/crates/hale-model/src/ids.rs
+++ b/crates/hale-model/src/ids.rs
@@ -1,0 +1,95 @@
+//! Dense typed IDs — indices into their owning table.
+//!
+//! Two identity laws from the epic:
+//!
+//! 1. **No semantic string joins.** Canonical declaration identity,
+//!    author-facing display spelling, wire subject/address identity,
+//!    payload-shape identity, and deployed-instance identity are
+//!    separate fields. The model never decides two things are the
+//!    same because display strings happen to match.
+//! 2. **Internal density, external stability.** These IDs are dense
+//!    table indices for in-memory speed. Serialized identities
+//!    (Change 3+) are stable canonical names, never these numbers —
+//!    an ID is meaningless outside the model value that minted it.
+
+macro_rules! table_id {
+    ($(#[$doc:meta])* $name:ident) => {
+        $(#[$doc])*
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+        pub struct $name(pub u32);
+
+        impl $name {
+            pub fn index(self) -> usize {
+                self.0 as usize
+            }
+        }
+    };
+}
+
+table_id!(
+    /// A function, method, lifecycle hook, or mode body.
+    FunctionId
+);
+table_id!(
+    /// A locus declaration (the type, not a running instance).
+    LocusDeclId
+);
+table_id!(
+    /// A statically exact locus instance in the main arrangement.
+    LocusInstanceId
+);
+table_id!(
+    /// A declared topic (name + subject + payload contract).
+    TopicId
+);
+table_id!(
+    /// A wire subject or subject pattern.
+    SubjectId
+);
+table_id!(
+    /// A payload shape contract.
+    PayloadContractId
+);
+table_id!(
+    /// A lifecycle phase (birth, run, handler, dissolve, method…).
+    PhaseId
+);
+table_id!(
+    /// A source seed (compilation unit set).
+    SeedId
+);
+table_id!(
+    /// A thread domain: a pinned thread, a cooperative pool's
+    /// worker, the main thread, an async-I/O pool.
+    ThreadDomainId
+);
+table_id!(
+    /// A transport binding declared on the main locus (or admitted
+    /// from deploy-time config).
+    BindingId
+);
+table_id!(
+    /// A source-neutral origin record in the [`ProvenanceTable`].
+    ///
+    /// [`ProvenanceTable`]: crate::provenance::ProvenanceTable
+    ProvenanceId
+);
+table_id!(
+    /// A source unit (path + content digest) provenance points into.
+    SourceId
+);
+
+/// A reference to any entity sort — the anchor vocabulary shared by
+/// holes, labels, weights, and (later) evidence steps.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum EntityRef {
+    Function(FunctionId),
+    LocusDecl(LocusDeclId),
+    LocusInstance(LocusInstanceId),
+    Topic(TopicId),
+    Subject(SubjectId),
+    Binding(BindingId),
+    ThreadDomain(ThreadDomainId),
+    Phase(PhaseId),
+    Seed(SeedId),
+}

--- a/crates/hale-model/src/ids.rs
+++ b/crates/hale-model/src/ids.rs
@@ -69,6 +69,10 @@ table_id!(
     BindingId
 );
 table_id!(
+    /// A declared claim-vocabulary group (`group g = { ... }`).
+    GroupId
+);
+table_id!(
     /// A source-neutral origin record in the [`ProvenanceTable`].
     ///
     /// [`ProvenanceTable`]: crate::provenance::ProvenanceTable

--- a/crates/hale-model/src/keys.rs
+++ b/crates/hale-model/src/keys.rs
@@ -86,7 +86,12 @@ pub enum KeyPredicate {
     Unknown,
 }
 
-/// What key values a publication site can produce.
+/// What key values a publication site can produce. Only meaningful
+/// on a KEYED topic: an unkeyed publish carries NO KeyDomain
+/// (`Publish.key_domain: Option<KeyDomain>` is `None`), and the
+/// validator enforces the correspondence both ways — inventing a
+/// domain for an unkeyed publish (or omitting one on a keyed topic)
+/// is not a model.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum KeyDomain {
     /// Statically exact value set (sorted, deduplicated).

--- a/crates/hale-model/src/keys.rs
+++ b/crates/hale-model/src/keys.rs
@@ -1,0 +1,103 @@
+//! Keyed delivery, bounds, and loss policy — recorded as authored,
+//! before any claim consumes them.
+//!
+//! The polarity law (crate docs, "Keyed delivery"): judgments derive
+//! `may_deliver` (unknown keys ADD possible edges — conservative for
+//! negative claims) and `must_deliver` (exact coverage only) from
+//! these raw facts. Three failure modes this schema exists to
+//! prevent: treating keyed delivery as broadcast (false
+//! reachability), dropping filtered edges (false isolation), and
+//! discarding the filter syntax so every keyed-topic judgment is
+//! permanently `uncertified`.
+//!
+//! The first implementation proves no arithmetic: it preserves the
+//! authored filter and says what it does not know (`Unknown`).
+
+/// A routing-key value. Typecheck fixes ONE key type per topic, so a
+/// topic's publishes and subscriptions never mix variants.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum KeyValue {
+    Int(i64),
+    Str(String),
+}
+
+/// A topic's declared key: the `keyed_by` payload field.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TopicKey {
+    pub field: String,
+}
+
+/// What a subscription's `where key == …` filter admits.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum KeyPredicate {
+    /// Unkeyed subscription: every message on the subject.
+    Any,
+    /// `where key == <literal>`.
+    EqLiteral(KeyValue),
+    /// `where key == replica` — satisfied by this instance's
+    /// replica index (the instance population comes from placement;
+    /// the delivery semantics stay on the subscription — placement
+    /// remains semantics-free).
+    EqReplica,
+    /// The filter exists but its value is not statically known.
+    /// Adds possible edges; never supports a guarantee.
+    Unknown,
+}
+
+/// What key values a publication site can produce.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum KeyDomain {
+    /// Statically exact value set (sorted, deduplicated).
+    Exact(Vec<KeyValue>),
+    /// An integer interval, inclusive.
+    IntRange { min: i64, max: i64 },
+    /// Any value of the key's type — exact *type*, unknown values.
+    AnyOfType(String),
+    /// Nothing is known about the produced keys.
+    Unknown,
+}
+
+/// A queue bound. `Unbounded` is the declared default, not an
+/// unknown — an unknown capacity would be a [`Hole`].
+///
+/// [`Hole`]: crate::hole::Hole
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Capacity {
+    Unbounded,
+    Bounded(u64),
+}
+
+/// What a bounded subscription does when full (GH #255 vocabulary).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ShedPolicy {
+    /// Unbounded, or bounded-with-refusal: nothing is shed.
+    None,
+    DropOld,
+    DropNew,
+}
+
+/// The publish site's declared disposition when delivery cannot be
+/// accepted (GH #255): the send-site half of the loss contract.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PublishDisposition {
+    /// No explicit disposition authored at the site.
+    Default,
+    Raise,
+    Discard,
+    Handler,
+    Wait,
+}
+
+/// A transport binding's declared loss behavior — what the publish
+/// contract says "accepted" obligates it to when the link degrades.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BindingLossBehavior {
+    /// Lossy by declaration (udp-class): downstream loss is within
+    /// contract.
+    Drop,
+    /// Loss is structural but `or wait` can park through a
+    /// reconnect window (unix connect-class).
+    WaitCapable,
+    /// Loss fails the binding (structural exit / supervision).
+    Fail,
+}

--- a/crates/hale-model/src/keys.rs
+++ b/crates/hale-model/src/keys.rs
@@ -33,7 +33,10 @@ pub enum KeyValue {
     EnumTag(String),
     /// The spec-defined u128 comparison pair (`key_lo`, `key_hi`) —
     /// equality over Decimal keys IS two i64 compares by contract.
-    Decimal { lo: u64, hi: u64 },
+    Decimal {
+        lo: u64,
+        hi: u64,
+    },
     Str(String),
 }
 

--- a/crates/hale-model/src/keys.rs
+++ b/crates/hale-model/src/keys.rs
@@ -13,18 +13,54 @@
 //! The first implementation proves no arithmetic: it preserves the
 //! authored filter and says what it does not know (`Unknown`).
 
-/// A routing-key value. Typecheck fixes ONE key type per topic, so a
-/// topic's publishes and subscriptions never mix variants.
+/// A routing-key value — one variant per key-eligible field type in
+/// the shipped routing contract (spec/semantics.md "Width is
+/// inherited from the keyed_by field's type"): `Bool`, `Int`,
+/// `Time`/`Duration` (ns), no-payload `enum` (by variant name — the
+/// source-level identity; the runtime tag is derivation), `Decimal`
+/// (the spec-defined u128 comparison pair), `String`. Typecheck
+/// fixes ONE key type per topic, so a topic's publishes and
+/// subscriptions never mix variants.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum KeyValue {
+    Bool(bool),
     Int(i64),
+    /// Nanoseconds since epoch.
+    Time(i64),
+    /// Nanoseconds.
+    Duration(i64),
+    /// A no-payload enum key, by variant name.
+    EnumTag(String),
+    /// The spec-defined u128 comparison pair (`key_lo`, `key_hi`) —
+    /// equality over Decimal keys IS two i64 compares by contract.
+    Decimal { lo: u64, hi: u64 },
     Str(String),
 }
 
-/// A topic's declared key: the `keyed_by` payload field.
+/// A topic's declared key: the `keyed_by` payload field plus the
+/// topic's `on_unmatched` policy — what happens when a keyed
+/// publish matches no subscriber. Both are routing-contract facts
+/// the delivery judgments need (a `Fail` policy changes the send
+/// contract; a `Fallback` policy adds a delivery edge to the
+/// catch-unmatched subscriber).
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TopicKey {
     pub field: String,
+    pub on_unmatched: KeyOnUnmatched,
+}
+
+/// `on_unmatched:` policy of a keyed topic (spec/semantics.md).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum KeyOnUnmatched {
+    /// Drop silently (the default).
+    Swallow,
+    /// The publish becomes fallible at the send site.
+    Fail,
+    /// A `where key == _` subscriber receives unmatched messages.
+    /// The model law (validated): a Fallback topic has at least one
+    /// [`KeyPredicate::Fallback`] subscription, and the `_`
+    /// sentinel is legal ONLY on Fallback topics.
+    Fallback,
 }
 
 /// What a subscription's `where key == …` filter admits.
@@ -39,6 +75,12 @@ pub enum KeyPredicate {
     /// the delivery semantics stay on the subscription — placement
     /// remains semantics-free).
     EqReplica,
+    /// The `where key == _` catch-unmatched subscription — receives
+    /// exactly the messages no other filter matched. Legal only on
+    /// topics with `on_unmatched: fallback` (validated). Distinct
+    /// from [`KeyPredicate::Any`], which is the ordinary unkeyed
+    /// full-delivery subscription.
+    Fallback,
     /// The filter exists but its value is not statically known.
     /// Adds possible edges; never supports a guarantee.
     Unknown,

--- a/crates/hale-model/src/keys.rs
+++ b/crates/hale-model/src/keys.rs
@@ -28,7 +28,7 @@ pub struct TopicKey {
 }
 
 /// What a subscription's `where key == …` filter admits.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum KeyPredicate {
     /// Unkeyed subscription: every message on the subject.
     Any,
@@ -59,12 +59,36 @@ pub enum KeyDomain {
 
 /// A queue bound. `Unbounded` is the declared default, not an
 /// unknown — an unknown capacity would be a [`Hole`].
+/// `Bounded(0)` is invalid (the settled #255 design excludes it);
+/// [`ApplicationModel::validate`] rejects it.
 ///
 /// [`Hole`]: crate::hole::Hole
+/// [`ApplicationModel::validate`]: crate::application::ApplicationModel::validate
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Capacity {
     Unbounded,
     Bounded(u64),
+}
+
+/// The topic-level half of the #255 bounds design: `bounded(N)`
+/// declared ON THE TOPIC, applying to every publisher, with the
+/// topic's `on_full` contract selected before any per-site
+/// disposition. Not reconstructible from publish rows — the N and
+/// the refusal contract are topic facts, which is why they are
+/// schema now (Change 1 pins what is expensive to retrofit).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct TopicBound {
+    /// Must be > 0; validate rejects `0`.
+    pub capacity: u64,
+    pub on_full: TopicOnFull,
+}
+
+/// What a full bounded topic does to a publish.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TopicOnFull {
+    /// `on_full: fail` — the send contract refuses at the publish
+    /// site (before any per-site disposition applies).
+    Fail,
 }
 
 /// What a bounded subscription does when full (GH #255 vocabulary).

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -138,15 +138,16 @@ pub use application::{
 };
 pub use capability::Capabilities;
 pub use entity::{
-    Binding, BindingRole, Function, FunctionKind, Group, LocusDecl,
-    LocusInstance, PayloadContract, Phase, Seed, Subject, ThreadDomain,
-    Topic, TransportKind,
+    Binding, BindingRole, Function, FunctionKind, Group, InterfaceDecl,
+    LocusDecl, LocusInstance, PayloadContract, Phase, Seed, Subject,
+    ThreadDomain, Topic, TransportKind, TypeDecl,
 };
 pub use hole::{Hole, HoleKind, RelationSet};
 pub use ids::{
-    BindingId, EntityRef, FunctionId, GroupId, LocusDeclId,
-    LocusInstanceId, PayloadContractId, PhaseId, ProvenanceId, SeedId,
-    SourceId, SubjectId, ThreadDomainId, TopicId,
+    BindingId, EntityRef, FunctionId, GroupId, InterfaceDeclId,
+    LocusDeclId, LocusInstanceId, PayloadContractId, PhaseId,
+    ProvenanceId, SeedId, SourceId, SubjectId, ThreadDomainId, TopicId,
+    TypeDeclId,
 };
 pub use keys::{
     BindingLossBehavior, Capacity, KeyDomain, KeyOnUnmatched, KeyPredicate,
@@ -155,7 +156,7 @@ pub use keys::{
 };
 pub use provenance::{Provenance, ProvenanceTable};
 pub use relation::{
-    AffinedTo, Call, CoreSet, DeclaredIn, DispatchKind, GroupMember,
-    MemberOf, Owns, PhaseOf, PlacedIn, Publish, Realizes, Subscribe,
-    Supervises, SupervisionPolicy, TopicBinding,
+    AffinedTo, Call, CoreSet, DeadInterfaceCall, DeclaredIn, DispatchKind,
+    GroupMember, MemberOf, Owns, PhaseOf, PlacedIn, Publish, Realizes,
+    Subscribe, Supervises, SupervisionPolicy, TopicBinding,
 };

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -154,7 +154,7 @@ pub use keys::{
 };
 pub use provenance::{Provenance, ProvenanceTable};
 pub use relation::{
-    AffinedTo, Call, CoreSet, DeadInterfaceCall, DeclaredIn, DispatchKind, GroupMember, MemberOf,
-    Owns, PhaseOf, PlacedIn, Publish, Realizes, Subscribe, Supervises, SupervisionPolicy,
-    TopicBinding,
+    AffinedTo, Call, CoreSet, DeadInterfaceCall, DeclaredIn, DispatchKind, GroupMember,
+    GroupSelector, MemberOf, Owns, PhaseOf, PlacedIn, Publish, Realizes, SelectorForm, Subscribe,
+    Supervises, SupervisionPolicy, TopicBinding,
 };

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -138,15 +138,15 @@ pub use application::{
 };
 pub use capability::Capabilities;
 pub use entity::{
-    Binding, BindingRole, Function, FunctionKind, LocusDecl, LocusInstance,
-    PayloadContract, Phase, Seed, Subject, ThreadDomain, Topic,
-    TransportKind,
+    Binding, BindingRole, Function, FunctionKind, Group, LocusDecl,
+    LocusInstance, PayloadContract, Phase, Seed, Subject, ThreadDomain,
+    Topic, TransportKind,
 };
 pub use hole::{Hole, HoleKind, RelationSet};
 pub use ids::{
-    BindingId, EntityRef, FunctionId, LocusDeclId, LocusInstanceId,
-    PayloadContractId, PhaseId, ProvenanceId, SeedId, SourceId, SubjectId,
-    ThreadDomainId, TopicId,
+    BindingId, EntityRef, FunctionId, GroupId, LocusDeclId,
+    LocusInstanceId, PayloadContractId, PhaseId, ProvenanceId, SeedId,
+    SourceId, SubjectId, ThreadDomainId, TopicId,
 };
 pub use keys::{
     BindingLossBehavior, Capacity, KeyDomain, KeyOnUnmatched, KeyPredicate,
@@ -155,7 +155,7 @@ pub use keys::{
 };
 pub use provenance::{Provenance, ProvenanceTable};
 pub use relation::{
-    AffinedTo, Call, CoreSet, DeclaredIn, DispatchKind, MemberOf, Owns,
-    PhaseOf, PlacedIn, Publish, Realizes, Subscribe, Supervises,
-    SupervisionPolicy, TopicBinding,
+    AffinedTo, Call, CoreSet, DeclaredIn, DispatchKind, GroupMember,
+    MemberOf, Owns, PhaseOf, PlacedIn, Publish, Realizes, Subscribe,
+    Supervises, SupervisionPolicy, TopicBinding,
 };

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -1,0 +1,160 @@
+//! # The canonical semantic model (GH #476, Change 1)
+//!
+//! One typed, provenance-bearing description of a checked Hale
+//! application — the value every structural consumer will read
+//! instead of re-deriving its own partial graph. This crate is the
+//! **schema and its laws**; derivation from a checked bundle
+//! (Change 2), the legacy-artifact projection and hash compatibility
+//! (Change 3), `ClaimIr` (Change 4), and the judgment engine
+//! (Changes 5a–5e) land separately per the epic's build order.
+//!
+//! ## The architectural law
+//!
+//! ```text
+//! Source --check/derive--> Model --judge(ClaimIr)--> Evidence
+//!                              |
+//!                              +--project--> Artifact
+//!
+//! Plan --admit/elaborate-------------------------------> Model
+//! Model --derive---------------------------------------> LoweringPlan
+//! ```
+//!
+//! Derive a modeled semantic fact **once**. Downstream consumers
+//! project or query it; they do not walk the AST, generic artifact
+//! JSON, or codegen state to rediscover it. Eight concepts stay
+//! distinct and un-conflated: source, plan, **model** (this crate),
+//! `ClaimIr`, evidence, artifact, lowering plan, and execution
+//! evidence.
+//!
+//! ## What a model is
+//!
+//! A model is **known facts plus an explicit account of what it does
+//! not know**, closed at a horizon:
+//!
+//! - typed entity tables ([`Entities`]) — not one homogeneous node
+//!   kind;
+//! - typed relation tables ([`Relations`]) — `calls`, `owns`,
+//!   `publishes` are different rows with different fields and
+//!   witness renderings, never interchangeable string edges;
+//! - typed **holes** ([`Hole`]) — unresolved residue as data, each
+//!   naming the relation families it hides;
+//! - positive **capabilities** ([`Capabilities`]) — what is exact,
+//!   stated, so a judgment can ask "is this model adequate?" without
+//!   reverse-engineering the absence of strings;
+//! - **provenance on every row** ([`Provenance`]) — source-neutral
+//!   (`SourceId` + byte span, or a named synthetic origin); this
+//!   crate never sees the AST.
+//!
+//! The judgment vocabulary this feeds (Changes 5a–5e): `holds` only
+//! over a complete relevant projection; `violated` with a concrete
+//! countermodel; `uncertified` when relevant reachable residue
+//! remains; `invalid` for a malformed law. A concrete path beats a
+//! hole; a hole beats a false proof of absence.
+//!
+//! ## Keyed delivery (first-class, two-sided)
+//!
+//! A keyed topic is not a broadcast edge. The schema records the
+//! authored facts — [`TopicKey`], per-publish [`KeyDomain`],
+//! per-subscription [`KeyPredicate`], replica indices — and
+//! judgments derive **two different relations** from them:
+//!
+//! - `may_deliver`: a subscriber is included when its predicate is
+//!   satisfiable **or unknown** — unknowns add possibilities, which
+//!   keeps negative claims (`forbid reaches`) conservative;
+//! - `must_deliver`: available only when key coverage and routing
+//!   are exact — a positive delivery guarantee never rests on an
+//!   unknown.
+//!
+//! `must_deliver` is **structural**: "dispatched ⇒ delivered, the
+//! process persisting." Temporal process-edge behavior (boot-window
+//! buffering, exit quiesce — GH #468) is runtime contract, not a
+//! static relation.
+//!
+//! ## Bounds and loss policy (recorded before claims need them)
+//!
+//! [`Capacity`], [`ShedPolicy`], [`PublishDisposition`], and
+//! [`BindingLossBehavior`] are schema rows now so a future
+//! must-arrive/no-loss claim does not retroactively change the
+//! meaning of existing delivery edges. Four query concepts stay
+//! distinct: a structural endpoint **exists**; a delivery is
+//! **possible**; a delivery is **guaranteed** under the declared
+//! contract; a path has **capacity**. A shedding policy never
+//! removes a possible-reachability edge; it invalidates an
+//! unqualified must-arrive guarantee.
+//!
+//! ## Identity and replay compatibility
+//!
+//! [`ModelHashKind`] names hash algorithms explicitly. The first
+//! model-backed artifact encoder must reproduce the legacy
+//! `TopologyShapeV1` hash exactly over the corpus before any cutover
+//! (Change 3); a richer identity is a **versioned transition** with
+//! an exact recording diagnostic, never a silent reinterpretation of
+//! the existing `u64`. Existing `.halerec` admission behavior is an
+//! acceptance criterion, not a casualty.
+//!
+//! ## Demand and the LSP contract
+//!
+//! Nothing in this crate runs unless demanded. The Change-2 builder
+//! is lazy per checked bundle, and a no-claims diagnostics-only
+//! check must provably never construct these tables ("cached" must
+//! not become "always built").
+//!
+//! ## Named consumers
+//!
+//! - **#464 (placement-aware devirtualization)** is Change 8's first
+//!   customer: its corpus domain survey becomes a model query and
+//!   `DispatchPlan::derive(&ApplicationModel)` owns the decision,
+//!   recorded in the execution digest — never as an authored
+//!   semantic row.
+//! - **iris**: obs registration/events gain canonical model entity
+//!   IDs stamped at codegen time, so runtime events join model rows
+//!   by ID instead of heuristic string matching, and holes give iris
+//!   an "expected-unpaired" category.
+//!
+//! ## Architecture canaries (enforced in `tests/architecture.rs`)
+//!
+//! - this crate depends on **nothing** — in particular never on
+//!   `hale-syntax` or `hale-types`;
+//! - every row carries provenance or a named synthetic origin (by
+//!   construction: the field is not optional);
+//! - a hole must hide at least one relation family;
+//! - a capability cannot claim exactness while a hole hides that
+//!   family ([`ApplicationModel::validate`]);
+//! - tables are canonically sorted and deduplicated — deterministic
+//!   iteration is a law, not a convention.
+
+pub mod application;
+pub mod capability;
+pub mod entity;
+pub mod hole;
+pub mod ids;
+pub mod keys;
+pub mod provenance;
+pub mod relation;
+
+pub use application::{
+    ApplicationModel, Entities, LabelRow, ModelError, ModelHashKind,
+    ModelHeader, Relations, WeightRow, MODEL_SEMANTICS_V1,
+};
+pub use capability::Capabilities;
+pub use entity::{
+    Binding, BindingRole, Function, FunctionKind, LocusDecl, LocusInstance,
+    PayloadContract, Phase, Seed, Subject, ThreadDomain, Topic,
+    TransportKind,
+};
+pub use hole::{Hole, HoleKind, RelationSet};
+pub use ids::{
+    BindingId, EntityRef, FunctionId, LocusDeclId, LocusInstanceId,
+    PayloadContractId, PhaseId, ProvenanceId, SeedId, SourceId, SubjectId,
+    ThreadDomainId, TopicId,
+};
+pub use keys::{
+    BindingLossBehavior, Capacity, KeyDomain, KeyPredicate, KeyValue,
+    PublishDisposition, ShedPolicy, TopicKey,
+};
+pub use provenance::{Provenance, ProvenanceTable};
+pub use relation::{
+    AffinedTo, Call, CoreSet, DeclaredIn, DispatchKind, MemberOf, Owns,
+    PhaseOf, PlacedIn, Publish, Realizes, Subscribe, Supervises,
+    SupervisionPolicy, TopicBinding,
+};

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -133,30 +133,28 @@ pub mod provenance;
 pub mod relation;
 
 pub use application::{
-    ApplicationModel, Entities, LabelRow, ModelError, ModelHashKind,
-    ModelHeader, Relations, WeightRow, MODEL_SEMANTICS_V1,
+    ApplicationModel, Entities, LabelRow, ModelError, ModelHashKind, ModelHeader, Relations,
+    WeightRow, MODEL_SEMANTICS_V1,
 };
 pub use capability::Capabilities;
 pub use entity::{
-    Binding, BindingRole, Function, FunctionKind, Group, InterfaceDecl,
-    LocusDecl, LocusInstance, PayloadContract, Phase, Seed, Subject,
-    ThreadDomain, Topic, TransportKind, TypeDecl,
+    Binding, BindingRole, DeclKind, Declaration, Function, FunctionKind, Group, InterfaceDecl,
+    LocusDecl, LocusInstance, PayloadContract, Phase, Seed, Subject, ThreadDomain, Topic,
+    TransportKind, TypeDecl,
 };
 pub use hole::{Hole, HoleKind, RelationSet};
 pub use ids::{
-    BindingId, EntityRef, FunctionId, GroupId, InterfaceDeclId,
-    LocusDeclId, LocusInstanceId, PayloadContractId, PhaseId,
-    ProvenanceId, SeedId, SourceId, SubjectId, ThreadDomainId, TopicId,
-    TypeDeclId,
+    BindingId, DeclarationId, EntityRef, FunctionId, GroupId, InterfaceDeclId, LocusDeclId,
+    LocusInstanceId, PayloadContractId, PhaseId, ProvenanceId, SeedId, SourceId, SubjectId,
+    ThreadDomainId, TopicId, TypeDeclId,
 };
 pub use keys::{
-    BindingLossBehavior, Capacity, KeyDomain, KeyOnUnmatched, KeyPredicate,
-    KeyValue, PublishDisposition, ShedPolicy, TopicBound, TopicKey,
-    TopicOnFull,
+    BindingLossBehavior, Capacity, KeyDomain, KeyOnUnmatched, KeyPredicate, KeyValue,
+    PublishDisposition, ShedPolicy, TopicBound, TopicKey, TopicOnFull,
 };
 pub use provenance::{Provenance, ProvenanceTable};
 pub use relation::{
-    AffinedTo, Call, CoreSet, DeadInterfaceCall, DeclaredIn, DispatchKind,
-    GroupMember, MemberOf, Owns, PhaseOf, PlacedIn, Publish, Realizes,
-    Subscribe, Supervises, SupervisionPolicy, TopicBinding,
+    AffinedTo, Call, CoreSet, DeadInterfaceCall, DeclaredIn, DispatchKind, GroupMember, MemberOf,
+    Owns, PhaseOf, PlacedIn, Publish, Realizes, Subscribe, Supervises, SupervisionPolicy,
+    TopicBinding,
 };

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -149,8 +149,9 @@ pub use ids::{
     ThreadDomainId, TopicId,
 };
 pub use keys::{
-    BindingLossBehavior, Capacity, KeyDomain, KeyPredicate, KeyValue,
-    PublishDisposition, ShedPolicy, TopicBound, TopicKey, TopicOnFull,
+    BindingLossBehavior, Capacity, KeyDomain, KeyOnUnmatched, KeyPredicate,
+    KeyValue, PublishDisposition, ShedPolicy, TopicBound, TopicKey,
+    TopicOnFull,
 };
 pub use provenance::{Provenance, ProvenanceTable};
 pub use relation::{

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -150,7 +150,7 @@ pub use ids::{
 };
 pub use keys::{
     BindingLossBehavior, Capacity, KeyDomain, KeyPredicate, KeyValue,
-    PublishDisposition, ShedPolicy, TopicKey,
+    PublishDisposition, ShedPolicy, TopicBound, TopicKey, TopicOnFull,
 };
 pub use provenance::{Provenance, ProvenanceTable};
 pub use relation::{

--- a/crates/hale-model/src/provenance.rs
+++ b/crates/hale-model/src/provenance.rs
@@ -1,0 +1,44 @@
+//! Source-neutral provenance.
+//!
+//! This crate never sees the AST: `hale-types` maps compiler spans
+//! into these records while deriving the model (Change 2). The law —
+//! enforced by construction, since no row type makes its provenance
+//! optional — is that **every** entity, relation, hole, label, and
+//! weight answers "where did this fact come from": either a source
+//! location or a *named* synthetic origin (facts the compiler
+//! introduces with no single authored location, e.g. the implicit
+//! main arrangement root).
+
+use crate::ids::SourceId;
+
+/// One origin record.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Provenance {
+    /// An authored fact: a byte span in a source unit.
+    Source {
+        source: SourceId,
+        /// Byte offsets `[start, end)` in the unit's content.
+        span: (u32, u32),
+    },
+    /// A derived fact with no single authored location. The origin
+    /// names the introducing rule so a witness can still say
+    /// something true ("synthetic: main-arrangement root").
+    Synthetic { origin: String },
+}
+
+/// One source unit provenance points into. `path` is as-authored
+/// (never absolutized — artifacts must not embed machine paths);
+/// `digest` pins the content the spans index.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SourceUnit {
+    pub path: String,
+    pub digest: u64,
+}
+
+/// The provenance store: sources plus origin records, referenced by
+/// dense IDs from every row in the model.
+#[derive(Clone, Default, Debug)]
+pub struct ProvenanceTable {
+    pub sources: Vec<SourceUnit>,
+    pub records: Vec<Provenance>,
+}

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -16,7 +16,7 @@
 
 use crate::ids::{
     BindingId, FunctionId, GroupId, LocusDeclId, LocusInstanceId, PhaseId,
-    ProvenanceId, SeedId, ThreadDomainId, TopicId,
+    ProvenanceId, SeedId, SubjectId, ThreadDomainId, TopicId,
 };
 use crate::keys::{Capacity, KeyDomain, KeyPredicate, PublishDisposition, ShedPolicy};
 
@@ -101,20 +101,27 @@ pub struct Call {
     pub provenance: ProvenanceId,
 }
 
-/// `publishes(function, topic)` at SITE grain, with the site's key
-/// domain and declared loss disposition. One function may publish
-/// one topic from several sites with DIFFERENT dispositions
-/// (`Orders <- a or wait; Orders <- b or discard;`) — each is its
-/// own row with its own provenance. `site` is the 0-based
-/// source-order ordinal within the function.
+/// `publishes(function, subject)` at SITE grain, with the site's
+/// key domain and declared loss disposition. The endpoint identity
+/// is the WIRE SUBJECT — literal (`publish "orders.created"`) and
+/// declared-topic publishes are both real endpoints; when a
+/// declared topic exists, `declared_topic` links it (and its
+/// subject must agree — validated). Synthesizing a fake Topic for
+/// a literal subject would corrupt the declared-topic sort and the
+/// legacy hash. One function may publish one subject from several
+/// sites with DIFFERENT dispositions — each its own row.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Publish {
     pub function: FunctionId,
-    pub topic: TopicId,
+    pub subject: SubjectId,
+    /// `Some` when a declared topic covers this endpoint; its
+    /// subject must equal `subject`.
+    pub declared_topic: Option<TopicId>,
     /// Source-order site ordinal within `function`.
     pub site: u32,
-    /// `Some` iff the topic is keyed (validated both ways) — an
-    /// unkeyed publish has no key domain to invent.
+    /// `Some` iff the declared topic is keyed (validated both
+    /// ways) — an undeclared or unkeyed endpoint has no key domain
+    /// to invent.
     pub key_domain: Option<KeyDomain>,
     pub disposition: PublishDisposition,
     pub provenance: ProvenanceId,
@@ -125,7 +132,12 @@ pub struct Publish {
 /// derive from.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Subscribe {
-    pub topic: TopicId,
+    /// The wire subject or pattern — wildcard subscriptions
+    /// (`subscribe "orders.**"`) are subject-only endpoints.
+    pub subject: SubjectId,
+    /// `Some` when a declared topic covers this endpoint; subjects
+    /// must agree (validated).
+    pub declared_topic: Option<TopicId>,
     pub handler: FunctionId,
     /// Source-order ordinal of the subscription declaration within
     /// its locus's bus block — two subscriptions of one topic by
@@ -144,6 +156,25 @@ pub struct Subscribe {
 pub struct GroupMember {
     pub group: GroupId,
     pub member: crate::ids::EntityRef,
+    pub provenance: ProvenanceId,
+}
+
+/// A known-DEAD interface dispatch: a call through an interface no
+/// locus in the closed world conforms to. NOT a hole — an
+/// uninhabited interface has no values, so the site contributes no
+/// edge and does not prevent certification (`exact_calls` stays
+/// claimable). Retained as a row because a conformer appearing
+/// later must change the model shape — exactly why the topology
+/// artifact records it inside the hashed half.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct DeadInterfaceCall {
+    pub from: FunctionId,
+    /// Source-order site ordinal within `from`.
+    pub site: u32,
+    /// The uninhabited interface's canonical name.
+    pub interface: String,
+    /// The dispatched method name.
+    pub method: String,
     pub provenance: ProvenanceId,
 }
 

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -15,7 +15,7 @@
 //! [`Hole`]: crate::hole::Hole
 
 use crate::ids::{
-    BindingId, FunctionId, GroupId, LocusDeclId, LocusInstanceId, PhaseId,
+    BindingId, FunctionId, GroupId, LocusDeclId, LocusInstanceId, PayloadContractId, PhaseId,
     ProvenanceId, SeedId, SubjectId, ThreadDomainId, TopicId,
 };
 use crate::keys::{Capacity, KeyDomain, KeyPredicate, PublishDisposition, ShedPolicy};
@@ -69,7 +69,9 @@ pub enum DispatchKind {
     /// Dispatch through an interface, fanned to a conformer in the
     /// closed world. `interface` is the contract's canonical name;
     /// one authored site yields one row per conformer.
-    Interface { interface: String },
+    Interface {
+        interface: String,
+    },
     /// A contracted through-stdlib path: the artifact deliberately
     /// hides stdlib interiors, but the endpoints are exact.
     ViaStdlib,
@@ -117,6 +119,11 @@ pub struct Publish {
     /// `Some` when a declared topic covers this endpoint; its
     /// subject must equal `subject`.
     pub declared_topic: Option<TopicId>,
+    /// The endpoint's payload contract. A literal endpoint carries
+    /// its `of type T` here (the checked fact BusGraph keeps); a
+    /// declared endpoint's payload must agree with its topic's
+    /// (validated).
+    pub payload: PayloadContractId,
     /// Source-order site ordinal within `function`.
     pub site: u32,
     /// `Some` iff the declared topic is keyed (validated both
@@ -138,6 +145,10 @@ pub struct Subscribe {
     /// `Some` when a declared topic covers this endpoint; subjects
     /// must agree (validated).
     pub declared_topic: Option<TopicId>,
+    /// The endpoint's payload contract (`of type T` on literal /
+    /// wildcard subscriptions; must agree with a declared topic's
+    /// payload).
+    pub payload: PayloadContractId,
     pub handler: FunctionId,
     /// Source-order ordinal of the subscription declaration within
     /// its locus's bus block — two subscriptions of one topic by

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -1,0 +1,159 @@
+//! Relation tables — typed rows, each with its own fields, proof
+//! obligations, and (later) witness rendering.
+//!
+//! Two laws:
+//!
+//! 1. **Resolved rows only.** An unresolved callee, computed
+//!    subject, or dynamic endpoint is a [`Hole`], never a row with a
+//!    stringly placeholder — the fail-closed vocabulary depends on
+//!    unknowns being typed residue, not fake edges.
+//! 2. **Facts, not conclusions.** Direct-call eligibility, static
+//!    dispatch buckets, and placement specialization are lowering
+//!    plans derived FROM these rows (Change 8); they never appear
+//!    here as if authored.
+//!
+//! [`Hole`]: crate::hole::Hole
+
+use crate::ids::{
+    BindingId, FunctionId, LocusDeclId, LocusInstanceId, PhaseId,
+    ProvenanceId, SeedId, ThreadDomainId, TopicId,
+};
+use crate::keys::{Capacity, KeyDomain, KeyPredicate, PublishDisposition, ShedPolicy};
+
+/// `member_of(function, locus)`.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct MemberOf {
+    pub function: FunctionId,
+    pub locus: LocusDeclId,
+    pub provenance: ProvenanceId,
+}
+
+/// `phase_of(function, phase)`.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct PhaseOf {
+    pub function: FunctionId,
+    pub phase: PhaseId,
+    pub provenance: ProvenanceId,
+}
+
+/// `declared_in(entity, seed)`.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct DeclaredIn {
+    pub entity: crate::ids::EntityRef,
+    pub seed: SeedId,
+    pub provenance: ProvenanceId,
+}
+
+/// `realizes(instance, locus_decl)`.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Realizes {
+    pub instance: LocusInstanceId,
+    pub decl: LocusDeclId,
+    pub provenance: ProvenanceId,
+}
+
+/// `owns(parent_instance, child_instance)` — the lifecycle tree.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Owns {
+    pub parent: LocusInstanceId,
+    pub child: LocusInstanceId,
+    pub provenance: ProvenanceId,
+}
+
+/// How a resolved call dispatches. The *fact* of the mechanism —
+/// which lowering flavor it gets (direct call, static bucket, local
+/// queue) is a `DispatchPlan` conclusion, not a model row.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum DispatchKind {
+    Direct,
+    /// Dispatch through an interface, fanned to a conformer in the
+    /// closed world. `interface` is the contract's canonical name;
+    /// one authored site yields one row per conformer.
+    Interface { interface: String },
+    /// A contracted through-stdlib path: the artifact deliberately
+    /// hides stdlib interiors, but the endpoints are exact.
+    ViaStdlib,
+}
+
+/// `calls(caller, callee)` — resolved calls only (law 1 above).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Call {
+    pub from: FunctionId,
+    pub to: FunctionId,
+    pub dispatch: DispatchKind,
+    /// The site sits inside a loop (quantitative judgments weight
+    /// it unbounded-per-activation unless bounded elsewhere).
+    pub in_loop: bool,
+    pub provenance: ProvenanceId,
+}
+
+/// `publishes(function, topic)` with the site's key domain and
+/// declared loss disposition.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Publish {
+    pub function: FunctionId,
+    pub topic: TopicId,
+    pub key_domain: KeyDomain,
+    pub disposition: PublishDisposition,
+    pub provenance: ProvenanceId,
+}
+
+/// `subscribes(topic, handler)` with the subscription's key
+/// predicate and bounds — the raw facts `may_deliver`/`must_deliver`
+/// derive from.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Subscribe {
+    pub topic: TopicId,
+    pub handler: FunctionId,
+    pub key_predicate: KeyPredicate,
+    pub capacity: Capacity,
+    pub shed: ShedPolicy,
+    pub provenance: ProvenanceId,
+}
+
+/// `placed_in(instance, thread_domain)`.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct PlacedIn {
+    pub instance: LocusInstanceId,
+    pub domain: ThreadDomainId,
+    pub provenance: ProvenanceId,
+}
+
+/// A resolved CPU set (sorted, deduplicated core indices).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct CoreSet(pub Vec<u32>);
+
+/// `affined_to(thread_domain, cores)`.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct AffinedTo {
+    pub domain: ThreadDomainId,
+    pub cores: CoreSet,
+    pub provenance: ProvenanceId,
+}
+
+/// `binds(topic, binding)` — the topic crosses a process boundary
+/// through this transport.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TopicBinding {
+    pub topic: TopicId,
+    pub binding: BindingId,
+    pub provenance: ProvenanceId,
+}
+
+/// A supervision policy as declared (ops vocabulary + retry bound),
+/// kept as authored strings at Change 1 — the artifact already
+/// serializes this row shape (schema 1.10).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SupervisionPolicy {
+    pub ops: Vec<String>,
+    pub retry_bound: Option<u32>,
+}
+
+/// `supervises(parent, child, policy)`.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Supervises {
+    pub parent: LocusDeclId,
+    pub child: LocusDeclId,
+    pub policy: SupervisionPolicy,
+    pub provenance: ProvenanceId,
+}

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -160,13 +160,46 @@ pub struct Subscribe {
     pub provenance: ProvenanceId,
 }
 
-/// `member_of_group(group, member)` — one row per resolved group
-/// member (loci and free fns; a glob is already enumerated by
-/// resolution, so members are always concrete).
+/// `member_of_group(group, member)` — one row per RESOLVED group
+/// member (loci and free fns; globs enumerated). This is the
+/// normalized grain judgments quantify over. It is deliberately
+/// NOT the authored grain: the legacy artifact hashes the selector
+/// list AS WRITTEN (`lib::*` stays unexpanded), so projection
+/// reads [`GroupSelector`] — `{ lib::* }` and `{ lib::A, lib::B }`
+/// may resolve to identical membership yet MUST keep distinct
+/// shapes.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct GroupMember {
     pub group: GroupId,
     pub member: crate::ids::EntityRef,
+    pub provenance: ProvenanceId,
+}
+
+/// One authored selector of a group declaration, in authored order
+/// (`ordinal`). The authored spelling is the fact the legacy hash
+/// covers; `GroupMember` carries the resolution.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum SelectorForm {
+    /// A single named member — canonical reference plus the
+    /// authored display spelling (`DeltaStore`, `lib::A`).
+    Named {
+        member: crate::ids::EntityRef,
+        display: String,
+    },
+    /// A trailing glob over a seed's exports, kept UNEXPANDED as
+    /// authored (`lib::*`) — a zero-member glob is still a
+    /// selector row even though it contributes no members.
+    SeedGlob { seed: SeedId, display: String },
+}
+
+/// `group_selector(group, ordinal)` — the authored selector list.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct GroupSelector {
+    pub group: GroupId,
+    /// 0-based authored position — the artifact hashes the list
+    /// ordered, so order is a semantic fact.
+    pub ordinal: u32,
+    pub selector: SelectorForm,
     pub provenance: ProvenanceId,
 }
 

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -63,7 +63,7 @@ pub struct Owns {
 /// How a resolved call dispatches. The *fact* of the mechanism —
 /// which lowering flavor it gets (direct call, static bucket, local
 /// queue) is a `DispatchPlan` conclusion, not a model row.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum DispatchKind {
     Direct,
     /// Dispatch through an interface, fanned to a conformer in the

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -15,7 +15,7 @@
 //! [`Hole`]: crate::hole::Hole
 
 use crate::ids::{
-    BindingId, FunctionId, LocusDeclId, LocusInstanceId, PhaseId,
+    BindingId, FunctionId, GroupId, LocusDeclId, LocusInstanceId, PhaseId,
     ProvenanceId, SeedId, ThreadDomainId, TopicId,
 };
 use crate::keys::{Capacity, KeyDomain, KeyPredicate, PublishDisposition, ShedPolicy};
@@ -113,7 +113,9 @@ pub struct Publish {
     pub topic: TopicId,
     /// Source-order site ordinal within `function`.
     pub site: u32,
-    pub key_domain: KeyDomain,
+    /// `Some` iff the topic is keyed (validated both ways) — an
+    /// unkeyed publish has no key domain to invent.
+    pub key_domain: Option<KeyDomain>,
     pub disposition: PublishDisposition,
     pub provenance: ProvenanceId,
 }
@@ -132,6 +134,16 @@ pub struct Subscribe {
     pub key_predicate: KeyPredicate,
     pub capacity: Capacity,
     pub shed: ShedPolicy,
+    pub provenance: ProvenanceId,
+}
+
+/// `member_of_group(group, member)` — one row per resolved group
+/// member (loci and free fns; a glob is already enumerated by
+/// resolution, so members are always concrete).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct GroupMember {
+    pub group: GroupId,
+    pub member: crate::ids::EntityRef,
     pub provenance: ProvenanceId,
 }
 

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -75,24 +75,44 @@ pub enum DispatchKind {
     ViaStdlib,
 }
 
-/// `calls(caller, callee)` — resolved calls only (law 1 above).
+/// `calls(caller, callee)` at SITE grain — resolved calls only
+/// (law 1 above). One row per call site: two sites sharing
+/// endpoints but differing in loop/boundedness facts are two rows,
+/// each with its own provenance span (witnesses point at sites).
+/// `site` is the 0-based source-order ordinal of the site within
+/// its caller — stable under source motion as long as relative
+/// order holds, which is the same stability class as the shape
+/// hash. Endpoint-grained projections (the artifact's merged
+/// `calls` relation) are DERIVED by conservative merge: `in_loop`
+/// and `unbounded` OR together, never dropped.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Call {
     pub from: FunctionId,
     pub to: FunctionId,
     pub dispatch: DispatchKind,
-    /// The site sits inside a loop (quantitative judgments weight
-    /// it unbounded-per-activation unless bounded elsewhere).
+    /// Source-order site ordinal within `from` (see above).
+    pub site: u32,
+    /// The site sits inside a loop.
     pub in_loop: bool,
+    /// The site's per-activation repetition is not statically
+    /// bounded (the topology model keeps loop and unbounded as
+    /// separate facts; so does this schema).
+    pub unbounded: bool,
     pub provenance: ProvenanceId,
 }
 
-/// `publishes(function, topic)` with the site's key domain and
-/// declared loss disposition.
+/// `publishes(function, topic)` at SITE grain, with the site's key
+/// domain and declared loss disposition. One function may publish
+/// one topic from several sites with DIFFERENT dispositions
+/// (`Orders <- a or wait; Orders <- b or discard;`) — each is its
+/// own row with its own provenance. `site` is the 0-based
+/// source-order ordinal within the function.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Publish {
     pub function: FunctionId,
     pub topic: TopicId,
+    /// Source-order site ordinal within `function`.
+    pub site: u32,
     pub key_domain: KeyDomain,
     pub disposition: PublishDisposition,
     pub provenance: ProvenanceId,
@@ -105,6 +125,10 @@ pub struct Publish {
 pub struct Subscribe {
     pub topic: TopicId,
     pub handler: FunctionId,
+    /// Source-order ordinal of the subscription declaration within
+    /// its locus's bus block — two subscriptions of one topic by
+    /// one handler with different filters are two rows.
+    pub site: u32,
     pub key_predicate: KeyPredicate,
     pub capacity: Capacity,
     pub shed: ShedPolicy,
@@ -149,11 +173,17 @@ pub struct SupervisionPolicy {
     pub retry_bound: Option<u32>,
 }
 
-/// `supervises(parent, child, policy)`.
+/// `supervises(parent, child, error_type, policy)` — one row per
+/// `on_failure` handler. Two handlers supervising the same child
+/// for DIFFERENT error types are distinct policies (the schema-1.10
+/// supervision section is per-handler), so the error type is part
+/// of the row and its canonical key.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Supervises {
     pub parent: LocusDeclId,
     pub child: LocusDeclId,
+    /// The handled error/violation type's canonical name.
+    pub error_type: String,
     pub policy: SupervisionPolicy,
     pub provenance: ProvenanceId,
 }

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -139,6 +139,8 @@ fn tiny_model() -> ApplicationModel {
             }],
             bindings: vec![],
             groups: vec![],
+            types: vec![],
+            interfaces: vec![],
         },
         relations: Relations {
             realizes: vec![Realizes {
@@ -160,14 +162,16 @@ fn tiny_model() -> ApplicationModel {
             ],
             publishes: vec![Publish {
                 function: FunctionId(0),
-                topic: TopicId(0),
+                subject: SubjectId(0),
+                declared_topic: Some(TopicId(0)),
                 site: 0,
                 key_domain: Some(KeyDomain::Exact(vec![KeyValue::Int(1)])),
                 disposition: PublishDisposition::Default,
                 provenance: p,
             }],
             subscribes: vec![Subscribe {
-                topic: TopicId(0),
+                subject: SubjectId(0),
+                declared_topic: Some(TopicId(0)),
                 handler: FunctionId(1),
                 site: 0,
                 key_predicate: KeyPredicate::EqReplica,
@@ -559,7 +563,8 @@ fn two_publish_sites_on_one_topic_are_representable() {
     let mut m = tiny_model();
     m.relations.publishes.push(Publish {
         function: FunctionId(0),
-        topic: TopicId(0),
+        subject: SubjectId(0),
+        declared_topic: Some(TopicId(0)),
         site: 1,
         key_domain: Some(KeyDomain::Exact(vec![KeyValue::Int(2)])),
         disposition: PublishDisposition::Wait,
@@ -797,4 +802,174 @@ fn keyedness_must_match_the_topic_both_ways() {
             index: 0
         })
     );
+}
+
+// -----------------------------------------------------------------
+// Review round 4 — dead dispatches, literal/wildcard endpoints, and
+// the full declaration universe.
+// -----------------------------------------------------------------
+
+/// A call through an uninhabited interface is a DEAD site, not a
+/// hole: representable without hiding CALLS, so `exact_calls` stays
+/// claimable — precisely the artifact's closed-world rule.
+#[test]
+fn dead_interface_calls_are_not_holes() {
+    let mut m = tiny_model();
+    m.relations.dead_interface_calls = vec![DeadInterfaceCall {
+        from: FunctionId(1),
+        site: 0,
+        interface: "Notifier".to_string(),
+        method: "notify".to_string(),
+        provenance: ProvenanceId(0),
+    }];
+    // exact_calls is TRUE in tiny_model — the dead site must not
+    // contradict it (it is not residue).
+    assert!(m.capabilities.exact_calls);
+    m.validate()
+        .expect("a dead dispatch coexists with exact_calls");
+    // Same (from, site) twice is a duplicate.
+    m.relations
+        .dead_interface_calls
+        .push(m.relations.dead_interface_calls[0].clone());
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::NotCanonical {
+            table: "dead_interface_calls",
+            index: 1
+        })
+    );
+}
+
+/// Literal and wildcard subjects are real endpoints WITHOUT topic
+/// declarations: subject-grained rows carry them, and no fake Topic
+/// enters the declared sort.
+#[test]
+fn literal_and_wildcard_endpoints_are_representable() {
+    let mut m = tiny_model();
+    let p = ProvenanceId(0);
+    m.entities.subjects.push(Subject {
+        pattern: "z.orders.**".to_string(),
+        exact: false,
+        provenance: p,
+    });
+    // A wildcard subscription with no declared topic.
+    m.relations.subscribes.push(Subscribe {
+        subject: SubjectId(1),
+        declared_topic: None,
+        handler: FunctionId(1),
+        site: 1,
+        key_predicate: KeyPredicate::Any,
+        capacity: Capacity::Unbounded,
+        shed: ShedPolicy::None,
+        provenance: p,
+    });
+    // A literal publish with no declared topic (unkeyed: None).
+    m.relations.publishes.push(Publish {
+        function: FunctionId(0),
+        subject: SubjectId(1),
+        declared_topic: None,
+        site: 1,
+        key_domain: None,
+        disposition: PublishDisposition::Default,
+        provenance: p,
+    });
+    m.validate()
+        .expect("undeclared endpoints are lawful subject rows");
+    assert_eq!(
+        m.entities.topics.len(),
+        1,
+        "no fake Topic was needed — the declared sort is untouched"
+    );
+
+    // A keyed predicate on an undeclared endpoint is refused.
+    m.relations.subscribes[1].key_predicate = KeyPredicate::EqReplica;
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::KeyContract {
+            table: "subscribes",
+            index: 1
+        })
+    );
+}
+
+/// A declared_topic whose subject disagrees with the row's subject
+/// is one endpoint with two addresses — refused.
+#[test]
+fn declared_topic_subject_must_agree() {
+    let mut m = tiny_model();
+    m.entities.subjects.push(Subject {
+        pattern: "z.other".to_string(),
+        exact: true,
+        provenance: ProvenanceId(0),
+    });
+    m.relations.publishes[0].subject = SubjectId(1);
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::DeclaredTopicDisagrees {
+            table: "publishes",
+            index: 0
+        })
+    );
+}
+
+/// The declaration universe covers the seed sort: types,
+/// interfaces, and groups participate in `declared_in` alongside
+/// loci, fns, and topics — the full rename table, no side channel.
+#[test]
+fn declared_in_covers_the_full_declaration_universe() {
+    let mut m = tiny_model();
+    let p = ProvenanceId(0);
+    m.entities.types = vec![TypeDecl {
+        name: "Reading".to_string(),
+        display: "Reading".to_string(),
+        provenance: p,
+    }];
+    m.entities.interfaces = vec![InterfaceDecl {
+        name: "Notifier".to_string(),
+        display: "Notifier".to_string(),
+        provenance: p,
+    }];
+    m.entities.groups = vec![Group {
+        name: "workers".to_string(),
+        may_be_empty: false,
+        provenance: p,
+    }];
+    m.relations.declared_in = vec![
+        DeclaredIn {
+            entity: EntityRef::Function(FunctionId(1)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::LocusDecl(LocusDeclId(1)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::Topic(TopicId(0)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::Group(GroupId(0)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::Type(TypeDeclId(0)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::Interface(InterfaceDeclId(0)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+    ];
+    m.validate()
+        .expect("the full declaration universe joins the seed sort");
+
+    // Dangling type id in an EntityRef is still refused.
+    m.relations.declared_in[4].entity = EntityRef::Type(TypeDeclId(7));
+    assert!(m.validate().is_err());
 }

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -138,6 +138,7 @@ fn tiny_model() -> ApplicationModel {
                 provenance: p,
             }],
             bindings: vec![],
+            groups: vec![],
         },
         relations: Relations {
             realizes: vec![Realizes {
@@ -161,7 +162,7 @@ fn tiny_model() -> ApplicationModel {
                 function: FunctionId(0),
                 topic: TopicId(0),
                 site: 0,
-                key_domain: KeyDomain::Exact(vec![KeyValue::Int(1)]),
+                key_domain: Some(KeyDomain::Exact(vec![KeyValue::Int(1)])),
                 disposition: PublishDisposition::Default,
                 provenance: p,
             }],
@@ -372,7 +373,7 @@ fn unsorted_supervises_are_not_canonical() {
 fn nested_key_sets_must_be_canonical() {
     let mut m = tiny_model();
     m.relations.publishes[0].key_domain =
-        KeyDomain::Exact(vec![KeyValue::Int(2), KeyValue::Int(1)]);
+        Some(KeyDomain::Exact(vec![KeyValue::Int(2), KeyValue::Int(1)]));
     assert_eq!(
         m.validate(),
         Err(ModelError::NotCanonical {
@@ -389,7 +390,7 @@ fn nested_key_sets_must_be_canonical() {
 fn inline_unknown_key_domain_requires_a_hole() {
     let mut m = tiny_model();
     m.capabilities.exact_key_filters = true;
-    m.relations.publishes[0].key_domain = KeyDomain::Unknown;
+    m.relations.publishes[0].key_domain = Some(KeyDomain::Unknown);
     // No hole at all: the unknown is unrepresented.
     assert_eq!(
         m.validate(),
@@ -560,7 +561,7 @@ fn two_publish_sites_on_one_topic_are_representable() {
         function: FunctionId(0),
         topic: TopicId(0),
         site: 1,
-        key_domain: KeyDomain::Exact(vec![KeyValue::Int(2)]),
+        key_domain: Some(KeyDomain::Exact(vec![KeyValue::Int(2)])),
         disposition: PublishDisposition::Wait,
         provenance: ProvenanceId(0),
     });
@@ -569,7 +570,7 @@ fn two_publish_sites_on_one_topic_are_representable() {
     // The SAME site twice is still a duplicate.
     m.relations.publishes[1].site = 0;
     m.relations.publishes[1].key_domain =
-        KeyDomain::Exact(vec![KeyValue::Int(1)]);
+        Some(KeyDomain::Exact(vec![KeyValue::Int(1)]));
     m.relations.publishes[1].disposition = PublishDisposition::Default;
     assert_eq!(
         m.validate(),
@@ -683,7 +684,7 @@ fn fallback_contract_is_validated_both_ways() {
 #[test]
 fn key_values_cover_the_shipped_routing_types() {
     let mut m = tiny_model();
-    m.relations.publishes[0].key_domain = KeyDomain::Exact(vec![
+    m.relations.publishes[0].key_domain = Some(KeyDomain::Exact(vec![
         KeyValue::Bool(true),
         KeyValue::Int(3),
         KeyValue::Time(1_000),
@@ -691,6 +692,109 @@ fn key_values_cover_the_shipped_routing_types() {
         KeyValue::EnumTag("Buy".to_string()),
         KeyValue::Decimal { lo: 1, hi: 2 },
         KeyValue::Str("sym".to_string()),
-    ]);
+    ]));
     m.validate().expect("all key-type variants are usable");
+}
+
+// -----------------------------------------------------------------
+// Review round 3 — groups and the unkeyed key contract.
+// -----------------------------------------------------------------
+
+/// Groups are model rows (claims resolve selectors through them and
+/// the artifact shape-hashes them) — with membership as a typed
+/// relation over EntityRefs, covering loci AND free fns.
+#[test]
+fn groups_are_typed_model_rows() {
+    let mut m = tiny_model();
+    let p = ProvenanceId(0);
+    m.entities.groups = vec![
+        Group {
+            name: "probes".to_string(),
+            may_be_empty: true,
+            provenance: p,
+        },
+        Group {
+            name: "workers".to_string(),
+            may_be_empty: false,
+            provenance: p,
+        },
+    ];
+    m.relations.group_members = vec![
+        GroupMember {
+            group: GroupId(1),
+            member: EntityRef::LocusDecl(LocusDeclId(1)),
+            provenance: p,
+        },
+        GroupMember {
+            group: GroupId(1),
+            member: EntityRef::Function(FunctionId(0)),
+            provenance: p,
+        },
+    ];
+    // Members sort by (group, member); the rows above are reversed.
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::NotCanonical {
+            table: "group_members",
+            index: 1
+        })
+    );
+    m.relations.group_members.swap(0, 1);
+    m.validate().expect("sorted group membership is lawful");
+
+    // Dangling group id refused (perturb the LAST row so the table
+    // stays sorted and the reference check is what fires).
+    m.relations.group_members[1].group = GroupId(9);
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::DanglingId {
+            table: "group_members",
+            index: 1
+        })
+    );
+}
+
+/// The unkeyed contract, all four directions: an unkeyed publish
+/// carries NO key domain; a keyed publish carries one; an unkeyed
+/// topic admits only the plain subscription; keyed predicates need
+/// keyed topics.
+#[test]
+fn keyedness_must_match_the_topic_both_ways() {
+    // Keyed topic (tiny_model default), publish without a domain.
+    let mut m = tiny_model();
+    m.relations.publishes[0].key_domain = None;
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::KeyContract {
+            table: "publishes",
+            index: 0
+        })
+    );
+
+    // Unkeyed topic, publish WITH a domain: inventing a meaning.
+    let mut m = tiny_model();
+    m.entities.topics[0].key = None;
+    m.relations.subscribes[0].key_predicate = KeyPredicate::Any;
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::KeyContract {
+            table: "publishes",
+            index: 0
+        })
+    );
+
+    // Fully unkeyed: publish None + Any subscription is lawful.
+    m.relations.publishes[0].key_domain = None;
+    m.validate().expect("unkeyed topic, unkeyed rows: lawful");
+
+    // A keyed predicate on the unkeyed topic is refused.
+    m.relations.subscribes[0].key_predicate =
+        KeyPredicate::EqLiteral(KeyValue::Int(1));
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::KeyContract {
+            table: "subscribes",
+            index: 0
+        })
+    );
 }

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -108,6 +108,10 @@ fn tiny_model() -> ApplicationModel {
                 key: Some(TopicKey {
                     field: "sensor".to_string(),
                 }),
+                bound: Some(TopicBound {
+                    capacity: 64,
+                    on_full: TopicOnFull::Fail,
+                }),
                 provenance: p,
             }],
             subjects: vec![Subject {
@@ -135,6 +139,11 @@ fn tiny_model() -> ApplicationModel {
             bindings: vec![],
         },
         relations: Relations {
+            realizes: vec![Realizes {
+                instance: LocusInstanceId(0),
+                decl: LocusDeclId(1),
+                provenance: p,
+            }],
             member_of: vec![
                 MemberOf {
                     function: FunctionId(0),
@@ -298,4 +307,234 @@ fn duplicate_rows_are_not_canonical() {
             index: 1
         })
     );
+}
+
+// -----------------------------------------------------------------
+// Review round 1 — the laws validate() previously stated but did
+// not enforce.
+// -----------------------------------------------------------------
+
+/// The review's exact counterexample: a duplicated relation row
+/// near the END of the schema must be rejected, so a newly added
+/// table cannot accidentally miss the canonical law.
+#[test]
+fn duplicate_publishes_are_not_canonical() {
+    let mut m = tiny_model();
+    m.relations.publishes.push(m.relations.publishes[0].clone());
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::NotCanonical {
+            table: "publishes",
+            index: 1
+        })
+    );
+}
+
+#[test]
+fn unsorted_supervises_are_not_canonical() {
+    let mut m = tiny_model();
+    let p = ProvenanceId(0);
+    m.relations.supervises = vec![
+        Supervises {
+            parent: LocusDeclId(1),
+            child: LocusDeclId(0),
+            policy: SupervisionPolicy {
+                ops: vec!["restart".to_string()],
+                retry_bound: Some(3),
+            },
+            provenance: p,
+        },
+        Supervises {
+            parent: LocusDeclId(0),
+            child: LocusDeclId(1),
+            policy: SupervisionPolicy {
+                ops: vec!["restart".to_string()],
+                retry_bound: None,
+            },
+            provenance: p,
+        },
+    ];
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::NotCanonical {
+            table: "supervises",
+            index: 1
+        })
+    );
+}
+
+#[test]
+fn nested_key_sets_must_be_canonical() {
+    let mut m = tiny_model();
+    m.relations.publishes[0].key_domain =
+        KeyDomain::Exact(vec![KeyValue::Int(2), KeyValue::Int(1)]);
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::NotCanonical {
+            table: "publishes.key_domain",
+            index: 0
+        })
+    );
+}
+
+/// The review's second counterexample: an inline Unknown may not
+/// hide inside an otherwise resolved row — it needs typed residue,
+/// and the residue then drives the capability law.
+#[test]
+fn inline_unknown_key_domain_requires_a_hole() {
+    let mut m = tiny_model();
+    m.capabilities.exact_key_filters = true;
+    m.relations.publishes[0].key_domain = KeyDomain::Unknown;
+    // No hole at all: the unknown is unrepresented.
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::UnrepresentedUnknown {
+            table: "publishes",
+            index: 0
+        })
+    );
+    // With the hole, the capability contradiction fires instead.
+    m.holes.push(Hole {
+        at: EntityRef::Function(FunctionId(0)),
+        kind: HoleKind::UnknownKeyDomain,
+        hides: RelationSet::KEY_FILTERS,
+        reason: "computed shard key".to_string(),
+        provenance: ProvenanceId(0),
+    });
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::CapabilityContradiction {
+            capability: "exact_key_filters"
+        })
+    );
+    // Withdrawing the claim makes the honest value lawful.
+    m.capabilities.exact_key_filters = false;
+    m.validate().expect("unknown + hole + no claim is lawful");
+}
+
+#[test]
+fn zero_bounds_are_invalid() {
+    let mut m = tiny_model();
+    m.relations.subscribes[0].capacity = Capacity::Bounded(0);
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::InvalidBound {
+            table: "subscribes",
+            index: 0
+        })
+    );
+    let mut m = tiny_model();
+    m.entities.topics[0].bound = Some(TopicBound {
+        capacity: 0,
+        on_full: TopicOnFull::Fail,
+    });
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::InvalidBound {
+            table: "topics",
+            index: 0
+        })
+    );
+}
+
+/// One fact, two access paths: the instance's `decl` field and its
+/// `realizes` row must exist (totality), be unique, and agree.
+#[test]
+fn realizes_must_be_total_unique_and_agree() {
+    // Missing row.
+    let mut m = tiny_model();
+    m.relations.realizes.clear();
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::RealizesIncomplete { instance: 0 })
+    );
+    // Disagreeing row (instance says Worker, relation says App).
+    let mut m = tiny_model();
+    m.relations.realizes[0].decl = LocusDeclId(0);
+    assert_eq!(m.validate(), Err(ModelError::RealizesDisagrees { index: 0 }));
+    // Duplicate rows: not unique (tripped as incomplete-≠-1).
+    let mut m = tiny_model();
+    let mut dup = m.relations.realizes[0].clone();
+    dup.decl = LocusDeclId(0);
+    m.relations.realizes.insert(0, dup);
+    assert!(m.validate().is_err());
+}
+
+#[test]
+fn binds_subject_agreement_is_checked() {
+    let mut m = tiny_model();
+    let p = ProvenanceId(0);
+    // A second subject the binding points at while the topic keeps
+    // the first — the repeated fact drifted.
+    m.entities.subjects.push(Subject {
+        pattern: "z.other".to_string(),
+        exact: true,
+        provenance: p,
+    });
+    m.entities.bindings.push(Binding {
+        subject: SubjectId(1),
+        transport: TransportKind::Unix,
+        role: BindingRole::Listen,
+        loss: BindingLossBehavior::Fail,
+        provenance: p,
+    });
+    m.relations.binds.push(TopicBinding {
+        topic: TopicId(0),
+        binding: BindingId(0),
+        provenance: p,
+    });
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::BindingSubjectDisagrees { index: 0 })
+    );
+    // Agreeing subjects are lawful.
+    m.entities.bindings[0].subject = SubjectId(0);
+    m.validate().expect("agreeing binding subject is lawful");
+}
+
+#[test]
+fn provenance_record_contents_must_resolve() {
+    // Dangling SourceId inside an otherwise-indexed record.
+    let mut m = tiny_model();
+    m.provenance.records[0] = Provenance::Source {
+        source: SourceId(999),
+        span: (0, 10),
+    };
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::InvalidProvenanceRecord { index: 0 })
+    );
+    // Inverted span.
+    let mut m = tiny_model();
+    m.provenance.records[0] = Provenance::Source {
+        source: SourceId(0),
+        span: (10, 4),
+    };
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::InvalidProvenanceRecord { index: 0 })
+    );
+}
+
+/// Every capability flag participates in the contradiction law — an
+/// unmapped flag would be unfalsifiable.
+#[test]
+fn every_capability_flag_is_mapped_to_a_family() {
+    let all = Capabilities {
+        exact_calls: true,
+        exact_bus_endpoints: true,
+        exact_key_filters: true,
+        exact_ownership: true,
+        exact_placement: true,
+        exact_routes: true,
+        exact_effects: true,
+        exact_cardinality: true,
+        exact_delivery_guarantees: true,
+    };
+    let vouched = all.vouched_families();
+    assert_eq!(vouched.len(), 9, "every flag appears exactly once");
+    for (name, claimed, family) in vouched {
+        assert!(claimed, "{} must carry its flag", name);
+        assert!(!family.is_empty(), "{} must vouch a real family", name);
+    }
 }

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -107,6 +107,7 @@ fn tiny_model() -> ApplicationModel {
                 payload: PayloadContractId(0),
                 key: Some(TopicKey {
                     field: "sensor".to_string(),
+                    on_unmatched: KeyOnUnmatched::Swallow,
                 }),
                 bound: Some(TopicBound {
                     capacity: 64,
@@ -159,6 +160,7 @@ fn tiny_model() -> ApplicationModel {
             publishes: vec![Publish {
                 function: FunctionId(0),
                 topic: TopicId(0),
+                site: 0,
                 key_domain: KeyDomain::Exact(vec![KeyValue::Int(1)]),
                 disposition: PublishDisposition::Default,
                 provenance: p,
@@ -166,6 +168,7 @@ fn tiny_model() -> ApplicationModel {
             subscribes: vec![Subscribe {
                 topic: TopicId(0),
                 handler: FunctionId(1),
+                site: 0,
                 key_predicate: KeyPredicate::EqReplica,
                 capacity: Capacity::Bounded(16),
                 shed: ShedPolicy::DropOld,
@@ -338,6 +341,7 @@ fn unsorted_supervises_are_not_canonical() {
         Supervises {
             parent: LocusDeclId(1),
             child: LocusDeclId(0),
+            error_type: "IoError".to_string(),
             policy: SupervisionPolicy {
                 ops: vec!["restart".to_string()],
                 retry_bound: Some(3),
@@ -347,6 +351,7 @@ fn unsorted_supervises_are_not_canonical() {
         Supervises {
             parent: LocusDeclId(0),
             child: LocusDeclId(1),
+            error_type: "IoError".to_string(),
             policy: SupervisionPolicy {
                 ops: vec!["restart".to_string()],
                 retry_bound: None,
@@ -537,4 +542,155 @@ fn every_capability_flag_is_mapped_to_a_family() {
         assert!(claimed, "{} must carry its flag", name);
         assert!(!family.is_empty(), "{} must vouch a real family", name);
     }
+}
+
+// -----------------------------------------------------------------
+// Review round 2 — site grain, supervision error types, and the
+// full routing contract.
+// -----------------------------------------------------------------
+
+/// The review's motivating program: one function publishing one
+/// topic twice with different dispositions
+/// (`Orders <- a or wait; Orders <- b or discard;`) — two rows at
+/// site grain, each keeping its own disposition and provenance.
+#[test]
+fn two_publish_sites_on_one_topic_are_representable() {
+    let mut m = tiny_model();
+    m.relations.publishes.push(Publish {
+        function: FunctionId(0),
+        topic: TopicId(0),
+        site: 1,
+        key_domain: KeyDomain::Exact(vec![KeyValue::Int(2)]),
+        disposition: PublishDisposition::Wait,
+        provenance: ProvenanceId(0),
+    });
+    m.validate()
+        .expect("two sites with different dispositions are lawful");
+    // The SAME site twice is still a duplicate.
+    m.relations.publishes[1].site = 0;
+    m.relations.publishes[1].key_domain =
+        KeyDomain::Exact(vec![KeyValue::Int(1)]);
+    m.relations.publishes[1].disposition = PublishDisposition::Default;
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::NotCanonical {
+            table: "publishes",
+            index: 1
+        })
+    );
+}
+
+/// Two call sites sharing endpoints with different loop facts are
+/// two rows; the endpoint merge is a projection concern, never a
+/// schema collapse.
+#[test]
+fn call_sites_keep_their_own_loop_facts() {
+    let mut m = tiny_model();
+    let p = ProvenanceId(0);
+    m.relations.calls = vec![
+        Call {
+            from: FunctionId(0),
+            to: FunctionId(1),
+            dispatch: DispatchKind::Direct,
+            site: 0,
+            in_loop: false,
+            unbounded: false,
+            provenance: p,
+        },
+        Call {
+            from: FunctionId(0),
+            to: FunctionId(1),
+            dispatch: DispatchKind::Direct,
+            site: 1,
+            in_loop: true,
+            unbounded: true,
+            provenance: p,
+        },
+    ];
+    m.validate().expect("site-grained call rows are lawful");
+}
+
+/// Two on_failure handlers for the same child, different error
+/// types: distinct policies, both representable (the schema-1.10
+/// supervision section is per-handler).
+#[test]
+fn supervision_is_per_error_type() {
+    let mut m = tiny_model();
+    let p = ProvenanceId(0);
+    m.relations.supervises = vec![
+        Supervises {
+            parent: LocusDeclId(0),
+            child: LocusDeclId(1),
+            error_type: "ClosureViolation".to_string(),
+            policy: SupervisionPolicy {
+                ops: vec!["restart".to_string()],
+                retry_bound: Some(3),
+            },
+            provenance: p,
+        },
+        Supervises {
+            parent: LocusDeclId(0),
+            child: LocusDeclId(1),
+            error_type: "IoError".to_string(),
+            policy: SupervisionPolicy {
+                ops: vec!["replace".to_string()],
+                retry_bound: None,
+            },
+            provenance: p,
+        },
+    ];
+    m.validate().expect("per-error-type supervision is lawful");
+    // Same (parent, child, error_type) twice is a duplicate.
+    m.relations.supervises[1].error_type =
+        "ClosureViolation".to_string();
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::NotCanonical {
+            table: "supervises",
+            index: 1
+        })
+    );
+}
+
+/// The fallback contract, both directions: `where key == _` is
+/// legal only on `on_unmatched: fallback` topics, and a fallback
+/// topic must have its catch.
+#[test]
+fn fallback_contract_is_validated_both_ways() {
+    // `_` on a swallow topic: illegal.
+    let mut m = tiny_model();
+    m.relations.subscribes[0].key_predicate = KeyPredicate::Fallback;
+    assert_eq!(m.validate(), Err(ModelError::IllegalFallback { index: 0 }));
+
+    // Fallback topic without a catch: uncovered.
+    let mut m = tiny_model();
+    m.entities.topics[0].key = Some(TopicKey {
+        field: "sensor".to_string(),
+        on_unmatched: KeyOnUnmatched::Fallback,
+    });
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::FallbackUncovered { topic: 0 })
+    );
+
+    // Properly paired: lawful.
+    m.relations.subscribes[0].key_predicate = KeyPredicate::Fallback;
+    m.validate().expect("fallback topic + catch is lawful");
+}
+
+/// Every shipped key-eligible type has a KeyValue variant, and
+/// mixed-variant canonical sets stay ordered.
+#[test]
+fn key_values_cover_the_shipped_routing_types() {
+    let mut m = tiny_model();
+    m.relations.publishes[0].key_domain = KeyDomain::Exact(vec![
+        KeyValue::Bool(true),
+        KeyValue::Int(3),
+        KeyValue::Time(1_000),
+        KeyValue::Duration(5_000),
+        KeyValue::EnumTag("Buy".to_string()),
+        KeyValue::Decimal { lo: 1, hi: 2 },
+        KeyValue::Str("sym".to_string()),
+    ]);
+    m.validate().expect("all key-type variants are usable");
 }

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -22,11 +22,8 @@ use hale_model::*;
 
 #[test]
 fn the_model_crate_depends_on_nothing() {
-    let manifest = std::fs::read_to_string(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/Cargo.toml"
-    ))
-    .expect("read own manifest");
+    let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+        .expect("read own manifest");
     let deps = manifest
         .split("[dependencies]")
         .nth(1)
@@ -141,6 +138,7 @@ fn tiny_model() -> ApplicationModel {
             groups: vec![],
             types: vec![],
             interfaces: vec![],
+            declarations: vec![],
         },
         relations: Relations {
             realizes: vec![Realizes {
@@ -164,6 +162,7 @@ fn tiny_model() -> ApplicationModel {
                 function: FunctionId(0),
                 subject: SubjectId(0),
                 declared_topic: Some(TopicId(0)),
+                payload: PayloadContractId(0),
                 site: 0,
                 key_domain: Some(KeyDomain::Exact(vec![KeyValue::Int(1)])),
                 disposition: PublishDisposition::Default,
@@ -172,6 +171,7 @@ fn tiny_model() -> ApplicationModel {
             subscribes: vec![Subscribe {
                 subject: SubjectId(0),
                 declared_topic: Some(TopicId(0)),
+                payload: PayloadContractId(0),
                 handler: FunctionId(1),
                 site: 0,
                 key_predicate: KeyPredicate::EqReplica,
@@ -461,7 +461,10 @@ fn realizes_must_be_total_unique_and_agree() {
     // Disagreeing row (instance says Worker, relation says App).
     let mut m = tiny_model();
     m.relations.realizes[0].decl = LocusDeclId(0);
-    assert_eq!(m.validate(), Err(ModelError::RealizesDisagrees { index: 0 }));
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::RealizesDisagrees { index: 0 })
+    );
     // Duplicate rows: not unique (tripped as incomplete-≠-1).
     let mut m = tiny_model();
     let mut dup = m.relations.realizes[0].clone();
@@ -565,6 +568,7 @@ fn two_publish_sites_on_one_topic_are_representable() {
         function: FunctionId(0),
         subject: SubjectId(0),
         declared_topic: Some(TopicId(0)),
+        payload: PayloadContractId(0),
         site: 1,
         key_domain: Some(KeyDomain::Exact(vec![KeyValue::Int(2)])),
         disposition: PublishDisposition::Wait,
@@ -574,8 +578,7 @@ fn two_publish_sites_on_one_topic_are_representable() {
         .expect("two sites with different dispositions are lawful");
     // The SAME site twice is still a duplicate.
     m.relations.publishes[1].site = 0;
-    m.relations.publishes[1].key_domain =
-        Some(KeyDomain::Exact(vec![KeyValue::Int(1)]));
+    m.relations.publishes[1].key_domain = Some(KeyDomain::Exact(vec![KeyValue::Int(1)]));
     m.relations.publishes[1].disposition = PublishDisposition::Default;
     assert_eq!(
         m.validate(),
@@ -647,8 +650,7 @@ fn supervision_is_per_error_type() {
     ];
     m.validate().expect("per-error-type supervision is lawful");
     // Same (parent, child, error_type) twice is a duplicate.
-    m.relations.supervises[1].error_type =
-        "ClosureViolation".to_string();
+    m.relations.supervises[1].error_type = "ClosureViolation".to_string();
     assert_eq!(
         m.validate(),
         Err(ModelError::NotCanonical {
@@ -793,8 +795,7 @@ fn keyedness_must_match_the_topic_both_ways() {
     m.validate().expect("unkeyed topic, unkeyed rows: lawful");
 
     // A keyed predicate on the unkeyed topic is refused.
-    m.relations.subscribes[0].key_predicate =
-        KeyPredicate::EqLiteral(KeyValue::Int(1));
+    m.relations.subscribes[0].key_predicate = KeyPredicate::EqLiteral(KeyValue::Int(1));
     assert_eq!(
         m.validate(),
         Err(ModelError::KeyContract {
@@ -856,6 +857,7 @@ fn literal_and_wildcard_endpoints_are_representable() {
     m.relations.subscribes.push(Subscribe {
         subject: SubjectId(1),
         declared_topic: None,
+        payload: PayloadContractId(0),
         handler: FunctionId(1),
         site: 1,
         key_predicate: KeyPredicate::Any,
@@ -868,6 +870,7 @@ fn literal_and_wildcard_endpoints_are_representable() {
         function: FunctionId(0),
         subject: SubjectId(1),
         declared_topic: None,
+        payload: PayloadContractId(0),
         site: 1,
         key_domain: None,
         disposition: PublishDisposition::Default,
@@ -972,4 +975,187 @@ fn declared_in_covers_the_full_declaration_universe() {
     // Dangling type id in an EntityRef is still refused.
     m.relations.declared_in[4].entity = EntityRef::Type(TypeDeclId(7));
     assert!(m.validate().is_err());
+}
+
+// -----------------------------------------------------------------
+// Review round 5 — the COMPLETE nameable universe + endpoint
+// payloads.
+// -----------------------------------------------------------------
+
+/// The declaration-universe canary, covering every variant the
+/// compiler's `top_decl_name` names — not a hand-picked subset:
+/// locus, fn, topic, type, interface, group (specialized sorts)
+/// PLUS perspective, const, ring layout, target (opaque
+/// Declaration rows). Module/Claims/Constitution are deliberately
+/// nameless there and absent here. A new nameable TopDecl variant
+/// must extend this test alongside the schema.
+#[test]
+fn the_nameable_declaration_universe_is_complete() {
+    let mut m = tiny_model();
+    let p = ProvenanceId(0);
+    m.entities.types = vec![TypeDecl {
+        name: "Reading".to_string(),
+        display: "Reading".to_string(),
+        provenance: p,
+    }];
+    m.entities.interfaces = vec![InterfaceDecl {
+        name: "Notifier".to_string(),
+        display: "Notifier".to_string(),
+        provenance: p,
+    }];
+    m.entities.groups = vec![Group {
+        name: "workers".to_string(),
+        may_be_empty: false,
+        provenance: p,
+    }];
+    m.entities.declarations = vec![
+        Declaration {
+            kind: DeclKind::Const,
+            name: "MAX_DEPTH".to_string(),
+            display: "MAX_DEPTH".to_string(),
+            provenance: p,
+        },
+        Declaration {
+            kind: DeclKind::RingLayout,
+            name: "TickRing".to_string(),
+            display: "TickRing".to_string(),
+            provenance: p,
+        },
+        Declaration {
+            kind: DeclKind::Target,
+            name: "edge_node".to_string(),
+            display: "edge_node".to_string(),
+            provenance: p,
+        },
+        Declaration {
+            kind: DeclKind::Perspective,
+            name: "public_api".to_string(),
+            display: "public_api".to_string(),
+            provenance: p,
+        },
+    ];
+    m.entities
+        .declarations
+        .sort_by(|a, b| (&a.name, a.kind).cmp(&(&b.name, b.kind)));
+    // ALL ten nameable kinds join the seed sort.
+    m.relations.declared_in = vec![
+        DeclaredIn {
+            entity: EntityRef::Function(FunctionId(1)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::LocusDecl(LocusDeclId(1)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::Topic(TopicId(0)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::Group(GroupId(0)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::Type(TypeDeclId(0)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::Interface(InterfaceDeclId(0)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::Declaration(DeclarationId(0)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::Declaration(DeclarationId(1)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::Declaration(DeclarationId(2)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+        DeclaredIn {
+            entity: EntityRef::Declaration(DeclarationId(3)),
+            seed: SeedId(0),
+            provenance: p,
+        },
+    ];
+    m.validate()
+        .expect("all ten nameable declaration kinds join the seed sort");
+    // Kind is part of the DeclKind vocabulary — all four opaque
+    // kinds are present in this model.
+    let kinds: std::collections::BTreeSet<_> =
+        m.entities.declarations.iter().map(|d| d.kind).collect();
+    assert_eq!(
+        kinds.len(),
+        4,
+        "perspective, const, ring layout, target all representable"
+    );
+    // Dangling opaque-declaration ref is refused.
+    m.relations.declared_in[9].entity = EntityRef::Declaration(DeclarationId(9));
+    assert!(m.validate().is_err());
+}
+
+/// Literal/wildcard endpoints keep their `of type T` payload — the
+/// checked BusGraph fact — and a declared endpoint's payload must
+/// agree with its topic's.
+#[test]
+fn endpoint_payloads_are_kept_and_must_agree() {
+    // Undeclared endpoint with its own payload: lawful, payload
+    // reachable straight off the row.
+    let mut m = tiny_model();
+    let p = ProvenanceId(0);
+    m.entities.subjects.push(Subject {
+        pattern: "z.orders.**".to_string(),
+        exact: false,
+        provenance: p,
+    });
+    m.entities.payloads.push(PayloadContract {
+        shape: "z_op:i".to_string(),
+        hash: 0x828a,
+        provenance: p,
+    });
+    m.relations.subscribes.push(Subscribe {
+        subject: SubjectId(1),
+        declared_topic: None,
+        payload: PayloadContractId(1),
+        handler: FunctionId(1),
+        site: 1,
+        key_predicate: KeyPredicate::Any,
+        capacity: Capacity::Unbounded,
+        shed: ShedPolicy::None,
+        provenance: p,
+    });
+    m.validate().expect("undeclared endpoint keeps its payload");
+
+    // Declared endpoint whose payload disagrees with the topic's:
+    // one endpoint, two shapes — refused.
+    m.relations.publishes[0].payload = PayloadContractId(1);
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::EndpointPayloadDisagrees {
+            table: "publishes",
+            index: 0
+        })
+    );
+
+    // Dangling payload id refused.
+    m.relations.publishes[0].payload = PayloadContractId(9);
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::DanglingId {
+            table: "publishes",
+            index: 0
+        })
+    );
 }

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -1,0 +1,301 @@
+//! GH #476 Change 1 — architecture canaries for the model schema.
+//!
+//! These tests are the epic's review laws made executable:
+//!   1. `hale-model` depends on NOTHING — in particular never on
+//!      `hale-syntax` (the crate is source-independent by law) and
+//!      never on serde (no external serialization promise before the
+//!      Change-3 projection).
+//!   2. Every row carries provenance (by construction — exercised by
+//!      building a small valid model) and dangling provenance is a
+//!      validation error, not a tolerated quirk.
+//!   3. A hole must hide at least one relation family.
+//!   4. A capability cannot claim exactness while a hole hides that
+//!      family — the positive and negative completeness accounts
+//!      cannot drift.
+//!   5. Canonical order is a law: an unsorted table is not a model.
+
+use hale_model::*;
+
+// -----------------------------------------------------------------
+// 1. Dependency direction
+// -----------------------------------------------------------------
+
+#[test]
+fn the_model_crate_depends_on_nothing() {
+    let manifest = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/Cargo.toml"
+    ))
+    .expect("read own manifest");
+    let deps = manifest
+        .split("[dependencies]")
+        .nth(1)
+        .expect("dependencies section exists");
+    // Everything after [dependencies] must be empty (comments and
+    // whitespace aside) — no hale-syntax, no hale-types, no serde,
+    // no anything. The law is stronger than a denylist: source
+    // independence is guaranteed by having zero deps at all.
+    for line in deps.lines() {
+        let l = line.trim();
+        assert!(
+            l.is_empty() || l.starts_with('#') || l.starts_with('['),
+            "hale-model must stay dependency-free; found dependency \
+             line: {}",
+            l
+        );
+    }
+}
+
+// -----------------------------------------------------------------
+// A minimal valid model the law tests perturb.
+// -----------------------------------------------------------------
+
+fn tiny_model() -> ApplicationModel {
+    let mut prov = ProvenanceTable::default();
+    prov.sources.push(provenance_source());
+    prov.records.push(Provenance::Source {
+        source: SourceId(0),
+        span: (0, 10),
+    });
+    let p = ProvenanceId(0);
+
+    ApplicationModel {
+        header: ModelHeader {
+            semantics: MODEL_SEMANTICS_V1,
+            entrypoint: "App".to_string(),
+        },
+        entities: Entities {
+            functions: vec![
+                Function {
+                    name: "App::run".to_string(),
+                    display: "App::run".to_string(),
+                    kind: FunctionKind::Hook,
+                    effects: vec!["publish".to_string()],
+                    provenance: p,
+                },
+                Function {
+                    name: "Worker::on_r".to_string(),
+                    display: "Worker::on_r".to_string(),
+                    kind: FunctionKind::Method,
+                    effects: vec![],
+                    provenance: p,
+                },
+            ],
+            loci: vec![
+                LocusDecl {
+                    name: "App".to_string(),
+                    display: "App".to_string(),
+                    sealed: false,
+                    provenance: p,
+                },
+                LocusDecl {
+                    name: "Worker".to_string(),
+                    display: "Worker".to_string(),
+                    sealed: false,
+                    provenance: p,
+                },
+            ],
+            locus_instances: vec![LocusInstance {
+                path: "App.w".to_string(),
+                decl: LocusDeclId(1),
+                replica: Some(0),
+                provenance: p,
+            }],
+            topics: vec![Topic {
+                name: "Readings".to_string(),
+                subject: SubjectId(0),
+                payload: PayloadContractId(0),
+                key: Some(TopicKey {
+                    field: "sensor".to_string(),
+                }),
+                provenance: p,
+            }],
+            subjects: vec![Subject {
+                pattern: "sense.reading".to_string(),
+                exact: true,
+                provenance: p,
+            }],
+            payloads: vec![PayloadContract {
+                shape: "sensor:i;v:i".to_string(),
+                hash: 0xfb9f,
+                provenance: p,
+            }],
+            phases: vec![Phase {
+                name: "run".to_string(),
+                provenance: p,
+            }],
+            seeds: vec![Seed {
+                name: "app".to_string(),
+                provenance: p,
+            }],
+            thread_domains: vec![ThreadDomain {
+                name: "main".to_string(),
+                provenance: p,
+            }],
+            bindings: vec![],
+        },
+        relations: Relations {
+            member_of: vec![
+                MemberOf {
+                    function: FunctionId(0),
+                    locus: LocusDeclId(0),
+                    provenance: p,
+                },
+                MemberOf {
+                    function: FunctionId(1),
+                    locus: LocusDeclId(1),
+                    provenance: p,
+                },
+            ],
+            publishes: vec![Publish {
+                function: FunctionId(0),
+                topic: TopicId(0),
+                key_domain: KeyDomain::Exact(vec![KeyValue::Int(1)]),
+                disposition: PublishDisposition::Default,
+                provenance: p,
+            }],
+            subscribes: vec![Subscribe {
+                topic: TopicId(0),
+                handler: FunctionId(1),
+                key_predicate: KeyPredicate::EqReplica,
+                capacity: Capacity::Bounded(16),
+                shed: ShedPolicy::DropOld,
+                provenance: p,
+            }],
+            ..Relations::default()
+        },
+        labels: vec![],
+        weights: vec![],
+        holes: vec![],
+        capabilities: Capabilities {
+            exact_calls: true,
+            exact_bus_endpoints: true,
+            ..Capabilities::default()
+        },
+        provenance: prov,
+    }
+}
+
+fn provenance_source() -> hale_model::provenance::SourceUnit {
+    hale_model::provenance::SourceUnit {
+        path: "app.hl".to_string(),
+        digest: 0xec85,
+    }
+}
+
+#[test]
+fn a_well_formed_model_validates() {
+    tiny_model().validate().expect("tiny model is lawful");
+}
+
+// -----------------------------------------------------------------
+// 2. Provenance cannot dangle
+// -----------------------------------------------------------------
+
+#[test]
+fn dangling_provenance_is_rejected() {
+    let mut m = tiny_model();
+    m.entities.functions[0].provenance = ProvenanceId(99);
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::DanglingProvenance {
+            table: "functions",
+            index: 0
+        })
+    );
+}
+
+#[test]
+fn dangling_entity_ids_are_rejected() {
+    let mut m = tiny_model();
+    m.relations.subscribes[0].handler = FunctionId(41);
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::DanglingId {
+            table: "subscribes",
+            index: 0
+        })
+    );
+}
+
+// -----------------------------------------------------------------
+// 3. A hole must hide something
+// -----------------------------------------------------------------
+
+#[test]
+fn an_empty_hole_is_not_a_hole() {
+    let mut m = tiny_model();
+    m.holes.push(Hole {
+        at: EntityRef::Function(FunctionId(1)),
+        kind: HoleKind::IndirectCall,
+        hides: RelationSet(0),
+        reason: "hides nothing".to_string(),
+        provenance: ProvenanceId(0),
+    });
+    assert_eq!(m.validate(), Err(ModelError::EmptyHole { index: 0 }));
+}
+
+// -----------------------------------------------------------------
+// 4. Capabilities cannot contradict holes
+// -----------------------------------------------------------------
+
+#[test]
+fn a_capability_cannot_claim_exactness_over_a_hole() {
+    let mut m = tiny_model();
+    // The model claims exact_calls, then grows a hole hiding CALLS:
+    // the two completeness accounts drifted — refuse the value.
+    m.holes.push(Hole {
+        at: EntityRef::Function(FunctionId(1)),
+        kind: HoleKind::IndirectCall,
+        hides: RelationSet::CALLS,
+        reason: "call through fn param `f`".to_string(),
+        provenance: ProvenanceId(0),
+    });
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::CapabilityContradiction {
+            capability: "exact_calls"
+        })
+    );
+    // Withdrawing the claim makes the same value lawful — holes and
+    // capabilities agree that calls are inexact.
+    m.capabilities.exact_calls = false;
+    m.validate().expect("hole + withdrawn capability is lawful");
+}
+
+// -----------------------------------------------------------------
+// 5. Canonical order is a law
+// -----------------------------------------------------------------
+
+#[test]
+fn unsorted_tables_are_not_models() {
+    let mut m = tiny_model();
+    m.entities.functions.swap(0, 1);
+    // Fix up the rows that index functions so ONLY order is wrong.
+    m.relations.member_of[0].function = FunctionId(1);
+    m.relations.member_of[1].function = FunctionId(0);
+    m.relations.member_of.swap(0, 1);
+    m.relations.publishes[0].function = FunctionId(1);
+    m.relations.subscribes[0].handler = FunctionId(0);
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::NotCanonical {
+            table: "functions",
+            index: 1
+        })
+    );
+}
+
+#[test]
+fn duplicate_rows_are_not_canonical() {
+    let mut m = tiny_model();
+    let dup = m.relations.member_of[0].clone();
+    m.relations.member_of.insert(1, dup);
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::NotCanonical {
+            table: "member_of",
+            index: 1
+        })
+    );
+}

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -1159,3 +1159,109 @@ fn endpoint_payloads_are_kept_and_must_agree() {
         })
     );
 }
+
+// -----------------------------------------------------------------
+// Review round 6 — authored selectors alongside resolved members.
+// -----------------------------------------------------------------
+
+/// The legacy hash covers group selectors AS AUTHORED — `{ lib::* }`
+/// and `{ lib::A, lib::B }` may resolve identically but must keep
+/// distinct shapes. Both grains coexist: GroupSelector (authored,
+/// ordered, globs unexpanded) and GroupMember (resolved).
+#[test]
+fn authored_selectors_are_kept_alongside_resolved_members() {
+    let mut m = tiny_model();
+    let p = ProvenanceId(0);
+    m.entities.groups = vec![Group {
+        name: "workers".to_string(),
+        may_be_empty: false,
+        provenance: p,
+    }];
+    // Resolved membership: one locus (as if lib::* enumerated it).
+    m.relations.group_members = vec![GroupMember {
+        group: GroupId(0),
+        member: EntityRef::LocusDecl(LocusDeclId(1)),
+        provenance: p,
+    }];
+    // Authored grain, variant A: a glob, UNEXPANDED.
+    m.relations.group_selectors = vec![GroupSelector {
+        group: GroupId(0),
+        ordinal: 0,
+        selector: SelectorForm::SeedGlob {
+            seed: SeedId(0),
+            display: "lib::*".to_string(),
+        },
+        provenance: p,
+    }];
+    m.validate().expect("glob selector + resolved member coexist");
+    let glob_selectors = m.relations.group_selectors.clone();
+
+    // Authored grain, variant B: the same membership spelled as a
+    // named selector — the RESOLVED rows are identical, the
+    // AUTHORED rows differ, which is exactly what keeps the two
+    // programs' shapes distinct.
+    m.relations.group_selectors = vec![GroupSelector {
+        group: GroupId(0),
+        ordinal: 0,
+        selector: SelectorForm::Named {
+            member: EntityRef::LocusDecl(LocusDeclId(1)),
+            display: "lib::Worker".to_string(),
+        },
+        provenance: p,
+    }];
+    m.validate().expect("named selector variant is lawful");
+    assert_ne!(
+        glob_selectors, m.relations.group_selectors,
+        "identical membership, distinct authored shapes"
+    );
+
+    // A zero-member glob is still a selector row: authored shape
+    // survives even when resolution contributes nothing.
+    m.relations.group_members.clear();
+    m.entities.groups[0].may_be_empty = true;
+    m.relations.group_selectors = vec![GroupSelector {
+        group: GroupId(0),
+        ordinal: 0,
+        selector: SelectorForm::SeedGlob {
+            seed: SeedId(0),
+            display: "lib::*".to_string(),
+        },
+        provenance: p,
+    }];
+    m.validate().expect("zero-member glob keeps its authored row");
+
+    // Ordinals are ordered facts; a duplicate ordinal is refused.
+    m.relations.group_selectors.push(GroupSelector {
+        group: GroupId(0),
+        ordinal: 0,
+        selector: SelectorForm::Named {
+            member: EntityRef::Function(FunctionId(0)),
+            display: "App::run".to_string(),
+        },
+        provenance: p,
+    });
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::NotCanonical {
+            table: "group_selectors",
+            index: 1
+        })
+    );
+    // Dangling glob seed is refused.
+    m.relations.group_selectors = vec![GroupSelector {
+        group: GroupId(0),
+        ordinal: 0,
+        selector: SelectorForm::SeedGlob {
+            seed: SeedId(7),
+            display: "ghost::*".to_string(),
+        },
+        provenance: p,
+    }];
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::DanglingId {
+            table: "group_selectors",
+            index: 0
+        })
+    );
+}


### PR DESCRIPTION
Change 1 of the #476 epic: the typed schema and its laws, nothing more. No derivation (that's Change 2), no consumers, **zero behavior change** — this PR exists to pin exactly the facts the epic says are expensive to retrofit, with the design note shipping as the crate's rustdoc.

## What's pinned

- **Typed sorts with the declaration/instance split** (application claims will count declarations; fleet claims count deployed instances — the distinction starts in the schema), and typed relation tables whose rows are real structs: `Call` carries dispatch kind + loop flag, `Subscribe` carries its key predicate and bounds. **Resolved rows only** — an unresolved callee or computed subject is a typed `Hole`, never a stringly edge.
- **Keyed delivery first-class**: `TopicKey`, per-publish `KeyDomain`, per-subscription `KeyPredicate` (incl. `EqReplica`), replica indices — with the two-sided polarity documented as law: `may_deliver` adds possible edges on unknowns (conservative for `forbid`), `must_deliver` requires exact coverage and is *structural* ("dispatched ⇒ delivered, process persisting" — #468's boot/quiesce temporal semantics stay out of the static relation).
- **Bounds and loss policy recorded before claims need them**: `Capacity`, `ShedPolicy`, `PublishDisposition`, `BindingLossBehavior`. A shedding policy never removes a possible-reachability edge; it invalidates an unqualified must-arrive guarantee.
- **Holes + capabilities as dual bookkeeping with a validated no-contradiction law**: `validate()` refuses a model that claims `exact_calls` while any hole hides `CALLS`, and refuses a hole that hides nothing. The positive and negative completeness accounts cannot drift.
- **`ModelHashKind::TopologyShapeV1`** names the legacy hash algorithm now, so the Change-3 projection cannot ship an unnamed identity and `.halerec` admission compatibility is a named contract from day one.
- **Canonical order as law**: unsorted or duplicated tables are not models — determinism for hashing/projection/diff is enforced once at the boundary rather than through ordered maps on hot paths.

## Architecture canaries (tests/architecture.rs, 8 tests)

The crate depends on **nothing** — the dependency canary fails on *any* dependency line, which enforces both source independence (never `hale-syntax`) and the no-serialization-promise (no serde before the Change-3 projection) with one law stronger than a denylist. Plus: dangling provenance/IDs rejected, empty holes rejected, capability-vs-hole contradiction rejected then accepted once the claim is withdrawn, unsorted/duplicate tables rejected.

Relation to the other open work: independent of #477 (Track A renderer — deliberately has no dependency on this crate); the demand-gated builder that populates these tables from a checked bundle is Change 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)