### PR TITLE
feat(judgment): the endpoint/coverage/count family on the canonical model — Change 5c (GH #476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ behavior.
 
 ## Unreleased
 
+### The endpoint/coverage/count judgment - family 5c (GH #476 Change 5c)
+
+`judgment::judge_endpoints` - `require publishes/subscribes`
+(declared-end existence over `declares_publish` and the
+subscription rows, joined by canonical spelling), `require sealed`
+(universal over group loci with the empty-projection vacuity
+refusal), `require attributed` (the direct-site predicate computed
+by the evaluator's own extracted rule into new model facts
+`Function.attribution` + `Function.opaque_call`; the opaque-call
+Uncertified fallback included), `cover` (seed topic domain via
+`declared_in`), and `count` (distinct declared-end loci with the
+full who-list rendering). Validation ports: unknown topics with
+did-you-mean, unresolvable import paths, non-attributable classes,
+topicless seeds. Adoption-collision diagnostics from the clause
+enumeration surface as lowering issues at the head of the
+diagnostic stream, exactly where the evaluator emits them. Same
+corpus differential; negative control drops declares_publish.
+
 ### The boundary-grant judgment - family 5b (GH #476 Change 5b)
 
 `judgment::judge_only_edges` - the `only edges` family on the

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -49,6 +49,13 @@ pub struct Function {
     /// classified leaf would match, making the sink set nearly
     /// vacuous (GH #476 Change 5a).
     pub direct_effects: Vec<String>,
+    /// Built-in classes for which this fn PERFORMS a direct site
+    /// (`require attributed`'s predicate, computed by the
+    /// evaluator's own rule). Sorted.
+    pub attribution: Vec<String>,
+    /// Has an unresolved call that is not a frontier path — the
+    /// `require attributed` opaque fallback (GH #476 Change 5c).
+    pub opaque_call: bool,
     pub provenance: ProvenanceId,
 }
 

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -56,6 +56,12 @@ pub struct Function {
     /// Has an unresolved call that is not a frontier path — the
     /// `require attributed` opaque fallback (GH #476 Change 5c).
     pub opaque_call: bool,
+    /// The author wrote `@effects(is: { <user class> })` on this fn
+    /// — AUTHORED classification, distinct from the expanded label
+    /// set (a composed class labels its atomic members, but the
+    /// purpose the author supplied is the composed NAME; review:
+    /// composed attribution classes).
+    pub carries_user_class: bool,
     pub provenance: ProvenanceId,
 }
 

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -72,6 +72,7 @@ fn tiny_model() -> ApplicationModel {
                     direct_effects: Vec::new(),
                     attribution: Vec::new(),
                     opaque_call: false,
+                    carries_user_class: false,
                     provenance: p,
                 },
                 Function {
@@ -82,6 +83,7 @@ fn tiny_model() -> ApplicationModel {
                     direct_effects: Vec::new(),
                     attribution: Vec::new(),
                     opaque_call: false,
+                    carries_user_class: false,
                     provenance: p,
                 },
             ],

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -70,6 +70,8 @@ fn tiny_model() -> ApplicationModel {
                     kind: FunctionKind::Hook,
                     effects: vec!["publish".to_string()],
                     direct_effects: Vec::new(),
+                    attribution: Vec::new(),
+                    opaque_call: false,
                     provenance: p,
                 },
                 Function {
@@ -78,6 +80,8 @@ fn tiny_model() -> ApplicationModel {
                     kind: FunctionKind::Method,
                     effects: vec![],
                     direct_effects: Vec::new(),
+                    attribution: Vec::new(),
+                    opaque_call: false,
                     provenance: p,
                 },
             ],

--- a/crates/hale-types/src/claims.rs
+++ b/crates/hale-types/src/claims.rs
@@ -2474,7 +2474,7 @@ fn evaluate_require_sealed(
 ///
 /// Validation and evaluation share this so a form the evaluator would
 /// answer with unconditional success can never be accepted.
-fn attributed_mask(
+pub(crate) fn attributed_mask(
     name: &str,
 ) -> Option<crate::stdlib_surface::EffectSet> {
     use crate::stdlib_surface::EffectSet;
@@ -2488,6 +2488,67 @@ fn attributed_mask(
         "alloc" => EffectSet::ALLOC,
         "secret_use" => EffectSet::SECRET_USE,
         _ => return None,
+    })
+}
+
+
+/// The `require attributed` DIRECT-site predicate, extracted so the
+/// model builder computes `Function.attribution` with the SAME rule
+/// (GH #476 Change 5c) — one definition, never approximated.
+pub(crate) fn performs_directly_for(
+    summary: &AllocSummary,
+    model: &crate::model::Model,
+    ffi: &BTreeSet<String>,
+    key: &FnKey,
+    fs: &crate::alloc_summary::FnSummary,
+    mask: crate::stdlib_surface::EffectSet,
+) -> bool {
+    use crate::stdlib_surface::EffectSet;
+    let direct_ffi = mask == EffectSet::SYSCALL
+        && key.locus.is_none()
+        && ffi.contains(&key.fn_name);
+    let directly_classified = summary
+        .carries
+        .get(key)
+        .map_or(false, |eff| eff.contains(mask));
+    direct_ffi
+        || directly_classified
+        || fs.calls.iter().any(|e| match &e.callee {
+            Callee::Unresolved(name) => {
+                let segs: Vec<&str> = name.split("::").collect();
+                crate::stdlib_surface::effects_for(&segs)
+                    .map_or(false, |eff| eff.contains(mask))
+            }
+            Callee::Resolved(callee) => {
+                if model.is_bundle_fn(callee) {
+                    return false;
+                }
+                crate::frontier::infer_effects(summary, callee, ffi)
+                    .contains(mask)
+            }
+        })
+        || (mask == EffectSet::ALLOC && !fs.sites.is_empty())
+        || (mask == EffectSet::PUBLISH
+            && fs.effect_sites.iter().any(|s| {
+                matches!(
+                    s.kind,
+                    crate::alloc_summary::EffectSiteKind::Publish(_)
+                )
+            }))
+}
+
+/// The `require attributed` opaque-call predicate (an unresolved
+/// callee that is not a frontier path), shared with the model
+/// builder for `Function.opaque_call`.
+pub(crate) fn has_opaque_unresolved(
+    fs: &crate::alloc_summary::FnSummary,
+) -> bool {
+    fs.calls.iter().any(|e| match &e.callee {
+        Callee::Unresolved(n) => {
+            let segs: Vec<&str> = n.split("::").collect();
+            crate::stdlib_surface::effects_for(&segs).is_none()
+        }
+        Callee::Resolved(_) => false,
     })
 }
 
@@ -2536,60 +2597,14 @@ fn evaluate_require_attributed(
         // secret_use at once. The declaration is application-owned
         // and can carry the purpose itself, which keeps ordinary
         // callers ordinary and attribution direct.
-        let direct_ffi = mask == EffectSet::SYSCALL
-            && key.locus.is_none()
-            && cx.ffi.contains(&key.fn_name);
-        // A fn that DECLARES it carries the class is a direct site by
-        // definition. Without this, `@effects(is: { secret_use }) fn
-        // sign(…)` — the whole shape the secrets architecture rests
-        // on — was invisible to `require attributed(all secret_use)`,
-        // because it calls nothing classified and allocates nothing.
-        // A built-in in `is:` establishes that the operation exists;
-        // it still is not its purpose, so a user class is required.
-        let directly_classified = cx
-            .summary
-            .carries
-            .get(key)
-            .map_or(false, |eff| eff.contains(mask));
-        let performs_directly = direct_ffi
-            || directly_classified
-            || fs.calls.iter().any(|e| match &e.callee {
-            Callee::Unresolved(name) => {
-                let segs: Vec<&str> = name.split("::").collect();
-                crate::stdlib_surface::effects_for(&segs)
-                    .map_or(false, |eff| eff.contains(mask))
-            }
-            Callee::Resolved(callee) => {
-                // A resolved BUNDLE fn is judged on its own row —
-                // that is what keeps attribution direct rather than
-                // transitive.
-                //
-                // A resolved callee the author does not own is a
-                // different case, and treating it like a bundle fn
-                // was a hole: `@ffi` declarations and Hale-source
-                // stdlib bodies both resolve, so
-                // `self.logger.info(m)` crossed a publish boundary
-                // and nothing owed a purpose, while the same
-                // operation written as a path call did. Attribution
-                // has to attach to the first APPLICATION-OWNED fn
-                // crossing out, or it depends on whether an API
-                // happens to be a frontier path or a Hale-source
-                // wrapper — not a stable boundary.
-                if cx.model.is_bundle_fn(callee) {
-                    return false;
-                }
-                crate::frontier::infer_effects(
-                    &cx.summary,
-                    callee,
-                    &cx.ffi,
-                )
-                .contains(mask)
-            }
-        }) || (mask == EffectSet::ALLOC && !fs.sites.is_empty())
-            || (mask == EffectSet::PUBLISH
-            && fs.effect_sites.iter().any(|s| {
-                matches!(s.kind, crate::alloc_summary::EffectSiteKind::Publish(_))
-            }));
+        let performs_directly = performs_directly_for(
+            &cx.summary,
+            &cx.model,
+            &cx.ffi,
+            key,
+            fs,
+            mask,
+        );
         if !performs_directly {
             continue;
         }
@@ -2617,16 +2632,7 @@ fn evaluate_require_attributed(
             .filter(|(key, _)| cx.model.is_bundle_fn(key))
             .filter(|(key, fs)| {
                 !fn_carries_a_user_class(key, cx)
-                    && fs.calls.iter().any(|e| match &e.callee {
-                        Callee::Unresolved(n) => {
-                            // A frontier path is classified, so it is
-                            // not a hole; anything else unresolved is.
-                            let segs: Vec<&str> = n.split("::").collect();
-                            crate::stdlib_surface::effects_for(&segs)
-                                .is_none()
-                        }
-                        Callee::Resolved(_) => false,
-                    })
+                    && has_opaque_unresolved(fs)
             })
             .map(|(key, _)| match &key.locus {
                 Some(l) => format!("{}::{}", l, key.fn_name),

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -2254,6 +2254,68 @@ pub fn judge_endpoints(
             None => (0, String::new(), raw.to_string()),
         }
     };
+    // Relation-aware endpoint holes (review round 4): PUBLISHES,
+    // SUBSCRIBES, and CARDINALITY are independently hideable at
+    // subject and topic grain, and a relevant hole means the known
+    // endpoint rows are a LOWER BOUND, never a proved absence.
+    // Monotone cases stay decidable: a known witness still proves
+    // an existential, and enough known rows still prove `>=`.
+    let subject_hole_pats: Vec<(String, hale_model::RelationSet)> =
+        model
+            .holes
+            .iter()
+            .filter_map(|h| match h.at {
+                EntityRef::Subject(sid) => Some((
+                    e.subjects[sid.index()].pattern.clone(),
+                    h.hides,
+                )),
+                _ => None,
+            })
+            .collect();
+    let topic_holes: BTreeMap<u32, hale_model::RelationSet> = {
+        let mut m: BTreeMap<u32, hale_model::RelationSet> =
+            BTreeMap::new();
+        for h in &model.holes {
+            if let EntityRef::Topic(t) = h.at {
+                let e2 = m
+                    .entry(t.0)
+                    .or_insert(hale_model::RelationSet(0));
+                *e2 = e2.union(h.hides);
+            }
+        }
+        m
+    };
+    let topic_by_name: BTreeMap<&str, u32> = e
+        .topics
+        .iter()
+        .enumerate()
+        .map(|(i, t)| (t.name.as_str(), i as u32))
+        .collect();
+    let endpoint_unknown = |topic_raw: &str, publishers: bool| {
+        let fam = if publishers {
+            hale_model::RelationSet::PUBLISHES
+        } else {
+            hale_model::RelationSet::SUBSCRIBES
+        };
+        let mask = fam.union(hale_model::RelationSet::CARDINALITY);
+        if topic_by_name
+            .get(topic_raw)
+            .and_then(|t| topic_holes.get(t))
+            .is_some_and(|m| m.intersects(mask))
+        {
+            return true;
+        }
+        let mut texts: Vec<&str> = vec![topic_raw];
+        if let Some(t) = topic_by_name.get(topic_raw) {
+            texts.push(
+                e.subjects
+                    [e.topics[*t as usize].subject.index()]
+                .pattern
+                .as_str(),
+            );
+        }
+        subject_hole_covers(&subject_hole_pats, mask, &texts)
+    };
 
     let mut out = Vec::new();
     for row in &table.rows {
@@ -2358,9 +2420,40 @@ pub fn judge_endpoints(
                     loci.iter().any(|l| g_loci.contains(l))
                 });
                 if hit {
+                    // A known witness proves the existential even
+                    // when the endpoint set is incomplete.
                     out.push(Judged {
                         ordinal: row.ordinal,
                         verdict: Verdict::Holds,
+                        diags,
+                    });
+                    continue;
+                }
+                if endpoint_unknown(&topic.name.raw, *publishers) {
+                    diags.push(Diag::ty(
+                        row_span,
+                        format!(
+                            "claim `{}` cannot be certified: the {} \
+                             set of `{}` is not fully modeled — a \
+                             member of `{}` may {} it",
+                            row.name,
+                            if *publishers {
+                                "publisher"
+                            } else {
+                                "subscriber"
+                            },
+                            topic.name.display,
+                            group.name.display,
+                            if *publishers {
+                                "publish"
+                            } else {
+                                "subscribe to"
+                            }
+                        ),
+                    ));
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Uncertified,
                         diags,
                     });
                     continue;
@@ -2619,6 +2712,7 @@ pub fn judge_endpoints(
                 let g_loci = group_loci(group.group.unwrap());
                 let mut uncovered: Vec<(String, String)> =
                     Vec::new();
+                let mut unknown: Vec<String> = Vec::new();
                 let mut tids: Vec<u32> =
                     seed_topics[seed.name.as_str()].clone();
                 tids.sort_by_key(|t| {
@@ -2632,11 +2726,42 @@ pub fn judge_endpoints(
                             loci.iter().any(|l| g_loci.contains(l))
                         });
                     if !covered {
-                        uncovered.push((
-                            topic.name.clone(),
-                            topic.display.clone(),
-                        ));
+                        // An apparently-uncovered topic whose
+                        // subscriber set is incomplete cannot prove
+                        // the violation (round 4) — but neither can
+                        // it prove coverage.
+                        if endpoint_unknown(&topic.name, false) {
+                            unknown.push(topic.display.clone());
+                        } else {
+                            uncovered.push((
+                                topic.name.clone(),
+                                topic.display.clone(),
+                            ));
+                        }
                     }
+                }
+                if uncovered.is_empty() && !unknown.is_empty() {
+                    diags.push(Diag::ty(
+                        row_span,
+                        format!(
+                            "claim `{}` cannot be certified: the \
+                             subscriber set of {} is not fully \
+                             modeled, so coverage cannot be decided \
+                             from the known rows",
+                            row.name,
+                            unknown
+                                .iter()
+                                .map(|d| format!("`{}`", d))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ),
+                    ));
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Uncertified,
+                        diags,
+                    });
+                    continue;
                 }
                 if uncovered.is_empty() {
                     out.push(Judged {
@@ -2702,11 +2827,53 @@ pub fn judge_endpoints(
                     })
                     .unwrap_or_default();
                 let actual = loci.len() as u64;
+                let unknown =
+                    endpoint_unknown(&topic.name.raw, *publishers);
                 let holds = match cmp {
                     hale_model::CountCmpIr::Eq => actual == *n,
                     hale_model::CountCmpIr::Le => actual <= *n,
                     hale_model::CountCmpIr::Ge => actual >= *n,
                 };
+                if unknown {
+                    // The known rows are a LOWER BOUND (round 4):
+                    // `>=` can still hold from enough known rows,
+                    // and a lower bound already over an upper
+                    // bound still violates — everything else is
+                    // undecidable from an incomplete set.
+                    let lower_bound_decides = match cmp {
+                        hale_model::CountCmpIr::Ge => actual >= *n,
+                        hale_model::CountCmpIr::Le
+                        | hale_model::CountCmpIr::Eq => {
+                            actual > *n
+                        }
+                    };
+                    if !lower_bound_decides {
+                        diags.push(Diag::ty(
+                            row_span,
+                            format!(
+                                "claim `{}` cannot be certified: \
+                                 the {} set of `{}` is not fully \
+                                 modeled — {} known {} a lower \
+                                 bound, not a count",
+                                row.name,
+                                if *publishers {
+                                    "publisher"
+                                } else {
+                                    "subscriber"
+                                },
+                                topic.name.display,
+                                actual,
+                                if actual == 1 { "is" } else { "are" }
+                            ),
+                        ));
+                        out.push(Judged {
+                            ordinal: row.ordinal,
+                            verdict: Verdict::Uncertified,
+                            diags,
+                        });
+                        continue;
+                    }
+                }
                 if holds {
                     out.push(Judged {
                         ordinal: row.ordinal,

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -2496,12 +2496,34 @@ pub fn judge_endpoints(
                     .map(|(_, f)| f.display.clone())
                     .collect();
                 if unattributed.is_empty() {
+                    // A fn whose EFFECTS the model declares hidden
+                    // (an unanalyzed body) may perform the class
+                    // without an authored purpose — same unknown as
+                    // an opaque call, same fallback (review round
+                    // 2: `require attributed` must consult holes,
+                    // not only Function.opaque_call).
+                    let effects_holed: BTreeSet<FunctionId> = model
+                        .holes
+                        .iter()
+                        .filter(|h| {
+                            h.hides.intersects(
+                                hale_model::RelationSet::EFFECTS,
+                            )
+                        })
+                        .filter_map(|h| match h.at {
+                            EntityRef::Function(f) => Some(f),
+                            _ => None,
+                        })
+                        .collect();
                     let mut opaque: Vec<String> = e
                         .functions
                         .iter()
                         .enumerate()
                         .filter(|(i, f)| {
-                            f.opaque_call
+                            (f.opaque_call
+                                || effects_holed.contains(
+                                    &FunctionId(*i as u32),
+                                ))
                                 && !carries_user.contains(
                                     &FunctionId(*i as u32),
                                 )

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -2274,16 +2274,18 @@ pub fn judge_endpoints(
             hale_model::RelationSet::SUBSCRIBES
         };
         let mask = fam.union(hale_model::RelationSet::CARDINALITY);
-        let mut texts: Vec<&str> = vec![topic_raw];
-        if let Some(t) = topic_by_name.get(topic_raw) {
-            texts.push(
-                e.subjects
-                    [e.topics[*t as usize].subject.index()]
+        // TYPED projection (round 6): the claim names a declared
+        // topic — its TopicId matches topic-grain holes, and its
+        // WIRE pattern (never its name) is what subject-grain
+        // holes cover. A subject hole whose pattern merely equals
+        // the topic's NAME is a different wire identity.
+        let topic = topic_by_name.get(topic_raw).copied();
+        let wire = topic.map(|t| {
+            e.subjects[e.topics[t as usize].subject.index()]
                 .pattern
-                .as_str(),
-            );
-        }
-        bus_holes.blocks(mask, &texts)
+                .as_str()
+        });
+        bus_holes.blocks(mask, topic, wire)
     };
 
     let mut out = Vec::new();

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -2167,3 +2167,575 @@ pub fn judge_only_edges(
     }
     out
 }
+
+/// Judge the endpoint/coverage/count family (GH #476 Change 5c):
+/// `require publishes/subscribes`, `require sealed`,
+/// `require attributed`, `cover`, and `count` rows.
+pub fn judge_endpoints(
+    table: &ClaimIrTable,
+    model: &ApplicationModel,
+    source_bases: &[u32],
+) -> Vec<Judged> {
+    let e = &model.entities;
+    let r = &model.relations;
+    let claim_span = |pid: ProvenanceId| -> Span {
+        span_of(&table.provenance, source_bases, pid)
+    };
+    // Group decl-grain projections.
+    let group_loci = |g: GroupId| -> BTreeSet<u32> {
+        r.group_members
+            .iter()
+            .filter(|gm| gm.group == g)
+            .filter_map(|gm| match gm.member {
+                EntityRef::LocusDecl(l) => Some(l.0),
+                _ => None,
+            })
+            .collect()
+    };
+    let locus_of: BTreeMap<FunctionId, u32> = r
+        .member_of
+        .iter()
+        .map(|mo| (mo.function, mo.locus.0))
+        .collect();
+    // Canonical-spelling endpoint maps: publisher loci come from
+    // DECLARED ends (`bus { publish T; }` — the graph's publisher
+    // rows), subscriber loci from subscription rows.
+    let mut publishers_at: BTreeMap<&str, BTreeSet<u32>> =
+        BTreeMap::new();
+    for dp in &r.declares_publish {
+        let key = match dp.declared_topic {
+            Some(t) => e.topics[t.index()].name.as_str(),
+            None => e.subjects[dp.subject.index()].pattern.as_str(),
+        };
+        publishers_at.entry(key).or_default().insert(dp.locus.0);
+    }
+    let mut subscribers_at: BTreeMap<&str, BTreeSet<u32>> =
+        BTreeMap::new();
+    for su in &r.subscribes {
+        let key = match su.declared_topic {
+            Some(t) => e.topics[t.index()].name.as_str(),
+            None => e.subjects[su.subject.index()].pattern.as_str(),
+        };
+        if let Some(l) = locus_of.get(&su.handler) {
+            subscribers_at.entry(key).or_default().insert(*l);
+        }
+    }
+    // The declared-topic name universe (validation) + seed topics.
+    let topic_names: BTreeSet<&str> =
+        e.topics.iter().map(|t| t.name.as_str()).collect();
+    let mut seed_topics: BTreeMap<&str, Vec<u32>> = BTreeMap::new();
+    for di in &r.declared_in {
+        if let EntityRef::Topic(t) = di.entity {
+            seed_topics
+                .entry(e.seeds[di.seed.index()].name.as_str())
+                .or_default()
+                .push(t.0);
+        }
+    }
+    // User-class carriers: a labels row whose class is not builtin.
+    let carries_user: BTreeSet<FunctionId> = model
+        .labels
+        .iter()
+        .filter_map(|l| match l.at {
+            EntityRef::Function(f)
+                if !hale_model::is_builtin_effect_class(&l.label) =>
+            {
+                Some(f)
+            }
+            _ => None,
+        })
+        .collect();
+    let fn_raw = |f: FunctionId| e.functions[f.index()].name.clone();
+    let fn_disp =
+        |f: FunctionId| e.functions[f.index()].display.clone();
+    let fnkey_order = |raw: &str| -> (u8, String, String) {
+        match raw.rsplit_once("::") {
+            Some((l, m)) => (1, l.to_string(), m.to_string()),
+            None => (0, String::new(), raw.to_string()),
+        }
+    };
+
+    let mut out = Vec::new();
+    for row in &table.rows {
+        let mut diags: Vec<Diag> = Vec::new();
+        let row_span = claim_span(row.provenance);
+        // Shared validation helpers over ClaimIr refs.
+        let group_decl_names: Vec<&str> =
+            e.groups.iter().map(|g| g.display.as_str()).collect();
+        let check_group = |gref: &hale_model::GroupRef,
+                           diags: &mut Vec<Diag>|
+         -> bool {
+            if gref.group.is_some() {
+                return true;
+            }
+            let mut near: Vec<&&str> = group_decl_names
+                .iter()
+                .filter(|g| {
+                    crate::effects::close(g, &gref.name.display)
+                })
+                .collect();
+            near.sort();
+            let hint = match near.first() {
+                Some(n) => format!(" Did you mean `{}`?", n),
+                None => String::new(),
+            };
+            diags.push(Diag::ty(
+                claim_span(gref.provenance),
+                format!(
+                    "claim `{}` names group `{}`, which is never declared. \
+                     Add `group {} = {{ … }};` at the top level.{}",
+                    row.name,
+                    gref.name.display,
+                    gref.name.display,
+                    hint
+                ),
+            ));
+            false
+        };
+        let check_topic = |t: &hale_model::TopicIrRef,
+                           diags: &mut Vec<Diag>|
+         -> bool {
+            if !t.name.raw.contains("::")
+                && topic_names.contains(t.name.raw.as_str())
+            {
+                return true;
+            }
+            if t.name.raw.contains("::") {
+                diags.push(Diag::ty(
+                    claim_span(t.provenance),
+                    format!(
+                        "claim `{}`: topic reference `{}` does not \
+                         resolve — no imported topic matches this \
+                         path. Unknown names are errors, never empty \
+                         sets",
+                        row.name, t.name.display
+                    ),
+                ));
+                return false;
+            }
+            let mut near: Vec<&&str> = topic_names
+                .iter()
+                .filter(|n| crate::effects::close(n, &t.name.raw))
+                .collect();
+            near.sort();
+            let hint = match near.first() {
+                Some(n) => format!(" Did you mean `{}`?", n),
+                None => String::new(),
+            };
+            diags.push(Diag::ty(
+                claim_span(t.provenance),
+                format!(
+                    "claim `{}` names topic `{}`, which is never \
+                     declared.{}",
+                    row.name, t.name.raw, hint
+                ),
+            ));
+            false
+        };
+        match &row.law {
+            ClaimIr::RequireEndpoint {
+                publishers,
+                group,
+                topic,
+            } => {
+                let mut ok = check_group(group, &mut diags);
+                ok &= check_topic(topic, &mut diags);
+                if !ok {
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Invalid,
+                        diags,
+                    });
+                    continue;
+                }
+                let g_loci = group_loci(group.group.unwrap());
+                let ends = if *publishers {
+                    publishers_at.get(topic.name.raw.as_str())
+                } else {
+                    subscribers_at.get(topic.name.raw.as_str())
+                };
+                let hit = ends.is_some_and(|loci| {
+                    loci.iter().any(|l| g_loci.contains(l))
+                });
+                if hit {
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Holds,
+                        diags,
+                    });
+                    continue;
+                }
+                diags.push(Diag::ty(
+                    row_span,
+                    format!(
+                        "claim `{}` violated: no member of `{}` {} `{}`",
+                        row.name,
+                        group.name.display,
+                        if *publishers {
+                            "publishes"
+                        } else {
+                            "subscribes"
+                        },
+                        topic.name.display
+                    ),
+                ));
+                out.push(Judged {
+                    ordinal: row.ordinal,
+                    verdict: Verdict::Violated,
+                    diags,
+                });
+            }
+            ClaimIr::RequireSealed { group } => {
+                if !check_group(group, &mut diags) {
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Invalid,
+                        diags,
+                    });
+                    continue;
+                }
+                let g_loci = group_loci(group.group.unwrap());
+                if g_loci.is_empty() {
+                    diags.push(Diag::ty(
+                        row_span,
+                        format!(
+                            "claim `{}`: group `{}` contains no loci, so \
+                             `require sealed` would quantify over an empty set and \
+                             hold while confining nothing. Sealing is a property of \
+                             loci — name a group of them.",
+                            row.name, group.name.display
+                        ),
+                    ));
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Invalid,
+                        diags,
+                    });
+                    continue;
+                }
+                // Raw-sorted, display-rendered — the evaluator lists
+                // raw names and demangles the whole message after.
+                let mut unsealed: Vec<(String, String)> = g_loci
+                    .iter()
+                    .map(|l| &e.loci[*l as usize])
+                    .filter(|l| !l.sealed)
+                    .map(|l| (l.name.clone(), l.display.clone()))
+                    .collect();
+                unsealed.sort();
+                if unsealed.is_empty() {
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Holds,
+                        diags,
+                    });
+                    continue;
+                }
+                let one = unsealed.len() == 1;
+                diags.push(Diag::ty(
+                    row_span,
+                    format!(
+                        "claim `{}` violated: {} in `{}` {} not `@sealed`, so {} \
+                         state is readable by anything holding {} — {}",
+                        row.name,
+                        if one { "a locus" } else { "loci" },
+                        group.name.display,
+                        if one { "is" } else { "are" },
+                        if one { "its" } else { "their" },
+                        if one { "it" } else { "them" },
+                        unsealed
+                            .iter()
+                            .map(|(_, d)| d.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ),
+                ));
+                out.push(Judged {
+                    ordinal: row.ordinal,
+                    verdict: Verdict::Violated,
+                    diags,
+                });
+            }
+            ClaimIr::RequireAttributed { class } => {
+                if crate::claims::attributed_mask(&class.name)
+                    .is_none()
+                {
+                    diags.push(Diag::ty(
+                        claim_span(class.provenance),
+                        format!(
+                            "claim `{}`: `require attributed` takes a \
+                             built-in class with countable DIRECT sites — \
+                             `syscall`, `block`, `publish`, `time`, \
+                             `entropy`, `env`, `alloc`, `secret_use`. `{}` \
+                             is not one of those: a user class would be \
+                             trivially true, and `ffi` / `spawn` / \
+                             `recursion` are structural properties with no \
+                             site to attribute.",
+                            row.name, class.name
+                        ),
+                    ));
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Invalid,
+                        diags,
+                    });
+                    continue;
+                }
+                let mut unattributed: Vec<String> = e
+                    .functions
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, f)| {
+                        f.attribution
+                            .iter()
+                            .any(|c| *c == class.name)
+                    })
+                    .filter(|(i, _)| {
+                        !carries_user
+                            .contains(&FunctionId(*i as u32))
+                    })
+                    .map(|(_, f)| f.display.clone())
+                    .collect();
+                if unattributed.is_empty() {
+                    let mut opaque: Vec<String> = e
+                        .functions
+                        .iter()
+                        .enumerate()
+                        .filter(|(i, f)| {
+                            f.opaque_call
+                                && !carries_user.contains(
+                                    &FunctionId(*i as u32),
+                                )
+                        })
+                        .map(|(_, f)| f.display.clone())
+                        .collect();
+                    if !opaque.is_empty() {
+                        opaque.sort();
+                        diags.push(Diag::ty(
+                            row_span,
+                            format!(
+                                "claim `{}` uncertified: {} an indirect or opaque \
+                                 call whose target this check cannot resolve, and \
+                                 names no purpose of its own — so whether a `{}` \
+                                 boundary is crossed there is unknown. Classify \
+                                 the caller (`@effects(is: {{...}})`) or bind the \
+                                 callee so it resolves: {}",
+                                row.name,
+                                if opaque.len() == 1 {
+                                    "a fn makes"
+                                } else {
+                                    "fns make"
+                                },
+                                class.name,
+                                opaque.join(", ")
+                            ),
+                        ));
+                        out.push(Judged {
+                            ordinal: row.ordinal,
+                            verdict: Verdict::Uncertified,
+                            diags,
+                        });
+                        continue;
+                    }
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Holds,
+                        diags,
+                    });
+                    continue;
+                }
+                unattributed.sort();
+                diags.push(Diag::ty(
+                    row_span,
+                    format!(
+                        "claim `{}` violated: {} `{}` with no declared purpose — \
+                         classify {} (`@effects(is: {{...}})`) with a user effect \
+                         class so the operation is attributable: {}",
+                        row.name,
+                        if unattributed.len() == 1 {
+                            "a fn performs"
+                        } else {
+                            "fns perform"
+                        },
+                        class.name,
+                        if unattributed.len() == 1 {
+                            "it"
+                        } else {
+                            "them"
+                        },
+                        unattributed.join(", ")
+                    ),
+                ));
+                out.push(Judged {
+                    ordinal: row.ordinal,
+                    verdict: Verdict::Violated,
+                    diags,
+                });
+            }
+            ClaimIr::Cover { seed, group } => {
+                let mut ok = check_group(group, &mut diags);
+                if !seed_topics.contains_key(seed.name.as_str()) {
+                    diags.push(Diag::ty(
+                        claim_span(seed.provenance),
+                        format!(
+                            "claim `{}`: `seed({})` names no import alias \
+                             with declared topics — the coverage domain \
+                             would be empty, and a universal over an \
+                             empty domain holds vacuously",
+                            row.name, seed.name
+                        ),
+                    ));
+                    ok = false;
+                }
+                if !ok {
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Invalid,
+                        diags,
+                    });
+                    continue;
+                }
+                let g_loci = group_loci(group.group.unwrap());
+                let mut uncovered: Vec<(String, String)> =
+                    Vec::new();
+                let mut tids: Vec<u32> =
+                    seed_topics[seed.name.as_str()].clone();
+                tids.sort_by_key(|t| {
+                    e.topics[*t as usize].name.clone()
+                });
+                for t in tids {
+                    let topic = &e.topics[t as usize];
+                    let covered = subscribers_at
+                        .get(topic.name.as_str())
+                        .is_some_and(|loci| {
+                            loci.iter().any(|l| g_loci.contains(l))
+                        });
+                    if !covered {
+                        uncovered.push((
+                            topic.name.clone(),
+                            topic.display.clone(),
+                        ));
+                    }
+                }
+                if uncovered.is_empty() {
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Holds,
+                        diags,
+                    });
+                    continue;
+                }
+                let list = uncovered
+                    .iter()
+                    .map(|(_, d)| format!("`{}`", d))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                diags.push(Diag::ty(
+                    row_span,
+                    format!(
+                        "claim `{}` violated: {} topic(s) declared in seed `{}` \
+                         have no subscriber in `{}`: {}",
+                        row.name,
+                        uncovered.len(),
+                        seed.name,
+                        group.name.display,
+                        list
+                    ),
+                ));
+                out.push(Judged {
+                    ordinal: row.ordinal,
+                    verdict: Verdict::Violated,
+                    diags,
+                });
+            }
+            ClaimIr::Count {
+                publishers,
+                topic,
+                cmp,
+                n,
+            } => {
+                if !check_topic(topic, &mut diags) {
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Invalid,
+                        diags,
+                    });
+                    continue;
+                }
+                let ends = if *publishers {
+                    publishers_at.get(topic.name.raw.as_str())
+                } else {
+                    subscribers_at.get(topic.name.raw.as_str())
+                };
+                let loci: Vec<(String, String)> = ends
+                    .map(|set| {
+                        let mut v: Vec<(String, String)> = set
+                            .iter()
+                            .map(|l| {
+                                let ld = &e.loci[*l as usize];
+                                (ld.name.clone(), ld.display.clone())
+                            })
+                            .collect();
+                        v.sort();
+                        v
+                    })
+                    .unwrap_or_default();
+                let actual = loci.len() as u64;
+                let holds = match cmp {
+                    hale_model::CountCmpIr::Eq => actual == *n,
+                    hale_model::CountCmpIr::Le => actual <= *n,
+                    hale_model::CountCmpIr::Ge => actual >= *n,
+                };
+                if holds {
+                    out.push(Judged {
+                        ordinal: row.ordinal,
+                        verdict: Verdict::Holds,
+                        diags,
+                    });
+                    continue;
+                }
+                let who = if loci.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        " ({})",
+                        loci.iter()
+                            .map(|(_, d)| format!("`{}`", d))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                };
+                let cmp_str = match cmp {
+                    hale_model::CountCmpIr::Eq => "==",
+                    hale_model::CountCmpIr::Le => "<=",
+                    hale_model::CountCmpIr::Ge => ">=",
+                };
+                diags.push(Diag::ty(
+                    row_span,
+                    format!(
+                        "claim `{}` violated: counted {} {}{} of `{}`, claim \
+                         requires {} {}",
+                        row.name,
+                        actual,
+                        if *publishers {
+                            "publisher(s)"
+                        } else {
+                            "subscriber(s)"
+                        },
+                        who,
+                        topic.name.display,
+                        cmp_str,
+                        n
+                    ),
+                ));
+                out.push(Judged {
+                    ordinal: row.ordinal,
+                    verdict: Verdict::Violated,
+                    diags,
+                });
+            }
+            _ => continue,
+        }
+        let _ = (&fn_raw, &fn_disp, &fnkey_order);
+    }
+    out
+}

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -2260,31 +2260,7 @@ pub fn judge_endpoints(
     // endpoint rows are a LOWER BOUND, never a proved absence.
     // Monotone cases stay decidable: a known witness still proves
     // an existential, and enough known rows still prove `>=`.
-    let subject_hole_pats: Vec<(String, hale_model::RelationSet)> =
-        model
-            .holes
-            .iter()
-            .filter_map(|h| match h.at {
-                EntityRef::Subject(sid) => Some((
-                    e.subjects[sid.index()].pattern.clone(),
-                    h.hides,
-                )),
-                _ => None,
-            })
-            .collect();
-    let topic_holes: BTreeMap<u32, hale_model::RelationSet> = {
-        let mut m: BTreeMap<u32, hale_model::RelationSet> =
-            BTreeMap::new();
-        for h in &model.holes {
-            if let EntityRef::Topic(t) = h.at {
-                let e2 = m
-                    .entry(t.0)
-                    .or_insert(hale_model::RelationSet(0));
-                *e2 = e2.union(h.hides);
-            }
-        }
-        m
-    };
+    let bus_holes = BusHoles::build(model);
     let topic_by_name: BTreeMap<&str, u32> = e
         .topics
         .iter()
@@ -2298,13 +2274,6 @@ pub fn judge_endpoints(
             hale_model::RelationSet::SUBSCRIBES
         };
         let mask = fam.union(hale_model::RelationSet::CARDINALITY);
-        if topic_by_name
-            .get(topic_raw)
-            .and_then(|t| topic_holes.get(t))
-            .is_some_and(|m| m.intersects(mask))
-        {
-            return true;
-        }
         let mut texts: Vec<&str> = vec![topic_raw];
         if let Some(t) = topic_by_name.get(topic_raw) {
             texts.push(
@@ -2314,7 +2283,7 @@ pub fn judge_endpoints(
                 .as_str(),
             );
         }
-        subject_hole_covers(&subject_hole_pats, mask, &texts)
+        bus_holes.blocks(mask, &texts)
     };
 
     let mut out = Vec::new();

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -2232,18 +2232,18 @@ pub fn judge_endpoints(
                 .push(t.0);
         }
     }
