### PR TITLE
feat(judgment): the boundary-grant family on the canonical model — Change 5b (GH #476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ behavior.
 
 ## Unreleased
 
+### The boundary-grant judgment - family 5b (GH #476 Change 5b)
+
+`judgment::judge_only_edges` - the `only edges` family on the
+canonical model, direct-edge law with no walk: call edges into the
+destination group are never grantable; bus edges match grants by
+the subscription's canonical spelling (topic name for declared
+subscriptions, authored pattern for literal/wildcard ones - the
+same graph keying `subscribers_of` iterates, wildcards included).
+Fail-closed holes, projection vacuity, unknown-group validation,
+and the full three-diagnostic violation rendering (claim line,
+un-granted publish site, delivered-at subscription) are ported
+with the evaluator's exact spellings, held by the same corpus
+differential as 5a. Negative control: dropping subscribe rows
+flips the verdict.
+
 ### The reachability judgment - family 5a on the canonical model (GH #476 Change 5a)
 
 `hale_types::judgment::judge_forbid_reaches(&ClaimIrTable,

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -1657,11 +1657,13 @@ pub fn judge_only_edges(
         }
         out
     };
-    // Holes trigger by relation family; the kind picks wording.
-    // `authored_site` (first occurrence) lets the boundary check
-    // interleave holes with known edges as authored — the evaluator
-    // walks fs.calls in source order and refuses at the hole's
-    // authored position, BEFORE any later crossing is reported.
+    // Holes retain their hides-mask; each event space consults the
+    // family IT walks (call space → CALLS, publish space →
+    // PUBLISHES) and the kind picks wording only. `authored_site`
+    // (first occurrence) lets the boundary check interleave holes
+    // with known edges as authored — the evaluator walks bodies in
+    // source order and refuses at the hole's authored position,
+    // BEFORE any later crossing is reported.
     #[derive(Clone)]
     enum FnHole {
         Indirect,
@@ -1669,8 +1671,10 @@ pub fn judge_only_edges(
         Computed,
         Other { reason: String },
     }
-    let mut holes_of: BTreeMap<FunctionId, Vec<(Option<u32>, FnHole)>> =
-        BTreeMap::new();
+    let mut holes_of: BTreeMap<
+        FunctionId,
+        Vec<(hale_model::RelationSet, Option<u32>, FnHole)>,
+    > = BTreeMap::new();
     for h in &model.holes {
         let EntityRef::Function(f) = h.at else { continue };
         let families = hale_model::RelationSet::CALLS
@@ -1691,7 +1695,7 @@ pub fn judge_only_edges(
         holes_of
             .entry(f)
             .or_default()
-            .push((h.authored_site, hole));
+            .push((h.hides, h.authored_site, hole));
     }
 
     let mut out = Vec::new();
@@ -1815,8 +1819,10 @@ pub fn judge_only_edges(
             {
                 evs.push((*site, 0, CallEv::Edge(*to, *cprov)));
             }
-            for (site, h) in holes_of.get(f).into_iter().flatten() {
-                if matches!(h, FnHole::Computed) {
+            for (hides, site, h) in
+                holes_of.get(f).into_iter().flatten()
+            {
+                if !hides.intersects(hale_model::RelationSet::CALLS) {
                     continue;
                 }
                 evs.push((site.unwrap_or(u32::MAX), 1, CallEv::Hole(h)));
@@ -1874,7 +1880,21 @@ pub fn judge_only_edges(
                         verdict = Verdict::Uncertified;
                         break 'fns;
                     }
-                    CallEv::Hole(FnHole::Computed) => continue,
+                    CallEv::Hole(FnHole::Computed) => {
+                        diags.push(Diag::ty(
+                            row_span,
+                            format!(
+                                "claim `{}` cannot be certified: `{}` \
+                                 publishes to a computed subject, which could \
+                                 route to any subscriber. An unresolvable \
+                                 edge fails closed",
+                                row.name,
+                                fn_disp(*f)
+                            ),
+                        ));
+                        verdict = Verdict::Uncertified;
+                        break 'fns;
+                    }
                     CallEv::Edge(to, cprov) => (to, cprov),
                 };
                 {
@@ -1914,29 +1934,86 @@ pub fn judge_only_edges(
                 }
                 }
             }
-            if holes_of
-                .get(f)
-                .into_iter()
-                .flatten()
-                .any(|(_, h)| matches!(h, FnHole::Computed))
-            {
-                diags.push(Diag::ty(
-                    row_span,
-                    format!(
-                        "claim `{}` cannot be certified: `{}` \
-                         publishes to a computed subject, which could \
-                         route to any subscriber. An unresolvable \
-                         edge fails closed",
-                        row.name,
-                        fn_disp(*f)
-                    ),
-                ));
-                verdict = Verdict::Uncertified;
-                break 'fns;
+            enum PubEv<'x> {
+                Row(&'x str, ProvenanceId),
+                Hole(&'x FnHole),
             }
-            for (_, _sid, written, pprov) in
+            let mut pevs: Vec<(u32, u8, PubEv)> = Vec::new();
+            for (site, _sid, written, pprov) in
                 pubs_of.get(f).into_iter().flatten()
             {
+                pevs.push((
+                    *site,
+                    0,
+                    PubEv::Row(written.as_str(), *pprov),
+                ));
+            }
+            for (hides, site, h) in
+                holes_of.get(f).into_iter().flatten()
+            {
+                if !hides
+                    .intersects(hale_model::RelationSet::PUBLISHES)
+                {
+                    continue;
+                }
+                pevs.push((
+                    site.unwrap_or(u32::MAX),
+                    1,
+                    PubEv::Hole(h),
+                ));
+            }
+            pevs.sort_by_key(|(site, tie, _)| (*site, *tie));
+            for (_, _, pev) in pevs {
+                let (written, pprov) = match pev {
+                    PubEv::Hole(h) => {
+                        let msg = match h {
+                            FnHole::Computed => format!(
+                                "claim `{}` cannot be certified: `{}` \
+                                 publishes to a computed subject, which could \
+                                 route to any subscriber. An unresolvable \
+                                 edge fails closed",
+                                row.name,
+                                fn_disp(*f)
+                            ),
+                            FnHole::Indirect => format!(
+                                "claim `{}` cannot be certified: `{}` \
+                                 calls through a function-typed \
+                                 parameter, whose target is not \
+                                 knowable statically. An unresolvable \
+                                 edge fails closed",
+                                row.name,
+                                fn_disp(*f)
+                            ),
+                            FnHole::Untyped { callee } => format!(
+                                "claim `{}` cannot be certified: `{}` \
+                                 calls `{}` on a receiver the \
+                                 compiler cannot type, so the walk \
+                                 cannot follow the edge. An \
+                                 unresolvable edge fails closed — \
+                                 bind the receiver to a typed field \
+                                 or local so the call resolves",
+                                row.name,
+                                fn_disp(*f),
+                                callee
+                            ),
+                            FnHole::Other { reason } => format!(
+                                "claim `{}` cannot be certified: `{}` \
+                                 — {}. An unresolvable edge fails \
+                                 closed",
+                                row.name,
+                                fn_disp(*f),
+                                reason
+                            ),
+                        };
+                        diags.push(Diag::ty(row_span, msg));
+                        verdict = Verdict::Uncertified;
+                        break 'fns;
+                    }
+                    PubEv::Row(w, p) => (w, p),
+                };
+                let pprov = &pprov;
+                let written = &written.to_string();
+                {
                 for (handler, sprov) in subs_for(written) {
                     let Some(hl) = locus_of.get(&handler) else {
                         continue;
@@ -2002,6 +2079,7 @@ pub fn judge_only_edges(
                         ));
                         verdict = Verdict::Violated;
                     }
+                }
                 }
             }
         }

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -1678,10 +1678,10 @@ pub fn judge_only_edges(
     // Subject-grain holes: a hole at Subject(S) hiding SUBSCRIBES
     // means S's subscriber set is incomplete — boundary composition
     // through S must not certify absence from the known rows
-    // (review round 3: bus composition needs PUBLISHES ∪
-    // SUBSCRIBES, at the hole's entity grain).
-    let mut subject_hides: BTreeMap<u32, hale_model::RelationSet> =
-        BTreeMap::new();
+    // (round 3), and coverage uses the delivery predicate so a
+    // wildcard hole covers the subjects it matches (round 4).
+    let mut subject_hole_pats: Vec<(String, hale_model::RelationSet)> =
+        Vec::new();
     for h in &model.holes {
         match h.at {
             EntityRef::Function(f) => {
@@ -1708,10 +1708,10 @@ pub fn judge_only_edges(
                     .push((h.hides, h.authored_site, hole));
             }
             EntityRef::Subject(sid) => {
-                let e2 = subject_hides
-                    .entry(sid.0)
-                    .or_insert(hale_model::RelationSet(0));
-                *e2 = e2.union(h.hides);
+                subject_hole_pats.push((
+                    e.subjects[sid.index()].pattern.clone(),
+                    h.hides,
+                ));
             }
             _ => {}
         }
@@ -2029,11 +2029,16 @@ pub fn judge_only_edges(
                         break 'fns;
                     }
                     PubEv::Row(sid, w, p) => {
-                        if subject_hides.get(&sid).is_some_and(|m| {
-                            m.intersects(
-                                hale_model::RelationSet::SUBSCRIBES,
-                            )
-                        }) {
+                        if subject_hole_covers(
+                            &subject_hole_pats,
+                            hale_model::RelationSet::SUBSCRIBES,
+                            &[
+                                w,
+                                e.subjects[sid as usize]
+                                    .pattern
+                                    .as_str(),
+                            ],
+                        ) {
                             diags.push(Diag::ty(
                                 row_span,
                                 format!(

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -314,23 +314,39 @@ pub fn judge_forbid_reaches(
             .or_default()
             .push((a.site, ai as u32));
     }
-    // subject id → subscriber rows.
-    let mut subs_of: BTreeMap<u32, Vec<(FunctionId, ProvenanceId)>> =
-        BTreeMap::new();
+    // Subscription rows grouped by their subject PATTERN, sorted —
+    // the evaluator's subscribers_of iterates the graph's subject
+    // map in key order and matches exact-or-wildcard.
+    // Keyed by the subscription's CANONICAL spelling — the topic
+    // NAME for declared subscriptions, the authored pattern for
+    // literal/wildcard ones — exactly the graph keying the
+    // evaluator's subscribers_of iterates.
+    let mut subs_by_pattern: BTreeMap<
+        &str,
+        Vec<(FunctionId, ProvenanceId)>,
+    > = BTreeMap::new();
     for su in &r.subscribes {
-        subs_of
-            .entry(su.subject.0)
+        let key = match su.declared_topic {
+            Some(t) => e.topics[t.index()].name.as_str(),
+            None => e.subjects[su.subject.index()].pattern.as_str(),
+        };
+        subs_by_pattern
+            .entry(key)
             .or_default()
             .push((su.handler, su.provenance));
     }
-    // written publish text → subject id (topic name or pattern).
-    let mut subject_by_text: BTreeMap<&str, u32> = BTreeMap::new();
-    for (i, su) in e.subjects.iter().enumerate() {
-        subject_by_text.insert(su.pattern.as_str(), i as u32);
-    }
-    for t in &e.topics {
-        subject_by_text.insert(t.name.as_str(), t.subject.0);
-    }
+    let subs_for = |written: &str| -> Vec<(FunctionId, ProvenanceId)> {
+        let mut out = Vec::new();
+        for (pattern, subs) in &subs_by_pattern {
+            let covers = *pattern == written
+                || (pattern.contains("**")
+                    && crate::wildcard_match(pattern, written));
+            if covers {
+                out.extend(subs.iter().cloned());
+            }
+        }
+        out
+    };
     // fn → publish rows (site, subject id, written text, prov).
     let mut pubs_of: BTreeMap<
         FunctionId,
@@ -978,20 +994,18 @@ pub fn judge_forbid_reaches(
                                         written.clone(),
                                     ));
                                 }
-                                for (handler, spid) in subs_of
-                                    .get(sid)
-                                    .into_iter()
-                                    .flatten()
+                                for (handler, spid) in
+                                    subs_for(written)
                                 {
                                     edges.push((
-                                        V::User(*handler),
+                                        V::User(handler),
                                         StepIr::Bus {
                                             subject: written.clone(),
                                             publish_provenance: Some(
                                                 *ppid,
                                             ),
                                             subscribe_provenance:
-                                                *spid,
+                                                spid,
                                             from_stdlib: false,
                                         },
                                     ));
@@ -1162,23 +1176,17 @@ pub fn judge_forbid_reaches(
                                             ));
                                         }
                                         for (handler, spid) in
-                                            subject_by_text
-                                                .get(subject.as_str())
-                                                .and_then(|sid| {
-                                                    subs_of.get(sid)
-                                                })
-                                                .into_iter()
-                                                .flatten()
+                                            subs_for(subject)
                                         {
                                             edges.push((
-                                                V::User(*handler),
+                                                V::User(handler),
                                                 StepIr::Bus {
                                                     subject: subject
                                                         .clone(),
                                                     publish_provenance:
                                                         None,
                                                     subscribe_provenance:
-                                                        *spid,
+                                                        spid,
                                                     from_stdlib: true,
                                                 },
                                             ));
@@ -1508,4 +1516,449 @@ fn render_violation_ir(
             ));
         }
     }
+}
+
+/// Judge every `only edges` row of one lowered law table against
+/// its model (GH #476 Change 5b). Boundary grants are DIRECT-edge
+/// law — no walk: every direct call or bus edge from the source
+/// group into the destination group must match a granted line
+/// (call edges are never grantable).
+pub fn judge_only_edges(
+    table: &ClaimIrTable,
+    model: &ApplicationModel,
+    source_bases: &[u32],
+) -> Vec<Judged> {
+    let e = &model.entities;
+    let r = &model.relations;
+    let claim_span = |pid: ProvenanceId| -> Span {
+        span_of(&table.provenance, source_bases, pid)
+    };
+    let model_span = |pid: ProvenanceId| -> Span {
+        span_of(&model.provenance, source_bases, pid)
+    };
+    let fn_disp = |f: FunctionId| e.functions[f.index()].display.clone();
+    let v1: BTreeSet<FunctionId> =
+        model.legacy.topology_v1_fns.iter().copied().collect();
+
+    // Group projections (fn grain + locus decl grain), evaluator
+    // iteration order: FnKey Ord = (locus: None < Some, name) —
+    // free fns first, then methods grouped by locus.
+    let fnkey_order = |raw: &str| -> (u8, String, String) {
+        match raw.rsplit_once("::") {
+            Some((l, m)) => (1, l.to_string(), m.to_string()),
+            None => (0, String::new(), raw.to_string()),
+        }
+    };
+    let mut by_locus: BTreeMap<u32, Vec<FunctionId>> = BTreeMap::new();
+    for mo in &r.member_of {
+        by_locus.entry(mo.locus.0).or_default().push(mo.function);
+    }
+    let group_fns = |g: GroupId| -> Vec<FunctionId> {
+        let mut set: BTreeSet<FunctionId> = BTreeSet::new();
+        for gm in r.group_members.iter().filter(|gm| gm.group == g) {
+            match gm.member {
+                EntityRef::LocusDecl(l) => {
+                    for f in by_locus.get(&l.0).into_iter().flatten() {
+                        if v1.contains(f) {
+                            set.insert(*f);
+                        }
+                    }
+                }
+                EntityRef::Function(f) => {
+                    if v1.contains(&f) {
+                        set.insert(f);
+                    }
+                }
+                _ => {}
+            }
+        }
+        let mut v: Vec<FunctionId> = set.into_iter().collect();
+        v.sort_by_key(|f| fnkey_order(&e.functions[f.index()].name));
+        v
+    };
+    let group_loci = |g: GroupId| -> BTreeSet<u32> {
+        r.group_members
+            .iter()
+            .filter(|gm| gm.group == g)
+            .filter_map(|gm| match gm.member {
+                EntityRef::LocusDecl(l) => Some(l.0),
+                _ => None,
+            })
+            .collect()
+    };
+    // fn → its locus id.
+    let locus_of: BTreeMap<FunctionId, u32> = r
+        .member_of
+        .iter()
+        .map(|mo| (mo.function, mo.locus.0))
+        .collect();
+    // Per-fn call rows / publish rows by site; holes.
+    let mut calls_of: BTreeMap<
+        FunctionId,
+        Vec<(u32, FunctionId, ProvenanceId)>,
+    > = BTreeMap::new();
+    for c in &r.calls {
+        if matches!(c.dispatch, DispatchKind::ViaStdlib) {
+            continue;
+        }
+        calls_of
+            .entry(c.from)
+            .or_default()
+            .push((c.site, c.to, c.provenance));
+    }
+    for v in calls_of.values_mut() {
+        v.sort_by_key(|(site, to, _)| (*site, *to));
+    }
+    let mut pubs_of: BTreeMap<
+        FunctionId,
+        Vec<(u32, u32, String, ProvenanceId)>,
+    > = BTreeMap::new();
+    for p in &r.publishes {
+        let written = match p.declared_topic {
+            Some(t) => e.topics[t.index()].name.clone(),
+            None => e.subjects[p.subject.index()].pattern.clone(),
+        };
+        pubs_of.entry(p.function).or_default().push((
+            p.site,
+            p.subject.0,
+            written,
+            p.provenance,
+        ));
+    }
+    for v in pubs_of.values_mut() {
+        v.sort_by_key(|(site, ..)| *site);
+    }
+    // Keyed by the subscription's CANONICAL spelling — the topic
+    // NAME for declared subscriptions, the authored pattern for
+    // literal/wildcard ones — exactly the graph keying the
+    // evaluator's subscribers_of iterates.
+    let mut subs_by_pattern: BTreeMap<
+        &str,
+        Vec<(FunctionId, ProvenanceId)>,
+    > = BTreeMap::new();
+    for su in &r.subscribes {
+        let key = match su.declared_topic {
+            Some(t) => e.topics[t.index()].name.as_str(),
+            None => e.subjects[su.subject.index()].pattern.as_str(),
+        };
+        subs_by_pattern
+            .entry(key)
+            .or_default()
+            .push((su.handler, su.provenance));
+    }
+    let subs_for = |written: &str| -> Vec<(FunctionId, ProvenanceId)> {
+        let mut out = Vec::new();
+        for (pattern, subs) in &subs_by_pattern {
+            let covers = *pattern == written
+                || (pattern.contains("**")
+                    && crate::wildcard_match(pattern, written));
+            if covers {
+                out.extend(subs.iter().cloned());
+            }
+        }
+        out
+    };
+    #[derive(Clone)]
+    enum FnHole {
+        Indirect,
+        Untyped { callee: String },
+        Computed,
+    }
+    let mut holes_of: BTreeMap<FunctionId, Vec<FnHole>> =
+        BTreeMap::new();
+    for h in &model.holes {
+        let EntityRef::Function(f) = h.at else { continue };
+        let hole = match &h.kind {
+            HoleKind::IndirectCall => FnHole::Indirect,
+            HoleKind::UntypedReceiver { callee } => FnHole::Untyped {
+                callee: callee.clone(),
+            },
+            HoleKind::ComputedSubject => FnHole::Computed,
+            _ => continue,
+        };
+        holes_of.entry(f).or_default().push(hole);
+    }
+
+    let mut out = Vec::new();
+    for row in &table.rows {
+        let ClaimIr::OnlyEdges { src, dst, grants } = &row.law else {
+            continue;
+        };
+        let mut diags: Vec<Diag> = Vec::new();
+        let row_span = claim_span(row.provenance);
+        // Validation (unknown groups) — Invalid without evaluation.
+        let group_decl_names: Vec<&str> =
+            e.groups.iter().map(|g| g.display.as_str()).collect();
+        let mut ok = true;
+        for gref in [src, dst] {
+            if gref.group.is_none() {
+                let mut near: Vec<&&str> = group_decl_names
+                    .iter()
+                    .filter(|g| {
+                        crate::effects::close(g, &gref.name.display)
+                    })
+                    .collect();
+                near.sort();
+                let hint = match near.first() {
+                    Some(n) => format!(" Did you mean `{}`?", n),
+                    None => String::new(),
+                };
+                diags.push(Diag::ty(
+                    claim_span(gref.provenance),
+                    format!(
+                        "claim `{}` names group `{}`, which is never declared. \
+                         Add `group {} = {{ … }};` at the top level.{}",
+                        row.name,
+                        gref.name.display,
+                        gref.name.display,
+                        hint
+                    ),
+                ));
+                ok = false;
+            }
+        }
+        if !ok {
+            out.push(Judged {
+                ordinal: row.ordinal,
+                verdict: Verdict::Invalid,
+                diags,
+            });
+            continue;
+        }
+        let (src_gid, dst_gid) =
+            (src.group.unwrap(), dst.group.unwrap());
+        // Projection vacuity, source then target.
+        let decl_count = |g: GroupId| {
+            r.group_members.iter().filter(|gm| gm.group == g).count()
+        };
+        let src_fns = group_fns(src_gid);
+        let dst_fns_v = group_fns(dst_gid);
+        let mut vacuous = |gref: &hale_model::GroupRef,
+                           fns: &[FunctionId],
+                           which: &str,
+                           diags: &mut Vec<Diag>|
+         -> bool {
+            let gid = gref.group.unwrap();
+            if decl_count(gid) == 0 || !fns.is_empty() {
+                return false;
+            }
+            diags.push(Diag::ty(
+                claim_span(gref.provenance),
+                format!(
+                    "claim `{}`: group `{}` projects to no executable {} \
+                     vertices — its declarations have no fns, so the claim \
+                     proves nothing about them. The fn-grained walk cannot \
+                     see pure-data access; name the loci that HOLD the \
+                     behavior, or drop the claim",
+                    row.name, gref.name.display, which
+                ),
+            ));
+            true
+        };
+        if vacuous(src, &src_fns, "source", &mut diags)
+            || vacuous(dst, &dst_fns_v, "target", &mut diags)
+        {
+            out.push(Judged {
+                ordinal: row.ordinal,
+                verdict: Verdict::Invalid,
+                diags,
+            });
+            continue;
+        }
+        let dst_fn_set: BTreeSet<FunctionId> =
+            dst_fns_v.iter().copied().collect();
+        let dst_loci = group_loci(dst_gid);
+        // The grant set: first-segment topic spellings as written.
+        let granted: BTreeSet<&str> = grants
+            .iter()
+            .map(|g| g.topic.name.raw.as_str())
+            .collect();
+        let granted_disp = if granted.is_empty() {
+            "none".to_string()
+        } else {
+            granted
+                .iter()
+                .map(|s| format!("`{}`", s))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let mut verdict = Verdict::Holds;
+        let mut reported: BTreeSet<String> = BTreeSet::new();
+        'fns: for f in &src_fns {
+            for (_, to, cprov) in
+                calls_of.get(f).into_iter().flatten()
+            {
+                if dst_fn_set.contains(to) {
+                    let key =
+                        format!("{}->{}", fn_disp(*f), fn_disp(*to));
+                    if reported.insert(key) {
+                        diags.push(Diag::ty(
+                            row_span,
+                            format!(
+                                "claim `{}` violated: un-granted \
+                                 edge `{}` -> `{}` — call edges \
+                                 are not grantable; the boundary \
+                                 between `{}` and `{}` must be a \
+                                 bus edge named in the grant list",
+                                row.name,
+                                fn_disp(*f),
+                                fn_disp(*to),
+                                src.name.display,
+                                dst.name.display
+                            ),
+                        ));
+                        diags.push(Diag::ty(
+                            model_span(*cprov),
+                            format!(
+                                "claim `{}`: this call \
+                                 crosses the boundary. A \
+                                 call cannot be granted — \
+                                 route it through a topic \
+                                 named in the grant list, or \
+                                 move the callee out of `{}`",
+                                row.name, dst.name.display
+                            ),
+                        ));
+                        verdict = Verdict::Violated;
+                    }
+                }
+            }
+            for h in holes_of.get(f).into_iter().flatten() {
+                match h {
+                    FnHole::Indirect => {
+                        diags.push(Diag::ty(
+                            row_span,
+                            format!(
+                                "claim `{}` cannot be certified: `{}` \
+                                 calls through a function-typed \
+                                 parameter, whose target is not \
+                                 knowable statically. An unresolvable \
+                                 edge fails closed",
+                                row.name,
+                                fn_disp(*f)
+                            ),
+                        ));
+                        verdict = Verdict::Uncertified;
+                        break 'fns;
+                    }
+                    FnHole::Untyped { callee } => {
+                        diags.push(Diag::ty(
+                            row_span,
+                            format!(
+                                "claim `{}` cannot be certified: `{}` \
+                                 calls `{}` on a receiver the \
+                                 compiler cannot type, so the walk \
+                                 cannot follow the edge. An \
+                                 unresolvable edge fails closed — \
+                                 bind the receiver to a typed field \
+                                 or local so the call resolves",
+                                row.name,
+                                fn_disp(*f),
+                                callee
+                            ),
+                        ));
+                        verdict = Verdict::Uncertified;
+                        break 'fns;
+                    }
+                    FnHole::Computed => {}
+                }
+            }
+            if holes_of
+                .get(f)
+                .into_iter()
+                .flatten()
+                .any(|h| matches!(h, FnHole::Computed))
+            {
+                diags.push(Diag::ty(
+                    row_span,
+                    format!(
+                        "claim `{}` cannot be certified: `{}` \
+                         publishes to a computed subject, which could \
+                         route to any subscriber. An unresolvable \
+                         edge fails closed",
+                        row.name,
+                        fn_disp(*f)
+                    ),
+                ));
+                verdict = Verdict::Uncertified;
+                break 'fns;
+            }
+            for (_, _sid, written, pprov) in
+                pubs_of.get(f).into_iter().flatten()
+            {
+                for (handler, sprov) in subs_for(written) {
+                    let Some(hl) = locus_of.get(&handler) else {
+                        continue;
+                    };
+                    if !dst_loci.contains(hl) {
+                        continue;
+                    }
+                    if granted.contains(written.as_str()) {
+                        continue;
+                    }
+                    let handler_fn = &e.functions[handler.index()];
+                    let sprov = &sprov;
+                    let (sub_locus_disp, sub_handler) =
+                        match handler_fn.display.rsplit_once("::") {
+                            Some((l, m)) => {
+                                (l.to_string(), m.to_string())
+                            }
+                            None => (
+                                String::new(),
+                                handler_fn.display.clone(),
+                            ),
+                        };
+                    let key = format!(
+                        "{}-({})->{}::{}",
+                        fn_disp(*f),
+                        written,
+                        sub_locus_disp,
+                        sub_handler
+                    );
+                    if reported.insert(key) {
+                        diags.push(Diag::ty(
+                            row_span,
+                            format!(
+                                "claim `{}` violated: un-granted edge \
+                                 `{}` -(publishes \"{}\")-> `{}::{}`. \
+                                 Granted: {}. If this edge is intended, \
+                                 name it in the grant list — a grant is \
+                                 a reviewable line",
+                                row.name,
+                                fn_disp(*f),
+                                written,
+                                sub_locus_disp,
+                                sub_handler,
+                                granted_disp
+                            ),
+                        ));
+                        diags.push(Diag::ty(
+                            model_span(*pprov),
+                            format!(
+                                "claim `{}`: the un-granted publish \
+                                 happens here",
+                                row.name
+                            ),
+                        ));
+                        diags.push(Diag::ty(
+                            model_span(*sprov),
+                            format!(
+                                "claim `{}`: received here. Grant this \
+                                 edge with `publish {};` if it is \
+                                 intended",
+                                row.name, written
+                            ),
+                        ));
+                        verdict = Verdict::Violated;
+                    }
+                }
+            }
+        }
+        out.push(Judged {
+            ordinal: row.ordinal,
+            verdict,
+            diags,
+        });
+    }
+    out
 }

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -1610,7 +1610,7 @@ pub fn judge_only_edges(
     }
     let mut pubs_of: BTreeMap<
         FunctionId,
-        Vec<(u32, u32, String, ProvenanceId)>,
+        Vec<(u32, u32, Option<u32>, String, ProvenanceId)>,
     > = BTreeMap::new();
     for p in &r.publishes {
         let written = match p.declared_topic {
@@ -1620,6 +1620,7 @@ pub fn judge_only_edges(
         pubs_of.entry(p.function).or_default().push((
             p.site,
             p.subject.0,
+            p.declared_topic.map(|t| t.0),
             written,
             p.provenance,
         ));
@@ -1811,6 +1812,7 @@ pub fn judge_only_edges(
                 .join(", ")
         };
         let mut verdict = Verdict::Holds;
+        let mut bus_unknown: Option<(String, String)> = None;
         let mut reported: BTreeSet<String> = BTreeSet::new();
         'fns: for f in &src_fns {
             // The evaluator walks fs.calls in SOURCE order and
@@ -1944,17 +1946,22 @@ pub fn judge_only_edges(
                 }
             }
             enum PubEv<'x> {
-                Row(u32, &'x str, ProvenanceId),
+                Row(u32, Option<u32>, &'x str, ProvenanceId),
                 Hole(&'x FnHole),
             }
             let mut pevs: Vec<(u32, u8, PubEv)> = Vec::new();
-            for (site, sid, written, pprov) in
+            for (site, sid, topic, written, pprov) in
                 pubs_of.get(f).into_iter().flatten()
             {
                 pevs.push((
                     *site,
                     0,
-                    PubEv::Row(*sid, written.as_str(), *pprov),
+                    PubEv::Row(
+                        *sid,
+                        *topic,
+                        written.as_str(),
+                        *pprov,
+                    ),
                 ));
             }
             for (hides, site, h) in
@@ -2018,30 +2025,30 @@ pub fn judge_only_edges(
                         verdict = Verdict::Uncertified;
                         break 'fns;
                     }
-                    PubEv::Row(sid, w, p) => {
+                    PubEv::Row(sid, topic, w, p) => {
+                        // A set-level subscriber hole has no
+                        // authored position relative to the known
+                        // rows, so it DEFERS: the known rows below
+                        // are still checked — a known ungranted
+                        // crossing stays Violated — and the flag
+                        // downgrades only a would-be Holds
+                        // (round 6). TYPED identities: the topic
+                        // id and the wire pattern, never text
+                        // collisions.
                         if bus_holes.blocks(
                             hale_model::RelationSet::SUBSCRIBES,
-                            &[
-                                w,
+                            topic,
+                            Some(
                                 e.subjects[sid as usize]
                                     .pattern
                                     .as_str(),
-                            ],
-                        ) {
-                            diags.push(Diag::ty(
-                                row_span,
-                                format!(
-                                    "claim `{}` cannot be certified: `{}` \
-                                     publishes to \"{}\", whose subscribers \
-                                     are not fully modeled. An unresolvable \
-                                     edge fails closed",
-                                    row.name,
-                                    fn_disp(*f),
-                                    w
-                                ),
+                            ),
+                        ) && bus_unknown.is_none()
+                        {
+                            bus_unknown = Some((
+                                fn_disp(*f),
+                                w.to_string(),
                             ));
-                            verdict = Verdict::Uncertified;
-                            break 'fns;
                         }
                         (w, p)
                     }
@@ -2116,6 +2123,21 @@ pub fn judge_only_edges(
                     }
                 }
                 }
+            }
+        }
+        if verdict == Verdict::Holds {
+            if let Some((fd, w)) = &bus_unknown {
+                diags.push(Diag::ty(
+                    row_span,
+                    format!(
+                        "claim `{}` cannot be certified: `{}` \
+                         publishes to \"{}\", whose subscribers \
+                         are not fully modeled. An unresolvable \
+                         edge fails closed",
+                        row.name, fd, w
+                    ),
+                ));
+                verdict = Verdict::Uncertified;
             }
         }
         out.push(Judged {

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -1675,13 +1675,9 @@ pub fn judge_only_edges(
         FunctionId,
         Vec<(hale_model::RelationSet, Option<u32>, FnHole)>,
     > = BTreeMap::new();
-    // Subject-grain holes: a hole at Subject(S) hiding SUBSCRIBES
-    // means S's subscriber set is incomplete — boundary composition
-    // through S must not certify absence from the known rows
-    // (round 3), and coverage uses the delivery predicate so a
-    // wildcard hole covers the subjects it matches (round 4).
-    let mut subject_hole_pats: Vec<(String, hale_model::RelationSet)> =
-        Vec::new();
+    // Non-function holes participate through the shared two-grain
+    // BusHoles index (subject patterns + topic names, rounds 4–5).
+    let bus_holes = BusHoles::build(model);
     for h in &model.holes {
         match h.at {
             EntityRef::Function(f) => {
@@ -1706,12 +1702,6 @@ pub fn judge_only_edges(
                     .entry(f)
                     .or_default()
                     .push((h.hides, h.authored_site, hole));
-            }
-            EntityRef::Subject(sid) => {
-                subject_hole_pats.push((
-                    e.subjects[sid.index()].pattern.clone(),
-                    h.hides,
-                ));
             }
             _ => {}
         }
@@ -2029,8 +2019,7 @@ pub fn judge_only_edges(
                         break 'fns;
                     }
                     PubEv::Row(sid, w, p) => {
-                        if subject_hole_covers(
-                            &subject_hole_pats,
+                        if bus_holes.blocks(
                             hale_model::RelationSet::SUBSCRIBES,
                             &[
                                 w,

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -1675,27 +1675,46 @@ pub fn judge_only_edges(
         FunctionId,
         Vec<(hale_model::RelationSet, Option<u32>, FnHole)>,
     > = BTreeMap::new();
+    // Subject-grain holes: a hole at Subject(S) hiding SUBSCRIBES
+    // means S's subscriber set is incomplete — boundary composition
+    // through S must not certify absence from the known rows
+    // (review round 3: bus composition needs PUBLISHES ∪
+    // SUBSCRIBES, at the hole's entity grain).
+    let mut subject_hides: BTreeMap<u32, hale_model::RelationSet> =
+        BTreeMap::new();
     for h in &model.holes {
-        let EntityRef::Function(f) = h.at else { continue };
-        let families = hale_model::RelationSet::CALLS
-            .union(hale_model::RelationSet::PUBLISHES);
-        if !h.hides.intersects(families) {
-            continue;
+        match h.at {
+            EntityRef::Function(f) => {
+                let families = hale_model::RelationSet::CALLS
+                    .union(hale_model::RelationSet::PUBLISHES);
+                if !h.hides.intersects(families) {
+                    continue;
+                }
+                let hole = match &h.kind {
+                    HoleKind::IndirectCall => FnHole::Indirect,
+                    HoleKind::UntypedReceiver { callee } => {
+                        FnHole::Untyped {
+                            callee: callee.clone(),
+                        }
+                    }
+                    HoleKind::ComputedSubject => FnHole::Computed,
+                    _ => FnHole::Other {
+                        reason: h.reason.clone(),
+                    },
+                };
+                holes_of
+                    .entry(f)
+                    .or_default()
+                    .push((h.hides, h.authored_site, hole));
+            }
+            EntityRef::Subject(sid) => {
+                let e2 = subject_hides
+                    .entry(sid.0)
+                    .or_insert(hale_model::RelationSet(0));
+                *e2 = e2.union(h.hides);
+            }
+            _ => {}
         }
-        let hole = match &h.kind {
-            HoleKind::IndirectCall => FnHole::Indirect,
-            HoleKind::UntypedReceiver { callee } => FnHole::Untyped {
-                callee: callee.clone(),
-            },
-            HoleKind::ComputedSubject => FnHole::Computed,
-            _ => FnHole::Other {
-                reason: h.reason.clone(),
-            },
-        };
-        holes_of
-            .entry(f)
-            .or_default()
-            .push((h.hides, h.authored_site, hole));
     }
 
     let mut out = Vec::new();
@@ -1935,17 +1954,17 @@ pub fn judge_only_edges(
                 }
             }
             enum PubEv<'x> {
-                Row(&'x str, ProvenanceId),
+                Row(u32, &'x str, ProvenanceId),
                 Hole(&'x FnHole),
             }
             let mut pevs: Vec<(u32, u8, PubEv)> = Vec::new();
-            for (site, _sid, written, pprov) in
+            for (site, sid, written, pprov) in
                 pubs_of.get(f).into_iter().flatten()
             {
                 pevs.push((
                     *site,
                     0,
-                    PubEv::Row(written.as_str(), *pprov),
+                    PubEv::Row(*sid, written.as_str(), *pprov),
                 ));
             }
             for (hides, site, h) in
@@ -2009,7 +2028,29 @@ pub fn judge_only_edges(
                         verdict = Verdict::Uncertified;
                         break 'fns;
                     }
-                    PubEv::Row(w, p) => (w, p),
+                    PubEv::Row(sid, w, p) => {
+                        if subject_hides.get(&sid).is_some_and(|m| {
+                            m.intersects(
+                                hale_model::RelationSet::SUBSCRIBES,
+                            )
+                        }) {
+                            diags.push(Diag::ty(
+                                row_span,
+                                format!(
+                                    "claim `{}` cannot be certified: `{}` \
+                                     publishes to \"{}\", whose subscribers \
+                                     are not fully modeled. An unresolvable \
+                                     edge fails closed",
+                                    row.name,
+                                    fn_disp(*f),
+                                    w
+                                ),
+                            ));
+                            verdict = Verdict::Uncertified;
+                            break 'fns;
+                        }
+                        (w, p)
+                    }
                 };
                 let pprov = &pprov;
                 let written = &written.to_string();

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -2138,6 +2138,25 @@ pub fn judge_only_edges(
                     ),
                 ));
                 verdict = Verdict::Uncertified;
+            } else if let Some(subj) =
+                &bus_holes.publishers_incomplete
+            {
+                // Round 8: an unknown PUBLISHER — possibly a src
+                // fn — may create an ungranted crossing the known
+                // rows cannot show. A known counterexample above
+                // still wins.
+                diags.push(Diag::ty(
+                    row_span,
+                    format!(
+                        "claim `{}` cannot be certified: the \
+                         publisher set of \"{}\" is not fully \
+                         modeled — an unknown publisher may create \
+                         an ungranted edge. An unresolvable edge \
+                         fails closed",
+                        row.name, subj
+                    ),
+                ));
+                verdict = Verdict::Uncertified;
             }
         }
         out.push(Judged {

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -1565,9 +1565,8 @@ pub fn judge_only_edges(
                     }
                 }
                 EntityRef::Function(f) => {
-                    if v1.contains(&f) {
-                        set.insert(f);
-                    }
+                    // Declaration-only free fns are still decls.
+                    set.insert(f);
                 }
                 _ => {}
             }
@@ -1658,25 +1657,41 @@ pub fn judge_only_edges(
         }
         out
     };
+    // Holes trigger by relation family; the kind picks wording.
+    // `authored_site` (first occurrence) lets the boundary check
+    // interleave holes with known edges as authored — the evaluator
+    // walks fs.calls in source order and refuses at the hole's
+    // authored position, BEFORE any later crossing is reported.
     #[derive(Clone)]
     enum FnHole {
         Indirect,
         Untyped { callee: String },
         Computed,
+        Other { reason: String },
     }
-    let mut holes_of: BTreeMap<FunctionId, Vec<FnHole>> =
+    let mut holes_of: BTreeMap<FunctionId, Vec<(Option<u32>, FnHole)>> =
         BTreeMap::new();
     for h in &model.holes {
         let EntityRef::Function(f) = h.at else { continue };
+        let families = hale_model::RelationSet::CALLS
+            .union(hale_model::RelationSet::PUBLISHES);
+        if !h.hides.intersects(families) {
+            continue;
+        }
         let hole = match &h.kind {
             HoleKind::IndirectCall => FnHole::Indirect,
             HoleKind::UntypedReceiver { callee } => FnHole::Untyped {
                 callee: callee.clone(),
             },
             HoleKind::ComputedSubject => FnHole::Computed,
-            _ => continue,
+            _ => FnHole::Other {
+                reason: h.reason.clone(),
+            },
         };
-        holes_of.entry(f).or_default().push(hole);
+        holes_of
+            .entry(f)
+            .or_default()
+            .push((h.authored_site, hole));
     }
 
     let mut out = Vec::new();
@@ -1785,47 +1800,31 @@ pub fn judge_only_edges(
         let mut verdict = Verdict::Holds;
         let mut reported: BTreeSet<String> = BTreeSet::new();
         'fns: for f in &src_fns {
-            for (_, to, cprov) in
+            // The evaluator walks fs.calls in SOURCE order and
+            // refuses at an unfollowable edge's authored position —
+            // a crossing AFTER the hole is never reported.
+            // Interleave known call rows and call-space holes by
+            // authored site (review: ordered event streams).
+            enum CallEv<'x> {
+                Edge(FunctionId, ProvenanceId),
+                Hole(&'x FnHole),
+            }
+            let mut evs: Vec<(u32, u8, CallEv)> = Vec::new();
+            for (site, to, cprov) in
                 calls_of.get(f).into_iter().flatten()
             {
-                if dst_fn_set.contains(to) {
-                    let key =
-                        format!("{}->{}", fn_disp(*f), fn_disp(*to));
-                    if reported.insert(key) {
-                        diags.push(Diag::ty(
-                            row_span,
-                            format!(
-                                "claim `{}` violated: un-granted \
-                                 edge `{}` -> `{}` — call edges \
-                                 are not grantable; the boundary \
-                                 between `{}` and `{}` must be a \
-                                 bus edge named in the grant list",
-                                row.name,
-                                fn_disp(*f),
-                                fn_disp(*to),
-                                src.name.display,
-                                dst.name.display
-                            ),
-                        ));
-                        diags.push(Diag::ty(
-                            model_span(*cprov),
-                            format!(
-                                "claim `{}`: this call \
-                                 crosses the boundary. A \
-                                 call cannot be granted — \
-                                 route it through a topic \
-                                 named in the grant list, or \
-                                 move the callee out of `{}`",
-                                row.name, dst.name.display
-                            ),
-                        ));
-                        verdict = Verdict::Violated;
-                    }
-                }
+                evs.push((*site, 0, CallEv::Edge(*to, *cprov)));
             }
-            for h in holes_of.get(f).into_iter().flatten() {
-                match h {
-                    FnHole::Indirect => {
+            for (site, h) in holes_of.get(f).into_iter().flatten() {
+                if matches!(h, FnHole::Computed) {
+                    continue;
+                }
+                evs.push((site.unwrap_or(u32::MAX), 1, CallEv::Hole(h)));
+            }
+            evs.sort_by_key(|(site, tie, _)| (*site, *tie));
+            for (_, _, ev) in evs {
+                let (to, cprov) = match ev {
+                    CallEv::Hole(FnHole::Indirect) => {
                         diags.push(Diag::ty(
                             row_span,
                             format!(
@@ -1841,7 +1840,7 @@ pub fn judge_only_edges(
                         verdict = Verdict::Uncertified;
                         break 'fns;
                     }
-                    FnHole::Untyped { callee } => {
+                    CallEv::Hole(FnHole::Untyped { callee }) => {
                         diags.push(Diag::ty(
                             row_span,
                             format!(
@@ -1860,14 +1859,66 @@ pub fn judge_only_edges(
                         verdict = Verdict::Uncertified;
                         break 'fns;
                     }
-                    FnHole::Computed => {}
+                    CallEv::Hole(FnHole::Other { reason }) => {
+                        diags.push(Diag::ty(
+                            row_span,
+                            format!(
+                                "claim `{}` cannot be certified: `{}` \
+                                 — {}. An unresolvable edge fails \
+                                 closed",
+                                row.name,
+                                fn_disp(*f),
+                                reason
+                            ),
+                        ));
+                        verdict = Verdict::Uncertified;
+                        break 'fns;
+                    }
+                    CallEv::Hole(FnHole::Computed) => continue,
+                    CallEv::Edge(to, cprov) => (to, cprov),
+                };
+                {
+                if dst_fn_set.contains(&to) {
+                    let key =
+                        format!("{}->{}", fn_disp(*f), fn_disp(to));
+                    if reported.insert(key) {
+                        diags.push(Diag::ty(
+                            row_span,
+                            format!(
+                                "claim `{}` violated: un-granted \
+                                 edge `{}` -> `{}` — call edges \
+                                 are not grantable; the boundary \
+                                 between `{}` and `{}` must be a \
+                                 bus edge named in the grant list",
+                                row.name,
+                                fn_disp(*f),
+                                fn_disp(to),
+                                src.name.display,
+                                dst.name.display
+                            ),
+                        ));
+                        diags.push(Diag::ty(
+                            model_span(cprov),
+                            format!(
+                                "claim `{}`: this call \
+                                 crosses the boundary. A \
+                                 call cannot be granted — \
+                                 route it through a topic \
+                                 named in the grant list, or \
+                                 move the callee out of `{}`",
+                                row.name, dst.name.display
+                            ),
+                        ));
+                        verdict = Verdict::Violated;
+                    }
+                }
                 }
             }
             if holes_of
                 .get(f)
                 .into_iter()
                 .flatten()
-                .any(|h| matches!(h, FnHole::Computed))
+                .any(|(_, h)| matches!(h, FnHole::Computed))
             {
                 diags.push(Diag::ty(
                     row_span,

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -1835,3 +1835,63 @@ fn main() { App { }; }
         msgs
     );
 }
+
+/// Review pin (round 3): the boundary check consults SUBJECT-grain
+/// SUBSCRIBES holes — an ungranted edge cannot be ruled out when
+/// the subject's subscriber set is incomplete.
+#[test]
+fn subject_subscribes_hole_fails_only_edges_closed() {
+    let src = r#"
+type Cmd { v: Int = 0; }
+topic Sneaky { payload: Cmd; subject: "app.sneaky"; }
+locus Ops {
+    params { n: Int = 0; }
+    bus { publish Sneaky; }
+    fn act() { Sneaky <- Cmd { }; }
+}
+locus Core {
+    params { n: Int = 0; }
+    fn idle() { }
+}
+group ops = { Ops };
+group core = { Core };
+main locus App {
+    params { o: Ops = Ops { }; c: Core = Core { }; }
+    claims { boundary: only edges ops -> core { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let mut model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Holds,
+        "no known subscriber crosses the boundary"
+    );
+    let sid = model
+        .entities
+        .subjects
+        .iter()
+        .position(|su| su.pattern == "app.sneaky")
+        .expect("subject");
+    model.holes.push(hale_model::Hole {
+        at: hale_model::EntityRef::Subject(hale_model::SubjectId(
+            sid as u32,
+        )),
+        kind: hale_model::HoleKind::UnanalyzedBody,
+        hides: hale_model::RelationSet::SUBSCRIBES,
+        authored_site: None,
+        reason: "subscriber set incomplete".to_string(),
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Uncertified,
+        "unknown subscribers must fail the boundary closed"
+    );
+}

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -2013,3 +2013,116 @@ fn main() { App { }; }
         "a topic-grain hole must reach the boundary check"
     );
 }
+
+/// Review pin (round 6): a set-level subscriber hole cannot erase
+/// a known ungranted boundary crossing.
+#[test]
+fn known_boundary_violation_survives_subscriber_hole() {
+    let src = r#"
+type Cmd { v: Int = 0; }
+topic Sneaky { payload: Cmd; subject: "app.sneaky"; }
+locus Ops {
+    params { n: Int = 0; }
+    bus { publish Sneaky; }
+    fn act() { Sneaky <- Cmd { }; }
+}
+locus Core {
+    params { n: Int = 0; }
+    bus { subscribe Sneaky as on_sneaky; }
+    fn on_sneaky(c: Cmd) { self.n = c.v; }
+}
+group ops = { Ops };
+group core = { Core };
+main locus App {
+    params { o: Ops = Ops { }; c: Core = Core { }; }
+    claims { boundary: only edges ops -> core { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let mut model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Violated,
+        "the known subscriber row is an ungranted crossing"
+    );
+    let sid = model
+        .entities
+        .subjects
+        .iter()
+        .position(|su| su.pattern == "app.sneaky")
+        .expect("subject");
+    model.holes.push(hale_model::Hole {
+        at: hale_model::EntityRef::Subject(hale_model::SubjectId(
+            sid as u32,
+        )),
+        kind: hale_model::HoleKind::UnanalyzedBody,
+        hides: hale_model::RelationSet::SUBSCRIBES,
+        authored_site: None,
+        reason: "subscriber set incomplete".to_string(),
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Violated,
+        "unknown extra subscribers cannot un-prove the known \
+         crossing"
+    );
+}
+
+/// …typed identity in the boundary check: a topic hole does not
+/// block a literal publish whose text collides with the name.
+#[test]
+fn topic_hole_does_not_block_literal_publish_in_only_edges() {
+    let src = r#"
+type Cmd { v: Int = 0; }
+topic Orders { payload: Cmd; subject: "wire.orders"; }
+locus Ops {
+    params { n: Int = 0; }
+    fn act(v: Int) { "Orders" <- v; }
+}
+locus Core {
+    params { n: Int = 0; }
+    fn idle() { }
+}
+group ops = { Ops };
+group core = { Core };
+main locus App {
+    params { o: Ops = Ops { }; c: Core = Core { }; }
+    claims { boundary: only edges ops -> core { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let mut model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let tid = model
+        .entities
+        .topics
+        .iter()
+        .position(|t| t.name == "Orders")
+        .expect("topic");
+    model.holes.push(hale_model::Hole {
+        at: hale_model::EntityRef::Topic(hale_model::TopicId(
+            tid as u32,
+        )),
+        kind: hale_model::HoleKind::UnanalyzedBody,
+        hides: hale_model::RelationSet::SUBSCRIBES,
+        authored_site: None,
+        reason: "subscriber set incomplete".to_string(),
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Holds,
+        "the literal wire address is not the topic"
+    );
+}

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -1732,3 +1732,106 @@ fn main() {
         "a re-emergence must have its contracted row"
     );
 }
+
+/// Review pin (round 2): the publish space is ONE ordered stream —
+/// a computed-subject publish authored BEFORE an ungranted known
+/// publish refuses at its position (only the refusal diagnostic).
+#[test]
+fn computed_publish_before_known_refuses_first() {
+    let src = r#"
+type Cmd { v: Int = 0; }
+topic Sneaky { payload: Cmd; subject: "app.sneaky"; }
+locus Ops {
+    params { n: Int = 0; }
+    bus { publish Sneaky; }
+    fn act() {
+        self.n <- 1;
+        Sneaky <- Cmd { };
+    }
+}
+locus Core {
+    params { n: Int = 0; }
+    bus { subscribe Sneaky as on_sneaky; }
+    fn on_sneaky(c: Cmd) { self.n = c.v; }
+}
+group ops = { Ops };
+group core = { Core };
+main locus App {
+    params { o: Ops = Ops { }; c: Core = Core { }; }
+    claims { boundary: only edges ops -> core { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let out = diff_one(src, "computed publish first");
+    assert!(out.is_ok(), "old/new agree: {:?}", out);
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Uncertified
+    );
+    assert_eq!(
+        judged[0].diags.len(),
+        1,
+        "only the refusal — the later crossing is never reported: {:?}",
+        judged[0]
+            .diags
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// …and the converse: an ungranted known publish authored BEFORE
+/// the computed one reports its violation first, THEN refuses.
+#[test]
+fn known_violation_before_computed_publish_reports_then_refuses() {
+    let src = r#"
+type Cmd { v: Int = 0; }
+topic Sneaky { payload: Cmd; subject: "app.sneaky"; }
+locus Ops {
+    params { n: Int = 0; }
+    bus { publish Sneaky; }
+    fn act() {
+        Sneaky <- Cmd { };
+        self.n <- 1;
+    }
+}
+locus Core {
+    params { n: Int = 0; }
+    bus { subscribe Sneaky as on_sneaky; }
+    fn on_sneaky(c: Cmd) { self.n = c.v; }
+}
+group ops = { Ops };
+group core = { Core };
+main locus App {
+    params { o: Ops = Ops { }; c: Core = Core { }; }
+    claims { boundary: only edges ops -> core { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let out = diff_one(src, "known violation first");
+    assert!(out.is_ok(), "old/new agree: {:?}", out);
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_only_edges(&table, &model, &[0]);
+    let msgs: Vec<&String> =
+        judged[0].diags.iter().map(|d| &d.message).collect();
+    assert!(
+        msgs.first().is_some_and(|m| m.contains("violated")),
+        "the earlier crossing reports first: {:?}",
+        msgs
+    );
+    assert!(
+        msgs.last().is_some_and(|m| m.contains("computed subject")),
+        "the refusal follows at its authored position: {:?}",
+        msgs
+    );
+}

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 
 use hale_model::ClaimIr;
 use hale_types::claim_lowering::lower_claims;
-use hale_types::judgment::judge_forbid_reaches;
+use hale_types::judgment::{judge_forbid_reaches, judge_only_edges};
 use hale_types::model_builder::derive_application_model;
 use hale_types::symbol::SourceFile;
 use hale_types::Bundle;
@@ -44,7 +44,13 @@ fn family_names(
     table
         .rows
         .iter()
-        .filter(|r| matches!(r.law, ClaimIr::ForbidReaches { .. }))
+        .filter(|r| {
+            matches!(
+                r.law,
+                ClaimIr::ForbidReaches { .. }
+                    | ClaimIr::OnlyEdges { .. }
+            )
+        })
         .map(|r| r.name.clone())
         .collect()
 }
@@ -74,8 +80,16 @@ fn diff_one(
             &graph,
             &[],
         );
-    // New: engine over the lowered rows.
-    let (pre_diags, judged) = judge_forbid_reaches(&table, &model, &[0]);
+    // New: engine over the lowered rows — both migrated families,
+    // merged back into ordinal order (the evaluator's claim order).
+    let (pre_diags, judged_fr) =
+        judge_forbid_reaches(&table, &model, &[0]);
+    let judged_oe = judge_only_edges(&table, &model, &[0]);
+    let mut judged: Vec<hale_types::judgment::Judged> = judged_fr
+        .into_iter()
+        .chain(judged_oe.into_iter())
+        .collect();
+    judged.sort_by_key(|j| j.ordinal);
     // Verdict parity, matched by claim name.
     let old_verdicts: BTreeMap<&str, &hale_types::verdict::Verdict> =
         outcomes
@@ -336,6 +350,48 @@ fn main() {
         judged[0].verdict,
         hale_types::verdict::Verdict::Violated,
         "the alloc happens inside the stdlib body"
+/// Negative control (5b): the boundary judgment reads the
+/// subscribe relation — clearing it removes the un-granted bus
+/// edge and flips the verdict.
+#[test]
+fn dropping_subscribe_rows_changes_the_only_edges_verdict() {
+    let src = r#"
+type Cmd { v: Int = 0; }
+topic Sneaky { payload: Cmd; subject: "app.sneaky"; }
+locus Ops {
+    params { n: Int = 0; }
+    bus { publish Sneaky; }
+    fn act() { Sneaky <- Cmd { }; }
+}
+locus Core {
+    params { n: Int = 0; }
+    bus { subscribe Sneaky as on_sneaky; }
+    fn on_sneaky(c: Cmd) { self.n = c.v; }
+}
+group ops = { Ops };
+group core = { Core };
+main locus App {
+    params { o: Ops = Ops { }; c: Core = Core { }; }
+    claims { boundary: only edges ops -> core { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let mut model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Violated
+    );
+    model.relations.subscribes.clear();
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Holds,
+        "the judgment reads relations.subscribes"
     );
 }
 

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -2126,3 +2126,62 @@ fn main() { App { }; }
         "the literal wire address is not the topic"
     );
 }
+
+/// Review pin (round 8): a set-level PUBLISHES hole poisons the
+/// boundary — an unknown publisher may create an ungranted edge —
+/// while a known crossing still proves Violated.
+#[test]
+fn publisher_hole_fails_only_edges_closed() {
+    let src = r#"
+type Cmd { v: Int = 0; }
+topic Sig { payload: Cmd; subject: "app.sig"; }
+locus Ops {
+    params { n: Int = 0; }
+    bus { publish Sig; }
+    fn act() { Sig <- Cmd { }; }
+}
+locus Core {
+    params { n: Int = 0; }
+    fn idle() { }
+}
+group ops = { Ops };
+group core = { Core };
+main locus App {
+    params { o: Ops = Ops { }; c: Core = Core { }; }
+    claims { boundary: only edges ops -> core { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let mut model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Holds
+    );
+    let sid = model
+        .entities
+        .subjects
+        .iter()
+        .position(|su| su.pattern == "app.sig")
+        .expect("subject");
+    model.holes.push(hale_model::Hole {
+        at: hale_model::EntityRef::Subject(hale_model::SubjectId(
+            sid as u32,
+        )),
+        kind: hale_model::HoleKind::DynamicEndpoint,
+        hides: hale_model::RelationSet::PUBLISHES,
+        authored_site: None,
+        reason: "publisher set incomplete".to_string(),
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Uncertified,
+        "an unknown publisher may create an ungranted edge"
+    );
+}

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -350,6 +350,9 @@ fn main() {
         judged[0].verdict,
         hale_types::verdict::Verdict::Violated,
         "the alloc happens inside the stdlib body"
+    );
+}
+
 /// Negative control (5b): the boundary judgment reads the
 /// subscribe relation — clearing it removes the un-granted bus
 /// edge and flips the verdict.
@@ -392,6 +395,52 @@ fn main() { App { }; }
         judged[0].verdict,
         hale_types::verdict::Verdict::Holds,
         "the judgment reads relations.subscribes"
+    );
+}
+
+/// Review pin (5b): an indirect call BEFORE a boundary-crossing
+/// call refuses at its authored position — only the Uncertified
+/// diagnostic, never violation-then-refusal.
+#[test]
+fn hole_before_crossing_refuses_first() {
+    let src = r#"
+fn leak(v: Int) -> Int { return v; }
+locus A {
+    params { n: Int = 0; }
+    fn go(f: fn (Int) -> Int, v: Int) -> Int {
+        let x = f(v);
+        return leak(x);
+    }
+}
+group a_side = { A };
+group b_side = { leak };
+main locus App {
+    params { a: A = A { }; }
+    claims { boundary: only edges a_side -> b_side { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let out = diff_one(src, "hole before crossing");
+    assert!(out.is_ok(), "old/new agree: {:?}", out);
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Uncertified
+    );
+    assert_eq!(
+        judged[0].diags.len(),
+        1,
+        "only the refusal — no violation before it: {:?}",
+        judged[0]
+            .diags
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
     );
 }
 

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -1895,3 +1895,63 @@ fn main() { App { }; }
         "unknown subscribers must fail the boundary closed"
     );
 }
+
+/// Review pin (round 4): the boundary check applies the delivery
+/// predicate to subscriber holes — a wildcard hole at `audit.**`
+/// covers a publish to `audit.event`.
+#[test]
+fn wildcard_subscriber_hole_fails_only_edges_closed() {
+    let src = r#"
+type Cmd { v: Int = 0; }
+topic Ev { payload: Cmd; subject: "audit.event"; }
+locus Ops {
+    params { n: Int = 0; }
+    bus { publish Ev; }
+    fn act() { Ev <- Cmd { }; }
+}
+locus Core {
+    params { n: Int = 0; }
+    fn idle() { }
+}
+group ops = { Ops };
+group core = { Core };
+main locus App {
+    params { o: Ops = Ops { }; c: Core = Core { }; }
+    claims { boundary: only edges ops -> core { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let mut model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Holds
+    );
+    model.entities.subjects.push(hale_model::Subject {
+        pattern: "audit.**".to_string(),
+        exact: false,
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let wild = (model.entities.subjects.len() - 1) as u32;
+    model.holes.push(hale_model::Hole {
+        at: hale_model::EntityRef::Subject(hale_model::SubjectId(
+            wild,
+        )),
+        kind: hale_model::HoleKind::UnanalyzedBody,
+        hides: hale_model::RelationSet::SUBSCRIBES,
+        authored_site: None,
+        reason: "subscriber set incomplete".to_string(),
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Uncertified,
+        "`audit.**` may cover `audit.event` — the boundary must \
+         fail closed"
+    );
+}

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -1955,3 +1955,61 @@ fn main() { App { }; }
          fail closed"
     );
 }
+
+/// Review pin (round 5): topic-grain holes reach the boundary
+/// check identically to subject-grain ones.
+#[test]
+fn topic_grain_subscriber_hole_fails_only_edges_closed() {
+    let src = r#"
+type Cmd { v: Int = 0; }
+topic Sneaky { payload: Cmd; subject: "app.sneaky"; }
+locus Ops {
+    params { n: Int = 0; }
+    bus { publish Sneaky; }
+    fn act() { Sneaky <- Cmd { }; }
+}
+locus Core {
+    params { n: Int = 0; }
+    fn idle() { }
+}
+group ops = { Ops };
+group core = { Core };
+main locus App {
+    params { o: Ops = Ops { }; c: Core = Core { }; }
+    claims { boundary: only edges ops -> core { }; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let mut model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Holds
+    );
+    let tid = model
+        .entities
+        .topics
+        .iter()
+        .position(|t| t.name == "Sneaky")
+        .expect("topic");
+    model.holes.push(hale_model::Hole {
+        at: hale_model::EntityRef::Topic(hale_model::TopicId(
+            tid as u32,
+        )),
+        kind: hale_model::HoleKind::UnanalyzedBody,
+        hides: hale_model::RelationSet::SUBSCRIBES,
+        authored_site: None,
+        reason: "subscriber set incomplete".to_string(),
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let judged = judge_only_edges(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Uncertified,
+        "a topic-grain hole must reach the boundary check"
+    );
+}

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -1882,7 +1882,7 @@ fn main() { App { }; }
         at: hale_model::EntityRef::Subject(hale_model::SubjectId(
             sid as u32,
         )),
-        kind: hale_model::HoleKind::UnanalyzedBody,
+        kind: hale_model::HoleKind::DynamicEndpoint,
         hides: hale_model::RelationSet::SUBSCRIBES,
         authored_site: None,
         reason: "subscriber set incomplete".to_string(),
@@ -1941,7 +1941,7 @@ fn main() { App { }; }
         at: hale_model::EntityRef::Subject(hale_model::SubjectId(
             wild,
         )),
-        kind: hale_model::HoleKind::UnanalyzedBody,
+        kind: hale_model::HoleKind::DynamicEndpoint,
         hides: hale_model::RelationSet::SUBSCRIBES,
         authored_site: None,
         reason: "subscriber set incomplete".to_string(),
@@ -2000,7 +2000,7 @@ fn main() { App { }; }
         at: hale_model::EntityRef::Topic(hale_model::TopicId(
             tid as u32,
         )),
-        kind: hale_model::HoleKind::UnanalyzedBody,
+        kind: hale_model::HoleKind::DynamicEndpoint,
         hides: hale_model::RelationSet::SUBSCRIBES,
         authored_site: None,
         reason: "subscriber set incomplete".to_string(),
@@ -2060,7 +2060,7 @@ fn main() { App { }; }
         at: hale_model::EntityRef::Subject(hale_model::SubjectId(
             sid as u32,
         )),
-        kind: hale_model::HoleKind::UnanalyzedBody,
+        kind: hale_model::HoleKind::DynamicEndpoint,
         hides: hale_model::RelationSet::SUBSCRIBES,
         authored_site: None,
         reason: "subscriber set incomplete".to_string(),
@@ -2113,7 +2113,7 @@ fn main() { App { }; }
         at: hale_model::EntityRef::Topic(hale_model::TopicId(
             tid as u32,
         )),
-        kind: hale_model::HoleKind::UnanalyzedBody,
+        kind: hale_model::HoleKind::DynamicEndpoint,
         hides: hale_model::RelationSet::SUBSCRIBES,
         authored_site: None,
         reason: "subscriber set incomplete".to_string(),


### PR DESCRIPTION
Change 5b of the canonical-model epic (#476), stacked on #483 (5a): the `only edges` family migrated onto `ClaimIr` × `ApplicationModel` with the same bar — diagnostics parity, the shared corpus differential, negative controls. The old evaluator stays authoritative until Change 9.

## What ships

- **`judgment::judge_only_edges`** — direct-edge law, no walk. Call edges from the source group into the destination group are never grantable (violation pair: claim line + crossing-call span). Bus edges match grants by subject text, with delivery joined on the subscription's **canonical spelling** — topic name for declared subscriptions, authored pattern for literal/wildcard ones, exact-or-wildcard-covering — exactly the graph keying the evaluator's `subscribers_of` iterates. Fail-closed holes (this family's spellings carry no "reachable from"), projection vacuity, unknown-group validation, per-edge dedup, granted-list rendering, and the `FnKey` iteration order (free fns first, then methods by locus) are all ported byte-exact.
- **A latent 5a fix the differential surfaced**: the reachability fan-out also now joins on canonical spelling with wildcard covering — a `subscribe "log.**"` delivery appears in `forbid reaches` witnesses, as the evaluator has always seen it.

## The gate

The 5a corpus differential now judges **both families** and merges rows by ordinal before comparing against the evaluator's outcomes and diagnostic stream — one permanent gate per migration wave, extended per family as the epic prescribes. Two divergences were surfaced and retired on the way: wildcard subscription coverage and the wire-subject-vs-canonical-spelling join.

Negative control: clearing `relations.subscribes` flips a Violated boundary claim to Holds.

1261/1261 across the three crates; fmt clean; no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)