### PR TITLE
feat(types): model-backed artifact projection + TopologyShapeV1 corpus differential (GH #476 Change 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ behavior.
 
 ## Unreleased
 
+### The model-backed artifact projection (GH #476 Change 3)
+
+`hale_types::topology_projection::project_model_half(&ApplicationModel)`
+renders the topology artifact's hashed model half from the canonical
+model alone, and `project_shape_hash` reproduces `TopologyShapeV1`
+exactly - proven byte-for-byte against `dump_topology`'s own
+derivation over every checkable corpus program by a permanent
+differential gate (`tests/topology_projection.rs`). The projection
+maps the model's raw canonical identities back to the artifact's
+display spelling, merges site-grained rows to the legacy endpoint
+grain, renders `calls_via_stdlib` from the preserved legacy
+contraction rows, and re-folds typed holes + dead interface
+dispatches into the legacy `unknowns` vocabulary. Both derivations
+stay live until the Change-6 versioned identity transition: a model
+change that would silently re-key `.halerec` replay admission now
+fails the differential instead. No user-visible behavior change.
+
 ### The ApplicationModel builder - demand-gated derivation (GH #476 Change 2)
 
 `hale_types::model_builder::derive_application_model(&Bundle)` - one

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -737,9 +737,14 @@ impl ApplicationModel {
         }
         check_sorted_keys(
             "supervises",
-            r.supervises
-                .iter()
-                .map(|x| (x.parent, x.child.clone(), &x.error_type)),
+            r.supervises.iter().map(|x| {
+                (
+                    x.parent,
+                    x.child.clone(),
+                    &x.error_type,
+                    x.authored_ordinal,
+                )
+            }),
         )?;
         for (i, x) in r.supervises.iter().enumerate() {
             let child_ok = match &x.child {

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -792,7 +792,36 @@ impl ApplicationModel {
         }
 
         // --- labels / weights.
-        check_sorted_keys("labels", self.labels.iter().map(|l| (l.at, &l.label)))?;
+        // Labels are grouped by entity in canonical entity order,
+        // but WITHIN one entity the label order is semantic — the
+        // declared class order the artifact hashes (`zebra` declared
+        // before `alpha` renders before it) — so rows are NOT fully
+        // key-sorted (review round 11; mirrors `Function.effects`,
+        // whose declaration order was already preserved).
+        {
+            let mut prev_at: Option<crate::ids::EntityRef> = None;
+            let mut seen: std::collections::BTreeSet<(
+                crate::ids::EntityRef,
+                &String,
+            )> = std::collections::BTreeSet::new();
+            for (i, l) in self.labels.iter().enumerate() {
+                if let Some(p) = prev_at {
+                    if l.at < p {
+                        return Err(ModelError::NotCanonical {
+                            table: "labels",
+                            index: i,
+                        });
+                    }
+                }
+                prev_at = Some(l.at);
+                if !seen.insert((l.at, &l.label)) {
+                    return Err(ModelError::NotCanonical {
+                        table: "labels",
+                        index: i,
+                    });
+                }
+            }
+        }
         for (i, l) in self.labels.iter().enumerate() {
             if !ref_ok(&l.at) {
                 return Err(ModelError::DanglingId {

--- a/crates/hale-model/src/hole.rs
+++ b/crates/hale-model/src/hole.rs
@@ -58,8 +58,12 @@ impl RelationSet {
 pub enum HoleKind {
     /// A call through a fn pointer / indirect site.
     IndirectCall,
-    /// A method call on a receiver the summarizer cannot type.
-    UntypedReceiver,
+    /// A method call on a receiver the summarizer cannot type. The
+    /// dispatched method name is MACHINE data (the legacy artifact's
+    /// `untyped_receiver_call:<callee>` row requires it), so it
+    /// lives here in the kind — never parsed back out of the
+    /// human-readable `reason` text (review round 11).
+    UntypedReceiver { callee: String },
     /// A publish whose subject is computed at runtime.
     ComputedSubject,
     /// A keyed publish/subscription whose key values are unknown

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -303,5 +303,12 @@ pub struct Supervises {
     /// The handled error/violation type's canonical name.
     pub error_type: String,
     pub policy: SupervisionPolicy,
+    /// Authored declaration order across the bundle walk. Handler
+    /// order is an authored fact the legacy artifact depends on:
+    /// its encoder collects handlers in source order and
+    /// stable-sorts by (locus, child) only, so handlers sharing
+    /// both serialize in authored order, not error-type order
+    /// (review round 11). Not part of the canonical key.
+    pub authored_ordinal: u32,
     pub provenance: ProvenanceId,
 }

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -312,7 +312,10 @@ pub struct Supervises {
     /// its encoder collects handlers in source order and
     /// stable-sorts by (locus, child) only, so handlers sharing
     /// both serialize in authored order, not error-type order
-    /// (review round 11). Not part of the canonical key.
+    /// (review round 11). PART OF THE CANONICAL KEY: two handlers
+    /// with identical (parent, child, error_type) signatures are
+    /// check-clean and both serialize in the legacy artifact, so
+    /// the model must hold both rows (review round 14).
     pub authored_ordinal: u32,
     pub provenance: ProvenanceId,
 }

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -275,7 +275,11 @@ pub struct TopicBinding {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct SupervisionPolicy {
     pub ops: Vec<String>,
-    pub retry_bound: Option<u32>,
+    /// The literal as WRITTEN — i64 like the legacy artifact, which
+    /// serializes any int literal the parser accepted (`for
+    /// 4294967296` is check-clean; a narrower type here silently
+    /// truncated it — review round 13).
+    pub retry_bound: Option<i64>,
 }
 
 /// What an `on_failure` handler supervises. Usually a declared

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -353,6 +353,7 @@ fn unsorted_supervises_are_not_canonical() {
                 ops: vec!["restart".to_string()],
                 retry_bound: Some(3),
             },
+            authored_ordinal: 0,
             provenance: p,
         },
         Supervises {
@@ -363,6 +364,7 @@ fn unsorted_supervises_are_not_canonical() {
                 ops: vec!["restart".to_string()],
                 retry_bound: None,
             },
+            authored_ordinal: 0,
             provenance: p,
         },
     ];
@@ -637,6 +639,7 @@ fn supervision_is_per_error_type() {
                 ops: vec!["restart".to_string()],
                 retry_bound: Some(3),
             },
+            authored_ordinal: 0,
             provenance: p,
         },
         Supervises {
@@ -647,6 +650,7 @@ fn supervision_is_per_error_type() {
                 ops: vec!["replace".to_string()],
                 retry_bound: None,
             },
+            authored_ordinal: 0,
             provenance: p,
         },
     ];
@@ -1321,4 +1325,56 @@ fn legacy_projection_is_validated() {
             index: 0
         })
     );
+}
+
+/// Round 11: label rows are grouped by entity in canonical entity
+/// order, but WITHIN one entity the label order is semantic
+/// (declared class order, which the artifact hashes) — non-lexical
+/// in-entity order is LAWFUL, out-of-order entities and duplicate
+/// (entity, label) pairs are not.
+#[test]
+fn label_order_is_semantic_within_an_entity() {
+    use hale_model::LabelRow;
+    let mut m = tiny_model();
+    let p = m.labels.first().map(|l| l.provenance).unwrap_or(
+        hale_model::ProvenanceId(0),
+    );
+    // Non-lexical order within one entity: lawful.
+    m.labels = vec![
+        LabelRow {
+            at: EntityRef::Function(FunctionId(0)),
+            label: "zebra".to_string(),
+            provenance: p,
+        },
+        LabelRow {
+            at: EntityRef::Function(FunctionId(0)),
+            label: "alpha".to_string(),
+            provenance: p,
+        },
+    ];
+    m.validate().expect("declaration order within an entity is lawful");
+    // Duplicate (entity, label): rejected.
+    m.labels.push(LabelRow {
+        at: EntityRef::Function(FunctionId(0)),
+        label: "zebra".to_string(),
+        provenance: p,
+    });
+    assert!(matches!(
+        m.validate(),
+        Err(hale_model::ModelError::NotCanonical { table: "labels", .. })
+    ));
+    m.labels.pop();
+    // Interleaved entities (0, then 1, then 0 again): rejected.
+    m.labels.insert(
+        1,
+        LabelRow {
+            at: EntityRef::Function(FunctionId(1)),
+            label: "alpha".to_string(),
+            provenance: p,
+        },
+    );
+    assert!(matches!(
+        m.validate(),
+        Err(hale_model::ModelError::NotCanonical { table: "labels", .. })
+    ));
 }

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -351,7 +351,7 @@ fn unsorted_supervises_are_not_canonical() {
             error_type: "IoError".to_string(),
             policy: SupervisionPolicy {
                 ops: vec!["restart".to_string()],
-                retry_bound: Some(3),
+                retry_bound: Some(3i64),
             },
             authored_ordinal: 0,
             provenance: p,
@@ -637,7 +637,7 @@ fn supervision_is_per_error_type() {
             error_type: "ClosureViolation".to_string(),
             policy: SupervisionPolicy {
                 ops: vec!["restart".to_string()],
-                retry_bound: Some(3),
+                retry_bound: Some(3i64),
             },
             authored_ordinal: 0,
             provenance: p,

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -33,6 +33,7 @@ pub mod model;
 pub mod model_builder;
 pub mod topic_identity;
 pub mod topology;
+pub mod topology_projection;
 pub mod model_graph;
 pub mod verdict;
 pub mod stdlib_bodies;

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -1647,9 +1647,13 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     }
 
     // supervision (same walk as the artifact's, per-handler).
+    // Keyed WITH the authored ordinal: duplicate-signature handlers
+    // are check-clean and the legacy artifact serializes each
+    // declaration -- a (parent, child, err)-only key silently
+    // dropped the earlier one (review round 14).
     let mut sup: BTreeMap<
-        (LocusDeclId, SupervisedRef, String),
-        (Vec<String>, Option<i64>, u32, ProvenanceId),
+        (LocusDeclId, SupervisedRef, String, u32),
+        (Vec<String>, Option<i64>, ProvenanceId),
     > = BTreeMap::new();
     {
         fn te_name(t: &TypeExpr) -> String {
@@ -1743,8 +1747,8 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                         .unwrap_or_else(|| "?".to_string());
                     let pid = intern_span(&mut records, fd.span);
                     sup.insert(
-                        (parent, child, err),
-                        (ops, retry, authored, pid),
+                        (parent, child, err, authored),
+                        (ops, retry, pid),
                     );
                     authored += 1;
                 }
@@ -2077,7 +2081,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             provenance: *pid,
         });
     }
-    for ((parent, child, err), (ops, retry, authored, pid)) in &sup {
+    for ((parent, child, err, authored), (ops, retry, pid)) in &sup {
         r.supervises.push(Supervises {
             parent: *parent,
             child: child.clone(),

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -1649,7 +1649,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     // supervision (same walk as the artifact's, per-handler).
     let mut sup: BTreeMap<
         (LocusDeclId, SupervisedRef, String),
-        (Vec<String>, Option<u32>, u32, ProvenanceId),
+        (Vec<String>, Option<i64>, u32, ProvenanceId),
     > = BTreeMap::new();
     {
         fn te_name(t: &TypeExpr) -> String {
@@ -1666,7 +1666,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         fn walk_ops(
             b: &Block,
             ops: &mut Vec<String>,
-            retry: &mut Option<u32>,
+            retry: &mut Option<i64>,
         ) {
             for st in &b.stmts {
                 match st {
@@ -1687,7 +1687,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                             Expr::Literal(Literal::Int(kk), _),
                         )) = modifier
                         {
-                            *retry = Some(*kk as u32);
+                            *retry = Some(*kk);
                         }
                     }
                     Stmt::If(i) => {
@@ -1724,7 +1724,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             for member in &l.members {
                 if let LocusMember::Failure(fd) = member {
                     let mut ops = Vec::new();
-                    let mut retry = None;
+                    let mut retry: Option<i64> = None;
                     walk_ops(&fd.body, &mut ops, &mut retry);
                     let parent = locus_id[&l.name.name];
                     let child_name = fd

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -1099,7 +1099,9 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                         holes
                             .entry((
                                 anchor,
-                                HoleKind::UntypedReceiver,
+                                HoleKind::UntypedReceiver {
+                                    callee: n.clone(),
+                                },
                                 format!(
                                     "method call `{}` on untyped \
                                      receiver",
@@ -1647,7 +1649,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     // supervision (same walk as the artifact's, per-handler).
     let mut sup: BTreeMap<
         (LocusDeclId, SupervisedRef, String),
-        (Vec<String>, Option<u32>, ProvenanceId),
+        (Vec<String>, Option<u32>, u32, ProvenanceId),
     > = BTreeMap::new();
     {
         fn te_name(t: &TypeExpr) -> String {
@@ -1717,6 +1719,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 }
             }
         }
+        let mut authored: u32 = 0;
         for l in &ast.loci {
             for member in &l.members {
                 if let LocusMember::Failure(fd) = member {
@@ -1741,8 +1744,9 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                     let pid = intern_span(&mut records, fd.span);
                     sup.insert(
                         (parent, child, err),
-                        (ops, retry, pid),
+                        (ops, retry, authored, pid),
                     );
+                    authored += 1;
                 }
             }
         }
@@ -2073,7 +2077,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             provenance: *pid,
         });
     }
-    for ((parent, child, err), (ops, retry, pid)) in &sup {
+    for ((parent, child, err), (ops, retry, authored, pid)) in &sup {
         r.supervises.push(Supervises {
             parent: *parent,
             child: child.clone(),
@@ -2082,6 +2086,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 ops: ops.clone(),
                 retry_bound: *retry,
             },
+            authored_ordinal: *authored,
             provenance: *pid,
         });
     }
@@ -2101,10 +2106,17 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         });
     }
 
-    // labels: declared effect carriers.
+    // labels: declared effect carriers. Entities in canonical
+    // order, but WITHIN one entity the class order is semantic —
+    // `render_effects_named` order (fixed built-ins, then user
+    // classes in declaration order), which the artifact hashes.
+    // Flattening through a sorted set here once lexicalized
+    // `["zebra","alpha"]` into `["alpha","zebra"]` and silently
+    // changed the projected identity (review round 11).
     let mut labels: Vec<LabelRow> = Vec::new();
     {
-        let mut rows: BTreeSet<(EntityRef, String)> = BTreeSet::new();
+        let mut per_fn: BTreeMap<hale_model::FunctionId, Vec<String>> =
+            BTreeMap::new();
         for (k, set) in &summary.carries {
             if !user_key(k) {
                 continue;
@@ -2113,21 +2125,22 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 *set,
                 &effect_names,
             );
-            for c in classes {
-                rows.insert((
-                    EntityRef::Function(fn_id[&fn_name(k)]),
-                    c,
-                ));
+            if !classes.is_empty() {
+                per_fn.insert(fn_id[&fn_name(k)], classes);
             }
         }
-        for (at, label) in rows {
-            let pid =
-                intern_synth(&mut records, "declared effect carrier");
-            labels.push(LabelRow {
-                at,
-                label,
-                provenance: pid,
-            });
+        for (f, classes) in per_fn {
+            for label in classes {
+                let pid = intern_synth(
+                    &mut records,
+                    "declared effect carrier",
+                );
+                labels.push(LabelRow {
+                    at: EntityRef::Function(f),
+                    label,
+                    provenance: pid,
+                });
+            }
         }
     }
 

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -1239,7 +1239,7 @@ pub fn verify_artifact_digest(artifact: &str) -> Option<bool> {
     Some(claimed == format!("{:016x}", fnv1a64(body.as_bytes())))
 }
 
-fn join_str<'a>(items: impl Iterator<Item = &'a String>) -> String {
+pub(crate) fn join_str<'a>(items: impl Iterator<Item = &'a String>) -> String {
     items
         .map(|s| quote(s))
         .collect::<Vec<_>>()
@@ -1248,7 +1248,7 @@ fn join_str<'a>(items: impl Iterator<Item = &'a String>) -> String {
 
 /// Minimal JSON string escaping — names are identifiers and wire
 /// subjects, but fail-closed on the full set anyway.
-fn quote(s: &str) -> String {
+pub(crate) fn quote(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
     out.push('"');
     for ch in s.chars() {
@@ -1269,7 +1269,7 @@ fn quote(s: &str) -> String {
 }
 
 /// Drop the trailing ",\n" of the last array element (valid JSON).
-fn trim_trailing_comma(s: &mut String) {
+pub(crate) fn trim_trailing_comma(s: &mut String) {
     if s.ends_with(",\n") {
         s.truncate(s.len() - 2);
         s.push('\n');
@@ -1279,7 +1279,7 @@ fn trim_trailing_comma(s: &mut String) {
 /// FNV-1a, 64-bit — the runtime's hash family (lotus_obs.c uses
 /// FNV for the per-topic payload shape); deterministic, dependency-
 /// free, stable across platforms.
-fn fnv1a64(bytes: &[u8]) -> u64 {
+pub(crate) fn fnv1a64(bytes: &[u8]) -> u64 {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325;
     for b in bytes {
         h ^= *b as u64;

--- a/crates/hale-types/src/topology_projection.rs
+++ b/crates/hale-types/src/topology_projection.rs
@@ -57,7 +57,7 @@ pub fn project_shape_hash(m: &ApplicationModel) -> u64 {
 /// Render the hashed model half of the topology artifact from the
 /// model alone. Byte-compatible with the string `dump_topology`
 /// builds internally (the substring `shape_hash` covers).
-pub fn project_model_half(m: &ApplicationModel) -> String {
+pub fn project_model_half<'a>(m: &'a ApplicationModel) -> String {
     let e = &m.entities;
     let r = &m.relations;
 
@@ -72,6 +72,49 @@ pub fn project_model_half(m: &ApplicationModel) -> String {
             .iter()
             .find(|i| i.name == raw)
             .map(|i| i.display.clone())
+            .unwrap_or_else(|| raw.to_string())
+    };
+    // The V1 display map: raw post-merge symbol → author spelling,
+    // over EVERY declaration table. The legacy encoder ran name()
+    // (full-string demangle) unconditionally over subjects,
+    // supervision child/error types, and more — including strings
+    // that merely COLLIDE with an imported declaration's raw symbol
+    // (a literal subject spelled like a mangled name demangles
+    // under V1). The projection must apply the same rule everywhere
+    // name() ran (review round 11).
+    let mut v1_display: BTreeMap<&str, &str> = BTreeMap::new();
+    {
+        let mut add = |name: &'a str, display: &'a str| {
+            if name != display {
+                v1_display.insert(name, display);
+            }
+        };
+        for l in &e.loci {
+            add(&l.name, &l.display);
+        }
+        for t in &e.topics {
+            add(&t.name, &t.display);
+        }
+        for t in &e.types {
+            add(&t.name, &t.display);
+        }
+        for i in &e.interfaces {
+            add(&i.name, &i.display);
+        }
+        for g in &e.groups {
+            add(&g.name, &g.display);
+        }
+        for d in &e.declarations {
+            add(&d.name, &d.display);
+        }
+        for f in &e.functions {
+            add(&f.name, &f.display);
+        }
+    }
+    let v1_name = |raw: &str| -> String {
+        v1_display
+            .get(raw)
+            .map(|d| d.to_string())
             .unwrap_or_else(|| raw.to_string())
     };
     // The legacy fn universe: only these functions appear in the
@@ -104,7 +147,13 @@ pub fn project_model_half(m: &ApplicationModel) -> String {
     struct EdgeMeta {
         looped: bool,
         unbounded: bool,
-        via_interface: Option<String>,
+        // (authored site ordinal, display) — the legacy encoder
+        // walks call sites in SOURCE order and last-writer-wins, so
+        // when one (from, to) pair is dispatched through several
+        // interfaces the winner is the greatest authored site, NOT
+        // the lexicographically greatest interface the model's
+        // canonical row order would visit last (review round 11).
+        via_interface: Option<(u32, String)>,
     }
     let mut calls: BTreeMap<(String, String), EdgeMeta> = BTreeMap::new();
     for c in &r.calls {
@@ -123,7 +172,15 @@ pub fn project_model_half(m: &ApplicationModel) -> String {
         meta.looped |= c.in_loop;
         meta.unbounded |= c.unbounded;
         if let DispatchKind::Interface { interface } = &c.dispatch {
-            meta.via_interface = Some(iface_display(interface));
+            let cand = (c.site, iface_display(interface));
+            if meta
+                .via_interface
+                .as_ref()
+                .map(|(s, _)| cand.0 >= *s)
+                .unwrap_or(true)
+            {
+                meta.via_interface = Some(cand);
+            }
         }
     }
     let mut via_stdlib: BTreeMap<(String, String), bool> = BTreeMap::new();
@@ -140,7 +197,7 @@ pub fn project_model_half(m: &ApplicationModel) -> String {
      -> String {
         match declared {
             Some(t) => topic_display(t),
-            None => e.subjects[subject.index()].pattern.clone(),
+            None => v1_name(&e.subjects[subject.index()].pattern),
         }
     };
     let mut publishes: BTreeSet<(String, String)> = BTreeSet::new();
@@ -195,6 +252,9 @@ pub fn project_model_half(m: &ApplicationModel) -> String {
     }
 
     // ---- labels: declared effect carriers ----
+    // Row order within one entity IS the artifact's class order
+    // (render_effects_named order, preserved by the builder) — do
+    // not re-sort it (review round 11).
     let mut labels: BTreeMap<String, Vec<String>> = BTreeMap::new();
     for row in &m.labels {
         if let EntityRef::Function(f) = row.at {
@@ -297,6 +357,8 @@ pub fn project_model_half(m: &ApplicationModel) -> String {
         err: String,
         ops: Vec<String>,
         retry: Option<u32>,
+        // Authored position for the tie-break below.
+        origin: u32,
     }
     let mut sup_rows: Vec<SupRow> = r
         .supervises
@@ -305,13 +367,20 @@ pub fn project_model_half(m: &ApplicationModel) -> String {
             locus: locus_display(s.parent),
             child: match &s.child {
                 SupervisedRef::Locus(l) => locus_display(*l),
-                SupervisedRef::External(n) => n.clone(),
+                SupervisedRef::External(n) => v1_name(n),
             },
-            err: s.error_type.clone(),
+            err: v1_name(&s.error_type),
             ops: s.policy.ops.clone(),
             retry: s.policy.retry_bound,
+            origin: s.authored_ordinal,
         })
         .collect();
+    // The legacy encoder collects handlers in SOURCE order and then
+    // STABLE-sorts by (locus, child) only — handlers sharing both
+    // keep authored order, not error-type order (the model's
+    // canonical key). Recover authored order from provenance, then
+    // reproduce the legacy stable sort (review round 11).
+    sup_rows.sort_by(|a, b| a.origin.cmp(&b.origin));
     sup_rows.sort_by(|a, b| (&a.locus, &a.child).cmp(&(&b.locus, &b.child)));
 
     // ---- unknowns: re-fold holes + dead dispatches ----
@@ -321,17 +390,9 @@ pub fn project_model_half(m: &ApplicationModel) -> String {
         if !v1.contains(&f) {
             continue;
         }
-        let reason = match h.kind {
+        let reason = match &h.kind {
             HoleKind::IndirectCall => "indirect_call".to_string(),
-            HoleKind::UntypedReceiver => {
-                // The hole reason is the builder's stable rendering
-                // "method call `NAME` on untyped receiver"; the
-                // legacy row carries the callee name.
-                let callee = h
-                    .reason
-                    .split('`')
-                    .nth(1)
-                    .unwrap_or_default();
+            HoleKind::UntypedReceiver { callee } => {
                 format!("untyped_receiver_call:{}", callee)
             }
             HoleKind::ComputedSubject => "computed_publish".to_string(),
@@ -377,7 +438,7 @@ pub fn project_model_half(m: &ApplicationModel) -> String {
         if meta.unbounded {
             row.push_str(", \"unbounded\": true");
         }
-        if let Some(i) = &meta.via_interface {
+        if let Some((_, i)) = &meta.via_interface {
             row.push_str(&format!(", \"via_interface\": {}", quote(i)));
         }
         row.push_str("},\n");

--- a/crates/hale-types/src/topology_projection.rs
+++ b/crates/hale-types/src/topology_projection.rs
@@ -107,8 +107,17 @@ pub fn project_model_half<'a>(m: &'a ApplicationModel) -> String {
         for d in &e.declarations {
             add(&d.name, &d.display);
         }
+        // FREE functions only: the legacy name() is an EXACT lookup
+        // in import_renames, which holds renamed top-level
+        // declarations — a method identity (`__lib_x_Store::bump`)
+        // is never a renames key, so a literal subject spelled like
+        // one must NOT demangle (review round 12). Every other
+        // table above holds top-level declarations whose raw names
+        // are exactly the renames keys.
         for f in &e.functions {
-            add(&f.name, &f.display);
+            if f.kind == FunctionKind::Free {
+                add(&f.name, &f.display);
+            }
         }
     }
     let v1_name = |raw: &str| -> String {
@@ -255,9 +264,16 @@ pub fn project_model_half<'a>(m: &'a ApplicationModel) -> String {
     // Row order within one entity IS the artifact's class order
     // (render_effects_named order, preserved by the builder) — do
     // not re-sort it (review round 11).
+    // Restricted to the legacy fn universe (the legacy encoder
+    // iterates summary-keyed carriers): a lawful model may label a
+    // non-V1 function, and that row must not appear in a section
+    // whose fns are absent from sorts.fns (review round 12).
     let mut labels: BTreeMap<String, Vec<String>> = BTreeMap::new();
     for row in &m.labels {
         if let EntityRef::Function(f) = row.at {
+            if !v1.contains(&f) {
+                continue;
+            }
             labels
                 .entry(fn_display(f))
                 .or_default()
@@ -343,8 +359,12 @@ pub fn project_model_half<'a>(m: &'a ApplicationModel) -> String {
     }
 
     // ---- effects: derived per-fn classes, declaration order ----
+    // Same restriction: the legacy effects section iterates the
+    // stdlib-merged summary's user keys — the V1 universe — never
+    // the model's broader declaration universe (review round 12).
     let mut derived_effects: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for f in &e.functions {
+    for id in &m.legacy.topology_v1_fns {
+        let f = &e.functions[id.index()];
         if !f.effects.is_empty() {
             derived_effects.insert(f.display.clone(), f.effects.clone());
         }

--- a/crates/hale-types/src/topology_projection.rs
+++ b/crates/hale-types/src/topology_projection.rs
@@ -1,0 +1,501 @@
+//! GH #476 Change 3 — the model-backed artifact encoder.
+//!
+//! Projects an [`ApplicationModel`] down to the topology artifact's
+//! HASHED model half — the exact byte string `dump_topology` hashes
+//! as `shape_hash` (`TopologyShapeV1`). The epic's exit criterion:
+//! this projection must reproduce the legacy serialization
+//! byte-for-byte over the whole corpus BEFORE any cutover, so
+//! existing `.halerec` recordings keep admitting and a topology
+//! diff never moves because the derivation changed hands.
+//!
+//! Until the Change-6 versioned transition, BOTH derivations stay
+//! live and `tests/topology_projection.rs` holds them byte-equal
+//! over every corpus fixture — the same conformance-loop shape as
+//! the effects manifest. A model-builder change that would alter
+//! the artifact identity fails that differential loudly instead of
+//! silently re-keying replay admission. At Change 6 the legacy
+//! derivation and [`hale_model::LegacyProjection`] are deleted
+//! together and the artifact becomes a pure projection of the
+//! model.
+//!
+//! ## Projection rules (legacy artifact = DISPLAY spelling)
+//!
+//! The model keys everything by RAW post-merge symbol and carries
+//! author spelling in `display` fields; the legacy artifact renders
+//! displays. Specifically:
+//!
+//!  * `sorts.fns` / call endpoints — `Function.display`, restricted
+//!    to `legacy.topology_v1_fns` (the behavior-summary universe;
+//!    module-scoped and empty declarations exist in the model but
+//!    not in the legacy sort).
+//!  * `calls_via_stdlib` — `legacy.topology_v1_calls_via_stdlib`
+//!    verbatim: the legacy one-Boolean no-revisit walk's rows, NOT
+//!    the model's lattice rows (whose loop bits may be stronger).
+//!  * publish/subscribe subjects — a declared endpoint renders its
+//!    topic's display NAME (the legacy artifact never wrote wire
+//!    subjects into relations); an undeclared endpoint renders its
+//!    literal/authored pattern, which is author-spelled already.
+//!  * `unknowns` — re-folded from typed holes plus
+//!    `dead_interface_calls` (the model separates dead dispatches
+//!    from genuine residue; the legacy section conflates them).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use hale_model::{
+    ApplicationModel, DispatchKind, EntityRef, FunctionKind, HoleKind,
+    SelectorForm, SupervisedRef,
+};
+
+use crate::topology::{fnv1a64, join_str, quote, trim_trailing_comma};
+
+/// The projected `shape_hash` — FNV-1a/64 over
+/// [`project_model_half`], exactly as `dump_topology` stamps it.
+pub fn project_shape_hash(m: &ApplicationModel) -> u64 {
+    fnv1a64(project_model_half(m).as_bytes())
+}
+
+/// Render the hashed model half of the topology artifact from the
+/// model alone. Byte-compatible with the string `dump_topology`
+/// builds internally (the substring `shape_hash` covers).
+pub fn project_model_half(m: &ApplicationModel) -> String {
+    let e = &m.entities;
+    let r = &m.relations;
+
+    let fn_display =
+        |id: hale_model::FunctionId| e.functions[id.index()].display.clone();
+    let locus_display =
+        |id: hale_model::LocusDeclId| e.loci[id.index()].display.clone();
+    let topic_display =
+        |id: hale_model::TopicId| e.topics[id.index()].display.clone();
+    let iface_display = |raw: &str| -> String {
+        e.interfaces
+            .iter()
+            .find(|i| i.name == raw)
+            .map(|i| i.display.clone())
+            .unwrap_or_else(|| raw.to_string())
+    };
+    // The legacy fn universe: only these functions appear in the
+    // artifact's fn-keyed sections.
+    let v1: BTreeSet<hale_model::FunctionId> =
+        m.legacy.topology_v1_fns.iter().copied().collect();
+
+    // ---- sorts ----
+    let loci: BTreeSet<String> =
+        e.loci.iter().map(|l| l.display.clone()).collect();
+    let fns: BTreeSet<String> = m
+        .legacy
+        .topology_v1_fns
+        .iter()
+        .map(|id| fn_display(*id))
+        .collect();
+    let topics: BTreeSet<String> =
+        e.topics.iter().map(|t| t.display.clone()).collect();
+    let sealed: BTreeSet<String> = e
+        .loci
+        .iter()
+        .filter(|l| l.sealed)
+        .map(|l| l.display.clone())
+        .collect();
+
+    // ---- relations ----
+    // Site-grained model rows merge to the legacy endpoint grain:
+    // loop bits OR, any interface-dispatch site tags the edge.
+    #[derive(Default)]
+    struct EdgeMeta {
+        looped: bool,
+        unbounded: bool,
+        via_interface: Option<String>,
+    }
+    let mut calls: BTreeMap<(String, String), EdgeMeta> = BTreeMap::new();
+    for c in &r.calls {
+        if c.dispatch == DispatchKind::ViaStdlib {
+            continue;
+        }
+        // The legacy relation covers summary-resolved user→user
+        // edges only; edges the model recovers into unanalyzed
+        // callees (module-scoped bodies) have no legacy row.
+        if !v1.contains(&c.from) || !v1.contains(&c.to) {
+            continue;
+        }
+        let meta = calls
+            .entry((fn_display(c.from), fn_display(c.to)))
+            .or_default();
+        meta.looped |= c.in_loop;
+        meta.unbounded |= c.unbounded;
+        if let DispatchKind::Interface { interface } = &c.dispatch {
+            meta.via_interface = Some(iface_display(interface));
+        }
+    }
+    let mut via_stdlib: BTreeMap<(String, String), bool> = BTreeMap::new();
+    for (f, t, looped) in &m.legacy.topology_v1_calls_via_stdlib {
+        let entry = via_stdlib
+            .entry((fn_display(*f), fn_display(*t)))
+            .or_insert(false);
+        *entry |= *looped;
+    }
+    // Subjects: a declared endpoint renders the topic display NAME;
+    // an undeclared endpoint renders its authored pattern.
+    let subject_of = |declared: Option<hale_model::TopicId>,
+                      subject: hale_model::SubjectId|
+     -> String {
+        match declared {
+            Some(t) => topic_display(t),
+            None => e.subjects[subject.index()].pattern.clone(),
+        }
+    };
+    let mut publishes: BTreeSet<(String, String)> = BTreeSet::new();
+    for p in &r.publishes {
+        if !v1.contains(&p.function) {
+            continue;
+        }
+        publishes.insert((
+            fn_display(p.function),
+            subject_of(p.declared_topic, p.subject),
+        ));
+    }
+    // handler locus via member_of; handler short name from the
+    // canonical `Locus::method` identity (method names are never
+    // path-qualified).
+    let handler_locus: BTreeMap<hale_model::FunctionId, hale_model::LocusDeclId> =
+        r.member_of.iter().map(|mo| (mo.function, mo.locus)).collect();
+    let mut subscribes: BTreeSet<(String, String, String)> = BTreeSet::new();
+    for s in &r.subscribes {
+        let subj = subject_of(s.declared_topic, s.subject);
+        let handler_short = e.functions[s.handler.index()]
+            .name
+            .rsplit("::")
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        let locus = handler_locus
+            .get(&s.handler)
+            .map(|l| locus_display(*l))
+            .unwrap_or_default();
+        subscribes.insert((subj, locus, handler_short));
+    }
+
+    // ---- groups: authored selector lists, ordered ----
+    let mut group_rows: BTreeMap<String, Vec<(u32, String)>> = BTreeMap::new();
+    for g in &e.groups {
+        group_rows.insert(g.display.clone(), Vec::new());
+    }
+    for sel in &r.group_selectors {
+        let g = &e.groups[sel.group.index()];
+        let display = match &sel.selector {
+            SelectorForm::Named { display, .. } => display.clone(),
+            SelectorForm::SeedGlob { display, .. } => display.clone(),
+        };
+        group_rows
+            .entry(g.display.clone())
+            .or_default()
+            .push((sel.ordinal, display));
+    }
+    for members in group_rows.values_mut() {
+        members.sort_by_key(|(ord, _)| *ord);
+    }
+
+    // ---- labels: declared effect carriers ----
+    let mut labels: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for row in &m.labels {
+        if let EntityRef::Function(f) = row.at {
+            labels
+                .entry(fn_display(f))
+                .or_default()
+                .push(row.label.clone());
+        }
+    }
+
+    // ---- phases ----
+    // NO v1 filter: the legacy phase relation comes from the AST
+    // walk (vmodel), which includes empty-bodied hooks the behavior
+    // summary never keys — `run() { }` has a phase row and no fn
+    // sort entry.
+    let mut phase_rows: BTreeMap<String, (String, bool)> = BTreeMap::new();
+    for po in &r.phase_of {
+        let hook = matches!(
+            e.functions[po.function.index()].kind,
+            FunctionKind::Hook | FunctionKind::Mode
+        );
+        phase_rows.insert(
+            fn_display(po.function),
+            (e.phases[po.phase.index()].name.clone(), hook),
+        );
+    }
+
+    // ---- seeds: alias → member displays, in RAW-name order ----
+    // (the legacy sort iterates a BTreeSet of mangled names and
+    // display-maps afterwards, so raw order is the authored fact).
+    let raw_and_display = |er: &EntityRef| -> Option<(String, String)> {
+        Some(match er {
+            EntityRef::Function(id) => {
+                let f = &e.functions[id.index()];
+                (f.name.clone(), f.display.clone())
+            }
+            EntityRef::LocusDecl(id) => {
+                let l = &e.loci[id.index()];
+                (l.name.clone(), l.display.clone())
+            }
+            EntityRef::Topic(id) => {
+                let t = &e.topics[id.index()];
+                (t.name.clone(), t.display.clone())
+            }
+            EntityRef::Type(id) => {
+                let t = &e.types[id.index()];
+                (t.name.clone(), t.display.clone())
+            }
+            EntityRef::Interface(id) => {
+                let i = &e.interfaces[id.index()];
+                (i.name.clone(), i.display.clone())
+            }
+            EntityRef::Group(id) => {
+                let g = &e.groups[id.index()];
+                (g.name.clone(), g.display.clone())
+            }
+            EntityRef::Declaration(id) => {
+                let d = &e.declarations[id.index()];
+                (d.name.clone(), d.display.clone())
+            }
+            _ => return None,
+        })
+    };
+    let mut seed_rows: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for s in &e.seeds {
+        seed_rows.insert(s.name.clone(), Vec::new());
+    }
+    {
+        let mut by_seed: BTreeMap<String, BTreeMap<String, String>> =
+            BTreeMap::new();
+        for di in &r.declared_in {
+            let Some((raw, display)) = raw_and_display(&di.entity) else {
+                continue;
+            };
+            by_seed
+                .entry(e.seeds[di.seed.index()].name.clone())
+                .or_default()
+                .insert(raw, display);
+        }
+        for (alias, members) in by_seed {
+            seed_rows.insert(
+                alias,
+                members.into_values().collect(),
+            );
+        }
+    }
+
+    // ---- effects: derived per-fn classes, declaration order ----
+    let mut derived_effects: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for f in &e.functions {
+        if !f.effects.is_empty() {
+            derived_effects.insert(f.display.clone(), f.effects.clone());
+        }
+    }
+
+    // ---- supervision ----
+    struct SupRow {
+        locus: String,
+        child: String,
+        err: String,
+        ops: Vec<String>,
+        retry: Option<u32>,
+    }
+    let mut sup_rows: Vec<SupRow> = r
+        .supervises
+        .iter()
+        .map(|s| SupRow {
+            locus: locus_display(s.parent),
+            child: match &s.child {
+                SupervisedRef::Locus(l) => locus_display(*l),
+                SupervisedRef::External(n) => n.clone(),
+            },
+            err: s.error_type.clone(),
+            ops: s.policy.ops.clone(),
+            retry: s.policy.retry_bound,
+        })
+        .collect();
+    sup_rows.sort_by(|a, b| (&a.locus, &a.child).cmp(&(&b.locus, &b.child)));
+
+    // ---- unknowns: re-fold holes + dead dispatches ----
+    let mut unknowns: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for h in &m.holes {
+        let EntityRef::Function(f) = h.at else { continue };
+        if !v1.contains(&f) {
+            continue;
+        }
+        let reason = match h.kind {
+            HoleKind::IndirectCall => "indirect_call".to_string(),
+            HoleKind::UntypedReceiver => {
+                // The hole reason is the builder's stable rendering
+                // "method call `NAME` on untyped receiver"; the
+                // legacy row carries the callee name.
+                let callee = h
+                    .reason
+                    .split('`')
+                    .nth(1)
+                    .unwrap_or_default();
+                format!("untyped_receiver_call:{}", callee)
+            }
+            HoleKind::ComputedSubject => "computed_publish".to_string(),
+            _ => continue,
+        };
+        unknowns.entry(fn_display(f)).or_default().insert(reason);
+    }
+    for d in &r.dead_interface_calls {
+        if !v1.contains(&d.from) {
+            continue;
+        }
+        unknowns.entry(fn_display(d.from)).or_default().insert(format!(
+            "uninhabited_interface_call:{}.{}",
+            iface_display(&d.interface),
+            d.method
+        ));
+    }
+
+    // ---- serialize: byte-identical to dump_topology ----
+    let mut model = String::new();
+    model.push_str("  \"sorts\": {\n");
+    model.push_str(&format!("    \"loci\": [{}],\n", join_str(loci.iter())));
+    model.push_str(&format!("    \"fns\": [{}],\n", join_str(fns.iter())));
+    model.push_str(&format!(
+        "    \"topics\": [{}]\n",
+        join_str(topics.iter())
+    ));
+    model.push_str("  },\n");
+    model.push_str(&format!(
+        "  \"sealed\": [{}],\n",
+        join_str(sealed.iter())
+    ));
+    model.push_str("  \"relations\": {\n    \"calls\": [\n");
+    for ((from, to), meta) in &calls {
+        let mut row = format!(
+            "      {{\"from\": {}, \"to\": {}",
+            quote(from),
+            quote(to)
+        );
+        if meta.looped {
+            row.push_str(", \"loop\": true");
+        }
+        if meta.unbounded {
+            row.push_str(", \"unbounded\": true");
+        }
+        if let Some(i) = &meta.via_interface {
+            row.push_str(&format!(", \"via_interface\": {}", quote(i)));
+        }
+        row.push_str("},\n");
+        model.push_str(&row);
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("    ],\n    \"calls_via_stdlib\": [\n");
+    for ((from, to), looped) in &via_stdlib {
+        let mut row = format!(
+            "      {{\"from\": {}, \"to\": {}",
+            quote(from),
+            quote(to)
+        );
+        if *looped {
+            row.push_str(", \"loop\": true");
+        }
+        row.push_str("},\n");
+        model.push_str(&row);
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("    ],\n    \"publishes\": [\n");
+    for (f, s) in &publishes {
+        model.push_str(&format!(
+            "      {{\"fn\": {}, \"subject\": {}}},\n",
+            quote(f),
+            quote(s)
+        ));
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("    ],\n    \"subscribes\": [\n");
+    for (subj, locus, handler) in &subscribes {
+        model.push_str(&format!(
+            "      {{\"subject\": {}, \"locus\": {}, \"handler\": {}}},\n",
+            quote(subj),
+            quote(locus),
+            quote(handler)
+        ));
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("    ]\n  },\n");
+    model.push_str("  \"groups\": {\n");
+    for (g, members) in &group_rows {
+        let names: Vec<String> =
+            members.iter().map(|(_, d)| d.clone()).collect();
+        model.push_str(&format!(
+            "    {}: [{}],\n",
+            quote(g),
+            join_str(names.iter())
+        ));
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("  },\n  \"labels\": {\n");
+    for (f, classes) in &labels {
+        model.push_str(&format!(
+            "    {}: [{}],\n",
+            quote(f),
+            join_str(classes.iter())
+        ));
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("  },\n  \"phases\": {\n");
+    for (f, (phase, hook)) in &phase_rows {
+        model.push_str(&format!(
+            "    {}: {{\"phase\": {}, \"kind\": {}}},\n",
+            quote(f),
+            quote(phase),
+            quote(if *hook { "hook" } else { "method" })
+        ));
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("  },\n  \"seeds\": {\n");
+    for (alias, members) in &seed_rows {
+        model.push_str(&format!(
+            "    {}: [{}],\n",
+            quote(alias),
+            join_str(members.iter())
+        ));
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("  },\n  \"effects\": {\n");
+    for (f, classes) in &derived_effects {
+        model.push_str(&format!(
+            "    {}: [{}],\n",
+            quote(f),
+            join_str(classes.iter())
+        ));
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("  },\n  \"supervision\": [\n");
+    for r in &sup_rows {
+        let retry = r
+            .retry
+            .map(|n| format!(", \"retry_bound\": {}", n))
+            .unwrap_or_default();
+        model.push_str(&format!(
+            "    {{\"locus\": {}, \"child\": {}, \"err\": {}, \"ops\": [{}]{}}},\n",
+            quote(&r.locus),
+            quote(&r.child),
+            quote(&r.err),
+            join_str(r.ops.iter()),
+            retry
+        ));
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("  ],\n  \"unknowns\": [\n");
+    for (f, reasons) in &unknowns {
+        let rs = reasons
+            .iter()
+            .map(|r| quote(r))
+            .collect::<Vec<_>>()
+            .join(", ");
+        model.push_str(&format!(
+            "    {{\"fn\": {}, \"reasons\": [{}]}},\n",
+            quote(f),
+            rs
+        ));
+    }
+    trim_trailing_comma(&mut model);
+    model.push_str("  ]");
+    model
+}

--- a/crates/hale-types/src/topology_projection.rs
+++ b/crates/hale-types/src/topology_projection.rs
@@ -142,7 +142,13 @@ pub fn project_model_half<'a>(m: &'a ApplicationModel) -> String {
         .collect();
     let topics: BTreeSet<String> =
         e.topics.iter().map(|t| t.display.clone()).collect();
-    let sealed: BTreeSet<String> = e
+    // RAW-name order with display values: the legacy encoder sorts
+    // sealed loci by raw canonical name and demangles only while
+    // serializing, so two imports whose raw and alias orders
+    // disagree render displays in raw order (review round 13).
+    // `e.loci` is canonically raw-sorted — collect WITHOUT
+    // re-sorting.
+    let sealed: Vec<String> = e
         .loci
         .iter()
         .filter(|l| l.sealed)
@@ -376,7 +382,7 @@ pub fn project_model_half<'a>(m: &'a ApplicationModel) -> String {
         child: String,
         err: String,
         ops: Vec<String>,
-        retry: Option<u32>,
+        retry: Option<i64>,
         // Authored position for the tie-break below.
         origin: u32,
     }

--- a/crates/hale-types/tests/topology_projection.rs
+++ b/crates/hale-types/tests/topology_projection.rs
@@ -288,3 +288,163 @@ fn main() { App { }; }
         first_diff(legacy, &projected)
     );
 }
+
+/// Direct comparison without the check gate — for fixtures pinning
+/// legacy-order behavior the checker may or may not accept; both
+/// derivations are total over parseable programs.
+fn assert_projection_matches(src: &str, label: &str) -> String {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let art = hale_types::topology::dump_topology(&bundle);
+    let model = derive_application_model(&bundle);
+    let legacy = model_half_of(&art).to_string();
+    let projected = project_model_half(&model);
+    assert_eq!(
+        legacy,
+        projected,
+        "{}: {}",
+        label,
+        first_diff(&legacy, &projected)
+    );
+    legacy
+}
+
+/// P1 (round 11): when one (from, to) pair is dispatched through
+/// several interfaces, the legacy encoder's last-in-source site
+/// wins — NOT the lexicographically last interface the model's
+/// canonical row order visits last. Source order here is Z then A,
+/// so V1 selects A.
+#[test]
+fn via_interface_tie_follows_authored_order() {
+    let src = r#"
+interface AIface { fn notify(v: Int) -> Int; }
+interface ZIface { fn notify(v: Int) -> Int; }
+locus Conformer {
+    params { n: Int = 0; }
+    fn notify(v: Int) -> Int { return v + self.n; }
+}
+fn relay(z: ZIface, a: AIface, v: Int) -> Int {
+    let first = z.notify(v);
+    let second = a.notify(v);
+    return first + second;
+}
+main locus App {
+    params { c: Conformer = Conformer { }; }
+    run() { println(relay(self.c, self.c, 1)); }
+}
+fn main() { App { }; }
+"#;
+    let legacy = assert_projection_matches(src, "via_interface tie");
+    assert!(
+        legacy.contains("\"via_interface\": \"AIface\""),
+        "the LAST authored dispatch (AIface) wins:\n{}",
+        legacy
+    );
+}
+
+/// P1 (round 11): multi-class carrier labels render in
+/// render_effects_named order — built-ins in fixed order, then USER
+/// classes in declaration order — never lexical. `zebra` is
+/// declared before `alpha` and must render before it.
+#[test]
+fn label_order_follows_declaration_not_lexical() {
+    let src = r#"
+effect zebra;
+effect alpha;
+@effects(is: { zebra, alpha })
+fn classified() { println(1); }
+main locus App {
+    run() { classified(); }
+}
+fn main() { App { }; }
+"#;
+    let legacy =
+        assert_projection_matches(src, "label declaration order");
+    assert!(
+        legacy.contains("[\"zebra\", \"alpha\"]"),
+        "declaration order, not lexical:\n{}",
+        legacy
+    );
+}
+
+/// P1 (round 11): supervision handlers sharing (locus, child) keep
+/// AUTHORED order under the legacy stable sort — not the model's
+/// canonical error-type order. ZTrouble is authored before ATrouble.
+#[test]
+fn supervision_ties_keep_authored_order() {
+    let src = r#"
+type ZTrouble { n: Int = 0; }
+type ATrouble { n: Int = 0; }
+locus Child {
+    params { n: Int = 0; }
+}
+locus Parent {
+    params { c: Child = Child { }; }
+    on_failure(c: Child, err: ZTrouble) {
+        restart (c);
+    }
+    on_failure(c: Child, err: ATrouble) {
+        quarantine (c);
+    }
+}
+main locus App {
+    params { p: Parent = Parent { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let legacy =
+        assert_projection_matches(src, "supervision authored order");
+    let z = legacy.find("\"err\": \"ZTrouble\"").expect("Z row");
+    let a = legacy.find("\"err\": \"ATrouble\"").expect("A row");
+    assert!(
+        z < a,
+        "authored order (Z first) survives the stable sort:\n{}",
+        legacy
+    );
+}
+
+/// P1 (round 11): V1 runs name() over EVERY subject string — a
+/// literal subject whose text equals an imported declaration's raw
+/// symbol demangles in the legacy artifact, so the projection must
+/// apply the same map.
+#[test]
+fn literal_subject_colliding_with_raw_symbol_demangles() {
+    let lib = r#"
+type __lib_x_kv_Item { n: Int = 0; }
+"#;
+    let main_src = r#"
+type Note { text: String = ""; }
+locus Sink {
+    bus { subscribe "__lib_x_kv_Item" as on_x of type Note; }
+    fn on_x(n: Note) { }
+}
+main locus App {
+    params { s: Sink = Sink { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let main_p = hale_syntax::parse_source(main_src).expect("parse main");
+    let lib_p = hale_syntax::parse_source(lib).expect("parse lib");
+    let mut programs = BTreeMap::new();
+    programs.insert("app/main.hl".to_string(), &main_p);
+    programs.insert("lib/kv.hl".to_string(), &lib_p);
+    let mut bundle = Bundle::new(programs);
+    bundle.import_renames = vec![(
+        vec!["kv".to_string(), "Item".to_string()],
+        "__lib_x_kv_Item".to_string(),
+    )];
+    let art = hale_types::topology::dump_topology(&bundle);
+    let model = derive_application_model(&bundle);
+    let legacy = model_half_of(&art);
+    let projected = project_model_half(&model);
+    assert!(
+        legacy.contains("\"subject\": \"kv::Item\""),
+        "V1 demangles the colliding literal:\n{}",
+        legacy
+    );
+    assert_eq!(legacy, projected, "{}", first_diff(legacy, &projected));
+}

--- a/crates/hale-types/tests/topology_projection.rs
+++ b/crates/hale-types/tests/topology_projection.rs
@@ -662,3 +662,46 @@ fn main() { App { }; }
         legacy
     );
 }
+
+/// P1 (round 14): duplicate-signature handlers — identical
+/// (locus, child, error_type) — are check-clean, and the legacy
+/// artifact serializes one row PER DECLARATION. The model's
+/// canonical key includes the authored ordinal so both rows exist,
+/// and the projection renders both in authored order.
+#[test]
+fn duplicate_signature_supervision_rows_both_survive() {
+    let src = r#"
+locus Child {
+    params { n: Int = 0; }
+}
+locus Parent {
+    params { c: Child = Child { }; }
+    on_failure(c: Child, err: ClosureViolation) {
+        restart (c);
+    }
+    on_failure(c: Child, err: ClosureViolation) {
+        quarantine (c);
+    }
+}
+main locus App {
+    params { p: Parent = Parent { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let legacy = assert_projection_matches(
+        src,
+        "duplicate-signature supervision",
+    );
+    let restart = legacy
+        .find("\"ops\": [\"restart\"]")
+        .expect("first handler row");
+    let quarantine = legacy
+        .find("\"ops\": [\"quarantine\"]")
+        .expect("second handler row");
+    assert!(
+        restart < quarantine,
+        "both rows, authored order:\n{}",
+        legacy
+    );
+}

--- a/crates/hale-types/tests/topology_projection.rs
+++ b/crates/hale-types/tests/topology_projection.rs
@@ -577,3 +577,88 @@ fn labels_and_effects_are_restricted_to_the_v1_universe() {
     assert!(out.contains("\"hidden_extra\": [\"syscall\"]"));
     assert!(out.contains("\"hidden_extra\": [\"money\"]"));
 }
+
+/// P1 (round 13): sealed renders DISPLAY values in RAW-name order —
+/// the legacy encoder sorts raw and demangles only while
+/// serializing. Two imports with deliberately reversed raw/alias
+/// order pin it: raw `__lib_a_pack_Z` < `__lib_b_pack_A`, displays
+/// `z::Z` then `a::A` — non-lexical display order is CORRECT.
+#[test]
+fn sealed_order_is_raw_not_display() {
+    let lib_a = r#"
+@sealed
+locus __lib_a_pack_Z {
+    params { n: Int = 0; }
+}
+"#;
+    let lib_b = r#"
+@sealed
+locus __lib_b_pack_A {
+    params { n: Int = 0; }
+}
+"#;
+    let main_src = r#"
+main locus App {
+    params { z: __lib_a_pack_Z = __lib_a_pack_Z { }; a: __lib_b_pack_A = __lib_b_pack_A { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let main_p = hale_syntax::parse_source(main_src).expect("parse main");
+    let a_p = hale_syntax::parse_source(lib_a).expect("parse lib a");
+    let b_p = hale_syntax::parse_source(lib_b).expect("parse lib b");
+    let mut programs = BTreeMap::new();
+    programs.insert("app/main.hl".to_string(), &main_p);
+    programs.insert("lib/a.hl".to_string(), &a_p);
+    programs.insert("lib/b.hl".to_string(), &b_p);
+    let mut bundle = Bundle::new(programs);
+    bundle.import_renames = vec![
+        (
+            vec!["z".to_string(), "Z".to_string()],
+            "__lib_a_pack_Z".to_string(),
+        ),
+        (
+            vec!["a".to_string(), "A".to_string()],
+            "__lib_b_pack_A".to_string(),
+        ),
+    ];
+    let art = hale_types::topology::dump_topology(&bundle);
+    let model = derive_application_model(&bundle);
+    let legacy = model_half_of(&art);
+    let projected = project_model_half(&model);
+    assert!(
+        legacy.contains("\"sealed\": [\"z::Z\", \"a::A\"]"),
+        "raw order, display values:\n{}",
+        legacy
+    );
+    assert_eq!(legacy, projected, "{}", first_diff(legacy, &projected));
+}
+
+/// P1 (round 13): a retry bound is the literal AS WRITTEN — i64.
+/// `for 4294967296` is check-clean; a u32 field silently truncated
+/// it to 0 in the projected hash.
+#[test]
+fn retry_bound_keeps_the_full_literal() {
+    let src = r#"
+locus Child {
+    params { n: Int = 0; }
+}
+locus Parent {
+    params { c: Child = Child { }; }
+    on_failure(c: Child, err: ClosureViolation) {
+        restart (c) for 4294967296;
+    }
+}
+main locus App {
+    params { p: Parent = Parent { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let legacy = assert_projection_matches(src, "retry bound width");
+    assert!(
+        legacy.contains("\"retry_bound\": 4294967296"),
+        "the literal survives at full width:\n{}",
+        legacy
+    );
+}

--- a/crates/hale-types/tests/topology_projection.rs
+++ b/crates/hale-types/tests/topology_projection.rs
@@ -1,0 +1,290 @@
+//! GH #476 Change 3 — the projection differential.
+//!
+//! `topology_projection::project_model_half(derive(bundle))` must be
+//! BYTE-IDENTICAL to the hashed model half `dump_topology` builds
+//! from its own derivation, for every program in the corpus — the
+//! epic's exit criterion ("reproduce the legacy `TopologyShapeV1`
+//! hash exactly over the corpus before any cutover"). Until the
+//! Change-6 versioned transition this differential is a permanent
+//! conformance gate: a model-builder change that would alter the
+//! artifact identity fails HERE, loudly, instead of silently
+//! re-keying `.halerec` replay admission.
+
+use std::collections::BTreeMap;
+
+use hale_types::model_builder::derive_application_model;
+use hale_types::topology_projection::{
+    project_model_half, project_shape_hash,
+};
+use hale_types::Bundle;
+
+/// The hashed model half of a rendered artifact: everything from
+/// `"sorts"` up to (not including) the unhashed `"sources"` map.
+/// `dump_topology` hashes exactly this substring.
+fn model_half_of(artifact: &str) -> &str {
+    let start = artifact
+        .find("  \"sorts\": {")
+        .expect("artifact has a sorts section");
+    let end = artifact
+        .find(",\n  \"sources\": [")
+        .expect("artifact has a sources section");
+    &artifact[start..end]
+}
+
+fn artifact_shape_hash(artifact: &str) -> u64 {
+    artifact
+        .lines()
+        .find_map(|l| {
+            l.trim()
+                .strip_prefix("\"shape_hash\": \"")?
+                .strip_suffix("\",")
+        })
+        .and_then(|h| u64::from_str_radix(h, 16).ok())
+        .expect("artifact has a shape_hash")
+}
+
+/// First divergence between two strings, with context — a byte
+/// differential over a 60-line JSON body needs to say WHERE.
+fn first_diff(a: &str, b: &str) -> String {
+    let pos = a
+        .bytes()
+        .zip(b.bytes())
+        .position(|(x, y)| x != y)
+        .unwrap_or_else(|| a.len().min(b.len()));
+    let lo = pos.saturating_sub(120);
+    let a_end = (pos + 160).min(a.len());
+    let b_end = (pos + 160).min(b.len());
+    format!(
+        "first divergence at byte {}:\n--- legacy:\n…{}…\n--- projected:\n…{}…",
+        pos,
+        &a[lo..a_end],
+        &b[lo..b_end]
+    )
+}
+
+fn check_one(
+    origin: &str,
+    program: &hale_syntax::ast::Program,
+    bad: &mut Vec<String>,
+) {
+    let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+        || {
+            let mut programs = BTreeMap::new();
+            programs.insert("app.hl".to_string(), program);
+            let bundle = Bundle::new(programs);
+            let art = hale_types::topology::dump_topology(&bundle);
+            let model = derive_application_model(&bundle);
+            (art, model)
+        },
+    ));
+    let Ok((art, model)) = caught else {
+        bad.push(format!("{}: PANIC", origin));
+        return;
+    };
+    // The differential is a property of CHECKED programs — the
+    // corpus's negative fixtures can carry shapes the two
+    // derivations legitimately read differently, and the checker
+    // refuses them before either output exists.
+    let checks_clean = hale_types::check_program(program)
+        .iter()
+        .all(|d| !d.is_error());
+    if !checks_clean {
+        return;
+    }
+    let legacy = model_half_of(&art);
+    let projected = project_model_half(&model);
+    if legacy != projected {
+        bad.push(format!(
+            "{}: model half diverges.\n{}",
+            origin,
+            first_diff(legacy, &projected)
+        ));
+        return;
+    }
+    if artifact_shape_hash(&art) != project_shape_hash(&model) {
+        bad.push(format!(
+            "{}: byte-equal halves but hash mismatch (?)",
+            origin
+        ));
+    }
+}
+
+/// THE Change-3 gate: byte equality over every checkable corpus
+/// program.
+#[test]
+fn projection_matches_legacy_over_the_corpus() {
+    let mut bad: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+    for p in
+        hale_corpus::parseable(|s| hale_syntax::parse_source(s).is_ok())
+    {
+        let Ok(program) = hale_syntax::parse_source(&p.source) else {
+            continue;
+        };
+        let before = bad.len();
+        check_one(&p.origin, &program, &mut bad);
+        if bad.len() == before {
+            checked += 1;
+        }
+    }
+    assert!(
+        checked > 100,
+        "the corpus sweep must actually cover programs (got {})",
+        checked
+    );
+    assert!(
+        bad.is_empty(),
+        "{} corpus programs diverge:\n{}",
+        bad.len(),
+        bad.join("\n\n")
+    );
+}
+
+/// The same equality on a fixture exercising every hashed section at
+/// once — sealed loci, interface dispatch, stdlib contraction,
+/// groups, labels, phases, seeds are corpus-covered, but supervision
+/// + keyed topics + literal endpoints in ONE artifact pins the
+/// interleaving.
+#[test]
+fn projection_matches_legacy_on_a_dense_fixture() {
+    let src = r#"
+type Reading { sensor: Int = 0; v: Int = 0; }
+type Note { text: String = ""; }
+topic Readings {
+    payload: Reading;
+    subject: "sense.reading";
+    keyed_by sensor;
+}
+topic Cmds { payload: Note; subject: "ctl.cmd"; }
+
+interface Notifier {
+    fn notify(v: Int) -> Int;
+}
+
+fn double(v: Int) -> Int { return v * 2; }
+
+@sealed
+locus Vault {
+    params { secret: Int = 0; }
+    fn peek() -> Int { return self.secret; }
+}
+
+locus Child {
+    params { n: Int = 0; }
+    fn notify(v: Int) -> Int { return v; }
+}
+
+locus Worker {
+    params { c: Child = Child { }; }
+    bus {
+        publish Cmds;
+        subscribe Readings as on_reading where key == 3;
+        subscribe "raw.wire" as on_raw of type Note;
+    }
+    fn on_reading(r: Reading) {
+        let mut i = 0;
+        while i < 3 {
+            let d = double(r.v);
+            Cmds <- Note { };
+            i = i + 1;
+        }
+    }
+    fn on_raw(n: Note) { }
+    on_failure(c: Child, err: ClosureViolation) {
+        restart (c) for 2;
+    }
+}
+
+group Handlers = { Worker, Child };
+
+main locus App {
+    params { w: Worker = Worker { }; v: Vault = Vault { }; }
+    run() { println(self.v.peek()); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut bad = Vec::new();
+    check_one("dense fixture", &program, &mut bad);
+    assert!(bad.is_empty(), "{}", bad.join("\n"));
+    // …and the fixture actually reaches the sections it claims to:
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let art = hale_types::topology::dump_topology(&bundle);
+    for needle in [
+        "\"sealed\": [\"Vault\"]",
+        "\"supervision\": [\n    {\"locus\": \"Worker\"",
+        "\"retry_bound\": 2",
+        "\"Handlers\": [\"Worker\", \"Child\"]",
+        "\"subject\": \"raw.wire\"",
+    ] {
+        assert!(
+            art.contains(needle),
+            "fixture must exercise `{}`:\n{}",
+            needle,
+            art
+        );
+    }
+}
+
+/// Cross-seed: display-spelled artifact strings from a raw-keyed
+/// model — the projection's whole job is this mapping.
+#[test]
+fn projection_matches_legacy_across_seeds() {
+    let lib = r#"
+type __lib_x_kv_Item { n: Int = 0; }
+topic __lib_x_kv_Changed { payload: __lib_x_kv_Item; }
+locus __lib_x_kv_Store {
+    params { n: Int = 0; }
+    bus { publish __lib_x_kv_Changed; }
+    fn bump() { self.n = self.n + 1; __lib_x_kv_Changed <- __lib_x_kv_Item { }; }
+}
+"#;
+    let main_src = r#"
+locus Reader {
+    bus { subscribe __lib_x_kv_Changed as on_changed; }
+    fn on_changed(i: __lib_x_kv_Item) { }
+}
+main locus App {
+    params { s: __lib_x_kv_Store = __lib_x_kv_Store { }; r: Reader = Reader { }; }
+    run() { self.s.bump(); }
+}
+fn main() { App { }; }
+"#;
+    let main_p = hale_syntax::parse_source(main_src).expect("parse main");
+    let lib_p = hale_syntax::parse_source(lib).expect("parse lib");
+    let mut programs = BTreeMap::new();
+    programs.insert("app/main.hl".to_string(), &main_p);
+    programs.insert("lib/kv.hl".to_string(), &lib_p);
+    let mut bundle = Bundle::new(programs);
+    bundle.import_renames = vec![
+        (
+            vec!["kv".to_string(), "Item".to_string()],
+            "__lib_x_kv_Item".to_string(),
+        ),
+        (
+            vec!["kv".to_string(), "Changed".to_string()],
+            "__lib_x_kv_Changed".to_string(),
+        ),
+        (
+            vec!["kv".to_string(), "Store".to_string()],
+            "__lib_x_kv_Store".to_string(),
+        ),
+    ];
+    let art = hale_types::topology::dump_topology(&bundle);
+    let model = derive_application_model(&bundle);
+    let legacy = model_half_of(&art);
+    let projected = project_model_half(&model);
+    assert!(
+        legacy.contains("kv::Store"),
+        "artifact spells the import author-side:\n{}",
+        legacy
+    );
+    assert_eq!(
+        legacy,
+        projected,
+        "{}",
+        first_diff(legacy, &projected)
+    );
+}

--- a/crates/hale-types/tests/topology_projection.rs
+++ b/crates/hale-types/tests/topology_projection.rs
@@ -448,3 +448,132 @@ fn main() { App { }; }
     );
     assert_eq!(legacy, projected, "{}", first_diff(legacy, &projected));
 }
+
+/// P1 (round 12): the V1 display map is EXACT-renames scope. A
+/// literal subject spelled like an imported locus's METHOD identity
+/// (`__lib_x_kv_Store::bump`) is not a renames key — legacy name()
+/// leaves it verbatim, and so must the projection. (The type-symbol
+/// collision above demangles; the method shape must not.)
+#[test]
+fn method_shaped_literal_subject_does_not_demangle() {
+    let lib = r#"
+type __lib_x_kv_Event { n: Int = 0; }
+locus __lib_x_kv_Store {
+    params { n: Int = 0; }
+    fn bump() { self.n = self.n + 1; }
+}
+"#;
+    let main_src = r#"
+type Note { text: String = ""; }
+locus Sink {
+    bus { subscribe "__lib_x_kv_Store::bump" as on_ev of type Note; }
+    fn on_ev(n: Note) { }
+}
+main locus App {
+    params { s: Sink = Sink { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let main_p = hale_syntax::parse_source(main_src).expect("parse main");
+    let lib_p = hale_syntax::parse_source(lib).expect("parse lib");
+    let mut programs = BTreeMap::new();
+    programs.insert("app/main.hl".to_string(), &main_p);
+    programs.insert("lib/kv.hl".to_string(), &lib_p);
+    let mut bundle = Bundle::new(programs);
+    bundle.import_renames = vec![
+        (
+            vec!["kv".to_string(), "Event".to_string()],
+            "__lib_x_kv_Event".to_string(),
+        ),
+        (
+            vec!["kv".to_string(), "Store".to_string()],
+            "__lib_x_kv_Store".to_string(),
+        ),
+    ];
+    let art = hale_types::topology::dump_topology(&bundle);
+    let model = derive_application_model(&bundle);
+    let legacy = model_half_of(&art);
+    let projected = project_model_half(&model);
+    assert!(
+        legacy.contains("\"subject\": \"__lib_x_kv_Store::bump\""),
+        "V1 keeps the method-shaped literal verbatim:\n{}",
+        legacy
+    );
+    assert_eq!(legacy, projected, "{}", first_diff(legacy, &projected));
+}
+
+/// P1 (round 12): labels and effects are V1-universe sections. The
+/// projector is public over any lawful model — a non-V1 function
+/// (module-scoped, unanalyzed) carrying a label or an effect set
+/// must NOT surface in a section whose fns are absent from
+/// sorts.fns. Constructed directly: the current builder never
+/// populates behavior on non-V1 fns, and this pin must hold as it
+/// gains coverage.
+#[test]
+fn labels_and_effects_are_restricted_to_the_v1_universe() {
+    use hale_model::*;
+    let mut prov = ProvenanceTable::default();
+    prov.records.push(Provenance::Synthetic {
+        origin: "test".to_string(),
+    });
+    let p = ProvenanceId(0);
+    let f = |name: &str, effects: Vec<&str>| Function {
+        name: name.to_string(),
+        display: name.to_string(),
+        kind: FunctionKind::Free,
+        effects: effects.into_iter().map(String::from).collect(),
+        provenance: p,
+    };
+    let mut m = ApplicationModel {
+        header: ModelHeader {
+            semantics: MODEL_SEMANTICS_V1,
+            entrypoint: "main".to_string(),
+        },
+        entities: Entities {
+            functions: vec![
+                f("analyzed", vec!["alloc"]),
+                f("hidden_extra", vec!["syscall"]),
+            ],
+            ..Entities::default()
+        },
+        relations: Relations::default(),
+        labels: vec![
+            LabelRow {
+                at: EntityRef::Function(FunctionId(0)),
+                label: "money".to_string(),
+                provenance: p,
+            },
+            LabelRow {
+                at: EntityRef::Function(FunctionId(1)),
+                label: "money".to_string(),
+                provenance: p,
+            },
+        ],
+        weights: Vec::new(),
+        holes: Vec::new(),
+        capabilities: Capabilities::default(),
+        provenance: prov,
+        legacy: LegacyProjection {
+            topology_v1_fns: vec![FunctionId(0)],
+            topology_v1_calls_via_stdlib: Vec::new(),
+        },
+    };
+    let out = project_model_half(&m);
+    assert!(
+        out.contains("\"analyzed\": [\"alloc\"]"),
+        "V1 fn keeps its effects:\n{}",
+        out
+    );
+    assert!(
+        !out.contains("hidden_extra"),
+        "a non-V1 fn appears in NO fn-keyed section:\n{}",
+        out
+    );
+    // …and with the extra fn enrolled, both sections carry it —
+    // the filter is the universe, not the function.
+    m.legacy.topology_v1_fns = vec![FunctionId(0), FunctionId(1)];
+    let out = project_model_half(&m);
+    assert!(out.contains("\"hidden_extra\": [\"syscall\"]"));
+    assert!(out.contains("\"hidden_extra\": [\"money\"]"));
+}


### PR DESCRIPTION
Change 3 of the canonical-model epic (#476): the first model-backed artifact encoder, with the epic's exit criterion enforced in-tree.

## What ships

- **`topology_projection::project_model_half(&ApplicationModel) -> String`** — renders the topology artifact's hashed model half (sorts, sealed, relations, groups, labels, phases, seeds, effects, supervision, unknowns) from the canonical model alone. **`project_shape_hash`** reproduces `TopologyShapeV1` — FNV-1a/64 over that string, exactly as `dump_topology` stamps it.
- **The corpus differential** (`hale-types/tests/topology_projection.rs`) — for every checkable corpus program, `project_model_half(derive_application_model(bundle))` must be **byte-identical** to the substring `dump_topology` hashes, and the projected hash must equal the stamped one. Plus a dense fixture interleaving every hashed section (sealed loci, supervision with a retry bound, keyed + literal endpoints, groups, stdlib contraction) and a cross-seed bundle proving the display-spelling mapping.

## Projection rules

The model keys everything by raw post-merge symbol; the legacy artifact renders author spelling. The projection is that mapping, made explicit:

- `sorts.fns` / fn-keyed sections restrict to `legacy.topology_v1_fns`; **phases deliberately do not** — the legacy phase relation is AST-derived and includes empty-bodied hooks (`run() { }`) the behavior summary never keys. This was the one divergence class the corpus sweep caught, in two recording-oriented fixtures.
- Site-grained model call/publish rows merge to the legacy endpoint grain: loop bits OR, any interface-dispatch site tags the edge, sets dedupe.
- `calls_via_stdlib` renders `LegacyProjection.topology_v1_calls_via_stdlib` — the preserved one-Boolean no-revisit walk rows — never the model's lattice rows, whose loop bits may legitimately be stronger.
- Declared endpoints render their topic's display NAME (legacy relations never carried wire subjects); undeclared endpoints render their authored pattern. Edges the model recovers into unanalyzed callees have no legacy row and are filtered.
- Typed holes + `dead_interface_calls` re-fold into the legacy `unknowns` vocabulary (`indirect_call`, `untyped_receiver_call:<callee>`, `uninhabited_interface_call:<iface>.<method>`, `computed_publish`).

## The gate is permanent until Change 6

Both derivations stay live. Any model-builder change that would alter the artifact identity — and therefore silently re-key `.halerec` replay admission — now fails the differential loudly instead. At the Change-6 versioned identity transition, the legacy derivation and `LegacyProjection` get deleted together and the artifact becomes a pure projection. (Per Riley: backwards compat is not sacred — the Change-6 transition is pre-authorized to break cleanly; until then this differential is the drift alarm.)

The differential is negative-tested: perturbing a rendering rule (hook/method inversion) fails the corpus sweep.

## Verification

- 1226/1226 across hale-types + hale-model + hale-cli; `hale fmt --check` clean.
- Corpus sweep covers >100 checkable programs including modes, supervision, seeds, sealed loci.
- No user-visible behavior change: `dump_topology` output and `shape_hash` values are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)