-    // User-class carriers: a labels row whose class is not builtin.
-    let carries_user: BTreeSet<FunctionId> = model
-        .labels
+    // AUTHORED user-class carriage — the labels table holds the
+    // EXPANDED class set (a composed `effect io = {syscall, block}`
+    // labels its atoms), but `require attributed` asks whether the
+    // author wrote a user class, composed or atomic
+    // (Function.carries_user_class, computed by the evaluator's own
+    // fns_carrying_a_user_class).
+    let carries_user: BTreeSet<FunctionId> = e
+        .functions
         .iter()
-        .filter_map(|l| match l.at {
-            EntityRef::Function(f)
-                if !hale_model::is_builtin_effect_class(&l.label) =>
-            {
-                Some(f)
-            }
-            _ => None,
-        })
+        .enumerate()
+        .filter(|(_, f)| f.carries_user_class)
+        .map(|(i, _)| FunctionId(i as u32))
         .collect();
     let fn_raw = |f: FunctionId| e.functions[f.index()].name.clone();
     let fn_disp =

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -2007,6 +2007,40 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             derived_effects.insert(fn_name(k), classes);
         }
     }
+    let mut attribution: BTreeMap<String, Vec<String>> =
+        BTreeMap::new();
+    let mut opaque_calls: BTreeSet<String> = BTreeSet::new();
+    for (k, fs) in &merged.fns {
+        if !user_key(k) || !vmodel.is_bundle_fn(k) {
+            continue;
+        }
+        let mut classes: Vec<String> = Vec::new();
+        for name in [
+            "syscall",
+            "block",
+            "publish",
+            "time",
+            "entropy",
+            "env",
+            "alloc",
+            "secret_use",
+        ] {
+            let mask = crate::claims::attributed_mask(name)
+                .expect("builtin mask");
+            if crate::claims::performs_directly_for(
+                &merged, &vmodel, &ffi, k, fs, mask,
+            ) {
+                classes.push(name.to_string());
+            }
+        }
+        classes.sort();
+        if !classes.is_empty() {
+            attribution.insert(fn_name(k), classes);
+        }
+        if crate::claims::has_opaque_unresolved(fs) {
+            opaque_calls.insert(fn_name(k));
+        }
+    }
     for k in summary.fns.keys() {
         if !user_key(k) {
             continue;
@@ -2036,6 +2070,11 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 .get(n)
                 .cloned()
                 .unwrap_or_default(),
+            attribution: attribution
+                .get(n)
+                .cloned()
+                .unwrap_or_default(),
+            opaque_call: opaque_calls.contains(n),
             provenance: pid,
         });
     }

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -2007,6 +2007,11 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             derived_effects.insert(fn_name(k), classes);
         }
     }
