### PR TITLE
feat(fleet+artifact): Change 7 — schema 1.12 hashed endpoint identity + typed FleetModel (GH #476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ behavior.
 
 ### Typed FleetModel + the versioned shape transition (GH #476 Change 7)
 
+Fleet composition is TYPED end to end: component artifacts are
+decoded ONCE into a typed ComponentModel (fns, unioned call
+relations, V1 publish/subscribe rows, the topics join surface,
+unknowns, decl provenance, and the hashed endpoint identity)
+immediately after the shared admission - the rest of composition
+never walks generic JSON for a modeled fact (the #476
+architecture canary). Route endpoint checks now read the
+byte-exact hashed wire identity: "declares but never sends" is
+judged from typed site rows, collision-proof.
+
 Schema 1.12: canonical ENDPOINT IDENTITY joins the hashed model
 half (`endpoint_identity`: verb, owner, source-order site
 ordinal, byte-exact wire subject, declared topic). The V1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ behavior.
 
 ### Typed FleetModel + the versioned shape transition (GH #476 Change 7)
 
+Round 3: the typed decode is strict, and keys are unambiguous.
+ComponentModel::decode refuses malformed semantic rows instead of
+filtering them - a number-typed call endpoint or unknown reason
+is an error, never a silently dropped edge or erased residue
+(both pinned against components that genuinely carry the shapes,
+with asserted premises). Duplicate object keys are rejected
+before parsing at both consumption boundaries: serde's last-wins
+map parse would otherwise let a second shape_hash shadow the
+raw-verified one (pinned).
+
 Round 2: route identity is one grain, and the declared identity
 is verified. Route role checks and edge construction both read
 the typed topic-identity endpoint rows (a literal end on the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ behavior.
 
 ### Typed FleetModel + the versioned shape transition (GH #476 Change 7)
 
+Round 2: route identity is one grain, and the declared identity
+is verified. Route role checks and edge construction both read
+the typed topic-identity endpoint rows (a literal end on the same
+wire satisfies neither; wire-grain accessors remain for the fleet
+claims that quantify over wire subjects). verify_shape_hash
+recomputes the model-half hash from the raw artifact at both
+consumption boundaries before any decoding - a coordinated
+hashed+unhashed endpoint edit under a stale shape_hash refuses.
+
 Fleet composition is TYPED end to end: component artifacts are
 decoded ONCE into a typed ComponentModel (fns, unioned call
 relations, V1 publish/subscribe rows, the topics join surface,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ behavior.
 
 ### Typed FleetModel + the versioned shape transition (GH #476 Change 7)
 
+Round 4: the raw admission pass is JSON-semantic and
+path-aware. One structural walk (scan_top_level) drives
+everything: duplicate keys compare DECODED names (an escaped
+spelling cannot smuggle a second shape_hash past the scanner into
+serde's last-wins map), and verify_shape_hash /
+verify_artifact_digest locate their fields at the TOP LEVEL - a
+nested decoy is data, never the verified value (pinned both ways:
+the decoy neither confuses the verifier on an honest artifact nor
+rescues a drifted one).
+
 Round 3: the typed decode is strict, and keys are unambiguous.
 ComponentModel::decode refuses malformed semantic rows instead of
 filtering them - a number-typed call endpoint or unknown reason

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ behavior.
 
 ### Typed FleetModel + the versioned shape transition (GH #476 Change 7)
 
+Round 6: completeness with the polarity of the law. The blanket
+holds->uncertified rule now applies only to the absence-certifying
+families (forbid_reaches/only_edges); require_* witnesses are
+positive facts no incomplete endpoint set can erase, and their
+route-backed failures are definite (the plan's route table is
+complete). Counts evaluate over a [known, known+hidden] interval
+with per-verb relevant flags (publish+cardinality /
+subscribe+cardinality): min met by known rows holds, max/eq
+exceeded by known rows violates, the undecided interval is
+uncertified - including the conjunctive eq/min/max form. The
+claim row is serialized after the final verdict (it previously
+recorded the pre-rewrite result). Track A is capped at exactly
+the current schema; the canonical layout table is versioned by
+it.
+
 Round 5: layout is law, and the completeness account is
 honored. The top-level key sequence is canonical and closed -
 order defines the verified hash ranges, so moving a model-half

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ behavior.
 
 ### Typed FleetModel + the versioned shape transition (GH #476 Change 7)
 
+Round 5: layout is law, and the completeness account is
+honored. The top-level key sequence is canonical and closed -
+order defines the verified hash ranges, so moving a model-half
+section outside the shape_hash interval, introducing an unknown
+top-level key, or demoting artifact_digest from final position
+all refuse (pinned). The typed component decode carries
+capabilities + adequacy, and fleet claims fail closed over
+admitted degradation: a family a component admits as `degraded`
+cannot certify holds through it - `uncertified`, naming the
+instances and withdrawn flags - scoped like the
+unreachable-unknown rule so unrelated degradation does not
+poison unrelated claims (pinned: exact_calls withdrawn, no
+legacy unknowns, reachability prohibition does not hold).
+
 Round 4: the raw admission pass is JSON-semantic and
 path-aware. One structural walk (scan_top_level) drives
 everything: duplicate keys compare DECODED names (an escaped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ behavior.
 
 ## Unreleased
 
+### Typed FleetModel + the versioned shape transition (GH #476 Change 7)
+
+Schema 1.12: canonical ENDPOINT IDENTITY joins the hashed model
+half (`endpoint_identity`: verb, owner, source-order site
+ordinal, byte-exact wire subject, declared topic). The V1
+relations render a topic-covered end and a display-colliding
+literal as one spelling, so the shape could not distinguish two
+systems that talk to different wire addresses - which is exactly
+what the shape exists to distinguish, and what replay admission
+relies on. The unhashed endpoint sections must agree with the
+hashed identity exactly, closing the round-12 substitution
+residual. SHAPE HASHES CHANGE for every bus-carrying program:
+re-record shape baselines and `.halerec` recordings once.
+
+
 ### Typed law artifact rows + adequacy (GH #476 Change 6)
 
 The topology artifact's law rows are now PROJECTED from the

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -1252,6 +1252,19 @@ fn load_artifact(
     // Integrity BEFORE meaning. `shape_hash` is an identity covering
     // the model half only, so it cannot vouch for the `topics` rows a
     // composition joins on; the whole-body digest can.
+    // One unambiguous value per key (round 3, #490): serde's
+    // last-wins map parse must not be able to shadow what the raw
+    // verifiers below check.
+    if let Err(e) =
+        hale_types::topology::scan_top_level(&src)
+    {
+        return Err(format!(
+            "{}: {} — the verified and consumed values could \
+             disagree",
+            p.display(),
+            e
+        ));
+    }
     match hale_types::topology::verify_artifact_digest(&src) {
         Some(true) => {}
         Some(false) => {
@@ -1268,19 +1281,6 @@ fn load_artifact(
                 p.display()
             ))
         }
-    }
-    // One unambiguous value per key (round 3, #490): serde's
-    // last-wins map parse must not be able to shadow what the raw
-    // verifiers below check.
-    if let Some(key) =
-        hale_types::topology::find_duplicate_key(&src)
-    {
-        return Err(format!(
-            "{}: duplicate object key `{}` — the verified and \
-             consumed values could disagree",
-            p.display(),
-            key
-        ));
     }
     // Identity BEFORE meaning too (round 2, #490): the declared
     // shape_hash must recompute from the hashed model half, or the

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -828,6 +828,114 @@ fn evaluate_claims(
             ));
             continue;
         };
+        // Round 5–6 (#490): the component's positive completeness
+        // account is HONORED — with the POLARITY of the law.
+        // `forbid_reaches` / `only_edges` certify an ABSENCE, so
+        // incomplete knowledge in an involved component prevents
+        // the proof (holds → uncertified). The endpoint and count
+        // forms handle completeness INSIDE their evaluators: a
+        // known routed witness is a positive fact no incomplete
+        // set can erase, and counts evaluate over a
+        // [known, known+hidden] interval. The scoping mirrors the
+        // unreachable-unknown rule. Serialized AFTER this final
+        // verdict (round 6: the row previously recorded the
+        // pre-rewrite result).
+        let negative_family = if c.forbid_reaches.is_some() {
+            Some("reachability")
+        } else if c.only_edges.is_some() {
+            Some("boundary")
+        } else {
+            None
+        };
+        let (result, witness) = if let (Some(family), "holds") =
+            (negative_family, result)
+        {
+            let involved = |k: &Component| -> bool {
+                if let Some(fr) = &c.forbid_reaches {
+                    let (Some(src), Some(dst)) = (
+                        groups.get(&fr.from),
+                        groups.get(&fr.to),
+                    ) else {
+                        return true;
+                    };
+                    if src.contains(&k.id)
+                        || dst.contains(&k.id)
+                    {
+                        return true;
+                    }
+                    let masked = fr
+                        .avoiding
+                        .as_ref()
+                        .and_then(|m| groups.get(m))
+                        .cloned()
+                        .unwrap_or_default();
+                    let mine: BTreeSet<String> = k
+                        .model
+                        .fns
+                        .iter()
+                        .map(|n| format!("{}::{}", k.id, n))
+                        .collect();
+                    !matches!(
+                        graph.reaches(
+                            &expand(src),
+                            &mine,
+                            &expand(&masked),
+                        ),
+                        hale_types::model_graph::Reach::None
+                    )
+                } else if let Some(oe) = &c.only_edges {
+                    [&oe.from, &oe.to].iter().any(|g| {
+                        groups
+                            .get(*g)
+                            .is_some_and(|g| g.contains(&k.id))
+                    })
+                } else {
+                    true
+                }
+            };
+            let degraded: Vec<String> = comps
+                .iter()
+                .filter(|k| {
+                    k.model
+                        .adequacy
+                        .get(family)
+                        .map(String::as_str)
+                        == Some("degraded")
+                        && involved(k)
+                })
+                .map(|k| {
+                    let withdrawn: Vec<&str> = k
+                        .model
+                        .capabilities
+                        .iter()
+                        .filter(|(_, on)| !**on)
+                        .map(|(f, _)| f.as_str())
+                        .collect();
+                    format!(
+                        "`{}` (withdraws {})",
+                        k.id,
+                        withdrawn.join(", ")
+                    )
+                })
+                .collect();
+            if degraded.is_empty() {
+                (result, witness)
+            } else {
+                (
+                    "uncertified",
+                    format!(
+                        "cannot certify this absence: \
+                         instance(s) {} carry a degraded `{}` \
+                         adequacy — the required relations are \
+                         not vouched by their own artifacts",
+                        degraded.join(", "),
+                        family
+                    ),
+                )
+            }
+        } else {
+            (result, witness)
+        };
         rows.push(format!(
             "    {{\"name\": {}, \"result\": {}, \"witness\": {}}}",
             q(&c.name),
@@ -839,115 +947,6 @@ fn evaluate_claims(
         // is recorded because the REPAIR differs (resolve the
         // unknown edge vs. fix the program), not because one of them
         // passes.
-        // Round 5 (#490): the component's positive completeness
-        // account is HONORED. An admitted `degraded` family is
-        // the component saying "I cannot support a proof of
-        // absence here" — a fleet claim of that family must not
-        // certify `holds` over it. Violations stand (a witness is
-        // a witness), and the SCOPING mirrors the unreachable-
-        // unknown rule: a degraded instance the claim's sources
-        // cannot reach — and which hosts no quantified endpoint —
-        // is not evidence about that claim.
-        let family = if c.forbid_reaches.is_some() {
-            "reachability"
-        } else if c.only_edges.is_some() {
-            "boundary"
-        } else {
-            "endpoint"
-        };
-        let involved = |k: &Component| -> bool {
-            if let Some(fr) = &c.forbid_reaches {
-                let (Some(src), Some(dst)) = (
-                    groups.get(&fr.from),
-                    groups.get(&fr.to),
-                ) else {
-                    return true;
-                };
-                if src.contains(&k.id) || dst.contains(&k.id) {
-                    return true;
-                }
-                let masked = fr
-                    .avoiding
-                    .as_ref()
-                    .and_then(|m| groups.get(m))
-                    .cloned()
-                    .unwrap_or_default();
-                let mine: BTreeSet<String> = k
-                    .model
-                    .fns
-                    .iter()
-                    .map(|n| format!("{}::{}", k.id, n))
-                    .collect();
-                !matches!(
-                    graph.reaches(
-                        &expand(src),
-                        &mine,
-                        &expand(&masked),
-                    ),
-                    hale_types::model_graph::Reach::None
-                )
-            } else if let Some(oe) = &c.only_edges {
-                [&oe.from, &oe.to].iter().any(|g| {
-                    groups
-                        .get(*g)
-                        .is_some_and(|g| g.contains(&k.id))
-                })
-            } else if let Some(r) = c
-                .require_subscribes
-                .as_ref()
-                .or(c.require_publishes.as_ref())
-            {
-                groups
-                    .get(&r.group)
-                    .is_some_and(|g| g.contains(&k.id))
-            } else {
-                // Count claims quantify over fleet-wide endpoint
-                // exposure: any degraded-endpoint component could
-                // change the count.
-                true
-            }
-        };
-        let degraded: Vec<String> = comps
-            .iter()
-            .filter(|k| {
-                k.model.adequacy.get(family).map(String::as_str)
-                    == Some("degraded")
-                    && involved(k)
-            })
-            .map(|k| {
-                // Name the withdrawn capability flags — the
-                // actionable half of the account.
-                let withdrawn: Vec<&str> = k
-                    .model
-                    .capabilities
-                    .iter()
-                    .filter(|(_, on)| !**on)
-                    .map(|(f, _)| f.as_str())
-                    .collect();
-                format!(
-                    "`{}` (withdraws {})",
-                    k.id,
-                    withdrawn.join(", ")
-                )
-            })
-            .collect();
-        let (result, witness) = if result == "holds"
-            && !degraded.is_empty()
-        {
-            (
-                "uncertified",
-                format!(
-                    "cannot certify this absence: instance(s) \
-                     {} carry a degraded `{}` adequacy — the \
-                     required relations are not vouched by their \
-                     own artifacts",
-                    degraded.join(", "),
-                    family
-                ),
-            )
-        } else {
-            (result, witness)
-        };
         if result == "violated" || result == "uncertified" {
             errs.push(format!(
                 "fleet claim `{}` {}{}{}",
@@ -1090,31 +1089,112 @@ fn count_claim(
     comps: &[Component],
     publishing: bool,
 ) -> (&'static str, String) {
+    // Round 6 (#490): counts are evaluated over an INTERVAL, with
+    // the canonical monotone rule. Known endpoint rows are a lower
+    // bound; an uncounted component that withdraws the RELEVANT
+    // completeness (publisher counts consult publish +
+    // cardinality; subscriber counts subscribe + cardinality)
+    // could hide another endpoint, so it raises only the upper
+    // bound. A `min` already met by known rows holds regardless
+    // of hidden candidates; a `max` already exceeded by known
+    // rows violates regardless; everything the interval cannot
+    // decide is uncertified.
     let hits: Vec<&str> = comps
         .iter()
         .filter(|c| c.model.has_endpoint(&k.subject, publishing))
         .map(|c| c.id.as_str())
         .collect();
-    let n = hits.len();
-    let ok = k.eq.map(|e| n == e).unwrap_or(true)
-        && k.max.map(|m| n <= m).unwrap_or(true)
-        && k.min.map(|m| n >= m).unwrap_or(true);
-    if ok {
+    let relevant = if publishing {
+        "exact_publishes"
+    } else {
+        "exact_subscribes"
+    };
+    let hidden: Vec<&str> = comps
+        .iter()
+        .filter(|c| {
+            !hits.contains(&c.id.as_str())
+                && (!c
+                    .model
+                    .capabilities
+                    .get(relevant)
+                    .copied()
+                    .unwrap_or(true)
+                    || !c
+                        .model
+                        .capabilities
+                        .get("exact_cardinality")
+                        .copied()
+                        .unwrap_or(true))
+        })
+        .map(|c| c.id.as_str())
+        .collect();
+    let lo = hits.len();
+    let hi = lo + hidden.len();
+    // Per bound: Ok(true) definite pass, Ok(false) definite
+    // violation, Err(()) undecidable on this interval.
+    let bounds: Vec<(&str, Result<bool, ()>)> = [
+        ("eq", k.eq.map(|e| {
+            if lo > e || hi < e {
+                Ok(false)
+            } else if lo == e && hi == e {
+                Ok(true)
+            } else {
+                Err(())
+            }
+        })),
+        ("max", k.max.map(|m| {
+            if lo > m {
+                Ok(false)
+            } else if hi <= m {
+                Ok(true)
+            } else {
+                Err(())
+            }
+        })),
+        ("min", k.min.map(|m| {
+            if lo >= m {
+                Ok(true)
+            } else if hi < m {
+                Ok(false)
+            } else {
+                Err(())
+            }
+        })),
+    ]
+    .into_iter()
+    .filter_map(|(n, v)| v.map(|v| (n, v)))
+    .collect();
+    let counted = format!(
+        "counted {} deployed {} endpoint(s) of `{}`{}{}",
+        lo,
+        if publishing { "publisher" } else { "subscriber" },
+        k.subject,
+        if hits.is_empty() {
+            String::new()
+        } else {
+            format!(": {}", hits.join(", "))
+        },
+        if hidden.is_empty() {
+            String::new()
+        } else {
+            format!(
+                " (up to {} more possible — {} withdraw(s) the \
+                 relevant completeness)",
+                hidden.len(),
+                hidden.join(", ")
+            )
+        }
+    );
+    // Conjunctive fleet form: any definite violation violates;
+    // all definite passes hold; otherwise uncertified.
+    if bounds.iter().any(|(_, v)| *v == Ok(false)) {
+        ("violated", counted)
+    } else if bounds.iter().all(|(_, v)| *v == Ok(true)) {
         ("holds", String::new())
     } else {
-        (
-            "violated",
-            format!(
-                "counted {} deployed {} endpoint(s) of `{}`: {}",
-                n,
-                if publishing { "publisher" } else { "subscriber" },
-                k.subject,
-                hits.join(", ")
-            ),
-        )
+        ("uncertified", counted)
     }
 }
-
 
 #[allow(clippy::too_many_arguments)]
 fn render(

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -357,7 +357,7 @@ pub fn compose(
                 }
                 Some(w) if !c
                     .model
-                    .has_endpoint(&w.subject, publishing) =>
+                    .has_topic_endpoint(&ep.topic, publishing) =>
                 {
                     errs.push(format!(
                         "route `{}`: instance `{}` is named as a {} of \
@@ -416,17 +416,20 @@ pub fn compose(
             let Some(pc) = by_id.get(p.instance.as_str()) else {
                 continue;
             };
-            for pf in pc.model.publishers_of(&p.topic) {
+            for pf in pc.model.topic_publishers(&p.topic) {
                 for s in &r.subscribers {
                     let Some(sc) = by_id.get(s.instance.as_str()) else {
                         continue;
                     };
-                    for (l, h) in
-                        sc.model.subscribers_of(&s.topic)
+                    for handler in
+                        sc.model.topic_subscribers(&s.topic)
                     {
                         route_edges.push((
                             format!("{}::{}", p.instance, pf),
-                            format!("{}::{}::{}", s.instance, l, h),
+                            format!(
+                                "{}::{}",
+                                s.instance, handler
+                            ),
                             r.id.clone(),
                         ));
                     }
@@ -1262,6 +1265,26 @@ fn load_artifact(
                 "{}: no artifact_digest — this predates schema 1.3 and \
                  cannot be verified, and an unverifiable component is \
                  not a foundation for a certificate",
+                p.display()
+            ))
+        }
+    }
+    // Identity BEFORE meaning too (round 2, #490): the declared
+    // shape_hash must recompute from the hashed model half, or the
+    // wire identity could drift under a stale identity — the exact
+    // residual schema 1.12 closes.
+    match hale_types::topology::verify_shape_hash(&src) {
+        Some(true) => {}
+        Some(false) => {
+            return Err(format!(
+                "{}: shape_hash does not recompute from the \
+                 model half — the declared identity is stale",
+                p.display()
+            ))
+        }
+        None => {
+            return Err(format!(
+                "{}: no recomputable shape_hash",
                 p.display()
             ))
         }

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -1269,6 +1269,19 @@ fn load_artifact(
             ))
         }
     }
+    // One unambiguous value per key (round 3, #490): serde's
+    // last-wins map parse must not be able to shadow what the raw
+    // verifiers below check.
+    if let Some(key) =
+        hale_types::topology::find_duplicate_key(&src)
+    {
+        return Err(format!(
+            "{}: duplicate object key `{}` — the verified and \
+             consumed values could disagree",
+            p.display(),
+            key
+        ));
+    }
     // Identity BEFORE meaning too (round 2, #490): the declared
     // shape_hash must recompute from the hashed model half, or the
     // wire identity could drift under a stale identity — the exact

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -839,6 +839,115 @@ fn evaluate_claims(
         // is recorded because the REPAIR differs (resolve the
         // unknown edge vs. fix the program), not because one of them
         // passes.
+        // Round 5 (#490): the component's positive completeness
+        // account is HONORED. An admitted `degraded` family is
+        // the component saying "I cannot support a proof of
+        // absence here" — a fleet claim of that family must not
+        // certify `holds` over it. Violations stand (a witness is
+        // a witness), and the SCOPING mirrors the unreachable-
+        // unknown rule: a degraded instance the claim's sources
+        // cannot reach — and which hosts no quantified endpoint —
+        // is not evidence about that claim.
+        let family = if c.forbid_reaches.is_some() {
+            "reachability"
+        } else if c.only_edges.is_some() {
+            "boundary"
+        } else {
+            "endpoint"
+        };
+        let involved = |k: &Component| -> bool {
+            if let Some(fr) = &c.forbid_reaches {
+                let (Some(src), Some(dst)) = (
+                    groups.get(&fr.from),
+                    groups.get(&fr.to),
+                ) else {
+                    return true;
+                };
+                if src.contains(&k.id) || dst.contains(&k.id) {
+                    return true;
+                }
+                let masked = fr
+                    .avoiding
+                    .as_ref()
+                    .and_then(|m| groups.get(m))
+                    .cloned()
+                    .unwrap_or_default();
+                let mine: BTreeSet<String> = k
+                    .model
+                    .fns
+                    .iter()
+                    .map(|n| format!("{}::{}", k.id, n))
+                    .collect();
+                !matches!(
+                    graph.reaches(
+                        &expand(src),
+                        &mine,
+                        &expand(&masked),
+                    ),
+                    hale_types::model_graph::Reach::None
+                )
+            } else if let Some(oe) = &c.only_edges {
+                [&oe.from, &oe.to].iter().any(|g| {
+                    groups
+                        .get(*g)
+                        .is_some_and(|g| g.contains(&k.id))
+                })
+            } else if let Some(r) = c
+                .require_subscribes
+                .as_ref()
+                .or(c.require_publishes.as_ref())
+            {
+                groups
+                    .get(&r.group)
+                    .is_some_and(|g| g.contains(&k.id))
+            } else {
+                // Count claims quantify over fleet-wide endpoint
+                // exposure: any degraded-endpoint component could
+                // change the count.
+                true
+            }
+        };
+        let degraded: Vec<String> = comps
+            .iter()
+            .filter(|k| {
+                k.model.adequacy.get(family).map(String::as_str)
+                    == Some("degraded")
+                    && involved(k)
+            })
+            .map(|k| {
+                // Name the withdrawn capability flags — the
+                // actionable half of the account.
+                let withdrawn: Vec<&str> = k
+                    .model
+                    .capabilities
+                    .iter()
+                    .filter(|(_, on)| !**on)
+                    .map(|(f, _)| f.as_str())
+                    .collect();
+                format!(
+                    "`{}` (withdraws {})",
+                    k.id,
+                    withdrawn.join(", ")
+                )
+            })
+            .collect();
+        let (result, witness) = if result == "holds"
+            && !degraded.is_empty()
+        {
+            (
+                "uncertified",
+                format!(
+                    "cannot certify this absence: instance(s) \
+                     {} carry a degraded `{}` adequacy — the \
+                     required relations are not vouched by their \
+                     own artifacts",
+                    degraded.join(", "),
+                    family
+                ),
+            )
+        } else {
+            (result, witness)
+        };
         if result == "violated" || result == "uncertified" {
             errs.push(format!(
                 "fleet claim `{}` {}{}{}",
@@ -1255,15 +1364,24 @@ fn load_artifact(
     // One unambiguous value per key (round 3, #490): serde's
     // last-wins map parse must not be able to shadow what the raw
     // verifiers below check.
-    if let Err(e) =
-        hale_types::topology::scan_top_level(&src)
-    {
-        return Err(format!(
-            "{}: {} — the verified and consumed values could \
-             disagree",
-            p.display(),
-            e
-        ));
+    match hale_types::topology::scan_top_level(&src) {
+        Err(e) => {
+            return Err(format!(
+                "{}: {} — the verified and consumed values \
+                 could disagree",
+                p.display(),
+                e
+            ));
+        }
+        Ok(top) => {
+            if let Err(e) =
+                hale_types::topology::verify_top_level_order(
+                    &top,
+                )
+            {
+                return Err(format!("{}: {}", p.display(), e));
+            }
+        }
     }
     match hale_types::topology::verify_artifact_digest(&src) {
         Some(true) => {}

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -187,7 +187,9 @@ pub struct Endpoint {
 struct Component {
     id: String,
     labels: Vec<String>,
-    artifact: serde_json::Value,
+    /// The typed interior (GH #476 Change 7) — decoded once after
+    /// admission; composition never crawls generic JSON again.
+    model: crate::fleet_model::ComponentModel,
     path: PathBuf,
     /// SHA-256 of the artifact bytes that were ADMITTED — recorded
     /// in the fleet artifact so an auditor can re-check exactly what
@@ -233,10 +235,10 @@ pub fn compose(
             continue;
         }
         match load_artifact(&base.join(&inst.artifact), trust) {
-            Ok((v, sha256, signed_by)) => comps.push(Component {
+            Ok((model, sha256, signed_by)) => comps.push(Component {
                 id: inst.id.clone(),
                 labels: inst.labels.clone(),
-                artifact: v,
+                model,
                 path: base.join(&inst.artifact),
                 sha256,
                 signed_by,
@@ -259,10 +261,8 @@ pub fn compose(
     let mut call_edges: Vec<(String, String)> = Vec::new();
     let mut local_bus: Vec<(String, String)> = Vec::new();
     for c in &comps {
-        for f in arr(&c.artifact["sorts"]["fns"]) {
-            if let Some(n) = f.as_str() {
-                vertices.push(format!("{}::{}", c.id, n));
-            }
+        for n in &c.model.fns {
+            vertices.push(format!("{}::{}", c.id, n));
         }
         // BOTH call relations. `calls_via_stdlib` holds user→user
         // paths whose interior is stdlib code, contracted to their
@@ -272,36 +272,22 @@ pub fn compose(
         // whose routed handler reaches its routed publisher through
         // `std::http::Router` is invisible in `calls` alone, and a
         // prohibition spanning it would report a false absence.
-        for rel in ["calls", "calls_via_stdlib"] {
-            for e in arr(&c.artifact["relations"][rel]) {
-                if let (Some(f), Some(t)) =
-                    (e["from"].as_str(), e["to"].as_str())
-                {
-                    call_edges.push((
-                        format!("{}::{}", c.id, f),
-                        format!("{}::{}", c.id, t),
-                    ));
-                }
-            }
+        // (The typed decode already unions them.)
+        for (f, t) in &c.model.calls {
+            call_edges.push((
+                format!("{}::{}", c.id, f),
+                format!("{}::{}", c.id, t),
+            ));
         }
         // A local publish→subscribe pair inside one instance is a
         // real in-process edge and stays one.
-        for p in arr(&c.artifact["relations"]["publishes"]) {
-            let (Some(pf), Some(subj)) =
-                (p["fn"].as_str(), p["subject"].as_str())
-            else {
-                continue;
-            };
-            for s in arr(&c.artifact["relations"]["subscribes"]) {
-                if s["subject"].as_str() == Some(subj) {
-                    if let (Some(l), Some(h)) =
-                        (s["locus"].as_str(), s["handler"].as_str())
-                    {
-                        local_bus.push((
-                            format!("{}::{}", c.id, pf),
-                            format!("{}::{}::{}", c.id, l, h),
-                        ));
-                    }
+        for (pf, subj) in &c.model.publishes {
+            for (ssubj, l, h) in &c.model.subscribes {
+                if ssubj == subj {
+                    local_bus.push((
+                        format!("{}::{}", c.id, pf),
+                        format!("{}::{}::{}", c.id, l, h),
+                    ));
                 }
             }
         }
@@ -355,7 +341,12 @@ pub fn compose(
                 bad = true;
                 continue;
             };
-            match wire_id(&c.artifact, &ep.topic) {
+            match c.model.wire_of(&ep.topic).map(|(s, h)| {
+                WireId {
+                    subject: s.to_string(),
+                    payload_hash: h.to_string(),
+                }
+            }) {
                 None => {
                     errs.push(format!(
                         "route `{}`: instance `{}` declares no topic \
@@ -364,11 +355,9 @@ pub fn compose(
                     ));
                     bad = true;
                 }
-                Some(w) if !has_endpoint(
-                    &c.artifact,
-                    &w.subject,
-                    publishing,
-                ) =>
+                Some(w) if !c
+                    .model
+                    .has_endpoint(&w.subject, publishing) =>
                 {
                     errs.push(format!(
                         "route `{}`: instance `{}` is named as a {} of \
@@ -427,12 +416,14 @@ pub fn compose(
             let Some(pc) = by_id.get(p.instance.as_str()) else {
                 continue;
             };
-            for pf in publishers_of(&pc.artifact, &p.topic) {
+            for pf in pc.model.publishers_of(&p.topic) {
                 for s in &r.subscribers {
                     let Some(sc) = by_id.get(s.instance.as_str()) else {
                         continue;
                     };
-                    for (l, h) in subscribers_of(&sc.artifact, &s.topic) {
+                    for (l, h) in
+                        sc.model.subscribers_of(&s.topic)
+                    {
                         route_edges.push((
                             format!("{}::{}", p.instance, pf),
                             format!("{}::{}::{}", s.instance, l, h),
@@ -475,15 +466,18 @@ pub fn compose(
     // and leave `forbid_reaches` reporting `holds`.
     let mut holes: Vec<(String, String)> = Vec::new();
     for c in &comps {
-        for u in arr(&c.artifact["unknowns"]) {
+        for (f, reasons) in &c.model.unknowns {
             unknowns.push(format!(
-                "    {{\"instance\": {}, \"unknown\": {}}}",
+                "    {{\"instance\": {}, \"unknown\": {{\"fn\": {}, \"reasons\": [{}]}}}}",
                 q(&c.id),
-                serde_json::to_string(&u).unwrap_or_else(|_| "null".into())
+                q(f),
+                reasons
+                    .iter()
+                    .map(|r| q(r))
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ));
-            let Some(f) = u["fn"].as_str() else { continue };
-            for r in arr(&u["reasons"]) {
-                let Some(kind) = r.as_str() else { continue };
+            for kind in reasons {
                 if hale_types::model_graph::kind_hides_edges(kind) {
                     holes.push((
                         format!("{}::{}", c.id, f),
@@ -613,9 +607,9 @@ fn evaluate_claims(
     let all_vertices: Vec<String> = comps
         .iter()
         .flat_map(|c| {
-            arr(&c.artifact["sorts"]["fns"])
+            c.model
+                .fns
                 .iter()
-                .filter_map(|f| f.as_str())
                 .map(|n| format!("{}::{}", c.id, n))
                 .collect::<Vec<_>>()
         })
@@ -802,11 +796,11 @@ fn evaluate_claims(
                         .and_then(|r| {
                             r.publishers.first().and_then(|ep| {
                                 by_id.get(ep.instance.as_str()).and_then(
-                                    |c| wire_id(&c.artifact, &ep.topic),
+                                    |c| c.model.wire_of(&ep.topic),
                                 )
                             })
                         })
-                        .map(|w| w.subject)
+                        .map(|(subject, _)| subject.to_string())
                         .unwrap_or_default();
                     if !granted.contains(subj.as_str()) {
                         bad.push(format!(
@@ -879,7 +873,7 @@ fn render_witness(
         let inst = v.split("::").next().unwrap_or("");
         let local = v.strip_prefix(&format!("{}::", inst)).unwrap_or(v);
         if let Some(c) = by_id.get(inst) {
-            if let Some(loc) = decl_location(&c.artifact, local) {
+            if let Some(loc) = c.model.decl_location(local) {
                 out.push_str(&format!("  [{}]", loc));
             }
         }
@@ -887,19 +881,6 @@ fn render_witness(
     out
 }
 
-/// `path/to/file.hl` for a vertex, via the artifact's source map.
-fn decl_location(a: &serde_json::Value, local: &str) -> Option<String> {
-    let decl = local.split("::").next().unwrap_or(local);
-    let row = a["provenance"]["decls"].get(decl)?;
-    let sid = row["source"].as_i64()?;
-    if sid < 0 {
-        return None;
-    }
-    arr(&a["sources"])
-        .iter()
-        .find(|s| s["id"].as_i64() == Some(sid))
-        .and_then(|s| s["path"].as_str().map(str::to_string))
-}
 
 /// `require subscribes/publishes` is a STRUCTURAL DEPLOYMENT
 /// statement: some instance in the group exposes the endpoint **and
@@ -933,7 +914,7 @@ fn endpoint_claim(
         .iter()
         .filter(|c| {
             g.contains(&c.id)
-                && has_endpoint(&c.artifact, &r.subject, publishing)
+                && c.model.has_endpoint(&r.subject, publishing)
         })
         .map(|c| c.id.as_str())
         .collect();
@@ -999,7 +980,7 @@ fn count_claim(
 ) -> (&'static str, String) {
     let hits: Vec<&str> = comps
         .iter()
-        .filter(|c| has_endpoint(&c.artifact, &k.subject, publishing))
+        .filter(|c| c.model.has_endpoint(&k.subject, publishing))
         .map(|c| c.id.as_str())
         .collect();
     let n = hits.len();
@@ -1022,24 +1003,6 @@ fn count_claim(
     }
 }
 
-/// Does this component publish / subscribe the given WIRE subject?
-/// Resolved through its `topics` table, never by local name.
-fn has_endpoint(
-    a: &serde_json::Value,
-    subject: &str,
-    publishing: bool,
-) -> bool {
-    let locals: BTreeSet<String> = arr(&a["topics"])
-        .iter()
-        .filter(|t| t["subject"].as_str() == Some(subject))
-        .filter_map(|t| t["name"].as_str().map(str::to_string))
-        .collect();
-    let rel =
-        if publishing { "publishes" } else { "subscribes" };
-    arr(&a["relations"][rel]).iter().any(|r| {
-        r["subject"].as_str().is_some_and(|s| locals.contains(s))
-    })
-}
 
 #[allow(clippy::too_many_arguments)]
 fn render(
@@ -1063,7 +1026,7 @@ fn render(
         model.push_str(&format!(
             "    {{\"id\": {}, \"app_shape_hash\": {}, \"labels\": [{}]}}{}\n",
             q(&c.id),
-            q(c.artifact["shape_hash"].as_str().unwrap_or("")),
+            q(&c.model.shape_hash),
             c.labels
                 .iter()
                 .map(|l| q(l))
@@ -1253,7 +1216,10 @@ fn read_plan(p: &Path) -> Result<FleetPlan, Vec<String>> {
 fn load_artifact(
     p: &Path,
     trust: &crate::sign::Trust,
-) -> Result<(serde_json::Value, String, Option<String>), String> {
+) -> Result<
+    (crate::fleet_model::ComponentModel, String, Option<String>),
+    String,
+> {
     let src = std::fs::read_to_string(p)
         .map_err(|e| format!("read {}: {}", p.display(), e))?;
     // Provenance BEFORE integrity BEFORE meaning. The signature is
@@ -1341,52 +1307,17 @@ fn load_artifact(
         &v,
         &p.display().to_string(),
     )?;
-    Ok((v, sha256, signed_by))
+    // GH #476 Change 7: decode the typed interior ONCE — the last
+    // time this artifact's JSON is touched.
+    let model = crate::fleet_model::ComponentModel::decode(
+        &v,
+        &p.display().to_string(),
+    )?;
+    Ok((model, sha256, signed_by))
 }
 
-fn wire_id(a: &serde_json::Value, local: &str) -> Option<WireId> {
-    arr(&a["topics"]).iter().find_map(|t| {
-        if t["name"].as_str() == Some(local) {
-            Some(WireId {
-                subject: t["subject"].as_str().unwrap_or("").to_string(),
-                payload_hash: t["payload_hash"]
-                    .as_str()
-                    .unwrap_or("")
-                    .to_string(),
-            })
-        } else {
-            None
-        }
-    })
-}
 
-fn publishers_of(a: &serde_json::Value, local: &str) -> Vec<String> {
-    arr(&a["relations"]["publishes"])
-        .iter()
-        .filter(|p| p["subject"].as_str() == Some(local))
-        .filter_map(|p| p["fn"].as_str().map(str::to_string))
-        .collect()
-}
 
-fn subscribers_of(
-    a: &serde_json::Value,
-    local: &str,
-) -> Vec<(String, String)> {
-    arr(&a["relations"]["subscribes"])
-        .iter()
-        .filter(|s| s["subject"].as_str() == Some(local))
-        .filter_map(|s| {
-            Some((
-                s["locus"].as_str()?.to_string(),
-                s["handler"].as_str()?.to_string(),
-            ))
-        })
-        .collect()
-}
-
-fn arr(v: &serde_json::Value) -> Vec<serde_json::Value> {
-    v.as_array().cloned().unwrap_or_default()
-}
 
 fn q(s: &str) -> String {
     serde_json::to_string(s).unwrap_or_else(|_| "\"\"".into())

--- a/crates/hale-cli/src/fleet_model.rs
+++ b/crates/hale-cli/src/fleet_model.rs
@@ -250,24 +250,49 @@ impl ComponentModel {
         })
     }
 
-    /// Fns publishing a local subject name (V1 grain).
-    pub fn publishers_of(&self, local: &str) -> Vec<&str> {
-        self.publishes
+    /// Route-role check at TOPIC grain (round 2, #490): the plan
+    /// endpoint names a local topic, so the role must be judged
+    /// against endpoint rows carrying THAT topic identity — a
+    /// literal end on the same wire is a different endpoint and
+    /// must not satisfy it. A publisher role needs a send site;
+    /// a subscriber role is a declaration by nature.
+    pub fn has_topic_endpoint(
+        &self,
+        topic: &str,
+        publishing: bool,
+    ) -> bool {
+        self.endpoints.iter().any(|e| {
+            e.publish == publishing
+                && e.topic.as_deref() == Some(topic)
+                && (!publishing || e.site.is_some())
+        })
+    }
+
+    /// Route-edge owners at the SAME topic grain the role check
+    /// used: publishing fns whose site rows carry this topic
+    /// identity.
+    pub fn topic_publishers(&self, topic: &str) -> Vec<&str> {
+        self.endpoints
             .iter()
-            .filter(|(_, s)| s == local)
-            .map(|(f, _)| f.as_str())
+            .filter(|e| {
+                e.publish
+                    && e.site.is_some()
+                    && e.topic.as_deref() == Some(topic)
+            })
+            .map(|e| e.owner.as_str())
             .collect()
     }
 
-    /// (locus, handler) pairs subscribing a local subject name.
-    pub fn subscribers_of(
-        &self,
-        local: &str,
-    ) -> Vec<(&str, &str)> {
-        self.subscribes
+    /// Subscribing handlers (full `Locus::handler` displays) whose
+    /// rows carry this topic identity.
+    pub fn topic_subscribers(&self, topic: &str) -> Vec<&str> {
+        self.endpoints
             .iter()
-            .filter(|(s, _, _)| s == local)
-            .map(|(_, l, h)| (l.as_str(), h.as_str()))
+            .filter(|e| {
+                !e.publish
+                    && e.topic.as_deref() == Some(topic)
+            })
+            .map(|e| e.owner.as_str())
             .collect()
     }
 

--- a/crates/hale-cli/src/fleet_model.rs
+++ b/crates/hale-cli/src/fleet_model.rs
@@ -72,119 +72,224 @@ impl ComponentModel {
     /// law-account admission — this is a projection, not a
     /// validation pass).
     pub fn decode(v: &Value, label: &str) -> Result<Self, String> {
-        let arr = |x: &Value| -> Vec<Value> {
-            x.as_array().cloned().unwrap_or_default()
+        // STRICT and FALLIBLE (round 3, #490): a malformed
+        // semantic row is REFUSED, never filtered — a dropped
+        // call edge or hole reason is exactly the silent-omission
+        // failure #476 exists to eliminate. Only genuinely
+        // optional facts (provenance, unplaceable decl sources)
+        // may be absent.
+        let req_str = |x: &Value,
+                       what: &str|
+         -> Result<String, String> {
+            x.as_str().map(str::to_string).ok_or_else(|| {
+                format!("{}: {} must be a string", label, what)
+            })
         };
-        let shape_hash = v["shape_hash"]
-            .as_str()
-            .ok_or_else(|| {
-                format!("{}: shape_hash must be a string", label)
-            })?
-            .to_string();
-        let fns: Vec<String> = arr(&v["sorts"]["fns"])
-            .iter()
-            .filter_map(|f| f.as_str().map(str::to_string))
-            .collect();
+        let req_arr = |x: &Value,
+                       what: &str|
+         -> Result<Vec<Value>, String> {
+            x.as_array().cloned().ok_or_else(|| {
+                format!("{}: {} must be an array", label, what)
+            })
+        };
+        let shape_hash =
+            req_str(&v["shape_hash"], "shape_hash")?;
+        let mut fns: Vec<String> = Vec::new();
+        for (i, f) in
+            req_arr(&v["sorts"]["fns"], "sorts.fns")?
+                .iter()
+                .enumerate()
+        {
+            fns.push(req_str(
+                f,
+                &format!("sorts.fns[{}]", i),
+            )?);
+        }
         let mut calls: Vec<(String, String)> = Vec::new();
         for rel in ["calls", "calls_via_stdlib"] {
-            for e in arr(&v["relations"][rel]) {
-                if let (Some(f), Some(t)) =
-                    (e["from"].as_str(), e["to"].as_str())
-                {
-                    calls.push((f.to_string(), t.to_string()));
-                }
+            for (i, e) in req_arr(
+                &v["relations"][rel],
+                &format!("relations.{}", rel),
+            )?
+            .iter()
+            .enumerate()
+            {
+                calls.push((
+                    req_str(
+                        &e["from"],
+                        &format!(
+                            "relations.{}[{}].from",
+                            rel, i
+                        ),
+                    )?,
+                    req_str(
+                        &e["to"],
+                        &format!(
+                            "relations.{}[{}].to",
+                            rel, i
+                        ),
+                    )?,
+                ));
             }
         }
-        let publishes: Vec<(String, String)> = arr(
+        let mut publishes: Vec<(String, String)> = Vec::new();
+        for (i, p) in req_arr(
             &v["relations"]["publishes"],
-        )
+            "relations.publishes",
+        )?
         .iter()
-        .filter_map(|p| {
-            Some((
-                p["fn"].as_str()?.to_string(),
-                p["subject"].as_str()?.to_string(),
-            ))
-        })
-        .collect();
-        let subscribes: Vec<(String, String, String)> = arr(
+        .enumerate()
+        {
+            publishes.push((
+                req_str(
+                    &p["fn"],
+                    &format!("relations.publishes[{}].fn", i),
+                )?,
+                req_str(
+                    &p["subject"],
+                    &format!(
+                        "relations.publishes[{}].subject",
+                        i
+                    ),
+                )?,
+            ));
+        }
+        let mut subscribes: Vec<(String, String, String)> =
+            Vec::new();
+        for (i, r) in req_arr(
             &v["relations"]["subscribes"],
-        )
+            "relations.subscribes",
+        )?
         .iter()
-        .filter_map(|s| {
-            Some((
-                s["subject"].as_str()?.to_string(),
-                s["locus"].as_str()?.to_string(),
-                s["handler"].as_str()?.to_string(),
-            ))
-        })
-        .collect();
-        let topics: Vec<TopicRow> = arr(&v["topics"])
+        .enumerate()
+        {
+            let at = format!("relations.subscribes[{}]", i);
+            subscribes.push((
+                req_str(
+                    &r["subject"],
+                    &format!("{}.subject", at),
+                )?,
+                req_str(&r["locus"], &format!("{}.locus", at))?,
+                req_str(
+                    &r["handler"],
+                    &format!("{}.handler", at),
+                )?,
+            ));
+        }
+        let mut topics: Vec<TopicRow> = Vec::new();
+        for (i, t) in
+            req_arr(&v["topics"], "topics")?.iter().enumerate()
+        {
+            let at = format!("topics[{}]", i);
+            topics.push(TopicRow {
+                name: req_str(
+                    &t["name"],
+                    &format!("{}.name", at),
+                )?,
+                subject: req_str(
+                    &t["subject"],
+                    &format!("{}.subject", at),
+                )?,
+                payload_hash: req_str(
+                    &t["payload_hash"],
+                    &format!("{}.payload_hash", at),
+                )?,
+            });
+        }
+        let mut unknowns: Vec<(String, Vec<String>)> =
+            Vec::new();
+        for (i, u) in req_arr(&v["unknowns"], "unknowns")?
             .iter()
-            .filter_map(|t| {
-                Some(TopicRow {
-                    name: t["name"].as_str()?.to_string(),
-                    subject: t["subject"].as_str()?.to_string(),
-                    payload_hash: t["payload_hash"]
-                        .as_str()?
-                        .to_string(),
-                })
-            })
-            .collect();
-        let unknowns: Vec<(String, Vec<String>)> =
-            arr(&v["unknowns"])
-                .iter()
-                .filter_map(|u| {
-                    Some((
-                        u["fn"].as_str()?.to_string(),
-                        arr(&u["reasons"])
-                            .iter()
-                            .filter_map(|r| {
-                                r.as_str().map(str::to_string)
-                            })
-                            .collect(),
-                    ))
-                })
-                .collect();
+            .enumerate()
+        {
+            let at = format!("unknowns[{}]", i);
+            let mut reasons: Vec<String> = Vec::new();
+            for (k, r) in req_arr(
+                &u["reasons"],
+                &format!("{}.reasons", at),
+            )?
+            .iter()
+            .enumerate()
+            {
+                reasons.push(req_str(
+                    r,
+                    &format!("{}.reasons[{}]", at, k),
+                )?);
+            }
+            unknowns.push((
+                req_str(&u["fn"], &format!("{}.fn", at))?,
+                reasons,
+            ));
+        }
         // decl → source path, resolved through the sources table.
-        let source_path: BTreeMap<i64, String> = arr(&v["sources"])
-            .iter()
-            .filter_map(|s| {
-                Some((
-                    s["id"].as_i64()?,
-                    s["path"].as_str()?.to_string(),
-                ))
-            })
-            .collect();
+        let mut source_path: BTreeMap<i64, String> =
+            BTreeMap::new();
+        for (i, srow) in
+            req_arr(&v["sources"], "sources")?.iter().enumerate()
+        {
+            let at = format!("sources[{}]", i);
+            let id =
+                srow["id"].as_i64().ok_or_else(|| {
+                    format!(
+                        "{}: {}.id must be a number",
+                        label, at
+                    )
+                })?;
+            source_path.insert(
+                id,
+                req_str(&srow["path"], &format!("{}.path", at))?,
+            );
+        }
         let mut decl_sources: BTreeMap<String, String> =
             BTreeMap::new();
         if let Some(decls) =
             v["provenance"]["decls"].as_object()
         {
             for (decl, row) in decls {
-                let Some(sid) = row["source"].as_i64() else {
-                    continue;
-                };
+                let sid =
+                    row["source"].as_i64().ok_or_else(|| {
+                        format!(
+                            "{}: provenance.decls.{}.source                              must be a number",
+                            label, decl
+                        )
+                    })?;
                 if sid < 0 {
+                    // Unplaceable (foreign/synthetic) — a
+                    // legitimate absence, not a defect.
                     continue;
                 }
-                if let Some(p) = source_path.get(&sid) {
-                    decl_sources
-                        .insert(decl.clone(), p.clone());
-                }
+                let p2 =
+                    source_path.get(&sid).ok_or_else(|| {
+                        format!(
+                            "{}: provenance.decls.{} names                              source {}, which is not in the                              sources table",
+                            label, decl, sid
+                        )
+                    })?;
+                decl_sources.insert(decl.clone(), p2.clone());
             }
         }
         // The hashed endpoint identity (schema 1.12) — admission
         // has already proven the unhashed sections agree with it.
         let mut endpoints: Vec<EndpointIdentity> = Vec::new();
-        for e in arr(&v["endpoint_identity"]) {
+        // Absent = a bus-free program (the section is emitted
+        // only when endpoints exist); present-but-not-an-array =
+        // malformed, refused.
+        let ep_rows: Vec<Value> =
+            match v.get("endpoint_identity") {
+                None | Some(Value::Null) => Vec::new(),
+                Some(x) => {
+                    req_arr(x, "endpoint_identity")?
+                }
+            };
+        for (i, e) in ep_rows.iter().enumerate() {
+            let at = format!("endpoint_identity[{}]", i);
             let publish = match e["verb"].as_str() {
                 Some("publish") => true,
                 Some("subscribe") => false,
                 _ => {
                     return Err(format!(
-                        "{}: endpoint_identity verb outside the \
-                         closed vocabulary",
-                        label
+                        "{}: {}.verb outside the closed                          vocabulary",
+                        label, at
                     ))
                 }
             };
@@ -193,9 +298,8 @@ impl ComponentModel {
                 .or_else(|| e["locus"].as_str())
                 .ok_or_else(|| {
                     format!(
-                        "{}: endpoint_identity row without an \
-                         owner",
-                        label
+                        "{}: {} carries no owner",
+                        label, at
                     )
                 })?
                 .to_string();
@@ -203,19 +307,17 @@ impl ComponentModel {
                 publish,
                 owner,
                 site: e["site"].as_u64(),
-                wire: e["wire"]
-                    .as_str()
-                    .ok_or_else(|| {
-                        format!(
-                            "{}: endpoint_identity row without a \
-                             wire subject",
-                            label
-                        )
-                    })?
-                    .to_string(),
-                topic: e["topic"]
-                    .as_str()
-                    .map(str::to_string),
+                wire: req_str(
+                    &e["wire"],
+                    &format!("{}.wire", at),
+                )?,
+                topic: match e.get("topic") {
+                    None => None,
+                    Some(t) => Some(req_str(
+                        t,
+                        &format!("{}.topic", at),
+                    )?),
+                },
             });
         }
         endpoints.sort();

--- a/crates/hale-cli/src/fleet_model.rs
+++ b/crates/hale-cli/src/fleet_model.rs
@@ -64,6 +64,14 @@ pub struct ComponentModel {
     pub decl_sources: BTreeMap<String, String>,
     /// The hashed endpoint identity rows (schema 1.12).
     pub endpoints: Vec<EndpointIdentity>,
+    /// The component's POSITIVE completeness account (round 5,
+    /// #490): capability flags and per-family adequacy. An
+    /// admitted `degraded` family is an honest statement that the
+    /// component cannot support a proof of absence for that
+    /// family — fleet judgments must fail closed over it, not
+    /// discard it.
+    pub capabilities: BTreeMap<String, bool>,
+    pub adequacy: BTreeMap<String, String>,
 }
 
 impl ComponentModel {
@@ -321,6 +329,39 @@ impl ComponentModel {
             });
         }
         endpoints.sort();
+        let mut capabilities: BTreeMap<String, bool> =
+            BTreeMap::new();
+        for (k, x) in v["capabilities"]
+            .as_object()
+            .ok_or_else(|| {
+                format!(
+                    "{}: capabilities must be an object",
+                    label
+                )
+            })?
+        {
+            capabilities.insert(
+                k.clone(),
+                x.as_bool().ok_or_else(|| {
+                    format!(
+                        "{}: capabilities.{} must be a bool",
+                        label, k
+                    )
+                })?,
+            );
+        }
+        let mut adequacy: BTreeMap<String, String> =
+            BTreeMap::new();
+        for (k, x) in
+            v["adequacy"].as_object().ok_or_else(|| {
+                format!("{}: adequacy must be an object", label)
+            })?
+        {
+            adequacy.insert(
+                k.clone(),
+                req_str(x, &format!("adequacy.{}", k))?,
+            );
+        }
         Ok(ComponentModel {
             shape_hash,
             fns,
@@ -331,6 +372,8 @@ impl ComponentModel {
             unknowns,
             decl_sources,
             endpoints,
+            capabilities,
+            adequacy,
         })
     }
 

--- a/crates/hale-cli/src/fleet_model.rs
+++ b/crates/hale-cli/src/fleet_model.rs
@@ -1,0 +1,298 @@
+//! GH #476 Change 7 — the typed component decode behind
+//! `FleetModel`.
+//!
+//! Composition is the one consumer that reads artifacts it did not
+//! produce, across a trust boundary. Everything it needs is decoded
+//! ONCE, here, into typed rows — after signature, integrity,
+//! semantics, verdict, and the shared law-account admission have
+//! all passed — and the rest of fleet composition never touches
+//! generic JSON for a modeled fact again (the #476 architecture
+//! canary: "artifact/fleet code cannot walk source or generic JSON
+//! for a modeled fact after cutover").
+//!
+//! The decode reads the SAME sections admission validated:
+//! `sorts.fns`, both call relations, the V1 publish/subscribe
+//! relations, the `topics` join surface, `unknowns`, the decl
+//! provenance, and the hashed `endpoint_identity` (schema 1.12) —
+//! interiors preserved exactly, at the grain composition composes.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+/// One declared topic's join surface: the wire subject is the
+/// cross-binary identity, the payload hash the compatibility check.
+#[derive(Clone, Debug)]
+pub struct TopicRow {
+    pub name: String,
+    pub subject: String,
+    pub payload_hash: String,
+}
+
+/// One row of the HASHED endpoint identity (schema 1.12).
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EndpointIdentity {
+    pub publish: bool,
+    /// Owning fn/handler for site rows; owning locus for
+    /// declaration rows.
+    pub owner: String,
+    /// `None` for declared-publisher rows.
+    pub site: Option<u64>,
+    pub wire: String,
+    pub topic: Option<String>,
+}
+
+/// The typed interior of ONE admitted component artifact — exactly
+/// the facts fleet composition consumes, decoded once.
+#[derive(Clone, Debug)]
+pub struct ComponentModel {
+    pub shape_hash: String,
+    /// `sorts.fns` — the component's vertex universe.
+    pub fns: Vec<String>,
+    /// `calls` ∪ `calls_via_stdlib`, (from, to) — the union the
+    /// component's own checker walks.
+    pub calls: Vec<(String, String)>,
+    /// V1 publish relation, (fn, subject-name).
+    pub publishes: Vec<(String, String)>,
+    /// V1 subscribe relation, (subject-name, locus, handler).
+    pub subscribes: Vec<(String, String, String)>,
+    pub topics: Vec<TopicRow>,
+    /// `unknowns` — (fn, reasons): the component's own residue,
+    /// surfaced as fleet holes.
+    pub unknowns: Vec<(String, Vec<String>)>,
+    /// decl name → source path (for witness locations).
+    pub decl_sources: BTreeMap<String, String>,
+    /// The hashed endpoint identity rows (schema 1.12).
+    pub endpoints: Vec<EndpointIdentity>,
+}
+
+impl ComponentModel {
+    /// Decode an ADMITTED artifact (the caller has already run
+    /// signature/integrity/semantics/verdict checks and the shared
+    /// law-account admission — this is a projection, not a
+    /// validation pass).
+    pub fn decode(v: &Value, label: &str) -> Result<Self, String> {
+        let arr = |x: &Value| -> Vec<Value> {
+            x.as_array().cloned().unwrap_or_default()
+        };
+        let shape_hash = v["shape_hash"]
+            .as_str()
+            .ok_or_else(|| {
+                format!("{}: shape_hash must be a string", label)
+            })?
+            .to_string();
+        let fns: Vec<String> = arr(&v["sorts"]["fns"])
+            .iter()
+            .filter_map(|f| f.as_str().map(str::to_string))
+            .collect();
+        let mut calls: Vec<(String, String)> = Vec::new();
+        for rel in ["calls", "calls_via_stdlib"] {
+            for e in arr(&v["relations"][rel]) {
+                if let (Some(f), Some(t)) =
+                    (e["from"].as_str(), e["to"].as_str())
+                {
+                    calls.push((f.to_string(), t.to_string()));
+                }
+            }
+        }
+        let publishes: Vec<(String, String)> = arr(
+            &v["relations"]["publishes"],
+        )
+        .iter()
+        .filter_map(|p| {
+            Some((
+                p["fn"].as_str()?.to_string(),
+                p["subject"].as_str()?.to_string(),
+            ))
+        })
+        .collect();
+        let subscribes: Vec<(String, String, String)> = arr(
+            &v["relations"]["subscribes"],
+        )
+        .iter()
+        .filter_map(|s| {
+            Some((
+                s["subject"].as_str()?.to_string(),
+                s["locus"].as_str()?.to_string(),
+                s["handler"].as_str()?.to_string(),
+            ))
+        })
+        .collect();
+        let topics: Vec<TopicRow> = arr(&v["topics"])
+            .iter()
+            .filter_map(|t| {
+                Some(TopicRow {
+                    name: t["name"].as_str()?.to_string(),
+                    subject: t["subject"].as_str()?.to_string(),
+                    payload_hash: t["payload_hash"]
+                        .as_str()?
+                        .to_string(),
+                })
+            })
+            .collect();
+        let unknowns: Vec<(String, Vec<String>)> =
+            arr(&v["unknowns"])
+                .iter()
+                .filter_map(|u| {
+                    Some((
+                        u["fn"].as_str()?.to_string(),
+                        arr(&u["reasons"])
+                            .iter()
+                            .filter_map(|r| {
+                                r.as_str().map(str::to_string)
+                            })
+                            .collect(),
+                    ))
+                })
+                .collect();
+        // decl → source path, resolved through the sources table.
+        let source_path: BTreeMap<i64, String> = arr(&v["sources"])
+            .iter()
+            .filter_map(|s| {
+                Some((
+                    s["id"].as_i64()?,
+                    s["path"].as_str()?.to_string(),
+                ))
+            })
+            .collect();
+        let mut decl_sources: BTreeMap<String, String> =
+            BTreeMap::new();
+        if let Some(decls) =
+            v["provenance"]["decls"].as_object()
+        {
+            for (decl, row) in decls {
+                let Some(sid) = row["source"].as_i64() else {
+                    continue;
+                };
+                if sid < 0 {
+                    continue;
+                }
+                if let Some(p) = source_path.get(&sid) {
+                    decl_sources
+                        .insert(decl.clone(), p.clone());
+                }
+            }
+        }
+        // The hashed endpoint identity (schema 1.12) — admission
+        // has already proven the unhashed sections agree with it.
+        let mut endpoints: Vec<EndpointIdentity> = Vec::new();
+        for e in arr(&v["endpoint_identity"]) {
+            let publish = match e["verb"].as_str() {
+                Some("publish") => true,
+                Some("subscribe") => false,
+                _ => {
+                    return Err(format!(
+                        "{}: endpoint_identity verb outside the \
+                         closed vocabulary",
+                        label
+                    ))
+                }
+            };
+            let owner = e["fn"]
+                .as_str()
+                .or_else(|| e["locus"].as_str())
+                .ok_or_else(|| {
+                    format!(
+                        "{}: endpoint_identity row without an \
+                         owner",
+                        label
+                    )
+                })?
+                .to_string();
+            endpoints.push(EndpointIdentity {
+                publish,
+                owner,
+                site: e["site"].as_u64(),
+                wire: e["wire"]
+                    .as_str()
+                    .ok_or_else(|| {
+                        format!(
+                            "{}: endpoint_identity row without a \
+                             wire subject",
+                            label
+                        )
+                    })?
+                    .to_string(),
+                topic: e["topic"]
+                    .as_str()
+                    .map(str::to_string),
+            });
+        }
+        endpoints.sort();
+        Ok(ComponentModel {
+            shape_hash,
+            fns,
+            calls,
+            publishes,
+            subscribes,
+            topics,
+            unknowns,
+            decl_sources,
+            endpoints,
+        })
+    }
+
+    /// The wire identity a LOCAL topic name resolves to — the
+    /// cross-binary join key.
+    pub fn wire_of(
+        &self,
+        local: &str,
+    ) -> Option<(&str, &str)> {
+        self.topics.iter().find_map(|t| {
+            if t.name == local {
+                Some((
+                    t.subject.as_str(),
+                    t.payload_hash.as_str(),
+                ))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Fns publishing a local subject name (V1 grain).
+    pub fn publishers_of(&self, local: &str) -> Vec<&str> {
+        self.publishes
+            .iter()
+            .filter(|(_, s)| s == local)
+            .map(|(f, _)| f.as_str())
+            .collect()
+    }
+
+    /// (locus, handler) pairs subscribing a local subject name.
+    pub fn subscribers_of(
+        &self,
+        local: &str,
+    ) -> Vec<(&str, &str)> {
+        self.subscribes
+            .iter()
+            .filter(|(s, _, _)| s == local)
+            .map(|(_, l, h)| (l.as_str(), h.as_str()))
+            .collect()
+    }
+
+    /// Does the component actually USE this wire subject in the
+    /// given direction? Declaring a topic is not using it: a
+    /// publisher end needs a SEND SITE (an identity row with a
+    /// site ordinal); a subscriber end is a declaration by
+    /// nature. Reads the hashed endpoint identity — byte-exact
+    /// wire subjects, collision-proof (schema 1.12).
+    pub fn has_endpoint(
+        &self,
+        wire: &str,
+        publishing: bool,
+    ) -> bool {
+        self.endpoints.iter().any(|e| {
+            e.publish == publishing
+                && e.wire == wire
+                && (!publishing || e.site.is_some())
+        })
+    }
+
+    /// The source path of a symbol's owning declaration, when the
+    /// artifact placed it.
+    pub fn decl_location(&self, local: &str) -> Option<&str> {
+        let decl = local.split("::").next().unwrap_or(local);
+        self.decl_sources.get(decl).map(String::as_str)
+    }
+}

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -33,6 +33,7 @@ mod pkg;
 mod replay;
 mod sign;
 mod topology_graph;
+mod fleet_model;
 mod topology_law;
 
 fn main() -> ExitCode {

--- a/crates/hale-cli/src/topology_graph.rs
+++ b/crates/hale-cli/src/topology_graph.rs
@@ -209,6 +209,19 @@ impl Artifact {
         path: &std::path::Path,
         raw: &str,
     ) -> Result<Artifact, String> {
+        // Round 3 (#490): one unambiguous value per key — a
+        // duplicated key would let the raw-verified value and the
+        // parsed (last-wins) value disagree.
+        if let Err(e) =
+            hale_types::topology::scan_top_level(raw)
+        {
+            return Err(format!(
+                "{}: {} — the verified and consumed values \
+                 could disagree",
+                path.display(),
+                e
+            ));
+        }
         match hale_types::topology::verify_artifact_digest(raw) {
             Some(true) => {}
             Some(false) => {
@@ -237,19 +250,6 @@ impl Artifact {
                 path.display(),
                 sem.map(|s| s.to_string()).unwrap_or_else(|| "absent".into()),
                 hale_types::topology::MODEL_SEMANTICS
-            ));
-        }
-        // Round 3 (#490): one unambiguous value per key — a
-        // duplicated key would let the raw-verified value and the
-        // parsed (last-wins) value disagree.
-        if let Some(key) =
-            hale_types::topology::find_duplicate_key(&raw)
-        {
-            return Err(format!(
-                "{}: duplicate object key `{}` — the verified \
-                 and consumed values could disagree",
-                path.display(),
-                key
             ));
         }
         // Round 2 (#490): the declared IDENTITY must recompute

--- a/crates/hale-cli/src/topology_graph.rs
+++ b/crates/hale-cli/src/topology_graph.rs
@@ -239,6 +239,19 @@ impl Artifact {
                 hale_types::topology::MODEL_SEMANTICS
             ));
         }
+        // Round 3 (#490): one unambiguous value per key — a
+        // duplicated key would let the raw-verified value and the
+        // parsed (last-wins) value disagree.
+        if let Some(key) =
+            hale_types::topology::find_duplicate_key(&raw)
+        {
+            return Err(format!(
+                "{}: duplicate object key `{}` — the verified \
+                 and consumed values could disagree",
+                path.display(),
+                key
+            ));
+        }
         // Round 2 (#490): the declared IDENTITY must recompute
         // from the hashed model half — artifact_digest proves the
         // bytes were not edited; this proves the shape_hash names

--- a/crates/hale-cli/src/topology_graph.rs
+++ b/crates/hale-cli/src/topology_graph.rs
@@ -212,15 +212,28 @@ impl Artifact {
         // Round 3 (#490): one unambiguous value per key — a
         // duplicated key would let the raw-verified value and the
         // parsed (last-wins) value disagree.
-        if let Err(e) =
-            hale_types::topology::scan_top_level(raw)
-        {
-            return Err(format!(
-                "{}: {} — the verified and consumed values \
-                 could disagree",
-                path.display(),
-                e
-            ));
+        match hale_types::topology::scan_top_level(raw) {
+            Err(e) => {
+                return Err(format!(
+                    "{}: {} — the verified and consumed values \
+                     could disagree",
+                    path.display(),
+                    e
+                ));
+            }
+            Ok(top) => {
+                if let Err(e) =
+                    hale_types::topology::verify_top_level_order(
+                        &top,
+                    )
+                {
+                    return Err(format!(
+                        "{}: {}",
+                        path.display(),
+                        e
+                    ));
+                }
+            }
         }
         match hale_types::topology::verify_artifact_digest(raw) {
             Some(true) => {}

--- a/crates/hale-cli/src/topology_graph.rs
+++ b/crates/hale-cli/src/topology_graph.rs
@@ -287,21 +287,21 @@ impl Artifact {
         }
         let art = Artifact { v };
         let schema = art.schema();
-        let minor: Option<u32> = schema
-            .strip_prefix("1.")
-            .and_then(|m| m.parse().ok());
-        match minor {
-            Some(m) if m >= 4 => {}
-            _ => {
-                return Err(format!(
-                    "{}: unsupported topology artifact schema `{}` — this \
-                     renderer's adapter covers 1.4+ (topics landed in \
-                     1.2, verdict in 1.4; an older artifact would render \
-                     misleadingly incomplete)",
-                    path.display(),
-                    schema
-                ))
-            }
+        // Round 6 (#490): the adapter is CAPPED at the current
+        // schema — the closed canonical layout table is versioned
+        // by it, so an artifact from any other schema (older or
+        // newer) is refused rather than consumed against the
+        // wrong layout contract. Pre-release: no additive-minor
+        // promise exists.
+        if schema != hale_types::topology::TOPOLOGY_SCHEMA {
+            return Err(format!(
+                "{}: unsupported topology artifact schema `{}` — \
+                 this build consumes exactly schema {}; re-dump \
+                 with the current compiler",
+                path.display(),
+                schema,
+                hale_types::topology::TOPOLOGY_SCHEMA
+            ));
         }
         // Structural presence: every section this adapter reads.
         let need = |ok: bool, what: &str| -> Result<(), String> {

--- a/crates/hale-cli/src/topology_graph.rs
+++ b/crates/hale-cli/src/topology_graph.rs
@@ -239,6 +239,26 @@ impl Artifact {
                 hale_types::topology::MODEL_SEMANTICS
             ));
         }
+        // Round 2 (#490): the declared IDENTITY must recompute
+        // from the hashed model half — artifact_digest proves the
+        // bytes were not edited; this proves the shape_hash names
+        // those bytes.
+        match hale_types::topology::verify_shape_hash(&raw) {
+            Some(true) => {}
+            Some(false) => {
+                return Err(format!(
+                    "{}: shape_hash does not recompute from the \
+                     model half — the declared identity is stale",
+                    path.display()
+                ));
+            }
+            None => {
+                return Err(format!(
+                    "{}: no recomputable shape_hash",
+                    path.display()
+                ));
+            }
+        }
         let art = Artifact { v };
         let schema = art.schema();
         let minor: Option<u32> = schema

--- a/crates/hale-cli/src/topology_law.rs
+++ b/crates/hale-cli/src/topology_law.rs
@@ -1203,6 +1203,142 @@ impl RefContext {
                 derived_sub, rel_sub
             ));
         }
+        // Change 7 (schema 1.12): the UNHASHED endpoint rows must
+        // equal the HASHED `endpoint_identity` section exactly —
+        // the wire identity now lives inside the shape, so
+        // substituting a colliding literal's content is no longer
+        // a self-consistent unhashed edit: it contradicts the
+        // hashed half, and editing the hashed half changes the
+        // program's identity.
+        {
+            let mut h_site_pub: BTreeSet<(
+                String,
+                u64,
+                String,
+                Option<String>,
+            )> = BTreeSet::new();
+            let mut h_decl_pub: BTreeSet<(
+                String,
+                String,
+                Option<String>,
+            )> = BTreeSet::new();
+            let mut h_subs: BTreeSet<(
+                String,
+                u64,
+                String,
+                Option<String>,
+            )> = BTreeSet::new();
+            for (i, e) in v["endpoint_identity"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .enumerate()
+            {
+                let what =
+                    format!("endpoint_identity[{}]", i);
+                let wire = e["wire"]
+                    .as_str()
+                    .ok_or_else(|| {
+                        format!(
+                            "{}: wire must be a string",
+                            what
+                        )
+                    })?
+                    .to_string();
+                let topic = e["topic"]
+                    .as_str()
+                    .map(|t| t.to_string());
+                match (
+                    e["verb"].as_str(),
+                    e["fn"].as_str(),
+                    e["locus"].as_str(),
+                ) {
+                    (Some("publish"), Some(f), None) => {
+                        only_keys(
+                            e,
+                            "endpoint_identity[*]",
+                            &["verb", "fn", "site", "wire"],
+                            &["topic"],
+                        )
+                        .map_err(|x| {
+                            format!("{}: {}", what, x)
+                        })?;
+                        h_site_pub.insert((
+                            f.to_string(),
+                            e["site"].as_u64().ok_or_else(
+                                || {
+                                    format!(
+                                        "{}: site must be a \
+                                         number",
+                                        what
+                                    )
+                                },
+                            )?,
+                            wire,
+                            topic,
+                        ));
+                    }
+                    (Some("publish"), None, Some(l)) => {
+                        only_keys(
+                            e,
+                            "endpoint_identity[*]",
+                            &["verb", "locus", "wire"],
+                            &["topic"],
+                        )
+                        .map_err(|x| {
+                            format!("{}: {}", what, x)
+                        })?;
+                        h_decl_pub.insert((
+                            l.to_string(),
+                            wire,
+                            topic,
+                        ));
+                    }
+                    (Some("subscribe"), Some(f), None) => {
+                        only_keys(
+                            e,
+                            "endpoint_identity[*]",
+                            &["verb", "fn", "site", "wire"],
+                            &["topic"],
+                        )
+                        .map_err(|x| {
+                            format!("{}: {}", what, x)
+                        })?;
+                        h_subs.insert((
+                            f.to_string(),
+                            e["site"].as_u64().ok_or_else(
+                                || {
+                                    format!(
+                                        "{}: site must be a \
+                                         number",
+                                        what
+                                    )
+                                },
+                            )?,
+                            wire,
+                            topic,
+                        ));
+                    }
+                    _ => {
+                        return Err(format!(
+                            "{}: outside the closed shape",
+                            what
+                        ));
+                    }
+                }
+            }
+            if h_site_pub != site_pub
+                || h_decl_pub != decl_pub
+                || h_subs != subs
+            {
+                return Err(
+                    "the endpoint sections do not agree with \
+                     the HASHED endpoint identity — the wire \
+                     identity is part of the shape"
+                        .to_string(),
+                );
+            }
+        }
         // Round 12: SPAN-multiset tie against the span-grained
         // provenance section — each typed site row is anchored to
         // its authored span, one-to-one, not merely counted.

--- a/crates/hale-cli/tests/fixtures/topology/golden-claim.mmd
+++ b/crates/hale-cli/tests/fixtures/topology/golden-claim.mmd
@@ -1,5 +1,5 @@
 flowchart LR
-  %% topology · claim view — schema 1.11 · shape 9e25ca5ffbf88ac3 · verdict clean
+  %% topology · claim view — schema 1.12 · shape e7e11084cc75bf03 · verdict clean
   subgraph g_App["App"]
     n_App_3a_3arun["run  [hook]  {publish,alloc}"]
   end

--- a/crates/hale-cli/tests/fixtures/topology/golden-system.mmd
+++ b/crates/hale-cli/tests/fixtures/topology/golden-system.mmd
@@ -1,5 +1,5 @@
 flowchart LR
-  %% topology · system view — schema 1.11 · shape 9e25ca5ffbf88ac3 · verdict clean
+  %% topology · system view — schema 1.12 · shape e7e11084cc75bf03 · verdict clean
   subgraph g_App["App"]
     n_App_3a_3arun["run  [hook]  {publish,alloc}"]
   end

--- a/crates/hale-cli/tests/fixtures/topology/golden-system.svg
+++ b/crates/hale-cli/tests/fixtures/topology/golden-system.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1196" height="422" viewBox="0 0 1196 422" font-family="monospace" font-size="13">
 <rect x="0" y="0" width="1196" height="422" fill="#ffffff"/>
 <text x="90" y="18" font-size="15" font-weight="bold" fill="#1a202c">topology · system view</text>
-<text x="90" y="36" fill="#718096">schema 1.11 · shape 9e25ca5ffbf88ac3 · verdict clean</text>
+<text x="90" y="36" fill="#718096">schema 1.12 · shape e7e11084cc75bf03 · verdict clean</text>
 <path d="M 344 97 C 414 97, 414 163, 484 163" fill="none" stroke="#2f855a" stroke-width="1.5"/>
 <path d="M 484 163 l -7 -4 l 0 8 z" fill="#2f855a"/>
 <text x="358" y="110" font-size="11" fill="#2f855a">publish</text>

--- a/crates/hale-cli/tests/fleet_compose.rs
+++ b/crates/hale-cli/tests/fleet_compose.rs
@@ -1560,3 +1560,135 @@ fn degraded_component_blocks_absence_certification() {
         out
     );
 }
+
+/// Round 6 (#490): completeness is applied with the POLARITY of
+/// the law. Positive witnesses survive degradation; counts
+/// evaluate over a [known, known+hidden] interval; definite
+/// violations from known rows stand.
+#[test]
+fn completeness_polarity_is_respected() {
+    fn fnv1a64(bytes: &[u8]) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for b in bytes {
+            h ^= u64::from(*b);
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    }
+    // Withdraw one capability flag coherently (every family
+    // consumes EFFECTS and PUBLISHES, so all five degrade).
+    let withdraw = |src: &str, flag: &str| -> String {
+        let mut out = src.replacen(
+            &format!("\"{}\": true", flag),
+            &format!("\"{}\": false", flag),
+            1,
+        );
+        for fam in [
+            "reachability",
+            "boundary",
+            "endpoint",
+            "bound",
+            "certificate",
+        ] {
+            out = out.replacen(
+                &format!("\"{}\": \"exact\"", fam),
+                &format!("\"{}\": \"degraded\"", fam),
+                1,
+            );
+        }
+        let key = ",\n  \"artifact_digest\": \"";
+        let cut = out.rfind(key).expect("digest trailer");
+        let body = out[..cut].to_string();
+        format!(
+            "{}{}{:016x}\"\n}}\n",
+            body,
+            key,
+            fnv1a64(body.as_bytes())
+        )
+    };
+    let r = fleet("polarity");
+    // gw-0 withdraws exact_publishes: an UNCOUNTED component that
+    // could hide a publisher — and whose endpoint adequacy is
+    // degraded by flags unrelated to any subscribe witness.
+    let p = r.join("artifacts/gw.json");
+    let good = std::fs::read_to_string(&p).expect("read");
+    std::fs::write(&p, withdraw(&good, "exact_publishes"))
+        .expect("write");
+    write(
+        &r,
+        "prod.plan.json",
+        r#"{
+  "schema": "1.0",
+  "name": "prod",
+  "instances": [
+    {"id": "prober-0", "artifact": "artifacts/prober.json", "labels": ["strategy"]},
+    {"id": "oms-0",    "artifact": "artifacts/oms.json",    "labels": ["oms"]},
+    {"id": "gw-0",     "artifact": "artifacts/gw.json",     "labels": ["gateway"]}
+  ],
+  "groups": {
+    "gateways": {"labels": ["gateway"]}
+  },
+  "claims": [
+    {"name": "gw_gets_orders",
+     "require_subscribes": {"group": "gateways", "subject": "svc.order.request"}},
+    {"name": "at_least_one",
+     "count_publisher_instances": {"subject": "svc.order.intent", "min": 1}},
+    {"name": "at_least_two",
+     "count_publisher_instances": {"subject": "svc.order.intent", "min": 2}},
+    {"name": "at_most_zero",
+     "count_publisher_instances": {"subject": "svc.order.intent", "max": 0}},
+    {"name": "exactly_zero",
+     "count_publisher_instances": {"subject": "svc.order.intent", "eq": 0}},
+    {"name": "exactly_two",
+     "count_publisher_instances": {"subject": "svc.order.intent", "eq": 2}}
+  ],
+  "routes": [
+    {"id": "intent", "transport": "unix",
+     "publishers":  [{"instance": "prober-0", "topic": "t::OrderIntent"}],
+     "subscribers": [{"instance": "oms-0",    "topic": "t::OrderIntent"}]},
+    {"id": "request", "transport": "unix",
+     "publishers":  [{"instance": "oms-0", "topic": "t::OrderRequest"}],
+     "subscribers": [{"instance": "gw-0",  "topic": "t::OrderRequest"}]}
+  ]
+}"#,
+    );
+    let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    // A known routed subscriber is a POSITIVE witness — unrelated
+    // endpoint-family degradation cannot erase it; likewise a
+    // `min` already met by the known row. Neither may appear as a
+    // failing claim.
+    assert!(
+        !out.contains("`gw_gets_orders`"),
+        "the routed witness stays holds: {}",
+        out
+    );
+    assert!(
+        !out.contains("`at_least_one`"),
+        "min met by the known lower bound stays holds: {}",
+        out
+    );
+    // Interval [1, 2]: one known publisher (prober-0), one hidden
+    // candidate (gw-0 withdraws publisher completeness).
+    assert!(
+        out.contains("`at_least_two` uncertified"),
+        "min above the lower bound but inside the interval is          uncertified, not violated: {}",
+        out
+    );
+    assert!(
+        out.contains("`at_most_zero` violated"),
+        "a known count already exceeding max stays violated: {}",
+        out
+    );
+    assert!(
+        out.contains("`exactly_zero` violated"),
+        "eq below the known lower bound is a definite violation:          {}",
+        out
+    );
+    assert!(
+        out.contains("`exactly_two` uncertified"),
+        "eq inside the undecided interval is uncertified: {}",
+        out
+    );
+}

--- a/crates/hale-cli/tests/fleet_compose.rs
+++ b/crates/hale-cli/tests/fleet_compose.rs
@@ -363,14 +363,6 @@ fn a_component_whose_own_claims_fail_is_refused() {
 /// law row is refused past the integrity gate.
 #[test]
 fn a_restamped_lying_verdict_is_refused() {
-    fn fnv1a64(bytes: &[u8]) -> u64 {
-        let mut h: u64 = 0xcbf29ce484222325;
-        for b in bytes {
-            h ^= u64::from(*b);
-            h = h.wrapping_mul(0x100000001b3);
-        }
-        h
-    }
     let r = fleet("lyingverdict");
     let p = r.join("artifacts/prober.json");
     let good = std::fs::read_to_string(&p).expect("read");
@@ -954,14 +946,6 @@ fn fleets_and_environments_are_independent_axes() {
 /// admission's claims↔law join refuses it.
 #[test]
 fn deleted_law_rows_are_refused() {
-    fn fnv1a64(bytes: &[u8]) -> u64 {
-        let mut h: u64 = 0xcbf29ce484222325;
-        for b in bytes {
-            h ^= u64::from(*b);
-            h = h.wrapping_mul(0x100000001b3);
-        }
-        h
-    }
     let r = fleet("deletedlaw");
     // Rebuild the prober WITH a claim so its law table is
     // non-empty (the base prober's is empty — deleting nothing

--- a/crates/hale-cli/tests/fleet_compose.rs
+++ b/crates/hale-cli/tests/fleet_compose.rs
@@ -1317,14 +1317,55 @@ fn escaped_duplicate_key_is_refused() {
     );
 }
 
-/// Round 4 (#490): the identity fields are located STRUCTURALLY —
-/// a nested `shape_hash` decoy placed before the real top-level
-/// field is data, not the value the verifier checks. The honest
-/// component with the decoy still admits (the verifier reads the
-/// top level), while the same decoy under a DRIFTED model still
-/// refuses on the top-level staleness.
+/// Round 5 (#490): the top-level layout is CLOSED and canonical —
+/// an unknown top-level key (the round-4 decoy vehicle) refuses by
+/// name before any verifier runs, and order defines the verified
+/// hash ranges, so a nested decoy has no host to hide in.
 #[test]
-fn nested_shape_hash_decoy_does_not_confuse_the_verifier() {
+fn unknown_top_level_key_is_refused() {
+    fn fnv1a64(bytes: &[u8]) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for b in bytes {
+            h ^= u64::from(*b);
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    }
+    let r = fleet("decoy");
+    let p = r.join("artifacts/prober.json");
+    let good = std::fs::read_to_string(&p).expect("read");
+    let decoyed = good.replacen(
+        "\n  \"shape_hash\": \"",
+        "\n  \"aa_decoy\": {\"shape_hash\": \
+         \"deadbeefdeadbeef\"},\n  \"shape_hash\": \"",
+        1,
+    );
+    assert_ne!(decoyed, good, "test premise: the decoy landed");
+    let key = ",\n  \"artifact_digest\": \"";
+    let cut = decoyed.rfind(key).expect("digest trailer");
+    let body = &decoyed[..cut];
+    let restamped = format!(
+        "{}{}{:016x}\"\n}}\n",
+        body,
+        key,
+        fnv1a64(body.as_bytes())
+    );
+    std::fs::write(&p, restamped).expect("write");
+    let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    assert!(
+        out.contains("unknown top-level key `aa_decoy`"),
+        "the closed layout refuses the decoy by name: {}",
+        out
+    );
+}
+
+/// Round 5 (#490): ORDER defines the verified hash ranges. Moving
+/// `relations` before `shape_hash` (out of the model-half
+/// interval) refuses; a non-final `artifact_digest` refuses.
+#[test]
+fn top_level_reordering_is_refused() {
     fn fnv1a64(bytes: &[u8]) -> u64 {
         let mut h: u64 = 0xcbf29ce484222325;
         for b in bytes {
@@ -1340,41 +1381,182 @@ fn nested_shape_hash_decoy_does_not_confuse_the_verifier() {
             fnv1a64(body.as_bytes())
         )
     };
-    let r = fleet("decoy");
+    // 1. Move the relations section BEFORE shape_hash: its edits
+    //    would then leave shape_hash unchanged.
+    let r = fleet("reorder");
     let p = r.join("artifacts/prober.json");
     let good = std::fs::read_to_string(&p).expect("read");
-    // Insert a decoy object BEFORE the real top-level shape_hash.
-    let decoyed = good.replacen(
-        "\n  \"shape_hash\": \"",
-        "\n  \"aa_decoy\": {\"shape_hash\": \
-         \"deadbeefdeadbeef\"},\n  \"shape_hash\": \"",
-        1,
+    let rel_at = good.find("  \"relations\": {").expect("relations");
+    let rel_end = good[rel_at..]
+        .find("\n  \"groups\"")
+        .map(|i| rel_at + i)
+        .expect("groups follows relations");
+    let rel_text = &good[rel_at..rel_end];
+    let moved = format!(
+        "{}{}\n{}{}",
+        &good[..good.find("  \"shape_hash\"").expect("sh")],
+        rel_text.trim_end_matches('\n'),
+        &good[good.find("  \"shape_hash\"").expect("sh")..rel_at],
+        &good[rel_end + 1..]
     );
-    assert_ne!(decoyed, good, "test premise: the decoy landed");
     let key = ",\n  \"artifact_digest\": \"";
-    let cut = decoyed.rfind(key).expect("digest trailer");
-    std::fs::write(&p, restamp_doc(&decoyed[..cut]))
+    let cut = moved.rfind(key).expect("digest trailer");
+    std::fs::write(&p, restamp_doc(&moved[..cut]))
         .expect("write");
     let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
-    assert_eq!(
-        code, 0,
-        "the honest artifact with a decoy admits (the verifier \
-         reads the top level): {}",
+    assert_ne!(code, 0, "{}", out);
+    assert!(
+        out.contains("out of canonical order"),
+        "the moved model-half section refuses: {}",
         out
     );
-    // Now DRIFT the wire consistently while keeping the stale
-    // top-level shape_hash — the decoy must not rescue it.
-    let drifted = decoyed
-        .replace("svc.order.intent", "svc.order.hijack");
-    let cut = drifted.rfind(key).expect("digest trailer");
-    std::fs::write(&p, restamp_doc(&drifted[..cut]))
-        .expect("write");
+    // 2. artifact_digest not final: move it before `verdict`.
+    let good2 = {
+        // regenerate a clean artifact
+        let dst = r.join("artifacts/prober.json");
+        let (o, c) = hale(&[
+            "check",
+            r.join("prober").to_str().expect("utf8"),
+            &format!("--dump-topology={}", dst.display()),
+        ]);
+        assert_eq!(c, 0, "{}", o);
+        std::fs::read_to_string(&dst).expect("read")
+    };
+    let cut = good2.rfind(key).expect("digest trailer");
+    let digest_entry = &good2[cut + 2..]; // skip ",\n"
+    let digest_entry =
+        digest_entry.trim_end_matches("\n}\n").to_string();
+    let body = &good2[..cut];
+    let verdict_at =
+        body.rfind(",\n  \"verdict\"").expect("verdict");
+    let nonfinal = format!(
+        "{},\n  {}{}\n}}\n",
+        &body[..verdict_at],
+        digest_entry,
+        &body[verdict_at..]
+    );
+    std::fs::write(&p, nonfinal).expect("write");
     let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
     let _ = std::fs::remove_dir_all(&r);
     assert_ne!(code, 0, "{}", out);
     assert!(
-        out.contains("shape_hash does not recompute"),
-        "the top-level staleness refuses despite the decoy: {}",
+        out.contains("out of canonical order")
+            || out.contains("must be the final top-level entry"),
+        "the non-final digest refuses: {}",
+        out
+    );
+}
+
+/// Round 5 (#490): an admitted component whose own account says
+/// `exact_calls: false` / `adequacy.reachability: "degraded"` —
+/// with NO legacy unknowns — must not let a fleet reachability
+/// prohibition certify `holds` over it. The account is honored,
+/// scoped like the unreachable-unknown rule.
+#[test]
+fn degraded_component_blocks_absence_certification() {
+    fn fnv1a64(bytes: &[u8]) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for b in bytes {
+            h ^= u64::from(*b);
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    }
+    let r = fleet("degraded");
+    // The oms component (routed FROM the strategy source) declares
+    // the degraded account, self-consistently: exact_calls off,
+    // reachability degraded — an HONEST direction (claiming less).
+    let p = r.join("artifacts/oms.json");
+    let good = std::fs::read_to_string(&p).expect("read");
+    // Withdrawing exact_calls degrades every CALLS-consuming
+    // family — the account must stay self-consistent (admission
+    // recomputes adequacy from the capability flags).
+    let humble = good
+        .replacen(
+            "\"exact_calls\": true",
+            "\"exact_calls\": false",
+            1,
+        )
+        .replacen(
+            "\"reachability\": \"exact\"",
+            "\"reachability\": \"degraded\"",
+            1,
+        )
+        .replacen(
+            "\"boundary\": \"exact\"",
+            "\"boundary\": \"degraded\"",
+            1,
+        )
+        .replacen(
+            "\"bound\": \"exact\"",
+            "\"bound\": \"degraded\"",
+            1,
+        )
+        .replacen(
+            "\"certificate\": \"exact\"",
+            "\"certificate\": \"degraded\"",
+            1,
+        );
+    assert_ne!(humble, good, "test premise: the account changed");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&good).expect("parses");
+    assert!(
+        parsed["unknowns"]
+            .as_array()
+            .is_some_and(Vec::is_empty),
+        "test premise: no legacy unknowns:\n{}",
+        parsed["unknowns"]
+    );
+    let key = ",\n  \"artifact_digest\": \"";
+    let cut = humble.rfind(key).expect("digest trailer");
+    let body = &humble[..cut];
+    let restamped = format!(
+        "{}{}{:016x}\"\n}}\n",
+        body,
+        key,
+        fnv1a64(body.as_bytes())
+    );
+    std::fs::write(&p, restamped).expect("write");
+    // A reachability prohibition from the strategy label to the
+    // gateway label spans oms (the routed middle hop). With the
+    // routes in place there is no MODELED path only because oms's
+    // interior carries the edge — whose completeness oms itself
+    // has withdrawn.
+    write(
+        &r,
+        "prod.plan.json",
+        r#"{
+  "schema": "1.0",
+  "name": "prod",
+  "instances": [
+    {"id": "prober-0", "artifact": "artifacts/prober.json", "labels": ["strategy"]},
+    {"id": "oms-0",    "artifact": "artifacts/oms.json",    "labels": ["oms"]},
+    {"id": "gw-0",     "artifact": "artifacts/gw.json",     "labels": ["gateway"]}
+  ],
+  "groups": {
+    "strategies": {"labels": ["strategy"]},
+    "gateways":   {"labels": ["gateway"]}
+  },
+  "claims": [
+    {"name": "no_reach",
+     "forbid_reaches": {"from": "strategies", "to": "gateways"}}
+  ],
+  "routes": [
+    {"id": "intent", "transport": "unix",
+     "publishers":  [{"instance": "prober-0", "topic": "t::OrderIntent"}],
+     "subscribers": [{"instance": "oms-0",    "topic": "t::OrderIntent"}]}
+  ]
+}"#,
+    );
+    let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    assert!(
+        out.contains("uncertified")
+            && out.contains("degraded `reachability` adequacy")
+            && out.contains("exact_calls"),
+        "the degraded account blocks holds and names the \
+         withdrawn capability: {}",
         out
     );
 }

--- a/crates/hale-cli/tests/fleet_compose.rs
+++ b/crates/hale-cli/tests/fleet_compose.rs
@@ -1154,3 +1154,119 @@ fn stale_shape_hash_is_refused() {
         out
     );
 }
+
+/// Round 3 (#490): the typed decoder is STRICT — a malformed
+/// semantic row is refused, never silently filtered. A call edge
+/// whose endpoint is a number would otherwise vanish before the
+/// shared traversal, flipping a violated fleet prohibition to
+/// holds; a non-string unknown reason would erase residue the
+/// graph must certify over. The oms component is rebuilt to carry
+/// BOTH shapes, and each premise is asserted — no silent skip.
+#[test]
+fn malformed_semantic_rows_are_refused_not_dropped() {
+    const OMS_WITH_SHAPES: &str = r#"
+import "../lib" as t;
+fn helper(v: Int) -> Int { return v + 1; }
+fn call_it(f: fn(Int) -> Int, v: Int) -> Int { return f(v); }
+locus Oms {
+    params { n: Int = 0; }
+    bus { subscribe t::OrderIntent as on_intent; publish t::OrderRequest; }
+    fn on_intent(i: t::Intent) {
+        self.n = call_it(helper, i.id);
+        let o = t::Order { id: i.id };
+        t::OrderRequest <- o;
+    }
+}
+main locus OmsApp { params { o: Oms = Oms { }; } }
+fn main() { OmsApp { }; }
+"#;
+    for (tag, needle, patched, expect) in [
+        (
+            "badcall",
+            "{\"from\": \"Oms::on_intent\", \"to\": \"call_it\"}",
+            "{\"from\": \"Oms::on_intent\", \"to\": 7}",
+            "relations.calls[0].to must be a string",
+        ),
+        (
+            "badreason",
+            "\"reasons\": [\"indirect_call\"]",
+            "\"reasons\": [7]",
+            "unknowns[0].reasons[0] must be a string",
+        ),
+    ] {
+        let r = fleet(tag);
+        write(&r, "oms/main.hl", OMS_WITH_SHAPES);
+        let p = r.join("artifacts/oms.json");
+        let (out, code) = hale(&[
+            "check",
+            r.join("oms").to_str().expect("utf8"),
+            &format!("--dump-topology={}", p.display()),
+        ]);
+        assert_eq!(code, 0, "{}: oms rebuilds clean: {}", tag, out);
+        let good = std::fs::read_to_string(&p).expect("read");
+        assert!(
+            good.contains(needle),
+            "{}: test premise — the shape is present:\n{}",
+            tag,
+            good
+        );
+        let bad = good.replacen(needle, patched, 1);
+        std::fs::write(&p, restamp_both(&bad)).expect("write");
+        let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
+        let _ = std::fs::remove_dir_all(&r);
+        assert_ne!(code, 0, "{}: {}", tag, out);
+        assert!(
+            out.contains(expect),
+            "{}: the strict decoder refuses (wanted `{}`): {}",
+            tag,
+            expect,
+            out
+        );
+    }
+}
+
+/// Round 3 (#490): duplicate object keys are refused before/// Round 3 (#490): duplicate object keys are refused before
+/// parsing — serde's last-wins map would otherwise let a stale
+/// `shape_hash` shadow the raw-verified one.
+#[test]
+fn duplicate_shape_hash_is_refused() {
+    fn fnv1a64(bytes: &[u8]) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for b in bytes {
+            h ^= u64::from(*b);
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    }
+    let r = fleet("dupkey");
+    let p = r.join("artifacts/prober.json");
+    let good = std::fs::read_to_string(&p).expect("read");
+    // Append a SECOND shape_hash after the sources section — the
+    // raw verifier reads the first; serde would keep this one.
+    let marker = ",\n  \"claims\": [";
+    let poisoned = good.replacen(
+        marker,
+        ",\n  \"shape_hash\": \"deadbeefdeadbeef\",\n  \
+         \"claims\": [",
+        1,
+    );
+    assert_ne!(poisoned, good, "test premise: the key landed");
+    let key = ",\n  \"artifact_digest\": \"";
+    let cut = poisoned.rfind(key).expect("digest trailer");
+    let body = &poisoned[..cut];
+    let restamped = format!(
+        "{}{}{:016x}\"\n}}\n",
+        body,
+        key,
+        fnv1a64(body.as_bytes())
+    );
+    std::fs::write(&p, restamped).expect("write");
+    let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    assert!(
+        out.contains("duplicate object key `shape_hash`"),
+        "the duplicate key refuses before parsing: {}",
+        out
+    );
+}

--- a/crates/hale-cli/tests/fleet_compose.rs
+++ b/crates/hale-cli/tests/fleet_compose.rs
@@ -1270,3 +1270,111 @@ fn duplicate_shape_hash_is_refused() {
         out
     );
 }
+
+/// Round 4 (#490): duplicate detection compares DECODED key names
+/// — `"shape_hash"` and `"shape_hash"` are one parsed key,
+/// so the escaped spelling cannot smuggle a second value past the
+/// scanner into serde's last-wins map.
+#[test]
+fn escaped_duplicate_key_is_refused() {
+    fn fnv1a64(bytes: &[u8]) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for b in bytes {
+            h ^= u64::from(*b);
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    }
+    let r = fleet("escdup");
+    let p = r.join("artifacts/prober.json");
+    let good = std::fs::read_to_string(&p).expect("read");
+    let marker = ",\n  \"claims\": [";
+    let poisoned = good.replacen(
+        marker,
+        ",\n  \"shape\\u005fhash\": \"deadbeefdeadbeef\",\n  \
+         \"claims\": [",
+        1,
+    );
+    assert_ne!(poisoned, good, "test premise: the key landed");
+    let key = ",\n  \"artifact_digest\": \"";
+    let cut = poisoned.rfind(key).expect("digest trailer");
+    let body = &poisoned[..cut];
+    let restamped = format!(
+        "{}{}{:016x}\"\n}}\n",
+        body,
+        key,
+        fnv1a64(body.as_bytes())
+    );
+    std::fs::write(&p, restamped).expect("write");
+    let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    assert!(
+        out.contains("duplicate object key `shape_hash`"),
+        "the DECODED key comparison refuses the escaped \
+         duplicate: {}",
+        out
+    );
+}
+
+/// Round 4 (#490): the identity fields are located STRUCTURALLY —
+/// a nested `shape_hash` decoy placed before the real top-level
+/// field is data, not the value the verifier checks. The honest
+/// component with the decoy still admits (the verifier reads the
+/// top level), while the same decoy under a DRIFTED model still
+/// refuses on the top-level staleness.
+#[test]
+fn nested_shape_hash_decoy_does_not_confuse_the_verifier() {
+    fn fnv1a64(bytes: &[u8]) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for b in bytes {
+            h ^= u64::from(*b);
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    }
+    let restamp_doc = |body: &str| -> String {
+        format!(
+            "{},\n  \"artifact_digest\": \"{:016x}\"\n}}\n",
+            body,
+            fnv1a64(body.as_bytes())
+        )
+    };
+    let r = fleet("decoy");
+    let p = r.join("artifacts/prober.json");
+    let good = std::fs::read_to_string(&p).expect("read");
+    // Insert a decoy object BEFORE the real top-level shape_hash.
+    let decoyed = good.replacen(
+        "\n  \"shape_hash\": \"",
+        "\n  \"aa_decoy\": {\"shape_hash\": \
+         \"deadbeefdeadbeef\"},\n  \"shape_hash\": \"",
+        1,
+    );
+    assert_ne!(decoyed, good, "test premise: the decoy landed");
+    let key = ",\n  \"artifact_digest\": \"";
+    let cut = decoyed.rfind(key).expect("digest trailer");
+    std::fs::write(&p, restamp_doc(&decoyed[..cut]))
+        .expect("write");
+    let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
+    assert_eq!(
+        code, 0,
+        "the honest artifact with a decoy admits (the verifier \
+         reads the top level): {}",
+        out
+    );
+    // Now DRIFT the wire consistently while keeping the stale
+    // top-level shape_hash — the decoy must not rescue it.
+    let drifted = decoyed
+        .replace("svc.order.intent", "svc.order.hijack");
+    let cut = drifted.rfind(key).expect("digest trailer");
+    std::fs::write(&p, restamp_doc(&drifted[..cut]))
+        .expect("write");
+    let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    assert!(
+        out.contains("shape_hash does not recompute"),
+        "the top-level staleness refuses despite the decoy: {}",
+        out
+    );
+}

--- a/crates/hale-cli/tests/fleet_compose.rs
+++ b/crates/hale-cli/tests/fleet_compose.rs
@@ -147,6 +147,33 @@ fn restamp_both(artifact: &str) -> String {
     let key = ",\n  \"artifact_digest\": \"";
     let cut = artifact.rfind(key).expect("digest trailer");
     let mut body = artifact[..cut].to_string();
+    // Round 2 (#490): the shape_hash is recomputed at admission,
+    // so hashed-half tampers must restamp it too — each pin then
+    // exercises the deep binding it targets, not the identity
+    // gate. (The stale-identity control below does NOT use this
+    // helper.)
+    let sk = "\"shape_hash\": \"";
+    if let Some(at) = body.find(sk) {
+        let start = at + sk.len();
+        if let Some(rel) = body[start..].find('"') {
+            let claimed_end = start + rel;
+            let model_start =
+                claimed_end + "\",\n".len();
+            if let Some(end_rel) =
+                body[model_start..].find(",\n  \"sources\": [")
+            {
+                let fresh = format!(
+                    "{:016x}",
+                    fnv1a64(
+                        body[model_start
+                            ..model_start + end_rel]
+                            .as_bytes()
+                    )
+                );
+                body.replace_range(start..claimed_end, &fresh);
+            }
+        }
+    }
     let lk = "\"law_digest\": \"";
     if let (Some(at), Ok(v)) = (
         body.find(lk),
@@ -1032,6 +1059,98 @@ fn main() { Prober { }; }
     assert!(
         !out.contains("artifact_digest"),
         "integrity passed; the law account is what refused: {}",
+        out
+    );
+}
+
+/// Round 2 (#490): route identity is ONE grain. A component with
+/// only a LITERAL end on the topic's wire (a raw send to
+/// "svc.order.intent", never `publish t::OrderIntent`) cannot
+/// satisfy a route naming the topic — the role check and the edge
+/// builder both read the typed topic-identity rows.
+#[test]
+fn literal_only_publisher_cannot_satisfy_a_topic_route() {
+    let r = fleet("literalroute");
+    // Rebuild the prober to publish the WIRE literally, never the
+    // topic identity.
+    write(
+        &r,
+        "prober/main.hl",
+        r#"
+import "../lib" as t;
+locus Probe {
+    params { n: Int = 0; }
+    bus { publish "svc.order.intent" of type t::Intent; }
+    fn submit() {
+        let i = t::Intent { id: 1 };
+        "svc.order.intent" <- i;
+    }
+}
+main locus Prober { params { p: Probe = Probe { }; } }
+fn main() { Prober { }; }
+"#,
+    );
+    let dst = r.join("artifacts/prober.json");
+    let (out, code) = hale(&[
+        "check",
+        r.join("prober").to_str().expect("utf8"),
+        &format!("--dump-topology={}", dst.display()),
+    ]);
+    assert_eq!(code, 0, "literal prober checks clean: {}", out);
+    let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    assert!(
+        out.contains("declares no topic")
+            || out.contains("nothing in that component"),
+        "the topic-grain role check refuses the literal-only \
+         publisher: {}",
+        out
+    );
+}
+
+/// Round 2 (#490): the declared IDENTITY must recompute. A
+/// coordinated edit of the hashed endpoint_identity AND its
+/// unhashed mirrors under a STALE shape_hash — with only
+/// artifact_digest restamped — refuses before any decoding.
+#[test]
+fn stale_shape_hash_is_refused() {
+    fn fnv1a64(bytes: &[u8]) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for b in bytes {
+            h ^= u64::from(*b);
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    }
+    let r = fleet("staleshape");
+    let p = r.join("artifacts/prober.json");
+    let good = std::fs::read_to_string(&p).expect("read");
+    // Rewrite the literal wire in BOTH the hashed identity and the
+    // unhashed mirrors, consistently.
+    let drifted = good.replace(
+        "svc.order.intent",
+        "svc.order.hijack",
+    );
+    assert_ne!(drifted, good, "test premise: the wire drifted");
+    // Restamp ONLY the document digest — the shape_hash stays
+    // stale.
+    let key = ",\n  \"artifact_digest\": \"";
+    let cut = drifted.rfind(key).expect("digest trailer");
+    let body = &drifted[..cut];
+    let restamped = format!(
+        "{}{}{:016x}\"\n}}\n",
+        body,
+        key,
+        fnv1a64(body.as_bytes())
+    );
+    std::fs::write(&p, restamped).expect("write");
+    let (out, code) = hale(&["fleet", "check", &plan_of(&r)]);
+    let _ = std::fs::remove_dir_all(&r);
+    assert_ne!(code, 0, "{}", out);
+    assert!(
+        out.contains("shape_hash does not recompute"),
+        "the stale identity refuses: {}",
         out
     );
 }

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -331,6 +331,33 @@ fn fnv1a64(bytes: &[u8]) -> u64 {
 /// binding it targets, not the digest gate.
 fn restamp_digest(body_without_trailer: &str) -> String {
     let mut body = body_without_trailer.to_string();
+    // Round 2 (#490): the shape_hash is recomputed at admission,
+    // so hashed-half tampers must restamp it too — each pin then
+    // exercises the deep binding it targets, not the identity
+    // gate. (The stale-identity control below does NOT use this
+    // helper.)
+    let sk = "\"shape_hash\": \"";
+    if let Some(at) = body.find(sk) {
+        let start = at + sk.len();
+        if let Some(rel) = body[start..].find('"') {
+            let claimed_end = start + rel;
+            let model_start =
+                claimed_end + "\",\n".len();
+            if let Some(end_rel) =
+                body[model_start..].find(",\n  \"sources\": [")
+            {
+                let fresh = format!(
+                    "{:016x}",
+                    fnv1a64(
+                        body[model_start
+                            ..model_start + end_rel]
+                            .as_bytes()
+                    )
+                );
+                body.replace_range(start..claimed_end, &fresh);
+            }
+        }
+    }
     let key = "\"law_digest\": \"";
     if let (Some(at), Ok(v)) = (
         body.find(key),

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -3087,3 +3087,76 @@ fn main() { App { }; }
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Change 7 (schema 1.12): wire identity is part of the SHAPE.
+/// The round-12 residual — substituting a colliding literal's
+/// content at an unchanged site, with every unhashed section
+/// edited consistently — now contradicts the hashed
+/// `endpoint_identity` section and refuses. Rewriting the hashed
+/// half instead changes the program's identity.
+#[test]
+fn colliding_content_substitution_is_refused() {
+    let dir = workdir("subst");
+    let src = dir.join("app.hl");
+    std::fs::write(
+        &src,
+        r#"
+type Msg { n: Int = 0; }
+topic Orders { payload: Msg; subject: "wire.orders"; }
+locus Emitter {
+    params { n: Int = 0; }
+    bus { publish Orders; publish "Orders" of type Msg; }
+    fn emit(v: Int) {
+        let m = Msg { n: v };
+        Orders <- m;
+        "Orders" <- m;
+    }
+}
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe Orders as on_t; subscribe "Orders" as on_l of type Msg; }
+    fn on_t(m: Msg) { self.n = m.n; }
+    fn on_l(m: Msg) { self.n = m.n; }
+}
+main locus App {
+    params { e: Emitter = Emitter { }; s: Sink = Sink { }; }
+    run() { self.e.emit(1); }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let artifact = dump_artifact(&dir, &src);
+    let raw = std::fs::read_to_string(&artifact).unwrap();
+    // Retag the literal site-1 end as another copy of the
+    // topic-covered end — the exact round-12 substitution — in
+    // the UNHASHED endpoints section.
+    let needle = "\"subject\": \"Orders\", \"via\": \"site\", \
+                  \"fn\": \"Emitter::emit\", \"site\": 1";
+    assert!(raw.contains(needle), "literal site row:\n{}", raw);
+    let swapped = raw.replacen(
+        needle,
+        "\"subject\": \"wire.orders\", \"via\": \"site\", \
+         \"fn\": \"Emitter::emit\", \"site\": 1, \"topic\": \
+         \"Orders\"",
+        1,
+    );
+    let p2 = dir.join("subst.topology");
+    std::fs::write(&p2, restamp_digest(&strip_trailer(&swapped)))
+        .unwrap();
+    let out = hale()
+        .arg("topology")
+        .arg("graph")
+        .arg(&p2)
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains(
+            "do not agree with the HASHED endpoint identity"
+        ),
+        "the hashed identity refuses the substitution: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -284,9 +284,15 @@ fn bad_inputs_fail_closed() {
         .output()
         .unwrap();
     assert!(!out.status.success());
+    // Round 5 (#490): the canonical-layout gate runs first, so
+    // the minimal crafted document refuses on its layout (no
+    // final artifact_digest) — either refusal is fail-closed.
+    let err = String::from_utf8_lossy(&out.stderr);
     assert!(
-        String::from_utf8_lossy(&out.stderr).contains("schema"),
-        "refusal names the schema"
+        err.contains("schema")
+            || err.contains("artifact_digest must be the final"),
+        "refusal names the schema or the layout: {}",
+        err
     );
 
     // Unknown view / format / missing --claim.

--- a/crates/hale-cli/tests/xseed_claims_verbs.rs
+++ b/crates/hale-cli/tests/xseed_claims_verbs.rs
@@ -138,6 +138,9 @@ fn the_topology_artifact_round_trips() {
                 }
                 if l.starts_with("  \"topics\": [")
                     || l.starts_with("  \"law\": {")
+                    || l.starts_with(
+                        "  \"endpoint_identity\": [",
+                    )
                 {
                     skip = true;
                 }

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -1961,50 +1961,93 @@ pub const ARTIFACT_DIGEST_KEY: &str = ",\n  \"artifact_digest\": \"";
 /// older artifact, but it must never mistake "nothing to check"
 /// for "checked and intact".
 pub fn verify_artifact_digest(artifact: &str) -> Option<bool> {
-    // rfind: the digest is the final key, and searching from the end
-    // means a user-authored string that happens to contain the
-    // marker cannot shadow the real one.
-    let at = artifact.rfind(ARTIFACT_DIGEST_KEY)?;
-    let body = &artifact[..at];
-    let rest = &artifact[at + ARTIFACT_DIGEST_KEY.len()..];
-    let claimed = rest.split('"').next()?;
+    // Round 4 (#490): located STRUCTURALLY — the digest is the
+    // TOP-LEVEL entry, and the covered body is everything before
+    // the comma that terminates the preceding top-level entry
+    // (byte-identical to what the emitter hashed). A nested
+    // `artifact_digest` inside some section is data, never the
+    // verified value.
+    let top = scan_top_level(artifact).ok()?;
+    let at = top
+        .iter()
+        .position(|(k, _, _)| k == "artifact_digest")?;
+    let body_end = top.get(at.checked_sub(1)?)?.2;
+    let body = &artifact[..body_end];
+    let entry = &artifact[top[at].1..top[at].2];
+    let claimed = entry.split('"').nth(3)?;
     Some(claimed == format!("{:016x}", fnv1a64(body.as_bytes())))
 }
 
-/// Recompute the MODEL-HALF hash from the raw artifact text and
-/// compare it with the declared `shape_hash` (GH #476 Change 7,
-/// round 2). `artifact_digest` proves the document was not edited;
-/// this proves the declared IDENTITY matches the hashed content —
-/// without it, a consistent edit of the hashed `endpoint_identity`
-/// (plus its unhashed mirrors) under a STALE shape_hash would keep
-/// the old identity while changing the wire facts, which is the
-/// exact drift schema 1.12 exists to prevent. `None` = the
-/// document has no shape_hash / model half to check.
-pub fn verify_shape_hash(artifact: &str) -> Option<bool> {
-    const KEY: &str = "\"shape_hash\": \"";
-    let at = artifact.find(KEY)?;
-    let rest = &artifact[at + KEY.len()..];
-    let claimed = rest.split('"').next()?;
-    // The model half starts on the next line and runs to the
-    // unhashed tail, which always begins with the sources section.
-    // JSON strings cannot contain raw newlines, so the line-anchored
-    // marker is unambiguous.
-    let start = at + KEY.len() + claimed.len() + "\",\n".len();
-    let body = &artifact[start..];
-    let end = body.find(",\n  \"sources\": [")?;
-    let model = &body[..end];
-    Some(claimed == format!("{:016x}", fnv1a64(model.as_bytes())))
-}
-
-/// Scan a JSON document for DUPLICATE OBJECT KEYS (GH #476
-/// Change 7, round 3). serde's map parse is last-wins, while the
-/// raw digest/identity verifiers read first occurrences — a
-/// duplicated key would let the verified value and the consumed
-/// value disagree (a stale `shape_hash` shadowing the verified
-/// one is the concrete attack). One unambiguous value per key,
-/// enforced BEFORE parsing, for every object at every depth.
-/// Returns the first duplicated key, or `None` when clean.
-pub fn find_duplicate_key(doc: &str) -> Option<String> {
+/// One RAW STRUCTURAL scan of an artifact document (GH #476
+/// Change 7, rounds 3–4). The raw admission pass and the parsed
+/// consumption must never disagree, which forces two properties
+/// the earlier textual helpers lacked:
+///
+///  * duplicate object keys are detected on their DECODED names —
+///    `"shape\u005fhash"` and `"shape_hash"` are one parsed key,
+///    so they are one scanner key (serde's last-wins map would
+///    otherwise consume a value the raw pass never verified);
+///  * the identity fields are located STRUCTURALLY at the top
+///    level — a nested `shape_hash` (or `artifact_digest`) inside
+///    some other section is data, never the value the verifiers
+///    check.
+///
+/// Returns the top-level entries in document order:
+/// (decoded key, key position, terminator position — the byte
+/// index of the `,` or `}` that ends the entry). `Err` names the
+/// first duplicated key (any depth) or the malformation.
+pub fn scan_top_level(
+    doc: &str,
+) -> Result<Vec<(String, usize, usize)>, String> {
+    fn unescape(raw: &str) -> Option<String> {
+        let mut out = String::with_capacity(raw.len());
+        let mut it = raw.chars();
+        while let Some(c) = it.next() {
+            if c != '\\' {
+                out.push(c);
+                continue;
+            }
+            match it.next()? {
+                '"' => out.push('"'),
+                '\\' => out.push('\\'),
+                '/' => out.push('/'),
+                'b' => out.push('\u{8}'),
+                'f' => out.push('\u{c}'),
+                'n' => out.push('\n'),
+                'r' => out.push('\r'),
+                't' => out.push('\t'),
+                'u' => {
+                    let mut cp = 0u32;
+                    for _ in 0..4 {
+                        cp = cp * 16
+                            + it.next()?.to_digit(16)?;
+                    }
+                    if (0xD800..0xDC00).contains(&cp) {
+                        // Surrogate pair.
+                        if it.next()? != '\\'
+                            || it.next()? != 'u'
+                        {
+                            return None;
+                        }
+                        let mut lo = 0u32;
+                        for _ in 0..4 {
+                            lo = lo * 16
+                                + it.next()?.to_digit(16)?;
+                        }
+                        if !(0xDC00..0xE000).contains(&lo) {
+                            return None;
+                        }
+                        cp = 0x10000
+                            + ((cp - 0xD800) << 10)
+                            + (lo - 0xDC00);
+                    }
+                    out.push(char::from_u32(cp)?);
+                }
+                _ => return None,
+            }
+        }
+        Some(out)
+    }
     enum Scope {
         Object {
             keys: std::collections::BTreeSet<String>,
@@ -2013,6 +2056,8 @@ pub fn find_duplicate_key(doc: &str) -> Option<String> {
         Array,
     }
     let mut stack: Vec<Scope> = Vec::new();
+    let mut top: Vec<(String, usize, usize)> = Vec::new();
+    let mut open_entry: Option<(String, usize)> = None;
     let mut chars = doc.char_indices().peekable();
     while let Some((i, c)) = chars.next() {
         match c {
@@ -2022,9 +2067,19 @@ pub fn find_duplicate_key(doc: &str) -> Option<String> {
             }),
             '[' => stack.push(Scope::Array),
             '}' | ']' => {
+                if stack.len() == 1 {
+                    if let Some((k, pos)) = open_entry.take() {
+                        top.push((k, pos, i));
+                    }
+                }
                 stack.pop();
             }
             ',' => {
+                if stack.len() == 1 {
+                    if let Some((k, pos)) = open_entry.take() {
+                        top.push((k, pos, i));
+                    }
+                }
                 if let Some(Scope::Object {
                     expect_key, ..
                 }) = stack.last_mut()
@@ -2033,7 +2088,6 @@ pub fn find_duplicate_key(doc: &str) -> Option<String> {
                 }
             }
             '"' => {
-                // Consume the string, tracking escapes.
                 let start = i + 1;
                 let mut end = start;
                 let mut esc = false;
@@ -2051,6 +2105,7 @@ pub fn find_duplicate_key(doc: &str) -> Option<String> {
                         _ => {}
                     }
                 }
+                let at_top = stack.len() == 1;
                 if let Some(Scope::Object {
                     keys,
                     expect_key,
@@ -2058,9 +2113,22 @@ pub fn find_duplicate_key(doc: &str) -> Option<String> {
                 {
                     if *expect_key {
                         *expect_key = false;
-                        let key = &doc[start..end];
-                        if !keys.insert(key.to_string()) {
-                            return Some(key.to_string());
+                        let key = unescape(&doc[start..end])
+                            .ok_or_else(|| {
+                                format!(
+                                    "malformed string escape in \
+                                     key at byte {}",
+                                    start
+                                )
+                            })?;
+                        if !keys.insert(key.clone()) {
+                            return Err(format!(
+                                "duplicate object key `{}`",
+                                key
+                            ));
+                        }
+                        if at_top {
+                            open_entry = Some((key, i));
                         }
                     }
                 }
@@ -2068,9 +2136,39 @@ pub fn find_duplicate_key(doc: &str) -> Option<String> {
             _ => {}
         }
     }
-    None
+    Ok(top)
 }
 
+/// Recompute the MODEL-HALF hash from the raw artifact text and
+/// compare it with the declared `shape_hash` (GH #476 Change 7).
+/// Rounds 2 + 4: the field is located STRUCTURALLY at the top
+/// level (a nested `shape_hash` is never the checked value), and
+/// the model half is exactly the bytes between the top-level
+/// `shape_hash` entry and the top-level `sources` entry — the
+/// substring the emitter hashed. `None` = the document has no
+/// top-level shape_hash / sources to check.
+pub fn verify_shape_hash(artifact: &str) -> Option<bool> {
+    let top = scan_top_level(artifact).ok()?;
+    let sh = top.iter().find(|(k, _, _)| k == "shape_hash")?;
+    let sources_at = top
+        .iter()
+        .position(|(k, _, _)| k == "sources")?;
+    // The model half runs from just after the shape_hash entry's
+    // terminator (`,` + newline) to the terminator of the entry
+    // preceding `sources` — the comma the tail's `,\n  "sources"`
+    // begins with.
+    let model_start = sh.2 + ",\n".len();
+    let model_end = top.get(sources_at.checked_sub(1)?)?.2;
+    if model_end <= model_start {
+        return None;
+    }
+    let model = &artifact[model_start..model_end];
+    // The declared value: the quoted string after the key.
+    let val = artifact[sh.1..sh.2]
+        .split('"')
+        .nth(3)?;
+    Some(val == format!("{:016x}", fnv1a64(model.as_bytes())))
+}
 pub(crate) fn join_str<'a>(items: impl Iterator<Item = &'a String>) -> String {
     items
         .map(|s| quote(s))

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -127,7 +127,11 @@ use crate::symbol::Bundle;
 /// judgment consumes, else `degraded`). The legacy `claims` /
 /// `lowered` string rows remain, now PROJECTED from the same
 /// canonical path.
-pub const TOPOLOGY_SCHEMA: &str = "1.11";
+// 1.12 (GH #476 Change 7): canonical endpoint identity joins the
+// HASHED model half — an explicitly versioned shape transition.
+// Shape hashes change for every bus-carrying program; recorded
+// baselines and `.halerec` admissions must be re-recorded once.
+pub const TOPOLOGY_SCHEMA: &str = "1.12";
 
 /// GH #408 Phase 0: what the rows MEAN, as distinct from their shape.
 ///

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -2139,6 +2139,79 @@ pub fn scan_top_level(
     Ok(top)
 }
 
+/// The canonical TOP-LEVEL key sequence the emitter writes
+/// (GH #476 Change 7, round 5). Order is not JSON pedantry here:
+/// it DEFINES the verified hash ranges — `shape_hash` covers the
+/// bytes between its entry and `sources`, and `artifact_digest`
+/// covers everything before itself — so a document that reorders
+/// known keys (or introduces unknown ones) moves modeled facts in
+/// or out of the verified ranges and is refused.
+const CANONICAL_TOP_LEVEL: &[&str] = &[
+    "schema",
+    "semantics",
+    "shape_hash",
+    "sorts",
+    "sealed",
+    "relations",
+    "groups",
+    "labels",
+    "phases",
+    "seeds",
+    "effects",
+    "supervision",
+    "unknowns",
+    "endpoint_identity",
+    "sources",
+    "provenance",
+    "topics",
+    "endpoints",
+    "declares_publish",
+    "claims",
+    "lowered",
+    "law",
+    "capabilities",
+    "adequacy",
+    "evaluation",
+    "verdict",
+    "artifact_digest",
+];
+
+/// Enforce the canonical top-level layout on a scanned document:
+/// every key known, keys in canonical relative order (absences
+/// allowed — a bus-free program has no `endpoint_identity`), and
+/// `artifact_digest` the FINAL entry. Run at every consumption
+/// boundary right after [`scan_top_level`].
+pub fn verify_top_level_order(
+    top: &[(String, usize, usize)],
+) -> Result<(), String> {
+    let mut cursor = 0usize;
+    for (k, _, _) in top {
+        let Some(pos) =
+            CANONICAL_TOP_LEVEL.iter().position(|c| c == k)
+        else {
+            return Err(format!(
+                "unknown top-level key `{}`",
+                k
+            ));
+        };
+        if pos < cursor {
+            return Err(format!(
+                "top-level key `{}` out of canonical order — \
+                 order defines the verified hash ranges",
+                k
+            ));
+        }
+        cursor = pos + 1;
+    }
+    match top.last() {
+        Some((k, _, _)) if k == "artifact_digest" => Ok(()),
+        _ => Err(
+            "artifact_digest must be the final top-level entry"
+                .to_string(),
+        ),
+    }
+}
+
 /// Recompute the MODEL-HALF hash from the raw artifact text and
 /// compare it with the declared `shape_hash` (GH #476 Change 7).
 /// Rounds 2 + 4: the field is located STRUCTURALLY at the top

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -1971,6 +1971,31 @@ pub fn verify_artifact_digest(artifact: &str) -> Option<bool> {
     Some(claimed == format!("{:016x}", fnv1a64(body.as_bytes())))
 }
 
+/// Recompute the MODEL-HALF hash from the raw artifact text and
+/// compare it with the declared `shape_hash` (GH #476 Change 7,
+/// round 2). `artifact_digest` proves the document was not edited;
+/// this proves the declared IDENTITY matches the hashed content —
+/// without it, a consistent edit of the hashed `endpoint_identity`
+/// (plus its unhashed mirrors) under a STALE shape_hash would keep
+/// the old identity while changing the wire facts, which is the
+/// exact drift schema 1.12 exists to prevent. `None` = the
+/// document has no shape_hash / model half to check.
+pub fn verify_shape_hash(artifact: &str) -> Option<bool> {
+    const KEY: &str = "\"shape_hash\": \"";
+    let at = artifact.find(KEY)?;
+    let rest = &artifact[at + KEY.len()..];
+    let claimed = rest.split('"').next()?;
+    // The model half starts on the next line and runs to the
+    // unhashed tail, which always begins with the sources section.
+    // JSON strings cannot contain raw newlines, so the line-anchored
+    // marker is unambiguous.
+    let start = at + KEY.len() + claimed.len() + "\",\n".len();
+    let body = &artifact[start..];
+    let end = body.find(",\n  \"sources\": [")?;
+    let model = &body[..end];
+    Some(claimed == format!("{:016x}", fnv1a64(model.as_bytes())))
+}
+
 pub(crate) fn join_str<'a>(items: impl Iterator<Item = &'a String>) -> String {
     items
         .map(|s| quote(s))

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -1996,6 +1996,81 @@ pub fn verify_shape_hash(artifact: &str) -> Option<bool> {
     Some(claimed == format!("{:016x}", fnv1a64(model.as_bytes())))
 }
 
+/// Scan a JSON document for DUPLICATE OBJECT KEYS (GH #476
+/// Change 7, round 3). serde's map parse is last-wins, while the
+/// raw digest/identity verifiers read first occurrences — a
+/// duplicated key would let the verified value and the consumed
+/// value disagree (a stale `shape_hash` shadowing the verified
+/// one is the concrete attack). One unambiguous value per key,
+/// enforced BEFORE parsing, for every object at every depth.
+/// Returns the first duplicated key, or `None` when clean.
+pub fn find_duplicate_key(doc: &str) -> Option<String> {
+    enum Scope {
+        Object {
+            keys: std::collections::BTreeSet<String>,
+            expect_key: bool,
+        },
+        Array,
+    }
+    let mut stack: Vec<Scope> = Vec::new();
+    let mut chars = doc.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        match c {
+            '{' => stack.push(Scope::Object {
+                keys: std::collections::BTreeSet::new(),
+                expect_key: true,
+            }),
+            '[' => stack.push(Scope::Array),
+            '}' | ']' => {
+                stack.pop();
+            }
+            ',' => {
+                if let Some(Scope::Object {
+                    expect_key, ..
+                }) = stack.last_mut()
+                {
+                    *expect_key = true;
+                }
+            }
+            '"' => {
+                // Consume the string, tracking escapes.
+                let start = i + 1;
+                let mut end = start;
+                let mut esc = false;
+                for (j, sc) in chars.by_ref() {
+                    if esc {
+                        esc = false;
+                        continue;
+                    }
+                    match sc {
+                        '\\' => esc = true,
+                        '"' => {
+                            end = j;
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+                if let Some(Scope::Object {
+                    keys,
+                    expect_key,
+                }) = stack.last_mut()
+                {
+                    if *expect_key {
+                        *expect_key = false;
+                        let key = &doc[start..end];
+                        if !keys.insert(key.to_string()) {
+                            return Some(key.to_string());
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 pub(crate) fn join_str<'a>(items: impl Iterator<Item = &'a String>) -> String {
     items
         .map(|s| quote(s))

--- a/crates/hale-types/src/topology_projection.rs
+++ b/crates/hale-types/src/topology_projection.rs
@@ -605,6 +605,75 @@ pub fn project_model_half<'a>(m: &'a ApplicationModel) -> String {
     }
     trim_trailing_comma(&mut model);
     model.push_str("  ]");
+    // GH #476 Change 7 (schema 1.12 — the explicitly versioned
+    // shape transition): canonical ENDPOINT IDENTITY joins the
+    // hashed half. The V1 relations render both a topic-covered
+    // end and a display-colliding literal as one spelling, so the
+    // shape could not distinguish two systems that talk to
+    // different wire addresses — which is exactly what the shape
+    // exists to distinguish (and what replay admission relies
+    // on). Rows carry the owner, source-order site ordinal
+    // (motion-stable), the byte-exact wire subject, and the
+    // declared topic when one covers the end. Emitted only when
+    // endpoints exist, so bus-free programs keep their identity.
+    {
+        let subj_pat = |sid: hale_model::SubjectId| -> &str {
+            e.subjects
+                .get(sid.index())
+                .map(|su| su.pattern.as_str())
+                .unwrap_or("")
+        };
+        let topic_disp = |t: &Option<hale_model::TopicId>|
+         -> String {
+            match t {
+                Some(tid) => e
+                    .topics
+                    .get(tid.index())
+                    .map(|tp| {
+                        format!(
+                            ", \"topic\": {}",
+                            quote(&tp.display)
+                        )
+                    })
+                    .unwrap_or_default(),
+                None => String::new(),
+            }
+        };
+        let mut rows: Vec<String> = Vec::new();
+        for p in &r.publishes {
+            rows.push(format!(
+                "    {{\"verb\": \"publish\", \"fn\": {}, \"site\": {}, \"wire\": {}{}}}",
+                quote(&fn_display(p.function)),
+                p.site,
+                quote(subj_pat(p.subject)),
+                topic_disp(&p.declared_topic)
+            ));
+        }
+        for d in &r.declares_publish {
+            rows.push(format!(
+                "    {{\"verb\": \"publish\", \"locus\": {}, \"wire\": {}{}}}",
+                quote(&locus_display(d.locus)),
+                quote(subj_pat(d.subject)),
+                topic_disp(&d.declared_topic)
+            ));
+        }
+        for su in &r.subscribes {
+            rows.push(format!(
+                "    {{\"verb\": \"subscribe\", \"fn\": {}, \"site\": {}, \"wire\": {}{}}}",
+                quote(&fn_display(su.handler)),
+                su.site,
+                quote(subj_pat(su.subject)),
+                topic_disp(&su.declared_topic)
+            ));
+        }
+        rows.sort();
+        rows.dedup();
+        if !rows.is_empty() {
+            model.push_str(",\n  \"endpoint_identity\": [\n");
+            model.push_str(&rows.join(",\n"));
+            model.push_str("\n  ]");
+        }
+    }
     model
 }
 

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -1643,7 +1643,7 @@ fn main() { App { }; }
         .find(|c| c.from.0 == go)
         .expect("call row")
         .site;
-    let mut with_hole = |kind: hale_model::HoleKind,
+    let with_hole = |kind: hale_model::HoleKind,
                          hides: hale_model::RelationSet,
                          site: Option<u32>|
      -> hale_model::ApplicationModel {

--- a/crates/hale-types/tests/topology_projection.rs
+++ b/crates/hale-types/tests/topology_projection.rs
@@ -43,6 +43,16 @@ fn legacy_arm(legacy_half: &str) -> &str {
     legacy_half
 }
 
+/// Change 7 (schema 1.12): `endpoint_identity` is new hashed
+/// content the legacy gathering never produced — strip it before a
+/// V1 byte comparison.
+fn strip_endpoint_identity(projected: &str) -> &str {
+    projected
+        .split(",\n  \"endpoint_identity\": [")
+        .next()
+        .unwrap_or(projected)
+}
+
 fn artifact_shape_hash(artifact: &str) -> u64 {
     artifact
         .lines()
@@ -106,7 +116,12 @@ fn check_one(
     }
     let legacy = legacy_arm(&legacy_half);
     let _ = model_half_of(&art);
-    let projected = project_model_half(&model);
+    let projected_full = project_model_half(&model);
+    // Change 7 (schema 1.12): `endpoint_identity` is NEW hashed
+    // content the legacy gathering never produced — the versioned
+    // shape transition. The differential's charter is the V1
+    // subset: strip the new section, compare the rest byte-exact.
+    let projected = strip_endpoint_identity(&projected_full);
     if legacy != projected {
         bad.push(format!(
             "{}: model half diverges.\n{}",
@@ -306,7 +321,8 @@ fn main() { App { }; }
     let model = derive_application_model(&bundle);
     let legacy = legacy_arm(&legacy_half);
     let _ = model_half_of(&art);
-    let projected = project_model_half(&model);
+    let projected_full = project_model_half(&model);
+    let projected = strip_endpoint_identity(&projected_full);
     assert!(
         legacy.contains("kv::Store"),
         "artifact spells the import author-side:\n{}",
@@ -333,7 +349,8 @@ fn assert_projection_matches(src: &str, label: &str) -> String {
     let model = derive_application_model(&bundle);
     let legacy = legacy_arm(&legacy_half).to_string();
     let _ = model_half_of(&art);
-    let projected = project_model_half(&model);
+    let projected_full = project_model_half(&model);
+    let projected = strip_endpoint_identity(&projected_full);
     assert_eq!(
         legacy,
         projected,
@@ -475,13 +492,14 @@ fn main() { App { }; }
     let model = derive_application_model(&bundle);
     let legacy = legacy_arm(&legacy_half);
     let _ = model_half_of(&art);
-    let projected = project_model_half(&model);
+    let projected_full = project_model_half(&model);
+    let projected = strip_endpoint_identity(&projected_full);
     assert!(
         legacy.contains("\"subject\": \"kv::Item\""),
         "V1 demangles the colliding literal:\n{}",
         legacy
     );
-    assert_eq!(legacy, projected, "{}", first_diff(legacy, &projected));
+    assert_eq!(legacy, projected, "{}", first_diff(legacy, projected));
 }
 
 /// P1 (round 12): the V1 display map is EXACT-renames scope. A
@@ -531,13 +549,14 @@ fn main() { App { }; }
     let model = derive_application_model(&bundle);
     let legacy = legacy_arm(&legacy_half);
     let _ = model_half_of(&art);
-    let projected = project_model_half(&model);
+    let projected_full = project_model_half(&model);
+    let projected = strip_endpoint_identity(&projected_full);
     assert!(
         legacy.contains("\"subject\": \"__lib_x_kv_Store::bump\""),
         "V1 keeps the method-shaped literal verbatim:\n{}",
         legacy
     );
-    assert_eq!(legacy, projected, "{}", first_diff(legacy, &projected));
+    assert_eq!(legacy, projected, "{}", first_diff(legacy, projected));
 }
 
 /// P1 (round 12): labels and effects are V1-universe sections. The
@@ -672,13 +691,14 @@ fn main() { App { }; }
     let model = derive_application_model(&bundle);
     let legacy = legacy_arm(&legacy_half);
     let _ = model_half_of(&art);
-    let projected = project_model_half(&model);
+    let projected_full = project_model_half(&model);
+    let projected = strip_endpoint_identity(&projected_full);
     assert!(
         legacy.contains("\"sealed\": [\"z::Z\", \"a::A\"]"),
         "raw order, display values:\n{}",
         legacy
     );
-    assert_eq!(legacy, projected, "{}", first_diff(legacy, &projected));
+    assert_eq!(legacy, projected, "{}", first_diff(legacy, projected));
 }
 
 /// P1 (round 13): a retry bound is the literal AS WRITTEN — i64.

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -931,11 +931,11 @@ fleet-family rows outright, and recomputes the document verdict.
 A restamped artifact whose sections disagree with each other is
 refused even though its digest verifies.
 
-The artifact shape (schema `1.11`):
+The artifact shape (schema `1.12`):
 
 ```text
 {
-  "schema": "1.11",
+  "schema": "1.12",
   "shape_hash": "<fnv1a-64 over the model half>",
   "sorts":     { "loci": […], "fns": […], "topics": […] },
   "relations": {
@@ -961,6 +961,8 @@ The artifact shape (schema `1.11`):
                   "decls": {name: span, topics included},
                   "supervision": [+span] },
   "topics":    [ {"name", "subject", "shape", "payload_hash"} ],
+  "endpoint_identity": [ {"verb", "fn" | "locus", "site"?,
+                          "wire", "topic"?} ],   // HASHED
   "endpoints": [ {"verb": "publish" | "subscribe", "subject",
                   "via": "site" | "declaration",
                   "fn"?, "site"?, "locus"?, "topic"?,

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -1001,9 +1001,14 @@ reason is precisely the omission the shared traversal must never
 see; only genuinely optional facts (provenance, unplaceable decl
 sources, a bus-free program's absent endpoint section) may be
 absent. And every consumed document must carry ONE unambiguous
-value per key: duplicate object keys are rejected before parsing
-(`find_duplicate_key`), because serde's last-wins map would let a
-duplicated `shape_hash` shadow the raw-verified one.
+value per key, judged the way a parser judges it (round 4):
+duplicate object keys are rejected before parsing on their
+DECODED names (`"shape\u005fhash"` and `"shape_hash"` are one
+key), and the identity fields are located STRUCTURALLY — one raw
+walk (`scan_top_level`) yields the top-level entries, and both
+`verify_shape_hash` and `verify_artifact_digest` read exactly the
+top-level field the parsed document consumes, so a nested decoy
+in some other section is data, never the verified value.
 
 Route admission validates **roles**, not just topic identity. A
 publisher endpoint must publish the subject and a subscriber endpoint

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -988,7 +988,16 @@ names a local topic, so the role check AND the edge builder both
 read the typed rows carrying that topic identity — a literal end
 on the same wire is a different endpoint and satisfies neither —
 while fleet claims that deliberately quantify over wire subjects
-keep the wire-grain accessor. And the declared identity is
+keep the wire-grain accessor. The component's POSITIVE
+completeness account is honored (round 5): the typed decode
+carries `capabilities` and `adequacy`, and a fleet claim of a
+family some involved component admits as `degraded` cannot
+certify `holds` — it reports `uncertified`, naming the instances
+and their withdrawn capability flags. Violations stand (a witness
+is a witness), and the scoping mirrors the unreachable-unknown
+rule: a degraded instance the claim's sources cannot reach, and
+which hosts no quantified endpoint, is not evidence about that
+claim. And the declared identity is
 VERIFIED: both Track A and fleet recompute `shape_hash` from the
 raw model half before any decoding (`verify_shape_hash`) — a
 consistent hashed+unhashed endpoint edit under a stale shape_hash
@@ -1000,8 +1009,17 @@ REFUSED, never filtered, because a silently dropped edge or hole
 reason is precisely the omission the shared traversal must never
 see; only genuinely optional facts (provenance, unplaceable decl
 sources, a bus-free program's absent endpoint section) may be
-absent. And every consumed document must carry ONE unambiguous
-value per key, judged the way a parser judges it (round 4):
+absent. The top-level LAYOUT is canonical and closed (round 5):
+order is not JSON pedantry here — it DEFINES the verified hash
+ranges (`shape_hash` covers the bytes between its entry and
+`sources`; `artifact_digest` covers everything before itself), so
+known keys must appear in the emitter's canonical sequence,
+unknown top-level keys are refused, and `artifact_digest` must be
+the FINAL entry — a model-half section cannot be moved outside
+the identity's coverage, and no tail entry can escape the
+document digest. And every consumed document must carry ONE
+unambiguous value per key, judged the way a parser judges it
+(round 4):
 duplicate object keys are rejected before parsing on their
 DECODED names (`"shape\u005fhash"` and `"shape_hash"` are one
 key), and the identity fields are located STRUCTURALLY — one raw

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -977,6 +977,15 @@ would be judged one at a time and recorded under that name as though
 the whole sentence held, so the shape is refused: split it, and each
 half gets its own name and verdict.
 
+Fleet composition decodes each admitted component ONCE into a
+typed interior (GH #476 Change 7) — the vertex universe, both
+call relations unioned, the publish/subscribe rows, the topics
+join surface, the component's own unknowns, decl provenance, and
+the hashed endpoint identity — and composes from those typed rows
+exclusively; no modeled fact is recovered from generic JSON after
+admission. Endpoint-use checks ("declaring a topic is not using
+it") read the hashed wire identity at site grain.
+
 Route admission validates **roles**, not just topic identity. A
 publisher endpoint must publish the subject and a subscriber endpoint
 must subscribe it, as its own artifact records — declaring a topic is

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -989,15 +989,27 @@ read the typed rows carrying that topic identity — a literal end
 on the same wire is a different endpoint and satisfies neither —
 while fleet claims that deliberately quantify over wire subjects
 keep the wire-grain accessor. The component's POSITIVE
-completeness account is honored (round 5): the typed decode
-carries `capabilities` and `adequacy`, and a fleet claim of a
-family some involved component admits as `degraded` cannot
-certify `holds` — it reports `uncertified`, naming the instances
-and their withdrawn capability flags. Violations stand (a witness
-is a witness), and the scoping mirrors the unreachable-unknown
-rule: a degraded instance the claim's sources cannot reach, and
-which hosts no quantified endpoint, is not evidence about that
-claim. And the declared identity is
+completeness account is honored WITH THE POLARITY OF THE LAW
+(rounds 5–6). `forbid_reaches` / `only_edges` certify an absence,
+so incomplete knowledge in an involved component prevents the
+proof: `holds` becomes `uncertified`, naming the instances and
+their withdrawn capability flags, scoped by the
+unreachable-unknown rule. The endpoint and count forms handle
+completeness INSIDE their evaluators: a known, routed `require_*`
+witness is a positive fact no incomplete set can erase, and a
+route-backed structural failure is definite (the plan's route
+table is complete). Counts follow the canonical monotone rule
+over a [known, known+hidden] interval — known endpoint rows are
+the lower bound; an uncounted component that withdraws the
+RELEVANT completeness (publisher counts consult publish +
+cardinality, subscriber counts subscribe + cardinality) raises
+only the upper bound; `min` holds once the lower bound reaches
+it, `max`/`eq` definitely violate once the lower bound exceeds
+them, and the undecided interval is `uncertified` — with the
+eq/min/max conjunction judged over that interval. The claim row
+is serialized AFTER this final verdict. Track A is capped at the
+current schema exactly: the canonical layout table is versioned
+by it. And the declared identity is
 VERIFIED: both Track A and fleet recompute `shape_hash` from the
 raw model half before any decoding (`verify_shape_hash`) — a
 consistent hashed+unhashed endpoint edit under a stale shape_hash

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -294,7 +294,7 @@ earlier in the same file as the family. Companion:
 class along any path, with the same loop/indirect unboundedness
 rules as every per-call dimension.
 
-**The topology artifact** (#382 phase 2; schema 1.11):
+**The topology artifact** (#382 phase 2; schema 1.12):
 `hale check <t> --dump-topology` emits the serialized model —
 sorts (loci, fns, topics), relations (calls with **weights**: loop
 nesting, unbounded-loop membership, interface-dispatch tags;
@@ -317,7 +317,7 @@ uninhabited-interface dispatch, or computed publish subjects), all
 in author spelling — plus every named claim's normalized form and
 result, under a schema version and a `shape_hash` (FNV-1a/64 over
 the canonical model half; claim RESULTS are excluded, so one
-topology under different law keeps one shape). Schema 1.11
+topology under different law keeps one shape). Schema 1.11+
 (GH #476 Change 6) adds three unhashed, digest-covered typed
 sections: **`law`** — every lowered `ClaimIr` row with its
 ordinal, origin (`main` / `constitution:<name>` / `library` /
@@ -463,13 +463,17 @@ participate in locus analyzability: they are invisible to the
 certificate machinery at every scope (a top-level closure-only
 locus already certifies synthetically), so the builder and
 admission share one membership rule — only members that produce
-function entities the engines could walk count. Known residual, by design: the CONTENT of a site
-row (its wire/topic identity) at an unchanged span is not
-independently verifiable without the source — the wire identity
-of a display-colliding literal lives only in unhashed sections,
-so substituting it at the same site is a self-consistent edit;
-closing it requires hashing endpoint wire identity (a shape-
-identity change).
+function entities the engines could walk count. The residual is CLOSED as of schema 1.12 (Change 7's
+versioned shape transition): the canonical endpoint identity —
+verb, owner, source-order site ordinal, byte-exact wire subject,
+and declared topic — is part of the HASHED model half
+(`endpoint_identity`), and the unhashed endpoint sections must
+agree with it exactly. Substituting a colliding literal's content
+now contradicts the hashed half; rewriting the hashed half
+changes the program's shape identity, which is what replay
+admission and recorded baselines compare. Shape hashes changed
+for every bus-carrying program at this transition — re-record
+baselines and `.halerec` recordings once.
 Analysis coverage is FUNCTION-grained with THREE typed
 states (rounds 10–11): `analyzed` (the body was walked),
 `summarized` (a behavior-summary row exists — this set IS the

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -983,8 +983,17 @@ call relations unioned, the publish/subscribe rows, the topics
 join surface, the component's own unknowns, decl provenance, and
 the hashed endpoint identity — and composes from those typed rows
 exclusively; no modeled fact is recovered from generic JSON after
-admission. Endpoint-use checks ("declaring a topic is not using
-it") read the hashed wire identity at site grain.
+admission. Route identity is ONE grain (round 2): a plan endpoint
+names a local topic, so the role check AND the edge builder both
+read the typed rows carrying that topic identity — a literal end
+on the same wire is a different endpoint and satisfies neither —
+while fleet claims that deliberately quantify over wire subjects
+keep the wire-grain accessor. And the declared identity is
+VERIFIED: both Track A and fleet recompute `shape_hash` from the
+raw model half before any decoding (`verify_shape_hash`) — a
+consistent hashed+unhashed endpoint edit under a stale shape_hash
+refuses, so the identity that replay and composition compare is
+always the identity of the bytes present.
 
 Route admission validates **roles**, not just topic identity. A
 publisher endpoint must publish the subject and a subscriber endpoint

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -993,7 +993,17 @@ VERIFIED: both Track A and fleet recompute `shape_hash` from the
 raw model half before any decoding (`verify_shape_hash`) — a
 consistent hashed+unhashed endpoint edit under a stale shape_hash
 refuses, so the identity that replay and composition compare is
-always the identity of the bytes present.
+always the identity of the bytes present. The typed decode is
+STRICT and fallible (round 3): a malformed semantic row — a call
+endpoint that is not a string, a non-string unknown reason — is
+REFUSED, never filtered, because a silently dropped edge or hole
+reason is precisely the omission the shared traversal must never
+see; only genuinely optional facts (provenance, unplaceable decl
+sources, a bus-free program's absent endpoint section) may be
+absent. And every consumed document must carry ONE unambiguous
+value per key: duplicate object keys are rejected before parsing
+(`find_duplicate_key`), because serde's last-wins map would let a
+duplicated `shape_hash` shadow the raw-verified one.
 
 Route admission validates **roles**, not just topic identity. A
 publisher endpoint must publish the subject and a subscriber endpoint


### PR DESCRIPTION
GH #476 Change 7, in two commits.

**Commit 1 — schema 1.12: canonical endpoint identity joins the hashed shape.** The versioned transition discussed at the end of #489: the V1 relations render a topic-covered end and a display-colliding literal as one spelling, so `shape_hash` could not distinguish two systems that talk to different wire addresses — which is exactly what the shape exists to distinguish, and what replay admission relies on. The hashed model half gains an `endpoint_identity` section (verb, owner, source-order site ordinal, byte-exact wire subject, declared topic; emitted only when endpoints exist, so bus-free programs keep their identity), and admission requires the unhashed endpoint sections to agree with it exactly. The round-12 substitution residual flips from admitted to refused (pinned): substituting a colliding literal's content now contradicts the hashed half, and rewriting the hashed half changes the program's identity.

Costs, taken deliberately and documented in CHANGELOG + spec: **shape hashes change for every bus-carrying program** — shape baselines and `.halerec` recordings need one re-record. `TOPOLOGY_SCHEMA` bumps to 1.12 as the explicit marker. The corpus differential keeps its V1 charter (the new section is stripped before the byte comparison — it is content the legacy gathering never produced, and cannot, which was the whole finding). Goldens regenerated.

**Commit 2 — the typed `FleetModel`.** `fleet_model::ComponentModel` decodes each admitted component artifact ONCE — after signature, integrity, semantics, verdict, and the shared law-account admission — into exactly the typed rows composition consumes: the vertex universe, both call relations unioned, the V1 publish/subscribe rows, the topics join surface, the component's unknowns, decl provenance for witness locations, and the hashed endpoint identity. `Component.artifact: serde_json::Value` is gone; every crawl site and all five `Value`-taking helpers are replaced by typed accessors. The only `serde_json::Value` left in fleet.rs is the parse at the decode boundary — the #476 architecture canary ("fleet code cannot walk generic JSON for a modeled fact after cutover") holds.

One behavioral strengthening rides the cutover: `has_endpoint` ("declaring a topic is not using it") now reads the hashed endpoint identity at byte-exact wire grain — a publisher end needs a send-site row, and a display-colliding literal can no longer satisfy a check aimed at the topic.

Workspace 2846/2846, corpus differentials green on their charter, zero build warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
