### PR TITLE
feat(types): the ApplicationModel builder — demand-gated derivation (#476 Change 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ behavior.
 
 ## Unreleased
 
+### The ApplicationModel builder - demand-gated derivation (GH #476 Change 2)
+
+`hale_types::model_builder::derive_application_model(&Bundle)` - one
+entry point assembling the canonical model from the same trusted
+analyses the topology artifact consumes (AllocSummary, BusGraph,
+model::Model, effects/frontier) plus direct AST reads for facts no
+summary carries (topic key/bound policy, subscription filters and
+bounds, authored group selectors, the declaration universe,
+@sealed). Sites stay site-grained; through-stdlib contraction uses
+the artifact's own walk; uninhabited dispatches land in
+`dead_interface_calls` while genuine residue becomes typed holes;
+capabilities are COMPUTED from the holes so the two completeness
+accounts cannot drift. Ownership/placement/bindings stay empty
+tables with capabilities false (Change 8 completes them - the
+artifact exports none today).
+
+DEMAND-GATED, proven cross-process: the builder runs only for
+`hale model dump <target>` (new, internal non-stable format,
+same ill-typed refusal as the artifact); plain `hale check` - even
+with claims present, even with `--dump-topology` - provably never
+derives it (HALE_MODEL_TRACE=1 stays silent; pinned by test).
+
+Tested three ways: family fixtures (keyed delivery incl. fallback
++ replica, bounds, literal/wildcard endpoints, supervision,
+groups, dead-vs-indirect separation); a model/artifact
+DIFFERENTIAL asserting both extractions agree on fns, loci, calls
+(endpoint projection), through-stdlib edges, publishes,
+subscribes, unknown anchors, authored group selectors,
+supervision, and per-fn effects; and a whole-corpus property -
+derivation never panics on any parseable program, and a derived
+model may violate a schema law ONLY where the checker also
+refuses the program (negative fixtures' models mirror the
+checker's refusals; checks-clean-but-unlawful is a builder bug).
+The corpus property earned its keep immediately: its first run
+caught a fail-open glob-alias fallback and two non-total lookup
+paths in the builder.
+
 ### `hale-model` - the canonical semantic model schema (GH #476 Change 1)
 
 The first change of the canonical-model epic: a new source-independent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,7 @@ name = "hale-types"
 version = "0.17.0"
 dependencies = [
  "hale-corpus",
+ "hale-model",
  "hale-stdlib",
  "hale-syntax",
  "serde_json",

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -162,6 +162,33 @@ fn main() -> ExitCode {
         return topology_graph::run_topology(&rest);
     }
 
+    // GH #476 Change 2: `hale model dump <target>` — derive and print
+    // the canonical ApplicationModel (internal, non-stable format).
+    // The DEMAND surface: this command is what builds the model;
+    // plain `hale check` provably never does (HALE_MODEL_TRACE=1
+    // shows the derivation line here and stays silent there).
+    // Implemented as a shim into the check pipeline so bundle
+    // loading, imports, and the ill-typed refusal are identical.
+    if cmd == "model" {
+        let rest: Vec<String> = args.iter().skip(2).cloned().collect();
+        if rest.first().map(String::as_str) != Some("dump") {
+            eprintln!(
+                "usage: hale model dump <file.hl | dir>\n\
+                 \n\
+                 Derives the canonical ApplicationModel (GH #476) and \
+                 prints an internal,\nnon-stable dump. Experimental \
+                 surface pre-1.0."
+            );
+            return ExitCode::from(2);
+        }
+        // The check pipeline's dump section reads PROCESS argv (it
+        // is a top-level-command scope), so the flag cannot ride the
+        // rest-args; the shim marks the demand via env instead.
+        std::env::set_var("HALE_DUMP_MODEL", "1");
+        let shim: Vec<String> = rest[1..].to_vec();
+        return run_check_cli(&shim, false);
+    }
+
     // `bench` is discovery-driven like `test`: *_bench.hl files,
     // bench_* fns, self-calibrating harness.
     if cmd == "bench" {
@@ -222,6 +249,7 @@ fn usage() {
     eprintln!("        (`hale check --help` for all)");
     eprintln!("    hale verify <file.hl | dir>   check + FAIL on any advisory (discipline gate)");
     eprintln!("    hale topology graph <artifact> render a --dump-topology artifact (svg|mermaid|dot; experimental)");
+    eprintln!("    hale model dump <file.hl | dir> derive + print the canonical ApplicationModel (internal; experimental)");
     eprintln!("    hale run   <file.hl | dir>    compile + run as a native binary");
     eprintln!("    hale build <file.hl | dir>    parse + typecheck + emit native binary");
     eprintln!("    hale replay <rec> <file.hl>   re-run a LOTUS_OBS_RECORD recording");
@@ -2891,6 +2919,7 @@ fn run_fleet(rest: &[String]) -> ExitCode {
 /// evaluations.
 const PER_SEED_FLAGS: &[&str] = &[
     "--dump-topology",
+    "--dump-model",
     "--check-topology",
     "--check-topology-shape",
     "--dump-effects-manifest",
@@ -2910,6 +2939,10 @@ const CHECK_FLAGS: &[(&str, bool)] = &[
     ("--dump-effects-manifest", false),
     ("--dump-resource-budget", false),
     ("--dump-topology", false),
+    // GH #476 Change 2: derive + print the canonical
+    // ApplicationModel (internal format). The demand surface the
+    // `hale model dump` shim routes through.
+    ("--dump-model", false),
     ("--json", false),
     ("--no-warn-unbounded-alloc", false),
     // Retired opt-in spelling from when the unbounded-alloc survey
@@ -4145,6 +4178,40 @@ fn run_check_impl_labelled(
             }
             None => print!("{}", artifact),
         }
+    }
+    // GH #476 Change 2: the canonical-model demand surface. Same
+    // refusal rule as the artifact — a model of a program that does
+    // not typecheck describes nothing.
+    if argv.iter().any(|a| a == "--dump-model")
+        || std::env::var("HALE_DUMP_MODEL").as_deref() == Ok("1")
+    {
+        if let Some(d) = checked.iter().find(|d| {
+            d.is_error()
+                && d.kind != hale_syntax::error::DiagKind::Claim
+        }) {
+            eprintln!(
+                "refusing to derive a model: `{}` does not typecheck,                  so its model is not a truthful description of any                  program. Fix the {} first.",
+                target.display(),
+                d.kind_str()
+            );
+            return 1;
+        }
+        let model =
+            hale_types::model_builder::derive_application_model(&bundle);
+        if let Err(e) = model.validate() {
+            // A builder bug, never user error: the derivation
+            // produced a value that is not a model. Loud, named, and
+            // fatal — an invalid model must not print as one.
+            eprintln!(
+                "internal error: derived model violates a model law:                  {:?} (this is a hale bug — please report it)",
+                e
+            );
+            return 2;
+        }
+        print!(
+            "{}",
+            hale_types::model_builder::render_internal(&model)
+        );
     }
     // P2 from the devex review: `--check-topology` compares the
     // ENTIRE artifact text, so a claim rename or a comment-only edit

--- a/crates/hale-cli/tests/model_cli.rs
+++ b/crates/hale-cli/tests/model_cli.rs
@@ -1,0 +1,195 @@
+//! GH #476 Change 2 — the demand contract, proven cross-process.
+//!
+//! The epic's LSP/performance rule: the model is lazy and demanded
+//! by consumers; a diagnostics-only check must PROVABLY not
+//! construct it ("cached" must not become "always built"). The
+//! builder prints one stderr line under HALE_MODEL_TRACE=1 — these
+//! tests run the real binary and read that channel.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn hale() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_hale"))
+}
+
+fn workdir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir()
+        .join(format!("hale_modelcli_{}_{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+const APP: &str = r#"
+type T { n: Int = 0; }
+topic Evt { payload: T; subject: "evt"; }
+locus Sub {
+    params { seen: Int = 0; }
+    bus { subscribe Evt as on_e; }
+    fn on_e(t: T) { self.seen = self.seen + 1; }
+}
+group subs = { Sub };
+main locus App {
+    params { s: Sub = Sub { }; }
+    bus { publish Evt; }
+    claims {
+        wired: require subscribes(some subs, topic Evt);
+    }
+    run() { Evt <- T { n: 1 }; }
+}
+fn main() { App { }; }
+"#;
+
+#[test]
+fn plain_check_never_builds_the_model() {
+    let dir = workdir("nodemand");
+    let src = dir.join("app.hl");
+    std::fs::write(&src, APP).unwrap();
+
+    // Diagnostics-only check — with CLAIMS present, even: nothing
+    // demands the model until the Change-5 evaluator migration, so
+    // the builder must not run.
+    let out = hale()
+        .arg("check")
+        .arg(&src)
+        .env("HALE_MODEL_TRACE", "1")
+        .output()
+        .expect("hale check");
+    assert!(out.status.success());
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !err.contains("[hale-model]"),
+        "a no-demand check must not derive the model:\n{}",
+        err
+    );
+
+    // The artifact dump path doesn't demand it either (it stays on
+    // its own gathering until the Change-3 projection).
+    let out = hale()
+        .arg("check")
+        .arg(&src)
+        .arg("--dump-topology")
+        .env("HALE_MODEL_TRACE", "1")
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    assert!(
+        !String::from_utf8_lossy(&out.stderr).contains("[hale-model]"),
+        "the legacy artifact path must not demand the model yet"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn model_dump_demands_derives_and_is_deterministic() {
+    let dir = workdir("demand");
+    let src = dir.join("app.hl");
+    std::fs::write(&src, APP).unwrap();
+
+    let out = hale()
+        .arg("model")
+        .arg("dump")
+        .arg(&src)
+        .env("HALE_MODEL_TRACE", "1")
+        .output()
+        .expect("hale model dump");
+    assert!(
+        out.status.success(),
+        "dump failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("[hale-model]"),
+        "the dump IS the demand — the trace line must appear"
+    );
+    let first = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert!(first.contains("# hale ApplicationModel"));
+    assert!(first.contains("entrypoint App"));
+    assert!(first.contains("subscribes (1):"));
+
+    let again = hale().arg("model").arg("dump").arg(&src).output().unwrap();
+    assert_eq!(
+        first,
+        String::from_utf8_lossy(&again.stdout),
+        "two dumps are byte-identical"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn cross_seed_models_carry_the_imported_universe() {
+    let dir = workdir("xseed");
+    let app = dir.join("app");
+    let lib = dir.join("lib/kv");
+    std::fs::create_dir_all(&app).unwrap();
+    std::fs::create_dir_all(&lib).unwrap();
+    std::fs::write(dir.join("hale.toml"), "name = \"xseed-model\"\n")
+        .unwrap();
+    std::fs::write(
+        lib.join("kv.hl"),
+        r#"
+type Pair { k: Int = 0; v: Int = 0; }
+locus Store {
+    params { total: Int = 0; }
+    fn get(k: Int) -> Int { return self.total + k; }
+}
+fn helper(v: Int) -> Int { return v + 1; }
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        app.join("main.hl"),
+        r#"
+import "lib/kv" as p;
+group kvs = { p::* };
+main locus App {
+    params { s: p::Store = p::Store { }; }
+    run() {
+        let a = self.s.get(1);
+        let b = p::helper(a);
+        println(b);
+    }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let out = hale().arg("model").arg("dump").arg(&app).output().unwrap();
+    assert!(
+        out.status.success(),
+        "cross-seed dump failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let dump = String::from_utf8_lossy(&out.stdout);
+    // Imported decls appear author-spelled; the glob selector stays
+    // AUTHORED (unexpanded) while membership resolves.
+    assert!(dump.contains("p::Store"), "imported locus:\n{}", dump);
+    assert!(dump.contains("p::helper"), "imported free fn:\n{}", dump);
+    assert!(
+        dump.contains("kvs[0] = p::* (glob)"),
+        "authored glob selector survives:\n{}",
+        dump
+    );
+    assert!(dump.contains("p::Pair"), "imported type in universe");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ill_typed_programs_refuse_a_model() {
+    let dir = workdir("refuse");
+    let src = dir.join("bad.hl");
+    std::fs::write(
+        &src,
+        "fn main() { let x: Int = \"not an int\"; println(x); }\n",
+    )
+    .unwrap();
+    let out = hale().arg("model").arg("dump").arg(&src).output().unwrap();
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stderr)
+            .contains("refusing to derive a model"),
+        "same refusal rule as the artifact"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -124,6 +124,17 @@ pub struct LegacyProjection {
     /// strict subset of `entities.functions` — a module-scoped or
     /// empty declaration exists in the universe but not here.
     pub topology_v1_fns: Vec<FunctionId>,
+    /// The legacy artifact's `calls_via_stdlib` rows, verbatim:
+    /// the output of the legacy one-Boolean, no-revisit contraction
+    /// walk, NOT of the model's two-component lattice. The two can
+    /// legitimately disagree on a loop bit — a stdlib node first
+    /// reached on a non-looped path is never revisited by the
+    /// legacy walk, while the lattice strengthens it — and the
+    /// loop bit is inside the hashed model half, so projecting the
+    /// lattice rows would silently change `TopologyShapeV1` for
+    /// unchanged source. Both endpoints are legacy fns
+    /// (∈ `topology_v1_fns`).
+    pub topology_v1_calls_via_stdlib: Vec<(FunctionId, FunctionId, bool)>,
 }
 
 #[derive(Clone, Debug)]
@@ -831,6 +842,33 @@ impl ApplicationModel {
                     table: "legacy.topology_v1_fns",
                     index: i,
                 });
+            }
+        }
+        check_sorted_keys(
+            "legacy.topology_v1_calls_via_stdlib",
+            self.legacy
+                .topology_v1_calls_via_stdlib
+                .iter()
+                .map(|(f, t, _)| (f, t)),
+        )?;
+        {
+            let legacy_set: std::collections::BTreeSet<&FunctionId> =
+                self.legacy.topology_v1_fns.iter().collect();
+            for (i, (f, t, _)) in self
+                .legacy
+                .topology_v1_calls_via_stdlib
+                .iter()
+                .enumerate()
+            {
+                // Endpoint law: a legacy contracted row only ever
+                // connects legacy fns — the legacy walk starts and
+                // ends at its own serialized sort.
+                if !legacy_set.contains(f) || !legacy_set.contains(t) {
+                    return Err(ModelError::DanglingId {
+                        table: "legacy.topology_v1_calls_via_stdlib",
+                        index: i,
+                    });
+                }
             }
         }
 

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -13,12 +13,12 @@ use crate::entity::{
     PayloadContract, Phase, Seed, Subject, ThreadDomain, Topic, TypeDecl,
 };
 use crate::hole::Hole;
-use crate::ids::{EntityRef, ProvenanceId};
+use crate::ids::{EntityRef, FunctionId, ProvenanceId};
 use crate::provenance::{Provenance, ProvenanceTable};
 use crate::relation::{
-    AffinedTo, Call, DeadInterfaceCall, DeclaredIn, GroupMember,
-    GroupSelector, MemberOf, Owns, PhaseOf, PlacedIn, Publish, Realizes,
-    SelectorForm, Subscribe, Supervises, TopicBinding,
+    AffinedTo, Call, DeadInterfaceCall, DeclaredIn, DeclaresPublish,
+    GroupMember, GroupSelector, MemberOf, Owns, PhaseOf, PlacedIn,
+    Publish, Realizes, SelectorForm, Subscribe, Supervises, TopicBinding,
 };
 
 /// The meaning of the model's rows. Bumped when a row's
@@ -98,6 +98,10 @@ pub struct Relations {
     pub calls: Vec<Call>,
     pub dead_interface_calls: Vec<DeadInterfaceCall>,
     pub publishes: Vec<Publish>,
+    /// Declared publisher ends (`bus { publish T; }`) — the
+    /// endpoint grain `require publishes(...)` quantifies over,
+    /// distinct from the site-grained sends above.
+    pub declares_publish: Vec<DeclaresPublish>,
     pub subscribes: Vec<Subscribe>,
     pub placed_in: Vec<PlacedIn>,
     pub affined_to: Vec<AffinedTo>,
@@ -107,6 +111,19 @@ pub struct Relations {
     /// The AUTHORED selector lists (legacy-hash grain), alongside
     /// the resolved `group_members` (judgment grain).
     pub group_selectors: Vec<GroupSelector>,
+}
+
+/// The Change-3 bridge, quarantined in one named structure: the
+/// EXACT membership of legacy serialized sorts that are narrower
+/// than the model's universe, so `TopologyShapeV1` can be projected
+/// from the model alone (no summary/AST side channel). Deleted when
+/// the legacy artifact schema is versioned past.
+#[derive(Clone, Debug, Default)]
+pub struct LegacyProjection {
+    /// The legacy artifact's fn sort (behavior-summary keys): a
+    /// strict subset of `entities.functions` — a module-scoped or
+    /// empty declaration exists in the universe but not here.
+    pub topology_v1_fns: Vec<FunctionId>,
 }
 
 #[derive(Clone, Debug)]
@@ -119,6 +136,7 @@ pub struct ApplicationModel {
     pub holes: Vec<Hole>,
     pub capabilities: Capabilities,
     pub provenance: ProvenanceTable,
+    pub legacy: LegacyProjection,
 }
 
 /// A violated model law. `validate` returns the FIRST violation —
@@ -202,6 +220,7 @@ impl ApplicationModel {
     /// | `owns`           | (parent, child)                  |
     /// | `calls`          | (from, to, dispatch, site)       |
     /// | `publishes`      | (function, subject, site)        |
+    /// | `declares_publish` | (locus, subject)               |
     /// | `subscribes`     | (subject, handler, site)         |
     /// | `dead_interface_calls` | (from, site)               |
     /// | `placed_in`      | (instance)                       |
@@ -538,6 +557,39 @@ impl ApplicationModel {
             prov("publishes", i, x.provenance)?;
         }
         check_sorted_keys(
+            "declares_publish",
+            r.declares_publish.iter().map(|x| (x.locus, x.subject)),
+        )?;
+        for (i, x) in r.declares_publish.iter().enumerate() {
+            if x.locus.index() >= loci
+                || x.subject.index() >= subjects
+                || x.payload.index() >= payloads
+                || x.declared_topic
+                    .map(|t| t.index() >= topics)
+                    .unwrap_or(false)
+            {
+                return Err(ModelError::DanglingId {
+                    table: "declares_publish",
+                    index: i,
+                });
+            }
+            if let Some(t) = x.declared_topic {
+                if e.topics[t.index()].subject != x.subject {
+                    return Err(ModelError::DeclaredTopicDisagrees {
+                        table: "declares_publish",
+                        index: i,
+                    });
+                }
+                if e.topics[t.index()].payload != x.payload {
+                    return Err(ModelError::EndpointPayloadDisagrees {
+                        table: "declares_publish",
+                        index: i,
+                    });
+                }
+            }
+            prov("declares_publish", i, x.provenance)?;
+        }
+        check_sorted_keys(
             "subscribes",
             r.subscribes.iter().map(|x| (x.subject, x.handler, x.site)),
         )?;
@@ -766,6 +818,20 @@ impl ApplicationModel {
                 return Err(ModelError::EmptyHole { index: i });
             }
             prov("holes", i, h.provenance)?;
+        }
+
+        // --- legacy projection: sorted ids, all in range.
+        check_sorted_keys(
+            "legacy.topology_v1_fns",
+            self.legacy.topology_v1_fns.iter(),
+        )?;
+        for (i, f) in self.legacy.topology_v1_fns.iter().enumerate() {
+            if f.index() >= fns {
+                return Err(ModelError::DanglingId {
+                    table: "legacy.topology_v1_fns",
+                    index: i,
+                });
+            }
         }
 
         // --- capability/hole contradiction: exactness may not be

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -676,10 +676,16 @@ impl ApplicationModel {
             "supervises",
             r.supervises
                 .iter()
-                .map(|x| (x.parent, x.child, &x.error_type)),
+                .map(|x| (x.parent, x.child.clone(), &x.error_type)),
         )?;
         for (i, x) in r.supervises.iter().enumerate() {
-            if x.parent.index() >= loci || x.child.index() >= loci {
+            let child_ok = match &x.child {
+                crate::relation::SupervisedRef::Locus(id) => {
+                    id.index() < loci
+                }
+                crate::relation::SupervisedRef::External(_) => true,
+            };
+            if x.parent.index() >= loci || !child_ok {
                 return Err(ModelError::DanglingId {
                     table: "supervises",
                     index: i,

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -90,7 +90,11 @@ pub struct PayloadContract {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Topic {
+    /// Canonical identity: the RAW post-merge declaration name.
     pub name: String,
+    /// Author-facing spelling (the alias-qualified form for
+    /// imports) — what the artifact's topic sort renders.
+    pub display: String,
     pub subject: SubjectId,
     pub payload: PayloadContractId,
     /// `Some` for `keyed_by` topics.
@@ -110,7 +114,10 @@ pub struct Topic {
 /// [`GroupMember`]: crate::relation::GroupMember
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Group {
+    /// Canonical identity: the RAW post-merge declaration name.
     pub name: String,
+    /// Author-facing spelling.
+    pub display: String,
     /// Declared `may_be_empty` — an empty group without it is a
     /// checker error (vacuity fail-closed), so the declared intent
     /// is a semantic fact selectors need.

--- a/crates/hale-model/src/hole.rs
+++ b/crates/hale-model/src/hole.rs
@@ -76,6 +76,13 @@ pub enum HoleKind {
     /// An artifact carried semantics this consumer does not
     /// implement (decode-side honesty: refuse to pretend).
     UnsupportedArtifactSemantics,
+    /// A declared executable body the behavior analysis did not
+    /// walk (module-scoped bodies, `on_failure` handlers at
+    /// Change 2). The declaration EXISTS as an entity; its calls,
+    /// publishes, and effects are unknown — this hole is what
+    /// keeps `exact_calls`/`exact_effects` honest until the
+    /// summary covers the body family.
+    UnanalyzedBody,
 }
 
 /// One hole: where, why, and — critically — which relation families

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -156,5 +156,5 @@ pub use provenance::{Provenance, ProvenanceTable};
 pub use relation::{
     AffinedTo, Call, CoreSet, DeadInterfaceCall, DeclaredIn, DispatchKind, GroupMember,
     GroupSelector, MemberOf, Owns, PhaseOf, PlacedIn, Publish, Realizes, SelectorForm, Subscribe,
-    Supervises, SupervisionPolicy, TopicBinding,
+    Supervises, SupervisedRef, SupervisionPolicy, TopicBinding,
 };

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -133,8 +133,8 @@ pub mod provenance;
 pub mod relation;
 
 pub use application::{
-    ApplicationModel, Entities, LabelRow, ModelError, ModelHashKind, ModelHeader, Relations,
-    WeightRow, MODEL_SEMANTICS_V1,
+    ApplicationModel, Entities, LabelRow, LegacyProjection, ModelError, ModelHashKind, ModelHeader,
+    Relations, WeightRow, MODEL_SEMANTICS_V1,
 };
 pub use capability::Capabilities;
 pub use entity::{
@@ -154,7 +154,7 @@ pub use keys::{
 };
 pub use provenance::{Provenance, ProvenanceTable};
 pub use relation::{
-    AffinedTo, Call, CoreSet, DeadInterfaceCall, DeclaredIn, DispatchKind, GroupMember,
+    AffinedTo, Call, CoreSet, DeadInterfaceCall, DeclaredIn, DeclaresPublish, DispatchKind, GroupMember,
     GroupSelector, MemberOf, Owns, PhaseOf, PlacedIn, Publish, Realizes, SelectorForm, Subscribe,
     Supervises, SupervisedRef, SupervisionPolicy, TopicBinding,
 };

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -260,6 +260,19 @@ pub struct SupervisionPolicy {
     pub retry_bound: Option<u32>,
 }
 
+/// What an `on_failure` handler supervises. Usually a declared
+/// locus — but transport supervision is shipped surface (GH #233:
+/// `on_failure(t: std::bus::UnixTransport, err: ClosureViolation)`),
+/// and a substrate type is not a locus declaration. External
+/// carries the canonical type name rather than pretending.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum SupervisedRef {
+    Locus(LocusDeclId),
+    /// A supervised non-locus (substrate transport, external
+    /// boundary), by canonical type name.
+    External(String),
+}
+
 /// `supervises(parent, child, error_type, policy)` — one row per
 /// `on_failure` handler. Two handlers supervising the same child
 /// for DIFFERENT error types are distinct policies (the schema-1.10
@@ -268,7 +281,7 @@ pub struct SupervisionPolicy {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Supervises {
     pub parent: LocusDeclId,
-    pub child: LocusDeclId,
+    pub child: SupervisedRef,
     /// The handled error/violation type's canonical name.
     pub error_type: String,
     pub policy: SupervisionPolicy,

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -222,6 +222,24 @@ pub struct DeadInterfaceCall {
     pub provenance: ProvenanceId,
 }
 
+/// `declares_publish(locus, subject)` — a DECLARED publisher end
+/// (`bus { publish Orders; }`), distinct from [`Publish`]'s
+/// site-grained send expressions. The `require publishes(...)`
+/// claim semantics quantify over declared ends: a locus that
+/// declares the end but never sends still publishes in the
+/// endpoint sense, and dropping this row while claiming
+/// `exact_bus_endpoints` was review round 7's catch.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct DeclaresPublish {
+    pub locus: LocusDeclId,
+    pub subject: SubjectId,
+    /// `Some` when a declared topic covers the end; subject and
+    /// payload agreement validated exactly as for `Publish`.
+    pub declared_topic: Option<TopicId>,
+    pub payload: PayloadContractId,
+    pub provenance: ProvenanceId,
+}
+
 /// `placed_in(instance, thread_domain)`.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct PlacedIn {

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -345,7 +345,7 @@ fn unsorted_supervises_are_not_canonical() {
     m.relations.supervises = vec![
         Supervises {
             parent: LocusDeclId(1),
-            child: LocusDeclId(0),
+            child: SupervisedRef::Locus(LocusDeclId(0)),
             error_type: "IoError".to_string(),
             policy: SupervisionPolicy {
                 ops: vec!["restart".to_string()],
@@ -355,7 +355,7 @@ fn unsorted_supervises_are_not_canonical() {
         },
         Supervises {
             parent: LocusDeclId(0),
-            child: LocusDeclId(1),
+            child: SupervisedRef::Locus(LocusDeclId(1)),
             error_type: "IoError".to_string(),
             policy: SupervisionPolicy {
                 ops: vec!["restart".to_string()],
@@ -629,7 +629,7 @@ fn supervision_is_per_error_type() {
     m.relations.supervises = vec![
         Supervises {
             parent: LocusDeclId(0),
-            child: LocusDeclId(1),
+            child: SupervisedRef::Locus(LocusDeclId(1)),
             error_type: "ClosureViolation".to_string(),
             policy: SupervisionPolicy {
                 ops: vec!["restart".to_string()],
@@ -639,7 +639,7 @@ fn supervision_is_per_error_type() {
         },
         Supervises {
             parent: LocusDeclId(0),
-            child: LocusDeclId(1),
+            child: SupervisedRef::Locus(LocusDeclId(1)),
             error_type: "IoError".to_string(),
             policy: SupervisionPolicy {
                 ops: vec!["replace".to_string()],

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -100,6 +100,7 @@ fn tiny_model() -> ApplicationModel {
             }],
             topics: vec![Topic {
                 name: "Readings".to_string(),
+                display: "Readings".to_string(),
                 subject: SubjectId(0),
                 payload: PayloadContractId(0),
                 key: Some(TopicKey {
@@ -190,6 +191,7 @@ fn tiny_model() -> ApplicationModel {
             ..Capabilities::default()
         },
         provenance: prov,
+        legacy: LegacyProjection::default(),
     }
 }
 
@@ -717,11 +719,13 @@ fn groups_are_typed_model_rows() {
     m.entities.groups = vec![
         Group {
             name: "probes".to_string(),
+            display: "probes".to_string(),
             may_be_empty: true,
             provenance: p,
         },
         Group {
             name: "workers".to_string(),
+            display: "workers".to_string(),
             may_be_empty: false,
             provenance: p,
         },
@@ -934,6 +938,7 @@ fn declared_in_covers_the_full_declaration_universe() {
     }];
     m.entities.groups = vec![Group {
         name: "workers".to_string(),
+        display: "workers".to_string(),
         may_be_empty: false,
         provenance: p,
     }];
@@ -1005,6 +1010,7 @@ fn the_nameable_declaration_universe_is_complete() {
     }];
     m.entities.groups = vec![Group {
         name: "workers".to_string(),
+        display: "workers".to_string(),
         may_be_empty: false,
         provenance: p,
     }];
@@ -1174,6 +1180,7 @@ fn authored_selectors_are_kept_alongside_resolved_members() {
     let p = ProvenanceId(0);
     m.entities.groups = vec![Group {
         name: "workers".to_string(),
+        display: "workers".to_string(),
         may_be_empty: false,
         provenance: p,
     }];
@@ -1261,6 +1268,56 @@ fn authored_selectors_are_kept_alongside_resolved_members() {
         m.validate(),
         Err(ModelError::DanglingId {
             table: "group_selectors",
+            index: 0
+        })
+    );
+}
+
+// -----------------------------------------------------------------
+// Review round 7 — declared publisher ends and the legacy bridge.
+// -----------------------------------------------------------------
+
+/// A declared publisher end is its own typed relation with the same
+/// agreement laws as sends.
+#[test]
+fn declared_publisher_ends_are_typed_rows() {
+    let mut m = tiny_model();
+    let p = ProvenanceId(0);
+    m.relations.declares_publish = vec![DeclaresPublish {
+        locus: LocusDeclId(0),
+        subject: SubjectId(0),
+        declared_topic: Some(TopicId(0)),
+        payload: PayloadContractId(0),
+        provenance: p,
+    }];
+    m.validate().expect("declared end is lawful");
+    // Payload disagreement with the declared topic refuses.
+    m.entities.payloads.push(PayloadContract {
+        shape: "z:i".to_string(),
+        hash: 0x2222,
+        provenance: p,
+    });
+    m.relations.declares_publish[0].payload = PayloadContractId(1);
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::EndpointPayloadDisagrees {
+            table: "declares_publish",
+            index: 0
+        })
+    );
+}
+
+/// The legacy projection is validated: sorted, in range.
+#[test]
+fn legacy_projection_is_validated() {
+    let mut m = tiny_model();
+    m.legacy.topology_v1_fns = vec![FunctionId(0), FunctionId(1)];
+    m.validate().expect("sorted legacy sort is lawful");
+    m.legacy.topology_v1_fns = vec![FunctionId(9)];
+    assert_eq!(
+        m.validate(),
+        Err(ModelError::DanglingId {
+            table: "legacy.topology_v1_fns",
             index: 0
         })
     );

--- a/crates/hale-types/Cargo.toml
+++ b/crates/hale-types/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 description = "Hale language: type checker (Phase 1 milestone 2)"
 
 [dependencies]
+hale-model = { path = "../hale-model" }
 hale-stdlib = { path = "../hale-stdlib" }
 hale-syntax = { path = "../hale-syntax" }
 

--- a/crates/hale-types/src/alloc_summary.rs
+++ b/crates/hale-types/src/alloc_summary.rs
@@ -537,13 +537,29 @@ pub struct EffectSite {
     pub span: Span,
 }
 
+/// A publish site's subject, WITH its syntactic form. The resolver
+/// distinguishes a string-literal wire address (`"subject" <- v`)
+/// from a declared-topic reference (`Topic <- v`) — a literal keeps
+/// its literal address even when its text collides with a topic
+/// NAME, so consumers must never decide "declared topic?" from the
+/// string alone (GH #476 Change 2, round 10).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublishSubject {
+    /// The subject as written: the literal text, the topic name, or
+    /// the author-spelled qualified path.
+    pub text: String,
+    /// `true` iff the source expression was a string literal — a
+    /// wire address, never a topic reference.
+    pub literal: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EffectSiteKind {
     /// `Topic <- value` / `"subject" <- value`. Carries the subject
     /// as written when it is a compile-time-constant string or a
     /// declared topic name (the closed topic set makes publish-set
     /// assertions exact); None for a computed subject.
-    Publish(Option<String>),
+    Publish(Option<PublishSubject>),
     /// A locus instantiation (`Child { ... }`) — an arena creation
     /// plus, depending on placement, a thread spawn or a pool post.
     Spawn(String),
@@ -2502,24 +2518,32 @@ impl<'a> Walker<'a> {
                 // the closed-topic-set claim hold.
                 let subj = match subject {
                     Expr::Literal(Literal::String(s), _) => {
-                        Some(s.clone())
+                        Some(PublishSubject {
+                            text: s.clone(),
+                            literal: true,
+                        })
                     }
                     // A declared topic name (`Sig <- v`) parses as a
                     // bare identifier.
-                    Expr::Ident(id) => Some(id.name.clone()),
+                    Expr::Ident(id) => Some(PublishSubject {
+                        text: id.name.clone(),
+                        literal: false,
+                    }),
                     // A topic imported from a shared catalog
                     // (`t::SharedTopic <- v`) is a qualified
                     // path. Treating it as "computed" made every
                     // publish of a SHARED topic unprovable — which is
                     // every topic that crosses a binary, and so the
                     // only ones a publish-set contract is really for.
-                    Expr::Path(qp) => Some(
-                        qp.segments
+                    Expr::Path(qp) => Some(PublishSubject {
+                        text: qp
+                            .segments
                             .iter()
                             .map(|s| s.name.as_str())
                             .collect::<Vec<_>>()
                             .join("::"),
-                    ),
+                        literal: false,
+                    }),
                     _ => None,
                 };
                 self.push_effect_site(

--- a/crates/hale-types/src/callgraph.rs
+++ b/crates/hale-types/src/callgraph.rs
@@ -372,3 +372,65 @@ pub fn render_witness(root: &FnKey, steps: &[WitnessStep]) -> String {
     }
     s
 }
+
+/// The LEGACY through-stdlib contraction (#392), byte-for-byte the
+/// algorithm whose output `TopologyShapeV1` hashes: one Boolean of
+/// path state, a no-revisit `seen` set, LIFO traversal, [`MAX_STEPS`]
+/// saturation. A stdlib node first reached on a non-looped path is
+/// **never revisited** when a looped path reaches it later — that
+/// order-dependence is part of the shipped hash, so this function is
+/// shared verbatim by `dump_topology` (which serializes it) and the
+/// model builder's `LegacyProjection` (which preserves it for
+/// Change 3). It is NOT the model's algorithm: the model relation
+/// uses a two-component revisit-on-strengthen lattice that can
+/// legitimately report a stronger loop bit for the same source.
+pub fn legacy_via_stdlib_contraction(
+    merged: &AllocSummary,
+    user_key: &dyn Fn(&FnKey) -> bool,
+) -> std::collections::BTreeMap<(FnKey, FnKey), bool> {
+    use std::collections::{BTreeMap, BTreeSet};
+    let mut via_stdlib: BTreeMap<(FnKey, FnKey), bool> =
+        BTreeMap::new();
+    for (k, fs) in &merged.fns {
+        if !user_key(k) {
+            continue;
+        }
+        let mut stack: Vec<(FnKey, bool)> = Vec::new();
+        let mut seen: BTreeSet<FnKey> = BTreeSet::new();
+        for edge in &fs.calls {
+            if let Callee::Resolved(next) = &edge.callee {
+                if !user_key(next) && seen.insert(next.clone()) {
+                    stack.push((
+                        next.clone(),
+                        edge.loop_depth > 0 || edge.in_unbounded_loop,
+                    ));
+                }
+            }
+        }
+        let mut steps = 0u32;
+        while let Some((n, lp)) = stack.pop() {
+            steps += 1;
+            if steps > MAX_STEPS {
+                break;
+            }
+            let Some(nfs) = merged.fns.get(&n) else { continue };
+            for edge in &nfs.calls {
+                let Callee::Resolved(next) = &edge.callee else {
+                    continue;
+                };
+                let l2 = lp
+                    || edge.loop_depth > 0
+                    || edge.in_unbounded_loop;
+                if user_key(next) {
+                    let e = via_stdlib
+                        .entry((k.clone(), next.clone()))
+                        .or_insert(false);
+                    *e |= l2;
+                } else if seen.insert(next.clone()) {
+                    stack.push((next.clone(), l2));
+                }
+            }
+        }
+    }
+    via_stdlib
+}

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -1683,6 +1683,7 @@ fn evaluate_forbid_reaches(
                         ));
                         return model_graph::Visit::hole(());
                     };
+                    let subj = &subj.text;
                     for (sub_locus, sub_handler, sub_span) in
                         subscribers_of(cx.graph, subj)
                     {
@@ -1898,6 +1899,7 @@ fn evaluate_only_edges(
                 ));
                 return Verdict::Uncertified;
             };
+            let subj = &subj.text;
             for (sub_locus, sub_handler, sub_span) in
                 subscribers_of(cx.graph, subj)
             {
@@ -2272,6 +2274,7 @@ fn site_count(
                 });
                 break;
             };
+            let subj = &subj.text;
             for (sub_locus, sub_handler, _sub_span) in
                 subscribers_of(cx.graph, subj)
             {

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -1074,7 +1074,7 @@ fn check_class(
                         EffectClass::Publish,
                         alloc_summary::EffectSiteKind::Publish(subj),
                     ) => Some(match subj {
-                        Some(s) => format!("publishes to `{}`", s),
+                        Some(s) => format!("publishes to `{}`", s.text),
                         None => "publishes".to_string(),
                     }),
                     (
@@ -1389,10 +1389,10 @@ fn check_publish_set(
 ) {
     let found = find_effect_site(summary, key, |k| match k {
         alloc_summary::EffectSiteKind::Publish(Some(subj)) => {
-            if allowed.iter().any(|a| topic_ref_matches(a, subj)) {
+            if allowed.iter().any(|a| topic_ref_matches(a, &subj.text)) {
                 None
             } else {
-                Some(format!("publishes to `{}`", subj))
+                Some(format!("publishes to `{}`", subj.text))
             }
         }
         alloc_summary::EffectSiteKind::Publish(None) => Some(

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -239,7 +239,7 @@ fn collect_published_subjects(
     let Some(fs) = summary.fns.get(key) else { return };
     for site in &fs.effect_sites {
         if let alloc_summary::EffectSiteKind::Publish(Some(s)) = &site.kind {
-            out.insert(s.clone());
+            out.insert(s.text.clone());
         }
     }
     for edge in &fs.calls {

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -30,6 +30,7 @@ pub mod frontier;
 pub mod check;
 pub mod claims;
 pub mod model;
+pub mod model_builder;
 pub mod topic_identity;
 pub mod topology;
 pub mod model_graph;

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -66,6 +66,19 @@ use crate::symbol::Bundle;
 
 static BUILDS: AtomicU64 = AtomicU64::new(0);
 
+/// A named TypeExpr's raw path (joined `::`), `"?"` otherwise.
+fn te_name_of(t: &TypeExpr) -> String {
+    match t {
+        TypeExpr::Named { path, .. } => path
+            .segments
+            .iter()
+            .map(|s| s.name.clone())
+            .collect::<Vec<_>>()
+            .join("::"),
+        _ => "?".to_string(),
+    }
+}
+
 /// How many times the builder has run in this process — the
 /// demand-gating instrumentation. The no-claims check path must
 /// leave this at zero.
@@ -109,7 +122,18 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     let name = |n: &str| -> String {
         demangle.get(n).cloned().unwrap_or_else(|| n.to_string())
     };
+    // CANONICAL identity is the RAW post-merge symbol (stable across
+    // importers — `p::Store` vs `db::Store` must be one identity);
+    // author spelling lives in per-row `display` fields and nothing
+    // else (review round 7). fn_name is raw; fn_display demangles
+    // both halves.
     let fn_name = |k: &FnKey| -> String {
+        match &k.locus {
+            Some(l) => format!("{}::{}", l, k.fn_name),
+            None => k.fn_name.clone(),
+        }
+    };
+    let fn_display = |k: &FnKey| -> String {
         match &k.locus {
             Some(l) => format!("{}::{}", name(l), k.fn_name),
             None => name(&k.fn_name),
@@ -316,13 +340,13 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         id
     };
 
-    // ---- entity tables (canonical order via BTree keys) ----
+    // ---- entity tables (canonical order via BTree keys, RAW) ----
     // Loci.
     let mut locus_rows: BTreeMap<String, (bool, hale_syntax::Span)> =
         BTreeMap::new();
     for l in &ast.loci {
         locus_rows
-            .insert(name(&l.name.name), (l.sealed, l.name.span));
+            .insert(l.name.name.clone(), (l.sealed, l.name.span));
     }
     let locus_id: BTreeMap<&String, LocusDeclId> = locus_rows
         .keys()
@@ -341,7 +365,12 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     struct FnInfo {
         kind: FunctionKind,
         locus: Option<String>,
+        display: String,
         span: Option<hale_syntax::Span>,
+        /// The behavior analysis did not walk this body (module
+        /// scope / on_failure at Change 2) — emits an
+        /// UnanalyzedBody hole.
+        unanalyzed: bool,
     }
     fn hook_name(k: &hale_syntax::ast::LifecycleKind) -> &'static str {
         use hale_syntax::ast::LifecycleKind as LK;
@@ -364,36 +393,64 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     }
     let mut fn_rows: BTreeMap<String, FnInfo> = BTreeMap::new();
     {
+        // depth > 0 = inside a module: the behavior summary's body
+        // walk does not recurse into modules, so those bodies are
+        // UNANALYZED at Change 2 and must hole out (review round 7).
         fn walk_free<'a>(
             items: &'a [TopDecl],
-            out: &mut Vec<(&'a str, hale_syntax::Span)>,
+            depth: u32,
+            out: &mut Vec<(&'a str, hale_syntax::Span, bool)>,
         ) {
             for item in items {
                 match item {
-                    TopDecl::Fn(f) => {
-                        out.push((f.name.name.as_str(), f.name.span))
+                    TopDecl::Fn(f) => out.push((
+                        f.name.name.as_str(),
+                        f.name.span,
+                        depth > 0,
+                    )),
+                    TopDecl::Module(m) => {
+                        walk_free(&m.items, depth + 1, out)
                     }
-                    TopDecl::Module(m) => walk_free(&m.items, out),
+                    _ => {}
+                }
+            }
+        }
+        fn walk_loci_mod<'a>(
+            items: &'a [TopDecl],
+            depth: u32,
+            out: &mut Vec<(&'a AstLocusDecl, bool)>,
+        ) {
+            for item in items {
+                match item {
+                    TopDecl::Locus(l) => out.push((l, depth > 0)),
+                    TopDecl::Module(m) => {
+                        walk_loci_mod(&m.items, depth + 1, out)
+                    }
                     _ => {}
                 }
             }
         }
         let mut frees = Vec::new();
+        let mut mod_loci = Vec::new();
         for pr in &programs {
-            walk_free(&pr.items, &mut frees);
+            walk_free(&pr.items, 0, &mut frees);
+            walk_loci_mod(&pr.items, 0, &mut mod_loci);
         }
-        for (n, sp) in frees {
+        for (n, sp, in_module) in frees {
             fn_rows.insert(
-                name(n),
+                n.to_string(),
                 FnInfo {
                     kind: FunctionKind::Free,
                     locus: None,
+                    display: name(n),
                     span: Some(sp),
+                    unanalyzed: in_module,
                 },
             );
         }
-        for l in &ast.loci {
-            let ld = name(&l.name.name);
+        for (l, in_module) in &mod_loci {
+            let ld = l.name.name.clone();
+            let ld_display = name(&ld);
             for m in &l.members {
                 let (fname, kind, sp) = match m {
                     LocusMember::Fn(f) => (
@@ -411,6 +468,40 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                         FunctionKind::Mode,
                         md.span,
                     ),
+                    LocusMember::Failure(fd) => {
+                        // on_failure handlers ARE executable hooks;
+                        // the summary never walks them, so they
+                        // enter the universe with an UnanalyzedBody
+                        // hole. Uniqueness: one handler per
+                        // (child, err) signature.
+                        let sig = fd
+                            .params
+                            .iter()
+                            .map(|pa| te_name_of(&pa.ty))
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        fn_rows.insert(
+                            format!("{}::on_failure({})", ld, sig),
+                            FnInfo {
+                                kind: FunctionKind::Hook,
+                                locus: Some(ld.clone()),
+                                display: format!(
+                                    "{}::on_failure({})",
+                                    ld_display,
+                                    fd.params
+                                        .iter()
+                                        .map(|pa| name(&te_name_of(
+                                            &pa.ty
+                                        )))
+                                        .collect::<Vec<_>>()
+                                        .join(",")
+                                ),
+                                span: Some(fd.span),
+                                unanalyzed: true,
+                            },
+                        );
+                        continue;
+                    }
                     _ => continue,
                 };
                 fn_rows.insert(
@@ -418,7 +509,9 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                     FnInfo {
                         kind,
                         locus: Some(ld.clone()),
+                        display: format!("{}::{}", ld_display, fname),
                         span: Some(sp),
+                        unanalyzed: *in_module,
                     },
                 );
             }
@@ -435,8 +528,10 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                     Some(_) => FunctionKind::Method,
                     None => FunctionKind::Free,
                 },
-                locus: k.locus.as_ref().map(|l| name(l)),
+                locus: k.locus.clone(),
+                display: fn_display(k),
                 span: None,
+                unanalyzed: false,
             });
         }
     }
@@ -493,6 +588,8 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         .collect();
     let wire_subjects =
         crate::topic_identity::topic_wire_subjects(&all_items);
+    // Keyed by RAW name — canonical identity — with the author
+    // spelling carried alongside.
     let mut topic_decl_by_name: BTreeMap<String, TInfo> = BTreeMap::new();
     for t in &ast.topics {
         let raw = t.name.name.clone();
@@ -504,7 +601,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             .cloned()
             .unwrap_or_else(|| raw.clone());
         topic_decl_by_name
-            .insert(name(&raw), TInfo { raw, decl: t, wire });
+            .insert(raw.clone(), TInfo { raw, decl: t, wire });
     }
 
     let mut subject_set: BTreeSet<String> = BTreeSet::new();
@@ -512,9 +609,8 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         subject_set.insert(info.wire.clone());
     }
     for (subject, _) in &graph.subjects {
-        let display = name(subject);
-        if !topic_decl_by_name.contains_key(&display) {
-            subject_set.insert(display);
+        if !topic_decl_by_name.contains_key(subject.as_str()) {
+            subject_set.insert(subject.clone());
         }
     }
 
@@ -569,7 +665,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     let mut endpoint_payload: BTreeMap<String, (String, u64)> =
         BTreeMap::new();
     for (subject, info) in &graph.subjects {
-        let display = name(subject);
+        let display = subject.clone();
         if topic_decl_by_name.contains_key(&display) {
             continue;
         }
@@ -595,14 +691,30 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     // still exists, holes and all.)
     let unresolved_payload = ("?".to_string(), fnv("?"));
     {
-        let mut need = |display: String| {
-            if !topic_decl_by_name.contains_key(&display)
-                && !endpoint_payload.contains_key(&display)
-            {
-                subject_set.insert(display.clone());
-                payload_rows.insert(unresolved_payload.clone(), ());
-                endpoint_payload
-                    .insert(display, unresolved_payload.clone());
+        // `known` overrides the "?" fallback with the endpoint's
+        // real structural contract (an explicit `of type T`) — one
+        // closure owns ALL mutation so the borrows stay linear.
+        let mut need = |display: String,
+                        known: Option<(String, u64)>| {
+            if topic_decl_by_name.contains_key(&display) {
+                return;
+            }
+            subject_set.insert(display.clone());
+            match known {
+                Some(key) => {
+                    payload_rows.insert(key.clone(), ());
+                    endpoint_payload.insert(display, key);
+                }
+                None => {
+                    if !endpoint_payload.contains_key(&display) {
+                        payload_rows
+                            .insert(unresolved_payload.clone(), ());
+                        endpoint_payload.insert(
+                            display,
+                            unresolved_payload.clone(),
+                        );
+                    }
+                }
             }
         };
         for (k, fs) in &summary.fns {
@@ -612,7 +724,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             for site in &fs.effect_sites {
                 if let EffectSiteKind::Publish(Some(subj)) = &site.kind
                 {
-                    need(name(subj));
+                    need(subj.clone(), None);
                 }
             }
         }
@@ -621,9 +733,20 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 let LocusMember::Bus(bus) = m else { continue };
                 for bm in &bus.members {
                     match bm {
-                        BusMember::Subscribe { subject, .. }
-                        | BusMember::Publish { subject, .. } => {
-                            need(name(subject.canonical()));
+                        BusMember::Subscribe {
+                            subject, ty, ..
+                        }
+                        | BusMember::Publish { subject, ty, .. } => {
+                            // An explicit `of type T` names the
+                            // endpoint's real structural contract —
+                            // registered so every consumer (graph,
+                            // sends, declared ends) shares one key.
+                            need(
+                                subject.canonical().to_string(),
+                                ty.as_ref().map(|t| {
+                                    shape_of_type(&te_name_of(t))
+                                }),
+                            );
                         }
                     }
                 }
@@ -676,10 +799,10 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         .map(|(i, k)| (k, SeedId(i as u32)))
         .collect();
 
-    // Groups.
+    // Groups, keyed raw.
     let mut group_rows: BTreeMap<String, &GroupDecl> = BTreeMap::new();
     for g in &ast.groups {
-        group_rows.insert(name(&g.name.name), g);
+        group_rows.insert(g.name.name.clone(), g);
     }
     let group_id: BTreeMap<&String, GroupId> = group_rows
         .keys()
@@ -691,7 +814,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     let mut type_rows: BTreeMap<String, hale_syntax::Span> =
         BTreeMap::new();
     for (n, sp) in &ast.types {
-        type_rows.insert(name(n), *sp);
+        type_rows.insert(n.to_string(), *sp);
     }
     let type_id: BTreeMap<&String, TypeDeclId> = type_rows
         .keys()
@@ -701,7 +824,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     let mut iface_rows: BTreeMap<String, hale_syntax::Span> =
         BTreeMap::new();
     for (n, sp) in &ast.interfaces {
-        iface_rows.insert(name(n), *sp);
+        iface_rows.insert(n.to_string(), *sp);
     }
     let iface_id: BTreeMap<&String, InterfaceDeclId> = iface_rows
         .keys()
@@ -711,7 +834,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     let mut other_rows: BTreeMap<(String, DeclKind), hale_syntax::Span> =
         BTreeMap::new();
     for (kind, n, sp) in &ast.others {
-        other_rows.insert((name(n), *kind), *sp);
+        other_rows.insert((n.to_string(), *kind), *sp);
     }
     let other_id: BTreeMap<&(String, DeclKind), hale_model::DeclarationId> =
         other_rows
@@ -806,7 +929,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                     let to = fn_id[&fn_name(next)];
                     let dispatch = match &edge.via_interface {
                         Some(i) => DispatchKind::Interface {
-                            interface: name(i),
+                            interface: i.clone(),
                         },
                         None => DispatchKind::Direct,
                     };
@@ -842,7 +965,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                     } else if let Some(iface) = &edge.via_interface {
                         dead.insert(
                             (from, site),
-                            (name(iface), n.clone(), pid),
+                            (iface.clone(), n.clone(), pid),
                         );
                     } else if edge.receiver_present
                         && edge.recv_ty.is_none()
@@ -1123,7 +1246,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         for s in &fs.effect_sites {
             match &s.kind {
                 EffectSiteKind::Publish(Some(subj)) => {
-                    let display = name(subj);
+                    let display = subj.clone();
                     let pid = intern_span(&mut records, s.span);
                     let (declared, subject_str, payload, keyed) =
                         match topic_decl_by_name.get(&display) {
@@ -1200,7 +1323,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         ),
     > = BTreeMap::new();
     for l in &ast.loci {
-        let locus_display = name(&l.name.name);
+        let locus_raw = l.name.name.clone();
         let mut site: u32 = 0;
         for m in &l.members {
             let LocusMember::Bus(bus) = m else { continue };
@@ -1216,9 +1339,9 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 else {
                     continue;
                 };
-                let display = name(subject.canonical());
+                let display = subject.canonical().to_string();
                 let handler_full =
-                    format!("{}::{}", locus_display, handler.name);
+                    format!("{}::{}", locus_raw, handler.name);
                 let Some(hid) = fn_id.get(&handler_full) else {
                     continue;
                 };
@@ -1386,11 +1509,11 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                     let mut ops = Vec::new();
                     let mut retry = None;
                     walk_ops(&fd.body, &mut ops, &mut retry);
-                    let parent = locus_id[&name(&l.name.name)];
+                    let parent = locus_id[&l.name.name];
                     let child_name = fd
                         .params
                         .first()
-                        .map(|p| name(&te_name(&p.ty)))
+                        .map(|p| te_name(&p.ty))
                         .unwrap_or_else(|| "?".to_string());
                     let child = match locus_id.get(&child_name) {
                         Some(id) => SupervisedRef::Locus(*id),
@@ -1399,7 +1522,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                     let err = fd
                         .params
                         .get(1)
-                        .map(|p| name(&te_name(&p.ty)))
+                        .map(|p| te_name(&p.ty))
                         .unwrap_or_else(|| "?".to_string());
                     let pid = intern_span(&mut records, fd.span);
                     sup.insert(
@@ -1440,7 +1563,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 // Enumerate: the alias's loci and free fns.
                 if let Some(members) = vmodel.seeds.get(&alias) {
                     for mangled in members {
-                        let display = name(mangled);
+                        let display = mangled.clone();
                         if let Some(id) =
                             locus_id.get(&display)
                         {
@@ -1470,7 +1593,10 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                     }
                 }
             } else {
-                let display = name(&m.display());
+                // Lookups are by RAW name (qualified members were
+                // collapsed to mangled segments by the import
+                // pass); the selector row's display re-spells them.
+                let display = m.display();
                 // Both-join rule: a name shared by a locus and a
                 // fn contributes both members; the selector row
                 // references the locus when both exist.
@@ -1496,10 +1622,11 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                             // Author spelling: qualified members have
                             // been collapsed to mangled single
                             // segments by the import pass, so the
-                            // raw display() may read __lib_… — run
-                            // it through the demangle map exactly as
-                            // the artifact does.
-                            display,
+                            // raw display() may read __lib_… — the
+                            // STORED spelling runs through the
+                            // demangle map exactly as the artifact's
+                            // does (lookups above stayed raw).
+                            display: name(&m.display()),
                         },
                         provenance: pid,
                     });
@@ -1516,8 +1643,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     for (alias, members) in &vmodel.seeds {
         let sid = seed_id[alias];
         for mangled in members {
-            let display = name(mangled);
-            if let Some(r) = entity_of(&display) {
+            if let Some(r) = entity_of(mangled) {
                 declared_in.insert((r, sid));
                 let pid = intern_synth(
                     &mut records,
@@ -1534,7 +1660,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         let pid = intern_span(&mut records, *sp);
         e.loci.push(LocusDecl {
             name: n.clone(),
-            display: n.clone(),
+            display: name(n),
             sealed: *sealed,
             provenance: pid,
         });
@@ -1560,7 +1686,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         };
         e.functions.push(Function {
             name: n.clone(),
-            display: n.clone(),
+            display: info.display.clone(),
             kind: info.kind,
             effects: derived_effects.get(n).cloned().unwrap_or_default(),
             provenance: pid,
@@ -1588,6 +1714,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         let pid = intern_span(&mut records, t.name.span);
         e.topics.push(Topic {
             name: tname.clone(),
+            display: name(tname),
             subject: subject_id[&info.wire],
             payload: payload_id[&topic_payload[tname].clone()],
             key: t.keyed_by.as_ref().map(|f| TopicKey {
@@ -1628,6 +1755,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         let pid = intern_span(&mut records, g.name.span);
         e.groups.push(Group {
             name: n.clone(),
+            display: name(n),
             may_be_empty: g.may_be_empty,
             provenance: pid,
         });
@@ -1636,7 +1764,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         let pid = intern_span(&mut records, *sp);
         e.types.push(MTypeDecl {
             name: n.clone(),
-            display: n.clone(),
+            display: name(n),
             provenance: pid,
         });
     }
@@ -1644,7 +1772,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         let pid = intern_span(&mut records, *sp);
         e.interfaces.push(InterfaceDecl {
             name: n.clone(),
-            display: n.clone(),
+            display: name(n),
             provenance: pid,
         });
     }
@@ -1653,7 +1781,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         e.declarations.push(Declaration {
             kind: *kind,
             name: n.clone(),
-            display: n.clone(),
+            display: name(n),
             provenance: pid,
         });
     }
@@ -1789,6 +1917,100 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         }
     }
 
+    // Unanalyzed bodies (module scope, on_failure): declared
+    // executable entities whose calls/publishes/effects the summary
+    // never walked — typed holes keep the capabilities honest.
+    for (n, info) in &fn_rows {
+        if info.unanalyzed {
+            let pid = match info.span {
+                Some(sp) => intern_span(&mut records, sp),
+                None => intern_synth(&mut records, "unanalyzed body"),
+            };
+            holes
+                .entry((
+                    EntityRef::Function(fn_id[n]),
+                    HoleKind::UnanalyzedBody,
+                    "body not walked by the behavior analysis"
+                        .to_string(),
+                ))
+                .or_insert((
+                    hale_model::RelationSet::CALLS
+                        .union(hale_model::RelationSet::PUBLISHES)
+                        .union(hale_model::RelationSet::EFFECTS),
+                    pid,
+                ));
+        }
+    }
+
+    // Declared publisher ends: `bus { publish T; }` — the endpoint
+    // grain, independent of whether any send exists.
+    {
+        let mut ends: BTreeMap<
+            (hale_model::LocusDeclId, SubjectId),
+            (Option<TopicId>, PayloadContractId, ProvenanceId),
+        > = BTreeMap::new();
+        for l in &ast.loci {
+            let Some(lid) = locus_id.get(&l.name.name) else {
+                continue;
+            };
+            for m in &l.members {
+                let LocusMember::Bus(bus) = m else { continue };
+                for bm in &bus.members {
+                    let BusMember::Publish { subject, ty, span, .. } =
+                        bm
+                    else {
+                        continue;
+                    };
+                    let raw = subject.canonical().to_string();
+                    let (declared, subj_str, payload) =
+                        match topic_decl_by_name.get(&raw) {
+                            Some(info) => (
+                                Some(topic_id[&raw]),
+                                info.wire.clone(),
+                                payload_id
+                                    [&topic_payload[&raw].clone()],
+                            ),
+                            None => {
+                                let _ = ty;
+                                let key = endpoint_payload
+                                    .get(&raw)
+                                    .cloned()
+                                    .unwrap_or_else(|| {
+                                        unresolved_payload.clone()
+                                    });
+                                (None, raw.clone(), payload_id[&key])
+                            }
+                        };
+                    let pid = intern_span(&mut records, *span);
+                    ends.entry((*lid, subject_id[&subj_str]))
+                        .or_insert((declared, payload, pid));
+                }
+            }
+        }
+        for ((lid, sid), (declared, payload, pid)) in ends {
+            r.declares_publish.push(
+                hale_model::DeclaresPublish {
+                    locus: lid,
+                    subject: sid,
+                    declared_topic: declared,
+                    payload,
+                    provenance: pid,
+                },
+            );
+        }
+    }
+
+    // The Change-3 bridge: the legacy artifact's fn sort, recorded
+    // so TopologyShapeV1 projects from the model alone.
+    let mut legacy_fns: Vec<hale_model::FunctionId> = summary
+        .fns
+        .keys()
+        .filter(|k| user_key(k))
+        .map(|k| fn_id[&fn_name(k)])
+        .collect();
+    legacy_fns.sort();
+    legacy_fns.dedup();
+
     // holes, canonically ordered.
     let mut hole_rows: Vec<Hole> = holes
         .into_iter()
@@ -1834,6 +2056,9 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
 
     prov.records = records;
     let model = ApplicationModel {
+        legacy: hale_model::LegacyProjection {
+            topology_v1_fns: legacy_fns,
+        },
         header: ModelHeader {
             semantics: MODEL_SEMANTICS_V1,
             entrypoint,
@@ -1863,16 +2088,17 @@ pub fn render_internal(m: &ApplicationModel) -> String {
         m.header.semantics, m.header.entrypoint
     ));
     let e = &m.entities;
-    let fn_name = |id: FunctionId| e.functions[id.index()].name.clone();
-    let locus_name = |id: LocusDeclId| e.loci[id.index()].name.clone();
+    let fn_name =
+        |id: FunctionId| e.functions[id.index()].display.clone();
+    let locus_name = |id: LocusDeclId| e.loci[id.index()].display.clone();
     let subject_pat = |id: SubjectId| e.subjects[id.index()].pattern.clone();
-    let topic_name = |id: TopicId| e.topics[id.index()].name.clone();
+    let topic_name = |id: TopicId| e.topics[id.index()].display.clone();
 
     s.push_str(&format!("loci ({}):\n", e.loci.len()));
     for l in &e.loci {
         s.push_str(&format!(
             "  {}{}\n",
-            l.name,
+            l.display,
             if l.sealed { " @sealed" } else { "" }
         ));
     }
@@ -1880,7 +2106,7 @@ pub fn render_internal(m: &ApplicationModel) -> String {
     for f in &e.functions {
         s.push_str(&format!(
             "  {} [{}]{}\n",
-            f.name,
+            f.display,
             match f.kind {
                 FunctionKind::Hook => "hook",
                 FunctionKind::Method => "method",
@@ -1898,7 +2124,7 @@ pub fn render_internal(m: &ApplicationModel) -> String {
     for t in &e.topics {
         let mut line = format!(
             "  {} -> {} payload#{:016x}",
-            t.name,
+            t.display,
             subject_pat(t.subject),
             e.payloads[t.payload.index()].hash
         );
@@ -1935,7 +2161,7 @@ pub fn render_internal(m: &ApplicationModel) -> String {
             .map(|g| {
                 format!(
                     "{}{}",
-                    g.name,
+                    g.display,
                     if g.may_be_empty { " may_be_empty" } else { "" }
                 )
             })
@@ -1946,17 +2172,17 @@ pub fn render_internal(m: &ApplicationModel) -> String {
         "declaration universe: types [{}], interfaces [{}], other [{}]\n",
         e.types
             .iter()
-            .map(|t| t.name.clone())
+            .map(|t| t.display.clone())
             .collect::<Vec<_>>()
             .join(", "),
         e.interfaces
             .iter()
-            .map(|t| t.name.clone())
+            .map(|t| t.display.clone())
             .collect::<Vec<_>>()
             .join(", "),
         e.declarations
             .iter()
-            .map(|d| format!("{:?}:{}", d.kind, d.name))
+            .map(|d| format!("{:?}:{}", d.kind, d.display))
             .collect::<Vec<_>>()
             .join(", ")
     ));
@@ -2049,7 +2275,7 @@ pub fn render_internal(m: &ApplicationModel) -> String {
     for gs in &r.group_selectors {
         s.push_str(&format!(
             "  {}[{}] = {}\n",
-            e.groups[gs.group.index()].name,
+            e.groups[gs.group.index()].display,
             gs.ordinal,
             match &gs.selector {
                 SelectorForm::Named { display, .. } => display.clone(),

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -55,10 +55,11 @@ use hale_model::{
     TypeDeclId, MODEL_SEMANTICS_V1,
 };
 use hale_syntax::ast::{
-    Block, BusMember, ElseBranch, Expr, GroupDecl, KeyFilter, Literal,
-    LocusDecl as AstLocusDecl, LocusMember, Program, RecoveryModifier,
-    RecoveryOp, ShedPolicy as AstShedPolicy, Stmt, TopDecl, TopicDecl,
-    TypeExpr, UnmatchedPolicy,
+    Block, BusMember, BusSubject, ElseBranch, Expr, GroupDecl,
+    KeyFilter, Literal, LocusDecl as AstLocusDecl, LocusMember,
+    Program, RecoveryModifier, RecoveryOp,
+    ShedPolicy as AstShedPolicy, Stmt, TopDecl, TopicDecl, TypeExpr,
+    UnmatchedPolicy,
 };
 
 use crate::alloc_summary::{self, Callee, EffectSiteKind, FnKey};
@@ -216,6 +217,13 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     let name = |n: &str| -> String {
         demangle.get(n).cloned().unwrap_or_else(|| n.to_string())
     };
+    // The inverse: author-spelled path ("alias::helper") → raw
+    // post-merge symbol. An unresolved call can carry the AUTHOR
+    // spelling while the model's tables are keyed raw (round 10).
+    let remangle: BTreeMap<String, String> = demangle
+        .iter()
+        .map(|(m, d)| (d.clone(), (*m).to_string()))
+        .collect();
     // CANONICAL identity is the RAW post-merge symbol (stable across
     // importers — `p::Store` vs `db::Store` must be one identity);
     // author spelling lives in per-row `display` fields and nothing
@@ -746,24 +754,28 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             (shape, h)
         }
     };
-    let mut payload_rows: BTreeMap<(String, u64), ()> = BTreeMap::new();
-    let mut topic_payload: BTreeMap<String, (String, u64)> =
-        BTreeMap::new();
-    for (tname, info) in &topic_decl_by_name {
-        let raw_ty = match &info.decl.payload {
+    // The ONE payload-contract rule for a type EXPRESSION — used by
+    // declared topics and explicit `of type T` endpoint clauses
+    // alike (round 10; endpoint clauses previously collapsed every
+    // non-named form to `opaque:?` through a name-only path):
+    //   bare named struct → canonical structural shape;
+    //   every other form  → opaque over the structural descriptor.
+    let contract_of_te = |te: &TypeExpr| -> (String, u64) {
+        match te {
             TypeExpr::Named { path, generic_args, .. }
                 if path.segments.len() == 1
                     && generic_args.is_empty() =>
             {
-                path.segments[0].name.clone()
+                shape_of_type(&path.segments[0].name)
             }
-            // Any other payload form gets a source-independent
-            // STRUCTURAL descriptor, not "?" — distinct primitive /
-            // array / tuple contracts must stay distinct identities
-            // (round 9).
-            other => type_descriptor(other),
-        };
-        let key = shape_of_type(&raw_ty);
+            other => shape_of_type(&type_descriptor(other)),
+        }
+    };
+    let mut payload_rows: BTreeMap<(String, u64), ()> = BTreeMap::new();
+    let mut topic_payload: BTreeMap<String, (String, u64)> =
+        BTreeMap::new();
+    for (tname, info) in &topic_decl_by_name {
+        let key = contract_of_te(&info.decl.payload);
         payload_rows.insert(key.clone(), ());
         topic_payload.insert(tname.clone(), key);
     }
@@ -799,9 +811,15 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         // `known` overrides the "?" fallback with the endpoint's
         // real structural contract (an explicit `of type T`) — one
         // closure owns ALL mutation so the borrows stay linear.
+        // `literal` is the SYNTACTIC form (round 10): a string-
+        // literal subject is a wire address and NEVER resolves
+        // through the topic table, even when its text collides with
+        // a topic NAME — only a topic REFERENCE takes the early
+        // return.
         let mut need = |display: String,
+                        literal: bool,
                         known: Option<(String, u64)>| {
-            if topic_decl_by_name.contains_key(&display) {
+            if !literal && topic_decl_by_name.contains_key(&display) {
                 return;
             }
             subject_set.insert(display.clone());
@@ -829,7 +847,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             for site in &fs.effect_sites {
                 if let EffectSiteKind::Publish(Some(subj)) = &site.kind
                 {
-                    need(subj.clone(), None);
+                    need(subj.text.clone(), subj.literal, None);
                 }
             }
         }
@@ -845,12 +863,15 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                             // An explicit `of type T` names the
                             // endpoint's real structural contract —
                             // registered so every consumer (graph,
-                            // sends, declared ends) shares one key.
+                            // sends, declared ends) shares one key,
+                            // through the ONE type-expression rule.
                             need(
                                 subject.canonical().to_string(),
-                                ty.as_ref().map(|t| {
-                                    shape_of_type(&te_name_of(t))
-                                }),
+                                matches!(
+                                    subject,
+                                    BusSubject::Literal { .. }
+                                ),
+                                ty.as_ref().map(&contract_of_te),
                             );
                         }
                     }
@@ -1091,7 +1112,44 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                                 ),
                                 pid,
                             ));
-                    } else if let Some(to) = fn_id.get(n) {
+                    } else if edge.receiver_present {
+                        // A TYPED method miss (`w.tick()` with
+                        // `recv_ty` known): resolve by call shape —
+                        // raw `RecvTy::method` in the declaration
+                        // universe, where a module-scoped locus's
+                        // method lands. A stdlib/external method
+                        // that resolves nowhere must NOT wire to a
+                        // same-named free fn (round 10); the effect
+                        // frontier and the stdlib contraction own
+                        // those.
+                        if let Some(t) = &edge.recv_ty {
+                            let mkey = format!("{}::{}", t, n);
+                            if let Some(to) = fn_id.get(&mkey) {
+                                calls.insert(
+                                    (
+                                        from,
+                                        *to,
+                                        DispatchKind::Direct,
+                                        site,
+                                    ),
+                                    (
+                                        edge.loop_depth > 0,
+                                        edge.in_unbounded_loop,
+                                        pid,
+                                    ),
+                                );
+                            }
+                        }
+                    } else if let Some(to) =
+                        fn_id.get(n).or_else(|| {
+                            // An imported qualified miss keeps its
+                            // AUTHOR spelling (`alias::helper`);
+                            // the universe is keyed raw.
+                            remangle
+                                .get(n)
+                                .and_then(|raw| fn_id.get(raw))
+                        })
+                    {
                         // The summary resolves callees against its
                         // own analyzed-body set only, so a direct
                         // call to a module-scoped fn arrives
@@ -1374,10 +1432,18 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         for s in &fs.effect_sites {
             match &s.kind {
                 EffectSiteKind::Publish(Some(subj)) => {
-                    let display = subj.clone();
+                    let display = subj.text.clone();
                     let pid = intern_span(&mut records, s.span);
+                    // The SYNTACTIC form decides: a string-literal
+                    // send is a wire address even when its text
+                    // collides with a topic NAME (round 10).
+                    let declared_info = if subj.literal {
+                        None
+                    } else {
+                        topic_decl_by_name.get(&display)
+                    };
                     let (declared, subject_str, payload, keyed) =
-                        match topic_decl_by_name.get(&display) {
+                        match declared_info {
                             Some(t) => {
                                 let shape_hash =
                                     topic_payload[&display].clone();
@@ -1462,6 +1528,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                     key_filter,
                     bound,
                     span,
+                    ty,
                     ..
                 } = bm
                 else {
@@ -1473,8 +1540,21 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 let Some(hid) = fn_id.get(&handler_full) else {
                     continue;
                 };
+                // The BusSubject VARIANT decides declaredness — a
+                // literal `subscribe "Orders"` keeps its literal
+                // wire address and its own `of type` contract even
+                // when the text collides with a topic NAME
+                // (round 10; the resolver's distinction must
+                // survive extraction).
+                let declared_info = match subject {
+                    BusSubject::Literal { .. } => None,
+                    BusSubject::Topic(_)
+                    | BusSubject::QualifiedTopic(_) => {
+                        topic_decl_by_name.get(&display)
+                    }
+                };
                 let (declared, subject_str, payload) =
-                    match topic_decl_by_name.get(&display) {
+                    match declared_info {
                         Some(_) => (
                             Some(topic_id[&display]),
                             wire_of(&display),
@@ -1484,7 +1564,13 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                         None => (
                             None,
                             display.clone(),
-                            payload_id[&endpoint_payload[&display]],
+                            match ty {
+                                Some(t) => {
+                                    payload_id[&contract_of_te(t)]
+                                }
+                                None => payload_id
+                                    [&endpoint_payload[&display]],
+                            },
                         ),
                     };
                 let predicate = match key_filter {
@@ -2090,8 +2176,20 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                         continue;
                     };
                     let raw = subject.canonical().to_string();
+                    // Variant-decided, like every endpoint: a
+                    // literal `publish "addr" of type T` declares a
+                    // publisher end on a WIRE ADDRESS with its own
+                    // contract, never on a name-colliding topic
+                    // (round 10).
+                    let declared_info = match subject {
+                        BusSubject::Literal { .. } => None,
+                        BusSubject::Topic(_)
+                        | BusSubject::QualifiedTopic(_) => {
+                            topic_decl_by_name.get(&raw)
+                        }
+                    };
                     let (declared, subj_str, payload) =
-                        match topic_decl_by_name.get(&raw) {
+                        match declared_info {
                             Some(info) => (
                                 Some(topic_id[&raw]),
                                 info.wire.clone(),
@@ -2099,10 +2197,14 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                                     [&topic_payload[&raw].clone()],
                             ),
                             None => {
-                                let _ = ty;
-                                let key = endpoint_payload
-                                    .get(&raw)
-                                    .cloned()
+                                let key = ty
+                                    .as_ref()
+                                    .map(&contract_of_te)
+                                    .or_else(|| {
+                                        endpoint_payload
+                                            .get(&raw)
+                                            .cloned()
+                                    })
                                     .unwrap_or_else(|| {
                                         unresolved_payload.clone()
                                     });

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -180,6 +180,70 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     }
     let raw_loci: BTreeSet<&str> =
         ast.loci.iter().map(|l| l.name.name.as_str()).collect();
+    // Raw type-name -> decl, for keyed_by field-type resolution.
+    let mut type_decl_by_raw: BTreeMap<&str, &hale_syntax::ast::TypeDecl> =
+        BTreeMap::new();
+    {
+        fn walk_types<'a>(
+            items: &'a [TopDecl],
+            out: &mut BTreeMap<&'a str, &'a hale_syntax::ast::TypeDecl>,
+        ) {
+            for item in items {
+                match item {
+                    TopDecl::Type(t) => {
+                        out.insert(t.name.name.as_str(), t);
+                    }
+                    TopDecl::Module(m) => walk_types(&m.items, out),
+                    _ => {}
+                }
+            }
+        }
+        for pr in &programs {
+            walk_types(&pr.items, &mut type_decl_by_raw);
+        }
+    }
+    // The canonical KEY-TYPE name for `keyed_by FIELD` on payload
+    // type `raw_ty` — AnyOfType names the key's TYPE (Int, Bool,
+    // Time, Duration, Decimal, String, or a no-payload enum's
+    // name), never the field. "?" when unresolvable (a hole-free
+    // fallback would be a lie; the differential pins the resolved
+    // cases and "?" only appears on programs the checker refuses).
+    let key_type_of = |raw_ty: &str, field: &str| -> String {
+        let Some(td) = type_decl_by_raw.get(raw_ty) else {
+            return "?".to_string();
+        };
+        let hale_syntax::ast::TypeDeclBody::Struct(fields) = &td.body
+        else {
+            return "?".to_string();
+        };
+        let Some(f) = fields.iter().find(|f| f.name.name == field)
+        else {
+            return "?".to_string();
+        };
+        match &f.ty {
+            TypeExpr::Primitive(prim, _) => {
+                use hale_syntax::ast::PrimType;
+                match prim {
+                    PrimType::Int | PrimType::Uint => "Int",
+                    PrimType::Bool => "Bool",
+                    PrimType::Time => "Time",
+                    PrimType::Duration => "Duration",
+                    PrimType::Decimal => "Decimal",
+                    PrimType::String | PrimType::StringView => "String",
+                    _ => "?",
+                }
+                .to_string()
+            }
+            TypeExpr::Named { path, .. }
+                if path.segments.len() == 1 =>
+            {
+                // A no-payload enum key routes by tag; its canonical
+                // key-type name is the enum's (author-spelled) name.
+                name(&path.segments[0].name)
+            }
+            _ => "?".to_string(),
+        }
+    };
     let user_key = |k: &FnKey| -> bool {
         match &k.locus {
             Some(l) => raw_loci.contains(l.as_str()),
@@ -266,11 +330,114 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         .map(|(i, k)| (k, LocusDeclId(i as u32)))
         .collect();
 
-    // Functions: the summary's user keys (the fn sort).
-    let mut fn_rows: BTreeMap<String, FnKey> = BTreeMap::new();
-    for k in summary.fns.keys() {
-        if user_key(k) {
-            fn_rows.insert(fn_name(k), k.clone());
+    // Functions: the DECLARATION universe (free fns, methods,
+    // lifecycle hooks, modes), unioned with the summary's user keys.
+    // The summary is a behavior analysis, not a declaration
+    // inventory — an EMPTY free fn has no summary entry but must
+    // still exist as an entity (group member, seed member, zero-
+    // length reachability endpoint); the claims layer carries the
+    // same correction. The union keeps the artifact's fn sort a
+    // subset of the model's.
+    struct FnInfo {
+        kind: FunctionKind,
+        locus: Option<String>,
+        span: Option<hale_syntax::Span>,
+    }
+    fn hook_name(k: &hale_syntax::ast::LifecycleKind) -> &'static str {
+        use hale_syntax::ast::LifecycleKind as LK;
+        match k {
+            LK::Birth => "birth",
+            LK::Accept => "accept",
+            LK::Release => "release",
+            LK::Run => "run",
+            LK::Drain => "drain",
+            LK::Dissolve => "dissolve",
+        }
+    }
+    fn mode_name(k: &hale_syntax::ast::ModeKind) -> &'static str {
+        use hale_syntax::ast::ModeKind as MK;
+        match k {
+            MK::Bulk => "bulk",
+            MK::Harmonic => "harmonic",
+            MK::Resolution => "resolution",
+        }
+    }
+    let mut fn_rows: BTreeMap<String, FnInfo> = BTreeMap::new();
+    {
+        fn walk_free<'a>(
+            items: &'a [TopDecl],
+            out: &mut Vec<(&'a str, hale_syntax::Span)>,
+        ) {
+            for item in items {
+                match item {
+                    TopDecl::Fn(f) => {
+                        out.push((f.name.name.as_str(), f.name.span))
+                    }
+                    TopDecl::Module(m) => walk_free(&m.items, out),
+                    _ => {}
+                }
+            }
+        }
+        let mut frees = Vec::new();
+        for pr in &programs {
+            walk_free(&pr.items, &mut frees);
+        }
+        for (n, sp) in frees {
+            fn_rows.insert(
+                name(n),
+                FnInfo {
+                    kind: FunctionKind::Free,
+                    locus: None,
+                    span: Some(sp),
+                },
+            );
+        }
+        for l in &ast.loci {
+            let ld = name(&l.name.name);
+            for m in &l.members {
+                let (fname, kind, sp) = match m {
+                    LocusMember::Fn(f) => (
+                        f.name.name.clone(),
+                        FunctionKind::Method,
+                        f.name.span,
+                    ),
+                    LocusMember::Lifecycle(lc) => (
+                        hook_name(&lc.kind).to_string(),
+                        FunctionKind::Hook,
+                        lc.span,
+                    ),
+                    LocusMember::Mode(md) => (
+                        mode_name(&md.kind).to_string(),
+                        FunctionKind::Mode,
+                        md.span,
+                    ),
+                    _ => continue,
+                };
+                fn_rows.insert(
+                    format!("{}::{}", ld, fname),
+                    FnInfo {
+                        kind,
+                        locus: Some(ld.clone()),
+                        span: Some(sp),
+                    },
+                );
+            }
+        }
+        // Union: summary keys the enumeration missed (analysis-
+        // synthesized shapes) join with kind inferred from phases.
+        for k in summary.fns.keys() {
+            if !user_key(k) {
+                continue;
+            }
+            fn_rows.entry(fn_name(k)).or_insert_with(|| FnInfo {
+                kind: match vmodel.phases.get(k) {
+                    Some(p) if p.hook => FunctionKind::Hook,
+                    Some(_) => FunctionKind::Method,
+                    None => FunctionKind::Free,
+                },
+                locus: k.locus.as_ref().map(|l| name(l)),
+                span: None,
+            });
         }
     }
     let fn_id: BTreeMap<&String, FunctionId> = fn_rows
@@ -296,30 +463,53 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         .map(|(i, k)| (k, PhaseId(i as u32)))
         .collect();
 
-    // Topics + subjects + payloads.
-    // Subject strings: a declared topic's WIRE subject; plus every
-    // literal endpoint subject from the bus graph.
-    let mut topic_decl_by_name: BTreeMap<String, &TopicDecl> =
-        BTreeMap::new();
-    for t in &ast.topics {
-        topic_decl_by_name.insert(name(&t.name.name), t);
+    // Topics + subjects + payloads. THREE identities per topic, kept
+    // apart (the review-1 law, re-learned here in review 6): the RAW
+    // post-merge declaration name (what wire_subjects and the graph
+    // key by), the DISPLAY spelling (what the model's Topic.name and
+    // the artifact's topic sort carry), and the WIRE subject (the
+    // byte-exact runtime/recording join key — deliberately RAW in
+    // the artifact, never author-spelled).
+    struct TInfo<'t> {
+        raw: String,
+        decl: &'t TopicDecl,
+        wire: String,
     }
-    let wire_subjects = crate::topic_identity::topic_wire_subjects(
-        &programs
-            .iter()
-            .flat_map(|p| p.items.iter().cloned())
-            .collect::<Vec<_>>(),
-    );
-    let wire_of = |topic_display: &str| -> String {
-        wire_subjects
-            .get(topic_display)
+    impl<'t> TInfo<'t> {
+        fn raw_payload_ty(&self) -> String {
+            match &self.decl.payload {
+                TypeExpr::Named { path, .. }
+                    if path.segments.len() == 1 =>
+                {
+                    path.segments[0].name.clone()
+                }
+                _ => "?".to_string(),
+            }
+        }
+    }
+    let all_items: Vec<TopDecl> = programs
+        .iter()
+        .flat_map(|p| p.items.iter().cloned())
+        .collect();
+    let wire_subjects =
+        crate::topic_identity::topic_wire_subjects(&all_items);
+    let mut topic_decl_by_name: BTreeMap<String, TInfo> = BTreeMap::new();
+    for t in &ast.topics {
+        let raw = t.name.name.clone();
+        // The wire map is keyed by the RAW name; a subject-less
+        // topic's default wire subject is likewise the raw name
+        // (parent joins included) — exactly the artifact's rule.
+        let wire = wire_subjects
+            .get(&raw)
             .cloned()
-            .unwrap_or_else(|| topic_display.to_string())
-    };
+            .unwrap_or_else(|| raw.clone());
+        topic_decl_by_name
+            .insert(name(&raw), TInfo { raw, decl: t, wire });
+    }
 
     let mut subject_set: BTreeSet<String> = BTreeSet::new();
-    for tname in topic_decl_by_name.keys() {
-        subject_set.insert(wire_of(tname));
+    for info in topic_decl_by_name.values() {
+        subject_set.insert(info.wire.clone());
     }
     for (subject, _) in &graph.subjects {
         let display = name(subject);
@@ -328,29 +518,14 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         }
     }
 
-    // Payload contracts: canonical shapes for declared topics, and
-    // name-only contracts for literal-endpoint payload types.
-    let all_items: Vec<TopDecl> = programs
-        .iter()
-        .flat_map(|p| p.items.iter().cloned())
-        .collect();
-    let mut payload_rows: BTreeMap<(String, u64), ()> = BTreeMap::new();
-    let mut topic_payload: BTreeMap<String, (String, u64)> =
-        BTreeMap::new();
-    for (tname, t) in &topic_decl_by_name {
-        let shape =
-            crate::topic_identity::canonical_topic_shape(&all_items, t);
-        let subject = wire_of(tname);
-        let hash = crate::topic_identity::topic_shape_hash(
-            &subject, &shape,
-        );
-        payload_rows.insert((shape.clone(), hash), ());
-        topic_payload.insert(tname.clone(), (shape, hash));
-    }
-    // Literal endpoints: the payload TYPE NAME is the contract
-    // identity we have (BusGraph resolves it); shape falls back to
-    // the type name with a name-derived hash — honest and stable,
-    // upgraded when Change 3 unifies shape rendering.
+    // Payload contracts: SHAPE-ONLY identity — the schema separates
+    // address identity (Subject) from payload identity, so the
+    // fused subject+shape hash the runtime keeps is a Change-3
+    // projection (`hash(wire ++ ':' ++ shape)`), never the payload
+    // schema. Structural equality across subjects shares one
+    // contract; a field change on a literal endpoint's type changes
+    // its contract; renaming a type without structural change does
+    // not.
     let fnv = |s: &str| -> u64 {
         let mut h: u64 = 0xcbf29ce484222325;
         for b in s.as_bytes() {
@@ -359,6 +534,38 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         }
         h
     };
+    // Structural shape of a payload TYPE (by raw post-merge name),
+    // through the SAME renderer topics use. A non-bare-struct
+    // payload has no canonical shape; its contract falls back to an
+    // opaque per-type identity (structure unknown ⇒ the name is the
+    // only honest identity we have).
+    let shape_of_type = |raw_ty: &str| -> (String, u64) {
+        let shape = crate::topic_identity::canonical_type_shape(
+            &all_items, raw_ty,
+        );
+        if shape.is_empty() {
+            let opaque = format!("opaque:{}", name(raw_ty));
+            let h = fnv(&opaque);
+            (opaque, h)
+        } else {
+            let h = fnv(&shape);
+            (shape, h)
+        }
+    };
+    let mut payload_rows: BTreeMap<(String, u64), ()> = BTreeMap::new();
+    let mut topic_payload: BTreeMap<String, (String, u64)> =
+        BTreeMap::new();
+    for (tname, info) in &topic_decl_by_name {
+        let raw_ty = match &info.decl.payload {
+            TypeExpr::Named { path, .. } if path.segments.len() == 1 => {
+                path.segments[0].name.clone()
+            }
+            _ => "?".to_string(),
+        };
+        let key = shape_of_type(&raw_ty);
+        payload_rows.insert(key.clone(), ());
+        topic_payload.insert(tname.clone(), key);
+    }
     let mut endpoint_payload: BTreeMap<String, (String, u64)> =
         BTreeMap::new();
     for (subject, info) in &graph.subjects {
@@ -374,7 +581,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 info.subscribers.first().map(|s| s.payload.clone())
             })
             .unwrap_or_else(|| "?".to_string());
-        let key = (ty.clone(), fnv(&ty));
+        let key = shape_of_type(&ty);
         payload_rows.insert(key.clone(), ());
         endpoint_payload.insert(display, key);
     }
@@ -437,6 +644,9 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
 
     let topic_names: Vec<String> =
         topic_decl_by_name.keys().cloned().collect();
+    let wire_of = |display: &str| -> String {
+        topic_decl_by_name[display].wire.clone()
+    };
     let topic_id: BTreeMap<&String, TopicId> = topic_names
         .iter()
         .enumerate()
@@ -565,11 +775,31 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             continue;
         }
         let from = fn_id[&fn_name(k)];
-        let mut site: u32 = 0;
-        let mut dead_site: u32 = 0;
+        // Authored-site ordinals: every conformer alternative of ONE
+        // interface dispatch shares one dispatch_group and therefore
+        // ONE site ordinal (one source expression = one site; a new
+        // conformer must not renumber later calls). Unresolved and
+        // dead edges consume ordinals too — they are authored sites.
+        let mut next_ordinal: u32 = 0;
+        let mut group_site: BTreeMap<u32, u32> = BTreeMap::new();
+        let mut site_of = |group: Option<u32>| -> u32 {
+            match group {
+                Some(g) => *group_site.entry(g).or_insert_with(|| {
+                    let o = next_ordinal;
+                    next_ordinal += 1;
+                    o
+                }),
+                None => {
+                    let o = next_ordinal;
+                    next_ordinal += 1;
+                    o
+                }
+            }
+        };
         for edge in &fs.calls {
             match &edge.callee {
                 Callee::Resolved(next) => {
+                    let site = site_of(edge.dispatch_group);
                     if !user_key(next) {
                         continue;
                     }
@@ -589,9 +819,9 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                             pid,
                         ),
                     );
-                    site += 1;
                 }
                 Callee::Unresolved(n) => {
+                    let site = site_of(edge.dispatch_group);
                     let anchor = EntityRef::Function(from);
                     let pid = intern_span(&mut records, edge.span);
                     if edge.indirect
@@ -611,10 +841,9 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                             ));
                     } else if let Some(iface) = &edge.via_interface {
                         dead.insert(
-                            (from, dead_site),
+                            (from, site),
                             (name(iface), n.clone(), pid),
                         );
-                        dead_site += 1;
                     } else if edge.receiver_present
                         && edge.recv_ty.is_none()
                     {
@@ -639,23 +868,54 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             }
         }
     }
-    // Through-stdlib contraction (same walk as the artifact's).
-    let mut via_stdlib: BTreeMap<(FunctionId, FunctionId), bool> =
+    // Through-stdlib contraction — with a TWO-component lattice.
+    // "Inside a loop" and "unbounded" are separate facts (a path
+    // through a statically bounded loop is looped but NOT
+    // unbounded), and a node is revisited whenever EITHER component
+    // strengthens, so results cannot depend on traversal order.
+    #[derive(Clone, Copy, PartialEq, Eq, Default)]
+    struct PathFlags {
+        in_loop: bool,
+        unbounded: bool,
+    }
+    impl PathFlags {
+        fn join(self, o: PathFlags) -> PathFlags {
+            PathFlags {
+                in_loop: self.in_loop || o.in_loop,
+                unbounded: self.unbounded || o.unbounded,
+            }
+        }
+        fn strengthens(self, prev: PathFlags) -> bool {
+            (self.in_loop && !prev.in_loop)
+                || (self.unbounded && !prev.unbounded)
+        }
+    }
+    let mut via_stdlib: BTreeMap<(FunctionId, FunctionId), PathFlags> =
         BTreeMap::new();
     for (k, fs) in &merged.fns {
         if !user_key(k) {
             continue;
         }
         let from = fn_id[&fn_name(k)];
-        let mut stack: Vec<(FnKey, bool)> = Vec::new();
-        let mut seen: BTreeSet<FnKey> = BTreeSet::new();
+        let mut stack: Vec<(FnKey, PathFlags)> = Vec::new();
+        let mut seen: BTreeMap<FnKey, PathFlags> = BTreeMap::new();
+        let edge_flags = |edge: &crate::alloc_summary::CallEdge| {
+            PathFlags {
+                in_loop: edge.loop_depth > 0,
+                unbounded: edge.in_unbounded_loop,
+            }
+        };
         for edge in &fs.calls {
             if let Callee::Resolved(next) = &edge.callee {
-                if !user_key(next) && seen.insert(next.clone()) {
-                    stack.push((
-                        next.clone(),
-                        edge.loop_depth > 0 || edge.in_unbounded_loop,
-                    ));
+                if !user_key(next) {
+                    let f = edge_flags(edge);
+                    let prev =
+                        seen.get(next).copied().unwrap_or_default();
+                    if !seen.contains_key(next) || f.strengthens(prev)
+                    {
+                        seen.insert(next.clone(), f.join(prev));
+                        stack.push((next.clone(), f));
+                    }
                 }
             }
         }
@@ -670,15 +930,22 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 let Callee::Resolved(next) = &edge.callee else {
                     continue;
                 };
-                let l2 =
-                    lp || edge.loop_depth > 0 || edge.in_unbounded_loop;
+                let f2 = lp.join(edge_flags(edge));
                 if user_key(next) {
                     let to = fn_id[&fn_name(next)];
-                    let e =
-                        via_stdlib.entry((from, to)).or_insert(false);
-                    *e |= l2;
-                } else if seen.insert(next.clone()) {
-                    stack.push((next.clone(), l2));
+                    let e = via_stdlib
+                        .entry((from, to))
+                        .or_insert_with(PathFlags::default);
+                    *e = e.join(f2);
+                } else {
+                    let prev =
+                        seen.get(next).copied().unwrap_or_default();
+                    if !seen.contains_key(next)
+                        || f2.strengthens(prev)
+                    {
+                        seen.insert(next.clone(), f2.join(prev));
+                        stack.push((next.clone(), f2));
+                    }
                 }
             }
         }
@@ -699,9 +966,9 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                     .unwrap_or(0),
             );
         }
-        let contracted: Vec<((FunctionId, FunctionId), bool)> =
+        let contracted: Vec<((FunctionId, FunctionId), PathFlags)> =
             via_stdlib.into_iter().collect();
-        for ((from, to), looped) in contracted {
+        for ((from, to), flags) in contracted {
             let pid = intern_synth(
                 &mut records,
                 "through-stdlib contraction",
@@ -714,15 +981,138 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             };
             calls.insert(
                 (from, to, DispatchKind::ViaStdlib, site),
-                (looped, looped, pid),
+                (flags.in_loop, flags.unbounded, pid),
             );
         }
     }
 
+    // Publish dispositions: a span-indexed map of every authored
+    // send statement's `or` disposition, joined to effect sites by
+    // containment (sends do not nest). Walks EVERY statement
+    // container so a send inside a match arm or nested block cannot
+    // silently read as Default.
+    let mut send_dispositions: Vec<(u32, u32, PublishDisposition)> =
+        Vec::new();
+    {
+        use hale_syntax::ast::OrDisposition;
+        fn disp(d: &Option<OrDisposition>) -> PublishDisposition {
+            match d {
+                None => PublishDisposition::Default,
+                Some(OrDisposition::Raise(_)) => {
+                    PublishDisposition::Raise
+                }
+                Some(OrDisposition::Discard(_)) => {
+                    PublishDisposition::Discard
+                }
+                Some(OrDisposition::Wait(_)) => PublishDisposition::Wait,
+                // `or fail <p>` / `or <handler-ish expr>` both route
+                // the refusal into user code — the Handler class.
+                Some(OrDisposition::Fail(..))
+                | Some(OrDisposition::Substitute(_)) => {
+                    PublishDisposition::Handler
+                }
+            }
+        }
+        fn walk_block(
+            b: &Block,
+            out: &mut Vec<(u32, u32, PublishDisposition)>,
+        ) {
+            for st in &b.stmts {
+                match st {
+                    Stmt::Send {
+                        or_disposition, span, ..
+                    } => out.push((
+                        span.start.as_usize() as u32,
+                        span.end.as_usize() as u32,
+                        disp(or_disposition),
+                    )),
+                    Stmt::If(i) => {
+                        walk_block(&i.then_block, out);
+                        let mut cur = i.else_block.as_deref();
+                        while let Some(eb) = cur {
+                            match eb {
+                                ElseBranch::Else(bb) => {
+                                    walk_block(bb, out);
+                                    cur = None;
+                                }
+                                ElseBranch::ElseIf(ei) => {
+                                    walk_block(&ei.then_block, out);
+                                    cur = ei.else_block.as_deref();
+                                }
+                            }
+                        }
+                    }
+                    Stmt::While { body, .. }
+                    | Stmt::For { body, .. } => walk_block(body, out),
+                    Stmt::Block(bb) => walk_block(bb, out),
+                    Stmt::Match(m) => {
+                        for arm in &m.arms {
+                            if let hale_syntax::ast::MatchArmBody::Block(
+                                bb,
+                            ) = &arm.body
+                            {
+                                walk_block(bb, out);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        fn walk_members(
+            items: &[TopDecl],
+            out: &mut Vec<(u32, u32, PublishDisposition)>,
+        ) {
+            for item in items {
+                match item {
+                    TopDecl::Fn(f) => walk_block(&f.body, out),
+                    TopDecl::Locus(l) => {
+                        for m in &l.members {
+                            match m {
+                                LocusMember::Fn(f) => {
+                                    walk_block(&f.body, out)
+                                }
+                                LocusMember::Lifecycle(lc) => {
+                                    walk_block(&lc.body, out)
+                                }
+                                LocusMember::Mode(md) => {
+                                    walk_block(&md.body, out)
+                                }
+                                LocusMember::Failure(fd) => {
+                                    walk_block(&fd.body, out)
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    TopDecl::Module(m) => walk_members(&m.items, out),
+                    _ => {}
+                }
+            }
+        }
+        for pr in &programs {
+            walk_members(&pr.items, &mut send_dispositions);
+        }
+        send_dispositions.sort_by_key(|(a, b, _)| (*a, *b));
+    }
+    let disposition_at = |pos: u32| -> PublishDisposition {
+        send_dispositions
+            .iter()
+            .find(|(s, e2, _)| *s <= pos && pos <= *e2)
+            .map(|(_, _, d)| *d)
+            .unwrap_or(PublishDisposition::Default)
+    };
+
     // publishes: effect sites at SITE grain, + computed-subject holes.
     let mut publishes: BTreeMap<
         (FunctionId, SubjectId, u32),
-        (Option<TopicId>, PayloadContractId, Option<KeyDomain>, ProvenanceId),
+        (
+            Option<TopicId>,
+            PayloadContractId,
+            Option<KeyDomain>,
+            PublishDisposition,
+            ProvenanceId,
+        ),
     > = BTreeMap::new();
     for (k, fs) in &summary.fns {
         if !user_key(k) {
@@ -744,9 +1134,12 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                                     Some(topic_id[&display]),
                                     wire_of(&display),
                                     payload_id[&shape_hash],
-                                    t.keyed_by.as_ref().map(|f| {
+                                    t.decl.keyed_by.as_ref().map(|f| {
                                         KeyDomain::AnyOfType(
-                                            f.name.clone(),
+                                            key_type_of(
+                                                &t.raw_payload_ty(),
+                                                &f.name,
+                                            ),
                                         )
                                     }),
                                 )
@@ -762,7 +1155,15 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                         };
                     publishes.insert(
                         (from, subject_id[&subject_str], site),
-                        (declared, payload, keyed, pid),
+                        (
+                            declared,
+                            payload,
+                            keyed,
+                            disposition_at(
+                                s.span.start.as_usize() as u32
+                            ),
+                            pid,
+                        ),
                     );
                     site += 1;
                 }
@@ -1092,7 +1493,13 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                         ordinal: ordinal as u32,
                         selector: SelectorForm::Named {
                             member: r,
-                            display: m.display(),
+                            // Author spelling: qualified members have
+                            // been collapsed to mangled single
+                            // segments by the import pass, so the
+                            // raw display() may read __lib_… — run
+                            // it through the demangle map exactly as
+                            // the artifact does.
+                            display,
                         },
                         provenance: pid,
                     });
@@ -1146,17 +1553,15 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             derived_effects.insert(fn_name(k), classes);
         }
     }
-    for (n, key) in &fn_rows {
-        let kind = match vmodel.phases.get(key) {
-            Some(p) if p.hook => FunctionKind::Hook,
-            Some(_) => FunctionKind::Method,
-            None => FunctionKind::Free,
+    for (n, info) in &fn_rows {
+        let pid = match info.span {
+            Some(sp) => intern_span(&mut records, sp),
+            None => intern_synth(&mut records, "fn (summary key)"),
         };
-        let pid = intern_synth(&mut records, "fn (summary key)");
         e.functions.push(Function {
             name: n.clone(),
             display: n.clone(),
-            kind,
+            kind: info.kind,
             effects: derived_effects.get(n).cloned().unwrap_or_default(),
             provenance: pid,
         });
@@ -1178,11 +1583,12 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         });
     }
     for tname in &topic_names {
-        let t = topic_decl_by_name[tname];
+        let info = &topic_decl_by_name[tname];
+        let t = info.decl;
         let pid = intern_span(&mut records, t.name.span);
         e.topics.push(Topic {
             name: tname.clone(),
-            subject: subject_id[&wire_of(tname)],
+            subject: subject_id[&info.wire],
             payload: payload_id[&topic_payload[tname].clone()],
             key: t.keyed_by.as_ref().map(|f| TopicKey {
                 field: f.name.clone(),
@@ -1254,10 +1660,9 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
 
     let mut r = Relations::default();
     // member_of + phase_of from the fn rows.
-    for (n, key) in &fn_rows {
-        if let Some(l) = &key.locus {
-            let ld = name(l);
-            if let Some(lid) = locus_id.get(&ld) {
+    for (n, info) in &fn_rows {
+        if let Some(ld) = &info.locus {
+            if let Some(lid) = locus_id.get(ld) {
                 let pid =
                     intern_synth(&mut records, "locus membership");
                 r.member_of.push(MemberOf {
@@ -1297,7 +1702,9 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             provenance: *pid,
         });
     }
-    for ((f, s, site), (declared, payload, keyed, pid)) in &publishes {
+    for ((f, s, site), (declared, payload, keyed, dispo, pid)) in
+        &publishes
+    {
         r.publishes.push(Publish {
             function: *f,
             subject: *s,
@@ -1305,7 +1712,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             payload: *payload,
             site: *site,
             key_domain: keyed.clone(),
-            disposition: PublishDisposition::Default,
+            disposition: *dispo,
             provenance: *pid,
         });
     }

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -90,6 +90,100 @@ pub fn builds() -> u64 {
 /// the bundle; every returned value passes
 /// `ApplicationModel::validate()` (asserted in tests over the
 /// corpus, and cheap enough to keep as a debug assertion here).
+/// A source-independent structural descriptor for a payload type
+/// expression that is not a bare named struct — the identity of an
+/// `opaque:` payload contract. Raw canonical names only (path
+/// segments as merged, no demangling), so the same type spelled
+/// through different importer aliases descriptorizes identically,
+/// and distinct primitive / array / tuple / fn forms stay distinct
+/// (round 9 — these previously collapsed to `opaque:?`).
+fn type_descriptor(ty: &TypeExpr) -> String {
+    fn prim(p: &hale_syntax::ast::PrimType) -> &'static str {
+        use hale_syntax::ast::PrimType as P;
+        match p {
+            P::Int => "Int",
+            P::Uint => "Uint",
+            P::Float => "Float",
+            P::Bool => "Bool",
+            P::Decimal => "Decimal",
+            P::Time => "Time",
+            P::Duration => "Duration",
+            P::String => "String",
+            P::StringView => "StringView",
+            P::Bytes => "Bytes",
+            P::BytesView => "BytesView",
+            P::BytesMut => "BytesMut",
+        }
+    }
+    match ty {
+        TypeExpr::Primitive(p, _) => prim(p).to_string(),
+        TypeExpr::Named { path, generic_args, .. } => {
+            let base = path
+                .segments
+                .iter()
+                .map(|s| s.name.as_str())
+                .collect::<Vec<_>>()
+                .join("::");
+            if generic_args.is_empty() {
+                base
+            } else {
+                format!(
+                    "{}<{}>",
+                    base,
+                    generic_args
+                        .iter()
+                        .map(type_descriptor)
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            }
+        }
+        TypeExpr::Projection { class, inner, .. } => format!(
+            "projection:{:?}({})",
+            class,
+            type_descriptor(inner)
+        ),
+        TypeExpr::Array { elem, size, .. } => {
+            // A literal length is part of the identity; a computed
+            // one degrades to `_` (still elem-distinct).
+            let n = match size {
+                Some(hale_syntax::ast::Expr::Literal(
+                    hale_syntax::ast::Literal::Int(v),
+                    _,
+                )) => format!("; {}", v),
+                Some(_) => "; _".to_string(),
+                None => String::new(),
+            };
+            format!("[{}{}]", type_descriptor(elem), n)
+        }
+        TypeExpr::Bounded { elem, cap, .. } => {
+            format!("bounded[{}; {}]", type_descriptor(elem), cap)
+        }
+        TypeExpr::Tuple(ts, _) => format!(
+            "({})",
+            ts.iter()
+                .map(type_descriptor)
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
+        TypeExpr::Function { params, ret, .. } => format!(
+            "fn({}){}",
+            params
+                .iter()
+                .map(type_descriptor)
+                .collect::<Vec<_>>()
+                .join(","),
+            match ret {
+                Some(r) => format!(" -> {}", type_descriptor(r)),
+                None => String::new(),
+            }
+        ),
+        TypeExpr::Perspective { name, .. } => {
+            format!("perspective({})", name.name)
+        }
+    }
+}
+
 pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     BUILDS.fetch_add(1, Ordering::Relaxed);
     if std::env::var("HALE_MODEL_TRACE").as_deref() == Ok("1") {
@@ -262,8 +356,10 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 if path.segments.len() == 1 =>
             {
                 // A no-payload enum key routes by tag; its canonical
-                // key-type name is the enum's (author-spelled) name.
-                name(&path.segments[0].name)
+                // key-type name is the enum's RAW post-merge name —
+                // importer-independent, like every identity
+                // (round 9; display never enters AnyOfType).
+                path.segments[0].name.clone()
             }
             _ => "?".to_string(),
         }
@@ -633,14 +729,16 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     // Structural shape of a payload TYPE (by raw post-merge name),
     // through the SAME renderer topics use. A non-bare-struct
     // payload has no canonical shape; its contract falls back to an
-    // opaque per-type identity (structure unknown ⇒ the name is the
-    // only honest identity we have).
+    // opaque per-type identity over the RAW name — the raw symbol
+    // is path-derived and importer-independent, so `p::Status` and
+    // `db::Status` share one contract (round 9; display spelling
+    // never enters an identity).
     let shape_of_type = |raw_ty: &str| -> (String, u64) {
         let shape = crate::topic_identity::canonical_type_shape(
             &all_items, raw_ty,
         );
         if shape.is_empty() {
-            let opaque = format!("opaque:{}", name(raw_ty));
+            let opaque = format!("opaque:{}", raw_ty);
             let h = fnv(&opaque);
             (opaque, h)
         } else {
@@ -653,10 +751,17 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         BTreeMap::new();
     for (tname, info) in &topic_decl_by_name {
         let raw_ty = match &info.decl.payload {
-            TypeExpr::Named { path, .. } if path.segments.len() == 1 => {
+            TypeExpr::Named { path, generic_args, .. }
+                if path.segments.len() == 1
+                    && generic_args.is_empty() =>
+            {
                 path.segments[0].name.clone()
             }
-            _ => "?".to_string(),
+            // Any other payload form gets a source-independent
+            // STRUCTURAL descriptor, not "?" — distinct primitive /
+            // array / tuple contracts must stay distinct identities
+            // (round 9).
+            other => type_descriptor(other),
         };
         let key = shape_of_type(&raw_ty);
         payload_rows.insert(key.clone(), ());
@@ -986,6 +1091,29 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                                 ),
                                 pid,
                             ));
+                    } else if let Some(to) = fn_id.get(n) {
+                        // The summary resolves callees against its
+                        // own analyzed-body set only, so a direct
+                        // call to a module-scoped fn arrives
+                        // Unresolved — but the DECLARATION universe
+                        // knows the target. The edge is authored
+                        // fact and must exist ("a concrete path
+                        // beats a hole" is impossible if the path is
+                        // dropped); the callee's UnanalyzedBody hole
+                        // bounds any reasoning past it (round 9).
+                        calls.insert(
+                            (
+                                from,
+                                *to,
+                                DispatchKind::Direct,
+                                site,
+                            ),
+                            (
+                                edge.loop_depth > 0,
+                                edge.in_unbounded_loop,
+                                pid,
+                            ),
+                        );
                     }
                 }
             }
@@ -2010,6 +2138,33 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         .collect();
     legacy_fns.sort();
     legacy_fns.dedup();
+    // …and the legacy contracted rows, from the SHARED legacy walk
+    // (one Boolean, no revisit) — NOT from the model's lattice rows,
+    // whose loop bits can legitimately be stronger. This is what
+    // lets Change 3 reproduce serialized `calls_via_stdlib` (and
+    // therefore the TopologyShapeV1 hash) from the model alone
+    // (round 9).
+    let legacy_via: Vec<(
+        hale_model::FunctionId,
+        hale_model::FunctionId,
+        bool,
+    )> = {
+        let mut rows: BTreeMap<
+            (hale_model::FunctionId, hale_model::FunctionId),
+            bool,
+        > = BTreeMap::new();
+        for ((k, next), looped) in
+            crate::callgraph::legacy_via_stdlib_contraction(
+                &merged, &user_key,
+            )
+        {
+            let e = rows
+                .entry((fn_id[&fn_name(&k)], fn_id[&fn_name(&next)]))
+                .or_insert(false);
+            *e |= looped;
+        }
+        rows.into_iter().map(|((f, t), l)| (f, t, l)).collect()
+    };
 
     // holes, canonically ordered.
     let mut hole_rows: Vec<Hole> = holes
@@ -2058,6 +2213,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     let model = ApplicationModel {
         legacy: hale_model::LegacyProjection {
             topology_v1_fns: legacy_fns,
+            topology_v1_calls_via_stdlib: legacy_via,
         },
         header: ModelHeader {
             semantics: MODEL_SEMANTICS_V1,

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -1,0 +1,1669 @@
+//! GH #476 Change 2 — derive the canonical `ApplicationModel` from a
+//! checked bundle.
+//!
+//! One entry point, [`derive_application_model`], assembling the
+//! model from the SAME trusted analyses the topology artifact
+//! consumes today: `AllocSummary` (calls, sites, unresolved
+//! residue), `BusGraph` (endpoints with spans), `model::Model`
+//! (decl provenance, phases, seeds), effects/frontier
+//! (classifications), plus direct AST reads for the facts no
+//! summary carries yet (topic key/bound policy, subscription
+//! filters and bounds, group selectors, the declaration universe,
+//! `@sealed`). Extraction recipes deliberately mirror
+//! `topology::dump_topology`'s — the Change-3 projection must
+//! reproduce that artifact from this value, and the differential
+//! tests in `tests/model_builder.rs` hold the two extractions to
+//! agreement until Change 3 folds the artifact's own gathering
+//! into this builder (strangler order: introduce → adapt →
+//! migrate → THEN deduplicate).
+//!
+//! ## Demand
+//!
+//! Nothing calls this on the ordinary check path. The model is
+//! built only when a consumer asks (`hale model dump` today; the
+//! claims evaluator from Change 5a; the artifact encoder from
+//! Change 3). [`builds`] counts invocations in-process, and
+//! `HALE_MODEL_TRACE=1` prints one stderr line per derivation —
+//! the cross-process hook the no-claims LSP/check test uses to
+//! prove the builder never ran ("cached" must not become "always
+//! built").
+//!
+//! ## What Change 2 deliberately leaves empty
+//!
+//! Locus instances, ownership, placement, thread domains, and
+//! bindings stay empty tables with their capabilities `false`:
+//! no current fragment exports them (the artifact carries none),
+//! the ownership facts live procedurally in codegen, and inventing
+//! loss semantics for adapter bindings would be guessing. They are
+//! Change 8's completion work — the schema seats exist so nothing
+//! must be retrofitted.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use hale_model::{
+    ApplicationModel, Call, Capabilities, DeadInterfaceCall, DeclKind,
+    Declaration, DeclaredIn, DispatchKind, Entities, EntityRef, Function,
+    FunctionId, FunctionKind, Group, GroupId, GroupMember, GroupSelector,
+    Hole, HoleKind, InterfaceDecl, InterfaceDeclId, KeyDomain,
+    KeyOnUnmatched, KeyPredicate, LabelRow, LocusDecl, LocusDeclId,
+    MemberOf, ModelHeader, PayloadContract, PayloadContractId, Phase,
+    PhaseId, PhaseOf, Provenance, ProvenanceId, ProvenanceTable, Publish,
+    PublishDisposition, Relations, Seed, SeedId, SelectorForm, Subject,
+    SubjectId, Subscribe, Supervises, SupervisedRef, SupervisionPolicy,
+    Topic, TopicBound, TopicId, TopicKey, TopicOnFull, TypeDecl as MTypeDecl,
+    TypeDeclId, MODEL_SEMANTICS_V1,
+};
+use hale_syntax::ast::{
+    Block, BusMember, ElseBranch, Expr, GroupDecl, KeyFilter, Literal,
+    LocusDecl as AstLocusDecl, LocusMember, Program, RecoveryModifier,
+    RecoveryOp, ShedPolicy as AstShedPolicy, Stmt, TopDecl, TopicDecl,
+    TypeExpr, UnmatchedPolicy,
+};
+
+use crate::alloc_summary::{self, Callee, EffectSiteKind, FnKey};
+use crate::symbol::Bundle;
+
+static BUILDS: AtomicU64 = AtomicU64::new(0);
+
+/// How many times the builder has run in this process — the
+/// demand-gating instrumentation. The no-claims check path must
+/// leave this at zero.
+pub fn builds() -> u64 {
+    BUILDS.load(Ordering::Relaxed)
+}
+
+/// Derive the canonical application model. Pure with respect to
+/// the bundle; every returned value passes
+/// `ApplicationModel::validate()` (asserted in tests over the
+/// corpus, and cheap enough to keep as a debug assertion here).
+pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
+    BUILDS.fetch_add(1, Ordering::Relaxed);
+    if std::env::var("HALE_MODEL_TRACE").as_deref() == Ok("1") {
+        eprintln!("[hale-model] deriving ApplicationModel");
+    }
+
+    let programs: Vec<&Program> =
+        bundle.programs.values().copied().collect();
+    let (top, _diags) = crate::resolve::build_top_scope(bundle);
+    let graph = crate::bus_graph::build_bus_graph(bundle, &top);
+    let summary = alloc_summary::summarize_programs_with_renames(
+        &programs,
+        &bundle.import_renames,
+    );
+    let merged = crate::stdlib_bodies::summarize_with_stdlib_and_renames(
+        &programs,
+        &bundle.import_renames,
+    );
+    let vmodel =
+        crate::model::Model::derive(&programs, &bundle.import_renames);
+    let effect_names = crate::effects::effect_names_of(&programs);
+    let ffi = crate::effects::ffi_names(&programs);
+
+    // ---- author-spelling map (same recipe as dump_topology) ----
+    let demangle: BTreeMap<&str, String> = bundle
+        .import_renames
+        .iter()
+        .map(|(segs, mangled)| (mangled.as_str(), segs.join("::")))
+        .collect();
+    let name = |n: &str| -> String {
+        demangle.get(n).cloned().unwrap_or_else(|| n.to_string())
+    };
+    let fn_name = |k: &FnKey| -> String {
+        match &k.locus {
+            Some(l) => format!("{}::{}", name(l), k.fn_name),
+            None => name(&k.fn_name),
+        }
+    };
+
+    // ---- AST walks: the declaration universe ----
+    struct Decls<'a> {
+        loci: Vec<&'a AstLocusDecl>,
+        topics: Vec<&'a TopicDecl>,
+        groups: Vec<&'a GroupDecl>,
+        types: Vec<(&'a str, hale_syntax::Span)>,
+        interfaces: Vec<(&'a str, hale_syntax::Span)>,
+        others: Vec<(DeclKind, &'a str, hale_syntax::Span)>,
+        free_fns: BTreeSet<&'a str>,
+    }
+    fn walk_decls<'a>(items: &'a [TopDecl], out: &mut Decls<'a>) {
+        for item in items {
+            match item {
+                TopDecl::Locus(l) => out.loci.push(l),
+                TopDecl::Topic(t) => out.topics.push(t),
+                TopDecl::Group(g) => out.groups.push(g),
+                TopDecl::Type(t) => {
+                    out.types.push((t.name.name.as_str(), t.name.span))
+                }
+                TopDecl::Interface(i) => out
+                    .interfaces
+                    .push((i.name.name.as_str(), i.name.span)),
+                TopDecl::Fn(f) => {
+                    out.free_fns.insert(f.name.name.as_str());
+                }
+                TopDecl::Perspective(p) => out.others.push((
+                    DeclKind::Perspective,
+                    p.name.name.as_str(),
+                    p.name.span,
+                )),
+                TopDecl::Const(c) => out.others.push((
+                    DeclKind::Const,
+                    c.name.name.as_str(),
+                    c.name.span,
+                )),
+                TopDecl::RingLayout(r) => out.others.push((
+                    DeclKind::RingLayout,
+                    r.name.name.as_str(),
+                    r.name.span,
+                )),
+                TopDecl::Target(t) => out.others.push((
+                    DeclKind::Target,
+                    t.name.name.as_str(),
+                    t.name.span,
+                )),
+                TopDecl::Module(m) => walk_decls(&m.items, out),
+                _ => {}
+            }
+        }
+    }
+    let mut ast = Decls {
+        loci: Vec::new(),
+        topics: Vec::new(),
+        groups: Vec::new(),
+        types: Vec::new(),
+        interfaces: Vec::new(),
+        others: Vec::new(),
+        free_fns: BTreeSet::new(),
+    };
+    for p in &programs {
+        walk_decls(&p.items, &mut ast);
+    }
+    let raw_loci: BTreeSet<&str> =
+        ast.loci.iter().map(|l| l.name.name.as_str()).collect();
+    let user_key = |k: &FnKey| -> bool {
+        match &k.locus {
+            Some(l) => raw_loci.contains(l.as_str()),
+            None => ast.free_fns.contains(k.fn_name.as_str()),
+        }
+    };
+
+    // ---- provenance interning ----
+    let mut prov = ProvenanceTable::default();
+    for sf in &bundle.sources {
+        prov.sources.push(hale_model::provenance::SourceUnit {
+            path: sf.path.clone(),
+            digest: u64::from_str_radix(&sf.digest, 16).unwrap_or(0),
+        });
+    }
+    let mut prov_map: BTreeMap<(i64, u32, u32), ProvenanceId> =
+        BTreeMap::new();
+    let mut synth_map: BTreeMap<String, ProvenanceId> = BTreeMap::new();
+    // Bundle-global offset -> (source id, local offset); same
+    // resolution rule as the artifact's provenance section.
+    let sources = bundle.sources.clone();
+    let loc = move |pos: u32| -> (i64, u32) {
+        match sources
+            .iter()
+            .filter(|f| {
+                pos >= f.base && pos < f.base.saturating_add(f.len + 1)
+            })
+            .max_by_key(|f| f.base)
+        {
+            Some(f) => (f.id as i64, pos - f.base),
+            None => (-1, pos),
+        }
+    };
+    let mut intern_span = |records: &mut Vec<Provenance>,
+                           span: hale_syntax::Span|
+     -> ProvenanceId {
+        let s = span.start.as_usize() as u32;
+        let e = span.end.as_usize() as u32;
+        let (src, ls) = loc(s);
+        let (_, le) = loc(e);
+        let key = (src, ls, le.max(ls));
+        if let Some(id) = prov_map.get(&key) {
+            return *id;
+        }
+        let id = ProvenanceId(records.len() as u32);
+        records.push(if src >= 0 {
+            Provenance::Source {
+                source: hale_model::SourceId(src as u32),
+                span: (ls, le.max(ls)),
+            }
+        } else {
+            Provenance::Synthetic {
+                origin: "unplaceable span".to_string(),
+            }
+        });
+        prov_map.insert(key, id);
+        id
+    };
+    let mut intern_synth = |records: &mut Vec<Provenance>,
+                            origin: &str|
+     -> ProvenanceId {
+        if let Some(id) = synth_map.get(origin) {
+            return *id;
+        }
+        let id = ProvenanceId(records.len() as u32);
+        records.push(Provenance::Synthetic {
+            origin: origin.to_string(),
+        });
+        synth_map.insert(origin.to_string(), id);
+        id
+    };
+
+    // ---- entity tables (canonical order via BTree keys) ----
+    // Loci.
+    let mut locus_rows: BTreeMap<String, (bool, hale_syntax::Span)> =
+        BTreeMap::new();
+    for l in &ast.loci {
+        locus_rows
+            .insert(name(&l.name.name), (l.sealed, l.name.span));
+    }
+    let locus_id: BTreeMap<&String, LocusDeclId> = locus_rows
+        .keys()
+        .enumerate()
+        .map(|(i, k)| (k, LocusDeclId(i as u32)))
+        .collect();
+
+    // Functions: the summary's user keys (the fn sort).
+    let mut fn_rows: BTreeMap<String, FnKey> = BTreeMap::new();
+    for k in summary.fns.keys() {
+        if user_key(k) {
+            fn_rows.insert(fn_name(k), k.clone());
+        }
+    }
+    let fn_id: BTreeMap<&String, FunctionId> = fn_rows
+        .keys()
+        .enumerate()
+        .map(|(i, k)| (k, FunctionId(i as u32)))
+        .collect();
+
+    // Phases (distinct names) + phase_of.
+    let mut phase_names: BTreeSet<String> = BTreeSet::new();
+    let mut phase_of_pairs: BTreeMap<String, (String, bool)> =
+        BTreeMap::new();
+    for (k, p) in &vmodel.phases {
+        if user_key(k) {
+            phase_names.insert(p.phase.clone());
+            phase_of_pairs
+                .insert(fn_name(k), (p.phase.clone(), p.hook));
+        }
+    }
+    let phase_id: BTreeMap<&String, PhaseId> = phase_names
+        .iter()
+        .enumerate()
+        .map(|(i, k)| (k, PhaseId(i as u32)))
+        .collect();
+
+    // Topics + subjects + payloads.
+    // Subject strings: a declared topic's WIRE subject; plus every
+    // literal endpoint subject from the bus graph.
+    let mut topic_decl_by_name: BTreeMap<String, &TopicDecl> =
+        BTreeMap::new();
+    for t in &ast.topics {
+        topic_decl_by_name.insert(name(&t.name.name), t);
+    }
+    let wire_subjects = crate::topic_identity::topic_wire_subjects(
+        &programs
+            .iter()
+            .flat_map(|p| p.items.iter().cloned())
+            .collect::<Vec<_>>(),
+    );
+    let wire_of = |topic_display: &str| -> String {
+        wire_subjects
+            .get(topic_display)
+            .cloned()
+            .unwrap_or_else(|| topic_display.to_string())
+    };
+
+    let mut subject_set: BTreeSet<String> = BTreeSet::new();
+    for tname in topic_decl_by_name.keys() {
+        subject_set.insert(wire_of(tname));
+    }
+    for (subject, _) in &graph.subjects {
+        let display = name(subject);
+        if !topic_decl_by_name.contains_key(&display) {
+            subject_set.insert(display);
+        }
+    }
+
+    // Payload contracts: canonical shapes for declared topics, and
+    // name-only contracts for literal-endpoint payload types.
+    let all_items: Vec<TopDecl> = programs
+        .iter()
+        .flat_map(|p| p.items.iter().cloned())
+        .collect();
+    let mut payload_rows: BTreeMap<(String, u64), ()> = BTreeMap::new();
+    let mut topic_payload: BTreeMap<String, (String, u64)> =
+        BTreeMap::new();
+    for (tname, t) in &topic_decl_by_name {
+        let shape =
+            crate::topic_identity::canonical_topic_shape(&all_items, t);
+        let subject = wire_of(tname);
+        let hash = crate::topic_identity::topic_shape_hash(
+            &subject, &shape,
+        );
+        payload_rows.insert((shape.clone(), hash), ());
+        topic_payload.insert(tname.clone(), (shape, hash));
+    }
+    // Literal endpoints: the payload TYPE NAME is the contract
+    // identity we have (BusGraph resolves it); shape falls back to
+    // the type name with a name-derived hash — honest and stable,
+    // upgraded when Change 3 unifies shape rendering.
+    let fnv = |s: &str| -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for b in s.as_bytes() {
+            h ^= *b as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    };
+    let mut endpoint_payload: BTreeMap<String, (String, u64)> =
+        BTreeMap::new();
+    for (subject, info) in &graph.subjects {
+        let display = name(subject);
+        if topic_decl_by_name.contains_key(&display) {
+            continue;
+        }
+        let ty = info
+            .publishers
+            .first()
+            .map(|p| p.payload.clone())
+            .or_else(|| {
+                info.subscribers.first().map(|s| s.payload.clone())
+            })
+            .unwrap_or_else(|| "?".to_string());
+        let key = (ty.clone(), fnv(&ty));
+        payload_rows.insert(key.clone(), ());
+        endpoint_payload.insert(display, key);
+    }
+    // Totality: a publish effect-site or bus declaration can name a
+    // subject the BusGraph never recorded (an unresolved cross-seed
+    // reference, a standalone parse of one seed of a multi-seed
+    // app). The builder must be TOTAL over parseable programs —
+    // such endpoints get a subject row and an unresolved "?"
+    // payload contract rather than a lookup panic. (An unresolvable
+    // program fails typecheck; the model of a parseable bundle
+    // still exists, holes and all.)
+    let unresolved_payload = ("?".to_string(), fnv("?"));
+    {
+        let mut need = |display: String| {
+            if !topic_decl_by_name.contains_key(&display)
+                && !endpoint_payload.contains_key(&display)
+            {
+                subject_set.insert(display.clone());
+                payload_rows.insert(unresolved_payload.clone(), ());
+                endpoint_payload
+                    .insert(display, unresolved_payload.clone());
+            }
+        };
+        for (k, fs) in &summary.fns {
+            if !user_key(k) {
+                continue;
+            }
+            for site in &fs.effect_sites {
+                if let EffectSiteKind::Publish(Some(subj)) = &site.kind
+                {
+                    need(name(subj));
+                }
+            }
+        }
+        for l in &ast.loci {
+            for m in &l.members {
+                let LocusMember::Bus(bus) = m else { continue };
+                for bm in &bus.members {
+                    match bm {
+                        BusMember::Subscribe { subject, .. }
+                        | BusMember::Publish { subject, .. } => {
+                            need(name(subject.canonical()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let subject_id: BTreeMap<&String, SubjectId> = subject_set
+        .iter()
+        .enumerate()
+        .map(|(i, k)| (k, SubjectId(i as u32)))
+        .collect();
+    let payload_id: BTreeMap<&(String, u64), PayloadContractId> =
+        payload_rows
+            .keys()
+            .enumerate()
+            .map(|(i, k)| (k, PayloadContractId(i as u32)))
+            .collect();
+
+    let topic_names: Vec<String> =
+        topic_decl_by_name.keys().cloned().collect();
+    let topic_id: BTreeMap<&String, TopicId> = topic_names
+        .iter()
+        .enumerate()
+        .map(|(i, k)| (k, TopicId(i as u32)))
+        .collect();
+
+    // Seeds: the rename-table aliases, PLUS any alias a group glob
+    // names that resolution never populated (a standalone parse of
+    // one seed) — the authored alias exists even when its members
+    // are unknown, and a dangling-id fail-open here was exactly the
+    // corpus property's first catch.
+    let mut seed_name_set: BTreeSet<String> =
+        vmodel.seeds.keys().cloned().collect();
+    for g in &ast.groups {
+        for m in &g.members {
+            if m.glob {
+                if let Some(a) = m.segments.first() {
+                    seed_name_set.insert(a.name.clone());
+                }
+            }
+        }
+    }
+    let seed_names: Vec<String> = seed_name_set.into_iter().collect();
+    let seed_id: BTreeMap<&String, SeedId> = seed_names
+        .iter()
+        .enumerate()
+        .map(|(i, k)| (k, SeedId(i as u32)))
+        .collect();
+
+    // Groups.
+    let mut group_rows: BTreeMap<String, &GroupDecl> = BTreeMap::new();
+    for g in &ast.groups {
+        group_rows.insert(name(&g.name.name), g);
+    }
+    let group_id: BTreeMap<&String, GroupId> = group_rows
+        .keys()
+        .enumerate()
+        .map(|(i, k)| (k, GroupId(i as u32)))
+        .collect();
+
+    // Types / interfaces / other declarations (display-spelled).
+    let mut type_rows: BTreeMap<String, hale_syntax::Span> =
+        BTreeMap::new();
+    for (n, sp) in &ast.types {
+        type_rows.insert(name(n), *sp);
+    }
+    let type_id: BTreeMap<&String, TypeDeclId> = type_rows
+        .keys()
+        .enumerate()
+        .map(|(i, k)| (k, TypeDeclId(i as u32)))
+        .collect();
+    let mut iface_rows: BTreeMap<String, hale_syntax::Span> =
+        BTreeMap::new();
+    for (n, sp) in &ast.interfaces {
+        iface_rows.insert(name(n), *sp);
+    }
+    let iface_id: BTreeMap<&String, InterfaceDeclId> = iface_rows
+        .keys()
+        .enumerate()
+        .map(|(i, k)| (k, InterfaceDeclId(i as u32)))
+        .collect();
+    let mut other_rows: BTreeMap<(String, DeclKind), hale_syntax::Span> =
+        BTreeMap::new();
+    for (kind, n, sp) in &ast.others {
+        other_rows.insert((name(n), *kind), *sp);
+    }
+    let other_id: BTreeMap<&(String, DeclKind), hale_model::DeclarationId> =
+        other_rows
+            .keys()
+            .enumerate()
+            .map(|(i, k)| (k, hale_model::DeclarationId(i as u32)))
+            .collect();
+
+    // A universal name -> EntityRef classifier for seed membership
+    // and group members, in the artifact's own precedence.
+    let entity_of = |display: &str| -> Option<EntityRef> {
+        if let Some(id) = locus_id.get(&display.to_string()) {
+            return Some(EntityRef::LocusDecl(*id));
+        }
+        if let Some(id) = fn_id.get(&display.to_string()) {
+            return Some(EntityRef::Function(*id));
+        }
+        if let Some(id) = topic_id.get(&display.to_string()) {
+            return Some(EntityRef::Topic(*id));
+        }
+        if let Some(id) = group_id.get(&display.to_string()) {
+            return Some(EntityRef::Group(*id));
+        }
+        if let Some(id) = type_id.get(&display.to_string()) {
+            return Some(EntityRef::Type(*id));
+        }
+        if let Some(id) = iface_id.get(&display.to_string()) {
+            return Some(EntityRef::Interface(*id));
+        }
+        for kind in [
+            DeclKind::Perspective,
+            DeclKind::Const,
+            DeclKind::RingLayout,
+            DeclKind::Target,
+        ] {
+            if let Some(id) =
+                other_id.get(&(display.to_string(), kind))
+            {
+                return Some(EntityRef::Declaration(*id));
+            }
+        }
+        None
+    };
+
+    // ---- relations ----
+    let mut records: Vec<Provenance> = Vec::new();
+
+    // calls / dead dispatches / holes, at SITE grain.
+    let mut calls: BTreeMap<
+        (FunctionId, FunctionId, DispatchKind, u32),
+        (bool, bool, ProvenanceId),
+    > = BTreeMap::new();
+    let mut dead: BTreeMap<(FunctionId, u32), (String, String, ProvenanceId)> =
+        BTreeMap::new();
+    let mut holes: BTreeMap<
+        (EntityRef, HoleKind, String),
+        (hale_model::RelationSet, ProvenanceId),
+    > = BTreeMap::new();
+    for (k, fs) in &summary.fns {
+        if !user_key(k) {
+            continue;
+        }
+        let from = fn_id[&fn_name(k)];
+        let mut site: u32 = 0;
+        let mut dead_site: u32 = 0;
+        for edge in &fs.calls {
+            match &edge.callee {
+                Callee::Resolved(next) => {
+                    if !user_key(next) {
+                        continue;
+                    }
+                    let to = fn_id[&fn_name(next)];
+                    let dispatch = match &edge.via_interface {
+                        Some(i) => DispatchKind::Interface {
+                            interface: name(i),
+                        },
+                        None => DispatchKind::Direct,
+                    };
+                    let pid = intern_span(&mut records, edge.span);
+                    calls.insert(
+                        (from, to, dispatch, site),
+                        (
+                            edge.loop_depth > 0,
+                            edge.in_unbounded_loop,
+                            pid,
+                        ),
+                    );
+                    site += 1;
+                }
+                Callee::Unresolved(n) => {
+                    let anchor = EntityRef::Function(from);
+                    let pid = intern_span(&mut records, edge.span);
+                    if edge.indirect
+                        || fs.fn_params.iter().any(|p| p == n)
+                    {
+                        holes
+                            .entry((
+                                anchor,
+                                HoleKind::IndirectCall,
+                                format!("call through `{}`", n),
+                            ))
+                            .or_insert((
+                                hale_model::RelationSet::CALLS.union(
+                                    hale_model::RelationSet::EFFECTS,
+                                ),
+                                pid,
+                            ));
+                    } else if let Some(iface) = &edge.via_interface {
+                        dead.insert(
+                            (from, dead_site),
+                            (name(iface), n.clone(), pid),
+                        );
+                        dead_site += 1;
+                    } else if edge.receiver_present
+                        && edge.recv_ty.is_none()
+                    {
+                        holes
+                            .entry((
+                                anchor,
+                                HoleKind::UntypedReceiver,
+                                format!(
+                                    "method call `{}` on untyped \
+                                     receiver",
+                                    n
+                                ),
+                            ))
+                            .or_insert((
+                                hale_model::RelationSet::CALLS.union(
+                                    hale_model::RelationSet::EFFECTS,
+                                ),
+                                pid,
+                            ));
+                    }
+                }
+            }
+        }
+    }
+    // Through-stdlib contraction (same walk as the artifact's).
+    let mut via_stdlib: BTreeMap<(FunctionId, FunctionId), bool> =
+        BTreeMap::new();
+    for (k, fs) in &merged.fns {
+        if !user_key(k) {
+            continue;
+        }
+        let from = fn_id[&fn_name(k)];
+        let mut stack: Vec<(FnKey, bool)> = Vec::new();
+        let mut seen: BTreeSet<FnKey> = BTreeSet::new();
+        for edge in &fs.calls {
+            if let Callee::Resolved(next) = &edge.callee {
+                if !user_key(next) && seen.insert(next.clone()) {
+                    stack.push((
+                        next.clone(),
+                        edge.loop_depth > 0 || edge.in_unbounded_loop,
+                    ));
+                }
+            }
+        }
+        let mut steps = 0u32;
+        while let Some((n, lp)) = stack.pop() {
+            steps += 1;
+            if steps > crate::callgraph::MAX_STEPS {
+                break;
+            }
+            let Some(nfs) = merged.fns.get(&n) else { continue };
+            for edge in &nfs.calls {
+                let Callee::Resolved(next) = &edge.callee else {
+                    continue;
+                };
+                let l2 =
+                    lp || edge.loop_depth > 0 || edge.in_unbounded_loop;
+                if user_key(next) {
+                    let to = fn_id[&fn_name(next)];
+                    let e =
+                        via_stdlib.entry((from, to)).or_insert(false);
+                    *e |= l2;
+                } else if seen.insert(next.clone()) {
+                    stack.push((next.clone(), l2));
+                }
+            }
+        }
+    }
+    // Contracted edges get site ordinals AFTER the direct sites of
+    // their caller (deterministic: sorted by callee id), with
+    // synthetic provenance — no single authored location exists.
+    {
+        let mut next_site: BTreeMap<FunctionId, u32> = BTreeMap::new();
+        for ((from, ..), _) in &calls {
+            let n = next_site.entry(*from).or_insert(0);
+            *n = (*n).max(
+                calls
+                    .keys()
+                    .filter(|(f, ..)| f == from)
+                    .map(|(.., s)| s + 1)
+                    .max()
+                    .unwrap_or(0),
+            );
+        }
+        let contracted: Vec<((FunctionId, FunctionId), bool)> =
+            via_stdlib.into_iter().collect();
+        for ((from, to), looped) in contracted {
+            let pid = intern_synth(
+                &mut records,
+                "through-stdlib contraction",
+            );
+            let site = {
+                let n = next_site.entry(from).or_insert(0);
+                let s = *n;
+                *n += 1;
+                s
+            };
+            calls.insert(
+                (from, to, DispatchKind::ViaStdlib, site),
+                (looped, looped, pid),
+            );
+        }
+    }
+
+    // publishes: effect sites at SITE grain, + computed-subject holes.
+    let mut publishes: BTreeMap<
+        (FunctionId, SubjectId, u32),
+        (Option<TopicId>, PayloadContractId, Option<KeyDomain>, ProvenanceId),
+    > = BTreeMap::new();
+    for (k, fs) in &summary.fns {
+        if !user_key(k) {
+            continue;
+        }
+        let from = fn_id[&fn_name(k)];
+        let mut site: u32 = 0;
+        for s in &fs.effect_sites {
+            match &s.kind {
+                EffectSiteKind::Publish(Some(subj)) => {
+                    let display = name(subj);
+                    let pid = intern_span(&mut records, s.span);
+                    let (declared, subject_str, payload, keyed) =
+                        match topic_decl_by_name.get(&display) {
+                            Some(t) => {
+                                let shape_hash =
+                                    topic_payload[&display].clone();
+                                (
+                                    Some(topic_id[&display]),
+                                    wire_of(&display),
+                                    payload_id[&shape_hash],
+                                    t.keyed_by.as_ref().map(|f| {
+                                        KeyDomain::AnyOfType(
+                                            f.name.clone(),
+                                        )
+                                    }),
+                                )
+                            }
+                            None => (
+                                None,
+                                display.clone(),
+                                payload_id[&endpoint_payload
+                                    [&display]
+                                    .clone()],
+                                None,
+                            ),
+                        };
+                    publishes.insert(
+                        (from, subject_id[&subject_str], site),
+                        (declared, payload, keyed, pid),
+                    );
+                    site += 1;
+                }
+                EffectSiteKind::Publish(None) => {
+                    let pid = intern_span(&mut records, s.span);
+                    holes
+                        .entry((
+                            EntityRef::Function(from),
+                            HoleKind::ComputedSubject,
+                            "publish with computed subject"
+                                .to_string(),
+                        ))
+                        .or_insert((
+                            hale_model::RelationSet::PUBLISHES,
+                            pid,
+                        ));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // subscribes: AST bus blocks (filters + bounds), joined with the
+    // graph's per-site spans.
+    let mut subscribes: BTreeMap<
+        (SubjectId, FunctionId, u32),
+        (
+            Option<TopicId>,
+            PayloadContractId,
+            KeyPredicate,
+            hale_model::Capacity,
+            hale_model::ShedPolicy,
+            ProvenanceId,
+        ),
+    > = BTreeMap::new();
+    for l in &ast.loci {
+        let locus_display = name(&l.name.name);
+        let mut site: u32 = 0;
+        for m in &l.members {
+            let LocusMember::Bus(bus) = m else { continue };
+            for bm in &bus.members {
+                let BusMember::Subscribe {
+                    subject,
+                    handler,
+                    key_filter,
+                    bound,
+                    span,
+                    ..
+                } = bm
+                else {
+                    continue;
+                };
+                let display = name(subject.canonical());
+                let handler_full =
+                    format!("{}::{}", locus_display, handler.name);
+                let Some(hid) = fn_id.get(&handler_full) else {
+                    continue;
+                };
+                let (declared, subject_str, payload) =
+                    match topic_decl_by_name.get(&display) {
+                        Some(_) => (
+                            Some(topic_id[&display]),
+                            wire_of(&display),
+                            payload_id
+                                [&topic_payload[&display].clone()],
+                        ),
+                        None => (
+                            None,
+                            display.clone(),
+                            payload_id[&endpoint_payload[&display]],
+                        ),
+                    };
+                let predicate = match key_filter {
+                    None => KeyPredicate::Any,
+                    Some(KeyFilter::Replica { .. }) => {
+                        KeyPredicate::EqReplica
+                    }
+                    Some(KeyFilter::Unmatched { .. }) => {
+                        KeyPredicate::Fallback
+                    }
+                    Some(KeyFilter::Specific { expr, .. }) => {
+                        match expr {
+                            Expr::Literal(Literal::Int(v), _) => {
+                                KeyPredicate::EqLiteral(
+                                    hale_model::KeyValue::Int(*v),
+                                )
+                            }
+                            Expr::Literal(Literal::String(sv), _) => {
+                                KeyPredicate::EqLiteral(
+                                    hale_model::KeyValue::Str(
+                                        sv.clone(),
+                                    ),
+                                )
+                            }
+                            Expr::Literal(Literal::Bool(b), _) => {
+                                KeyPredicate::EqLiteral(
+                                    hale_model::KeyValue::Bool(*b),
+                                )
+                            }
+                            _ => KeyPredicate::Unknown,
+                        }
+                    }
+                };
+                let pid = intern_span(&mut records, *span);
+                if matches!(predicate, KeyPredicate::Unknown) {
+                    holes
+                        .entry((
+                            EntityRef::Function(*hid),
+                            HoleKind::UnknownKeyDomain,
+                            "instantiation-time key filter"
+                                .to_string(),
+                        ))
+                        .or_insert((
+                            hale_model::RelationSet::KEY_FILTERS,
+                            pid,
+                        ));
+                }
+                let (cap, shed) = match bound {
+                    None => (
+                        hale_model::Capacity::Unbounded,
+                        hale_model::ShedPolicy::None,
+                    ),
+                    Some(b) => (
+                        hale_model::Capacity::Bounded(b.cap as u64),
+                        match b.policy {
+                            AstShedPolicy::DropOld => {
+                                hale_model::ShedPolicy::DropOld
+                            }
+                            AstShedPolicy::DropNew => {
+                                hale_model::ShedPolicy::DropNew
+                            }
+                        },
+                    ),
+                };
+                subscribes.insert(
+                    (subject_id[&subject_str], *hid, site),
+                    (declared, payload, predicate, cap, shed, pid),
+                );
+                site += 1;
+            }
+        }
+    }
+
+    // supervision (same walk as the artifact's, per-handler).
+    let mut sup: BTreeMap<
+        (LocusDeclId, SupervisedRef, String),
+        (Vec<String>, Option<u32>, ProvenanceId),
+    > = BTreeMap::new();
+    {
+        fn te_name(t: &TypeExpr) -> String {
+            match t {
+                TypeExpr::Named { path, .. } => path
+                    .segments
+                    .iter()
+                    .map(|s| s.name.clone())
+                    .collect::<Vec<_>>()
+                    .join("::"),
+                _ => "?".to_string(),
+            }
+        }
+        fn walk_ops(
+            b: &Block,
+            ops: &mut Vec<String>,
+            retry: &mut Option<u32>,
+        ) {
+            for st in &b.stmts {
+                match st {
+                    Stmt::Recovery { op, modifier, .. } => {
+                        let n = match op {
+                            RecoveryOp::Restart => "restart",
+                            RecoveryOp::RestartInPlace => {
+                                "restart_in_place"
+                            }
+                            RecoveryOp::Quarantine => "quarantine",
+                            RecoveryOp::Reorganize => "reorganize",
+                            RecoveryOp::Bubble => "bubble",
+                        };
+                        if !ops.iter().any(|o| o == n) {
+                            ops.push(n.to_string());
+                        }
+                        if let Some(RecoveryModifier::For(
+                            Expr::Literal(Literal::Int(kk), _),
+                        )) = modifier
+                        {
+                            *retry = Some(*kk as u32);
+                        }
+                    }
+                    Stmt::If(i) => {
+                        walk_ops(&i.then_block, ops, retry);
+                        let mut cur = i.else_block.as_deref();
+                        while let Some(eb) = cur {
+                            match eb {
+                                ElseBranch::Else(bb) => {
+                                    walk_ops(bb, ops, retry);
+                                    cur = None;
+                                }
+                                ElseBranch::ElseIf(ei) => {
+                                    walk_ops(
+                                        &ei.then_block,
+                                        ops,
+                                        retry,
+                                    );
+                                    cur = ei.else_block.as_deref();
+                                }
+                            }
+                        }
+                    }
+                    Stmt::While { body, .. }
+                    | Stmt::For { body, .. } => {
+                        walk_ops(body, ops, retry)
+                    }
+                    Stmt::Block(bb) => walk_ops(bb, ops, retry),
+                    _ => {}
+                }
+            }
+        }
+        for l in &ast.loci {
+            for member in &l.members {
+                if let LocusMember::Failure(fd) = member {
+                    let mut ops = Vec::new();
+                    let mut retry = None;
+                    walk_ops(&fd.body, &mut ops, &mut retry);
+                    let parent = locus_id[&name(&l.name.name)];
+                    let child_name = fd
+                        .params
+                        .first()
+                        .map(|p| name(&te_name(&p.ty)))
+                        .unwrap_or_else(|| "?".to_string());
+                    let child = match locus_id.get(&child_name) {
+                        Some(id) => SupervisedRef::Locus(*id),
+                        None => SupervisedRef::External(child_name),
+                    };
+                    let err = fd
+                        .params
+                        .get(1)
+                        .map(|p| name(&te_name(&p.ty)))
+                        .unwrap_or_else(|| "?".to_string());
+                    let pid = intern_span(&mut records, fd.span);
+                    sup.insert(
+                        (parent, child, err),
+                        (ops, retry, pid),
+                    );
+                }
+            }
+        }
+    }
+
+    // groups: authored selectors + resolved membership.
+    let mut group_members: BTreeSet<(GroupId, EntityRef)> =
+        BTreeSet::new();
+    let mut group_selectors: Vec<GroupSelector> = Vec::new();
+    let mut gm_prov: BTreeMap<(GroupId, EntityRef), ProvenanceId> =
+        BTreeMap::new();
+    for (gname, g) in &group_rows {
+        let gid = group_id[gname];
+        for (ordinal, m) in g.members.iter().enumerate() {
+            let pid = intern_span(&mut records, m.span);
+            if m.glob {
+                let alias = m
+                    .segments
+                    .first()
+                    .map(|s| s.name.clone())
+                    .unwrap_or_default();
+                let sid = seed_id[&alias];
+                group_selectors.push(GroupSelector {
+                    group: gid,
+                    ordinal: ordinal as u32,
+                    selector: SelectorForm::SeedGlob {
+                        seed: sid,
+                        display: m.display(),
+                    },
+                    provenance: pid,
+                });
+                // Enumerate: the alias's loci and free fns.
+                if let Some(members) = vmodel.seeds.get(&alias) {
+                    for mangled in members {
+                        let display = name(mangled);
+                        if let Some(id) =
+                            locus_id.get(&display)
+                        {
+                            group_members.insert((
+                                gid,
+                                EntityRef::LocusDecl(*id),
+                            ));
+                            gm_prov
+                                .entry((
+                                    gid,
+                                    EntityRef::LocusDecl(*id),
+                                ))
+                                .or_insert(pid);
+                        }
+                        if let Some(id) = fn_id.get(&display) {
+                            group_members.insert((
+                                gid,
+                                EntityRef::Function(*id),
+                            ));
+                            gm_prov
+                                .entry((
+                                    gid,
+                                    EntityRef::Function(*id),
+                                ))
+                                .or_insert(pid);
+                        }
+                    }
+                }
+            } else {
+                let display = name(&m.display());
+                // Both-join rule: a name shared by a locus and a
+                // fn contributes both members; the selector row
+                // references the locus when both exist.
+                let mut named_ref: Option<EntityRef> = None;
+                if let Some(id) = locus_id.get(&display) {
+                    let r = EntityRef::LocusDecl(*id);
+                    group_members.insert((gid, r));
+                    gm_prov.entry((gid, r)).or_insert(pid);
+                    named_ref.get_or_insert(r);
+                }
+                if let Some(id) = fn_id.get(&display) {
+                    let r = EntityRef::Function(*id);
+                    group_members.insert((gid, r));
+                    gm_prov.entry((gid, r)).or_insert(pid);
+                    named_ref.get_or_insert(r);
+                }
+                if let Some(r) = named_ref {
+                    group_selectors.push(GroupSelector {
+                        group: gid,
+                        ordinal: ordinal as u32,
+                        selector: SelectorForm::Named {
+                            member: r,
+                            display: m.display(),
+                        },
+                        provenance: pid,
+                    });
+                }
+            }
+        }
+    }
+    group_selectors.sort_by_key(|s| (s.group, s.ordinal));
+
+    // declared_in: alias-seed membership over the full universe.
+    let mut declared_in: BTreeSet<(EntityRef, SeedId)> = BTreeSet::new();
+    let mut di_prov: BTreeMap<(EntityRef, SeedId), ProvenanceId> =
+        BTreeMap::new();
+    for (alias, members) in &vmodel.seeds {
+        let sid = seed_id[alias];
+        for mangled in members {
+            let display = name(mangled);
+            if let Some(r) = entity_of(&display) {
+                declared_in.insert((r, sid));
+                let pid = intern_synth(
+                    &mut records,
+                    &format!("seed `{}` import table", alias),
+                );
+                di_prov.entry((r, sid)).or_insert(pid);
+            }
+        }
+    }
+
+    // ---- assemble, in canonical order ----
+    let mut e = Entities::default();
+    for (n, (sealed, sp)) in &locus_rows {
+        let pid = intern_span(&mut records, *sp);
+        e.loci.push(LocusDecl {
+            name: n.clone(),
+            display: n.clone(),
+            sealed: *sealed,
+            provenance: pid,
+        });
+    }
+    // Effects per fn (the derived classes the artifact exports).
+    let mut derived_effects: BTreeMap<String, Vec<String>> =
+        BTreeMap::new();
+    for k in merged.fns.keys() {
+        if !user_key(k) {
+            continue;
+        }
+        let eff = crate::frontier::infer_effects(&merged, k, &ffi);
+        let classes =
+            crate::frontier::render_effects_named(eff, &effect_names);
+        if !classes.is_empty() {
+            derived_effects.insert(fn_name(k), classes);
+        }
+    }
+    for (n, key) in &fn_rows {
+        let kind = match vmodel.phases.get(key) {
+            Some(p) if p.hook => FunctionKind::Hook,
+            Some(_) => FunctionKind::Method,
+            None => FunctionKind::Free,
+        };
+        let pid = intern_synth(&mut records, "fn (summary key)");
+        e.functions.push(Function {
+            name: n.clone(),
+            display: n.clone(),
+            kind,
+            effects: derived_effects.get(n).cloned().unwrap_or_default(),
+            provenance: pid,
+        });
+    }
+    for s in &subject_set {
+        let pid = intern_synth(&mut records, "wire subject");
+        e.subjects.push(Subject {
+            pattern: s.clone(),
+            exact: !s.contains('*'),
+            provenance: pid,
+        });
+    }
+    for ((shape, hash), ()) in &payload_rows {
+        let pid = intern_synth(&mut records, "payload contract");
+        e.payloads.push(PayloadContract {
+            shape: shape.clone(),
+            hash: *hash,
+            provenance: pid,
+        });
+    }
+    for tname in &topic_names {
+        let t = topic_decl_by_name[tname];
+        let pid = intern_span(&mut records, t.name.span);
+        e.topics.push(Topic {
+            name: tname.clone(),
+            subject: subject_id[&wire_of(tname)],
+            payload: payload_id[&topic_payload[tname].clone()],
+            key: t.keyed_by.as_ref().map(|f| TopicKey {
+                field: f.name.clone(),
+                on_unmatched: match t.on_unmatched {
+                    None | Some(UnmatchedPolicy::Swallow) => {
+                        KeyOnUnmatched::Swallow
+                    }
+                    Some(UnmatchedPolicy::Fail) => KeyOnUnmatched::Fail,
+                    Some(UnmatchedPolicy::Fallback) => {
+                        KeyOnUnmatched::Fallback
+                    }
+                },
+            }),
+            bound: t.bounded.map(|(n, _)| TopicBound {
+                capacity: n.max(1) as u64,
+                on_full: TopicOnFull::Fail,
+            }),
+            provenance: pid,
+        });
+    }
+    for p in &phase_names {
+        let pid = intern_synth(&mut records, "phase");
+        e.phases.push(Phase {
+            name: p.clone(),
+            provenance: pid,
+        });
+    }
+    for s in &seed_names {
+        let pid =
+            intern_synth(&mut records, &format!("seed `{}`", s));
+        e.seeds.push(Seed {
+            name: s.clone(),
+            provenance: pid,
+        });
+    }
+    for (n, g) in &group_rows {
+        let pid = intern_span(&mut records, g.name.span);
+        e.groups.push(Group {
+            name: n.clone(),
+            may_be_empty: g.may_be_empty,
+            provenance: pid,
+        });
+    }
+    for (n, sp) in &type_rows {
+        let pid = intern_span(&mut records, *sp);
+        e.types.push(MTypeDecl {
+            name: n.clone(),
+            display: n.clone(),
+            provenance: pid,
+        });
+    }
+    for (n, sp) in &iface_rows {
+        let pid = intern_span(&mut records, *sp);
+        e.interfaces.push(InterfaceDecl {
+            name: n.clone(),
+            display: n.clone(),
+            provenance: pid,
+        });
+    }
+    for ((n, kind), sp) in &other_rows {
+        let pid = intern_span(&mut records, *sp);
+        e.declarations.push(Declaration {
+            kind: *kind,
+            name: n.clone(),
+            display: n.clone(),
+            provenance: pid,
+        });
+    }
+
+    let mut r = Relations::default();
+    // member_of + phase_of from the fn rows.
+    for (n, key) in &fn_rows {
+        if let Some(l) = &key.locus {
+            let ld = name(l);
+            if let Some(lid) = locus_id.get(&ld) {
+                let pid =
+                    intern_synth(&mut records, "locus membership");
+                r.member_of.push(MemberOf {
+                    function: fn_id[n],
+                    locus: *lid,
+                    provenance: pid,
+                });
+            }
+        }
+        if let Some((phase, _)) = phase_of_pairs.get(n) {
+            let pid = intern_synth(&mut records, "phase relation");
+            r.phase_of.push(PhaseOf {
+                function: fn_id[n],
+                phase: phase_id[phase],
+                provenance: pid,
+            });
+        }
+    }
+    for ((from, to, dispatch, site), (in_loop, unbounded, pid)) in &calls
+    {
+        r.calls.push(Call {
+            from: *from,
+            to: *to,
+            dispatch: dispatch.clone(),
+            site: *site,
+            in_loop: *in_loop,
+            unbounded: *unbounded,
+            provenance: *pid,
+        });
+    }
+    for ((from, site), (iface, method, pid)) in &dead {
+        r.dead_interface_calls.push(DeadInterfaceCall {
+            from: *from,
+            site: *site,
+            interface: iface.clone(),
+            method: method.clone(),
+            provenance: *pid,
+        });
+    }
+    for ((f, s, site), (declared, payload, keyed, pid)) in &publishes {
+        r.publishes.push(Publish {
+            function: *f,
+            subject: *s,
+            declared_topic: *declared,
+            payload: *payload,
+            site: *site,
+            key_domain: keyed.clone(),
+            disposition: PublishDisposition::Default,
+            provenance: *pid,
+        });
+    }
+    for ((s, h, site), (declared, payload, pred, cap, shed, pid)) in
+        &subscribes
+    {
+        r.subscribes.push(Subscribe {
+            subject: *s,
+            declared_topic: *declared,
+            payload: *payload,
+            handler: *h,
+            site: *site,
+            key_predicate: pred.clone(),
+            capacity: *cap,
+            shed: *shed,
+            provenance: *pid,
+        });
+    }
+    for ((parent, child, err), (ops, retry, pid)) in &sup {
+        r.supervises.push(Supervises {
+            parent: *parent,
+            child: child.clone(),
+            error_type: err.clone(),
+            policy: SupervisionPolicy {
+                ops: ops.clone(),
+                retry_bound: *retry,
+            },
+            provenance: *pid,
+        });
+    }
+    for (gid, member) in &group_members {
+        r.group_members.push(GroupMember {
+            group: *gid,
+            member: *member,
+            provenance: gm_prov[&(*gid, *member)],
+        });
+    }
+    r.group_selectors = group_selectors;
+    for (entity, sid) in &declared_in {
+        r.declared_in.push(DeclaredIn {
+            entity: *entity,
+            seed: *sid,
+            provenance: di_prov[&(*entity, *sid)],
+        });
+    }
+
+    // labels: declared effect carriers.
+    let mut labels: Vec<LabelRow> = Vec::new();
+    {
+        let mut rows: BTreeSet<(EntityRef, String)> = BTreeSet::new();
+        for (k, set) in &summary.carries {
+            if !user_key(k) {
+                continue;
+            }
+            let classes = crate::frontier::render_effects_named(
+                *set,
+                &effect_names,
+            );
+            for c in classes {
+                rows.insert((
+                    EntityRef::Function(fn_id[&fn_name(k)]),
+                    c,
+                ));
+            }
+        }
+        for (at, label) in rows {
+            let pid =
+                intern_synth(&mut records, "declared effect carrier");
+            labels.push(LabelRow {
+                at,
+                label,
+                provenance: pid,
+            });
+        }
+    }
+
+    // holes, canonically ordered.
+    let mut hole_rows: Vec<Hole> = holes
+        .into_iter()
+        .map(|((at, kind, reason), (hides, pid))| Hole {
+            at,
+            kind,
+            hides,
+            reason,
+            provenance: pid,
+        })
+        .collect();
+    hole_rows.sort_by(|a, b| {
+        (a.at, a.kind.clone(), &a.reason)
+            .cmp(&(b.at, b.kind.clone(), &b.reason))
+    });
+
+    // capabilities: computed FROM the holes so the two accounts
+    // cannot disagree by construction. The Change-2 scope leaves
+    // ownership/placement/routes/cardinality/delivery unclaimed.
+    let hides_any = |fam: hale_model::RelationSet| {
+        hole_rows.iter().any(|h| h.hides.intersects(fam))
+    };
+    let capabilities = Capabilities {
+        exact_calls: !hides_any(hale_model::RelationSet::CALLS),
+        exact_bus_endpoints: !hides_any(
+            hale_model::RelationSet::PUBLISHES
+                .union(hale_model::RelationSet::SUBSCRIBES),
+        ),
+        exact_key_filters: !hides_any(
+            hale_model::RelationSet::KEY_FILTERS,
+        ),
+        exact_effects: !hides_any(hale_model::RelationSet::EFFECTS),
+        ..Capabilities::default()
+    };
+
+    // entrypoint: the main locus, else "main".
+    let entrypoint = ast
+        .loci
+        .iter()
+        .find(|l| l.is_main)
+        .map(|l| l.name.name.clone())
+        .unwrap_or_else(|| "main".to_string());
+
+    prov.records = records;
+    let model = ApplicationModel {
+        header: ModelHeader {
+            semantics: MODEL_SEMANTICS_V1,
+            entrypoint,
+        },
+        entities: e,
+        relations: r,
+        labels,
+        weights: Vec::new(),
+        holes: hole_rows,
+        capabilities,
+        provenance: prov,
+    };
+    debug_assert_eq!(model.validate(), Ok(()));
+    model
+}
+
+/// Deterministic internal rendering of a model — the `hale model
+/// dump` surface. EXPLICITLY not a stable format: it exists for
+/// inspection, corpus snapshots, and the Change-2 differential
+/// tests; the lossless external encoding is Change 3's projection.
+/// Canonical table order in, deterministic text out.
+pub fn render_internal(m: &ApplicationModel) -> String {
+    let mut s = String::new();
+    s.push_str("# hale ApplicationModel (internal dump — not a stable format)\n");
+    s.push_str(&format!(
+        "semantics {}\nentrypoint {}\n",
+        m.header.semantics, m.header.entrypoint
+    ));
+    let e = &m.entities;
+    let fn_name = |id: FunctionId| e.functions[id.index()].name.clone();
+    let locus_name = |id: LocusDeclId| e.loci[id.index()].name.clone();
+    let subject_pat = |id: SubjectId| e.subjects[id.index()].pattern.clone();
+    let topic_name = |id: TopicId| e.topics[id.index()].name.clone();
+
+    s.push_str(&format!("loci ({}):\n", e.loci.len()));
+    for l in &e.loci {
+        s.push_str(&format!(
+            "  {}{}\n",
+            l.name,
+            if l.sealed { " @sealed" } else { "" }
+        ));
+    }
+    s.push_str(&format!("functions ({}):\n", e.functions.len()));
+    for f in &e.functions {
+        s.push_str(&format!(
+            "  {} [{}]{}\n",
+            f.name,
+            match f.kind {
+                FunctionKind::Hook => "hook",
+                FunctionKind::Method => "method",
+                FunctionKind::Free => "free",
+                FunctionKind::Mode => "mode",
+            },
+            if f.effects.is_empty() {
+                String::new()
+            } else {
+                format!(" {{{}}}", f.effects.join(","))
+            }
+        ));
+    }
+    s.push_str(&format!("topics ({}):\n", e.topics.len()));
+    for t in &e.topics {
+        let mut line = format!(
+            "  {} -> {} payload#{:016x}",
+            t.name,
+            subject_pat(t.subject),
+            e.payloads[t.payload.index()].hash
+        );
+        if let Some(k) = &t.key {
+            line.push_str(&format!(
+                " keyed_by {} on_unmatched {}",
+                k.field,
+                match k.on_unmatched {
+                    KeyOnUnmatched::Swallow => "swallow",
+                    KeyOnUnmatched::Fail => "fail",
+                    KeyOnUnmatched::Fallback => "fallback",
+                }
+            ));
+        }
+        if let Some(b) = &t.bound {
+            line.push_str(&format!(" bounded({})", b.capacity));
+        }
+        s.push_str(&line);
+        s.push('\n');
+    }
+    s.push_str(&format!("subjects ({}):\n", e.subjects.len()));
+    for x in &e.subjects {
+        s.push_str(&format!(
+            "  {}{}\n",
+            x.pattern,
+            if x.exact { "" } else { " (pattern)" }
+        ));
+    }
+    s.push_str(&format!(
+        "groups ({}): {}\n",
+        e.groups.len(),
+        e.groups
+            .iter()
+            .map(|g| {
+                format!(
+                    "{}{}",
+                    g.name,
+                    if g.may_be_empty { " may_be_empty" } else { "" }
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+    s.push_str(&format!(
+        "declaration universe: types [{}], interfaces [{}], other [{}]\n",
+        e.types
+            .iter()
+            .map(|t| t.name.clone())
+            .collect::<Vec<_>>()
+            .join(", "),
+        e.interfaces
+            .iter()
+            .map(|t| t.name.clone())
+            .collect::<Vec<_>>()
+            .join(", "),
+        e.declarations
+            .iter()
+            .map(|d| format!("{:?}:{}", d.kind, d.name))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+
+    let r = &m.relations;
+    s.push_str(&format!("calls ({} sites):\n", r.calls.len()));
+    for c in &r.calls {
+        s.push_str(&format!(
+            "  {} -> {} [{}]{}{}{}\n",
+            fn_name(c.from),
+            fn_name(c.to),
+            match &c.dispatch {
+                DispatchKind::Direct => "direct".to_string(),
+                DispatchKind::Interface { interface } =>
+                    format!("iface {}", interface),
+                DispatchKind::ViaStdlib => "via-stdlib".to_string(),
+            },
+            format!(" site {}", c.site),
+            if c.in_loop { " loop" } else { "" },
+            if c.unbounded { " unbounded" } else { "" },
+        ));
+    }
+    s.push_str(&format!(
+        "dead_interface_calls ({}):\n",
+        r.dead_interface_calls.len()
+    ));
+    for d in &r.dead_interface_calls {
+        s.push_str(&format!(
+            "  {} -[dead]-> {}.{}\n",
+            fn_name(d.from),
+            d.interface,
+            d.method
+        ));
+    }
+    s.push_str(&format!("publishes ({} sites):\n", r.publishes.len()));
+    for p in &r.publishes {
+        s.push_str(&format!(
+            "  {} -> {}{} site {}{}\n",
+            fn_name(p.function),
+            subject_pat(p.subject),
+            p.declared_topic
+                .map(|t| format!(" (topic {})", topic_name(t)))
+                .unwrap_or_default(),
+            p.site,
+            match &p.key_domain {
+                None => String::new(),
+                Some(KeyDomain::AnyOfType(t)) =>
+                    format!(" key any-of {}", t),
+                Some(other) => format!(" key {:?}", other),
+            }
+        ));
+    }
+    s.push_str(&format!("subscribes ({}):\n", r.subscribes.len()));
+    for x in &r.subscribes {
+        s.push_str(&format!(
+            "  {}{} -> {} site {} where {:?} cap {:?} shed {:?}\n",
+            subject_pat(x.subject),
+            x.declared_topic
+                .map(|t| format!(" (topic {})", topic_name(t)))
+                .unwrap_or_default(),
+            fn_name(x.handler),
+            x.site,
+            x.key_predicate,
+            x.capacity,
+            x.shed
+        ));
+    }
+    s.push_str(&format!("supervises ({}):\n", r.supervises.len()));
+    for x in &r.supervises {
+        s.push_str(&format!(
+            "  {} -> {} on {} ops [{}]{}\n",
+            locus_name(x.parent),
+            match &x.child {
+                SupervisedRef::Locus(id) => locus_name(*id),
+                SupervisedRef::External(n) =>
+                    format!("(external) {}", n),
+            },
+            x.error_type,
+            x.policy.ops.join(","),
+            x.policy
+                .retry_bound
+                .map(|n| format!(" retry {}", n))
+                .unwrap_or_default()
+        ));
+    }
+    s.push_str(&format!(
+        "group_selectors ({}):\n",
+        r.group_selectors.len()
+    ));
+    for gs in &r.group_selectors {
+        s.push_str(&format!(
+            "  {}[{}] = {}\n",
+            e.groups[gs.group.index()].name,
+            gs.ordinal,
+            match &gs.selector {
+                SelectorForm::Named { display, .. } => display.clone(),
+                SelectorForm::SeedGlob { display, .. } =>
+                    format!("{} (glob)", display),
+            }
+        ));
+    }
+    s.push_str(&format!("holes ({}):\n", m.holes.len()));
+    for h in &m.holes {
+        s.push_str(&format!(
+            "  {:?} at {:?}: {} (hides {:#x})\n",
+            h.kind, h.at, h.reason, h.hides.0
+        ));
+    }
+    s.push_str(&format!(
+        "capabilities: calls={} bus={} keys={} effects={}\n",
+        m.capabilities.exact_calls,
+        m.capabilities.exact_bus_endpoints,
+        m.capabilities.exact_key_filters,
+        m.capabilities.exact_effects
+    ));
+    s
+}

--- a/crates/hale-types/src/quantitative.rs
+++ b/crates/hale-types/src/quantitative.rs
@@ -242,7 +242,7 @@ fn count_dim(
                 QuantDim::Publish => 1,
                 QuantDim::Fanout => subj
                     .as_ref()
-                    .map(|s| fanout_of(s))
+                    .map(|s| fanout_of(&s.text))
                     .unwrap_or(1),
                 _ => 0,
             };

--- a/crates/hale-types/src/topic_identity.rs
+++ b/crates/hale-types/src/topic_identity.rs
@@ -110,8 +110,24 @@ pub fn canonical_topic_shape(
     items: &[TopDecl],
     topic: &TopicDecl,
 ) -> String {
-    // Type decls by name, modules included, for struct lookup and
-    // alias resolution.
+    let TypeExpr::Named { path, generic_args, .. } = &topic.payload
+    else {
+        return String::new();
+    };
+    if path.segments.len() != 1 || !generic_args.is_empty() {
+        return String::new();
+    }
+    canonical_type_shape(items, path.segments[0].name.as_str())
+}
+
+/// The canonical structural shape of one declared bare struct type,
+/// by (post-merge) name — the type-level half of
+/// [`canonical_topic_shape`], exposed for the model builder (GH #476
+/// Change 2), which needs payload identity for LITERAL endpoints'
+/// `of type T` too, through the exact same renderer (a second shape
+/// renderer would drift). Empty string when the name is not a
+/// declared bare struct.
+pub fn canonical_type_shape(items: &[TopDecl], type_name: &str) -> String {
     let mut types: BTreeMap<&str, &TypeDecl> = BTreeMap::new();
     fn collect<'a>(
         items: &'a [TopDecl],
@@ -128,15 +144,7 @@ pub fn canonical_topic_shape(
         }
     }
     collect(items, &mut types);
-
-    let TypeExpr::Named { path, generic_args, .. } = &topic.payload
-    else {
-        return String::new();
-    };
-    if path.segments.len() != 1 || !generic_args.is_empty() {
-        return String::new();
-    }
-    let Some(td) = types.get(path.segments[0].name.as_str()) else {
+    let Some(td) = types.get(type_name) else {
         return String::new();
     };
     let TypeDeclBody::Struct(fields) = &td.body else {

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -279,10 +279,10 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
         }
         for site in &fs.effect_sites {
             if let EffectSiteKind::Publish(Some(s)) = &site.kind {
-                publishes.insert((fn_name(k), name(s)));
+                publishes.insert((fn_name(k), name(&s.text)));
                 publish_spans.insert((
                     fn_name(k),
-                    name(s),
+                    name(&s.text),
                     site.span.start.as_usize() as u32,
                     site.span.end.as_usize() as u32,
                 ));

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -301,48 +301,19 @@ pub fn dump_topology(bundle: &Bundle<'_>) -> String {
         &programs,
         &bundle.import_renames,
     );
+    // The walk itself lives in `callgraph::legacy_via_stdlib_contraction`,
+    // shared with the model builder's `LegacyProjection` so the
+    // projected `TopologyShapeV1` hash and this serialization cannot
+    // drift (GH #476 Change 2, review round 9).
     let mut via_stdlib: BTreeMap<(String, String), bool> =
         BTreeMap::new();
-    for (k, fs) in &merged.fns {
-        if !user_key(k) {
-            continue;
-        }
-        let mut stack: Vec<(FnKey, bool)> = Vec::new();
-        let mut seen: BTreeSet<FnKey> = BTreeSet::new();
-        for edge in &fs.calls {
-            if let Callee::Resolved(next) = &edge.callee {
-                if !user_key(next) && seen.insert(next.clone()) {
-                    stack.push((
-                        next.clone(),
-                        edge.loop_depth > 0 || edge.in_unbounded_loop,
-                    ));
-                }
-            }
-        }
-        let mut steps = 0u32;
-        while let Some((n, lp)) = stack.pop() {
-            steps += 1;
-            if steps > crate::callgraph::MAX_STEPS {
-                break;
-            }
-            let Some(nfs) = merged.fns.get(&n) else { continue };
-            for edge in &nfs.calls {
-                let Callee::Resolved(next) = &edge.callee else {
-                    continue;
-                };
-                let l2 = lp
-                    || edge.loop_depth > 0
-                    || edge.in_unbounded_loop;
-                if user_key(next) {
-                    let e = via_stdlib
-                        .entry((fn_name(k), fn_name(next)))
-                        .or_insert(false);
-                    *e |= l2;
-                } else if seen.insert(next.clone()) {
-                    stack.push((next.clone(), l2));
-                }
-            }
-        }
+    for ((k, next), looped) in
+        crate::callgraph::legacy_via_stdlib_contraction(&merged, &user_key)
+    {
+        let e = via_stdlib
+            .entry((fn_name(&k), fn_name(&next)))
+            .or_insert(false);
+        *e |= looped;
     }
     let mut subscribes: BTreeSet<(String, String, String)> =
         BTreeSet::new();

--- a/crates/hale-types/tests/model_builder.rs
+++ b/crates/hale-types/tests/model_builder.rs
@@ -1,0 +1,589 @@
+//! GH #476 Change 2 — the ApplicationModel builder.
+//!
+//! Two proof obligations:
+//!
+//!   1. **Lawfulness**: every derived model passes
+//!      `ApplicationModel::validate()` — all 31 schema laws — over
+//!      fixtures exercising each table family (calls at site grain,
+//!      stdlib contraction, keyed delivery incl. fallback, bounds,
+//!      literal/wildcard endpoints, groups with authored selectors,
+//!      supervision incl. external children, the declaration
+//!      universe, holes vs dead dispatches).
+//!   2. **Agreement**: the model and `dump_topology` extract the
+//!      SAME facts from one bundle — the Change-2 exit criterion
+//!      ("model rows match existing semantic fragments") and the
+//!      seed of Change 3's projection differential. Where the two
+//!      encode differently (sites vs merged endpoints, holes+dead
+//!      vs stringly unknowns), the test projects the model down and
+//!      compares.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use hale_model::{
+    DispatchKind, EntityRef, HoleKind, KeyOnUnmatched, KeyPredicate,
+    SelectorForm, SupervisedRef,
+};
+use hale_types::model_builder::derive_application_model;
+use hale_types::Bundle;
+
+fn bundle_of(src: &str) -> (hale_syntax::ast::Program, ()) {
+    (hale_syntax::parse_source(src).expect("parse"), ())
+}
+
+fn derive(src: &str) -> hale_model::ApplicationModel {
+    let (program, ()) = bundle_of(src);
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let m = derive_application_model(&bundle);
+    m.validate().expect("derived model is lawful");
+    m
+}
+
+const RICH: &str = r#"
+type Reading { sensor: Int = 0; v: Int = 0; }
+type Cmd { op: Int = 0; }
+type Event { n: Int = 0; }
+topic Readings {
+    payload: Reading;
+    subject: "sense.reading";
+    keyed_by sensor;
+    on_unmatched: fallback;
+}
+topic Cmds { payload: Cmd; subject: "ctl.cmd"; bounded(64); on_full: fail; }
+
+interface Notifier {
+    fn notify(v: Int) -> Int;
+}
+
+fn double(v: Int) -> Int { return v * 2; }
+fn call_it(f: fn (Int) -> Int, v: Int) -> Int { return f(v); }
+
+locus Worker {
+    params { seen: Int = 0; }
+    bus {
+        subscribe Readings as on_r where key == replica;
+        publish Cmds;
+    }
+    fn on_r(r: Reading) {
+        self.seen = self.seen + 1;
+        if r.v > 100 { Cmds <- Cmd { op: call_it(double, r.v) } or discard; }
+    }
+}
+
+locus Catcher {
+    params { seen: Int = 0; }
+    bus { subscribe Readings as on_any bounded(8, drop_old) where key == _; }
+    fn on_any(r: Reading) { self.seen = self.seen + 1; }
+}
+
+locus Store {
+    params { total: Int = 0; }
+    bus {
+        subscribe Cmds as on_c;
+        subscribe "audit.**" as on_audit of type Event;
+    }
+    fn on_c(c: Cmd) { self.total = self.total + double(c.op); }
+    fn on_audit(e: Event) { self.total = self.total + e.n; }
+    on_failure(w: Worker, err: ClosureViolation) {
+        restart (w) for 3;
+    }
+}
+
+group stores = { Store };
+group workers = { Worker, double };
+
+main locus App {
+    params { w: Worker = Worker { }; c: Catcher = Catcher { }; s: Store = Store { }; }
+    bus { publish Readings; publish "audit.trace" of type Event; }
+    run() {
+        Readings <- Reading { sensor: 1, v: 10 };
+        "audit.trace" <- Event { n: 1 };
+    }
+}
+fn main() { App { }; }
+"#;
+
+#[test]
+fn the_rich_fixture_derives_a_lawful_model_with_every_family() {
+    let m = derive(RICH);
+    let e = &m.entities;
+
+    // Sorts.
+    let loci: Vec<&str> =
+        e.loci.iter().map(|l| l.name.as_str()).collect();
+    assert_eq!(loci, ["App", "Catcher", "Store", "Worker"]);
+    assert!(e.functions.iter().any(|f| f.name == "call_it"));
+    assert_eq!(e.topics.len(), 2);
+
+    // Keyed topic facts survive: key field, fallback policy.
+    let readings =
+        e.topics.iter().find(|t| t.name == "Readings").unwrap();
+    let k = readings.key.as_ref().expect("keyed");
+    assert_eq!(k.field, "sensor");
+    assert_eq!(k.on_unmatched, KeyOnUnmatched::Fallback);
+    // Topic bound (the #255 publisher-facing knob).
+    let cmds = e.topics.iter().find(|t| t.name == "Cmds").unwrap();
+    assert_eq!(cmds.bound.map(|b| b.capacity), Some(64));
+
+    // Wire subjects are the subject sort; the wildcard and literal
+    // endpoints are subjects WITHOUT topic rows.
+    let pats: BTreeSet<&str> =
+        e.subjects.iter().map(|s| s.pattern.as_str()).collect();
+    assert!(pats.contains("sense.reading"));
+    assert!(pats.contains("audit.**"));
+    assert!(pats.contains("audit.trace"));
+
+    // Subscriptions: EqReplica, Fallback, plain, and wildcard rows.
+    let r = &m.relations;
+    let preds: Vec<&KeyPredicate> =
+        r.subscribes.iter().map(|s| &s.key_predicate).collect();
+    assert!(preds.iter().any(|p| **p == KeyPredicate::EqReplica));
+    assert!(preds.iter().any(|p| **p == KeyPredicate::Fallback));
+    // The bounded subscription carries its capacity + shed policy.
+    assert!(r.subscribes.iter().any(|s| matches!(
+        (s.capacity, s.shed),
+        (
+            hale_model::Capacity::Bounded(8),
+            hale_model::ShedPolicy::DropOld
+        )
+    )));
+    // The wildcard subscription is declared-topic-less.
+    assert!(r
+        .subscribes
+        .iter()
+        .any(|s| s.declared_topic.is_none()));
+
+    // Publishes: the literal-subject publish has no declared topic;
+    // the keyed publish carries an AnyOfType domain (typed, not
+    // Unknown — no spurious hole).
+    assert!(r.publishes.iter().any(|p| p.declared_topic.is_none()));
+    assert!(r
+        .publishes
+        .iter()
+        .any(|p| matches!(&p.key_domain, Some(hale_model::KeyDomain::AnyOfType(_)))));
+
+    // Calls: the indirect call is a HOLE (not a row); double's
+    // direct call from Store::on_c is a site row.
+    assert!(m
+        .holes
+        .iter()
+        .any(|h| h.kind == HoleKind::IndirectCall));
+    assert!(!m.capabilities.exact_calls, "indirect call ⇒ inexact");
+    let fname = |id: hale_model::FunctionId| {
+        e.functions[id.index()].name.clone()
+    };
+    assert!(r.calls.iter().any(|c| fname(c.from) == "Store::on_c"
+        && fname(c.to) == "double"
+        && c.dispatch == DispatchKind::Direct));
+
+    // Supervision: per-handler row with error type + retry bound.
+    let sup = &r.supervises[0];
+    assert!(matches!(sup.child, SupervisedRef::Locus(_)));
+    assert_eq!(sup.error_type, "ClosureViolation");
+    assert_eq!(sup.policy.retry_bound, Some(3));
+    assert_eq!(sup.policy.ops, ["restart"]);
+
+    // Groups: authored selectors in order; the both-form member
+    // list resolves loci AND free fns.
+    let sel: Vec<String> = r
+        .group_selectors
+        .iter()
+        .map(|s| match &s.selector {
+            SelectorForm::Named { display, .. } => display.clone(),
+            SelectorForm::SeedGlob { display, .. } => display.clone(),
+        })
+        .collect();
+    assert_eq!(sel, ["Store", "Worker", "double"]);
+    assert!(r.group_members.iter().any(|gm| matches!(
+        gm.member,
+        EntityRef::Function(_)
+    )));
+
+    // Declaration universe: types + the interface present.
+    assert!(e.types.iter().any(|t| t.name == "Reading"));
+    assert!(e.interfaces.iter().any(|i| i.name == "Notifier"));
+}
+
+#[test]
+fn model_and_artifact_extract_the_same_facts() {
+    let (program, ()) = bundle_of(RICH);
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let m = derive_application_model(&bundle);
+    let art: serde_json::Value = serde_json::from_str(
+        &hale_types::topology::dump_topology(&bundle),
+    )
+    .expect("artifact parses");
+
+    let e = &m.entities;
+    let fname =
+        |id: hale_model::FunctionId| e.functions[id.index()].name.clone();
+
+    // fn sort equality.
+    let art_fns: BTreeSet<String> = art["sorts"]["fns"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    let model_fns: BTreeSet<String> =
+        e.functions.iter().map(|f| f.name.clone()).collect();
+    assert_eq!(art_fns, model_fns, "fn sorts agree");
+
+    // loci sort equality.
+    let art_loci: BTreeSet<String> = art["sorts"]["loci"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    let model_loci: BTreeSet<String> =
+        e.loci.iter().map(|l| l.name.clone()).collect();
+    assert_eq!(art_loci, model_loci, "locus sorts agree");
+
+    // calls: endpoint projection of the model's site rows equals the
+    // artifact's merged relation (Direct + Interface dispatch; the
+    // ViaStdlib rows correspond to calls_via_stdlib).
+    let art_calls: BTreeSet<(String, String)> = art["relations"]["calls"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| {
+            (
+                r["from"].as_str().unwrap().to_string(),
+                r["to"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    let model_calls: BTreeSet<(String, String)> = m
+        .relations
+        .calls
+        .iter()
+        .filter(|c| c.dispatch != DispatchKind::ViaStdlib)
+        .map(|c| (fname(c.from), fname(c.to)))
+        .collect();
+    assert_eq!(art_calls, model_calls, "call endpoints agree");
+    let art_via: BTreeSet<(String, String)> = art["relations"]
+        ["calls_via_stdlib"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| {
+            (
+                r["from"].as_str().unwrap().to_string(),
+                r["to"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    let model_via: BTreeSet<(String, String)> = m
+        .relations
+        .calls
+        .iter()
+        .filter(|c| c.dispatch == DispatchKind::ViaStdlib)
+        .map(|c| (fname(c.from), fname(c.to)))
+        .collect();
+    assert_eq!(art_via, model_via, "through-stdlib contraction agrees");
+
+    // publishes: (fn, display subject) sets agree. The artifact
+    // spells declared topics by NAME; the model rows carry the wire
+    // subject + declared topic — project back to the display.
+    let display_of = |p: &hale_model::Publish| -> String {
+        match p.declared_topic {
+            Some(t) => e.topics[t.index()].name.clone(),
+            None => e.subjects[p.subject.index()].pattern.clone(),
+        }
+    };
+    let art_pubs: BTreeSet<(String, String)> = art["relations"]
+        ["publishes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| {
+            (
+                r["fn"].as_str().unwrap().to_string(),
+                r["subject"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    let model_pubs: BTreeSet<(String, String)> = m
+        .relations
+        .publishes
+        .iter()
+        .map(|p| (fname(p.function), display_of(p)))
+        .collect();
+    assert_eq!(art_pubs, model_pubs, "publish endpoints agree");
+
+    // subscribes: (subject display, handler) agree.
+    let art_subs: BTreeSet<(String, String, String)> = art["relations"]
+        ["subscribes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| {
+            (
+                r["subject"].as_str().unwrap().to_string(),
+                r["locus"].as_str().unwrap().to_string(),
+                r["handler"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    let model_subs: BTreeSet<(String, String, String)> = m
+        .relations
+        .subscribes
+        .iter()
+        .map(|s| {
+            let display = match s.declared_topic {
+                Some(t) => e.topics[t.index()].name.clone(),
+                None => e.subjects[s.subject.index()].pattern.clone(),
+            };
+            let handler_full = fname(s.handler);
+            let (locus, handler) =
+                handler_full.rsplit_once("::").expect("locus handler");
+            (display, locus.to_string(), handler.to_string())
+        })
+        .collect();
+    assert_eq!(art_subs, model_subs, "subscription endpoints agree");
+
+    // unknowns: the artifact's stringly reasons correspond to the
+    // model's typed holes (the dead-dispatch species would land in
+    // dead_interface_calls — none in this fixture).
+    let art_unknown_fns: BTreeSet<String> = art["unknowns"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["fn"].as_str().unwrap().to_string())
+        .collect();
+    let model_hole_fns: BTreeSet<String> = m
+        .holes
+        .iter()
+        .filter_map(|h| match h.at {
+            EntityRef::Function(id) => Some(fname(id)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(art_unknown_fns, model_hole_fns, "residue anchors agree");
+
+    // groups: the artifact's as-authored member lists equal the
+    // model's authored selector displays, per group, in order.
+    let art_groups = art["groups"].as_object().unwrap();
+    for g in &e.groups {
+        let art_members: Vec<String> = art_groups[&g.name]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        let gid = hale_model::GroupId(
+            e.groups.iter().position(|x| x.name == g.name).unwrap()
+                as u32,
+        );
+        let mut sel: Vec<(u32, String)> = m
+            .relations
+            .group_selectors
+            .iter()
+            .filter(|s| s.group == gid)
+            .map(|s| {
+                (
+                    s.ordinal,
+                    match &s.selector {
+                        SelectorForm::Named { display, .. } => {
+                            display.clone()
+                        }
+                        SelectorForm::SeedGlob { display, .. } => {
+                            display.clone()
+                        }
+                    },
+                )
+            })
+            .collect();
+        sel.sort();
+        let model_members: Vec<String> =
+            sel.into_iter().map(|(_, d)| d).collect();
+        assert_eq!(
+            art_members, model_members,
+            "group `{}` authored selectors agree",
+            g.name
+        );
+    }
+
+    // supervision agrees (locus + child spelling).
+    let art_sup: BTreeSet<(String, String)> = art["supervision"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| {
+            (
+                r["locus"].as_str().unwrap().to_string(),
+                r["child"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    let model_sup: BTreeSet<(String, String)> = m
+        .relations
+        .supervises
+        .iter()
+        .map(|s| {
+            (
+                e.loci[s.parent.index()].name.clone(),
+                match &s.child {
+                    SupervisedRef::Locus(id) => {
+                        e.loci[id.index()].name.clone()
+                    }
+                    SupervisedRef::External(n) => n.clone(),
+                },
+            )
+        })
+        .collect();
+    assert_eq!(art_sup, model_sup, "supervision rows agree");
+
+    // effects: per-fn derived classes agree.
+    let art_effects = art["effects"].as_object().unwrap();
+    for f in &e.functions {
+        let art_classes: Vec<String> = art_effects
+            .get(&f.name)
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .map(|x| x.as_str().unwrap().to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert_eq!(
+            art_classes, f.effects,
+            "effects agree for {}",
+            f.name
+        );
+    }
+}
+
+#[test]
+fn dead_dispatch_and_indirect_are_separated() {
+    // A call through an uninhabited interface + a genuine indirect
+    // call: one dead row, one hole — never conflated.
+    let src = r#"
+interface Notifier {
+    fn notify(v: Int) -> Int;
+}
+fn call_it(f: fn (Int) -> Int, v: Int) -> Int { return f(v); }
+fn poke(n: Notifier, v: Int) -> Int { return n.notify(v); }
+fn id(v: Int) -> Int { return v; }
+main locus App {
+    run() {
+        let a = call_it(id, 1);
+        println(a);
+    }
+}
+fn main() { App { }; }
+"#;
+    let m = derive(src);
+    assert!(
+        m.relations
+            .dead_interface_calls
+            .iter()
+            .any(|d| d.interface == "Notifier" && d.method == "notify"),
+        "uninhabited dispatch is a dead row: {:?}",
+        m.relations.dead_interface_calls
+    );
+    assert!(m
+        .holes
+        .iter()
+        .any(|h| h.kind == HoleKind::IndirectCall));
+    // The dead row does NOT make calls inexact; the indirect hole
+    // does.
+    assert!(!m.capabilities.exact_calls);
+}
+
+#[test]
+fn a_clean_program_claims_exactness() {
+    let src = r#"
+type T { n: Int = 0; }
+topic Evt { payload: T; subject: "evt"; }
+locus Sub {
+    params { seen: Int = 0; }
+    bus { subscribe Evt as on_e; }
+    fn on_e(t: T) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { s: Sub = Sub { }; }
+    bus { publish Evt; }
+    run() { Evt <- T { n: 1 }; }
+}
+fn main() { App { }; }
+"#;
+    let m = derive(src);
+    assert!(m.holes.is_empty());
+    assert!(m.capabilities.exact_calls);
+    assert!(m.capabilities.exact_bus_endpoints);
+    assert!(m.capabilities.exact_key_filters);
+    // Never claimed at Change 2 (empty tables, deferred adapters):
+    assert!(!m.capabilities.exact_ownership);
+    assert!(!m.capabilities.exact_placement);
+    assert!(!m.capabilities.exact_routes);
+}
+
+#[test]
+fn derivation_is_deterministic() {
+    let (program, ()) = bundle_of(RICH);
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let a = hale_types::model_builder::render_internal(
+        &derive_application_model(&bundle),
+    );
+    let b = hale_types::model_builder::render_internal(
+        &derive_application_model(&bundle),
+    );
+    assert_eq!(a, b, "two derivations render identically");
+}
+
+/// The corpus property, two-sided:
+///   - derivation NEVER panics on any parseable program;
+///   - a derived model may fail the schema laws ONLY where the
+///     checker also refuses the program (negative-test fixtures
+///     with deliberately ill-formed keyed/fallback usage derive
+///     models whose law violations MIRROR the checker's own
+///     refusals — `IllegalFallback` where the checker rejects a
+///     stray `_`, `KeyContract` where a filter hits an unkeyed
+///     topic). A program that CHECKS clean and derives an unlawful
+///     model is a builder bug, full stop.
+#[test]
+fn every_corpus_program_derives_a_lawful_model() {
+    let mut bad: Vec<String> = Vec::new();
+    for p in hale_corpus::parseable(|s| hale_syntax::parse_source(s).is_ok())
+    {
+        let Ok(program) = hale_syntax::parse_source(&p.source) else {
+            continue;
+        };
+        let caught =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let mut programs = BTreeMap::new();
+                programs.insert("app.hl".to_string(), &program);
+                let bundle = Bundle::new(programs);
+                let m = derive_application_model(&bundle);
+                m.validate().map_err(|e| format!("{:?}", e))
+            }));
+        match caught {
+            Err(_) => bad.push(format!("{}: PANIC", p.origin)),
+            Ok(Err(e)) => {
+                let checks_clean = hale_types::check_program(&program)
+                    .iter()
+                    .all(|d| !d.is_error());
+                if checks_clean {
+                    bad.push(format!(
+                        "{}: checks clean but unlawful: {}",
+                        p.origin, e
+                    ));
+                }
+            }
+            Ok(Ok(())) => {}
+        }
+    }
+    assert!(
+        bad.is_empty(),
+        "{} corpus programs violate the model property:\n{}",
+        bad.len(),
+        bad.join("\n")
+    );
+}

--- a/crates/hale-types/tests/model_builder.rs
+++ b/crates/hale-types/tests/model_builder.rs
@@ -233,11 +233,24 @@ fn model_and_artifact_extract_the_same_facts() {
         e.functions.iter().map(|f| f.name.clone()).collect();
     // The model's universe is DECLARATIONS (round 6): a superset of
     // the artifact's summary-derived sort — an empty fn exists here
-    // and not there. Change 3's projection filters back down.
+    // and not there.
     assert!(
         art_fns.is_subset(&model_fns),
         "artifact fn sort ⊆ model universe; missing: {:?}",
         art_fns.difference(&model_fns).collect::<Vec<_>>()
+    );
+    // …and the legacy projection recovers the EXACT legacy sort from
+    // the model alone (round 7): no summary/AST side channel for
+    // Change 3.
+    let legacy_fns: BTreeSet<String> = m
+        .legacy
+        .topology_v1_fns
+        .iter()
+        .map(|id| e.functions[id.index()].display.clone())
+        .collect();
+    assert_eq!(
+        art_fns, legacy_fns,
+        "legacy.topology_v1_fns projects the artifact's fn sort exactly"
     );
 
     // loci sort equality.
@@ -363,15 +376,29 @@ fn model_and_artifact_extract_the_same_facts() {
         .iter()
         .map(|r| r["fn"].as_str().unwrap().to_string())
         .collect();
+    // The model's residue is a SUPERSET: it holes bodies the legacy
+    // summary never walked (on_failure, module scope). Every
+    // artifact anchor must be a model hole, and every extra must be
+    // exactly that richer species.
     let model_hole_fns: BTreeSet<String> = m
         .holes
         .iter()
+        .filter(|h| h.kind != HoleKind::UnanalyzedBody)
         .filter_map(|h| match h.at {
             EntityRef::Function(id) => Some(fname(id)),
             _ => None,
         })
         .collect();
-    assert_eq!(art_unknown_fns, model_hole_fns, "residue anchors agree");
+    assert_eq!(
+        art_unknown_fns, model_hole_fns,
+        "legacy-visible residue anchors agree"
+    );
+    assert!(
+        m.holes
+            .iter()
+            .any(|h| h.kind == HoleKind::UnanalyzedBody),
+        "the on_failure body holes out (model-richer residue)"
+    );
 
     // groups: the artifact's as-authored member lists equal the
     // model's authored selector displays, per group, in order.
@@ -672,7 +699,15 @@ fn main() { App { }; }
     );
     let e = &m.entities;
     // Topic names are author-spelled…
-    let orders = e.topics.iter().find(|t| t.name == "e::Orders").unwrap();
+    let orders = e
+        .topics
+        .iter()
+        .find(|t| t.display == "e::Orders")
+        .unwrap();
+    assert_eq!(
+        orders.name, "__lib_e_events_Orders",
+        "canonical topic identity is the RAW post-merge symbol"
+    );
     // …but the wire subject is the DECLARED subject, raw.
     assert_eq!(
         e.subjects[orders.subject.index()].pattern, "orders.wire",
@@ -680,7 +715,11 @@ fn main() { App { }; }
     );
     // A subject-less imported topic defaults to the RAW mangled
     // name (the byte-exact runtime join key), NOT `e::Audit`.
-    let audit = e.topics.iter().find(|t| t.name == "e::Audit").unwrap();
+    let audit = e
+        .topics
+        .iter()
+        .find(|t| t.display == "e::Audit")
+        .unwrap();
     assert_eq!(
         e.subjects[audit.subject.index()].pattern,
         "__lib_e_events_Audit",
@@ -1051,4 +1090,164 @@ fn main() { App { }; }
     // contracted edge carries the path's truth even though the user
     // call site has none.
     assert!(via.in_loop, "path crosses the router's entry loop");
+}
+
+// -----------------------------------------------------------------
+// Review round 7 — declared ends, unanalyzed bodies, the legacy
+// bridge, canonical identity.
+// -----------------------------------------------------------------
+
+/// P1 (round 7): a locus that DECLARES a publisher end but never
+/// sends still publishes in the endpoint sense — the grain
+/// `require publishes(...)` quantifies over.
+#[test]
+fn declared_publisher_ends_survive_without_sends() {
+    let src = r#"
+type T { n: Int = 0; }
+topic Orders { payload: T; subject: "orders.wire"; }
+locus Gateway {
+    params { n: Int = 0; }
+    bus { publish Orders; }
+    fn idle(v: Int) -> Int { return v; }
+}
+locus Sub {
+    params { seen: Int = 0; }
+    bus { subscribe Orders as on_o; }
+    fn on_o(t: T) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { g: Gateway = Gateway { }; s: Sub = Sub { }; }
+    run() { println(self.g.idle(1)); }
+}
+fn main() { App { }; }
+"#;
+    let m = derive(src);
+    let e = &m.entities;
+    // No send site exists…
+    assert!(m.relations.publishes.is_empty(), "no send expressions");
+    // …but the declared end does, with the topic's contract.
+    let end = m
+        .relations
+        .declares_publish
+        .iter()
+        .find(|d| e.loci[d.locus.index()].name == "Gateway")
+        .expect("Gateway's declared publisher end exists");
+    assert!(end.declared_topic.is_some());
+    assert_eq!(
+        e.subjects[end.subject.index()].pattern, "orders.wire",
+        "declared end carries the wire subject"
+    );
+}
+
+/// P1 (round 7): module-scoped and on_failure bodies the behavior
+/// analysis never walked HOLE OUT — the entities exist, their
+/// behavior is typed-unknown, and the capabilities go false.
+#[test]
+fn unanalyzed_bodies_hole_out() {
+    let src = r#"
+type T { n: Int = 0; }
+topic Evt { payload: T; subject: "evt"; }
+module hidden {
+    fn sneaky(f: fn (Int) -> Int, v: Int) -> Int { return f(v); }
+}
+locus Child {
+    params { n: Int = 0; }
+    fn poke(v: Int) { self.n = v; }
+}
+locus Parent {
+    params { c: Child = Child { }; }
+    bus { publish Evt; }
+    on_failure(c: Child, err: ClosureViolation) {
+        Evt <- T { n: 1 };
+        restart (c);
+    }
+}
+main locus App {
+    params { p: Parent = Parent { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let m = derive(src);
+    let e = &m.entities;
+    // The module fn and the failure handler EXIST as entities…
+    assert!(e.functions.iter().any(|f| f.name == "sneaky"));
+    let handler = e
+        .functions
+        .iter()
+        .find(|f| f.name.contains("on_failure"))
+        .expect("failure handler is an executable entity");
+    assert_eq!(handler.kind, hale_model::FunctionKind::Hook);
+    // …and both hole out as UnanalyzedBody…
+    let unanalyzed: Vec<String> = m
+        .holes
+        .iter()
+        .filter(|h| h.kind == HoleKind::UnanalyzedBody)
+        .filter_map(|h| match h.at {
+            EntityRef::Function(id) => {
+                Some(e.functions[id.index()].name.clone())
+            }
+            _ => None,
+        })
+        .collect();
+    assert!(
+        unanalyzed.iter().any(|n| n == "sneaky"),
+        "module body holes out: {:?}",
+        unanalyzed
+    );
+    assert!(
+        unanalyzed.iter().any(|n| n.contains("on_failure")),
+        "failure body holes out: {:?}",
+        unanalyzed
+    );
+    // …so the capabilities cannot lie.
+    assert!(!m.capabilities.exact_calls);
+    assert!(!m.capabilities.exact_bus_endpoints);
+    assert!(!m.capabilities.exact_effects);
+}
+
+/// P1 (round 7): canonical identity is importer-independent — the
+/// same declaration imported under two aliases is ONE identity with
+/// two spellings only at the display layer.
+#[test]
+fn canonical_identity_is_alias_independent() {
+    let lib = r#"
+locus __lib_x_kv_Store {
+    params { n: Int = 0; }
+    fn get(k: Int) -> Int { return self.n + k; }
+}
+"#;
+    let main_src = r#"
+main locus App {
+    params { s: __lib_x_kv_Store = __lib_x_kv_Store { }; }
+    run() { println(self.s.get(1)); }
+}
+fn main() { App { }; }
+"#;
+    let via_p = xseed_bundle(
+        main_src,
+        lib,
+        &[(&["p", "Store"], "__lib_x_kv_Store")],
+    );
+    let via_db = xseed_bundle(
+        main_src,
+        lib,
+        &[(&["db", "Store"], "__lib_x_kv_Store")],
+    );
+    let canon = |m: &hale_model::ApplicationModel| -> Vec<String> {
+        m.entities.loci.iter().map(|l| l.name.clone()).collect()
+    };
+    assert_eq!(
+        canon(&via_p),
+        canon(&via_db),
+        "alias choice must not change canonical identity"
+    );
+    let disp = |m: &hale_model::ApplicationModel| -> Vec<String> {
+        m.entities.loci.iter().map(|l| l.display.clone()).collect()
+    };
+    assert_ne!(
+        disp(&via_p),
+        disp(&via_db),
+        "…only the display spelling differs"
+    );
 }

--- a/crates/hale-types/tests/model_builder.rs
+++ b/crates/hale-types/tests/model_builder.rs
@@ -1490,3 +1490,206 @@ fn main() {
         .collect();
     assert_eq!(lattice, proj_ends, "lattice and legacy endpoints agree");
 }
+
+/// P1 (round 10): unresolved calls resolve BY SHAPE. A typed method
+/// miss (`w.tick()`) must never wire to a same-named free fn; a
+/// method on a module-scoped locus resolves to `RecvTy::method` in
+/// the declaration universe.
+#[test]
+fn unresolved_method_calls_resolve_by_shape() {
+    let src = r#"
+module hidden {
+    locus Store {
+        params { n: Int = 0; }
+        fn get(k: Int) -> Int { return self.n + k; }
+    }
+}
+fn tick() -> Int { return 1; }
+locus W {
+    params { n: Int = 0; }
+}
+fn poke(w: W, s: Store) -> Int {
+    let a = w.tick();
+    return s.get(1) + a;
+}
+main locus App {
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let m = derive(src);
+    let e = &m.entities;
+    let fname =
+        |id: hale_model::FunctionId| e.functions[id.index()].name.clone();
+    // The typed method miss on the module locus resolves to the raw
+    // qualified method…
+    assert!(
+        m.relations.calls.iter().any(|c| fname(c.from) == "poke"
+            && fname(c.to) == "Store::get"
+            && c.dispatch == DispatchKind::Direct),
+        "typed method miss resolves to RecvTy::method"
+    );
+    // …and `w.tick()` (no such method on W) must NOT acquire a
+    // false edge to the free fn `tick`.
+    assert!(
+        !m.relations
+            .calls
+            .iter()
+            .any(|c| fname(c.from) == "poke" && fname(c.to) == "tick"),
+        "a method miss never wires to a same-named free fn"
+    );
+}
+
+/// P1 (round 10): a qualified call kept at its AUTHOR spelling
+/// (`p::helper`) resolves to its raw imported identity in the
+/// universe.
+#[test]
+fn qualified_calls_into_unanalyzed_imports_resolve_raw() {
+    let lib = r#"
+module m {
+    fn __lib_e_events_helper(v: Int) -> Int { return v; }
+}
+"#;
+    let main_src = r#"
+fn caller(v: Int) -> Int { return p::helper(v); }
+main locus App {
+    run() { println(caller(1)); }
+}
+fn main() { App { }; }
+"#;
+    let m = xseed_bundle(
+        main_src,
+        lib,
+        &[(&["p", "helper"], "__lib_e_events_helper")],
+    );
+    let e = &m.entities;
+    let fname =
+        |id: hale_model::FunctionId| e.functions[id.index()].name.clone();
+    assert!(
+        m.relations.calls.iter().any(|c| fname(c.from) == "caller"
+            && fname(c.to) == "__lib_e_events_helper"),
+        "author-spelled qualified call resolves to the raw identity: {:?}",
+        m.relations
+            .calls
+            .iter()
+            .map(|c| (fname(c.from), fname(c.to)))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// P1 (round 10): the BusSubject VARIANT survives extraction — a
+/// literal endpoint whose text collides with a topic NAME keeps its
+/// literal wire address and its own `of type` contract; it is never
+/// rewritten into the declared topic.
+#[test]
+fn literal_endpoints_never_conflate_with_topics() {
+    let src = r#"
+type NamedPayload { id: Int = 0; }
+type LiteralPayload { value: String = ""; }
+topic Orders { payload: NamedPayload; subject: "wire.orders"; }
+locus Sink {
+    bus { subscribe "Orders" as on_literal of type LiteralPayload; }
+    fn on_literal(v: LiteralPayload) { }
+}
+main locus App {
+    params { s: Sink = Sink { }; }
+    bus { publish "Orders" of type LiteralPayload; }
+    run() {
+        "Orders" <- LiteralPayload { };
+        Orders <- NamedPayload { };
+    }
+}
+fn main() { App { }; }
+"#;
+    let m = derive(src);
+    let e = &m.entities;
+    let pattern =
+        |id: hale_model::SubjectId| e.subjects[id.index()].pattern.clone();
+    let shape = |id: hale_model::PayloadContractId| {
+        e.payloads[id.index()].shape.clone()
+    };
+    // Both addresses exist as distinct subjects.
+    let subjects: BTreeSet<String> =
+        e.subjects.iter().map(|s| s.pattern.clone()).collect();
+    assert!(subjects.contains("Orders"), "literal address: {subjects:?}");
+    assert!(
+        subjects.contains("wire.orders"),
+        "topic wire address: {subjects:?}"
+    );
+    // The literal SUBSCRIBE keeps address "Orders", no declared
+    // topic, and the LiteralPayload contract.
+    let sub = m
+        .relations
+        .subscribes
+        .iter()
+        .find(|s| pattern(s.subject) == "Orders")
+        .expect("literal subscription exists at its literal address");
+    assert_eq!(sub.declared_topic, None);
+    assert_eq!(shape(sub.payload), "value:s");
+    // The literal SEND stays a wire-address publish; the topic send
+    // resolves through the declaration.
+    let lit_pub = m
+        .relations
+        .publishes
+        .iter()
+        .find(|p| pattern(p.subject) == "Orders")
+        .expect("literal publish keeps its literal address");
+    assert_eq!(lit_pub.declared_topic, None);
+    assert_eq!(shape(lit_pub.payload), "value:s");
+    let topic_pub = m
+        .relations
+        .publishes
+        .iter()
+        .find(|p| pattern(p.subject) == "wire.orders")
+        .expect("topic publish resolves to the wire subject");
+    assert!(topic_pub.declared_topic.is_some());
+    assert_eq!(shape(topic_pub.payload), "id:i");
+    // The declared publisher end on the literal address keeps its
+    // own contract as well.
+    let dp = m
+        .relations
+        .declares_publish
+        .iter()
+        .find(|d| pattern(d.subject) == "Orders")
+        .expect("literal declared end exists");
+    assert_eq!(dp.declared_topic, None);
+    assert_eq!(shape(dp.payload), "value:s");
+}
+
+/// P1 (round 10): explicit `of type` endpoint clauses go through the
+/// ONE type-expression contract rule — non-named forms stay
+/// structurally distinct instead of collapsing to `opaque:?`.
+#[test]
+fn explicit_endpoint_payloads_keep_structural_identity() {
+    let src = r#"
+locus S {
+    bus {
+        subscribe "a" as on_a of type Int;
+        subscribe "b" as on_b of type (Int, Bool);
+        subscribe "c" as on_c of type [Int; 4];
+    }
+    fn on_a(v: Int) { }
+    fn on_b(v: (Int, Bool)) { }
+    fn on_c(v: [Int; 4]) { }
+}
+main locus App {
+    params { s: S = S { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let m = derive(src);
+    let e = &m.entities;
+    let shape_at = |addr: &str| -> String {
+        let sub = m
+            .relations
+            .subscribes
+            .iter()
+            .find(|s| e.subjects[s.subject.index()].pattern == addr)
+            .unwrap_or_else(|| panic!("subscription at {addr}"));
+        e.payloads[sub.payload.index()].shape.clone()
+    };
+    assert_eq!(shape_at("a"), "opaque:Int");
+    assert_eq!(shape_at("b"), "opaque:(Int,Bool)");
+    assert_eq!(shape_at("c"), "opaque:[Int; 4]");
+}

--- a/crates/hale-types/tests/model_builder.rs
+++ b/crates/hale-types/tests/model_builder.rs
@@ -1253,3 +1253,240 @@ fn main() { App { }; }
         "…only the display spelling differs"
     );
 }
+
+/// P1 (round 9): a DIRECT call from an analyzed body into an
+/// unanalyzed (module-scoped) callee is a KNOWN edge — the summary
+/// resolves callees only against its analyzed-body set, so the edge
+/// arrives `Unresolved`, but the declaration universe knows the
+/// target. Dropping it would make "a concrete path beats a hole"
+/// impossible: the path would be absent, and a boundary claim would
+/// miss a concrete cross-group call.
+#[test]
+fn direct_call_into_unanalyzed_callee_is_a_known_edge() {
+    let src = r#"
+module hidden {
+    fn helper(v: Int) -> Int { return v + 1; }
+}
+fn caller(v: Int) -> Int { return helper(v); }
+main locus App {
+    run() { println(caller(1)); }
+}
+fn main() { App { }; }
+"#;
+    let m = derive(src);
+    let e = &m.entities;
+    let fname =
+        |id: hale_model::FunctionId| e.functions[id.index()].name.clone();
+    let edge = m
+        .relations
+        .calls
+        .iter()
+        .find(|c| fname(c.from) == "caller" && fname(c.to) == "helper")
+        .expect("the concrete edge into the unanalyzed callee exists");
+    assert_eq!(edge.dispatch, DispatchKind::Direct);
+    // …and the callee still holes out, bounding reasoning PAST it —
+    // the edge and the hole coexist.
+    assert!(m.holes.iter().any(|h| h.kind == HoleKind::UnanalyzedBody
+        && matches!(h.at, EntityRef::Function(id)
+            if e.functions[id.index()].name == "helper")));
+    assert!(!m.capabilities.exact_calls);
+}
+
+/// P1 (round 9): opaque payload contracts and enum key-type names
+/// are RAW canonical identities — importer-independent — and
+/// structurally distinct payload forms stay distinct (no `opaque:?`
+/// collapse).
+#[test]
+fn opaque_identities_are_alias_independent_and_distinct() {
+    let lib = r#"
+type __lib_e_events_Status = enum { Up, Down };
+"#;
+    let main_src = r#"
+type Ping { st: __lib_e_events_Status = __lib_e_events_Status::Up; }
+topic Health { payload: __lib_e_events_Status; subject: "health"; }
+topic Pings { payload: Ping; subject: "pings"; keyed_by st; }
+main locus App {
+    bus { publish Pings; }
+    run() { Pings <- Ping { }; }
+}
+fn main() { App { }; }
+"#;
+    let via_p = xseed_bundle(
+        main_src,
+        lib,
+        &[(&["p", "Status"], "__lib_e_events_Status")],
+    );
+    let via_db = xseed_bundle(
+        main_src,
+        lib,
+        &[(&["db", "Status"], "__lib_e_events_Status")],
+    );
+    let contracts = |m: &hale_model::ApplicationModel| -> Vec<String> {
+        m.entities
+            .payloads
+            .iter()
+            .map(|p| p.shape.clone())
+            .collect()
+    };
+    // The enum payload's contract is the raw opaque identity, and
+    // it is byte-identical under both importer aliases.
+    assert_eq!(contracts(&via_p), contracts(&via_db));
+    assert!(
+        contracts(&via_p)
+            .iter()
+            .any(|s| s == "opaque:__lib_e_events_Status"),
+        "raw opaque identity, never the alias spelling: {:?}",
+        contracts(&via_p)
+    );
+    // The enum KEY type name is raw and alias-independent too.
+    let key_of = |m: &hale_model::ApplicationModel| -> Vec<String> {
+        m.relations
+            .publishes
+            .iter()
+            .filter_map(|p| match &p.key_domain {
+                Some(hale_model::KeyDomain::AnyOfType(t)) => {
+                    Some(t.clone())
+                }
+                _ => None,
+            })
+            .collect()
+    };
+    assert_eq!(key_of(&via_p), key_of(&via_db));
+    assert!(
+        key_of(&via_p)
+            .iter()
+            .any(|t| t == "__lib_e_events_Status"),
+        "AnyOfType names the RAW enum: {:?}",
+        key_of(&via_p)
+    );
+
+    // Distinctness: structurally different non-struct payload forms
+    // get different descriptors, not one shared `opaque:?`.
+    let m = derive(
+        r#"
+topic Pair { payload: (Int, Bool); subject: "pair"; }
+topic Row { payload: [Int; 4]; subject: "row"; }
+main locus App {
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#,
+    );
+    let shapes: BTreeSet<String> = m
+        .entities
+        .payloads
+        .iter()
+        .map(|p| p.shape.clone())
+        .collect();
+    assert!(
+        shapes.contains("opaque:(Int,Bool)"),
+        "tuple descriptor: {:?}",
+        shapes
+    );
+    assert!(
+        shapes.contains("opaque:[Int; 4]"),
+        "sized-array descriptor: {:?}",
+        shapes
+    );
+}
+
+/// P1 (round 9): `LegacyProjection.topology_v1_calls_via_stdlib`
+/// reproduces the artifact's serialized rows EXACTLY — from/to AND
+/// the loop bit, which sits inside the hashed model half. The
+/// projection runs the shared LEGACY walk (one Boolean, no
+/// revisit), not the model's lattice, whose loop bits may be
+/// legitimately stronger.
+#[test]
+fn legacy_via_stdlib_projection_matches_the_artifact_exactly() {
+    // The #392 recipe that manufactures a real user→stdlib→user
+    // contracted edge: Router.dispatch's interior reaches the
+    // registered user handler.
+    let src = r#"
+locus Hello {
+    fn handle(ctx: std::http::Context) -> std::http::Response {
+        return std::http::Response {
+            status: 200,
+            content_type: "text/plain",
+            body: "hi"
+        };
+    }
+}
+locus Gate {
+    fn probe(r: std::http::Router, req: std::http::Request) -> Int {
+        let resp = r.dispatch(req);
+        return resp.status;
+    }
+}
+fn main() {
+    let r = std::http::Router { };
+    r.add("GET", "/", Hello { });
+    let req = std::http::Request { method: "GET", path: "/", body: "" };
+    println(Gate { }.probe(r, req));
+}
+"#;
+    let (program, ()) = bundle_of(src);
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let m = derive_application_model(&bundle);
+    m.validate().expect("lawful");
+    let art: serde_json::Value = serde_json::from_str(
+        &hale_types::topology::dump_topology(&bundle),
+    )
+    .expect("artifact parses");
+
+    let e = &m.entities;
+    let art_rows: BTreeSet<(String, String, bool)> = art["relations"]
+        ["calls_via_stdlib"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| {
+            (
+                r["from"].as_str().unwrap().to_string(),
+                r["to"].as_str().unwrap().to_string(),
+                r["loop"].as_bool().unwrap_or(false),
+            )
+        })
+        .collect();
+    assert!(
+        !art_rows.is_empty(),
+        "the recipe must manufacture a contracted edge"
+    );
+    // Artifact strings are DISPLAY — project through display fields.
+    let proj_rows: BTreeSet<(String, String, bool)> = m
+        .legacy
+        .topology_v1_calls_via_stdlib
+        .iter()
+        .map(|(f, t, l)| {
+            (
+                e.functions[f.index()].display.clone(),
+                e.functions[t.index()].display.clone(),
+                *l,
+            )
+        })
+        .collect();
+    assert_eq!(
+        art_rows, proj_rows,
+        "projection reproduces serialized rows incl. loop bits"
+    );
+    // The model's OWN lattice rows agree on endpoints (the loop bit
+    // may only ever be stronger there, never on fewer endpoints).
+    let lattice: BTreeSet<(String, String)> = m
+        .relations
+        .calls
+        .iter()
+        .filter(|c| c.dispatch == DispatchKind::ViaStdlib)
+        .map(|c| {
+            (
+                e.functions[c.from.index()].display.clone(),
+                e.functions[c.to.index()].display.clone(),
+            )
+        })
+        .collect();
+    let proj_ends: BTreeSet<(String, String)> = proj_rows
+        .iter()
+        .map(|(f, t, _)| (f.clone(), t.clone()))
+        .collect();
+    assert_eq!(lattice, proj_ends, "lattice and legacy endpoints agree");
+}

--- a/crates/hale-types/tests/model_builder.rs
+++ b/crates/hale-types/tests/model_builder.rs
@@ -1155,13 +1155,15 @@ locus Child {
     fn poke(v: Int) { self.n = v; }
 }
 locus Parent {
-    params { c: Child = Child { }; }
+    params { c: Child = Child { }; cb: fn (Int) -> Int = fallback_fn; }
     bus { publish Evt; }
     on_failure(c: Child, err: ClosureViolation) {
         Evt <- T { n: 1 };
-        restart (c);
+        let v = self.cb(1);
+        if v > 0 { restart (c); }
     }
 }
+fn fallback_fn(v: Int) -> Int { return v; }
 main locus App {
     params { p: Parent = Parent { }; }
     run() { println(1); }

--- a/crates/hale-types/tests/model_builder.rs
+++ b/crates/hale-types/tests/model_builder.rs
@@ -68,6 +68,7 @@ locus Worker {
     fn on_r(r: Reading) {
         self.seen = self.seen + 1;
         if r.v > 100 { Cmds <- Cmd { op: call_it(double, r.v) } or discard; }
+        Cmds <- Cmd { op: 0 } or raise;
     }
 }
 
@@ -230,7 +231,14 @@ fn model_and_artifact_extract_the_same_facts() {
         .collect();
     let model_fns: BTreeSet<String> =
         e.functions.iter().map(|f| f.name.clone()).collect();
-    assert_eq!(art_fns, model_fns, "fn sorts agree");
+    // The model's universe is DECLARATIONS (round 6): a superset of
+    // the artifact's summary-derived sort — an empty fn exists here
+    // and not there. Change 3's projection filters back down.
+    assert!(
+        art_fns.is_subset(&model_fns),
+        "artifact fn sort ⊆ model universe; missing: {:?}",
+        art_fns.difference(&model_fns).collect::<Vec<_>>()
+    );
 
     // loci sort equality.
     let art_loci: BTreeSet<String> = art["sorts"]["loci"]
@@ -586,4 +594,461 @@ fn every_corpus_program_derives_a_lawful_model() {
         bad.len(),
         bad.join("\n")
     );
+}
+
+// -----------------------------------------------------------------
+// Review round 6 — identity separation, dispositions, sites, the
+// declaration-derived function universe, and key types.
+// -----------------------------------------------------------------
+
+/// Builds a post-merge bundle the way the import pass does: the
+/// imported seed's decls arrive mangled, and import_renames maps
+/// author paths to mangled names.
+fn xseed_bundle(
+    main_src: &str,
+    lib_src: &str,
+    renames: &[(&[&str], &str)],
+) -> hale_model::ApplicationModel {
+    let main_p = hale_syntax::parse_source(main_src).expect("parse main");
+    let lib_p = hale_syntax::parse_source(lib_src).expect("parse lib");
+    let mut programs = BTreeMap::new();
+    programs.insert("app/main.hl".to_string(), &main_p);
+    programs.insert("lib/events.hl".to_string(), &lib_p);
+    let mut bundle = Bundle::new(programs);
+    bundle.import_renames = renames
+        .iter()
+        .map(|(segs, m)| {
+            (
+                segs.iter().map(|s| s.to_string()).collect(),
+                m.to_string(),
+            )
+        })
+        .collect();
+    let m = derive_application_model(&bundle);
+    m.validate().expect("cross-seed model is lawful");
+    m
+}
+
+/// P1 (round 6): raw identity vs author spelling for imported
+/// topics — the wire subject is the DECLARED subject (or the raw
+/// mangled default), never the author spelling; the topic NAME is
+/// the author spelling; named selectors store author spelling.
+#[test]
+fn imported_topic_identities_stay_separated() {
+    let lib = r#"
+type __lib_e_events_Order { id: Int = 0; }
+topic __lib_e_events_Orders {
+    payload: __lib_e_events_Order;
+    subject: "orders.wire";
+}
+topic __lib_e_events_Audit { payload: __lib_e_events_Order; }
+locus __lib_e_events_Worker {
+    params { n: Int = 0; }
+    fn poke(v: Int) -> Int { return v + self.n; }
+}
+"#;
+    let main_src = r#"
+group workers = { __lib_e_events_Worker };
+locus Sub {
+    params { seen: Int = 0; }
+    bus { subscribe __lib_e_events_Orders as on_o; }
+    fn on_o(o: __lib_e_events_Order) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { s: Sub = Sub { }; }
+    run() { println(self.s.seen); }
+}
+fn main() { App { }; }
+"#;
+    let m = xseed_bundle(
+        main_src,
+        lib,
+        &[
+            (&["e", "Order"], "__lib_e_events_Order"),
+            (&["e", "Orders"], "__lib_e_events_Orders"),
+            (&["e", "Audit"], "__lib_e_events_Audit"),
+            (&["e", "Worker"], "__lib_e_events_Worker"),
+        ],
+    );
+    let e = &m.entities;
+    // Topic names are author-spelled…
+    let orders = e.topics.iter().find(|t| t.name == "e::Orders").unwrap();
+    // …but the wire subject is the DECLARED subject, raw.
+    assert_eq!(
+        e.subjects[orders.subject.index()].pattern, "orders.wire",
+        "explicit subject survives import demangling"
+    );
+    // A subject-less imported topic defaults to the RAW mangled
+    // name (the byte-exact runtime join key), NOT `e::Audit`.
+    let audit = e.topics.iter().find(|t| t.name == "e::Audit").unwrap();
+    assert_eq!(
+        e.subjects[audit.subject.index()].pattern,
+        "__lib_e_events_Audit",
+        "subject-less imported topic keeps its raw wire identity"
+    );
+    // Named selector display is author-spelled even though the
+    // import pass collapsed the member to a mangled segment.
+    let sel = &m.relations.group_selectors[0];
+    match &sel.selector {
+        SelectorForm::Named { display, .. } => {
+            assert_eq!(display, "e::Worker", "selector display demangled")
+        }
+        other => panic!("expected Named selector, got {:?}", other),
+    }
+}
+
+/// P1 (round 6): payload identity is SHAPE-only. Equal shapes on
+/// two subjects share one contract; a field change on a literal
+/// endpoint's type changes its contract; a rename that keeps the
+/// structure does not.
+#[test]
+fn payload_identity_is_structural() {
+    let two_subjects = r#"
+type Evt { n: Int = 0; }
+topic A { payload: Evt; subject: "wire.a"; }
+topic B { payload: Evt; subject: "wire.b"; }
+locus S {
+    params { n: Int = 0; }
+    bus { subscribe A as on_a; subscribe B as on_b; }
+    fn on_a(e: Evt) { self.n = self.n + e.n; }
+    fn on_b(e: Evt) { self.n = self.n + e.n; }
+}
+main locus App {
+    params { s: S = S { }; }
+    bus { publish A; publish B; }
+    run() { A <- Evt { n: 1 }; B <- Evt { n: 2 }; }
+}
+fn main() { App { }; }
+"#;
+    let m = derive(two_subjects);
+    let a = m.entities.topics.iter().find(|t| t.name == "A").unwrap();
+    let b = m.entities.topics.iter().find(|t| t.name == "B").unwrap();
+    assert_eq!(
+        a.payload, b.payload,
+        "one shape on two subjects = ONE payload contract"
+    );
+
+    let lit = |fields: &str| {
+        format!(
+            r#"
+type Event {{ {} }}
+locus S {{
+    params {{ n: Int = 0; }}
+    bus {{ subscribe "orders.created" as on_e of type Event; }}
+    fn on_e(e: Event) {{ self.n = self.n + 1; }}
+}}
+main locus App {{
+    params {{ s: S = S {{ }}; }}
+    run() {{ println(self.n_of()); }}
+    fn n_of() -> Int {{ return 0; }}
+}}
+fn main() {{ App {{ }}; }}
+"#,
+            fields
+        )
+    };
+    let shape_of = |src: &str| -> (String, u64) {
+        let m = derive(src);
+        let sub = &m.relations.subscribes[0];
+        let p = &m.entities.payloads[sub.payload.index()];
+        (p.shape.clone(), p.hash)
+    };
+    let v1 = shape_of(&lit("id: Int = 0;"));
+    let v2 = shape_of(&lit("id: Int = 0; amount: Decimal = 0.0d;"));
+    assert_ne!(
+        v1, v2,
+        "adding a field to a literal endpoint's type MUST change \
+         its contract"
+    );
+    // Rename without structural change: same shape.
+    let renamed = lit("id: Int = 0;").replace("Event", "Evt2");
+    assert_eq!(
+        v1,
+        shape_of(&renamed),
+        "renaming a type without changing structure keeps the contract"
+    );
+}
+
+/// P1 (round 6): dispositions survive. Two sends to one topic in
+/// one function — `or discard` and `or raise` — are two site rows
+/// with distinct dispositions.
+#[test]
+fn publish_dispositions_are_preserved_per_site() {
+    let m = derive(RICH);
+    let e = &m.entities;
+    let cmds_rows: Vec<_> = m
+        .relations
+        .publishes
+        .iter()
+        .filter(|p| {
+            p.declared_topic
+                .map(|t| e.topics[t.index()].name == "Cmds")
+                .unwrap_or(false)
+        })
+        .collect();
+    assert_eq!(cmds_rows.len(), 2, "two authored sites on Cmds");
+    let dispositions: BTreeSet<_> = cmds_rows
+        .iter()
+        .map(|p| format!("{:?}", p.disposition))
+        .collect();
+    assert_eq!(
+        dispositions,
+        ["Discard".to_string(), "Raise".to_string()]
+            .into_iter()
+            .collect(),
+        "each site keeps ITS disposition"
+    );
+    assert_ne!(cmds_rows[0].site, cmds_rows[1].site);
+}
+
+/// P1 (round 6): AnyOfType names the key's TYPE, not the field.
+#[test]
+fn key_domain_names_the_key_type() {
+    let m = derive(RICH);
+    let keyed: Vec<_> = m
+        .relations
+        .publishes
+        .iter()
+        .filter_map(|p| match &p.key_domain {
+            Some(hale_model::KeyDomain::AnyOfType(t)) => Some(t.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(keyed, ["Int"], "keyed_by sensor (an Int field) → Int");
+}
+
+/// P1 (round 6): one interface dispatch = ONE authored site shared
+/// by every conformer row, and adding a conformer must not renumber
+/// later calls.
+#[test]
+fn interface_alternatives_share_one_site() {
+    let base = |extra_conformer: &str| {
+        format!(
+            r#"
+interface Notifier {{
+    fn notify(v: Int) -> Int;
+}}
+locus Bell {{
+    params {{ n: Int = 0; }}
+    fn notify(v: Int) -> Int {{ return v + 1; }}
+}}
+locus Horn {{
+    params {{ n: Int = 0; }}
+    fn notify(v: Int) -> Int {{ return v + 2; }}
+}}
+{}
+fn after(v: Int) -> Int {{ return v; }}
+fn go(x: Notifier, v: Int) -> Int {{
+    let a = x.notify(v);
+    let b = after(a);
+    return b;
+}}
+main locus App {{
+    run() {{
+        let e = Bell {{ }};
+        println(go(e, 1));
+    }}
+}}
+fn main() {{ App {{ }}; }}
+"#,
+            extra_conformer
+        )
+    };
+    let site_facts = |src: &str| {
+        let m = derive(src);
+        let e = m.entities.clone();
+        let fname = |id: hale_model::FunctionId| {
+            e.functions[id.index()].name.clone()
+        };
+        let iface_sites: BTreeSet<u32> = m
+            .relations
+            .calls
+            .iter()
+            .filter(|c| {
+                matches!(c.dispatch, DispatchKind::Interface { .. })
+            })
+            .map(|c| c.site)
+            .collect();
+        let iface_rows = m
+            .relations
+            .calls
+            .iter()
+            .filter(|c| {
+                matches!(c.dispatch, DispatchKind::Interface { .. })
+            })
+            .count();
+        let after_site = m
+            .relations
+            .calls
+            .iter()
+            .find(|c| fname(c.to) == "after")
+            .map(|c| c.site)
+            .expect("the later direct call exists");
+        (iface_rows, iface_sites, after_site)
+    };
+    let (rows2, sites2, after2) = site_facts(&base(""));
+    assert_eq!(rows2, 2, "two conformers = two rows");
+    assert_eq!(sites2.len(), 1, "…sharing ONE authored site");
+    let (rows3, sites3, after3) = site_facts(&base(
+        "locus Siren { params { n: Int = 0; } \
+         fn notify(v: Int) -> Int { return v + 3; } }",
+    ));
+    assert_eq!(rows3, 3, "three conformers = three rows");
+    assert_eq!(sites3.len(), 1, "…still one authored site");
+    assert_eq!(
+        after2, after3,
+        "adding a conformer must not renumber the later call"
+    );
+}
+
+/// P1 (round 6): the function universe comes from DECLARATIONS. An
+/// empty free fn exists (and stays groupable); a mode is a Mode,
+/// not a Hook.
+#[test]
+fn declaration_universe_includes_empty_fns_and_modes() {
+    let src = r#"
+fn unused_helper() { }
+locus Cell {
+    params { v: Int = 0; }
+    mode bulk() -> Int { return self.v; }
+    fn poke(v: Int) { self.v = v; }
+}
+group helpers = { unused_helper };
+main locus App {
+    params { c: Cell = Cell { }; }
+    run() { self.c.poke(2); println(self.c.bulk()); }
+}
+fn main() { App { }; }
+"#;
+    let m = derive(src);
+    let e = &m.entities;
+    let helper = e
+        .functions
+        .iter()
+        .find(|f| f.name == "unused_helper")
+        .expect("an EMPTY free fn is still an entity");
+    assert_eq!(helper.kind, hale_model::FunctionKind::Free);
+    // …and its group membership resolved.
+    assert!(m.relations.group_members.iter().any(|gm| matches!(
+        gm.member,
+        EntityRef::Function(id)
+            if e.functions[id.index()].name == "unused_helper"
+    )));
+    let bulk = e
+        .functions
+        .iter()
+        .find(|f| f.name == "Cell::bulk")
+        .expect("mode present");
+    assert_eq!(
+        bulk.kind,
+        hale_model::FunctionKind::Mode,
+        "a mode is a Mode, not a Hook"
+    );
+}
+
+/// P1 (round 6): "inside a loop" and "unbounded" are SEPARATE
+/// facts, at both grains the model records.
+///
+/// Direct grain: the summarizer proves `while i < 3` bounded, so a
+/// call inside it is (in_loop, !unbounded) — the exact cell the old
+/// single-boolean lattice destroyed — while `while true` is
+/// (in_loop, unbounded).
+///
+/// Contraction grain: the Router-dispatch path re-emerges at the
+/// user handler THROUGH the router's own entry loop, so the
+/// contracted edge is honestly (true, true) even when the user call
+/// site has no loop — the flags reflect the whole path, joined with
+/// the two-component lattice (revisit-on-strengthen, so results
+/// cannot depend on traversal order). No current stdlib surface
+/// re-emerges at user code through a PROVEN-bounded interior path;
+/// when one exists, pin the (true, false) contraction cell here.
+#[test]
+fn loop_and_unbounded_stay_separate_facts() {
+    let src = r#"
+fn leaf(v: Int) -> Int { return v + 1; }
+fn bounded_caller() -> Int {
+    let mut acc = 0;
+    let mut i = 0;
+    while i < 3 {
+        acc = acc + leaf(i);
+        i = i + 1;
+    }
+    return acc;
+}
+fn unbounded_caller() -> Int {
+    let mut acc = 0;
+    while true {
+        acc = acc + leaf(acc);
+        if acc > 10 { return acc; }
+    }
+    return acc;
+}
+fn main() { println(bounded_caller() + unbounded_caller()); }
+"#;
+    let m = derive(src);
+    let e = &m.entities;
+    let fname =
+        |id: hale_model::FunctionId| e.functions[id.index()].name.clone();
+    let flags = |from: &str| -> (bool, bool) {
+        let c = m
+            .relations
+            .calls
+            .iter()
+            .find(|c| fname(c.from) == from && fname(c.to) == "leaf")
+            .expect("edge exists");
+        (c.in_loop, c.unbounded)
+    };
+    assert_eq!(
+        flags("bounded_caller"),
+        (true, false),
+        "a PROVEN-bounded loop is looped but NOT unbounded — the \
+         cell a single-boolean lattice destroys"
+    );
+    assert_eq!(flags("unbounded_caller"), (true, true));
+}
+
+#[test]
+fn stdlib_contraction_reflects_the_whole_path() {
+    let src = r#"
+type Req { n: Int = 0; }
+locus Fwd {
+    params { n: Int = 0; }
+    fn handle(ctx: std::http::Context) -> std::http::Response {
+        return std::http::Response { status: 200, body: "ok" };
+    }
+}
+locus Oms {
+    params { n: Int = 0; }
+    fn kick(i: Int) {
+        let r = std::http::Router { };
+        r.add("GET", "/fwd", Fwd { });
+        let resp = r.dispatch(std::http::Request {
+            method: "GET", path: "/fwd", body: ""
+        });
+        self.n = resp.status;
+    }
+}
+main locus App {
+    params { o: Oms = Oms { }; }
+    run() { self.o.kick(1); }
+}
+fn main() { App { }; }
+"#;
+    let m = derive(src);
+    let e = &m.entities;
+    let fname =
+        |id: hale_model::FunctionId| e.functions[id.index()].name.clone();
+    let via = m
+        .relations
+        .calls
+        .iter()
+        .find(|c| {
+            c.dispatch == DispatchKind::ViaStdlib
+                && fname(c.to) == "Fwd::handle"
+        })
+        .expect("the through-stdlib edge to the handler exists");
+    // The router's entry walk is a loop the path crosses — the
+    // contracted edge carries the path's truth even though the user
+    // call site has none.
+    assert!(via.in_loop, "path crosses the router's entry loop");
 }


### PR DESCRIPTION
Change 2 of the #476 epic: one derivation entry point, `hale_types::model_builder::derive_application_model(&Bundle)`, assembling the canonical model from the same trusted analyses the topology artifact consumes — `AllocSummary` (calls at **site grain**, effect sites, unresolved residue), `BusGraph` (endpoint sites, payloads, spans), `model::Model` (phases, seeds, decl spans), effects/frontier (derived classes, declared carriers) — plus direct AST reads for the facts no summary carries: topic key/bound policy, subscription filters and bounds, **authored group selectors with globs unexpanded**, the full declaration universe, `@sealed`. The through-stdlib contraction is the artifact's own walk. Uninhabited dispatches land in `dead_interface_calls`; genuine residue becomes typed holes; **capabilities are computed from the holes**, so the two completeness accounts cannot drift by construction. Ownership/placement/bindings stay empty with capabilities `false` — Change 8 completes them; the artifact exports none today, so Change-2 parity doesn't need them.

One schema amendment rode along: `Supervises.child` became `SupervisedRef::{Locus, External}` — transport supervision (#233) supervises substrate types that are not locus declarations, and the schema shouldn't pretend.

## The demand contract, proven cross-process

The builder runs **only** for the new `hale model dump <target>` surface (internal, explicitly non-stable rendering; the same ill-typed refusal as the artifact; a `validate()` failure on a derived model reports as an internal error, loudly). Plain `hale check` — *with claims present*, *with `--dump-topology`* — provably never derives it: `HALE_MODEL_TRACE=1` stays silent, pinned by tests that run the real binary. In-process instrumentation via `model_builder::builds()`.

## Tested three ways

- **Family fixtures**: keyed delivery (EqReplica + fallback catch + `AnyOfType` publish domains — typed, no spurious holes), topic bounds, bounded subscriptions with shed policies, literal/wildcard endpoints, per-handler supervision with retry bounds, authored selectors in order, dead-vs-indirect separation, clean-program exactness.
- **A model/artifact differential**: both extractions agree on fns, loci, call endpoints, through-stdlib edges, publishes, subscribes, residue anchors, authored group selectors, supervision rows, and per-fn effects — the seed of Change 3's projection differential.
- **A whole-corpus property**, two-sided: derivation never panics on any parseable program, and a derived model may violate a schema law *only where the checker also refuses the program* (negative fixtures' models mirror the checker's refusals; checks-clean-but-unlawful is a builder bug). This property earned its keep on its first run: it caught a fail-open glob-alias default and two non-total lookup paths in this very builder — fixed with a totality pre-pass (unknown endpoints get subject rows + `?` payload contracts; unresolved glob aliases synthesize their authored Seed).

Local runs: builder 6/6, model CLI 4/4, renderer suite unaffected 15/15, hale-types + hale-model full suites 919/919, `hale fmt --check` clean.

Next per the build order: Change 3 (legacy topology projection + `TopologyShapeV1` differential over the corpus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)