+    let authored_user_class: BTreeSet<String> =
+        crate::effects::fns_carrying_a_user_class(&programs)
+            .into_iter()
+            .map(|k| fn_name(&k))
+            .collect();
     let mut attribution: BTreeMap<String, Vec<String>> =
         BTreeMap::new();
     let mut opaque_calls: BTreeSet<String> = BTreeSet::new();
@@ -2075,6 +2080,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 .cloned()
                 .unwrap_or_default(),
             opaque_call: opaque_calls.contains(n),
+            carries_user_class: authored_user_class.contains(n),
             provenance: pid,
         });
     }

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -451,23 +451,6 @@ group b_side = { leak };
 main locus App {
     params { a: A = A { }; }
     claims { boundary: only edges a_side -> b_side { }; }
-/// Negative control (5c): the endpoint judgment reads DECLARED
-/// publisher ends — clearing declares_publish flips a holding
-/// `require publishes` to Violated.
-#[test]
-fn dropping_declared_ends_changes_the_require_verdict() {
-    let src = r#"
-type T { n: Int = 0; }
-topic Orders { payload: T; subject: "orders"; }
-locus Gw {
-    params { n: Int = 0; }
-    bus { publish Orders; }
-    fn send(v: Int) { Orders <- T { }; }
-}
-group gws = { Gw };
-main locus App {
-    params { g: Gw = Gw { }; }
-    claims { writer: require publishes(some gws, topic Orders); }
     run() { println(1); }
 }
 fn main() { App { }; }
@@ -492,6 +475,30 @@ fn main() { App { }; }
             .iter()
             .map(|d| &d.message)
             .collect::<Vec<_>>()
+    );
+}
+
+/// Negative control (5c): the endpoint judgment reads DECLARED
+/// publisher ends — clearing declares_publish flips a holding
+/// `require publishes` to Violated.
+#[test]
+fn dropping_declared_ends_changes_the_require_verdict() {
+    let src = r#"
+type T { n: Int = 0; }
+topic Orders { payload: T; subject: "orders"; }
+locus Gw {
+    params { n: Int = 0; }
+    bus { publish Orders; }
+    fn send(v: Int) { Orders <- T { }; }
+}
+group gws = { Gw };
+main locus App {
+    params { g: Gw = Gw { }; }
+    claims { writer: require publishes(some gws, topic Orders); }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
     let program = hale_syntax::parse_source(src).expect("parse");
     let bundle = bundle_of(src, &program);
     let mut model = derive_application_model(&bundle);
@@ -504,6 +511,43 @@ fn main() { App { }; }
         judged[0].verdict,
         hale_types::verdict::Verdict::Violated,
         "the judgment reads relations.declares_publish"
+    );
+}
+
+/// Review pin (5c): a COMPOSED user class in `@effects(is:)` is
+/// authored purpose — the expanded label set (its atoms) must not
+/// hide it from `require attributed`.
+#[test]
+fn composed_class_counts_as_authored_attribution() {
+    let src = r#"
+effect io = { syscall, alloc };
+type Buf { n: Int = 0; }
+@effects(is: { io })
+fn make(v: Int) -> Int { let b = Buf { }; return v; }
+main locus App {
+    claims { tagged: require attributed(all alloc); }
+    run() { println(make(1)); }
+}
+fn main() { App { }; }
+"#;
+    let out = diff_one(src, "composed attribution");
+    assert!(out.is_ok(), "old/new agree: {:?}", out);
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_endpoints(&table, &model, &[0]);
+    // `main`/`run` alloc without purpose — the claim violates, but
+    // `make` (authored composed purpose) must NOT be in the list.
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Violated
+    );
+    let msg = &judged[0].diags[0].message;
+    assert!(
+        !msg.contains("make"),
+        "the composed `io` IS an authored purpose: {}",
+        msg
     );
 }
 

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -13,7 +13,9 @@ use std::collections::BTreeMap;
 
 use hale_model::ClaimIr;
 use hale_types::claim_lowering::lower_claims;
