### PR TITLE
docs: introduction leads general-purpose; Resolver docs match shipped API

### DIFF
--- a/docs/src/everyday/cli-config.md
+++ b/docs/src/everyday/cli-config.md
@@ -33,19 +33,24 @@ if given, else an environment variable, else a built-in default.
 
 ```hale
 fn main() {
-    let cfg = std::cli::Resolver { prefix: "MYAPP" };
+    let cfg = std::cli::Resolver {
+        env_prefix: "MYAPP_",
+        argv_keys:  "host\nport\n",
+    };
 
-    // argv positional "port", else $MYAPP_PORT, else "8080"
-    let port = cfg.get("port", "8080");
+    // argv positional "host", else $MYAPP_HOST, else the default
     let host = cfg.get("host", "127.0.0.1");
+    let port = cfg.get_int("port", 8080);
 
     println("listening on ", host, ":", port);
 }
 ```
 
-The resolver checks the argument, then the prefixed environment
-variable (`MYAPP_PORT`), then the supplied default. Empty values
-fall through to the next layer rather than counting as "set."
+The resolver checks the argument (positions come from `argv_keys`,
+one key per line, first line mapping to argv[1]), then the prefixed
+environment variable (`MYAPP_HOST`), then the supplied default —
+`get` for strings, `get_int` for numbers. Empty values fall through
+to the next layer rather than counting as "set."
 
 ## Interactive terminal I/O
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,9 +1,16 @@
 # Introduction
 
-**A concurrent systems language with a GC-free runtime — typed
+**A general-purpose language with a GC-free native runtime — typed
 message-bus concurrency, data-race-free by design.**
 
 *Write the system, not the lore.*
+
+A complete Hale program can be three lines — a `fn main()` that
+reads an argument and prints. You can write useful Hale — CLI
+tools, file and JSON work, HTTP clients and servers — without
+declaring a lifecycle, a topic, a placement, or a claim. Those
+constructs arrive when the program's growth earns them, and
+nothing you wrote earlier changes when they do.
 
 Most languages pick a level and live there. Python and
 JavaScript sit high — fast to write, far from the metal. Go


### PR DESCRIPTION
Companion to the hale-lang.org repositioning (general-purpose first — hale-lang.org#8 and the homepage PR to follow). Two edits:

1. **introduction.md** — the bold opener becomes *"A general-purpose language with a GC-free native runtime — typed message-bus concurrency, data-race-free by design."*, and a short paragraph after the epigraph states that a three-line `fn main()` is a complete Hale program; CLIs, files, JSON, and HTTP need no locus/topic/placement/claim, and nothing written earlier changes when those arrive. The four-altitudes material below is untouched — this just fronts the on-ramp.

2. **everyday/cli-config.md** — the `std::cli::Resolver { prefix: "MYAPP" }` example doesn't compile: the shipped locus takes `env_prefix` + `argv_keys` (newline-separated positional mapping) with `get`/`get_int`. Found while authoring the site's everyday examples against the real compiler; the doc now matches `crates/hale-stdlib/hl/cli.hl`.

The site syncs `docs/src` at deploy, so both propagate to hale-lang.org/docs on its next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)