### PR TITLE
feat(model+types+cli): ClaimIr — every law surface lowered to one typed vocabulary (GH #476 Change 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ behavior.
 
 ## Unreleased
 
+### ClaimIr - every law surface, lowered (GH #476 Change 4)
+
+`hale-model` gains `ClaimIr` - one typed variant per law form across
+every surface the language has grown: the eight claims-block forms
+(reachability, boundary grants, path bounds, endpoint existence,
+sealing, attribution, coverage, cardinality), constitution clauses
+with recorded origin, library-tier claims with alias attribution,
+the annotation surfaces (`@effects(none/publish/causes/only)`,
+`@no_panic`, `@effects(depends:)`, `@phase_effects`, `@budget` in
+both alloc and quantitative forms), and deployment-plan claim rows
+(name-level until Change 7's FleetModel).
+`hale_types::claim_lowering::lower_claims(bundle, model)` lowers
+the program surfaces through the evaluator's OWN clause enumeration
+(`enumerate_clauses`, extracted from `claims_report_inner` so two
+walks cannot drift); `fleet::lower_plan_claims` lowers plan rows.
+Lowering is total over parseable programs (unresolved refs keep
+raw+display spellings with no id - Change 5's `invalid` residue),
+rows keep authored order, and a corpus-wide differential holds the
+claims-family rows equal to the evaluator's outcomes on count,
+name, order, and constitution source. Lowering only: the old
+evaluators stay active and authoritative; nothing consumes these
+rows yet. `@effects(is:)` deliberately does not lower - carries is
+a classification fact the model already records as labels.
+
+
 ### The model-backed artifact projection (GH #476 Change 3)
 
 `hale_types::topology_projection::project_model_half(&ApplicationModel)`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ version = "0.17.0"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
+ "hale-model",
  "hale-syntax",
  "hale-types",
  "libc",

--- a/crates/hale-cli/Cargo.toml
+++ b/crates/hale-cli/Cargo.toml
@@ -11,6 +11,7 @@ name = "hale"
 path = "src/main.rs"
 
 [dependencies]
+hale-model = { path = "../hale-model" }
 hale-syntax = { path = "../hale-syntax" }
 hale-types = { path = "../hale-types" }
 hale-codegen = { path = "../hale-codegen" }

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -1393,106 +1393,108 @@ fn fnv(s: &str) -> String {
 }
 
 /// GH #476 Change 4 — lower the plan's claim rows to `ClaimIr`.
-/// Fleet targets are PLAN-level names (instances, plan groups, wire
-/// subjects); they resolve against a typed `FleetModel` at Change 7,
-/// so every row lowers name-level here and the old evaluator stays
-/// authoritative. A `CountSpec` with several bounds present lowers
-/// one row per bound (eq, then max, then min) — each is its own law.
+/// ONE row per `ClaimSpec`, mirroring the evaluator's
+/// one-name/one-sentence rule (a claim name identifies one sentence
+/// and one verdict): a spec with zero or several verbs set lowers to
+/// a structured [`hale_model::LoweringIssue`], never to a split or
+/// silently dropped law, and a `CountSpec`'s eq/max/min bounds stay
+/// ONE conjunctive law. Fleet targets are PLAN-level names
+/// (instances, plan groups, wire subjects); they resolve against a
+/// typed `FleetModel` at Change 7, so every row lowers name-level
+/// and the old evaluator stays authoritative.
 pub fn lower_plan_claims(
     claims: &[ClaimSpec],
 ) -> hale_model::ClaimIrTable {
     use hale_model::{
-        ClaimIr, ClaimIrTable, ClaimOrigin, ClaimRow, CountCmpIr,
-        ProvenanceId,
+        ClaimIr, ClaimIrTable, ClaimOrigin, ClaimRow, ProvenanceId,
     };
     let mut table = ClaimIrTable::default();
-    let push = |table: &mut ClaimIrTable,
-                    name: &str,
-                    law: ClaimIr| {
+    let mut prov = |table: &mut ClaimIrTable, name: &str| {
         let pid = ProvenanceId(table.provenance.records.len() as u32);
         table.provenance.records.push(
             hale_model::Provenance::Synthetic {
                 origin: format!("deployment plan claim `{}`", name),
             },
         );
+        pid
+    };
+    for c in claims {
+        let verbs = [
+            c.forbid_reaches.is_some(),
+            c.require_subscribes.is_some(),
+            c.require_publishes.is_some(),
+            c.count_publisher_instances.is_some(),
+            c.count_subscriber_instances.is_some(),
+            c.only_edges.is_some(),
+        ]
+        .iter()
+        .filter(|v| **v)
+        .count();
+        if verbs != 1 {
+            // The evaluator's one-name/one-sentence rule: this spec
+            // is not one law. Structured invalidity, not a split.
+            let pid = prov(&mut table, &c.name);
+            table.issues.push(hale_model::LoweringIssue {
+                message: format!(
+                    "plan claim `{}` sets {} verbs — a claim is ONE \
+                     sentence with one verdict",
+                    c.name, verbs
+                ),
+                provenance: pid,
+            });
+            continue;
+        }
+        let law = if let Some(fr) = &c.forbid_reaches {
+            ClaimIr::FleetForbidReaches {
+                from: fr.from.clone(),
+                to: fr.to.clone(),
+                avoiding: fr.avoiding.clone(),
+            }
+        } else if let Some(r) = &c.require_subscribes {
+            ClaimIr::FleetRequireEndpoint {
+                publishers: false,
+                target: r.group.clone(),
+                topic: r.subject.clone(),
+            }
+        } else if let Some(r) = &c.require_publishes {
+            ClaimIr::FleetRequireEndpoint {
+                publishers: true,
+                target: r.group.clone(),
+                topic: r.subject.clone(),
+            }
+        } else if let Some(spec) = &c.count_publisher_instances {
+            ClaimIr::FleetCountInstances {
+                publishers: true,
+                topic: spec.subject.clone(),
+                eq: spec.eq.map(|n| n as u64),
+                max: spec.max.map(|n| n as u64),
+                min: spec.min.map(|n| n as u64),
+            }
+        } else if let Some(spec) = &c.count_subscriber_instances {
+            ClaimIr::FleetCountInstances {
+                publishers: false,
+                topic: spec.subject.clone(),
+                eq: spec.eq.map(|n| n as u64),
+                max: spec.max.map(|n| n as u64),
+                min: spec.min.map(|n| n as u64),
+            }
+        } else {
+            let Some(oe) = &c.only_edges else { unreachable!() };
+            ClaimIr::FleetOnlyEdges {
+                src: oe.from.clone(),
+                dst: oe.to.clone(),
+                grants: oe.grant_subjects.clone(),
+            }
+        };
+        let pid = prov(&mut table, &c.name);
         let ordinal = table.rows.len() as u32;
         table.rows.push(ClaimRow {
             ordinal,
-            name: name.to_string(),
+            name: c.name.clone(),
             origin: ClaimOrigin::FleetPlan,
             law,
             provenance: pid,
         });
-    };
-    for c in claims {
-        if let Some(fr) = &c.forbid_reaches {
-            push(
-                &mut table,
-                &c.name,
-                ClaimIr::FleetForbidReaches {
-                    from: fr.from.clone(),
-                    to: fr.to.clone(),
-                    avoiding: fr.avoiding.clone(),
-                },
-            );
-        }
-        if let Some(r) = &c.require_subscribes {
-            push(
-                &mut table,
-                &c.name,
-                ClaimIr::FleetRequireEndpoint {
-                    publishers: false,
-                    target: r.group.clone(),
-                    topic: r.subject.clone(),
-                },
-            );
-        }
-        if let Some(r) = &c.require_publishes {
-            push(
-                &mut table,
-                &c.name,
-                ClaimIr::FleetRequireEndpoint {
-                    publishers: true,
-                    target: r.group.clone(),
-                    topic: r.subject.clone(),
-                },
-            );
-        }
-        for (publishers, spec) in [
-            (true, &c.count_publisher_instances),
-            (false, &c.count_subscriber_instances),
-        ] {
-            let Some(spec) = spec else { continue };
-            for (cmp, n) in [
-                (CountCmpIr::Eq, spec.eq),
-                (CountCmpIr::Le, spec.max),
-                (CountCmpIr::Ge, spec.min),
-            ] {
-                if let Some(n) = n {
-                    push(
-                        &mut table,
-                        &c.name,
-                        ClaimIr::FleetCountInstances {
-                            publishers,
-                            topic: spec.subject.clone(),
-                            cmp,
-                            n: n as u64,
-                        },
-                    );
-                }
-            }
-        }
-        if let Some(oe) = &c.only_edges {
-            push(
-                &mut table,
-                &c.name,
-                ClaimIr::FleetOnlyEdges {
-                    src: oe.from.clone(),
-                    dst: oe.to.clone(),
-                    grants: oe.grant_subjects.clone(),
-                },
-            );
-        }
     }
     table
 }
@@ -1500,71 +1502,74 @@ pub fn lower_plan_claims(
 #[cfg(test)]
 mod claim_ir_tests {
     use super::*;
-    use hale_model::{ClaimIr, ClaimOrigin, CountCmpIr};
+    use hale_model::{ClaimIr, ClaimOrigin};
 
-    /// GH #476 Change 4: every plan claim verb lowers, a multi-bound
-    /// CountSpec lowers one row per bound, and rows keep authored
-    /// order with FleetPlan origin.
+    fn empty_spec(name: &str) -> ClaimSpec {
+        ClaimSpec {
+            name: name.to_string(),
+            forbid_reaches: None,
+            require_subscribes: None,
+            require_publishes: None,
+            count_publisher_instances: None,
+            count_subscriber_instances: None,
+            only_edges: None,
+        }
+    }
+
+    /// GH #476 Change 4 (round 15): ONE row per ClaimSpec — the
+    /// evaluator's one-name/one-sentence rule. A multi-bound count
+    /// stays one conjunctive law; a multi-verb or verbless spec
+    /// lowers to a structured issue, never a split or a silent drop.
     #[test]
-    fn plan_claims_lower_one_row_per_law() {
-        let claims = vec![
-            ClaimSpec {
-                name: "iso".to_string(),
-                forbid_reaches: Some(ForbidReaches {
-                    from: "gw-0".to_string(),
-                    to: "risk-0".to_string(),
-                    avoiding: Some("audit".to_string()),
-                }),
-                require_subscribes: None,
-                require_publishes: None,
-                count_publisher_instances: None,
-                count_subscriber_instances: None,
-                only_edges: None,
-            },
-            ClaimSpec {
-                name: "writer".to_string(),
-                forbid_reaches: None,
-                require_subscribes: None,
-                require_publishes: Some(RequireEndpoint {
-                    group: "gw".to_string(),
-                    subject: "orders".to_string(),
-                }),
-                count_publisher_instances: Some(CountSpec {
-                    subject: "orders".to_string(),
-                    eq: None,
-                    max: Some(3),
-                    min: Some(1),
-                }),
-                count_subscriber_instances: None,
-                only_edges: Some(OnlyEdges {
-                    from: "gw".to_string(),
-                    to: "risk".to_string(),
-                    grant_subjects: vec!["orders".to_string()],
-                }),
-            },
-        ];
-        let t = lower_plan_claims(&claims);
-        assert_eq!(t.rows.len(), 5, "1 + (1 require + 2 bounds + 1 only)");
+    fn plan_claims_lower_one_row_per_sentence() {
+        let mut iso = empty_spec("iso");
+        iso.forbid_reaches = Some(ForbidReaches {
+            from: "gw-0".to_string(),
+            to: "risk-0".to_string(),
+            avoiding: Some("audit".to_string()),
+        });
+        let mut writers = empty_spec("writers");
+        writers.count_publisher_instances = Some(CountSpec {
+            subject: "orders".to_string(),
+            eq: None,
+            max: Some(3),
+            min: Some(1),
+        });
+        let mut broken = empty_spec("broken");
+        broken.require_publishes = Some(RequireEndpoint {
+            group: "gw".to_string(),
+            subject: "orders".to_string(),
+        });
+        broken.only_edges = Some(OnlyEdges {
+            from: "gw".to_string(),
+            to: "risk".to_string(),
+            grant_subjects: vec![],
+        });
+        let hollow = empty_spec("hollow");
+        let t = lower_plan_claims(&[iso, writers, broken, hollow]);
+        assert_eq!(t.rows.len(), 2, "one row per well-formed sentence");
         assert!(t
             .rows
             .iter()
             .all(|r| r.origin == ClaimOrigin::FleetPlan));
-        assert!((0..5).all(|i| t.rows[i].ordinal == i as u32));
         assert!(matches!(
             &t.rows[0].law,
             ClaimIr::FleetForbidReaches { avoiding: Some(a), .. } if a == "audit"
         ));
+        // The two-bound count is ONE conjunctive law.
         assert!(matches!(
-            &t.rows[2].law,
-            ClaimIr::FleetCountInstances { cmp: CountCmpIr::Le, n: 3, .. }
+            &t.rows[1].law,
+            ClaimIr::FleetCountInstances {
+                eq: None,
+                max: Some(3),
+                min: Some(1),
+                ..
+            }
         ));
-        assert!(matches!(
-            &t.rows[3].law,
-            ClaimIr::FleetCountInstances { cmp: CountCmpIr::Ge, n: 1, .. }
-        ));
-        assert!(matches!(
-            &t.rows[4].law,
-            ClaimIr::FleetOnlyEdges { grants, .. } if grants.len() == 1
-        ));
+        // Multi-verb and verbless specs are structured invalidity.
+        assert_eq!(t.issues.len(), 2);
+        assert!(t.issues[0].message.contains("`broken` sets 2 verbs"));
+        assert!(t.issues[1].message.contains("`hollow` sets 0 verbs"));
     }
 }
+

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -628,6 +628,18 @@ fn evaluate_claims(
             .collect()
     };
 
+    // GH #476 Change 4: the plan's law rows lower to ClaimIr
+    // alongside the evaluation (lowering only — this evaluator
+    // stays authoritative until Change 7's FleetModel). The trace
+    // line is the same demand-proof surface the model builder uses.
+    if std::env::var("HALE_MODEL_TRACE").as_deref() == Ok("1") {
+        let lowered = lower_plan_claims(&plan.claims);
+        eprintln!(
+            "[hale-model] lowered {} fleet claim row(s)",
+            lowered.rows.len()
+        );
+    }
+
     let mut rows: Vec<String> = Vec::new();
     for c in &plan.claims {
         // A claim is ONE sentence, exactly as it is in source.
@@ -1378,4 +1390,181 @@ fn fnv(s: &str) -> String {
         h = h.wrapping_mul(0x0000_0100_0000_01b3);
     }
     format!("{:016x}", h)
+}
+
+/// GH #476 Change 4 — lower the plan's claim rows to `ClaimIr`.
+/// Fleet targets are PLAN-level names (instances, plan groups, wire
+/// subjects); they resolve against a typed `FleetModel` at Change 7,
+/// so every row lowers name-level here and the old evaluator stays
+/// authoritative. A `CountSpec` with several bounds present lowers
+/// one row per bound (eq, then max, then min) — each is its own law.
+pub fn lower_plan_claims(
+    claims: &[ClaimSpec],
+) -> hale_model::ClaimIrTable {
+    use hale_model::{
+        ClaimIr, ClaimIrTable, ClaimOrigin, ClaimRow, CountCmpIr,
+        ProvenanceId,
+    };
+    let mut table = ClaimIrTable::default();
+    let push = |table: &mut ClaimIrTable,
+                    name: &str,
+                    law: ClaimIr| {
+        let pid = ProvenanceId(table.provenance.records.len() as u32);
+        table.provenance.records.push(
+            hale_model::Provenance::Synthetic {
+                origin: format!("deployment plan claim `{}`", name),
+            },
+        );
+        let ordinal = table.rows.len() as u32;
+        table.rows.push(ClaimRow {
+            ordinal,
+            name: name.to_string(),
+            origin: ClaimOrigin::FleetPlan,
+            law,
+            provenance: pid,
+        });
+    };
+    for c in claims {
+        if let Some(fr) = &c.forbid_reaches {
+            push(
+                &mut table,
+                &c.name,
+                ClaimIr::FleetForbidReaches {
+                    from: fr.from.clone(),
+                    to: fr.to.clone(),
+                    avoiding: fr.avoiding.clone(),
+                },
+            );
+        }
+        if let Some(r) = &c.require_subscribes {
+            push(
+                &mut table,
+                &c.name,
+                ClaimIr::FleetRequireEndpoint {
+                    publishers: false,
+                    target: r.group.clone(),
+                    topic: r.subject.clone(),
+                },
+            );
+        }
+        if let Some(r) = &c.require_publishes {
+            push(
+                &mut table,
+                &c.name,
+                ClaimIr::FleetRequireEndpoint {
+                    publishers: true,
+                    target: r.group.clone(),
+                    topic: r.subject.clone(),
+                },
+            );
+        }
+        for (publishers, spec) in [
+            (true, &c.count_publisher_instances),
+            (false, &c.count_subscriber_instances),
+        ] {
+            let Some(spec) = spec else { continue };
+            for (cmp, n) in [
+                (CountCmpIr::Eq, spec.eq),
+                (CountCmpIr::Le, spec.max),
+                (CountCmpIr::Ge, spec.min),
+            ] {
+                if let Some(n) = n {
+                    push(
+                        &mut table,
+                        &c.name,
+                        ClaimIr::FleetCountInstances {
+                            publishers,
+                            topic: spec.subject.clone(),
+                            cmp,
+                            n: n as u64,
+                        },
+                    );
+                }
+            }
+        }
+        if let Some(oe) = &c.only_edges {
+            push(
+                &mut table,
+                &c.name,
+                ClaimIr::FleetOnlyEdges {
+                    src: oe.from.clone(),
+                    dst: oe.to.clone(),
+                    grants: oe.grant_subjects.clone(),
+                },
+            );
+        }
+    }
+    table
+}
+
+#[cfg(test)]
+mod claim_ir_tests {
+    use super::*;
+    use hale_model::{ClaimIr, ClaimOrigin, CountCmpIr};
+
+    /// GH #476 Change 4: every plan claim verb lowers, a multi-bound
+    /// CountSpec lowers one row per bound, and rows keep authored
+    /// order with FleetPlan origin.
+    #[test]
+    fn plan_claims_lower_one_row_per_law() {
+        let claims = vec![
+            ClaimSpec {
+                name: "iso".to_string(),
+                forbid_reaches: Some(ForbidReaches {
+                    from: "gw-0".to_string(),
+                    to: "risk-0".to_string(),
+                    avoiding: Some("audit".to_string()),
+                }),
+                require_subscribes: None,
+                require_publishes: None,
+                count_publisher_instances: None,
+                count_subscriber_instances: None,
+                only_edges: None,
+            },
+            ClaimSpec {
+                name: "writer".to_string(),
+                forbid_reaches: None,
+                require_subscribes: None,
+                require_publishes: Some(RequireEndpoint {
+                    group: "gw".to_string(),
+                    subject: "orders".to_string(),
+                }),
+                count_publisher_instances: Some(CountSpec {
+                    subject: "orders".to_string(),
+                    eq: None,
+                    max: Some(3),
+                    min: Some(1),
+                }),
+                count_subscriber_instances: None,
+                only_edges: Some(OnlyEdges {
+                    from: "gw".to_string(),
+                    to: "risk".to_string(),
+                    grant_subjects: vec!["orders".to_string()],
+                }),
+            },
+        ];
+        let t = lower_plan_claims(&claims);
+        assert_eq!(t.rows.len(), 5, "1 + (1 require + 2 bounds + 1 only)");
+        assert!(t
+            .rows
+            .iter()
+            .all(|r| r.origin == ClaimOrigin::FleetPlan));
+        assert!((0..5).all(|i| t.rows[i].ordinal == i as u32));
+        assert!(matches!(
+            &t.rows[0].law,
+            ClaimIr::FleetForbidReaches { avoiding: Some(a), .. } if a == "audit"
+        ));
+        assert!(matches!(
+            &t.rows[2].law,
+            ClaimIr::FleetCountInstances { cmp: CountCmpIr::Le, n: 3, .. }
+        ));
+        assert!(matches!(
+            &t.rows[3].law,
+            ClaimIr::FleetCountInstances { cmp: CountCmpIr::Ge, n: 1, .. }
+        ));
+        assert!(matches!(
+            &t.rows[4].law,
+            ClaimIr::FleetOnlyEdges { grants, .. } if grants.len() == 1
+        ));
+    }
 }

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -1409,7 +1409,7 @@ pub fn lower_plan_claims(
         ClaimIr, ClaimIrTable, ClaimOrigin, ClaimRow, ProvenanceId,
     };
     let mut table = ClaimIrTable::default();
-    let mut prov = |table: &mut ClaimIrTable, name: &str| {
+    let prov = |table: &mut ClaimIrTable, name: &str| {
         let pid = ProvenanceId(table.provenance.records.len() as u32);
         table.provenance.records.push(
             hale_model::Provenance::Synthetic {

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -9,8 +9,9 @@
 
 use crate::capability::Capabilities;
 use crate::entity::{
-    Binding, Declaration, Function, Group, InterfaceDecl, LocusDecl, LocusInstance,
-    PayloadContract, Phase, Seed, Subject, ThreadDomain, Topic, TypeDecl,
+    Binding, Declaration, EffectClassDecl, Function, Group,
+    InterfaceDecl, LocusDecl, LocusInstance, PayloadContract, Phase,
+    Seed, Subject, ThreadDomain, Topic, TypeDecl,
 };
 use crate::hole::Hole;
 use crate::ids::{EntityRef, FunctionId, ProvenanceId};
@@ -83,6 +84,8 @@ pub struct Entities {
     pub groups: Vec<Group>,
     pub types: Vec<TypeDecl>,
     pub interfaces: Vec<InterfaceDecl>,
+    /// Declared/referenced USER effect classes (GH #476 Change 4).
+    pub effect_classes: Vec<EffectClassDecl>,
     /// Seed-membership-only declarations (perspective, const, ring
     /// layout, target) — the rest of the nameable universe.
     pub declarations: Vec<Declaration>,
@@ -270,6 +273,10 @@ impl ApplicationModel {
         check_sorted_keys("thread_domains", e.thread_domains.iter().map(|d| &d.name))?;
         check_sorted_keys("groups", e.groups.iter().map(|g| &g.name))?;
         check_sorted_keys("types", e.types.iter().map(|t| &t.name))?;
+        check_sorted_keys(
+            "effect_classes",
+            e.effect_classes.iter().map(|c| &c.name),
+        )?;
         check_sorted_keys("interfaces", e.interfaces.iter().map(|t| &t.name))?;
         check_sorted_keys(
             "declarations",
@@ -301,6 +308,19 @@ impl ApplicationModel {
                 Ok(())
             }
         };
+        for (i, c) in e.effect_classes.iter().enumerate() {
+            // Composition is the NORMALIZED atomic expansion:
+            // sorted, deduplicated, and never self-referential.
+            if c.composition.windows(2).any(|w| w[0] >= w[1])
+                || c.composition.iter().any(|m| *m == c.name)
+            {
+                return Err(ModelError::NotCanonical {
+                    table: "effect_classes.composition",
+                    index: i,
+                });
+            }
+            prov("effect_classes", i, c.provenance)?;
+        }
         for (i, f) in e.functions.iter().enumerate() {
             prov("functions", i, f.provenance)?;
         }

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -309,15 +309,22 @@ impl ApplicationModel {
             }
         };
         for (i, c) in e.effect_classes.iter().enumerate() {
-            // Composition is the NORMALIZED atomic expansion:
-            // sorted, deduplicated, and never self-referential.
-            if c.composition.windows(2).any(|w| w[0] >= w[1])
-                || c.composition.iter().any(|m| *m == c.name)
+            // A composed definition is the NORMALIZED atomic
+            // expansion: sorted, deduplicated, never
+            // self-referential. Atomic and InvalidCycle carry no
+            // atoms by construction.
+            if let crate::entity::EffectClassDefinition::Composed {
+                atoms,
+            } = &c.definition
             {
-                return Err(ModelError::NotCanonical {
-                    table: "effect_classes.composition",
-                    index: i,
-                });
+                if atoms.windows(2).any(|w| w[0] >= w[1])
+                    || atoms.iter().any(|m| *m == c.name)
+                {
+                    return Err(ModelError::NotCanonical {
+                        table: "effect_classes.definition",
+                        index: i,
+                    });
+                }
             }
             prov("effect_classes", i, c.provenance)?;
         }

--- a/crates/hale-model/src/claim_ir.rs
+++ b/crates/hale-model/src/claim_ir.rs
@@ -56,6 +56,29 @@ use crate::ids::{
 use crate::provenance::ProvenanceTable;
 use crate::ApplicationModel;
 
+/// The CANONICAL bus-set matching rule (review round 19): exact
+/// string equality first, trailing-name equality second — the same
+/// `topic_ref_matches` the authoritative evaluator applies
+/// (`hale-types::effects` delegates HERE, so there is exactly one
+/// definition and the dependency-free schema can validate candidate
+/// sets against it).
+pub fn bus_ref_matches(declared: &str, resolved: &str) -> bool {
+    if declared == resolved {
+        return true;
+    }
+    bus_topic_tail(declared) == bus_topic_tail(resolved)
+}
+
+/// The bare topic name, whichever spelling reached us: the last
+/// `::` segment; for a merged `__lib_…` symbol, the last `_` token.
+pub fn bus_topic_tail(s: &str) -> &str {
+    let s = s.rsplit("::").next().unwrap_or(s);
+    match s.strip_prefix("__lib_") {
+        Some(rest) => rest.rsplit('_').next().unwrap_or(rest),
+        None => s,
+    }
+}
+
 /// A name in claim position: raw canonical spelling + author
 /// display. Two spellings, same doctrine as every entity table.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -381,6 +404,9 @@ pub enum ClaimIrError {
     /// duplicated name/display fields — an evaluator using the id
     /// and a renderer using the name would describe different laws.
     NameDisagreement { index: usize, what: &'static str },
+    /// A provenance record's contents are unresolvable: a dangling
+    /// `SourceId` or an inverted span.
+    InvalidProvenanceRecord { index: usize },
 }
 
 impl ClaimIrTable {
@@ -397,6 +423,27 @@ impl ClaimIrTable {
     ) -> Result<(), ClaimIrError> {
         let e = &model.entities;
         let prov_len = self.provenance.records.len();
+        // The records themselves must resolve — the same boundary
+        // ApplicationModel::validate draws (review round 19): a
+        // dangling SourceId or inverted span is a primary
+        // diagnostic location Change 5 could not resolve without
+        // reopening the AST.
+        let src_len = self.provenance.sources.len();
+        for (i, r) in self.provenance.records.iter().enumerate() {
+            if let crate::provenance::Provenance::Source {
+                source,
+                span,
+            } = r
+            {
+                if source.index() >= src_len || span.0 > span.1 {
+                    return Err(
+                        ClaimIrError::InvalidProvenanceRecord {
+                            index: i,
+                        },
+                    );
+                }
+            }
+        }
         for (i, issue) in self.issues.iter().enumerate() {
             if issue.provenance.index() >= prov_len {
                 return Err(ClaimIrError::DanglingProvenance {
@@ -544,24 +591,36 @@ impl ClaimIrTable {
                             index: i,
                         });
                     }
-                    if sel.topics.windows(2).any(|w| w[0] >= w[1])
-                        || sel
-                            .subjects
-                            .windows(2)
-                            .any(|w| w[0] >= w[1])
-                    {
-                        return Err(bad("selector candidates"));
-                    }
-                    if sel
+                    // The candidate sets are DERIVED data: exactly
+                    // what `bus_ref_matches(name, …)` produces over
+                    // the model's topic and subject tables — an
+                    // unrelated candidate widens the law a renderer
+                    // reads from `name`, an omitted same-tailed
+                    // candidate silently narrows it (review
+                    // round 19; the same machine/display-agreement
+                    // doctrine as NameDisagreement).
+                    let want_topics: Vec<TopicId> = e
                         .topics
                         .iter()
-                        .any(|c| c.index() >= e.topics.len())
-                        || sel
-                            .subjects
-                            .iter()
-                            .any(|c| c.index() >= e.subjects.len())
+                        .enumerate()
+                        .filter(|(_, t)| {
+                            bus_ref_matches(&sel.name, &t.name)
+                        })
+                        .map(|(k, _)| TopicId(k as u32))
+                        .collect();
+                    let want_subjects: Vec<SubjectId> = e
+                        .subjects
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, su)| {
+                            bus_ref_matches(&sel.name, &su.pattern)
+                        })
+                        .map(|(k, _)| SubjectId(k as u32))
+                        .collect();
+                    if sel.topics != want_topics
+                        || sel.subjects != want_subjects
                     {
-                        return Err(bad("selector candidate"));
+                        return Err(dis("bus selector"));
                     }
                     Ok(())
                 };

--- a/crates/hale-model/src/claim_ir.rs
+++ b/crates/hale-model/src/claim_ir.rs
@@ -1,0 +1,466 @@
+//! `ClaimIr` — every law surface, lowered to one typed vocabulary
+//! (GH #476 Change 4).
+//!
+//! The epic's law: `Source --check/derive--> Model --judge(ClaimIr)
+//! --> Evidence`. A judgment engine (Changes 5a–5e) evaluates laws
+//! against the [`ApplicationModel`]; this module is the laws' typed
+//! form — **one variant per law form**, across every surface the
+//! language has grown:
+//!
+//! * `claims { }` block forms (#382): reachability, boundary
+//!   grants, endpoint existence, sealing, attribution, coverage,
+//!   cardinality, path bounds;
+//! * constitution clauses (#409) — the same forms, arriving through
+//!   adoption, with their origin recorded;
+//! * library-tier claims (#392 thread 2) — a seed swearing about
+//!   itself, alias-attributed;
+//! * fn/locus effect assertions (#265/#330/#345/#354):
+//!   `@effects(none/publish/causes/only)`, `@no_panic`,
+//!   `@effects(depends: …)`, `@phase_effects`, `@budget`;
+//! * fleet plan rows (#408) — deployment claims over instances,
+//!   name-level until `FleetModel` (Change 7) gives them typed
+//!   targets.
+//!
+//! **Change 4 is lowering only.** The old evaluators stay active
+//! and authoritative; nothing consumes these rows yet. What this
+//! buys now: the clause universe is enumerated ONCE (the lowering
+//! shares the evaluator's own collection walk), every law is
+//! representable in model vocabulary, and the Change-5 migration
+//! can proceed family-by-family against a stable target.
+//!
+//! ## Reference doctrine
+//!
+//! A lowered reference carries three things: the **raw** canonical
+//! spelling (post-merge symbol — the model's identity space), the
+//! **display** spelling (what the author wrote / what diagnostics
+//! print), and — when the model resolves it — the typed **id**.
+//! `id: None` is not an error at this layer: the lowering is total
+//! over parseable programs, and an unresolvable name is exactly
+//! what the judgment vocabulary's `invalid` verdict exists for
+//! (Change 5). Fleet rows always carry `None` ids at Change 4 —
+//! their targets live in a plan, not in this application's model.
+//!
+//! ## Ordering
+//!
+//! Rows keep AUTHORED order via `ordinal` — the evaluator reports
+//! outcomes in authored order and Change 5's diagnostics-parity
+//! differential needs to walk both lists in lockstep. `validate`
+//! enforces ordinal contiguity from zero, which makes the table
+//! canonically ordered without imposing a lexical sort that would
+//! scramble evaluation order.
+
+use crate::ids::{
+    FunctionId, GroupId, LocusDeclId, PhaseId, ProvenanceId, SeedId,
+    SubjectId, TopicId,
+};
+use crate::provenance::ProvenanceTable;
+use crate::ApplicationModel;
+
+/// A name in claim position: raw canonical spelling + author
+/// display. Two spellings, same doctrine as every entity table.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct NameRef {
+    pub raw: String,
+    pub display: String,
+}
+
+/// A group reference, resolved against `entities.groups` when the
+/// model knows it.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct GroupRef {
+    pub group: Option<GroupId>,
+    pub name: NameRef,
+}
+
+/// A topic reference (`T` / `alias::T`, canonicalized at mangle).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TopicIrRef {
+    pub topic: Option<TopicId>,
+    pub name: NameRef,
+}
+
+/// An effect class by canonical name — the model's label/effects
+/// vocabulary (`syscall`, `alloc`, …, or a declared user class).
+/// String-keyed on purpose: the class universe is program-declared
+/// and the model's labels/effects sections already speak it.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct EffectClassRef {
+    pub name: String,
+}
+
+/// A set expression in claim-argument position.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum SetIr {
+    Group(GroupRef),
+    /// `effects(money)` — declared carriers of the class.
+    EffectCarriers(EffectClassRef),
+}
+
+/// One granted edge inside `only edges { … }`.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct GrantIr {
+    /// `publish T` when true, `subscribe T` when false — both admit
+    /// the same edge; the verb names the reviewable declaration.
+    pub publish: bool,
+    pub topic: TopicIrRef,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CountCmpIr {
+    Eq,
+    Le,
+    Ge,
+}
+
+/// A quantitative budget dimension (`@budget(<dim> = N)`).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum QuantDimIr {
+    StackBytes,
+    BlockPoints,
+    Publish,
+    Fanout,
+    /// `@budget(<user class> = N)` — carrier-call bound.
+    UserClass(EffectClassRef),
+}
+
+/// Where a law came from. Origin is provenance at the law grain —
+/// the same clause text means different lifetimes depending on
+/// whether it was authored here, adopted, or shipped with a seed.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ClaimOrigin {
+    /// Authored in this main's `claims { }` block.
+    Main,
+    /// Adopted from a constitution (#409); carries its name as the
+    /// evaluator reports it (`ClaimOutcome::source`).
+    Constitution { name: String },
+    /// A library-tier top-level block (#392 thread 2); the alias the
+    /// evaluator attributes rows to, when one resolved.
+    Library { alias: Option<String> },
+    /// An `@effects` / `@budget` / `@phase_effects` annotation — the
+    /// law rides on a declaration rather than a claims block.
+    Annotation,
+    /// A deployment-plan claim row (#408). Targets are plan-level
+    /// names until Change 7's `FleetModel`.
+    FleetPlan,
+}
+
+/// One law form. ONE variant per form, across every surface.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ClaimIr {
+    // ---------- claims-block forms (#382) ----------
+    /// `forbid reaches(SRC, DST) [via { … }] [during P] [avoiding G]`.
+    ForbidReaches {
+        src: SetIr,
+        dst: SetIr,
+        via_calls: bool,
+        via_bus: bool,
+        during: Option<(Option<PhaseId>, String)>,
+        avoiding: Option<GroupRef>,
+    },
+    /// `only edges SRC -> DST { grants }`.
+    OnlyEdges {
+        src: GroupRef,
+        dst: GroupRef,
+        grants: Vec<GrantIr>,
+    },
+    /// `bound C <= N on paths from G`.
+    Bound {
+        class: EffectClassRef,
+        limit: u64,
+        from: GroupRef,
+    },
+    /// `require publishes/subscribes(some G, topic T)`.
+    RequireEndpoint {
+        publishers: bool,
+        group: GroupRef,
+        topic: TopicIrRef,
+    },
+    /// `require sealed(all G)` (GH #436).
+    RequireSealed { group: GroupRef },
+    /// `require attributed(all <class>)` (GH #436).
+    RequireAttributed { class: EffectClassRef },
+    /// `cover topic in seed(a): subscribed_by(some G)`.
+    Cover {
+        seed: (Option<SeedId>, String),
+        group: GroupRef,
+    },
+    /// `count publishers/subscribers(topic T) <cmp> N`.
+    Count {
+        publishers: bool,
+        topic: TopicIrRef,
+        cmp: CountCmpIr,
+        n: u64,
+    },
+
+    // ---------- fn/locus effect assertions (#265) ----------
+    /// `@effects(none: {…})` — forbidden classes.
+    EffectForbid {
+        at: (Option<FunctionId>, NameRef),
+        classes: Vec<EffectClassRef>,
+    },
+    /// `@effects(publish: {…})` — the closed allowed publish set.
+    EffectPublishSet {
+        at: (Option<FunctionId>, NameRef),
+        subjects: Vec<(Option<SubjectId>, NameRef)>,
+    },
+    /// `@effects(causes: {…})` — transitive through bus edges.
+    EffectCauses {
+        at: (Option<FunctionId>, NameRef),
+        classes: Vec<EffectClassRef>,
+    },
+    /// `@effects(only: {…})` — the closed subset form (#354).
+    EffectOnly {
+        at: (Option<FunctionId>, NameRef),
+        classes: Vec<EffectClassRef>,
+    },
+    /// `@no_panic`.
+    NoPanic { at: (Option<FunctionId>, NameRef) },
+    /// `@effects(depends: {…})` on a locus (RFC #330) — the
+    /// COMPLETE backward-reachable subject set.
+    DependsSet {
+        locus: (Option<LocusDeclId>, NameRef),
+        subjects: Vec<(Option<SubjectId>, NameRef)>,
+    },
+    /// `@phase_effects(birth: {alloc}, run: {})` on a locus.
+    PhaseEffects {
+        locus: (Option<LocusDeclId>, NameRef),
+        /// (phase name, allowed classes); absent phase =
+        /// unconstrained, present-empty = forbids all.
+        phases: Vec<(String, Vec<EffectClassRef>)>,
+    },
+    /// `@budget(alloc_per_call = N)`.
+    AllocBudget {
+        at: (Option<FunctionId>, NameRef),
+        per_call: u32,
+    },
+    /// `@budget(<dim> = N)` beyond `alloc_per_call`.
+    QuantBudget {
+        at: (Option<FunctionId>, NameRef),
+        dim: QuantDimIr,
+        limit: u64,
+    },
+
+    // ---------- fleet plan rows (#408) ----------
+    /// Plan `forbid_reaches` — instance/group names are plan-level.
+    FleetForbidReaches {
+        from: String,
+        to: String,
+        avoiding: Option<String>,
+    },
+    /// Plan `require_subscribes` / `require_publishes`.
+    FleetRequireEndpoint {
+        publishers: bool,
+        target: String,
+        topic: String,
+    },
+    /// Plan `count_publisher_instances` / `count_subscriber_instances`.
+    FleetCountInstances {
+        publishers: bool,
+        topic: String,
+        cmp: CountCmpIr,
+        n: u64,
+    },
+    /// Plan `only_edges`.
+    FleetOnlyEdges {
+        src: String,
+        dst: String,
+        grants: Vec<String>,
+    },
+}
+
+/// One lowered law row.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ClaimRow {
+    /// Authored position (see module docs) — the canonical order.
+    pub ordinal: u32,
+    /// The claim's name where the surface has one (claims-block
+    /// forms; library rows arrive alias-prefixed exactly as the
+    /// evaluator attributes them). Annotations and plan rows carry
+    /// the annotated declaration's / plan row's name.
+    pub name: String,
+    pub origin: ClaimOrigin,
+    pub law: ClaimIr,
+    pub provenance: ProvenanceId,
+}
+
+/// The lowered law table for one application (or one plan).
+#[derive(Clone, Debug, Default)]
+pub struct ClaimIrTable {
+    pub rows: Vec<ClaimRow>,
+    /// Row provenance — its OWN table (the laws are judged WITH the
+    /// model, not stored in it; sharing the model's interner would
+    /// force the lowering to mutate a finished model).
+    pub provenance: ProvenanceTable,
+}
+
+/// A violated `ClaimIr` law.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ClaimIrError {
+    /// `rows[i].ordinal != i` — authored order is the canonical
+    /// order and must be contiguous from zero.
+    NonContiguousOrdinal { index: usize },
+    /// A resolved id points outside the model's table.
+    DanglingId { index: usize, what: &'static str },
+    /// A row's provenance id is out of range.
+    DanglingProvenance { index: usize },
+    /// An empty name — every row must be addressable in diagnostics.
+    UnnamedRow { index: usize },
+}
+
+impl ClaimIrTable {
+    /// Structural laws, checked against the model the rows were
+    /// lowered from. Resolution is OPTIONAL (`None` ids are lawful
+    /// residue for Change 5's `invalid` verdict); a PRESENT id must
+    /// be in range.
+    pub fn validate(
+        &self,
+        model: &ApplicationModel,
+    ) -> Result<(), ClaimIrError> {
+        let e = &model.entities;
+        for (i, row) in self.rows.iter().enumerate() {
+            if row.ordinal as usize != i {
+                return Err(ClaimIrError::NonContiguousOrdinal {
+                    index: i,
+                });
+            }
+            if row.name.is_empty() {
+                return Err(ClaimIrError::UnnamedRow { index: i });
+            }
+            if row.provenance.index() >= self.provenance.records.len()
+            {
+                return Err(ClaimIrError::DanglingProvenance {
+                    index: i,
+                });
+            }
+            let bad =
+                |what: &'static str| ClaimIrError::DanglingId {
+                    index: i,
+                    what,
+                };
+            let group_ok = |g: &GroupRef| match g.group {
+                Some(id) => id.index() < e.groups.len(),
+                None => true,
+            };
+            let topic_ok = |t: &TopicIrRef| match t.topic {
+                Some(id) => id.index() < e.topics.len(),
+                None => true,
+            };
+            let set_ok = |s: &SetIr| match s {
+                SetIr::Group(g) => group_ok(g),
+                SetIr::EffectCarriers(_) => true,
+            };
+            let fn_ok = |f: &(Option<FunctionId>, NameRef)| match f.0 {
+                Some(id) => id.index() < e.functions.len(),
+                None => true,
+            };
+            let locus_ok =
+                |l: &(Option<LocusDeclId>, NameRef)| match l.0 {
+                    Some(id) => id.index() < e.loci.len(),
+                    None => true,
+                };
+            let subj_ok =
+                |s: &(Option<SubjectId>, NameRef)| match s.0 {
+                    Some(id) => id.index() < e.subjects.len(),
+                    None => true,
+                };
+            match &row.law {
+                ClaimIr::ForbidReaches {
+                    src,
+                    dst,
+                    during,
+                    avoiding,
+                    ..
+                } => {
+                    if !set_ok(src) || !set_ok(dst) {
+                        return Err(bad("set"));
+                    }
+                    if let Some((Some(p), _)) = during {
+                        if p.index() >= e.phases.len() {
+                            return Err(bad("phase"));
+                        }
+                    }
+                    if let Some(a) = avoiding {
+                        if !group_ok(a) {
+                            return Err(bad("avoiding"));
+                        }
+                    }
+                }
+                ClaimIr::OnlyEdges { src, dst, grants } => {
+                    if !group_ok(src) || !group_ok(dst) {
+                        return Err(bad("group"));
+                    }
+                    if grants.iter().any(|g| !topic_ok(&g.topic)) {
+                        return Err(bad("grant topic"));
+                    }
+                }
+                ClaimIr::Bound { from, .. } => {
+                    if !group_ok(from) {
+                        return Err(bad("group"));
+                    }
+                }
+                ClaimIr::RequireEndpoint { group, topic, .. } => {
+                    if !group_ok(group) || !topic_ok(topic) {
+                        return Err(bad("endpoint ref"));
+                    }
+                }
+                ClaimIr::RequireSealed { group } => {
+                    if !group_ok(group) {
+                        return Err(bad("group"));
+                    }
+                }
+                ClaimIr::RequireAttributed { .. } => {}
+                ClaimIr::Cover { seed, group } => {
+                    if let Some(s) = seed.0 {
+                        if s.index() >= e.seeds.len() {
+                            return Err(bad("seed"));
+                        }
+                    }
+                    if !group_ok(group) {
+                        return Err(bad("group"));
+                    }
+                }
+                ClaimIr::Count { topic, .. } => {
+                    if !topic_ok(topic) {
+                        return Err(bad("topic"));
+                    }
+                }
+                ClaimIr::EffectForbid { at, .. }
+                | ClaimIr::EffectCauses { at, .. }
+                | ClaimIr::EffectOnly { at, .. }
+                | ClaimIr::NoPanic { at }
+                | ClaimIr::AllocBudget { at, .. }
+                | ClaimIr::QuantBudget { at, .. } => {
+                    if !fn_ok(at) {
+                        return Err(bad("function"));
+                    }
+                }
+                ClaimIr::EffectPublishSet { at, subjects } => {
+                    if !fn_ok(at) {
+                        return Err(bad("function"));
+                    }
+                    if subjects.iter().any(|s| !subj_ok(s)) {
+                        return Err(bad("subject"));
+                    }
+                }
+                ClaimIr::DependsSet { locus, subjects } => {
+                    if !locus_ok(locus) {
+                        return Err(bad("locus"));
+                    }
+                    if subjects.iter().any(|s| !subj_ok(s)) {
+                        return Err(bad("subject"));
+                    }
+                }
+                ClaimIr::PhaseEffects { locus, .. } => {
+                    if !locus_ok(locus) {
+                        return Err(bad("locus"));
+                    }
+                }
+                ClaimIr::FleetForbidReaches { .. }
+                | ClaimIr::FleetRequireEndpoint { .. }
+                | ClaimIr::FleetCountInstances { .. }
+                | ClaimIr::FleetOnlyEdges { .. } => {}
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/hale-model/src/claim_ir.rs
+++ b/crates/hale-model/src/claim_ir.rs
@@ -50,8 +50,8 @@
 //! scramble evaluation order.
 
 use crate::ids::{
-    FunctionId, GroupId, LocusDeclId, PhaseId, ProvenanceId, SeedId,
-    SubjectId, TopicId,
+    EffectClassId, FunctionId, GroupId, LocusDeclId, PhaseId,
+    ProvenanceId, SeedId, SubjectId, TopicId,
 };
 use crate::provenance::ProvenanceTable;
 use crate::ApplicationModel;
@@ -65,11 +65,15 @@ pub struct NameRef {
 }
 
 /// A group reference, resolved against `entities.groups` when the
-/// model knows it.
+/// model knows it. Every source-bearing reference carries its OWN
+/// provenance — the evaluator anchors "unknown group" at the
+/// reference, not at the clause (review round 15), and Change 5
+/// must preserve those primary spans without reopening the AST.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct GroupRef {
     pub group: Option<GroupId>,
     pub name: NameRef,
+    pub provenance: ProvenanceId,
 }
 
 /// A topic reference (`T` / `alias::T`, canonicalized at mangle).
@@ -77,15 +81,48 @@ pub struct GroupRef {
 pub struct TopicIrRef {
     pub topic: Option<TopicId>,
     pub name: NameRef,
+    pub provenance: ProvenanceId,
 }
 
-/// An effect class by canonical name — the model's label/effects
-/// vocabulary (`syscall`, `alloc`, …, or a declared user class).
-/// String-keyed on purpose: the class universe is program-declared
-/// and the model's labels/effects sections already speak it.
+/// A phase reference (`during P`).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct PhaseIrRef {
+    pub phase: Option<PhaseId>,
+    pub name: String,
+    pub provenance: ProvenanceId,
+}
+
+/// A seed reference (`in seed(a)`).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SeedIrRef {
+    pub seed: Option<SeedId>,
+    pub name: String,
+    pub provenance: ProvenanceId,
+}
+
+/// A wire-subject reference (`@effects(depends: {"evt"})`).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SubjectIrRef {
+    pub subject: Option<SubjectId>,
+    pub name: NameRef,
+    pub provenance: ProvenanceId,
+}
+
+/// An effect class reference. The class universe is TYPED
+/// (review round 15): a built-in is language-fixed and always
+/// valid; a user class resolves into `entities.effect_classes`,
+/// whose row records declaration status and the normalized
+/// composition — so an IR consumer can distinguish a declared
+/// class from an interned typo and expand `effect io = {…}`
+/// without the AST.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct EffectClassRef {
+    /// `Some` iff the name resolves to a user-class table row.
+    pub class: Option<EffectClassId>,
+    /// `true` iff the name is a language built-in (`syscall`, …).
+    pub builtin: bool,
     pub name: String,
+    pub provenance: ProvenanceId,
 }
 
 /// A set expression in claim-argument position.
@@ -154,7 +191,7 @@ pub enum ClaimIr {
         dst: SetIr,
         via_calls: bool,
         via_bus: bool,
-        during: Option<(Option<PhaseId>, String)>,
+        during: Option<PhaseIrRef>,
         avoiding: Option<GroupRef>,
     },
     /// `only edges SRC -> DST { grants }`.
@@ -180,10 +217,7 @@ pub enum ClaimIr {
     /// `require attributed(all <class>)` (GH #436).
     RequireAttributed { class: EffectClassRef },
     /// `cover topic in seed(a): subscribed_by(some G)`.
-    Cover {
-        seed: (Option<SeedId>, String),
-        group: GroupRef,
-    },
+    Cover { seed: SeedIrRef, group: GroupRef },
     /// `count publishers/subscribers(topic T) <cmp> N`.
     Count {
         publishers: bool,
@@ -199,9 +233,13 @@ pub enum ClaimIr {
         classes: Vec<EffectClassRef>,
     },
     /// `@effects(publish: {…})` — the closed allowed publish set.
+    /// TOPIC references, not wire subjects: the source names topics
+    /// and the evaluator matches topic identity across local /
+    /// alias-qualified / mangled spellings (review round 15) — a
+    /// declared topic must never masquerade as its wire subject.
     EffectPublishSet {
         at: (Option<FunctionId>, NameRef),
-        subjects: Vec<(Option<SubjectId>, NameRef)>,
+        topics: Vec<TopicIrRef>,
     },
     /// `@effects(causes: {…})` — transitive through bus edges.
     EffectCauses {
@@ -219,7 +257,7 @@ pub enum ClaimIr {
     /// COMPLETE backward-reachable subject set.
     DependsSet {
         locus: (Option<LocusDeclId>, NameRef),
-        subjects: Vec<(Option<SubjectId>, NameRef)>,
+        subjects: Vec<SubjectIrRef>,
     },
     /// `@phase_effects(birth: {alloc}, run: {})` on a locus.
     PhaseEffects {
@@ -253,12 +291,16 @@ pub enum ClaimIr {
         target: String,
         topic: String,
     },
-    /// Plan `count_publisher_instances` / `count_subscriber_instances`.
+    /// Plan `count_publisher_instances` / `count_subscriber_instances`
+    /// — ONE law: the fleet evaluator judges the eq/max/min bounds
+    /// conjunctively under one claim name and one verdict (review
+    /// round 15), so the IR must not split them into separate laws.
     FleetCountInstances {
         publishers: bool,
         topic: String,
-        cmp: CountCmpIr,
-        n: u64,
+        eq: Option<u64>,
+        max: Option<u64>,
+        min: Option<u64>,
     },
     /// Plan `only_edges`.
     FleetOnlyEdges {
@@ -283,10 +325,25 @@ pub struct ClaimRow {
     pub provenance: ProvenanceId,
 }
 
+/// A structured lowering issue: law-SELECTION state that produced
+/// no row — an unknown or cyclic constitution, an illegal
+/// library-tier `adopt`, a duplicate declaration, a name collision,
+/// a malformed plan claim. Preserved so an IR-only evaluator
+/// (Change 5) observes the invalidity instead of "no law"
+/// (review round 15) — the lowering never silently drops law-shaped
+/// source.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct LoweringIssue {
+    pub message: String,
+    pub provenance: ProvenanceId,
+}
+
 /// The lowered law table for one application (or one plan).
 #[derive(Clone, Debug, Default)]
 pub struct ClaimIrTable {
     pub rows: Vec<ClaimRow>,
+    /// Law-selection invalidity (see [`LoweringIssue`]).
+    pub issues: Vec<LoweringIssue>,
     /// Row provenance — its OWN table (the laws are judged WITH the
     /// model, not stored in it; sharing the model's interner would
     /// force the lowering to mutate a finished model).
@@ -305,18 +362,33 @@ pub enum ClaimIrError {
     DanglingProvenance { index: usize },
     /// An empty name — every row must be addressable in diagnostics.
     UnnamedRow { index: usize },
+    /// A resolved id's entity disagrees with the reference's
+    /// duplicated name/display fields — an evaluator using the id
+    /// and a renderer using the name would describe different laws.
+    NameDisagreement { index: usize, what: &'static str },
 }
 
 impl ClaimIrTable {
     /// Structural laws, checked against the model the rows were
     /// lowered from. Resolution is OPTIONAL (`None` ids are lawful
     /// residue for Change 5's `invalid` verdict); a PRESENT id must
-    /// be in range.
+    /// be in range AND agree with the reference's duplicated
+    /// name/display fields — an evaluator using the id and a
+    /// renderer using the name must describe the same law
+    /// (review round 15).
     pub fn validate(
         &self,
         model: &ApplicationModel,
     ) -> Result<(), ClaimIrError> {
         let e = &model.entities;
+        let prov_len = self.provenance.records.len();
+        for (i, issue) in self.issues.iter().enumerate() {
+            if issue.provenance.index() >= prov_len {
+                return Err(ClaimIrError::DanglingProvenance {
+                    index: i,
+                });
+            }
+        }
         for (i, row) in self.rows.iter().enumerate() {
             if row.ordinal as usize != i {
                 return Err(ClaimIrError::NonContiguousOrdinal {
@@ -326,42 +398,151 @@ impl ClaimIrTable {
             if row.name.is_empty() {
                 return Err(ClaimIrError::UnnamedRow { index: i });
             }
-            if row.provenance.index() >= self.provenance.records.len()
-            {
+            let pr = |p: ProvenanceId| p.index() < prov_len;
+            if !pr(row.provenance) {
                 return Err(ClaimIrError::DanglingProvenance {
                     index: i,
                 });
             }
-            let bad =
-                |what: &'static str| ClaimIrError::DanglingId {
-                    index: i,
-                    what,
+            let bad = |what: &'static str| ClaimIrError::DanglingId {
+                index: i,
+                what,
+            };
+            let dis = |what: &'static str| {
+                ClaimIrError::NameDisagreement { index: i, what }
+            };
+            let group_ok =
+                |g: &GroupRef| -> Result<(), ClaimIrError> {
+                    if !pr(g.provenance) {
+                        return Err(ClaimIrError::DanglingProvenance {
+                            index: i,
+                        });
+                    }
+                    match g.group {
+                        None => Ok(()),
+                        Some(id) => {
+                            let Some(row) = e.groups.get(id.index())
+                            else {
+                                return Err(bad("group"));
+                            };
+                            if row.name != g.name.raw
+                                || row.display != g.name.display
+                            {
+                                return Err(dis("group"));
+                            }
+                            Ok(())
+                        }
+                    }
                 };
-            let group_ok = |g: &GroupRef| match g.group {
-                Some(id) => id.index() < e.groups.len(),
-                None => true,
-            };
-            let topic_ok = |t: &TopicIrRef| match t.topic {
-                Some(id) => id.index() < e.topics.len(),
-                None => true,
-            };
-            let set_ok = |s: &SetIr| match s {
-                SetIr::Group(g) => group_ok(g),
-                SetIr::EffectCarriers(_) => true,
-            };
-            let fn_ok = |f: &(Option<FunctionId>, NameRef)| match f.0 {
-                Some(id) => id.index() < e.functions.len(),
-                None => true,
-            };
-            let locus_ok =
-                |l: &(Option<LocusDeclId>, NameRef)| match l.0 {
-                    Some(id) => id.index() < e.loci.len(),
-                    None => true,
+            let topic_ok =
+                |t: &TopicIrRef| -> Result<(), ClaimIrError> {
+                    if !pr(t.provenance) {
+                        return Err(ClaimIrError::DanglingProvenance {
+                            index: i,
+                        });
+                    }
+                    match t.topic {
+                        None => Ok(()),
+                        Some(id) => {
+                            let Some(row) = e.topics.get(id.index())
+                            else {
+                                return Err(bad("topic"));
+                            };
+                            if row.name != t.name.raw
+                                || row.display != t.name.display
+                            {
+                                return Err(dis("topic"));
+                            }
+                            Ok(())
+                        }
+                    }
                 };
+            let class_ok =
+                |c: &EffectClassRef| -> Result<(), ClaimIrError> {
+                    if !pr(c.provenance) {
+                        return Err(ClaimIrError::DanglingProvenance {
+                            index: i,
+                        });
+                    }
+                    match c.class {
+                        None => Ok(()),
+                        Some(id) => {
+                            if c.builtin {
+                                // A built-in never has a table row.
+                                return Err(dis("effect class"));
+                            }
+                            let Some(row) =
+                                e.effect_classes.get(id.index())
+                            else {
+                                return Err(bad("effect class"));
+                            };
+                            if row.name != c.name {
+                                return Err(dis("effect class"));
+                            }
+                            Ok(())
+                        }
+                    }
+                };
+            let set_ok = |s: &SetIr| -> Result<(), ClaimIrError> {
+                match s {
+                    SetIr::Group(g) => group_ok(g),
+                    SetIr::EffectCarriers(c) => class_ok(c),
+                }
+            };
+            let fn_ok = |f: &(Option<FunctionId>, NameRef)| -> Result<(), ClaimIrError> {
+                match f.0 {
+                    None => Ok(()),
+                    Some(id) => {
+                        let Some(row) = e.functions.get(id.index())
+                        else {
+                            return Err(bad("function"));
+                        };
+                        if row.name != f.1.raw
+                            || row.display != f.1.display
+                        {
+                            return Err(dis("function"));
+                        }
+                        Ok(())
+                    }
+                }
+            };
+            let locus_ok = |l: &(Option<LocusDeclId>, NameRef)| -> Result<(), ClaimIrError> {
+                match l.0 {
+                    None => Ok(()),
+                    Some(id) => {
+                        let Some(row) = e.loci.get(id.index()) else {
+                            return Err(bad("locus"));
+                        };
+                        if row.name != l.1.raw
+                            || row.display != l.1.display
+                        {
+                            return Err(dis("locus"));
+                        }
+                        Ok(())
+                    }
+                }
+            };
             let subj_ok =
-                |s: &(Option<SubjectId>, NameRef)| match s.0 {
-                    Some(id) => id.index() < e.subjects.len(),
-                    None => true,
+                |s: &SubjectIrRef| -> Result<(), ClaimIrError> {
+                    if !pr(s.provenance) {
+                        return Err(ClaimIrError::DanglingProvenance {
+                            index: i,
+                        });
+                    }
+                    match s.subject {
+                        None => Ok(()),
+                        Some(id) => {
+                            let Some(row) =
+                                e.subjects.get(id.index())
+                            else {
+                                return Err(bad("subject"));
+                            };
+                            if row.pattern != s.name.raw {
+                                return Err(dis("subject"));
+                            }
+                            Ok(())
+                        }
+                    }
                 };
             match &row.law {
                 ClaimIr::ForbidReaches {
@@ -371,88 +552,102 @@ impl ClaimIrTable {
                     avoiding,
                     ..
                 } => {
-                    if !set_ok(src) || !set_ok(dst) {
-                        return Err(bad("set"));
-                    }
-                    if let Some((Some(p), _)) = during {
-                        if p.index() >= e.phases.len() {
-                            return Err(bad("phase"));
+                    set_ok(src)?;
+                    set_ok(dst)?;
+                    if let Some(d) = during {
+                        if !pr(d.provenance) {
+                            return Err(
+                                ClaimIrError::DanglingProvenance {
+                                    index: i,
+                                },
+                            );
+                        }
+                        if let Some(pid) = d.phase {
+                            let Some(row) =
+                                e.phases.get(pid.index())
+                            else {
+                                return Err(bad("phase"));
+                            };
+                            if row.name != d.name {
+                                return Err(dis("phase"));
+                            }
                         }
                     }
                     if let Some(a) = avoiding {
-                        if !group_ok(a) {
-                            return Err(bad("avoiding"));
-                        }
+                        group_ok(a)?;
                     }
                 }
                 ClaimIr::OnlyEdges { src, dst, grants } => {
-                    if !group_ok(src) || !group_ok(dst) {
-                        return Err(bad("group"));
-                    }
-                    if grants.iter().any(|g| !topic_ok(&g.topic)) {
-                        return Err(bad("grant topic"));
+                    group_ok(src)?;
+                    group_ok(dst)?;
+                    for g in grants {
+                        topic_ok(&g.topic)?;
                     }
                 }
-                ClaimIr::Bound { from, .. } => {
-                    if !group_ok(from) {
-                        return Err(bad("group"));
-                    }
+                ClaimIr::Bound { class, from, .. } => {
+                    class_ok(class)?;
+                    group_ok(from)?;
                 }
                 ClaimIr::RequireEndpoint { group, topic, .. } => {
-                    if !group_ok(group) || !topic_ok(topic) {
-                        return Err(bad("endpoint ref"));
-                    }
+                    group_ok(group)?;
+                    topic_ok(topic)?;
                 }
-                ClaimIr::RequireSealed { group } => {
-                    if !group_ok(group) {
-                        return Err(bad("group"));
-                    }
+                ClaimIr::RequireSealed { group } => group_ok(group)?,
+                ClaimIr::RequireAttributed { class } => {
+                    class_ok(class)?
                 }
-                ClaimIr::RequireAttributed { .. } => {}
                 ClaimIr::Cover { seed, group } => {
-                    if let Some(s) = seed.0 {
-                        if s.index() >= e.seeds.len() {
+                    if !pr(seed.provenance) {
+                        return Err(ClaimIrError::DanglingProvenance {
+                            index: i,
+                        });
+                    }
+                    if let Some(id) = seed.seed {
+                        let Some(row) = e.seeds.get(id.index())
+                        else {
                             return Err(bad("seed"));
+                        };
+                        if row.name != seed.name {
+                            return Err(dis("seed"));
                         }
                     }
-                    if !group_ok(group) {
-                        return Err(bad("group"));
+                    group_ok(group)?;
+                }
+                ClaimIr::Count { topic, .. } => topic_ok(topic)?,
+                ClaimIr::EffectForbid { at, classes }
+                | ClaimIr::EffectCauses { at, classes }
+                | ClaimIr::EffectOnly { at, classes } => {
+                    fn_ok(at)?;
+                    for c in classes {
+                        class_ok(c)?;
                     }
                 }
-                ClaimIr::Count { topic, .. } => {
-                    if !topic_ok(topic) {
-                        return Err(bad("topic"));
+                ClaimIr::EffectPublishSet { at, topics } => {
+                    fn_ok(at)?;
+                    for t in topics {
+                        topic_ok(t)?;
                     }
                 }
-                ClaimIr::EffectForbid { at, .. }
-                | ClaimIr::EffectCauses { at, .. }
-                | ClaimIr::EffectOnly { at, .. }
-                | ClaimIr::NoPanic { at }
-                | ClaimIr::AllocBudget { at, .. }
-                | ClaimIr::QuantBudget { at, .. } => {
-                    if !fn_ok(at) {
-                        return Err(bad("function"));
-                    }
-                }
-                ClaimIr::EffectPublishSet { at, subjects } => {
-                    if !fn_ok(at) {
-                        return Err(bad("function"));
-                    }
-                    if subjects.iter().any(|s| !subj_ok(s)) {
-                        return Err(bad("subject"));
+                ClaimIr::NoPanic { at } => fn_ok(at)?,
+                ClaimIr::AllocBudget { at, .. } => fn_ok(at)?,
+                ClaimIr::QuantBudget { at, dim, .. } => {
+                    fn_ok(at)?;
+                    if let QuantDimIr::UserClass(c) = dim {
+                        class_ok(c)?;
                     }
                 }
                 ClaimIr::DependsSet { locus, subjects } => {
-                    if !locus_ok(locus) {
-                        return Err(bad("locus"));
-                    }
-                    if subjects.iter().any(|s| !subj_ok(s)) {
-                        return Err(bad("subject"));
+                    locus_ok(locus)?;
+                    for su in subjects {
+                        subj_ok(su)?;
                     }
                 }
-                ClaimIr::PhaseEffects { locus, .. } => {
-                    if !locus_ok(locus) {
-                        return Err(bad("locus"));
+                ClaimIr::PhaseEffects { locus, phases } => {
+                    locus_ok(locus)?;
+                    for (_, cs) in phases {
+                        for c in cs {
+                            class_ok(c)?;
+                        }
                     }
                 }
                 ClaimIr::FleetForbidReaches { .. }

--- a/crates/hale-model/src/claim_ir.rs
+++ b/crates/hale-model/src/claim_ir.rs
@@ -102,30 +102,25 @@ pub struct SeedIrRef {
 
 
 /// A bus selector for annotation surfaces (`@effects(publish:)`,
-/// `@effects(depends:)`) — review rounds 16/17. The authoritative
-/// evaluator compares each entry against RESOLVED bus subjects with
-/// `topic_ref_matches` (exact string, or trailing-name), and the
-/// entry list admits identifiers AND string literals — so one
-/// spelling can legitimately denote a literal wire subject
-/// (`"audit.log"`), a declared topic, or an unqualified cross-seed
-/// name matching several same-tailed merged topics ("the
-/// permissiveness the author asked for"). The selector represents
-/// all three; only an explicit alias path is a single exact
-/// reference.
+/// `@effects(depends:)`) — review rounds 16/17/18. The entry list
+/// admits identifiers AND string literals, and the parser collapses
+/// both to a plain string — so a spelling containing `::` can be an
+/// alias path OR a literal wire subject (`"audit::log"`), and the
+/// syntax cannot be recovered from the AST. The authoritative
+/// evaluator never needs to: `topic_ref_matches` tests exact string
+/// equality first and trailing-name equality second for EVERY
+/// spelling, qualified or not. The selector therefore has exactly
+/// one shape — the candidate sets that rule produces over declared
+/// TOPICS and wire SUBJECTS, sorted. A literal wire subject lands
+/// in `subjects`; two same-tailed imports both land in `topics`
+/// ("the permissiveness the author asked for"); both empty =
+/// resolves to nothing (Change 5's residue).
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub enum BusSelector {
-    /// A qualified alias path — the author named one topic.
-    Exact(TopicIrRef),
-    /// Any other spelling: matched exact-or-trailing-name against
-    /// declared TOPICS and wire SUBJECTS — both candidate sets,
-    /// sorted. A literal wire subject lands in `subjects`; both
-    /// empty = resolves to nothing (Change 5's residue).
-    Match {
-        name: String,
-        topics: Vec<TopicId>,
-        subjects: Vec<SubjectId>,
-        provenance: ProvenanceId,
-    },
+pub struct BusSelector {
+    pub name: String,
+    pub topics: Vec<TopicId>,
+    pub subjects: Vec<SubjectId>,
+    pub provenance: ProvenanceId,
 }
 
 /// An effect class reference. The class universe is TYPED
@@ -544,36 +539,31 @@ impl ClaimIrTable {
             };
             let sel_ok =
                 |sel: &BusSelector| -> Result<(), ClaimIrError> {
-                    match sel {
-                        BusSelector::Exact(t) => topic_ok(t),
-                        BusSelector::Match {
-                            topics,
-                            subjects,
-                            provenance,
-                            ..
-                        } => {
-                            if !pr(*provenance) {
-                                return Err(ClaimIrError::DanglingProvenance { index: i });
-                            }
-                            if topics
-                                .windows(2)
-                                .any(|w| w[0] >= w[1])
-                                || subjects
-                                    .windows(2)
-                                    .any(|w| w[0] >= w[1])
-                            {
-                                return Err(bad("selector candidates"));
-                            }
-                            if topics.iter().any(|c| {
-                                c.index() >= e.topics.len()
-                            }) || subjects.iter().any(|c| {
-                                c.index() >= e.subjects.len()
-                            }) {
-                                return Err(bad("selector candidate"));
-                            }
-                            Ok(())
-                        }
+                    if !pr(sel.provenance) {
+                        return Err(ClaimIrError::DanglingProvenance {
+                            index: i,
+                        });
                     }
+                    if sel.topics.windows(2).any(|w| w[0] >= w[1])
+                        || sel
+                            .subjects
+                            .windows(2)
+                            .any(|w| w[0] >= w[1])
+                    {
+                        return Err(bad("selector candidates"));
+                    }
+                    if sel
+                        .topics
+                        .iter()
+                        .any(|c| c.index() >= e.topics.len())
+                        || sel
+                            .subjects
+                            .iter()
+                            .any(|c| c.index() >= e.subjects.len())
+                    {
+                        return Err(bad("selector candidate"));
+                    }
+                    Ok(())
                 };
             match &row.law {
                 ClaimIr::ForbidReaches {

--- a/crates/hale-model/src/claim_ir.rs
+++ b/crates/hale-model/src/claim_ir.rs
@@ -100,31 +100,30 @@ pub struct SeedIrRef {
     pub provenance: ProvenanceId,
 }
 
-/// A wire-subject reference (`@effects(depends: {"evt"})`).
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct SubjectIrRef {
-    pub subject: Option<SubjectId>,
-    pub name: NameRef,
-    pub provenance: ProvenanceId,
-}
 
-/// A topic selector for annotation surfaces (review round 16). The
-/// evaluator's documented cross-seed rule: a library author writes
-/// an UNQUALIFIED topic name (they cannot know the consumer's
-/// alias), and it matches merged topics by TRAILING name — possibly
-/// several same-tailed topics, "the permissiveness the author asked
-/// for". A qualified/canonical spelling stays an exact reference.
+/// A bus selector for annotation surfaces (`@effects(publish:)`,
+/// `@effects(depends:)`) — review rounds 16/17. The authoritative
+/// evaluator compares each entry against RESOLVED bus subjects with
+/// `topic_ref_matches` (exact string, or trailing-name), and the
+/// entry list admits identifiers AND string literals — so one
+/// spelling can legitimately denote a literal wire subject
+/// (`"audit.log"`), a declared topic, or an unqualified cross-seed
+/// name matching several same-tailed merged topics ("the
+/// permissiveness the author asked for"). The selector represents
+/// all three; only an explicit alias path is a single exact
+/// reference.
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub enum TopicSelector {
-    /// A qualified or canonical spelling — one topic (or an
-    /// unresolved reference).
+pub enum BusSelector {
+    /// A qualified alias path — the author named one topic.
     Exact(TopicIrRef),
-    /// An unqualified spelling: the candidate set of merged topics
-    /// whose trailing name matches, sorted. Empty = resolves to
-    /// nothing (Change 5's residue).
-    Unqualified {
+    /// Any other spelling: matched exact-or-trailing-name against
+    /// declared TOPICS and wire SUBJECTS — both candidate sets,
+    /// sorted. A literal wire subject lands in `subjects`; both
+    /// empty = resolves to nothing (Change 5's residue).
+    Match {
         name: String,
-        candidates: Vec<TopicId>,
+        topics: Vec<TopicId>,
+        subjects: Vec<SubjectId>,
         provenance: ProvenanceId,
     },
 }
@@ -260,7 +259,7 @@ pub enum ClaimIr {
     /// declared topic must never masquerade as its wire subject.
     EffectPublishSet {
         at: (Option<FunctionId>, NameRef),
-        topics: Vec<TopicSelector>,
+        entries: Vec<BusSelector>,
     },
     /// `@effects(causes: {…})` — transitive through bus edges.
     EffectCauses {
@@ -278,7 +277,7 @@ pub enum ClaimIr {
     /// COMPLETE backward-reachable subject set.
     DependsSet {
         locus: (Option<LocusDeclId>, NameRef),
-        subjects: Vec<SubjectIrRef>,
+        entries: Vec<BusSelector>,
     },
     /// `@phase_effects(birth: {alloc}, run: {})` on a locus.
     PhaseEffects {
@@ -543,23 +542,34 @@ impl ClaimIrTable {
                     }
                 }
             };
-            let subj_ok =
-                |s: &SubjectIrRef| -> Result<(), ClaimIrError> {
-                    if !pr(s.provenance) {
-                        return Err(ClaimIrError::DanglingProvenance {
-                            index: i,
-                        });
-                    }
-                    match s.subject {
-                        None => Ok(()),
-                        Some(id) => {
-                            let Some(row) =
-                                e.subjects.get(id.index())
-                            else {
-                                return Err(bad("subject"));
-                            };
-                            if row.pattern != s.name.raw {
-                                return Err(dis("subject"));
+            let sel_ok =
+                |sel: &BusSelector| -> Result<(), ClaimIrError> {
+                    match sel {
+                        BusSelector::Exact(t) => topic_ok(t),
+                        BusSelector::Match {
+                            topics,
+                            subjects,
+                            provenance,
+                            ..
+                        } => {
+                            if !pr(*provenance) {
+                                return Err(ClaimIrError::DanglingProvenance { index: i });
+                            }
+                            if topics
+                                .windows(2)
+                                .any(|w| w[0] >= w[1])
+                                || subjects
+                                    .windows(2)
+                                    .any(|w| w[0] >= w[1])
+                            {
+                                return Err(bad("selector candidates"));
+                            }
+                            if topics.iter().any(|c| {
+                                c.index() >= e.topics.len()
+                            }) || subjects.iter().any(|c| {
+                                c.index() >= e.subjects.len()
+                            }) {
+                                return Err(bad("selector candidate"));
                             }
                             Ok(())
                         }
@@ -643,36 +653,10 @@ impl ClaimIrTable {
                         class_ok(c)?;
                     }
                 }
-                ClaimIr::EffectPublishSet { at, topics } => {
+                ClaimIr::EffectPublishSet { at, entries } => {
                     fn_ok(at)?;
-                    for t in topics {
-                        match t {
-                            TopicSelector::Exact(t) => topic_ok(t)?,
-                            TopicSelector::Unqualified {
-                                candidates,
-                                provenance,
-                                ..
-                            } => {
-                                if !pr(*provenance) {
-                                    return Err(ClaimIrError::DanglingProvenance { index: i });
-                                }
-                                if candidates
-                                    .windows(2)
-                                    .any(|w| w[0] >= w[1])
-                                {
-                                    return Err(bad(
-                                        "topic candidates",
-                                    ));
-                                }
-                                if candidates.iter().any(|c| {
-                                    c.index() >= e.topics.len()
-                                }) {
-                                    return Err(bad(
-                                        "topic candidate",
-                                    ));
-                                }
-                            }
-                        }
+                    for t in entries {
+                        sel_ok(t)?;
                     }
                 }
                 ClaimIr::NoPanic { at } => fn_ok(at)?,
@@ -683,10 +667,10 @@ impl ClaimIrTable {
                         class_ok(c)?;
                     }
                 }
-                ClaimIr::DependsSet { locus, subjects } => {
+                ClaimIr::DependsSet { locus, entries } => {
                     locus_ok(locus)?;
-                    for su in subjects {
-                        subj_ok(su)?;
+                    for t in entries {
+                        sel_ok(t)?;
                     }
                 }
                 ClaimIr::PhaseEffects { locus, phases } => {

--- a/crates/hale-model/src/claim_ir.rs
+++ b/crates/hale-model/src/claim_ir.rs
@@ -108,6 +108,27 @@ pub struct SubjectIrRef {
     pub provenance: ProvenanceId,
 }
 
+/// A topic selector for annotation surfaces (review round 16). The
+/// evaluator's documented cross-seed rule: a library author writes
+/// an UNQUALIFIED topic name (they cannot know the consumer's
+/// alias), and it matches merged topics by TRAILING name — possibly
+/// several same-tailed topics, "the permissiveness the author asked
+/// for". A qualified/canonical spelling stays an exact reference.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum TopicSelector {
+    /// A qualified or canonical spelling — one topic (or an
+    /// unresolved reference).
+    Exact(TopicIrRef),
+    /// An unqualified spelling: the candidate set of merged topics
+    /// whose trailing name matches, sorted. Empty = resolves to
+    /// nothing (Change 5's residue).
+    Unqualified {
+        name: String,
+        candidates: Vec<TopicId>,
+        provenance: ProvenanceId,
+    },
+}
+
 /// An effect class reference. The class universe is TYPED
 /// (review round 15): a built-in is language-fixed and always
 /// valid; a user class resolves into `entities.effect_classes`,
@@ -239,7 +260,7 @@ pub enum ClaimIr {
     /// declared topic must never masquerade as its wire subject.
     EffectPublishSet {
         at: (Option<FunctionId>, NameRef),
-        topics: Vec<TopicIrRef>,
+        topics: Vec<TopicSelector>,
     },
     /// `@effects(causes: {…})` — transitive through bus edges.
     EffectCauses {
@@ -625,7 +646,33 @@ impl ClaimIrTable {
                 ClaimIr::EffectPublishSet { at, topics } => {
                     fn_ok(at)?;
                     for t in topics {
-                        topic_ok(t)?;
+                        match t {
+                            TopicSelector::Exact(t) => topic_ok(t)?,
+                            TopicSelector::Unqualified {
+                                candidates,
+                                provenance,
+                                ..
+                            } => {
+                                if !pr(*provenance) {
+                                    return Err(ClaimIrError::DanglingProvenance { index: i });
+                                }
+                                if candidates
+                                    .windows(2)
+                                    .any(|w| w[0] >= w[1])
+                                {
+                                    return Err(bad(
+                                        "topic candidates",
+                                    ));
+                                }
+                                if candidates.iter().any(|c| {
+                                    c.index() >= e.topics.len()
+                                }) {
+                                    return Err(bad(
+                                        "topic candidate",
+                                    ));
+                                }
+                            }
+                        }
                     }
                 }
                 ClaimIr::NoPanic { at } => fn_ok(at)?,

--- a/crates/hale-model/src/claim_ir.rs
+++ b/crates/hale-model/src/claim_ir.rs
@@ -79,6 +79,31 @@ pub fn bus_topic_tail(s: &str) -> &str {
     }
 }
 
+/// The language's built-in effect classes — the CANONICAL
+/// vocabulary (review round 20), mirrored from the compiler's
+/// `EffectClass` (a conformance test in `hale-types` pins the two
+/// lists to each other, since this crate cannot depend on the
+/// AST). `validate` holds every [`EffectClassRef::builtin`] flag to
+/// exactly this list.
+pub const BUILTIN_EFFECT_CLASSES: [&str; 11] = [
+    "syscall",
+    "block",
+    "time",
+    "entropy",
+    "env",
+    "ffi",
+    "publish",
+    "spawn",
+    "recursion",
+    "alloc",
+    "secret_use",
+];
+
+/// Is `name` a language built-in effect class?
+pub fn is_builtin_effect_class(name: &str) -> bool {
+    BUILTIN_EFFECT_CLASSES.contains(&name)
+}
+
 /// A name in claim position: raw canonical spelling + author
 /// display. Two spellings, same doctrine as every entity table.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -526,6 +551,14 @@ impl ClaimIrTable {
                             index: i,
                         });
                     }
+                    // The discriminator is DERIVED from the name:
+                    // `builtin` must agree with the canonical
+                    // vocabulary exactly (review round 20) — a
+                    // judgment branching on the flag and a renderer
+                    // reading the name must describe one law.
+                    if c.builtin != is_builtin_effect_class(&c.name) {
+                        return Err(dis("effect class builtin"));
+                    }
                     match c.class {
                         None => Ok(()),
                         Some(id) => {
@@ -714,6 +747,14 @@ impl ClaimIrTable {
                     fn_ok(at)?;
                     if let QuantDimIr::UserClass(c) = dim {
                         class_ok(c)?;
+                        // The variant specifically means a USER
+                        // class budget (built-ins have their own
+                        // dimensions).
+                        if c.builtin {
+                            return Err(dis(
+                                "quant budget user class",
+                            ));
+                        }
                     }
                 }
                 ClaimIr::DependsSet { locus, entries } => {

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -194,12 +194,28 @@ pub struct EffectClassDecl {
     pub name: String,
     /// `effect NAME;` exists (false = bare reference only).
     pub declared: bool,
-    /// The NORMALIZED atomic expansion for a composed class
-    /// (`effect io = { syscall, block }` → `["block", "syscall"]`,
-    /// sorted) — a composed class owns no bit of its own and means
-    /// its expansion. Empty for atomic classes.
-    pub composition: Vec<String>,
+    pub definition: EffectClassDefinition,
     pub provenance: ProvenanceId,
+}
+
+/// How a user effect class is defined. An EXPLICIT shape (review
+/// round 16): a cyclic definition (`effect a = { b }; effect b =
+/// { a };`) expands to nothing and would otherwise be
+/// indistinguishable from an atomic class — the evaluator rejects
+/// cycles at the declaration precisely because they make contracts
+/// vacuous, and the model must preserve that invalidity.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum EffectClassDefinition {
+    /// `effect money;` — the class is its own atom.
+    Atomic,
+    /// `effect io = { syscall, block };` — the NORMALIZED atomic
+    /// expansion, sorted and deduplicated; the class owns no bit of
+    /// its own and means its expansion.
+    Composed { atoms: Vec<String> },
+    /// The definition participates in a cycle: it resolves to no
+    /// effect, and every contract naming it is vacuous. Diagnosed
+    /// at the declaration by the checker.
+    InvalidCycle,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -181,6 +181,27 @@ pub struct Phase {
     pub provenance: ProvenanceId,
 }
 
+/// A declared USER effect class (`effect NAME;` /
+/// `effect io = { syscall, block };`) — the vocabulary
+/// `@effects` contracts and `bound`/`effects(...)` claims speak
+/// (GH #476 Change 4). The interner also creates entries for BARE
+/// references in `@effects(...)` clauses, and the evaluators
+/// distinguish a declared class from an interned typo — so the
+/// model must too: `declared: false` is exactly "referenced,
+/// never declared".
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct EffectClassDecl {
+    pub name: String,
+    /// `effect NAME;` exists (false = bare reference only).
+    pub declared: bool,
+    /// The NORMALIZED atomic expansion for a composed class
+    /// (`effect io = { syscall, block }` → `["block", "syscall"]`,
+    /// sorted) — a composed class owns no bit of its own and means
+    /// its expansion. Empty for atomic classes.
+    pub composition: Vec<String>,
+    pub provenance: ProvenanceId,
+}
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Seed {
     pub name: String,

--- a/crates/hale-model/src/ids.rs
+++ b/crates/hale-model/src/ids.rs
@@ -31,6 +31,11 @@ table_id!(
     FunctionId
 );
 table_id!(
+    /// A declared USER effect class (GH #476 Change 4) — built-in
+    /// classes are language-fixed and never table rows.
+    EffectClassId
+);
+table_id!(
     /// A locus declaration (the type, not a running instance).
     LocusDeclId
 );

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -125,6 +125,7 @@
 
 pub mod application;
 pub mod capability;
+pub mod claim_ir;
 pub mod entity;
 pub mod hole;
 pub mod ids;
@@ -137,6 +138,11 @@ pub use application::{
     Relations, WeightRow, MODEL_SEMANTICS_V1,
 };
 pub use capability::Capabilities;
+pub use claim_ir::{
+    ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin, ClaimRow,
+    CountCmpIr, EffectClassRef, GrantIr, GroupRef, NameRef, QuantDimIr,
+    SetIr, TopicIrRef,
+};
 pub use entity::{
     Binding, BindingRole, DeclKind, Declaration, Function, FunctionKind, Group, InterfaceDecl,
     LocusDecl, LocusInstance, PayloadContract, Phase, Seed, Subject, ThreadDomain, Topic,

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -139,7 +139,7 @@ pub use application::{
 };
 pub use capability::Capabilities;
 pub use claim_ir::{
-    ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin, ClaimRow,
+    bus_ref_matches, bus_topic_tail, ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin, ClaimRow,
     CountCmpIr, EffectClassRef, GrantIr, GroupRef, LoweringIssue,
     NameRef, PhaseIrRef, QuantDimIr, SeedIrRef, SetIr,
     BusSelector, TopicIrRef,

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -139,7 +139,7 @@ pub use application::{
 };
 pub use capability::Capabilities;
 pub use claim_ir::{
-    bus_ref_matches, bus_topic_tail, ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin, ClaimRow,
+    bus_ref_matches, bus_topic_tail, is_builtin_effect_class, ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin, ClaimRow,
     CountCmpIr, EffectClassRef, GrantIr, GroupRef, LoweringIssue,
     NameRef, PhaseIrRef, QuantDimIr, SeedIrRef, SetIr,
     BusSelector, TopicIrRef,

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -142,10 +142,10 @@ pub use claim_ir::{
     ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin, ClaimRow,
     CountCmpIr, EffectClassRef, GrantIr, GroupRef, LoweringIssue,
     NameRef, PhaseIrRef, QuantDimIr, SeedIrRef, SetIr, SubjectIrRef,
-    TopicIrRef,
+    TopicIrRef, TopicSelector,
 };
 pub use entity::{
-    Binding, BindingRole, DeclKind, Declaration, EffectClassDecl, Function, FunctionKind, Group, InterfaceDecl,
+    Binding, BindingRole, DeclKind, Declaration, EffectClassDecl, EffectClassDefinition, Function, FunctionKind, Group, InterfaceDecl,
     LocusDecl, LocusInstance, PayloadContract, Phase, Seed, Subject, ThreadDomain, Topic,
     TransportKind, TypeDecl,
 };

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -140,17 +140,18 @@ pub use application::{
 pub use capability::Capabilities;
 pub use claim_ir::{
     ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin, ClaimRow,
-    CountCmpIr, EffectClassRef, GrantIr, GroupRef, NameRef, QuantDimIr,
-    SetIr, TopicIrRef,
+    CountCmpIr, EffectClassRef, GrantIr, GroupRef, LoweringIssue,
+    NameRef, PhaseIrRef, QuantDimIr, SeedIrRef, SetIr, SubjectIrRef,
+    TopicIrRef,
 };
 pub use entity::{
-    Binding, BindingRole, DeclKind, Declaration, Function, FunctionKind, Group, InterfaceDecl,
+    Binding, BindingRole, DeclKind, Declaration, EffectClassDecl, Function, FunctionKind, Group, InterfaceDecl,
     LocusDecl, LocusInstance, PayloadContract, Phase, Seed, Subject, ThreadDomain, Topic,
     TransportKind, TypeDecl,
 };
 pub use hole::{Hole, HoleKind, RelationSet};
 pub use ids::{
-    BindingId, DeclarationId, EntityRef, FunctionId, GroupId, InterfaceDeclId, LocusDeclId,
+    BindingId, DeclarationId, EffectClassId, EntityRef, FunctionId, GroupId, InterfaceDeclId, LocusDeclId,
     LocusInstanceId, PayloadContractId, PhaseId, ProvenanceId, SeedId, SourceId, SubjectId,
     ThreadDomainId, TopicId, TypeDeclId,
 };

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -141,8 +141,8 @@ pub use capability::Capabilities;
 pub use claim_ir::{
     ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin, ClaimRow,
     CountCmpIr, EffectClassRef, GrantIr, GroupRef, LoweringIssue,
-    NameRef, PhaseIrRef, QuantDimIr, SeedIrRef, SetIr, SubjectIrRef,
-    TopicIrRef, TopicSelector,
+    NameRef, PhaseIrRef, QuantDimIr, SeedIrRef, SetIr,
+    BusSelector, TopicIrRef,
 };
 pub use entity::{
     Binding, BindingRole, DeclKind, Declaration, EffectClassDecl, EffectClassDefinition, Function, FunctionKind, Group, InterfaceDecl,

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -1607,3 +1607,78 @@ fn claim_table_provenance_records_must_resolve() {
         Err(ClaimIrError::InvalidProvenanceRecord { .. })
     ));
 }
+
+/// Round 20: `EffectClassRef.builtin` is DERIVED from the name via
+/// the canonical vocabulary — both mismatch directions are
+/// rejected, and `QuantDimIr::UserClass` never holds a built-in.
+#[test]
+fn effect_class_builtin_flag_must_agree_with_the_name() {
+    use hale_model::{
+        ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin, ClaimRow,
+        EffectClassRef, NameRef, QuantDimIr,
+    };
+    let m = tiny_model();
+    let class = |builtin: bool, name: &str| EffectClassRef {
+        class: None,
+        builtin,
+        name: name.to_string(),
+        provenance: ProvenanceId(0),
+    };
+    let table = |law: ClaimIr| {
+        let mut t = ClaimIrTable::default();
+        t.provenance.records.push(Provenance::Synthetic {
+            origin: "test".to_string(),
+        });
+        t.rows.push(ClaimRow {
+            ordinal: 0,
+            name: "tagged".to_string(),
+            origin: ClaimOrigin::Main,
+            law,
+            provenance: ProvenanceId(0),
+        });
+        t
+    };
+    // A user name marked builtin: rejected.
+    let t = table(ClaimIr::RequireAttributed {
+        class: class(true, "money"),
+    });
+    assert!(matches!(
+        t.validate(&m),
+        Err(ClaimIrError::NameDisagreement { .. })
+    ));
+    // A builtin name marked user: rejected.
+    let t = table(ClaimIr::RequireAttributed {
+        class: class(false, "syscall"),
+    });
+    assert!(matches!(
+        t.validate(&m),
+        Err(ClaimIrError::NameDisagreement { .. })
+    ));
+    // The agreeing forms: lawful.
+    table(ClaimIr::RequireAttributed {
+        class: class(true, "syscall"),
+    })
+    .validate(&m)
+    .expect("builtin agrees");
+    table(ClaimIr::RequireAttributed {
+        class: class(false, "money"),
+    })
+    .validate(&m)
+    .expect("user agrees");
+    // A built-in inside a USER-class budget dimension: rejected.
+    let t = table(ClaimIr::QuantBudget {
+        at: (
+            None,
+            NameRef {
+                raw: "f".to_string(),
+                display: "f".to_string(),
+            },
+        ),
+        dim: QuantDimIr::UserClass(class(true, "syscall")),
+        limit: 1,
+    });
+    assert!(matches!(
+        t.validate(&m),
+        Err(ClaimIrError::NameDisagreement { .. })
+    ));
+}

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -62,6 +62,7 @@ fn tiny_model() -> ApplicationModel {
             entrypoint: "App".to_string(),
         },
         entities: Entities {
+            effect_classes: Vec::new(),
             functions: vec![
                 Function {
                     name: "App::run".to_string(),
@@ -1404,6 +1405,7 @@ fn claim_ir_table_laws_hold() {
                     raw: "gates".to_string(),
                     display: "gates".to_string(),
                 },
+                provenance: ProvenanceId(0),
             },
         },
         provenance: ProvenanceId(0),
@@ -1423,4 +1425,47 @@ fn claim_ir_table_laws_hold() {
         t.validate(&m),
         Err(ClaimIrError::NonContiguousOrdinal { .. })
     ));
+}
+
+/// Round 15: a resolved id must AGREE with its duplicated
+/// name/display — an evaluator using the id and a renderer using
+/// the name must describe the same law.
+#[test]
+fn claim_ref_name_disagreement_is_rejected() {
+    use hale_model::{
+        ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin, ClaimRow,
+        GroupRef, NameRef,
+    };
+    let mut m = tiny_model();
+    m.entities.groups = vec![Group {
+        name: "gates".to_string(),
+        display: "gates".to_string(),
+        may_be_empty: false,
+        provenance: ProvenanceId(0),
+    }];
+    let mut t = ClaimIrTable::default();
+    t.provenance.records.push(Provenance::Synthetic {
+        origin: "test".to_string(),
+    });
+    t.rows.push(ClaimRow {
+        ordinal: 0,
+        name: "vault".to_string(),
+        origin: ClaimOrigin::Main,
+        law: ClaimIr::RequireSealed {
+            group: GroupRef {
+                group: Some(hale_model::GroupId(0)),
+                name: NameRef {
+                    raw: "some_other_group".to_string(),
+                    display: "anything".to_string(),
+                },
+                provenance: ProvenanceId(0),
+            },
+        },
+        provenance: ProvenanceId(0),
+    });
+    assert!(matches!(
+        t.validate(&m),
+        Err(ClaimIrError::NameDisagreement { .. })
+    ));
+    let _ = &mut m;
 }

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -1469,3 +1469,141 @@ fn claim_ref_name_disagreement_is_rejected() {
     ));
     let _ = &mut m;
 }
+
+/// Round 19: BusSelector candidate sets are DERIVED data — validate
+/// recomputes them with the canonical matching rule and requires
+/// exact equality. An unrelated candidate (widens) and an omitted
+/// same-tailed candidate (narrows) are both rejected.
+#[test]
+fn bus_selector_candidates_must_match_the_name() {
+    use hale_model::{
+        BusSelector, ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin,
+        ClaimRow, NameRef, Topic,
+    };
+    let mut m = tiny_model();
+    let p = ProvenanceId(0);
+    m.entities.topics = vec![
+        Topic {
+            name: "__lib_a_x_Recalled".to_string(),
+            display: "a::Recalled".to_string(),
+            subject: SubjectId(0),
+            payload: PayloadContractId(0),
+            key: None,
+            bound: None,
+            provenance: p,
+        },
+        Topic {
+            name: "__lib_b_y_Recalled".to_string(),
+            display: "b::Recalled".to_string(),
+            subject: SubjectId(0),
+            payload: PayloadContractId(0),
+            key: None,
+            bound: None,
+            provenance: p,
+        },
+        Topic {
+            name: "payments".to_string(),
+            display: "payments".to_string(),
+            subject: SubjectId(0),
+            payload: PayloadContractId(0),
+            key: None,
+            bound: None,
+            provenance: p,
+        },
+    ];
+    let mut t = ClaimIrTable::default();
+    t.provenance.records.push(Provenance::Synthetic {
+        origin: "test".to_string(),
+    });
+    let row = |topics: Vec<hale_model::TopicId>| ClaimRow {
+        ordinal: 0,
+        name: "emit".to_string(),
+        origin: ClaimOrigin::Annotation,
+        law: ClaimIr::EffectPublishSet {
+            at: (
+                None,
+                NameRef {
+                    raw: "emit".to_string(),
+                    display: "emit".to_string(),
+                },
+            ),
+            entries: vec![BusSelector {
+                name: "Recalled".to_string(),
+                topics,
+                subjects: Vec::new(),
+                provenance: ProvenanceId(0),
+            }],
+        },
+        provenance: ProvenanceId(0),
+    };
+    // The full same-tailed set: lawful.
+    t.rows = vec![row(vec![
+        hale_model::TopicId(0),
+        hale_model::TopicId(1),
+    ])];
+    t.validate(&m).expect("the derived candidate set is lawful");
+    // An unrelated candidate widens the law: rejected.
+    t.rows = vec![row(vec![
+        hale_model::TopicId(0),
+        hale_model::TopicId(1),
+        hale_model::TopicId(2),
+    ])];
+    assert!(matches!(
+        t.validate(&m),
+        Err(ClaimIrError::NameDisagreement { .. })
+    ));
+    // An omitted same-tailed candidate narrows it: rejected.
+    t.rows = vec![row(vec![hale_model::TopicId(0)])];
+    assert!(matches!(
+        t.validate(&m),
+        Err(ClaimIrError::NameDisagreement { .. })
+    ));
+}
+
+/// Round 19: the claim table's OWN provenance records must resolve
+/// — the same boundary `ApplicationModel::validate` draws.
+#[test]
+fn claim_table_provenance_records_must_resolve() {
+    use hale_model::{
+        ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin, ClaimRow,
+        EffectClassRef,
+    };
+    let m = tiny_model();
+    let row = ClaimRow {
+        ordinal: 0,
+        name: "tagged".to_string(),
+        origin: ClaimOrigin::Main,
+        law: ClaimIr::RequireAttributed {
+            class: EffectClassRef {
+                class: None,
+                builtin: true,
+                name: "syscall".to_string(),
+                provenance: ProvenanceId(0),
+            },
+        },
+        provenance: ProvenanceId(0),
+    };
+    // Dangling SourceId: rejected.
+    let mut t = ClaimIrTable::default();
+    t.provenance.records.push(Provenance::Source {
+        source: SourceId(999),
+        span: (0, 10),
+    });
+    t.rows = vec![row.clone()];
+    assert!(matches!(
+        t.validate(&m),
+        Err(ClaimIrError::InvalidProvenanceRecord { .. })
+    ));
+    // Inverted span: rejected.
+    let mut t = ClaimIrTable::default();
+    t.provenance.sources.push(provenance_source());
+    t.provenance.records.push(Provenance::Source {
+        source: SourceId(0),
+        span: (10, 4),
+    });
+    t.rows = vec![row];
+    assert!(matches!(
+        t.validate(&m),
+        Err(ClaimIrError::InvalidProvenanceRecord { .. })
+    ));
+}

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -1378,3 +1378,49 @@ fn label_order_is_semantic_within_an_entity() {
         Err(hale_model::ModelError::NotCanonical { table: "labels", .. })
     ));
 }
+
+/// GH #476 Change 4: `ClaimIrTable` laws — authored-ordinal
+/// contiguity is the canonical order, present ids must be in range,
+/// and every row is named.
+#[test]
+fn claim_ir_table_laws_hold() {
+    use hale_model::{
+        ClaimIr, ClaimIrError, ClaimIrTable, ClaimOrigin, ClaimRow,
+        GroupRef, NameRef,
+    };
+    let m = tiny_model();
+    let mut t = ClaimIrTable::default();
+    t.provenance.records.push(Provenance::Synthetic {
+        origin: "test".to_string(),
+    });
+    let row = |ordinal: u32, group: Option<hale_model::GroupId>| ClaimRow {
+        ordinal,
+        name: "vault".to_string(),
+        origin: ClaimOrigin::Main,
+        law: ClaimIr::RequireSealed {
+            group: GroupRef {
+                group,
+                name: NameRef {
+                    raw: "gates".to_string(),
+                    display: "gates".to_string(),
+                },
+            },
+        },
+        provenance: ProvenanceId(0),
+    };
+    // Unresolved is lawful residue…
+    t.rows.push(row(0, None));
+    t.validate(&m).expect("None id is lawful");
+    // …a PRESENT id must be in range…
+    t.rows[0] = row(0, Some(hale_model::GroupId(99)));
+    assert!(matches!(
+        t.validate(&m),
+        Err(ClaimIrError::DanglingId { .. })
+    ));
+    // …and ordinals are contiguous from zero.
+    t.rows[0] = row(1, None);
+    assert!(matches!(
+        t.validate(&m),
+        Err(ClaimIrError::NonContiguousOrdinal { .. })
+    ));
+}

--- a/crates/hale-types/src/claim_lowering.rs
+++ b/crates/hale-types/src/claim_lowering.rs
@@ -38,7 +38,7 @@ use hale_model::{
     ApplicationModel, ClaimIr, ClaimIrTable, ClaimOrigin, ClaimRow,
     CountCmpIr, EffectClassRef, GrantIr, GroupRef, LoweringIssue,
     NameRef, PhaseIrRef, Provenance, ProvenanceId, QuantDimIr,
-    SeedIrRef, SetIr, SubjectIrRef, TopicIrRef,
+    SeedIrRef, SetIr, SubjectIrRef, TopicIrRef, TopicSelector,
 };
 use hale_syntax::ast::{
     ClaimForm, ClaimSet, CountCmp, EffectAssert, EffectClass,
@@ -251,6 +251,37 @@ pub fn lower_claims(
      -> TopicIrRef {
         let segs: Vec<&str> = s.split("::").collect();
         topic_ref_parts(recs, s, &segs, span)
+    };
+    let topic_selector = |recs: &mut Vec<Provenance>,
+                          s: &str,
+                          span: hale_syntax::Span|
+     -> TopicSelector {
+        if s.contains("::") {
+            // Qualified — the author named one topic through an
+            // alias path.
+            return TopicSelector::Exact(topic_ref_str(recs, s, span));
+        }
+        // Unqualified: ALWAYS the tail-match candidate set,
+        // mirroring `effects::topic_ref_matches` — the evaluator
+        // never privileges an exact hit for an unqualified
+        // spelling, so a local topic and a same-tailed import both
+        // match (the documented permissiveness).
+        let mut candidates: Vec<hale_model::TopicId> = e
+            .topics
+            .iter()
+            .enumerate()
+            .filter(|(_, t)| {
+                crate::effects::topic_tail(&t.name) == s
+            })
+            .map(|(i, _)| hale_model::TopicId(i as u32))
+            .collect();
+        candidates.sort();
+        candidates.dedup();
+        TopicSelector::Unqualified {
+            name: s.to_string(),
+            candidates,
+            provenance: intern(recs, span),
+        }
     };
     let subject_ref = |recs: &mut Vec<Provenance>,
                        s: &str,
@@ -537,16 +568,20 @@ pub fn lower_claims(
                         .map(|c| class_ref(recs, c, f.name.span))
                         .collect(),
                 },
-                // TOPIC references (review round 15): the source
-                // names topics and the evaluator matches topic
-                // identity across spellings — never wire subjects.
+                // TOPIC selectors (review rounds 15/16): a
+                // qualified/canonical spelling is exact; an
+                // UNQUALIFIED spelling follows the evaluator's
+                // documented cross-seed rule — a library author
+                // cannot know the consumer's alias, so the name
+                // matches merged topics by TRAILING name, possibly
+                // several.
                 EffectAssert::PublishSet(topics) => {
                     ClaimIr::EffectPublishSet {
                         at,
                         topics: topics
                             .iter()
                             .map(|t| {
-                                topic_ref_str(recs, t, f.name.span)
+                                topic_selector(recs, t, f.name.span)
                             })
                             .collect(),
                     }

--- a/crates/hale-types/src/claim_lowering.rs
+++ b/crates/hale-types/src/claim_lowering.rs
@@ -13,11 +13,20 @@
 //!
 //! **Lowering only** (the epic's Change-4 scope): the old
 //! evaluators stay active and authoritative; nothing consumes
-//! these rows yet. The lowering is TOTAL over parseable programs —
-//! an unresolvable reference lowers with `id: None` (the raw and
-//! display spellings are kept), which is the residue Change 5's
-//! `invalid` verdict consumes; it never panics and never drops a
-//! law on the floor.
+//! these rows yet. The lowering is TOTAL over parseable programs
+//! and never drops law-shaped source: an unresolvable reference
+//! lowers with `id: None` (raw and display spellings kept, its own
+//! provenance), and law-SELECTION invalidity the enumeration
+//! reports (unknown/cyclic constitutions, illegal library-tier
+//! `adopt`, duplicates, name collisions) becomes structured
+//! [`LoweringIssue`]s on the table — an IR-only evaluator observes
+//! the invalidity, never "no law" (review round 15).
+//!
+//! Reference doctrine (review round 15): when an id RESOLVES, the
+//! reference's name/display are taken from the model entity — one
+//! construction, so an evaluator using the id and a renderer using
+//! the name cannot describe different laws (`validate` enforces the
+//! agreement). Unresolved references keep the source spelling.
 //!
 //! `@effects(is: {…})` (carries) deliberately does NOT lower: it
 //! is a classification FACT, not an obligation — the model already
@@ -27,8 +36,9 @@ use std::collections::BTreeMap;
 
 use hale_model::{
     ApplicationModel, ClaimIr, ClaimIrTable, ClaimOrigin, ClaimRow,
-    CountCmpIr, EffectClassRef, GrantIr, GroupRef, NameRef,
-    ProvenanceId, QuantDimIr, SetIr, TopicIrRef,
+    CountCmpIr, EffectClassRef, GrantIr, GroupRef, LoweringIssue,
+    NameRef, PhaseIrRef, Provenance, ProvenanceId, QuantDimIr,
+    SeedIrRef, SetIr, SubjectIrRef, TopicIrRef,
 };
 use hale_syntax::ast::{
     ClaimForm, ClaimSet, CountCmp, EffectAssert, EffectClass,
@@ -52,117 +62,62 @@ pub fn lower_claims(
         .map(|(segs, mangled)| (mangled.as_str(), segs.join("::")))
         .collect();
     let display_of = |raw: &str| -> String {
-        demangle.get(raw).cloned().unwrap_or_else(|| raw.to_string())
+        demangle.get(raw).cloned().unwrap_or_else(|| n_to_owned(raw))
     };
-    let name_ref = |raw: &str| NameRef {
-        raw: raw.to_string(),
-        display: display_of(raw),
-    };
+    fn n_to_owned(s: &str) -> String {
+        s.to_string()
+    }
 
     // ---- resolution maps out of the model ----
     let e = &model.entities;
-    let group_id: BTreeMap<&str, hale_model::GroupId> = e
+    let group_id: BTreeMap<&str, u32> = e
         .groups
         .iter()
         .enumerate()
-        .map(|(i, g)| (g.name.as_str(), hale_model::GroupId(i as u32)))
+        .map(|(i, g)| (g.name.as_str(), i as u32))
         .collect();
-    let topic_id: BTreeMap<&str, hale_model::TopicId> = e
+    let topic_id: BTreeMap<&str, u32> = e
         .topics
         .iter()
         .enumerate()
-        .map(|(i, t)| (t.name.as_str(), hale_model::TopicId(i as u32)))
+        .map(|(i, t)| (t.name.as_str(), i as u32))
         .collect();
-    let fn_id: BTreeMap<&str, hale_model::FunctionId> = e
+    let fn_id: BTreeMap<&str, u32> = e
         .functions
         .iter()
         .enumerate()
-        .map(|(i, f)| {
-            (f.name.as_str(), hale_model::FunctionId(i as u32))
-        })
+        .map(|(i, f)| (f.name.as_str(), i as u32))
         .collect();
-    let locus_id: BTreeMap<&str, hale_model::LocusDeclId> = e
+    let locus_id: BTreeMap<&str, u32> = e
         .loci
         .iter()
         .enumerate()
-        .map(|(i, l)| {
-            (l.name.as_str(), hale_model::LocusDeclId(i as u32))
-        })
+        .map(|(i, l)| (l.name.as_str(), i as u32))
         .collect();
-    let phase_id: BTreeMap<&str, hale_model::PhaseId> = e
+    let phase_id: BTreeMap<&str, u32> = e
         .phases
         .iter()
         .enumerate()
-        .map(|(i, p)| (p.name.as_str(), hale_model::PhaseId(i as u32)))
+        .map(|(i, p)| (p.name.as_str(), i as u32))
         .collect();
-    let seed_id: BTreeMap<&str, hale_model::SeedId> = e
+    let seed_id: BTreeMap<&str, u32> = e
         .seeds
         .iter()
         .enumerate()
-        .map(|(i, s)| (s.name.as_str(), hale_model::SeedId(i as u32)))
+        .map(|(i, s)| (s.name.as_str(), i as u32))
         .collect();
-    let subject_id: BTreeMap<&str, hale_model::SubjectId> = e
+    let subject_id: BTreeMap<&str, u32> = e
         .subjects
         .iter()
         .enumerate()
-        .map(|(i, s)| {
-            (s.pattern.as_str(), hale_model::SubjectId(i as u32))
-        })
+        .map(|(i, s)| (s.pattern.as_str(), i as u32))
         .collect();
-
-    // ---- ref lowerers ----
-    let group_ref = |n: &str| GroupRef {
-        group: group_id.get(n).copied(),
-        name: name_ref(n),
-    };
-    // A topic ref: post-mangle it is a single canonical segment; an
-    // unmangled 2-segment `alias::T` resolves through the rename
-    // table to the same canonical symbol.
-    let topic_ref = |t: &TopicRef| -> TopicIrRef {
-        let joined = t.display();
-        let raw = if t.segments.len() == 2 {
-            bundle
-                .import_renames
-                .iter()
-                .find(|(segs, _)| {
-                    segs.len() == 2
-                        && segs[0] == t.segments[0].name
-                        && segs[1] == t.segments[1].name
-                })
-                .map(|(_, m)| m.clone())
-                .unwrap_or(joined.clone())
-        } else {
-            joined.clone()
-        };
-        TopicIrRef {
-            topic: topic_id.get(raw.as_str()).copied(),
-            name: NameRef {
-                display: display_of(&raw),
-                raw,
-            },
-        }
-    };
-    let effect_names = crate::effects::effect_names_of(&programs);
-    let class_ref = |c: &EffectClass| EffectClassRef {
-        name: match c {
-            EffectClass::User(i) => effect_names
-                .get(*i as usize)
-                .cloned()
-                .unwrap_or_else(|| format!("<user:{}>", i)),
-            other => other.as_str().to_string(),
-        },
-    };
-    let set_ir = |s: &ClaimSet| match s {
-        ClaimSet::Group(g) => SetIr::Group(group_ref(&g.name)),
-        ClaimSet::Effects { name, .. } => {
-            SetIr::EffectCarriers(EffectClassRef { name: name.clone() })
-        }
-    };
-    let cmp_ir = |c: CountCmp| match c {
-        CountCmp::Eq => CountCmpIr::Eq,
-        CountCmp::Le => CountCmpIr::Le,
-        CountCmp::Ge => CountCmpIr::Ge,
-    };
+    let class_id: BTreeMap<&str, u32> = e
+        .effect_classes
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (c.name.as_str(), i as u32))
+        .collect();
 
     // ---- provenance (same resolution rule as the model builder) ----
     let mut table = ClaimIrTable::default();
@@ -188,43 +143,262 @@ pub fn lower_claims(
             None => (-1, pos),
         }
     };
-    let intern = |records: &mut Vec<hale_model::Provenance>,
-                      span: hale_syntax::Span|
+    let intern = |records: &mut Vec<Provenance>,
+                  span: hale_syntax::Span|
      -> ProvenanceId {
         let s = span.start.as_usize() as u32;
         let (src, ls) = loc(s);
         let (_, le) = loc(span.end.as_usize() as u32);
         let id = ProvenanceId(records.len() as u32);
         records.push(if src >= 0 {
-            hale_model::Provenance::Source {
+            Provenance::Source {
                 source: hale_model::SourceId(src as u32),
                 span: (ls, le.max(ls)),
             }
         } else {
-            hale_model::Provenance::Synthetic {
+            Provenance::Synthetic {
                 origin: "unplaceable span".to_string(),
             }
         });
         id
     };
 
+    // ---- ref lowerers (entity-sourced names when resolved) ----
+    let group_ref = |recs: &mut Vec<Provenance>,
+                     n: &str,
+                     span: hale_syntax::Span|
+     -> GroupRef {
+        let pid = intern(recs, span);
+        match group_id.get(n) {
+            Some(i) => {
+                let row = &e.groups[*i as usize];
+                GroupRef {
+                    group: Some(hale_model::GroupId(*i)),
+                    name: NameRef {
+                        raw: row.name.clone(),
+                        display: row.display.clone(),
+                    },
+                    provenance: pid,
+                }
+            }
+            None => GroupRef {
+                group: None,
+                name: NameRef {
+                    raw: n.to_string(),
+                    display: display_of(n),
+                },
+                provenance: pid,
+            },
+        }
+    };
+    // A topic name: post-mangle a single canonical segment; an
+    // unmangled `alias::T` resolves through the rename table.
+    let topic_raw = |joined: &str, segments: &[&str]| -> String {
+        if segments.len() == 2 {
+            bundle
+                .import_renames
+                .iter()
+                .find(|(segs, _)| {
+                    segs.len() == 2
+                        && segs[0] == segments[0]
+                        && segs[1] == segments[1]
+                })
+                .map(|(_, m)| m.clone())
+                .unwrap_or_else(|| joined.to_string())
+        } else {
+            joined.to_string()
+        }
+    };
+    let topic_ref_parts = |recs: &mut Vec<Provenance>,
+                           joined: &str,
+                           segments: &[&str],
+                           span: hale_syntax::Span|
+     -> TopicIrRef {
+        let pid = intern(recs, span);
+        let raw = topic_raw(joined, segments);
+        match topic_id.get(raw.as_str()) {
+            Some(i) => {
+                let row = &e.topics[*i as usize];
+                TopicIrRef {
+                    topic: Some(hale_model::TopicId(*i)),
+                    name: NameRef {
+                        raw: row.name.clone(),
+                        display: row.display.clone(),
+                    },
+                    provenance: pid,
+                }
+            }
+            None => TopicIrRef {
+                topic: None,
+                name: NameRef {
+                    display: display_of(&raw),
+                    raw,
+                },
+                provenance: pid,
+            },
+        }
+    };
+    let topic_ref = |recs: &mut Vec<Provenance>,
+                     t: &TopicRef|
+     -> TopicIrRef {
+        let segs: Vec<&str> =
+            t.segments.iter().map(|s| s.name.as_str()).collect();
+        topic_ref_parts(recs, &t.display(), &segs, t.span)
+    };
+    let topic_ref_str = |recs: &mut Vec<Provenance>,
+                         s: &str,
+                         span: hale_syntax::Span|
+     -> TopicIrRef {
+        let segs: Vec<&str> = s.split("::").collect();
+        topic_ref_parts(recs, s, &segs, span)
+    };
+    let subject_ref = |recs: &mut Vec<Provenance>,
+                       s: &str,
+                       span: hale_syntax::Span|
+     -> SubjectIrRef {
+        let pid = intern(recs, span);
+        match subject_id.get(s) {
+            Some(i) => SubjectIrRef {
+                subject: Some(hale_model::SubjectId(*i)),
+                name: NameRef {
+                    raw: e.subjects[*i as usize].pattern.clone(),
+                    display: e.subjects[*i as usize].pattern.clone(),
+                },
+                provenance: pid,
+            },
+            None => SubjectIrRef {
+                subject: None,
+                name: NameRef {
+                    raw: s.to_string(),
+                    display: display_of(s),
+                },
+                provenance: pid,
+            },
+        }
+    };
+    let effect_names = crate::effects::effect_names_of(&programs);
+    let class_ref_named = |recs: &mut Vec<Provenance>,
+                           name: &str,
+                           span: hale_syntax::Span|
+     -> EffectClassRef {
+        let pid = intern(recs, span);
+        let builtin = EffectClass::from_ident(name)
+            .map(|c| !matches!(c, EffectClass::User(_)))
+            .unwrap_or(false);
+        EffectClassRef {
+            class: if builtin {
+                None
+            } else {
+                class_id
+                    .get(name)
+                    .map(|i| hale_model::EffectClassId(*i))
+            },
+            builtin,
+            name: name.to_string(),
+            provenance: pid,
+        }
+    };
+    let class_ref = |recs: &mut Vec<Provenance>,
+                     c: &EffectClass,
+                     span: hale_syntax::Span|
+     -> EffectClassRef {
+        let name = match c {
+            EffectClass::User(i) => effect_names
+                .get(*i as usize)
+                .cloned()
+                .unwrap_or_else(|| format!("<user:{}>", i)),
+            other => other.as_str().to_string(),
+        };
+        class_ref_named(recs, &name, span)
+    };
+    let fn_at = |raw: &str| -> (Option<hale_model::FunctionId>, NameRef) {
+        match fn_id.get(raw) {
+            Some(i) => {
+                let row = &e.functions[*i as usize];
+                (
+                    Some(hale_model::FunctionId(*i)),
+                    NameRef {
+                        raw: row.name.clone(),
+                        display: row.display.clone(),
+                    },
+                )
+            }
+            None => (
+                None,
+                NameRef {
+                    raw: raw.to_string(),
+                    display: display_of(raw),
+                },
+            ),
+        }
+    };
+    let locus_at =
+        |raw: &str| -> (Option<hale_model::LocusDeclId>, NameRef) {
+            match locus_id.get(raw) {
+                Some(i) => {
+                    let row = &e.loci[*i as usize];
+                    (
+                        Some(hale_model::LocusDeclId(*i)),
+                        NameRef {
+                            raw: row.name.clone(),
+                            display: row.display.clone(),
+                        },
+                    )
+                }
+                None => (
+                    None,
+                    NameRef {
+                        raw: raw.to_string(),
+                        display: display_of(raw),
+                    },
+                ),
+            }
+        };
+    let cmp_ir = |c: CountCmp| match c {
+        CountCmp::Eq => CountCmpIr::Eq,
+        CountCmp::Le => CountCmpIr::Le,
+        CountCmp::Ge => CountCmpIr::Ge,
+    };
+
     // ---- 1. claims-block forms, via the evaluator's enumeration ----
-    let universe =
-        crate::claims::enumerate_clauses(&programs, &bundle.import_renames);
+    let universe = crate::claims::enumerate_clauses(
+        &programs,
+        &bundle.import_renames,
+    );
+    // Law-SELECTION invalidity becomes structured issues — never
+    // silently dropped (review round 15).
+    for d in &universe.diags {
+        let pid = intern(&mut table.provenance.records, d.span);
+        table.issues.push(LoweringIssue {
+            message: d.message.clone(),
+            provenance: pid,
+        });
+    }
+    let recs = &mut table.provenance.records;
     let mut rows: Vec<(String, ClaimOrigin, ClaimIr, hale_syntax::Span)> =
         Vec::new();
     for c in &universe.claims {
         let origin = if let Some(k) = universe.origins.get(&c.name.name)
         {
             ClaimOrigin::Constitution { name: k.clone() }
-        } else if let Some(alias) =
-            universe.library.get(&c.name.name)
+        } else if let Some(alias) = universe.library.get(&c.name.name)
         {
             ClaimOrigin::Library {
                 alias: alias.clone(),
             }
         } else {
             ClaimOrigin::Main
+        };
+        let set_ir = |recs: &mut Vec<Provenance>, s: &ClaimSet| match s
+        {
+            ClaimSet::Group(g) => {
+                SetIr::Group(group_ref(recs, &g.name, g.span))
+            }
+            ClaimSet::Effects { name, span, .. } => {
+                SetIr::EffectCarriers(class_ref_named(
+                    recs, name, *span,
+                ))
+            }
         };
         let law = match &c.form {
             ClaimForm::ForbidReaches {
@@ -235,44 +409,44 @@ pub fn lower_claims(
                 during,
                 avoiding,
             } => ClaimIr::ForbidReaches {
-                src: set_ir(src),
-                dst: set_ir(dst),
+                src: set_ir(recs, src),
+                dst: set_ir(recs, dst),
                 via_calls: *via_calls,
                 via_bus: *via_bus,
-                during: during.as_ref().map(|p| {
-                    (
-                        phase_id.get(p.name.as_str()).copied(),
-                        p.name.clone(),
-                    )
+                during: during.as_ref().map(|p| PhaseIrRef {
+                    phase: phase_id
+                        .get(p.name.as_str())
+                        .map(|i| hale_model::PhaseId(*i)),
+                    name: p.name.clone(),
+                    provenance: intern(recs, p.span),
                 }),
                 avoiding: avoiding
                     .as_ref()
-                    .map(|a| group_ref(&a.name)),
+                    .map(|a| group_ref(recs, &a.name, a.span)),
             },
             ClaimForm::OnlyEdges { src, dst, grants } => {
                 ClaimIr::OnlyEdges {
-                    src: group_ref(&src.name),
-                    dst: group_ref(&dst.name),
+                    src: group_ref(recs, &src.name, src.span),
+                    dst: group_ref(recs, &dst.name, dst.span),
                     grants: grants
                         .iter()
                         .map(|g| GrantIr {
                             publish: g.publish,
-                            topic: topic_ref(&g.topic),
+                            topic: topic_ref(recs, &g.topic),
                         })
                         .collect(),
                 }
             }
             ClaimForm::Bound {
                 class_name,
+                class_span,
                 limit,
                 from,
                 ..
             } => ClaimIr::Bound {
-                class: EffectClassRef {
-                    name: class_name.clone(),
-                },
+                class: class_ref_named(recs, class_name, *class_span),
                 limit: *limit,
-                from: group_ref(&from.name),
+                from: group_ref(recs, &from.name, from.span),
             },
             ClaimForm::Require {
                 publishers,
@@ -280,27 +454,32 @@ pub fn lower_claims(
                 topic,
             } => ClaimIr::RequireEndpoint {
                 publishers: *publishers,
-                group: group_ref(&group.name),
-                topic: topic_ref(topic),
+                group: group_ref(recs, &group.name, group.span),
+                topic: topic_ref(recs, topic),
             },
             ClaimForm::RequireSealed { group } => {
                 ClaimIr::RequireSealed {
-                    group: group_ref(&group.name),
+                    group: group_ref(recs, &group.name, group.span),
                 }
             }
             ClaimForm::RequireAttributed { class_name } => {
                 ClaimIr::RequireAttributed {
-                    class: EffectClassRef {
-                        name: class_name.name.clone(),
-                    },
+                    class: class_ref_named(
+                        recs,
+                        &class_name.name,
+                        class_name.span,
+                    ),
                 }
             }
             ClaimForm::Cover { alias, group } => ClaimIr::Cover {
-                seed: (
-                    seed_id.get(alias.name.as_str()).copied(),
-                    alias.name.clone(),
-                ),
-                group: group_ref(&group.name),
+                seed: SeedIrRef {
+                    seed: seed_id
+                        .get(alias.name.as_str())
+                        .map(|i| hale_model::SeedId(*i)),
+                    name: alias.name.clone(),
+                    provenance: intern(recs, alias.span),
+                },
+                group: group_ref(recs, &group.name, group.span),
             },
             ClaimForm::Count {
                 publishers,
@@ -309,7 +488,7 @@ pub fn lower_claims(
                 n,
             } => ClaimIr::Count {
                 publishers: *publishers,
-                topic: topic_ref(topic),
+                topic: topic_ref(recs, topic),
                 cmp: cmp_ir(*cmp),
                 n: *n,
             },
@@ -318,99 +497,10 @@ pub fn lower_claims(
     }
 
     // ---- 2. annotation surfaces, in declaration order ----
-    let fn_at = |raw: String| {
-        let id = fn_id.get(raw.as_str()).copied();
-        (id, name_ref(&raw))
-    };
-    let subj_at = |s: &str| {
-        (subject_id.get(s).copied(), name_ref(s))
-    };
-    struct AnnCtx<'x> {
-        rows: &'x mut Vec<(
-            String,
-            ClaimOrigin,
-            ClaimIr,
-            hale_syntax::Span,
-        )>,
+    enum AnnSite<'a> {
+        Free(&'a hale_syntax::ast::FnDecl),
+        Locus(&'a hale_syntax::ast::LocusDecl),
     }
-    let lower_fn_anns =
-        |ctx: &mut AnnCtx,
-         raw: String,
-         f: &hale_syntax::ast::FnDecl| {
-            for a in &f.effects {
-                let at = fn_at(raw.clone());
-                let law = match a {
-                    EffectAssert::Forbid(cs) => ClaimIr::EffectForbid {
-                        at,
-                        classes: cs.iter().map(&class_ref).collect(),
-                    },
-                    EffectAssert::PublishSet(subjects) => {
-                        ClaimIr::EffectPublishSet {
-                            at,
-                            subjects: subjects
-                                .iter()
-                                .map(|s| subj_at(s))
-                                .collect(),
-                        }
-                    }
-                    EffectAssert::Causes(cs) => ClaimIr::EffectCauses {
-                        at,
-                        classes: cs.iter().map(&class_ref).collect(),
-                    },
-                    EffectAssert::Only(cs) => ClaimIr::EffectOnly {
-                        at,
-                        classes: cs.iter().map(&class_ref).collect(),
-                    },
-                    EffectAssert::NoPanic => ClaimIr::NoPanic { at },
-                    // Classification fact, not a law — the model's
-                    // `labels` rows already carry it.
-                    EffectAssert::Carries(_) => continue,
-                };
-                ctx.rows.push((
-                    raw.clone(),
-                    ClaimOrigin::Annotation,
-                    law,
-                    f.name.span,
-                ));
-            }
-            if let Some(n) = f.budget {
-                ctx.rows.push((
-                    raw.clone(),
-                    ClaimOrigin::Annotation,
-                    ClaimIr::AllocBudget {
-                        at: fn_at(raw.clone()),
-                        per_call: n,
-                    },
-                    f.name.span,
-                ));
-            }
-            for (dim, limit) in &f.quantities {
-                ctx.rows.push((
-                    raw.clone(),
-                    ClaimOrigin::Annotation,
-                    ClaimIr::QuantBudget {
-                        at: fn_at(raw.clone()),
-                        dim: match dim {
-                            QuantDim::StackBytes => {
-                                QuantDimIr::StackBytes
-                            }
-                            QuantDim::BlockPoints => {
-                                QuantDimIr::BlockPoints
-                            }
-                            QuantDim::Publish => QuantDimIr::Publish,
-                            QuantDim::Fanout => QuantDimIr::Fanout,
-                            QuantDim::UserClass(i) => {
-                                QuantDimIr::UserClass(class_ref(
-                                    &EffectClass::User(*i),
-                                ))
-                            }
-                        },
-                        limit: *limit,
-                    },
-                    f.name.span,
-                ));
-            }
-        };
     fn walk_decls<'a>(
         items: &'a [TopDecl],
         out: &mut Vec<AnnSite<'a>>,
@@ -424,88 +514,171 @@ pub fn lower_claims(
             }
         }
     }
-    enum AnnSite<'a> {
-        Free(&'a hale_syntax::ast::FnDecl),
-        Locus(&'a hale_syntax::ast::LocusDecl),
-    }
     let mut sites = Vec::new();
     for p in &programs {
         walk_decls(&p.items, &mut sites);
     }
-    {
-        let mut ctx = AnnCtx { rows: &mut rows };
-        for site in &sites {
-            match site {
-                AnnSite::Free(f) => {
-                    lower_fn_anns(&mut ctx, f.name.name.clone(), f)
+    let lower_fn_anns = |recs: &mut Vec<Provenance>,
+                         rows: &mut Vec<(
+        String,
+        ClaimOrigin,
+        ClaimIr,
+        hale_syntax::Span,
+    )>,
+                         raw: &str,
+                         f: &hale_syntax::ast::FnDecl| {
+        for a in &f.effects {
+            let at = fn_at(raw);
+            let law = match a {
+                EffectAssert::Forbid(cs) => ClaimIr::EffectForbid {
+                    at,
+                    classes: cs
+                        .iter()
+                        .map(|c| class_ref(recs, c, f.name.span))
+                        .collect(),
+                },
+                // TOPIC references (review round 15): the source
+                // names topics and the evaluator matches topic
+                // identity across spellings — never wire subjects.
+                EffectAssert::PublishSet(topics) => {
+                    ClaimIr::EffectPublishSet {
+                        at,
+                        topics: topics
+                            .iter()
+                            .map(|t| {
+                                topic_ref_str(recs, t, f.name.span)
+                            })
+                            .collect(),
+                    }
                 }
-                AnnSite::Locus(l) => {
-                    let lname = l.name.name.clone();
-                    if let Some(pe) = &l.phase_effects {
-                        ctx.rows.push((
-                            lname.clone(),
-                            ClaimOrigin::Annotation,
-                            ClaimIr::PhaseEffects {
-                                locus: (
-                                    locus_id
-                                        .get(lname.as_str())
-                                        .copied(),
-                                    name_ref(&lname),
-                                ),
-                                phases: pe
-                                    .phases
-                                    .iter()
-                                    .map(|(ph, cs)| {
-                                        (
-                                            ph.clone(),
-                                            cs.iter()
-                                                .map(&class_ref)
-                                                .collect(),
-                                        )
+                EffectAssert::Causes(cs) => ClaimIr::EffectCauses {
+                    at,
+                    classes: cs
+                        .iter()
+                        .map(|c| class_ref(recs, c, f.name.span))
+                        .collect(),
+                },
+                EffectAssert::Only(cs) => ClaimIr::EffectOnly {
+                    at,
+                    classes: cs
+                        .iter()
+                        .map(|c| class_ref(recs, c, f.name.span))
+                        .collect(),
+                },
+                EffectAssert::NoPanic => ClaimIr::NoPanic { at },
+                // Classification fact, not a law — the model's
+                // `labels` rows already carry it.
+                EffectAssert::Carries(_) => continue,
+            };
+            rows.push((
+                raw.to_string(),
+                ClaimOrigin::Annotation,
+                law,
+                f.name.span,
+            ));
+        }
+        if let Some(n) = f.budget {
+            rows.push((
+                raw.to_string(),
+                ClaimOrigin::Annotation,
+                ClaimIr::AllocBudget {
+                    at: fn_at(raw),
+                    per_call: n,
+                },
+                f.name.span,
+            ));
+        }
+        for (dim, limit) in &f.quantities {
+            rows.push((
+                raw.to_string(),
+                ClaimOrigin::Annotation,
+                ClaimIr::QuantBudget {
+                    at: fn_at(raw),
+                    dim: match dim {
+                        QuantDim::StackBytes => QuantDimIr::StackBytes,
+                        QuantDim::BlockPoints => {
+                            QuantDimIr::BlockPoints
+                        }
+                        QuantDim::Publish => QuantDimIr::Publish,
+                        QuantDim::Fanout => QuantDimIr::Fanout,
+                        QuantDim::UserClass(i) => {
+                            QuantDimIr::UserClass(class_ref(
+                                recs,
+                                &EffectClass::User(*i),
+                                f.name.span,
+                            ))
+                        }
+                    },
+                    limit: *limit,
+                },
+                f.name.span,
+            ));
+        }
+    };
+    for site in &sites {
+        match site {
+            AnnSite::Free(f) => {
+                lower_fn_anns(recs, &mut rows, &f.name.name, f)
+            }
+            AnnSite::Locus(l) => {
+                let lname = &l.name.name;
+                if let Some(pe) = &l.phase_effects {
+                    let phases = pe
+                        .phases
+                        .iter()
+                        .map(|(ph, cs)| {
+                            (
+                                ph.clone(),
+                                cs.iter()
+                                    .map(|c| {
+                                        class_ref(recs, c, pe.span)
                                     })
                                     .collect(),
-                            },
-                            pe.span,
-                        ));
-                    }
-                    if let Some(ds) = &l.depends {
-                        ctx.rows.push((
-                            lname.clone(),
-                            ClaimOrigin::Annotation,
-                            ClaimIr::DependsSet {
-                                locus: (
-                                    locus_id
-                                        .get(lname.as_str())
-                                        .copied(),
-                                    name_ref(&lname),
-                                ),
-                                subjects: ds
-                                    .subjects
-                                    .iter()
-                                    .map(|s| subj_at(s))
-                                    .collect(),
-                            },
-                            ds.span,
-                        ));
-                    }
-                    for m in &l.members {
-                        if let LocusMember::Fn(f) = m {
-                            lower_fn_anns(
-                                &mut ctx,
-                                format!("{}::{}", lname, f.name.name),
-                                f,
-                            );
-                        }
+                            )
+                        })
+                        .collect();
+                    rows.push((
+                        lname.clone(),
+                        ClaimOrigin::Annotation,
+                        ClaimIr::PhaseEffects {
+                            locus: locus_at(lname),
+                            phases,
+                        },
+                        pe.span,
+                    ));
+                }
+                if let Some(ds) = &l.depends {
+                    rows.push((
+                        lname.clone(),
+                        ClaimOrigin::Annotation,
+                        ClaimIr::DependsSet {
+                            locus: locus_at(lname),
+                            subjects: ds
+                                .subjects
+                                .iter()
+                                .map(|s| {
+                                    subject_ref(recs, s, ds.span)
+                                })
+                                .collect(),
+                        },
+                        ds.span,
+                    ));
+                }
+                for m in &l.members {
+                    if let LocusMember::Fn(f) = m {
+                        let raw =
+                            format!("{}::{}", lname, f.name.name);
+                        lower_fn_anns(recs, &mut rows, &raw, f);
                     }
                 }
             }
         }
     }
 
-    // ---- finalize: authored ordinals + interned provenance ----
+    // ---- finalize: authored ordinals + row provenance ----
     for (i, (name, origin, law, span)) in rows.into_iter().enumerate()
     {
-        let pid = intern(&mut table.provenance.records, span);
+        let pid = intern(recs, span);
         table.rows.push(ClaimRow {
             ordinal: i as u32,
             name,

--- a/crates/hale-types/src/claim_lowering.rs
+++ b/crates/hale-types/src/claim_lowering.rs
@@ -246,28 +246,26 @@ pub fn lower_claims(
         let segs: Vec<&str> = s.split("::").collect();
         topic_ref_parts(recs, s, &segs, span)
     };
-    // The ONE bus selector for annotation entries (rounds 16/17):
-    // a qualified alias path is exact; any other spelling matches
-    // exact-or-trailing-name against declared topics AND wire
-    // subjects — mirroring `effects::topic_ref_matches`, which is
-    // how the evaluator admits a literal wire subject
-    // (`"audit.log"`), a local topic, and an imported unqualified
-    // name alike.
+    // The ONE bus selector for annotation entries (rounds 16-18):
+    // EVERY spelling — identifier, alias path, string literal —
+    // gets its candidate sets from `effects::topic_ref_matches`
+    // DIRECTLY (exact string equality first, trailing-name second).
+    // The parser collapses literals and paths to plain strings, so
+    // `"audit::log"` cannot be told from `alias::Topic`
+    // syntactically — and the evaluator never tells them apart
+    // either: a qualified path also tail-matches every same-tailed
+    // import. One rule, shared, no guessing from string contents.
     let bus_selector = |recs: &mut Vec<Provenance>,
                         s: &str,
                         span: hale_syntax::Span|
      -> BusSelector {
-        if s.contains("::") {
-            return BusSelector::Exact(topic_ref_str(recs, s, span));
-        }
-        let tail = crate::effects::topic_tail(s);
-        let matches =
-            |x: &str| x == s || crate::effects::topic_tail(x) == tail;
         let mut topics: Vec<hale_model::TopicId> = e
             .topics
             .iter()
             .enumerate()
-            .filter(|(_, t)| matches(&t.name))
+            .filter(|(_, t)| {
+                crate::effects::topic_ref_matches(s, &t.name)
+            })
             .map(|(i, _)| hale_model::TopicId(i as u32))
             .collect();
         topics.sort();
@@ -276,12 +274,14 @@ pub fn lower_claims(
             .subjects
             .iter()
             .enumerate()
-            .filter(|(_, su)| matches(&su.pattern))
+            .filter(|(_, su)| {
+                crate::effects::topic_ref_matches(s, &su.pattern)
+            })
             .map(|(i, _)| hale_model::SubjectId(i as u32))
             .collect();
         subjects.sort();
         subjects.dedup();
-        BusSelector::Match {
+        BusSelector {
             name: s.to_string(),
             topics,
             subjects,

--- a/crates/hale-types/src/claim_lowering.rs
+++ b/crates/hale-types/src/claim_lowering.rs
@@ -1,0 +1,518 @@
+//! GH #476 Change 4 — lowering every law surface to `ClaimIr`.
+//!
+//! `lower_claims(bundle, model)` produces the typed law table for
+//! one application: claims-block forms (world tier, adopted
+//! constitution clauses, library-tier blocks) through the SAME
+//! clause enumeration the evaluator walks
+//! (`claims::enumerate_clauses` — one authority, extracted so two
+//! walks cannot drift), plus the annotation surfaces
+//! (`@effects` / `@no_panic` / `@budget` / `@phase_effects` /
+//! `@effects(depends:)`). Fleet plan rows lower in `hale-cli`
+//! (`fleet::lower_plan_claims`) — their targets are plan-level
+//! names until Change 7's `FleetModel`.
+//!
+//! **Lowering only** (the epic's Change-4 scope): the old
+//! evaluators stay active and authoritative; nothing consumes
+//! these rows yet. The lowering is TOTAL over parseable programs —
+//! an unresolvable reference lowers with `id: None` (the raw and
+//! display spellings are kept), which is the residue Change 5's
+//! `invalid` verdict consumes; it never panics and never drops a
+//! law on the floor.
+//!
+//! `@effects(is: {…})` (carries) deliberately does NOT lower: it
+//! is a classification FACT, not an obligation — the model already
+//! records it as `labels` rows, and a judgment never evaluates it.
+
+use std::collections::BTreeMap;
+
+use hale_model::{
+    ApplicationModel, ClaimIr, ClaimIrTable, ClaimOrigin, ClaimRow,
+    CountCmpIr, EffectClassRef, GrantIr, GroupRef, NameRef,
+    ProvenanceId, QuantDimIr, SetIr, TopicIrRef,
+};
+use hale_syntax::ast::{
+    ClaimForm, ClaimSet, CountCmp, EffectAssert, EffectClass,
+    LocusMember, Program, QuantDim, TopDecl, TopicRef,
+};
+
+use crate::symbol::Bundle;
+
+/// Lower every law surface of one bundle against its derived model.
+pub fn lower_claims(
+    bundle: &Bundle<'_>,
+    model: &ApplicationModel,
+) -> ClaimIrTable {
+    let programs: Vec<&Program> =
+        bundle.programs.values().copied().collect();
+
+    // ---- display mapping (author spelling) ----
+    let demangle: BTreeMap<&str, String> = bundle
+        .import_renames
+        .iter()
+        .map(|(segs, mangled)| (mangled.as_str(), segs.join("::")))
+        .collect();
+    let display_of = |raw: &str| -> String {
+        demangle.get(raw).cloned().unwrap_or_else(|| raw.to_string())
+    };
+    let name_ref = |raw: &str| NameRef {
+        raw: raw.to_string(),
+        display: display_of(raw),
+    };
+
+    // ---- resolution maps out of the model ----
+    let e = &model.entities;
+    let group_id: BTreeMap<&str, hale_model::GroupId> = e
+        .groups
+        .iter()
+        .enumerate()
+        .map(|(i, g)| (g.name.as_str(), hale_model::GroupId(i as u32)))
+        .collect();
+    let topic_id: BTreeMap<&str, hale_model::TopicId> = e
+        .topics
+        .iter()
+        .enumerate()
+        .map(|(i, t)| (t.name.as_str(), hale_model::TopicId(i as u32)))
+        .collect();
+    let fn_id: BTreeMap<&str, hale_model::FunctionId> = e
+        .functions
+        .iter()
+        .enumerate()
+        .map(|(i, f)| {
+            (f.name.as_str(), hale_model::FunctionId(i as u32))
+        })
+        .collect();
+    let locus_id: BTreeMap<&str, hale_model::LocusDeclId> = e
+        .loci
+        .iter()
+        .enumerate()
+        .map(|(i, l)| {
+            (l.name.as_str(), hale_model::LocusDeclId(i as u32))
+        })
+        .collect();
+    let phase_id: BTreeMap<&str, hale_model::PhaseId> = e
+        .phases
+        .iter()
+        .enumerate()
+        .map(|(i, p)| (p.name.as_str(), hale_model::PhaseId(i as u32)))
+        .collect();
+    let seed_id: BTreeMap<&str, hale_model::SeedId> = e
+        .seeds
+        .iter()
+        .enumerate()
+        .map(|(i, s)| (s.name.as_str(), hale_model::SeedId(i as u32)))
+        .collect();
+    let subject_id: BTreeMap<&str, hale_model::SubjectId> = e
+        .subjects
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            (s.pattern.as_str(), hale_model::SubjectId(i as u32))
+        })
+        .collect();
+
+    // ---- ref lowerers ----
+    let group_ref = |n: &str| GroupRef {
+        group: group_id.get(n).copied(),
+        name: name_ref(n),
+    };
+    // A topic ref: post-mangle it is a single canonical segment; an
+    // unmangled 2-segment `alias::T` resolves through the rename
+    // table to the same canonical symbol.
+    let topic_ref = |t: &TopicRef| -> TopicIrRef {
+        let joined = t.display();
+        let raw = if t.segments.len() == 2 {
+            bundle
+                .import_renames
+                .iter()
+                .find(|(segs, _)| {
+                    segs.len() == 2
+                        && segs[0] == t.segments[0].name
+                        && segs[1] == t.segments[1].name
+                })
+                .map(|(_, m)| m.clone())
+                .unwrap_or(joined.clone())
+        } else {
+            joined.clone()
+        };
+        TopicIrRef {
+            topic: topic_id.get(raw.as_str()).copied(),
+            name: NameRef {
+                display: display_of(&raw),
+                raw,
+            },
+        }
+    };
+    let effect_names = crate::effects::effect_names_of(&programs);
+    let class_ref = |c: &EffectClass| EffectClassRef {
+        name: match c {
+            EffectClass::User(i) => effect_names
+                .get(*i as usize)
+                .cloned()
+                .unwrap_or_else(|| format!("<user:{}>", i)),
+            other => other.as_str().to_string(),
+        },
+    };
+    let set_ir = |s: &ClaimSet| match s {
+        ClaimSet::Group(g) => SetIr::Group(group_ref(&g.name)),
+        ClaimSet::Effects { name, .. } => {
+            SetIr::EffectCarriers(EffectClassRef { name: name.clone() })
+        }
+    };
+    let cmp_ir = |c: CountCmp| match c {
+        CountCmp::Eq => CountCmpIr::Eq,
+        CountCmp::Le => CountCmpIr::Le,
+        CountCmp::Ge => CountCmpIr::Ge,
+    };
+
+    // ---- provenance (same resolution rule as the model builder) ----
+    let mut table = ClaimIrTable::default();
+    for sf in &bundle.sources {
+        table.provenance.sources.push(
+            hale_model::provenance::SourceUnit {
+                path: sf.path.clone(),
+                digest: u64::from_str_radix(&sf.digest, 16)
+                    .unwrap_or(0),
+            },
+        );
+    }
+    let sources = bundle.sources.clone();
+    let loc = move |pos: u32| -> (i64, u32) {
+        match sources
+            .iter()
+            .filter(|f| {
+                pos >= f.base && pos < f.base.saturating_add(f.len + 1)
+            })
+            .max_by_key(|f| f.base)
+        {
+            Some(f) => (f.id as i64, pos - f.base),
+            None => (-1, pos),
+        }
+    };
+    let intern = |records: &mut Vec<hale_model::Provenance>,
+                      span: hale_syntax::Span|
+     -> ProvenanceId {
+        let s = span.start.as_usize() as u32;
+        let (src, ls) = loc(s);
+        let (_, le) = loc(span.end.as_usize() as u32);
+        let id = ProvenanceId(records.len() as u32);
+        records.push(if src >= 0 {
+            hale_model::Provenance::Source {
+                source: hale_model::SourceId(src as u32),
+                span: (ls, le.max(ls)),
+            }
+        } else {
+            hale_model::Provenance::Synthetic {
+                origin: "unplaceable span".to_string(),
+            }
+        });
+        id
+    };
+
+    // ---- 1. claims-block forms, via the evaluator's enumeration ----
+    let universe =
+        crate::claims::enumerate_clauses(&programs, &bundle.import_renames);
+    let mut rows: Vec<(String, ClaimOrigin, ClaimIr, hale_syntax::Span)> =
+        Vec::new();
+    for c in &universe.claims {
+        let origin = if let Some(k) = universe.origins.get(&c.name.name)
+        {
+            ClaimOrigin::Constitution { name: k.clone() }
+        } else if let Some(alias) =
+            universe.library.get(&c.name.name)
+        {
+            ClaimOrigin::Library {
+                alias: alias.clone(),
+            }
+        } else {
+            ClaimOrigin::Main
+        };
+        let law = match &c.form {
+            ClaimForm::ForbidReaches {
+                src,
+                dst,
+                via_calls,
+                via_bus,
+                during,
+                avoiding,
+            } => ClaimIr::ForbidReaches {
+                src: set_ir(src),
+                dst: set_ir(dst),
+                via_calls: *via_calls,
+                via_bus: *via_bus,
+                during: during.as_ref().map(|p| {
+                    (
+                        phase_id.get(p.name.as_str()).copied(),
+                        p.name.clone(),
+                    )
+                }),
+                avoiding: avoiding
+                    .as_ref()
+                    .map(|a| group_ref(&a.name)),
+            },
+            ClaimForm::OnlyEdges { src, dst, grants } => {
+                ClaimIr::OnlyEdges {
+                    src: group_ref(&src.name),
+                    dst: group_ref(&dst.name),
+                    grants: grants
+                        .iter()
+                        .map(|g| GrantIr {
+                            publish: g.publish,
+                            topic: topic_ref(&g.topic),
+                        })
+                        .collect(),
+                }
+            }
+            ClaimForm::Bound {
+                class_name,
+                limit,
+                from,
+                ..
+            } => ClaimIr::Bound {
+                class: EffectClassRef {
+                    name: class_name.clone(),
+                },
+                limit: *limit,
+                from: group_ref(&from.name),
+            },
+            ClaimForm::Require {
+                publishers,
+                group,
+                topic,
+            } => ClaimIr::RequireEndpoint {
+                publishers: *publishers,
+                group: group_ref(&group.name),
+                topic: topic_ref(topic),
+            },
+            ClaimForm::RequireSealed { group } => {
+                ClaimIr::RequireSealed {
+                    group: group_ref(&group.name),
+                }
+            }
+            ClaimForm::RequireAttributed { class_name } => {
+                ClaimIr::RequireAttributed {
+                    class: EffectClassRef {
+                        name: class_name.name.clone(),
+                    },
+                }
+            }
+            ClaimForm::Cover { alias, group } => ClaimIr::Cover {
+                seed: (
+                    seed_id.get(alias.name.as_str()).copied(),
+                    alias.name.clone(),
+                ),
+                group: group_ref(&group.name),
+            },
+            ClaimForm::Count {
+                publishers,
+                topic,
+                cmp,
+                n,
+            } => ClaimIr::Count {
+                publishers: *publishers,
+                topic: topic_ref(topic),
+                cmp: cmp_ir(*cmp),
+                n: *n,
+            },
+        };
+        rows.push((c.name.name.clone(), origin, law, c.span));
+    }
+
+    // ---- 2. annotation surfaces, in declaration order ----
+    let fn_at = |raw: String| {
+        let id = fn_id.get(raw.as_str()).copied();
+        (id, name_ref(&raw))
+    };
+    let subj_at = |s: &str| {
+        (subject_id.get(s).copied(), name_ref(s))
+    };
+    struct AnnCtx<'x> {
+        rows: &'x mut Vec<(
+            String,
+            ClaimOrigin,
+            ClaimIr,
+            hale_syntax::Span,
+        )>,
+    }
+    let lower_fn_anns =
+        |ctx: &mut AnnCtx,
+         raw: String,
+         f: &hale_syntax::ast::FnDecl| {
+            for a in &f.effects {
+                let at = fn_at(raw.clone());
+                let law = match a {
+                    EffectAssert::Forbid(cs) => ClaimIr::EffectForbid {
+                        at,
+                        classes: cs.iter().map(&class_ref).collect(),
+                    },
+                    EffectAssert::PublishSet(subjects) => {
+                        ClaimIr::EffectPublishSet {
+                            at,
+                            subjects: subjects
+                                .iter()
+                                .map(|s| subj_at(s))
+                                .collect(),
+                        }
+                    }
+                    EffectAssert::Causes(cs) => ClaimIr::EffectCauses {
+                        at,
+                        classes: cs.iter().map(&class_ref).collect(),
+                    },
+                    EffectAssert::Only(cs) => ClaimIr::EffectOnly {
+                        at,
+                        classes: cs.iter().map(&class_ref).collect(),
+                    },
+                    EffectAssert::NoPanic => ClaimIr::NoPanic { at },
+                    // Classification fact, not a law — the model's
+                    // `labels` rows already carry it.
+                    EffectAssert::Carries(_) => continue,
+                };
+                ctx.rows.push((
+                    raw.clone(),
+                    ClaimOrigin::Annotation,
+                    law,
+                    f.name.span,
+                ));
+            }
+            if let Some(n) = f.budget {
+                ctx.rows.push((
+                    raw.clone(),
+                    ClaimOrigin::Annotation,
+                    ClaimIr::AllocBudget {
+                        at: fn_at(raw.clone()),
+                        per_call: n,
+                    },
+                    f.name.span,
+                ));
+            }
+            for (dim, limit) in &f.quantities {
+                ctx.rows.push((
+                    raw.clone(),
+                    ClaimOrigin::Annotation,
+                    ClaimIr::QuantBudget {
+                        at: fn_at(raw.clone()),
+                        dim: match dim {
+                            QuantDim::StackBytes => {
+                                QuantDimIr::StackBytes
+                            }
+                            QuantDim::BlockPoints => {
+                                QuantDimIr::BlockPoints
+                            }
+                            QuantDim::Publish => QuantDimIr::Publish,
+                            QuantDim::Fanout => QuantDimIr::Fanout,
+                            QuantDim::UserClass(i) => {
+                                QuantDimIr::UserClass(class_ref(
+                                    &EffectClass::User(*i),
+                                ))
+                            }
+                        },
+                        limit: *limit,
+                    },
+                    f.name.span,
+                ));
+            }
+        };
+    fn walk_decls<'a>(
+        items: &'a [TopDecl],
+        out: &mut Vec<AnnSite<'a>>,
+    ) {
+        for item in items {
+            match item {
+                TopDecl::Fn(f) => out.push(AnnSite::Free(f)),
+                TopDecl::Locus(l) => out.push(AnnSite::Locus(l)),
+                TopDecl::Module(m) => walk_decls(&m.items, out),
+                _ => {}
+            }
+        }
+    }
+    enum AnnSite<'a> {
+        Free(&'a hale_syntax::ast::FnDecl),
+        Locus(&'a hale_syntax::ast::LocusDecl),
+    }
+    let mut sites = Vec::new();
+    for p in &programs {
+        walk_decls(&p.items, &mut sites);
+    }
+    {
+        let mut ctx = AnnCtx { rows: &mut rows };
+        for site in &sites {
+            match site {
+                AnnSite::Free(f) => {
+                    lower_fn_anns(&mut ctx, f.name.name.clone(), f)
+                }
+                AnnSite::Locus(l) => {
+                    let lname = l.name.name.clone();
+                    if let Some(pe) = &l.phase_effects {
+                        ctx.rows.push((
+                            lname.clone(),
+                            ClaimOrigin::Annotation,
+                            ClaimIr::PhaseEffects {
+                                locus: (
+                                    locus_id
+                                        .get(lname.as_str())
+                                        .copied(),
+                                    name_ref(&lname),
+                                ),
+                                phases: pe
+                                    .phases
+                                    .iter()
+                                    .map(|(ph, cs)| {
+                                        (
+                                            ph.clone(),
+                                            cs.iter()
+                                                .map(&class_ref)
+                                                .collect(),
+                                        )
+                                    })
+                                    .collect(),
+                            },
+                            pe.span,
+                        ));
+                    }
+                    if let Some(ds) = &l.depends {
+                        ctx.rows.push((
+                            lname.clone(),
+                            ClaimOrigin::Annotation,
+                            ClaimIr::DependsSet {
+                                locus: (
+                                    locus_id
+                                        .get(lname.as_str())
+                                        .copied(),
+                                    name_ref(&lname),
+                                ),
+                                subjects: ds
+                                    .subjects
+                                    .iter()
+                                    .map(|s| subj_at(s))
+                                    .collect(),
+                            },
+                            ds.span,
+                        ));
+                    }
+                    for m in &l.members {
+                        if let LocusMember::Fn(f) = m {
+                            lower_fn_anns(
+                                &mut ctx,
+                                format!("{}::{}", lname, f.name.name),
+                                f,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- finalize: authored ordinals + interned provenance ----
+    for (i, (name, origin, law, span)) in rows.into_iter().enumerate()
+    {
+        let pid = intern(&mut table.provenance.records, span);
+        table.rows.push(ClaimRow {
+            ordinal: i as u32,
+            name,
+            origin,
+            law,
+            provenance: pid,
+        });
+    }
+    table
+}

--- a/crates/hale-types/src/claim_lowering.rs
+++ b/crates/hale-types/src/claim_lowering.rs
@@ -38,7 +38,7 @@ use hale_model::{
     ApplicationModel, ClaimIr, ClaimIrTable, ClaimOrigin, ClaimRow,
     CountCmpIr, EffectClassRef, GrantIr, GroupRef, LoweringIssue,
     NameRef, PhaseIrRef, Provenance, ProvenanceId, QuantDimIr,
-    SeedIrRef, SetIr, SubjectIrRef, TopicIrRef, TopicSelector,
+    SeedIrRef, BusSelector, SetIr, TopicIrRef,
 };
 use hale_syntax::ast::{
     ClaimForm, ClaimSet, CountCmp, EffectAssert, EffectClass,
@@ -105,12 +105,6 @@ pub fn lower_claims(
         .iter()
         .enumerate()
         .map(|(i, s)| (s.name.as_str(), i as u32))
-        .collect();
-    let subject_id: BTreeMap<&str, u32> = e
-        .subjects
-        .iter()
-        .enumerate()
-        .map(|(i, s)| (s.pattern.as_str(), i as u32))
         .collect();
     let class_id: BTreeMap<&str, u32> = e
         .effect_classes
@@ -252,59 +246,46 @@ pub fn lower_claims(
         let segs: Vec<&str> = s.split("::").collect();
         topic_ref_parts(recs, s, &segs, span)
     };
-    let topic_selector = |recs: &mut Vec<Provenance>,
-                          s: &str,
-                          span: hale_syntax::Span|
-     -> TopicSelector {
+    // The ONE bus selector for annotation entries (rounds 16/17):
+    // a qualified alias path is exact; any other spelling matches
+    // exact-or-trailing-name against declared topics AND wire
+    // subjects — mirroring `effects::topic_ref_matches`, which is
+    // how the evaluator admits a literal wire subject
+    // (`"audit.log"`), a local topic, and an imported unqualified
+    // name alike.
+    let bus_selector = |recs: &mut Vec<Provenance>,
+                        s: &str,
+                        span: hale_syntax::Span|
+     -> BusSelector {
         if s.contains("::") {
-            // Qualified — the author named one topic through an
-            // alias path.
-            return TopicSelector::Exact(topic_ref_str(recs, s, span));
+            return BusSelector::Exact(topic_ref_str(recs, s, span));
         }
-        // Unqualified: ALWAYS the tail-match candidate set,
-        // mirroring `effects::topic_ref_matches` — the evaluator
-        // never privileges an exact hit for an unqualified
-        // spelling, so a local topic and a same-tailed import both
-        // match (the documented permissiveness).
-        let mut candidates: Vec<hale_model::TopicId> = e
+        let tail = crate::effects::topic_tail(s);
+        let matches =
+            |x: &str| x == s || crate::effects::topic_tail(x) == tail;
+        let mut topics: Vec<hale_model::TopicId> = e
             .topics
             .iter()
             .enumerate()
-            .filter(|(_, t)| {
-                crate::effects::topic_tail(&t.name) == s
-            })
+            .filter(|(_, t)| matches(&t.name))
             .map(|(i, _)| hale_model::TopicId(i as u32))
             .collect();
-        candidates.sort();
-        candidates.dedup();
-        TopicSelector::Unqualified {
+        topics.sort();
+        topics.dedup();
+        let mut subjects: Vec<hale_model::SubjectId> = e
+            .subjects
+            .iter()
+            .enumerate()
+            .filter(|(_, su)| matches(&su.pattern))
+            .map(|(i, _)| hale_model::SubjectId(i as u32))
+            .collect();
+        subjects.sort();
+        subjects.dedup();
+        BusSelector::Match {
             name: s.to_string(),
-            candidates,
+            topics,
+            subjects,
             provenance: intern(recs, span),
-        }
-    };
-    let subject_ref = |recs: &mut Vec<Provenance>,
-                       s: &str,
-                       span: hale_syntax::Span|
-     -> SubjectIrRef {
-        let pid = intern(recs, span);
-        match subject_id.get(s) {
-            Some(i) => SubjectIrRef {
-                subject: Some(hale_model::SubjectId(*i)),
-                name: NameRef {
-                    raw: e.subjects[*i as usize].pattern.clone(),
-                    display: e.subjects[*i as usize].pattern.clone(),
-                },
-                provenance: pid,
-            },
-            None => SubjectIrRef {
-                subject: None,
-                name: NameRef {
-                    raw: s.to_string(),
-                    display: display_of(s),
-                },
-                provenance: pid,
-            },
         }
     };
     let effect_names = crate::effects::effect_names_of(&programs);
@@ -575,13 +556,13 @@ pub fn lower_claims(
                 // cannot know the consumer's alias, so the name
                 // matches merged topics by TRAILING name, possibly
                 // several.
-                EffectAssert::PublishSet(topics) => {
+                EffectAssert::PublishSet(entries) => {
                     ClaimIr::EffectPublishSet {
                         at,
-                        topics: topics
+                        entries: entries
                             .iter()
                             .map(|t| {
-                                topic_selector(recs, t, f.name.span)
+                                bus_selector(recs, t, f.name.span)
                             })
                             .collect(),
                     }
@@ -688,11 +669,11 @@ pub fn lower_claims(
                         ClaimOrigin::Annotation,
                         ClaimIr::DependsSet {
                             locus: locus_at(lname),
-                            subjects: ds
+                            entries: ds
                                 .subjects
                                 .iter()
                                 .map(|s| {
-                                    subject_ref(recs, s, ds.span)
+                                    bus_selector(recs, s, ds.span)
                                 })
                                 .collect(),
                         },

--- a/crates/hale-types/src/claim_lowering.rs
+++ b/crates/hale-types/src/claim_lowering.rs
@@ -239,13 +239,6 @@ pub fn lower_claims(
             t.segments.iter().map(|s| s.name.as_str()).collect();
         topic_ref_parts(recs, &t.display(), &segs, t.span)
     };
-    let topic_ref_str = |recs: &mut Vec<Provenance>,
-                         s: &str,
-                         span: hale_syntax::Span|
-     -> TopicIrRef {
-        let segs: Vec<&str> = s.split("::").collect();
-        topic_ref_parts(recs, s, &segs, span)
-    };
     // The ONE bus selector for annotation entries (rounds 16-18):
     // EVERY spelling — identifier, alias path, string literal —
     // gets its candidate sets from `effects::topic_ref_matches`
@@ -294,9 +287,7 @@ pub fn lower_claims(
                            span: hale_syntax::Span|
      -> EffectClassRef {
         let pid = intern(recs, span);
-        let builtin = EffectClass::from_ident(name)
-            .map(|c| !matches!(c, EffectClass::User(_)))
-            .unwrap_or(false);
+        let builtin = hale_model::is_builtin_effect_class(name);
         EffectClassRef {
             class: if builtin {
                 None

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -604,11 +604,29 @@ fn expand_adoptions(
     origins
 }
 
-fn claims_report_inner(
-    programs: &[&Program],
-    graph: &BusGraph,
+/// The clause universe — the ONE enumeration of every claims-block
+/// law the evaluator sees: this main's world tier, adopted
+/// constitution clauses (#409), and library-tier top-level blocks
+/// (#392 thread 2), plus the group declarations and adoption info
+/// the evaluation needs. Extracted from `claims_report_inner` so
+/// the `ClaimIr` lowering (GH #476 Change 4) walks EXACTLY the
+/// clauses the evaluator walks — two enumerations would drift.
+pub(crate) struct ClauseUniverse<'a> {
+    pub claims: Vec<ClaimDecl>,
+    /// claim name → originating constitution (adopted clauses).
+    pub origins: BTreeMap<String, String>,
+    /// claim name → attribution alias (library-tier clauses).
+    pub library: BTreeMap<String, Option<String>>,
+    pub group_decls: Vec<&'a GroupDecl>,
+    pub adoption: AdoptionInfo,
+    pub diags: Vec<Diag>,
+}
+
+pub(crate) fn enumerate_clauses<'a>(
+    programs: &[&'a Program],
     import_renames: &[(Vec<String>, String)],
-) -> (Vec<Diag>, Vec<ClaimOutcome>, AdoptionInfo) {
+) -> ClauseUniverse<'a> {
+    let mut library: BTreeMap<String, Option<String>> = BTreeMap::new();
     // ---- collect group decls + claims blocks (modules included) ----
     //
     // #392 thread 2 — two tiers. Main-locus blocks are the WORLD
@@ -747,9 +765,37 @@ fn claims_report_inner(
             if let Some(a) = alias {
                 c.name.name = format!("{}::{}", a, c.name.name);
             }
+            library.insert(
+                c.name.name.clone(),
+                alias.map(|a| a.to_string()),
+            );
             claims.push(c);
         }
     }
+    ClauseUniverse {
+        claims,
+        origins,
+        library,
+        group_decls,
+        adoption,
+        diags,
+    }
+}
+
+fn claims_report_inner(
+    programs: &[&Program],
+    graph: &BusGraph,
+    import_renames: &[(Vec<String>, String)],
+) -> (Vec<Diag>, Vec<ClaimOutcome>, AdoptionInfo) {
+    let ClauseUniverse {
+        claims,
+        origins,
+        library: _,
+        group_decls,
+        adoption,
+        diags,
+    } = enumerate_clauses(programs, import_renames);
+    let mut diags = diags;
     if group_decls.is_empty() && claims.is_empty() {
         return (diags, Vec::new(), adoption);
     }

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -1344,10 +1344,11 @@ fn check_class(
 /// more permissive than intended, but it is the permissiveness the
 /// author asked for by writing an unqualified name.
 pub(crate) fn topic_ref_matches(declared: &str, resolved: &str) -> bool {
-    if declared == resolved {
-        return true;
-    }
-    topic_tail(declared) == topic_tail(resolved)
+    // The definition lives in hale-model (`bus_ref_matches`) so the
+    // dependency-free schema can validate candidate sets against
+    // the SAME rule (review round 19); this is a delegation, not a
+    // second implementation.
+    hale_model::bus_ref_matches(declared, resolved)
 }
 
 /// The bare topic name, whichever spelling reached us.
@@ -1368,11 +1369,7 @@ pub(crate) fn topic_ref_matches(declared: &str, resolved: &str) -> bool {
 /// different seeds are indistinguishable here. Disambiguating them
 /// needs the resolver's alias table, which this layer does not have.
 pub(crate) fn topic_tail(s: &str) -> &str {
-    let s = s.rsplit("::").next().unwrap_or(s);
-    match s.strip_prefix("__lib_") {
-        Some(rest) => rest.rsplit('_').next().unwrap_or(rest),
-        None => s,
-    }
+    hale_model::bus_topic_tail(s)
 }
 
 

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -1367,7 +1367,7 @@ pub(crate) fn topic_ref_matches(declared: &str, resolved: &str) -> bool {
 /// Known limitation: two topics with the same trailing name from
 /// different seeds are indistinguishable here. Disambiguating them
 /// needs the resolver's alias table, which this layer does not have.
-fn topic_tail(s: &str) -> &str {
+pub(crate) fn topic_tail(s: &str) -> &str {
     let s = s.rsplit("::").next().unwrap_or(s);
     match s.strip_prefix("__lib_") {
         Some(rest) => rest.rsplit('_').next().unwrap_or(rest),

--- a/crates/hale-types/src/effects.rs
+++ b/crates/hale-types/src/effects.rs
@@ -1351,26 +1351,6 @@ pub(crate) fn topic_ref_matches(declared: &str, resolved: &str) -> bool {
     hale_model::bus_ref_matches(declared, resolved)
 }
 
-/// The bare topic name, whichever spelling reached us.
-///
-/// Subjects arrive in three shapes depending on the phase that
-/// produced them, which is the trap this exists to absorb:
-///   - `Recalled`                        bus-graph subject key
-///   - `relay::Recalled`                 what the author wrote
-///   - `__lib_lib_relay_main_Recalled`   merged publish site
-///
-/// The merged form embeds the LIBRARY PATH, not the import alias, so
-/// the qualifier can never be matched against it — `relay` and
-/// `lib_relay_main` are different strings and only the resolver knows
-/// they correspond. Comparing trailing names is what works for every
-/// pair.
-///
-/// Known limitation: two topics with the same trailing name from
-/// different seeds are indistinguishable here. Disambiguating them
-/// needs the resolver's alias table, which this layer does not have.
-pub(crate) fn topic_tail(s: &str) -> &str {
-    hale_model::bus_topic_tail(s)
-}
 
 
 /// `@effects(publish: {A, B})` — the allowed publish set. A publish

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -28,6 +28,7 @@ pub mod callgraph;
 pub mod effects;
 pub mod frontier;
 pub mod check;
+pub mod claim_lowering;
 pub mod claims;
 pub mod model;
 pub mod model_builder;

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -1888,23 +1888,30 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         let defs = crate::effects::defs_of(&programs);
         let declared: BTreeSet<u16> =
             crate::effects::declared_of(&programs);
+        // Returns true iff the expansion re-entered a class on the
+        // current path — a CYCLE, which resolves to no effect and
+        // must stay distinguishable from an atomic class (review
+        // round 16; the checker rejects it at the declaration).
         fn expand(
             i: u16,
             names: &[String],
             defs: &[Option<Vec<hale_syntax::ast::EffectClass>>],
             out: &mut BTreeSet<String>,
             stack: &mut Vec<u16>,
-        ) {
+        ) -> bool {
             if stack.contains(&i) {
-                return;
+                return true;
             }
             stack.push(i);
+            let mut cyclic = false;
             match defs.get(i as usize).and_then(|d| d.as_ref()) {
                 Some(members) => {
                     for m in members {
                         match m {
                             hale_syntax::ast::EffectClass::User(j) => {
-                                expand(*j, names, defs, out, stack)
+                                cyclic |= expand(
+                                    *j, names, defs, out, stack,
+                                );
                             }
                             b => {
                                 out.insert(b.as_str().to_string());
@@ -1919,24 +1926,30 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 }
             }
             stack.pop();
+            cyclic
         }
         let mut rows: Vec<hale_model::EffectClassDecl> = Vec::new();
         for (i, n) in names.iter().enumerate() {
             let composed =
                 defs.get(i).map(|d| d.is_some()).unwrap_or(false);
-            let composition: Vec<String> = if composed {
+            let definition = if composed {
                 let mut atoms = BTreeSet::new();
-                expand(
+                let cyclic = expand(
                     i as u16,
                     &names,
                     &defs,
                     &mut atoms,
                     &mut Vec::new(),
                 );
-                atoms.remove(n.as_str());
-                atoms.into_iter().collect()
+                if cyclic {
+                    hale_model::EffectClassDefinition::InvalidCycle
+                } else {
+                    hale_model::EffectClassDefinition::Composed {
+                        atoms: atoms.into_iter().collect(),
+                    }
+                }
             } else {
-                Vec::new()
+                hale_model::EffectClassDefinition::Atomic
             };
             let pid = intern_synth(
                 &mut records,
@@ -1945,7 +1958,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             rows.push(hale_model::EffectClassDecl {
                 name: n.clone(),
                 declared: declared.contains(&(i as u16)),
-                composition,
+                definition,
                 provenance: pid,
             });
         }

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -1878,6 +1878,80 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
 
     // ---- assemble, in canonical order ----
     let mut e = Entities::default();
+    // Effect classes (GH #476 Change 4): the USER class vocabulary,
+    // with declaration status and NORMALIZED atomic composition —
+    // the evaluators' declared_of / defs_of facts, made model rows
+    // so a ClaimIr consumer can tell a declared class from an
+    // interned typo and expand `effect io = {…}` without the AST.
+    {
+        let names = crate::effects::effect_names_of(&programs);
+        let defs = crate::effects::defs_of(&programs);
+        let declared: BTreeSet<u16> =
+            crate::effects::declared_of(&programs);
+        fn expand(
+            i: u16,
+            names: &[String],
+            defs: &[Option<Vec<hale_syntax::ast::EffectClass>>],
+            out: &mut BTreeSet<String>,
+            stack: &mut Vec<u16>,
+        ) {
+            if stack.contains(&i) {
+                return;
+            }
+            stack.push(i);
+            match defs.get(i as usize).and_then(|d| d.as_ref()) {
+                Some(members) => {
+                    for m in members {
+                        match m {
+                            hale_syntax::ast::EffectClass::User(j) => {
+                                expand(*j, names, defs, out, stack)
+                            }
+                            b => {
+                                out.insert(b.as_str().to_string());
+                            }
+                        }
+                    }
+                }
+                None => {
+                    if let Some(n) = names.get(i as usize) {
+                        out.insert(n.clone());
+                    }
+                }
+            }
+            stack.pop();
+        }
+        let mut rows: Vec<hale_model::EffectClassDecl> = Vec::new();
+        for (i, n) in names.iter().enumerate() {
+            let composed =
+                defs.get(i).map(|d| d.is_some()).unwrap_or(false);
+            let composition: Vec<String> = if composed {
+                let mut atoms = BTreeSet::new();
+                expand(
+                    i as u16,
+                    &names,
+                    &defs,
+                    &mut atoms,
+                    &mut Vec::new(),
+                );
+                atoms.remove(n.as_str());
+                atoms.into_iter().collect()
+            } else {
+                Vec::new()
+            };
+            let pid = intern_synth(
+                &mut records,
+                "effect class declaration",
+            );
+            rows.push(hale_model::EffectClassDecl {
+                name: n.clone(),
+                declared: declared.contains(&(i as u16)),
+                composition,
+                provenance: pid,
+            });
+        }
+        rows.sort_by(|a, b| a.name.cmp(&b.name));
+        e.effect_classes = rows;
+    }
     for (n, (sealed, sp)) in &locus_rows {
         let pid = intern_span(&mut records, *sp);
         e.loci.push(LocusDecl {

--- a/crates/hale-types/tests/claim_lowering.rs
+++ b/crates/hale-types/tests/claim_lowering.rs
@@ -211,10 +211,7 @@ fn main() { App { }; }
         unreachable!()
     };
     assert!(locus.0.is_some());
-    let hale_model::BusSelector::Match { subjects, .. } = &entries[0]
-    else {
-        panic!("unqualified depends entry is a selector")
-    };
+    let hale_model::BusSelector { subjects, .. } = &entries[0];
     assert!(!subjects.is_empty(), "subject `evt` resolves");
     let pe = by("Worker", &|l| {
         matches!(l, ClaimIr::PhaseEffects { .. })
@@ -462,11 +459,7 @@ fn main() { App { }; }
     else {
         unreachable!()
     };
-    let hale_model::BusSelector::Match { name, topics, .. } =
-        &entries[0]
-    else {
-        panic!("unqualified spelling is a candidate-set selector")
-    };
+    let hale_model::BusSelector { name, topics, .. } = &entries[0];
     assert_eq!(name, "Orders");
     assert_eq!(topics.len(), 1, "the local topic is the candidate");
     assert_eq!(m.entities.topics[topics[0].index()].name, "Orders");
@@ -640,11 +633,7 @@ fn main() { App { }; }
     else {
         unreachable!()
     };
-    let hale_model::BusSelector::Match { name, topics, .. } =
-        &entries[0]
-    else {
-        panic!("unqualified library spelling is a candidate set")
-    };
+    let hale_model::BusSelector { name, topics, .. } = &entries[0];
     assert_eq!(name, "Recalled");
     assert_eq!(topics.len(), 1);
     assert_eq!(
@@ -680,12 +669,9 @@ fn main() { App { }; }
     else {
         unreachable!()
     };
-    let hale_model::BusSelector::Match {
+    let hale_model::BusSelector {
         subjects, topics, ..
-    } = &entries[0]
-    else {
-        panic!("literal entry is a selector")
-    };
+    } = &entries[0];
     assert!(topics.is_empty());
     assert_eq!(subjects.len(), 1, "the literal wire subject resolves");
     assert_eq!(
@@ -749,15 +735,12 @@ fn main() { App { }; }
     else {
         unreachable!()
     };
-    let hale_model::BusSelector::Match {
+    let hale_model::BusSelector {
         name,
         topics,
         subjects,
         ..
-    } = &entries[0]
-    else {
-        panic!("unqualified depends entry is a selector")
-    };
+    } = &entries[0];
     assert_eq!(name, "Recalled");
     assert!(
         !topics.is_empty() || !subjects.is_empty(),
@@ -769,5 +752,127 @@ fn main() { App { }; }
             .any(|t| model.entities.topics[t.index()].name
                 == "__lib_r_main_Recalled"),
         "the merged topic is a candidate"
+    );
+}
+
+/// P1 (round 18): a LITERAL wire subject containing `::`
+/// (`"audit::log"`) cannot be told from an alias path
+/// syntactically — and the evaluator never tells them apart. Both
+/// surfaces resolve it as a subject candidate through
+/// `topic_ref_matches`, never as an unresolved "qualified topic".
+#[test]
+fn double_colon_literal_subject_resolves_on_both_surfaces() {
+    let src = r#"
+type Event { n: Int = 0; }
+@effects(depends: { "audit::log" })
+locus Sink {
+    bus { subscribe "audit::log" as on_e of type Event; }
+    fn on_e(v: Event) { }
+}
+main locus App {
+    params { s: Sink = Sink { }; }
+    bus { publish "audit::log" of type Event; }
+    @effects(publish: { "audit::log" })
+    fn emit(v: Int) { "audit::log" <- Event { }; }
+    run() { self.emit(1); }
+}
+fn main() { App { }; }
+"#;
+    let (t, m) = lower(src);
+    let ClaimIr::EffectPublishSet { entries, .. } = &t
+        .rows
+        .iter()
+        .find(|r| matches!(r.law, ClaimIr::EffectPublishSet { .. }))
+        .expect("publish-set row")
+        .law
+    else {
+        unreachable!()
+    };
+    let sel = &entries[0];
+    assert_eq!(
+        sel.subjects.len(),
+        1,
+        "the ::-literal resolves as a SUBJECT candidate: {:?}",
+        sel
+    );
+    assert_eq!(
+        m.entities.subjects[sel.subjects[0].index()].pattern,
+        "audit::log"
+    );
+    let ClaimIr::DependsSet { entries, .. } = &t
+        .rows
+        .iter()
+        .find(|r| matches!(r.law, ClaimIr::DependsSet { .. }))
+        .expect("depends row")
+        .law
+    else {
+        unreachable!()
+    };
+    assert!(
+        !entries[0].subjects.is_empty(),
+        "same on depends:: {:?}",
+        entries[0]
+    );
+}
+
+/// P1 (round 18): a QUALIFIED path tail-matches every same-tailed
+/// import — `topic_ref_matches` compares trailing names after exact
+/// equality, so `a::Recalled` covers both `__lib_a_x_Recalled` and
+/// `__lib_b_y_Recalled` (the evaluator's current behavior, pinned
+/// as-is; making paths exact would be an evaluator change).
+#[test]
+fn qualified_path_tail_matches_same_tailed_imports() {
+    let lib_a = r#"
+type __lib_a_x_Item { n: Int = 0; }
+topic __lib_a_x_Recalled { payload: __lib_a_x_Item; }
+"#;
+    let lib_b = r#"
+type __lib_b_y_Item { n: Int = 0; }
+topic __lib_b_y_Recalled { payload: __lib_b_y_Item; }
+"#;
+    let main_src = r#"
+@effects(publish: { "a::Recalled" })
+fn emit(v: Int) { __lib_a_x_Recalled <- __lib_a_x_Item { }; }
+main locus App {
+    bus { publish __lib_a_x_Recalled; }
+    run() { emit(1); }
+}
+fn main() { App { }; }
+"#;
+    let main_p = hale_syntax::parse_source(main_src).expect("parse");
+    let a_p = hale_syntax::parse_source(lib_a).expect("parse a");
+    let b_p = hale_syntax::parse_source(lib_b).expect("parse b");
+    let mut programs = BTreeMap::new();
+    programs.insert("app/main.hl".to_string(), &main_p);
+    programs.insert("lib/a.hl".to_string(), &a_p);
+    programs.insert("lib/b.hl".to_string(), &b_p);
+    let mut bundle = Bundle::new(programs);
+    bundle.import_renames = vec![
+        (
+            vec!["a".to_string(), "Recalled".to_string()],
+            "__lib_a_x_Recalled".to_string(),
+        ),
+        (
+            vec!["b".to_string(), "Recalled".to_string()],
+            "__lib_b_y_Recalled".to_string(),
+        ),
+    ];
+    let model = derive_application_model(&bundle);
+    let t = lower_claims(&bundle, &model);
+    t.validate(&model).expect("lawful");
+    let ClaimIr::EffectPublishSet { entries, .. } = &t
+        .rows
+        .iter()
+        .find(|r| matches!(r.law, ClaimIr::EffectPublishSet { .. }))
+        .expect("row")
+        .law
+    else {
+        unreachable!()
+    };
+    assert_eq!(
+        entries[0].topics.len(),
+        2,
+        "both same-tailed imports are candidates: {:?}",
+        entries[0]
     );
 }

--- a/crates/hale-types/tests/claim_lowering.rs
+++ b/crates/hale-types/tests/claim_lowering.rs
@@ -207,11 +207,15 @@ fn main() { App { }; }
     let dep = by("Worker", &|l| {
         matches!(l, ClaimIr::DependsSet { .. })
     });
-    let ClaimIr::DependsSet { locus, subjects } = &dep.law else {
+    let ClaimIr::DependsSet { locus, entries } = &dep.law else {
         unreachable!()
     };
     assert!(locus.0.is_some());
-    assert!(subjects[0].subject.is_some(), "subject `evt` resolves");
+    let hale_model::BusSelector::Match { subjects, .. } = &entries[0]
+    else {
+        panic!("unqualified depends entry is a selector")
+    };
+    assert!(!subjects.is_empty(), "subject `evt` resolves");
     let pe = by("Worker", &|l| {
         matches!(l, ClaimIr::PhaseEffects { .. })
     });
@@ -449,7 +453,7 @@ main locus App {
 fn main() { App { }; }
 "#;
     let (t, m) = lower(src);
-    let ClaimIr::EffectPublishSet { topics, .. } = &t
+    let ClaimIr::EffectPublishSet { entries, .. } = &t
         .rows
         .iter()
         .find(|r| matches!(r.law, ClaimIr::EffectPublishSet { .. }))
@@ -458,18 +462,14 @@ fn main() { App { }; }
     else {
         unreachable!()
     };
-    let hale_model::TopicSelector::Unqualified {
-        name, candidates, ..
-    } = &topics[0]
+    let hale_model::BusSelector::Match { name, topics, .. } =
+        &entries[0]
     else {
         panic!("unqualified spelling is a candidate-set selector")
     };
     assert_eq!(name, "Orders");
-    assert_eq!(candidates.len(), 1, "the local topic is the candidate");
-    assert_eq!(
-        m.entities.topics[candidates[0].index()].name,
-        "Orders"
-    );
+    assert_eq!(topics.len(), 1, "the local topic is the candidate");
+    assert_eq!(m.entities.topics[topics[0].index()].name, "Orders");
 }
 
 /// P1 (round 15): a resolved reference takes its name/display from
@@ -631,7 +631,7 @@ fn main() { App { }; }
     let model = derive_application_model(&bundle);
     let t = lower_claims(&bundle, &model);
     t.validate(&model).expect("lawful");
-    let ClaimIr::EffectPublishSet { topics, .. } = &t
+    let ClaimIr::EffectPublishSet { entries, .. } = &t
         .rows
         .iter()
         .find(|r| matches!(r.law, ClaimIr::EffectPublishSet { .. }))
@@ -640,17 +640,134 @@ fn main() { App { }; }
     else {
         unreachable!()
     };
-    let hale_model::TopicSelector::Unqualified {
-        name, candidates, ..
-    } = &topics[0]
+    let hale_model::BusSelector::Match { name, topics, .. } =
+        &entries[0]
     else {
         panic!("unqualified library spelling is a candidate set")
     };
     assert_eq!(name, "Recalled");
-    assert_eq!(candidates.len(), 1);
+    assert_eq!(topics.len(), 1);
     assert_eq!(
-        model.entities.topics[candidates[0].index()].name,
+        model.entities.topics[topics[0].index()].name,
         "__lib_r_main_Recalled",
         "trailing-name match reaches the merged topic"
+    );
+}
+
+/// P1 (round 17): a LITERAL wire subject in `@effects(publish:)` is
+/// a valid certificate the evaluator accepts — the selector must
+/// resolve it (as a subject candidate), never document it as
+/// unresolved residue.
+#[test]
+fn literal_publish_subject_resolves_as_subject_candidate() {
+    let src = r#"
+type Event { n: Int = 0; }
+main locus App {
+    bus { publish "audit.log" of type Event; }
+    @effects(publish: { "audit.log" })
+    fn emit(v: Int) { "audit.log" <- Event { }; }
+    run() { self.emit(1); }
+}
+fn main() { App { }; }
+"#;
+    let (t, m) = lower(src);
+    let ClaimIr::EffectPublishSet { entries, .. } = &t
+        .rows
+        .iter()
+        .find(|r| matches!(r.law, ClaimIr::EffectPublishSet { .. }))
+        .expect("publish-set row")
+        .law
+    else {
+        unreachable!()
+    };
+    let hale_model::BusSelector::Match {
+        subjects, topics, ..
+    } = &entries[0]
+    else {
+        panic!("literal entry is a selector")
+    };
+    assert!(topics.is_empty());
+    assert_eq!(subjects.len(), 1, "the literal wire subject resolves");
+    assert_eq!(
+        m.entities.subjects[subjects[0].index()].pattern,
+        "audit.log"
+    );
+}
+
+/// P1 (round 17): an UNQUALIFIED `@effects(depends:)` entry authored
+/// in an imported seed tail-matches the merged wire subject — the
+/// evaluator's `topic_ref_matches` rule, now shared by both bus-set
+/// surfaces.
+#[test]
+fn unqualified_imported_depends_entry_resolves() {
+    let lib = r#"
+type __lib_r_main_Alert { n: Int = 0; }
+topic __lib_r_main_Recalled { payload: __lib_r_main_Alert; }
+@effects(depends: { "Recalled" })
+locus __lib_r_main_Sink {
+    params { n: Int = 0; }
+    bus { subscribe __lib_r_main_Recalled as on_r; }
+    fn on_r(a: __lib_r_main_Alert) { }
+}
+"#;
+    let main_src = r#"
+main locus App {
+    params { s: __lib_r_main_Sink = __lib_r_main_Sink { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let main_p = hale_syntax::parse_source(main_src).expect("parse");
+    let lib_p = hale_syntax::parse_source(lib).expect("parse lib");
+    let mut programs = BTreeMap::new();
+    programs.insert("app/main.hl".to_string(), &main_p);
+    programs.insert("lib/relay.hl".to_string(), &lib_p);
+    let mut bundle = Bundle::new(programs);
+    bundle.import_renames = vec![
+        (
+            vec!["relay".to_string(), "Alert".to_string()],
+            "__lib_r_main_Alert".to_string(),
+        ),
+        (
+            vec!["relay".to_string(), "Recalled".to_string()],
+            "__lib_r_main_Recalled".to_string(),
+        ),
+        (
+            vec!["relay".to_string(), "Sink".to_string()],
+            "__lib_r_main_Sink".to_string(),
+        ),
+    ];
+    let model = derive_application_model(&bundle);
+    let t = lower_claims(&bundle, &model);
+    t.validate(&model).expect("lawful");
+    let ClaimIr::DependsSet { entries, .. } = &t
+        .rows
+        .iter()
+        .find(|r| matches!(r.law, ClaimIr::DependsSet { .. }))
+        .expect("the imported seed's depends lowers")
+        .law
+    else {
+        unreachable!()
+    };
+    let hale_model::BusSelector::Match {
+        name,
+        topics,
+        subjects,
+        ..
+    } = &entries[0]
+    else {
+        panic!("unqualified depends entry is a selector")
+    };
+    assert_eq!(name, "Recalled");
+    assert!(
+        !topics.is_empty() || !subjects.is_empty(),
+        "trailing-name match reaches the merged topic/subject"
+    );
+    assert!(
+        topics
+            .iter()
+            .any(|t| model.entities.topics[t.index()].name
+                == "__lib_r_main_Recalled"),
+        "the merged topic is a candidate"
     );
 }

--- a/crates/hale-types/tests/claim_lowering.rs
+++ b/crates/hale-types/tests/claim_lowering.rs
@@ -211,7 +211,7 @@ fn main() { App { }; }
         unreachable!()
     };
     assert!(locus.0.is_some());
-    assert!(subjects[0].0.is_some(), "subject `evt` resolves");
+    assert!(subjects[0].subject.is_some(), "subject `evt` resolves");
     let pe = by("Worker", &|l| {
         matches!(l, ClaimIr::PhaseEffects { .. })
     });
@@ -322,5 +322,202 @@ fn lowering_matches_evaluator_outcomes_over_the_corpus() {
         "{} corpus programs diverge:\n{}",
         bad.len(),
         bad.join("\n")
+    );
+}
+
+/// P1 (round 15): law-SELECTION invalidity is preserved as
+/// structured issues — `adopt Missing` produced an evaluator
+/// diagnostic but lowered to an empty table, so an IR-only
+/// evaluator would have observed "no law" with nothing to reject.
+#[test]
+fn invalid_law_selection_becomes_issues() {
+    let src = r#"
+main locus App {
+    claims { adopt Missing; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let (t, _m) = lower(src);
+    assert!(t.rows.is_empty());
+    assert!(
+        t.issues
+            .iter()
+            .any(|i| i.message.contains("Missing")),
+        "the unknown constitution is a structured issue: {:?}",
+        t.issues
+    );
+}
+
+/// P1 (round 15): the effect-class vocabulary is typed. A declared
+/// class resolves to a table row with `declared: true`; a bare
+/// reference (interned typo) resolves to a row with
+/// `declared: false`; a composed class carries its normalized
+/// atomic expansion.
+#[test]
+fn effect_class_vocabulary_is_typed() {
+    let declared_src = r#"
+effect money;
+effect io = { syscall, block };
+@effects(none: { money, io })
+fn f(v: Int) -> Int { return v; }
+main locus App { run() { println(f(1)); } }
+fn main() { App { }; }
+"#;
+    let (t, m) = lower(declared_src);
+    let ClaimIr::EffectForbid { classes, .. } = &t
+        .rows
+        .iter()
+        .find(|r| matches!(r.law, ClaimIr::EffectForbid { .. }))
+        .expect("forbid row")
+        .law
+    else {
+        unreachable!()
+    };
+    let money = &classes[0];
+    assert!(!money.builtin);
+    let row = &m.entities.effect_classes
+        [money.class.expect("declared class resolves").index()];
+    assert!(row.declared && row.composition.is_empty());
+    let io = &classes[1];
+    let io_row = &m.entities.effect_classes
+        [io.class.expect("composed class resolves").index()];
+    assert!(io_row.declared);
+    assert_eq!(io_row.composition, ["block", "syscall"]);
+
+    let typo_src = r#"
+@effects(none: { money })
+fn f(v: Int) -> Int { return v; }
+main locus App { run() { println(f(1)); } }
+fn main() { App { }; }
+"#;
+    let (t2, m2) = lower(typo_src);
+    let ClaimIr::EffectForbid { classes, .. } = &t2
+        .rows
+        .iter()
+        .find(|r| matches!(r.law, ClaimIr::EffectForbid { .. }))
+        .expect("forbid row")
+        .law
+    else {
+        unreachable!()
+    };
+    let interned = &m2.entities.effect_classes
+        [classes[0].class.expect("interned ref resolves").index()];
+    assert!(
+        !interned.declared,
+        "a bare reference is distinguishable from a declaration"
+    );
+    // Built-ins never resolve into the user table.
+    let (t3, _m3) = lower(
+        r#"
+@effects(none: { syscall })
+fn f(v: Int) -> Int { return v; }
+main locus App { run() { println(f(1)); } }
+fn main() { App { }; }
+"#,
+    );
+    let ClaimIr::EffectForbid { classes, .. } = &t3.rows[0].law
+    else {
+        unreachable!()
+    };
+    assert!(classes[0].builtin && classes[0].class.is_none());
+}
+
+/// P1 (round 15): `@effects(publish: {Orders})` is TOPIC-space —
+/// the entry resolves to the declared topic even though its wire
+/// subject is different, never to a subject-pattern lookup miss.
+#[test]
+fn publish_set_is_topic_space() {
+    let src = r#"
+type Order { n: Int = 0; }
+topic Orders { payload: Order; subject: "wire.orders"; }
+main locus App {
+    bus { publish Orders; }
+    @effects(publish: { Orders })
+    fn send(v: Int) { Orders <- Order { }; }
+    run() { self.send(1); }
+}
+fn main() { App { }; }
+"#;
+    let (t, m) = lower(src);
+    let ClaimIr::EffectPublishSet { topics, .. } = &t
+        .rows
+        .iter()
+        .find(|r| matches!(r.law, ClaimIr::EffectPublishSet { .. }))
+        .expect("publish-set row")
+        .law
+    else {
+        unreachable!()
+    };
+    let tref = &topics[0];
+    let tid = tref.topic.expect("`Orders` resolves as a TOPIC");
+    assert_eq!(m.entities.topics[tid.index()].name, "Orders");
+}
+
+/// P1 (round 15): a resolved reference takes its name/display from
+/// the model ENTITY — an imported locus method's display demangles
+/// the locus half (`kv::Store::bump`), which a whole-symbol lookup
+/// missed. Per-reference provenance is distinct from the row's.
+#[test]
+fn resolved_refs_are_entity_sourced() {
+    let lib = r#"
+locus __lib_x_kv_Store {
+    params { n: Int = 0; }
+    @no_panic
+    fn bump(v: Int) -> Int { return v; }
+}
+"#;
+    let main_src = r#"
+main locus App {
+    params { s: __lib_x_kv_Store = __lib_x_kv_Store { }; }
+    run() { println(self.s.bump(1)); }
+}
+fn main() { App { }; }
+"#;
+    let main_p = hale_syntax::parse_source(main_src).expect("parse");
+    let lib_p = hale_syntax::parse_source(lib).expect("parse lib");
+    let mut programs = BTreeMap::new();
+    programs.insert("app/main.hl".to_string(), &main_p);
+    programs.insert("lib/kv.hl".to_string(), &lib_p);
+    let mut bundle = Bundle::new(programs);
+    bundle.import_renames = vec![(
+        vec!["kv".to_string(), "Store".to_string()],
+        "__lib_x_kv_Store".to_string(),
+    )];
+    let model = derive_application_model(&bundle);
+    let t = lower_claims(&bundle, &model);
+    t.validate(&model).expect("lawful");
+    let row = t
+        .rows
+        .iter()
+        .find(|r| matches!(r.law, ClaimIr::NoPanic { .. }))
+        .expect("annotation on the imported method lowers");
+    let ClaimIr::NoPanic { at } = &row.law else { unreachable!() };
+    assert!(at.0.is_some());
+    assert_eq!(at.1.raw, "__lib_x_kv_Store::bump");
+    assert_eq!(
+        at.1.display, "kv::Store::bump",
+        "display demangles the locus half (entity-sourced)"
+    );
+}
+
+/// P1 (round 15): source-bearing references carry their OWN
+/// provenance, anchored at the reference — not the clause.
+#[test]
+fn references_carry_their_own_provenance() {
+    let (t, _m) = lower(ALL_FORMS);
+    let row = &t.rows[0];
+    let ClaimIr::ForbidReaches { src, avoiding, .. } = &row.law
+    else {
+        unreachable!()
+    };
+    let SetIr::Group(g) = src else { unreachable!() };
+    assert_ne!(
+        g.provenance, row.provenance,
+        "the group ref anchors at its own span"
+    );
+    assert_ne!(
+        avoiding.as_ref().unwrap().provenance,
+        row.provenance
     );
 }

--- a/crates/hale-types/tests/claim_lowering.rs
+++ b/crates/hale-types/tests/claim_lowering.rs
@@ -876,3 +876,42 @@ fn main() { App { }; }
         entries[0]
     );
 }
+
+/// P1 (round 20): the canonical built-in vocabulary in hale-model
+/// must mirror the compiler's `EffectClass` exactly — this is the
+/// drift seam between the dependency-free schema and the AST, and
+/// this test IS the pin.
+#[test]
+fn builtin_vocabulary_mirrors_the_compiler() {
+    use hale_syntax::ast::EffectClass;
+    for name in hale_model::claim_ir::BUILTIN_EFFECT_CLASSES {
+        let c = EffectClass::from_ident(name)
+            .unwrap_or_else(|| panic!("`{}` is a compiler builtin", name));
+        assert!(
+            !matches!(c, EffectClass::User(_)),
+            "`{}` must not be a user class",
+            name
+        );
+        assert_eq!(c.as_str(), name);
+    }
+    // …and every compiler builtin is in the model's list.
+    for c in [
+        EffectClass::Syscall,
+        EffectClass::Block,
+        EffectClass::Time,
+        EffectClass::Entropy,
+        EffectClass::Env,
+        EffectClass::Ffi,
+        EffectClass::Publish,
+        EffectClass::Spawn,
+        EffectClass::Recursion,
+        EffectClass::Alloc,
+        EffectClass::SecretUse,
+    ] {
+        assert!(
+            hale_model::is_builtin_effect_class(c.as_str()),
+            "compiler builtin `{}` missing from the model vocabulary",
+            c.as_str()
+        );
+    }
+}

--- a/crates/hale-types/tests/claim_lowering.rs
+++ b/crates/hale-types/tests/claim_lowering.rs
@@ -1,0 +1,326 @@
+//! GH #476 Change 4 — every law surface lowers to one `ClaimIr`
+//! variant, through the evaluator's own clause enumeration.
+//!
+//! Two proof obligations:
+//!  1. **Exactness** per form: each surface lowers to its variant
+//!     with resolved model ids, raw/display spellings, and origin.
+//!  2. **Parity with the evaluator**: the claims-family rows agree
+//!     with `claims_report_with_identities` outcomes on count, name,
+//!     order, and constitution source — the lowering walks EXACTLY
+//!     the clauses the evaluator walks — over fixtures AND the
+//!     whole corpus (where the lowering must also be total and
+//!     lawful).
+
+use std::collections::BTreeMap;
+
+use hale_model::{ClaimIr, ClaimOrigin, CountCmpIr, QuantDimIr, SetIr};
+use hale_types::claim_lowering::lower_claims;
+use hale_types::model_builder::derive_application_model;
+use hale_types::Bundle;
+
+fn lower(src: &str) -> (hale_model::ClaimIrTable, hale_model::ApplicationModel)
+{
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    table.validate(&model).expect("lowered table is lawful");
+    (table, model)
+}
+
+const ALL_FORMS: &str = r#"
+type Reading { sensor: Int = 0; }
+topic Readings { payload: Reading; subject: "sense.reading"; }
+effect money;
+@effects(is: { money })
+fn spend(v: Int) -> Int { return v; }
+locus Gate {
+    params { n: Int = 0; }
+    fn relay(v: Int) -> Int { return spend(v); }
+}
+locus Sink {
+    bus { subscribe Readings as on_r; }
+    fn on_r(r: Reading) { }
+}
+group wings = { Gate, Sink };
+group gates = { Gate };
+main locus App {
+    params { g: Gate = Gate { }; s: Sink = Sink { }; }
+    claims {
+        iso: forbid reaches(gates, wings) via { calls } avoiding gates;
+        edge: only edges gates -> wings { publish Readings; };
+        spendcap: bound money <= 2 on paths from gates;
+        haveit: require subscribes(some wings, topic Readings);
+        vault: require sealed(all gates);
+        tagged: require attributed(all syscall);
+        onewriter: count publishers(topic Readings) == 0;
+    }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+
+/// Every claims-block form lowers to its variant with resolved ids.
+#[test]
+fn every_claim_form_lowers_exactly() {
+    let (t, m) = lower(ALL_FORMS);
+    let claims: Vec<&hale_model::ClaimRow> = t
+        .rows
+        .iter()
+        .filter(|r| r.origin == ClaimOrigin::Main)
+        .collect();
+    assert_eq!(claims.len(), 7, "one row per authored claim");
+    // Ordinals are authored order.
+    assert_eq!(claims[0].name, "iso");
+    let ClaimIr::ForbidReaches {
+        src,
+        via_calls,
+        via_bus,
+        avoiding,
+        ..
+    } = &claims[0].law
+    else {
+        panic!("iso lowers to ForbidReaches: {:?}", claims[0].law)
+    };
+    assert!(matches!(src, SetIr::Group(g) if g.group.is_some()));
+    assert!(*via_calls && !*via_bus);
+    assert!(avoiding.as_ref().unwrap().group.is_some());
+    let ClaimIr::OnlyEdges { grants, .. } = &claims[1].law else {
+        panic!("edge lowers to OnlyEdges")
+    };
+    assert_eq!(grants.len(), 1);
+    assert!(grants[0].publish && grants[0].topic.topic.is_some());
+    let ClaimIr::Bound { class, limit, from } = &claims[2].law else {
+        panic!("spendcap lowers to Bound")
+    };
+    assert_eq!(class.name, "money");
+    assert_eq!(*limit, 2);
+    assert!(from.group.is_some());
+    let ClaimIr::RequireEndpoint {
+        publishers, topic, ..
+    } = &claims[3].law
+    else {
+        panic!("haveit lowers to RequireEndpoint")
+    };
+    assert!(!*publishers && topic.topic.is_some());
+    assert!(matches!(&claims[4].law, ClaimIr::RequireSealed { group } if group.group.is_some()));
+    assert!(matches!(&claims[5].law, ClaimIr::RequireAttributed { class } if class.name == "syscall"));
+    let ClaimIr::Count { cmp, n, topic, .. } = &claims[6].law else {
+        panic!("onewriter lowers to Count")
+    };
+    assert!(matches!(cmp, CountCmpIr::Eq) && *n == 0);
+    assert!(topic.topic.is_some());
+    // `@effects(is:)` did NOT lower — it is a model label, not a law.
+    assert!(
+        !t.rows.iter().any(|r| r.name == "spend"),
+        "carries is classification, not obligation"
+    );
+    let _ = m;
+}
+
+/// Annotation surfaces lower with resolved fn/locus ids; a
+/// constitution clause carries its origin.
+#[test]
+fn annotations_and_origins_lower() {
+    let src = r#"
+type T { n: Int = 0; }
+topic Evt { payload: T; subject: "evt"; }
+effect money;
+constitution Core {
+    quiet: count subscribers(topic Evt) == 0;
+}
+@effects(none: { syscall, block })
+fn pure_math(v: Int) -> Int { return v * 2; }
+@budget(stack_bytes = 256) fn tight(v: Int) -> Int { return v; }
+@budget(alloc_per_call = 0) fn lean(v: Int) -> Int { return v; }
+@no_panic
+fn safe(v: Int) -> Int { return v; }
+@effects(depends: { "evt" })
+@phase_effects(birth: { alloc }, run: {})
+locus Worker {
+    params { n: Int = 0; }
+    bus { subscribe Evt as on_e; }
+    @effects(only: { alloc })
+    fn on_e(t: T) { }
+}
+main locus App {
+    params { w: Worker = Worker { }; }
+    claims { adopt Core; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let (t, _m) = lower(src);
+    let by = |name: &str, pred: &dyn Fn(&ClaimIr) -> bool| {
+        t.rows
+            .iter()
+            .find(|r| r.name == name && pred(&r.law))
+            .unwrap_or_else(|| {
+                panic!(
+                    "no `{}` row: {:?}",
+                    name,
+                    t.rows
+                        .iter()
+                        .map(|r| (&r.name, &r.law))
+                        .collect::<Vec<_>>()
+                )
+            })
+    };
+    // Adopted clause: constitution origin.
+    let quiet =
+        by("quiet", &|l| matches!(l, ClaimIr::Count { .. }));
+    assert_eq!(
+        quiet.origin,
+        ClaimOrigin::Constitution {
+            name: "Core".to_string()
+        }
+    );
+    // @effects(none:) — resolved fn id.
+    let forbid = by("pure_math", &|l| {
+        matches!(l, ClaimIr::EffectForbid { .. })
+    });
+    let ClaimIr::EffectForbid { at, classes } = &forbid.law else {
+        unreachable!()
+    };
+    assert!(at.0.is_some());
+    assert_eq!(
+        classes.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+        ["syscall", "block"]
+    );
+    by("safe", &|l| matches!(l, ClaimIr::NoPanic { .. }));
+    by("lean", &|l| {
+        matches!(l, ClaimIr::AllocBudget { per_call: 0, .. })
+    });
+    by("tight", &|l| {
+        matches!(
+            l,
+            ClaimIr::QuantBudget {
+                dim: QuantDimIr::StackBytes,
+                limit: 256,
+                ..
+            }
+        )
+    });
+    // Locus surfaces — resolved locus ids, method fn resolved.
+    let dep = by("Worker", &|l| {
+        matches!(l, ClaimIr::DependsSet { .. })
+    });
+    let ClaimIr::DependsSet { locus, subjects } = &dep.law else {
+        unreachable!()
+    };
+    assert!(locus.0.is_some());
+    assert!(subjects[0].0.is_some(), "subject `evt` resolves");
+    let pe = by("Worker", &|l| {
+        matches!(l, ClaimIr::PhaseEffects { .. })
+    });
+    let ClaimIr::PhaseEffects { phases, .. } = &pe.law else {
+        unreachable!()
+    };
+    assert_eq!(phases.len(), 2);
+    assert_eq!(phases[0].0, "birth");
+    assert_eq!(phases[0].1[0].name, "alloc");
+    assert!(phases[1].1.is_empty(), "run: {{}} forbids all");
+    let only = by("Worker::on_e", &|l| {
+        matches!(l, ClaimIr::EffectOnly { .. })
+    });
+    let ClaimIr::EffectOnly { at, .. } = &only.law else {
+        unreachable!()
+    };
+    assert!(at.0.is_some(), "locus method resolves");
+    assert!(t.rows.iter().all(|r| !r.name.is_empty()));
+}
+
+/// THE parity property: the claims-family rows match the
+/// evaluator's outcomes on count, name, authored order, and
+/// constitution source — over the whole corpus, where the lowering
+/// must also be total (no panic) and lawful (validate).
+#[test]
+fn lowering_matches_evaluator_outcomes_over_the_corpus() {
+    let mut bad: Vec<String> = Vec::new();
+    let mut with_laws = 0usize;
+    for p in
+        hale_corpus::parseable(|s| hale_syntax::parse_source(s).is_ok())
+    {
+        let Ok(program) = hale_syntax::parse_source(&p.source) else {
+            continue;
+        };
+        let caught = std::panic::catch_unwind(
+            std::panic::AssertUnwindSafe(|| {
+                let mut programs = BTreeMap::new();
+                programs.insert("app.hl".to_string(), &program);
+                let bundle = Bundle::new(programs);
+                let model = derive_application_model(&bundle);
+                let table = lower_claims(&bundle, &model);
+                table
+                    .validate(&model)
+                    .map_err(|e| format!("{:?}", e))?;
+                let programs_v: Vec<&hale_syntax::ast::Program> =
+                    vec![&program];
+                let top =
+                    hale_types::resolve::build_top_scope(&bundle).0;
+                let graph = hale_types::bus_graph::build_bus_graph(
+                    &bundle, &top,
+                );
+                let (_d, outcomes, _a) =
+                    hale_types::claims::claims_report_with_identities(
+                        &programs_v,
+                        &graph,
+                        &[],
+                    );
+                let lowered: Vec<(String, Option<String>)> = table
+                    .rows
+                    .iter()
+                    .filter_map(|r| match &r.origin {
+                        ClaimOrigin::Main => {
+                            Some((r.name.clone(), None))
+                        }
+                        ClaimOrigin::Constitution { name } => Some((
+                            r.name.clone(),
+                            Some(name.clone()),
+                        )),
+                        ClaimOrigin::Library { .. } => {
+                            Some((r.name.clone(), None))
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                let evaluated: Vec<(String, Option<String>)> =
+                    outcomes
+                        .iter()
+                        .map(|o| (o.name.clone(), o.source.clone()))
+                        .collect();
+                if lowered != evaluated {
+                    return Err(format!(
+                        "lowered {:?} != evaluated {:?}",
+                        lowered, evaluated
+                    ));
+                }
+                Ok::<usize, String>(outcomes.len())
+            }),
+        );
+        match caught {
+            Err(_) => bad.push(format!("{}: PANIC", p.origin)),
+            Ok(Err(e)) => {
+                bad.push(format!("{}: {}", p.origin, e))
+            }
+            Ok(Ok(n)) => {
+                if n > 0 {
+                    with_laws += 1;
+                }
+            }
+        }
+    }
+    assert!(
+        with_laws > 10,
+        "the corpus must exercise claims ({} programs had any)",
+        with_laws
+    );
+    assert!(
+        bad.is_empty(),
+        "{} corpus programs diverge:\n{}",
+        bad.len(),
+        bad.join("\n")
+    );
+}

--- a/crates/hale-types/tests/claim_lowering.rs
+++ b/crates/hale-types/tests/claim_lowering.rs
@@ -378,12 +378,21 @@ fn main() { App { }; }
     assert!(!money.builtin);
     let row = &m.entities.effect_classes
         [money.class.expect("declared class resolves").index()];
-    assert!(row.declared && row.composition.is_empty());
+    assert!(row.declared);
+    assert_eq!(
+        row.definition,
+        hale_model::EffectClassDefinition::Atomic
+    );
     let io = &classes[1];
     let io_row = &m.entities.effect_classes
         [io.class.expect("composed class resolves").index()];
     assert!(io_row.declared);
-    assert_eq!(io_row.composition, ["block", "syscall"]);
+    assert_eq!(
+        io_row.definition,
+        hale_model::EffectClassDefinition::Composed {
+            atoms: vec!["block".to_string(), "syscall".to_string()]
+        }
+    );
 
     let typo_src = r#"
 @effects(none: { money })
@@ -449,9 +458,18 @@ fn main() { App { }; }
     else {
         unreachable!()
     };
-    let tref = &topics[0];
-    let tid = tref.topic.expect("`Orders` resolves as a TOPIC");
-    assert_eq!(m.entities.topics[tid.index()].name, "Orders");
+    let hale_model::TopicSelector::Unqualified {
+        name, candidates, ..
+    } = &topics[0]
+    else {
+        panic!("unqualified spelling is a candidate-set selector")
+    };
+    assert_eq!(name, "Orders");
+    assert_eq!(candidates.len(), 1, "the local topic is the candidate");
+    assert_eq!(
+        m.entities.topics[candidates[0].index()].name,
+        "Orders"
+    );
 }
 
 /// P1 (round 15): a resolved reference takes its name/display from
@@ -519,5 +537,120 @@ fn references_carry_their_own_provenance() {
     assert_ne!(
         avoiding.as_ref().unwrap().provenance,
         row.provenance
+    );
+}
+
+/// P1 (round 16): a cyclic effect-class definition stays
+/// distinguishable from an atomic class — the evaluator rejects it
+/// at the declaration because it resolves to no effect and makes
+/// contracts vacuous, and the model preserves that as
+/// `EffectClassDefinition::InvalidCycle`.
+#[test]
+fn cyclic_effect_class_definitions_stay_invalid() {
+    let src = r#"
+effect a = { b };
+effect b = { a };
+@effects(none: { a })
+fn f(v: Int) -> Int { return v; }
+main locus App { run() { println(f(1)); } }
+fn main() { App { }; }
+"#;
+    let (t, m) = lower(src);
+    let ClaimIr::EffectForbid { classes, .. } = &t
+        .rows
+        .iter()
+        .find(|r| matches!(r.law, ClaimIr::EffectForbid { .. }))
+        .expect("forbid row")
+        .law
+    else {
+        unreachable!()
+    };
+    let a_row = &m.entities.effect_classes
+        [classes[0].class.expect("`a` resolves").index()];
+    assert_eq!(
+        a_row.definition,
+        hale_model::EffectClassDefinition::InvalidCycle,
+        "a cycle is NOT an atomic class"
+    );
+    let b_row = m
+        .entities
+        .effect_classes
+        .iter()
+        .find(|c| c.name == "b")
+        .expect("b row");
+    assert_eq!(
+        b_row.definition,
+        hale_model::EffectClassDefinition::InvalidCycle
+    );
+}
+
+/// P1 (round 16): an UNQUALIFIED `@effects(publish:)` reference
+/// authored inside an imported seed resolves by trailing name to
+/// the merged (mangled) topic — the evaluator's documented
+/// cross-seed rule; the library author cannot know the consumer's
+/// alias.
+#[test]
+fn unqualified_imported_publish_ref_gets_candidates() {
+    let lib = r#"
+type __lib_r_main_Alert { n: Int = 0; }
+topic __lib_r_main_Recalled { payload: __lib_r_main_Alert; }
+locus __lib_r_main_Relay {
+    params { n: Int = 0; }
+    bus { publish __lib_r_main_Recalled; }
+    @effects(publish: { Recalled })
+    fn emit(v: Int) { __lib_r_main_Recalled <- __lib_r_main_Alert { }; }
+}
+"#;
+    let main_src = r#"
+main locus App {
+    params { r: __lib_r_main_Relay = __lib_r_main_Relay { }; }
+    run() { self.r.emit(1); }
+}
+fn main() { App { }; }
+"#;
+    let main_p = hale_syntax::parse_source(main_src).expect("parse");
+    let lib_p = hale_syntax::parse_source(lib).expect("parse lib");
+    let mut programs = BTreeMap::new();
+    programs.insert("app/main.hl".to_string(), &main_p);
+    programs.insert("lib/relay.hl".to_string(), &lib_p);
+    let mut bundle = Bundle::new(programs);
+    bundle.import_renames = vec![
+        (
+            vec!["relay".to_string(), "Alert".to_string()],
+            "__lib_r_main_Alert".to_string(),
+        ),
+        (
+            vec!["relay".to_string(), "Recalled".to_string()],
+            "__lib_r_main_Recalled".to_string(),
+        ),
+        (
+            vec!["relay".to_string(), "Relay".to_string()],
+            "__lib_r_main_Relay".to_string(),
+        ),
+    ];
+    let model = derive_application_model(&bundle);
+    let t = lower_claims(&bundle, &model);
+    t.validate(&model).expect("lawful");
+    let ClaimIr::EffectPublishSet { topics, .. } = &t
+        .rows
+        .iter()
+        .find(|r| matches!(r.law, ClaimIr::EffectPublishSet { .. }))
+        .expect("the imported seed's annotation lowers")
+        .law
+    else {
+        unreachable!()
+    };
+    let hale_model::TopicSelector::Unqualified {
+        name, candidates, ..
+    } = &topics[0]
+    else {
+        panic!("unqualified library spelling is a candidate set")
+    };
+    assert_eq!(name, "Recalled");
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(
+        model.entities.topics[candidates[0].index()].name,
+        "__lib_r_main_Recalled",
+        "trailing-name match reaches the merged topic"
     );
 }


### PR DESCRIPTION
Change 4 of the canonical-model epic (#476): **`ClaimIr` lowering only** — one typed variant per law form across every surface, with the old evaluators fully active and authoritative.

## What ships

- **`hale-model::claim_ir`** — the schema. One variant per law form: the eight claims-block forms (`ForbidReaches`, `OnlyEdges`, `Bound`, `RequireEndpoint`, `RequireSealed`, `RequireAttributed`, `Cover`, `Count`), the annotation surfaces (`EffectForbid`/`EffectPublishSet`/`EffectCauses`/`EffectOnly`/`NoPanic` for `@effects`/`@no_panic`, `DependsSet` for `@effects(depends:)`, `PhaseEffects`, `AllocBudget` + `QuantBudget` for both `@budget` families), and the four deployment-plan forms. Reference doctrine matches the model: raw canonical spelling + author display + optional resolved id — `None` is lawful residue (Change 5's `invalid` verdict consumes it), and fleet targets stay name-level until Change 7's `FleetModel`. Rows keep **authored order** via contiguous ordinals (Change 5's diagnostics-parity differential walks outcomes and rows in lockstep); `ClaimIrTable::validate(&ApplicationModel)` enforces ordinal contiguity, in-range ids, named rows, and provenance.
- **`claims::enumerate_clauses`** — the clause-collection phase of `claims_report_inner` (world tier + constitution adoption + library-tier attribution) extracted into one shared function, so the lowering walks **exactly** the clauses the evaluator walks. Same one-authority move as the Change-3 shared contraction walk; the evaluator's behavior is unchanged (full claims/constitutions/library suites green).
- **`claim_lowering::lower_claims(bundle, model)`** — program surfaces: claims through the shared enumeration with origins (`Main` / `Constitution { name }` / `Library { alias }` — origin matches `ClaimOutcome::source`), annotations through a declaration-order AST walk. Total over parseable programs; never drops a law.
- **`fleet::lower_plan_claims`** — plan rows, one `ClaimIr` row per SENTENCE (a multi-bound `CountSpec` stays one conjunctive law; a multi-verb or verbless spec is a structured issue), wired behind the `HALE_MODEL_TRACE` demand surface at the fleet check site.

## What deliberately does NOT lower

`@effects(is: {…})` — carries is a classification **fact**, not an obligation; the model already records it as `labels` rows and no judgment evaluates it. Pinned in the exact-form test.

## Verification

- **Evaluator parity over the corpus**: for every corpus program, the claims-family rows equal `claims_report_with_identities` outcomes on count, name, authored order, and constitution source — and the lowering is total (no panics) and lawful (`validate`) everywhere, with a vacuity guard (>10 corpus programs must actually carry claims).
- Exact-form fixtures for every claims-block and annotation variant with resolved-id assertions; fleet unit test; `hale-model` canaries (ordinal contiguity, dangling id, unresolved-is-lawful).
- 1241/1241 across hale-types + hale-model + hale-cli; fmt clean; no user-visible behavior change.

Next per the epic: Changes 5a–5e migrate the judgment families onto `ClaimIr` × `ApplicationModel` — the epic's largest tranche, now with a stable typed target on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