-use hale_types::judgment::{judge_forbid_reaches, judge_only_edges};
+use hale_types::judgment::{
+    judge_endpoints, judge_forbid_reaches, judge_only_edges,
+};
 use hale_types::model_builder::derive_application_model;
 use hale_types::symbol::SourceFile;
 use hale_types::Bundle;
@@ -49,6 +51,11 @@ fn family_names(
                 r.law,
                 ClaimIr::ForbidReaches { .. }
                     | ClaimIr::OnlyEdges { .. }
+                    | ClaimIr::RequireEndpoint { .. }
+                    | ClaimIr::RequireSealed { .. }
+                    | ClaimIr::RequireAttributed { .. }
+                    | ClaimIr::Cover { .. }
+                    | ClaimIr::Count { .. }
             )
         })
         .map(|r| r.name.clone())
@@ -85,9 +92,11 @@ fn diff_one(
     let (pre_diags, judged_fr) =
         judge_forbid_reaches(&table, &model, &[0]);
     let judged_oe = judge_only_edges(&table, &model, &[0]);
+    let judged_ep = judge_endpoints(&table, &model, &[0]);
     let mut judged: Vec<hale_types::judgment::Judged> = judged_fr
         .into_iter()
         .chain(judged_oe.into_iter())
+        .chain(judged_ep.into_iter())
         .collect();
     judged.sort_by_key(|j| j.ordinal);
     // Verdict parity, matched by claim name.
@@ -126,10 +135,35 @@ fn diff_one(
         })
         .map(|d| (d.message.clone(), d.span))
         .collect();
-    let new_family: Vec<(String, hale_syntax::Span)> = pre_diags
+    // The evaluator's stream: enumeration diagnostics first (the
+    // lowering preserves them as table ISSUES), then the dup
+    // pre-pass, then per-row validation+evaluation.
+    let issue_span = |pid: hale_model::ProvenanceId| {
+        match table.provenance.records.get(pid.index()) {
+            Some(hale_model::Provenance::Source { span, .. }) => {
+                hale_syntax::Span::new(
+                    span.0 as usize,
+                    span.1 as usize,
+                )
+            }
+            _ => hale_syntax::Span::new(0, 0),
+        }
+    };
+    let new_family: Vec<(String, hale_syntax::Span)> = table
+        .issues
         .iter()
-        .chain(judged.iter().flat_map(|j| j.diags.iter()))
-        .map(|d| (d.message.clone(), d.span))
+        .filter(|i| {
+            names.iter().any(|n| {
+                i.message.contains(&format!("claim `{}`", n))
+            })
+        })
+        .map(|i| (i.message.clone(), issue_span(i.provenance)))
+        .chain(
+            pre_diags
+                .iter()
+                .chain(judged.iter().flat_map(|j| j.diags.iter()))
+                .map(|d| (d.message.clone(), d.span)),
+        )
         .collect();
     if old_family != new_family {
         let first = old_family
@@ -417,6 +451,23 @@ group b_side = { leak };
 main locus App {
     params { a: A = A { }; }
     claims { boundary: only edges a_side -> b_side { }; }
+/// Negative control (5c): the endpoint judgment reads DECLARED
+/// publisher ends — clearing declares_publish flips a holding
+/// `require publishes` to Violated.
+#[test]
+fn dropping_declared_ends_changes_the_require_verdict() {
+    let src = r#"
+type T { n: Int = 0; }
+topic Orders { payload: T; subject: "orders"; }
+locus Gw {
+    params { n: Int = 0; }
+    bus { publish Orders; }
+    fn send(v: Int) { Orders <- T { }; }
+}
+group gws = { Gw };
+main locus App {
+    params { g: Gw = Gw { }; }
+    claims { writer: require publishes(some gws, topic Orders); }
     run() { println(1); }
 }
 fn main() { App { }; }
@@ -441,6 +492,18 @@ fn main() { App { }; }
             .iter()
             .map(|d| &d.message)
             .collect::<Vec<_>>()
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let mut model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_endpoints(&table, &model, &[0]);
+    assert_eq!(judged[0].verdict, hale_types::verdict::Verdict::Holds);
+    model.relations.declares_publish.clear();
+    let judged = judge_endpoints(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Violated,
+        "the judgment reads relations.declares_publish"
     );
 }
 

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -2436,7 +2436,7 @@ fn main() { App { }; }
         at: hale_model::EntityRef::Subject(hale_model::SubjectId(
             sid as u32,
         )),
-        kind: hale_model::HoleKind::UnanalyzedBody,
+        kind: hale_model::HoleKind::DynamicEndpoint,
         hides: hale_model::RelationSet::SUBSCRIBES
             .union(hale_model::RelationSet::CARDINALITY),
         authored_site: None,
@@ -2460,7 +2460,7 @@ fn main() { App { }; }
         at: hale_model::EntityRef::Subject(hale_model::SubjectId(
             sid as u32,
         )),
-        kind: hale_model::HoleKind::UnanalyzedBody,
+        kind: hale_model::HoleKind::DynamicEndpoint,
         hides: hale_model::RelationSet::PUBLISHES,
         authored_site: None,
         reason: "publisher set incomplete".to_string(),
@@ -2531,7 +2531,7 @@ fn main() { App { }; }
         at: hale_model::EntityRef::Subject(hale_model::SubjectId(
             sid as u32,
         )),
-        kind: hale_model::HoleKind::UnanalyzedBody,
+        kind: hale_model::HoleKind::DynamicEndpoint,
         hides: hale_model::RelationSet::SUBSCRIBES,
         authored_site: None,
         reason: "subscriber set incomplete".to_string(),
@@ -2587,7 +2587,7 @@ fn main() { App { }; }
         at: hale_model::EntityRef::Subject(hale_model::SubjectId(
             collider,
         )),
-        kind: hale_model::HoleKind::UnanalyzedBody,
+        kind: hale_model::HoleKind::DynamicEndpoint,
         hides: hale_model::RelationSet::SUBSCRIBES,
         authored_site: None,
         reason: "subscriber set incomplete".to_string(),
@@ -2611,7 +2611,7 @@ fn main() { App { }; }
         at: hale_model::EntityRef::Subject(hale_model::SubjectId(
             real as u32,
         )),
-        kind: hale_model::HoleKind::UnanalyzedBody,
+        kind: hale_model::HoleKind::DynamicEndpoint,
         hides: hale_model::RelationSet::SUBSCRIBES,
         authored_site: None,
         reason: "subscriber set incomplete".to_string(),

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -108,6 +108,10 @@ fn diff_one(
             .collect();
     let by_ordinal: BTreeMap<u32, &hale_model::ClaimRow> =
         table.rows.iter().map(|r| (r.ordinal, r)).collect();
+    // Rows under the documented 5c divergence: their (new-only)
+    // diagnostics are excluded from the byte comparison too.
+    let mut carved_out: std::collections::BTreeSet<u32> =
+        std::collections::BTreeSet::new();
     for j in &judged {
         let row = by_ordinal[&j.ordinal];
         let Some(old) = old_verdicts.get(row.name.as_str()) else {
@@ -116,7 +120,23 @@ fn diff_one(
                 origin, row.name
             ));
         };
-        if **old != j.verdict {
+        // Documented divergence (5c round 2): the evaluator never
+        // sees unanalyzed bodies (module fns, on_failure hooks), so
+        // `require attributed` fail-opens to Holds where the model
+        // records an EFFECTS-hiding hole and the judgment refuses.
+        let attributed_hole_carveout = matches!(
+            row.law,
+            ClaimIr::RequireAttributed { .. }
+        ) && **old == hale_types::verdict::Verdict::Holds
+            && j.verdict == hale_types::verdict::Verdict::Uncertified
+            && model.holes.iter().any(|h| {
+                h.hides
+                    .intersects(hale_model::RelationSet::EFFECTS)
+            });
+        if attributed_hole_carveout {
+            carved_out.insert(j.ordinal);
+        }
+        if **old != j.verdict && !attributed_hole_carveout {
             return Err(format!(
                 "{}: claim `{}` verdict diverges: old {:?}, new {:?}",
                 origin, row.name, old, j.verdict
@@ -161,7 +181,12 @@ fn diff_one(
         .chain(
             pre_diags
                 .iter()
-                .chain(judged.iter().flat_map(|j| j.diags.iter()))
+                .chain(
+                    judged
+                        .iter()
+                        .filter(|j| !carved_out.contains(&j.ordinal))
+                        .flat_map(|j| j.diags.iter()),
+                )
                 .map(|d| (d.message.clone(), d.span)),
         )
         .collect();
@@ -2290,5 +2315,59 @@ fn main() { App { }; }
         judged[0].verdict,
         hale_types::verdict::Verdict::Uncertified,
         "an unknown publisher may create an ungranted edge"
+    );
+}
+
+/// Review pin (round 2): `require attributed` consults the model's
+/// HOLES, not only `Function.opaque_call` — an on_failure handler
+/// enters the universe with an UnanalyzedBody hole hiding EFFECTS,
+/// so it may perform the class without an authored purpose and the
+/// claim must be Uncertified, never a fail-open Holds.
+#[test]
+fn attributed_fails_closed_on_unanalyzed_bodies() {
+    let held = r#"
+main locus App {
+    params { n: Int = 0; }
+    claims { tagged: require attributed(all syscall); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(held).expect("parse");
+    let bundle = bundle_of(held, &program);
+    let model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_endpoints(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Holds,
+        "nothing is unattributed or unanalyzed"
+    );
+    let src = r#"
+type Violation { code: Int = 0; }
+locus Sup {
+    params { n: Int = 0; }
+    on_failure(e: Violation) { }
+}
+main locus App {
+    params { s: Sup = Sup { }; }
+    claims { tagged: require attributed(all syscall); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let model = derive_application_model(&bundle);
+    assert!(
+        model.holes.iter().any(|h| h
+            .hides
+            .intersects(hale_model::RelationSet::EFFECTS)),
+        "the on_failure body arrives as an EFFECTS-hiding hole"
+    );
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_endpoints(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Uncertified,
+        "an unanalyzed application-owned body blocks certification"
     );
 }

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -2544,3 +2544,83 @@ fn main() { App { }; }
         "an incomplete subscriber set cannot prove the violation"
     );
 }
+
+/// Review pin (round 6): endpoint counts use TYPED identity — a
+/// subject hole whose wire pattern merely equals the topic's NAME
+/// does not make the topic's count incomplete (the topic's wire is
+/// different), while a hole at the topic's REAL wire still does.
+#[test]
+fn literal_collision_subject_hole_does_not_block_topic_count() {
+    let src = r#"
+type Cmd { v: Int = 0; }
+topic Orders { payload: Cmd; subject: "wire.orders"; }
+locus Pub {
+    params { n: Int = 0; }
+    bus { publish Orders; }
+    fn act() { Orders <- Cmd { }; }
+}
+main locus App {
+    params { p: Pub = Pub { }; }
+    claims { none_yet: count subscribers(topic Orders) <= 0; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let mut model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_endpoints(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Holds
+    );
+    // A subject whose WIRE ADDRESS text happens to be "Orders" —
+    // not the topic's wire subject "wire.orders".
+    model.entities.subjects.push(hale_model::Subject {
+        pattern: "Orders".to_string(),
+        exact: true,
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let collider = (model.entities.subjects.len() - 1) as u32;
+    model.holes.push(hale_model::Hole {
+        at: hale_model::EntityRef::Subject(hale_model::SubjectId(
+            collider,
+        )),
+        kind: hale_model::HoleKind::UnanalyzedBody,
+        hides: hale_model::RelationSet::SUBSCRIBES,
+        authored_site: None,
+        reason: "subscriber set incomplete".to_string(),
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let judged = judge_endpoints(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Holds,
+        "the literal wire address `Orders` is not topic Orders' \
+         wire — its hole must not touch the topic's count"
+    );
+    // Control: a hole at the topic's REAL wire flips it.
+    let real = model
+        .entities
+        .subjects
+        .iter()
+        .position(|su| su.pattern == "wire.orders")
+        .expect("real wire");
+    model.holes.push(hale_model::Hole {
+        at: hale_model::EntityRef::Subject(hale_model::SubjectId(
+            real as u32,
+        )),
+        kind: hale_model::HoleKind::UnanalyzedBody,
+        hides: hale_model::RelationSet::SUBSCRIBES,
+        authored_site: None,
+        reason: "subscriber set incomplete".to_string(),
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let judged = judge_endpoints(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Uncertified,
+        "the topic's real wire subject IS its delivery identity"
+    );
+}

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -2371,3 +2371,176 @@ fn main() { App { }; }
         "an unanalyzed application-owned body blocks certification"
     );
 }
+
+/// Review pin (round 4): endpoint/count judgments consult
+/// PUBLISHES/SUBSCRIBES/CARDINALITY holes — known rows are a lower
+/// bound, never a proved absence, with monotone cases preserved.
+#[test]
+fn count_and_require_fail_closed_on_endpoint_holes() {
+    let src = r#"
+type Cmd { v: Int = 0; }
+topic T { payload: Cmd; subject: "app.t"; }
+locus Pub {
+    params { n: Int = 0; }
+    bus { publish T; }
+    fn act() { T <- Cmd { }; }
+}
+group pubs = { Pub };
+main locus App {
+    params { p: Pub = Pub { }; }
+    claims {
+        none_yet: count subscribers(topic T) <= 0;
+        one_pub: count publishers(topic T) >= 1;
+        someone: require subscribes(some pubs, topic T);
+    }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let mut model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let by_name = |judged: &[hale_types::judgment::Judged],
+                   name: &str|
+     -> hale_types::verdict::Verdict {
+        let row = table
+            .rows
+            .iter()
+            .find(|r| r.name == name)
+            .expect("row");
+        judged
+            .iter()
+            .find(|j| j.ordinal == row.ordinal)
+            .expect("judged")
+            .verdict
+    };
+    let judged = judge_endpoints(&table, &model, &[0]);
+    assert_eq!(
+        by_name(&judged, "none_yet"),
+        hale_types::verdict::Verdict::Holds
+    );
+    assert_eq!(
+        by_name(&judged, "someone"),
+        hale_types::verdict::Verdict::Violated
+    );
+    // The reviewer's shape: a hole at T's subject hiding
+    // SUBSCRIBES | CARDINALITY.
+    let sid = model
+        .entities
+        .subjects
+        .iter()
+        .position(|su| su.pattern == "app.t")
+        .expect("subject");
+    model.holes.push(hale_model::Hole {
+        at: hale_model::EntityRef::Subject(hale_model::SubjectId(
+            sid as u32,
+        )),
+        kind: hale_model::HoleKind::UnanalyzedBody,
+        hides: hale_model::RelationSet::SUBSCRIBES
+            .union(hale_model::RelationSet::CARDINALITY),
+        authored_site: None,
+        reason: "subscriber set incomplete".to_string(),
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let judged = judge_endpoints(&table, &model, &[0]);
+    assert_eq!(
+        by_name(&judged, "none_yet"),
+        hale_types::verdict::Verdict::Uncertified,
+        "count <= 0 cannot hold from an incomplete set"
+    );
+    assert_eq!(
+        by_name(&judged, "someone"),
+        hale_types::verdict::Verdict::Uncertified,
+        "an absent witness plus a relevant hole is not a violation"
+    );
+    // Monotone preserved: a known publisher still proves `>= 1`
+    // even when the publisher set is ALSO marked incomplete.
+    model.holes.push(hale_model::Hole {
+        at: hale_model::EntityRef::Subject(hale_model::SubjectId(
+            sid as u32,
+        )),
+        kind: hale_model::HoleKind::UnanalyzedBody,
+        hides: hale_model::RelationSet::PUBLISHES,
+        authored_site: None,
+        reason: "publisher set incomplete".to_string(),
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let judged = judge_endpoints(&table, &model, &[0]);
+    assert_eq!(
+        by_name(&judged, "one_pub"),
+        hale_types::verdict::Verdict::Holds,
+        "enough known rows still prove a lower bound"
+    );
+}
+
+/// …and `cover`: an apparently-uncovered topic with an incomplete
+/// subscriber set is Uncertified, while a concretely uncovered
+/// topic still proves the violation.
+#[test]
+fn cover_fails_closed_on_subscriber_holes() {
+    let lib = r#"
+type __lib_x_kv_Item { n: Int = 0; }
+topic __lib_x_kv_Changed { payload: __lib_x_kv_Item; subject: "kv.changed"; }
+"#;
+    let main_src = r#"
+locus Reader {
+    params { n: Int = 0; }
+    fn idle() { }
+}
+group readers = { Reader };
+main locus App {
+    params { r: Reader = Reader { }; }
+    claims { covered: cover topic in seed(kv): subscribed_by(some readers); }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let main_p =
+        hale_syntax::parse_source(main_src).expect("parse main");
+    let lib_p = hale_syntax::parse_source(lib).expect("parse lib");
+    let mut programs = BTreeMap::new();
+    programs.insert("app/main.hl".to_string(), &main_p);
+    programs.insert("lib/kv.hl".to_string(), &lib_p);
+    let mut bundle = Bundle::new(programs);
+    bundle.import_renames = vec![
+        (
+            vec!["kv".to_string(), "Item".to_string()],
+            "__lib_x_kv_Item".to_string(),
+        ),
+        (
+            vec!["kv".to_string(), "Changed".to_string()],
+            "__lib_x_kv_Changed".to_string(),
+        ),
+    ];
+    let mut model = derive_application_model(&bundle);
+    let table = lower_claims(&bundle, &model);
+    let judged = judge_endpoints(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Violated,
+        "concretely uncovered"
+    );
+    let sid = model
+        .entities
+        .subjects
+        .iter()
+        .position(|su| su.pattern == "kv.changed")
+        .expect("subject");
+    model.holes.push(hale_model::Hole {
+        at: hale_model::EntityRef::Subject(hale_model::SubjectId(
+            sid as u32,
+        )),
+        kind: hale_model::HoleKind::UnanalyzedBody,
+        hides: hale_model::RelationSet::SUBSCRIBES,
+        authored_site: None,
+        reason: "subscriber set incomplete".to_string(),
+        provenance: hale_model::ProvenanceId(0),
+    });
+    let judged = judge_endpoints(&table, &model, &[0]);
+    assert_eq!(
+        judged[0].verdict,
+        hale_types::verdict::Verdict::Uncertified,
+        "an incomplete subscriber set cannot prove the violation"
+    );
+}

--- a/crates/hale-types/tests/topology_projection.rs
+++ b/crates/hale-types/tests/topology_projection.rs
@@ -524,6 +524,8 @@ fn labels_and_effects_are_restricted_to_the_v1_universe() {
         kind: FunctionKind::Free,
         effects: effects.into_iter().map(String::from).collect(),
         direct_effects: Vec::new(),
+        attribution: Vec::new(),
+        opaque_call: false,
         provenance: p,
     };
     let mut m = ApplicationModel {

--- a/crates/hale-types/tests/topology_projection.rs
+++ b/crates/hale-types/tests/topology_projection.rs
@@ -526,6 +526,7 @@ fn labels_and_effects_are_restricted_to_the_v1_universe() {
         direct_effects: Vec::new(),
         attribution: Vec::new(),
         opaque_call: false,
+        carries_user_class: false,
         provenance: p,
     };
     let mut m = ApplicationModel {


### PR DESCRIPTION
Change 5c of the canonical-model epic (#476), stacked on #484 (5b): `require publishes/subscribes`, `require sealed`, `require attributed`, `cover`, and `count` migrated onto `ClaimIr` × `ApplicationModel` — same bar, same shared corpus differential, negative controls. Old evaluators stay authoritative until Change 9.

## What ships

- **`judgment::judge_endpoints`** — all five forms with the evaluator's exact spellings: declared-end existence joined by canonical spelling at the locus-decl grain; the sealed universal with its vacuity refusal; the attribution law with its opaque-call Uncertified fallback; seed coverage over `declared_in`; distinct-loci counting with the who-list rendering. Validation ports include unknown-topic did-you-mean, unresolvable import paths, non-attributable classes (validation and evaluation share the predicate, as the evaluator insists), and topicless seeds.
- **Two new model facts, computed by extracted evaluator rules**: `Function.attribution` (the `performs_directly` predicate per built-in class, moved to `claims::performs_directly_for` and *called* by the builder) and `Function.opaque_call` (`has_opaque_unresolved`) — the round-9 doctrine again: when the evaluator owns a rule, extract and call it.
- **Stream completion**: the differential now prepends the lowering's `issues` (adoption-collision diagnostics from the shared clause enumeration, preserved since round 15) to the expected diagnostic stream — the evaluator emits them before any validation, and with 5c families in scope they became observable.

## The gate

The one corpus differential now covers **seven claim forms across three families**, merged by ordinal. One divergence class surfaced and retired this round (the issues-stream position). Negative control: clearing `relations.declares_publish` flips a holding `require publishes` to Violated.

1262/1262 across the three crates; fmt clean; no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)