### PR TITLE
feat(model): deployment consumers — the arrangement, the dispatch plan, canonical obs ids (GH #476 Change 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,58 @@ behavior.
 
 ### Deployment consumers: the arrangement + the dispatch plan (GH #476 Change 8)
 
+Review round 1 (PR #491), five blockers plus two identity bugs they
+uncovered:
+
+- **Replica rows carry their index, not the count.** `replicas = 3`
+  produced `[3, 3, 3]` where the runtime has replicas 0, 1, 2 — the
+  keyed-delivery model the arrangement exists to feed would have
+  named a population no process has. `validate` now enforces that a
+  replicated field's instances form a contiguous 0-based set and
+  that the index in the path and the index in the row agree.
+- **Binding rows are decoded, not defaulted.** Every unix binding
+  was modeled `role: Listen, loss: WaitCapable` regardless of what
+  was authored, so an explicit (or inferred) `connect` binding was
+  its own opposite in the model. Roles now come from ONE rule shared
+  with the desugar, loss follows the role, and rows are canonically
+  sorted BEFORE ids are assigned — two bindings authored in reverse
+  subject order used to produce a model that failed its own
+  canonical-order law.
+- **A partly dynamic population is not same-domain.** The plan built
+  its domain map from arranged instances only, so a locus with one
+  arranged instance and one dynamic birth answered "main" for the
+  whole population — a false stage-0 optimization opportunity, and
+  an unsafe precondition for the placement-driven lowering it is
+  meant to inform. A placement hole now deletes the locus's answer.
+- **`hale build` artifacts carry an execution identity.** The
+  identity plumbing reached `hale run` and `hale replay` but not the
+  path that produces the binaries users ship, which set a model hash
+  and no digest at all. It now stamps the digest from the FINAL
+  build options plus the plan.
+- **Canonical ids are identity-bound and total.** `model_hash` does
+  not cover every table these ids index (binding rows are not in the
+  artifact), so the header publishes `entity_id_digest` at `0x88`
+  (proto 0.3) over the exact stamped rows: a consumer recomputes it
+  from its own model and joins only on a match. The mapping table
+  grows with the program instead of silently dropping entities past
+  a fixed 512 — a dropped row read back as "unstamped", which is
+  what a build with no ids at all looks like. Out of memory now
+  withholds the whole channel, loudly, rather than half of it.
+
+**Fix (observation identity).** A program with a `bindings { }`
+block published `model_hash 0` for its whole life: registering a
+binding creates the observation segment, segment creation snapshots
+the identity fields, and the prelude stamped them afterwards. The
+identity setters now run before anything that can register. Eager
+recording/replay init deliberately stays after binding realization,
+so a backend with no replay class still refuses at its own seam.
+
+**Fix (binding role inference).** The documented inference
+(publish-only → `connect`, subscribe-only → `listen`) was dead code:
+the desugar ran it after rewriting topic references to literal
+subjects, so it saw no topic ends and filled in nothing, and codegen
+refused every binding that did not spell `role:` explicitly.
+
 The model's arrangement tables are populated and their consumers
 land on them. `locus_instances` / `realizes` / `owns` /
 `placed_in` / `thread_domains` / `bindings` / `binds` now carry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,64 @@ behavior.
 
 ## Unreleased
 
+### Deployment consumers: the arrangement + the dispatch plan (GH #476 Change 8)
+
+The model's arrangement tables are populated and their consumers
+land on them. `locus_instances` / `realizes` / `owns` /
+`placed_in` / `thread_domains` / `bindings` / `binds` now carry
+the static deployment: the params-default tree rooted at the main
+locus, `pinned(replicas = K)` fanned to K instances, thread domains
+by the runtime's own rule (pinned owns a domain, `cooperative(pool
+= X)` runs on X's worker, everything else inherits its owner, the
+root is `main`, a binding reader is its own domain). What the
+arrangement cannot see is a typed hole, not silence: instances born
+outside it (method bodies AND free functions - `fn main() { W { };
+}` is the corpus's most common shape) hide OWNS|PLACED at the born
+locus, adapter transports hide BINDS|DELIVERY at the topic, and the
+capability account gains `exact_ownership` / `exact_placement` /
+`exact_routes` accordingly. This closed a fail-open: a program whose
+loci are all born in `fn main` used to claim exact placement over
+zero modeled instances.
+
+`DispatchPlan::derive(&ApplicationModel)` owns the lowering
+decision: one row per subject with the flavor (dynamic /
+static_bucket / static_direct), the gate's reason, the subscriber
+list, publisher and subscriber THREAD DOMAINS, and `same_domain` -
+GH #464's stage-0 survey question as a model query rather than a
+bespoke topology walk. `hale model dump` prints the plan and the
+same-domain count. Codegen no longer decides: it still computes its
+own gate facts over the merged, desugared program it emits from,
+but the ladder is `DispatchFlavor::of` in hale-model and its ids /
+direct set / direct-subscriber lists come from the plan. A corpus
+differential runs both fact sources through the real binaries and
+requires agreement on every subject the model names.
+
+The plan is part of build identity: `exec_digest` frames
+`DispatchPlan::digest()`, so two builds of identical sources that
+lower dispatch differently - notably the `LOTUS_NO_BUS_DEVIRT=1`
+control arm - no longer share a recording identity, and replay
+across that boundary is refused by name.
+
+Iris joins by ID instead of by name: manifest rows carry the
+canonical model entity id in `aux_b` (a field in the entry layout
+since v0, written as 0 by every path until now). MK_TOPIC rows
+carry the `SubjectId` (the manifest fuses publishers by wire
+subject), MK_LOCUS_TYPE the `LocusDeclId`, MK_BINDING the
+`BindingId`, all as `index + 1` so **0 still means unstamped** -
+harness builds, and entities the model does not name, read exactly
+as before. The ids are indices into the model whose `shape_hash`
+the header already carries, so the two travel together.
+
+**Fix (bus dispatch, transport-bound subjects).** A subject named
+by a `bindings { }` entry is exempt from devirtualization - the
+adapter's peer is the real counterparty - but the exemption was
+keyed only by the topic DECL name, while codegen builds its graph
+after topic desugaring, where subjects are wire strings. A bound
+topic could therefore be lowered into a static bucket its own
+adapter is not part of. The gate now records both grains. Found by
+the Change-8 plan differential: 1 of 21 bus programs in the corpus
+disagreed.
+
 ### Typed FleetModel + the versioned shape transition (GH #476 Change 7)
 
 Round 6: completeness with the polarity of the law. The blanket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ identity setters now run before anything that can register. Eager
 recording/replay init deliberately stays after binding realization,
 so a backend with no replay class still refuses at its own seam.
 
+Review round 2: the replica-index law read `path.rfind('[')`, so any
+descendant of a replica (`App.workers[0].leaf` — the arrangement
+walks into each replica, and a leaf beneath one is an ordinary
+child) was treated as a malformed replica row and refused the whole
+model. Replica-ness is a property of the last path component only.
+
 **Fix (binding role inference).** The documented inference
 (publish-only → `connect`, subscribe-only → `listen`) was dead code:
 the desugar ran it after rewriting topic references to literal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ name = "hale-codegen"
 version = "0.17.0"
 dependencies = [
  "hale-corpus",
+ "hale-model",
  "hale-stdlib",
  "hale-syntax",
  "hale-types",

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -4595,6 +4595,7 @@ fn compile_and_exec(
     user_args: &[String],
     model_hash: u64,
     exec_digest: [u64; 4],
+    obs_entity_ids: Vec<hale_model::obs_ids::ObsEntityId>,
 ) -> ExitCode {
     let mut bin = std::env::temp_dir();
     let mut h = DefaultHasher::new();
@@ -4604,6 +4605,7 @@ fn compile_and_exec(
     let options = hale_codegen::BuildOptions {
         model_hash: Some(model_hash),
         exec_digest: Some(exec_digest),
+        obs_entity_ids,
         ..Default::default()
     };
     if let Err(e) = hale_codegen::build_executable_with_options(
@@ -4641,9 +4643,10 @@ fn compile_and_exec(
 /// inputs". Residue it cannot see: the LLVM/libc toolchain outside
 /// this binary and the linker environment — a post-link binary
 /// digest is the staged stronger form.
-/// GH #476 Change 8: the dispatch plan's identity for the bundle
-/// about to be built — `DispatchPlan::derive(&ApplicationModel)`,
-/// digested.
+/// GH #476 Change 8: everything the BUILD needs from the canonical
+/// model, from ONE derivation — the dispatch plan's digest (folded
+/// into the execution identity below) and the canonical entity ids
+/// codegen stamps into the observation manifest.
 ///
 /// `LOTUS_NO_BUS_DEVIRT=1` (the differential harness's control arm)
 /// makes codegen emit the empty plan — every subject dynamic — so
@@ -4652,15 +4655,19 @@ fn compile_and_exec(
 /// arm would share a build identity while running different
 /// lowerings, and a recording taken under one would be admitted
 /// against the other.
-fn dispatch_plan_digest(bundle: &hale_types::Bundle<'_>) -> u64 {
-    if std::env::var("LOTUS_NO_BUS_DEVIRT")
+fn model_identity(
+    bundle: &hale_types::Bundle<'_>,
+) -> (u64, Vec<hale_model::obs_ids::ObsEntityId>) {
+    let model = hale_types::model_builder::derive_application_model(bundle);
+    let plan_digest = if std::env::var("LOTUS_NO_BUS_DEVIRT")
         .map(|v| v == "1" || v == "true" || v == "TRUE")
         .unwrap_or(false)
     {
-        return hale_model::dispatch_plan::DispatchPlan::default().digest();
-    }
-    let model = hale_types::model_builder::derive_application_model(bundle);
-    hale_model::dispatch_plan::DispatchPlan::derive(&model).digest()
+        hale_model::dispatch_plan::DispatchPlan::default().digest()
+    } else {
+        hale_model::dispatch_plan::DispatchPlan::derive(&model).digest()
+    };
+    (plan_digest, hale_model::obs_ids::obs_entity_ids(&model))
 }
 
 fn exec_digest(
@@ -5207,8 +5214,8 @@ fn run_replay(args: &[String]) -> ExitCode {
         base_options.dev_profile,
         base_options.debug.is_some()
     );
-    let digest =
-        exec_digest(&sources, &prog, &options_fp, dispatch_plan_digest(&bundle));
+    let (plan_digest, obs_ids) = model_identity(&bundle);
+    let digest = exec_digest(&sources, &prog, &options_fp, plan_digest);
 
     // GH #296 phase 5b (review round): a binding backend with no
     // replay class cannot be suppressed OR injected — replaying or
@@ -5414,6 +5421,7 @@ fn run_replay(args: &[String]) -> ExitCode {
     let options = hale_codegen::BuildOptions {
         model_hash: Some(model_hash),
         exec_digest: Some(digest),
+        obs_entity_ids: obs_ids.clone(),
         ..Default::default()
     };
     if let Err(e) = hale_codegen::build_executable_with_options(
@@ -5669,14 +5677,11 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
             base_options.dev_profile,
             base_options.debug.is_some()
         );
-        let digest = exec_digest(
-            &sources,
-            target,
-            &options_fp,
-            dispatch_plan_digest(&bundle),
-        );
+        let (plan_digest, obs_ids) = model_identity(&bundle);
+        let digest =
+            exec_digest(&sources, target, &options_fp, plan_digest);
         return compile_and_exec(
-            &program, &renames, user_args, model_hash, digest,
+            &program, &renames, user_args, model_hash, digest, obs_ids,
         );
     }
 
@@ -5806,13 +5811,12 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         base_options.dev_profile,
         base_options.debug.is_some()
     );
-    let digest = exec_digest(
-        &path_sources,
-        target,
-        &options_fp,
-        dispatch_plan_digest(&bundle),
-    );
-    compile_and_exec(&program, &renames, user_args, model_hash, digest)
+    let (plan_digest, obs_ids) = model_identity(&bundle);
+    let digest =
+        exec_digest(&path_sources, target, &options_fp, plan_digest);
+    compile_and_exec(
+        &program, &renames, user_args, model_hash, digest, obs_ids,
+    )
 }
 
 fn run_build(target: &Path) -> ExitCode {
@@ -6042,6 +6046,9 @@ fn run_build(target: &Path) -> ExitCode {
     // the binary, for the observation segment header.
     options.model_hash =
         Some(hale_types::topology::model_shape_hash(&bundle));
+    // GH #476 Change 8: and the canonical entity ids a consumer
+    // joins the live manifest to that model with.
+    options.obs_entity_ids = model_identity(&bundle).1;
     // WASM plan: a wasm build emits `<stem>.wasm` (a relocatable wasm
     // object at this stage) rather than the extension-less native binary.
     // Output naming is a property of the target, not a special case

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -4655,6 +4655,20 @@ fn compile_and_exec(
 /// arm would share a build identity while running different
 /// lowerings, and a recording taken under one would be admitted
 /// against the other.
+/// The build-options half of the execution identity. One spelling,
+/// so `hale build` and `hale run` fingerprint the same options the
+/// same way (they did not: the build path never computed a digest
+/// at all — GH #476 Change 8 review).
+fn options_fingerprint(o: &hale_codegen::BuildOptions) -> String {
+    format!(
+        "target={:?};cpu={:?};dev={};debug={}",
+        o.target,
+        o.target_cpu,
+        o.dev_profile,
+        o.debug.is_some()
+    )
+}
+
 fn model_identity(
     bundle: &hale_types::Bundle<'_>,
 ) -> (u64, Vec<hale_model::obs_ids::ObsEntityId>) {
@@ -5206,14 +5220,8 @@ fn run_replay(args: &[String]) -> ExitCode {
         }
     }
     let model_hash = hale_types::topology::model_shape_hash(&bundle);
-    let base_options = hale_codegen::BuildOptions::default();
-    let options_fp = format!(
-        "target={:?};cpu={:?};dev={};debug={}",
-        base_options.target,
-        base_options.target_cpu,
-        base_options.dev_profile,
-        base_options.debug.is_some()
-    );
+    let options_fp =
+        options_fingerprint(&hale_codegen::BuildOptions::default());
     let (plan_digest, obs_ids) = model_identity(&bundle);
     let digest = exec_digest(&sources, &prog, &options_fp, plan_digest);
 
@@ -5669,14 +5677,8 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         // P26: stamp the model identity of the bundle just checked.
         let model_hash =
             hale_types::topology::model_shape_hash(&bundle);
-        let base_options = hale_codegen::BuildOptions::default();
-        let options_fp = format!(
-            "target={:?};cpu={:?};dev={};debug={}",
-            base_options.target,
-            base_options.target_cpu,
-            base_options.dev_profile,
-            base_options.debug.is_some()
-        );
+        let options_fp =
+            options_fingerprint(&hale_codegen::BuildOptions::default());
         let (plan_digest, obs_ids) = model_identity(&bundle);
         let digest =
             exec_digest(&sources, target, &options_fp, plan_digest);
@@ -5803,14 +5805,8 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
     }
     // P26: stamp the model identity of the bundle just checked.
     let model_hash = hale_types::topology::model_shape_hash(&bundle);
-    let base_options = hale_codegen::BuildOptions::default();
-    let options_fp = format!(
-        "target={:?};cpu={:?};dev={};debug={}",
-        base_options.target,
-        base_options.target_cpu,
-        base_options.dev_profile,
-        base_options.debug.is_some()
-    );
+    let options_fp =
+        options_fingerprint(&hale_codegen::BuildOptions::default());
     let (plan_digest, obs_ids) = model_identity(&bundle);
     let digest =
         exec_digest(&path_sources, target, &options_fp, plan_digest);
@@ -6046,9 +6042,13 @@ fn run_build(target: &Path) -> ExitCode {
     // the binary, for the observation segment header.
     options.model_hash =
         Some(hale_types::topology::model_shape_hash(&bundle));
-    // GH #476 Change 8: and the canonical entity ids a consumer
-    // joins the live manifest to that model with.
-    options.obs_entity_ids = model_identity(&bundle).1;
+    // GH #476 Change 8: the canonical entity ids a consumer joins
+    // the live manifest to that model with, and the dispatch
+    // plan's digest — held here and folded into the execution
+    // identity once the options are FINAL (below), since the
+    // fingerprint covers options that are still being set.
+    let (plan_digest, obs_ids) = model_identity(&bundle);
+    options.obs_entity_ids = obs_ids;
     // WASM plan: a wasm build emits `<stem>.wasm` (a relocatable wasm
     // object at this stage) rather than the extension-less native binary.
     // Output naming is a property of the target, not a special case
@@ -6203,6 +6203,19 @@ fn run_build(target: &Path) -> ExitCode {
                 .collect(),
         });
     }
+    // The execution identity, stamped LAST: every option that
+    // alters emitted code is set by now, and the digest frames the
+    // finalized fingerprint together with the dispatch plan. Before
+    // this, `hale build` artifacts carried a model hash and no
+    // execution identity at all — so a recording from one could not
+    // be refused against a differently-lowered sibling, which is
+    // exactly what the identity is for.
+    options.exec_digest = Some(exec_digest(
+        &sources,
+        target,
+        &options_fingerprint(&options),
+        plan_digest,
+    ));
     match hale_codegen::build_executable_with_options(
         &program,
         &output,

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -4641,10 +4641,33 @@ fn compile_and_exec(
 /// inputs". Residue it cannot see: the LLVM/libc toolchain outside
 /// this binary and the linker environment — a post-link binary
 /// digest is the staged stronger form.
+/// GH #476 Change 8: the dispatch plan's identity for the bundle
+/// about to be built — `DispatchPlan::derive(&ApplicationModel)`,
+/// digested.
+///
+/// `LOTUS_NO_BUS_DEVIRT=1` (the differential harness's control arm)
+/// makes codegen emit the empty plan — every subject dynamic — so
+/// the identity folded into the exec digest must be the EMPTY
+/// plan's, not the model's. Otherwise the control arm and the live
+/// arm would share a build identity while running different
+/// lowerings, and a recording taken under one would be admitted
+/// against the other.
+fn dispatch_plan_digest(bundle: &hale_types::Bundle<'_>) -> u64 {
+    if std::env::var("LOTUS_NO_BUS_DEVIRT")
+        .map(|v| v == "1" || v == "true" || v == "TRUE")
+        .unwrap_or(false)
+    {
+        return hale_model::dispatch_plan::DispatchPlan::default().digest();
+    }
+    let model = hale_types::model_builder::derive_application_model(bundle);
+    hale_model::dispatch_plan::DispatchPlan::derive(&model).digest()
+}
+
 fn exec_digest(
     sources: &BTreeMap<PathBuf, String>,
     entry: &Path,
     options_fp: &str,
+    plan_digest: u64,
 ) -> [u64; 4] {
     let mut buf: Vec<u8> = Vec::new();
     let frame = |b: &[u8], buf: &mut Vec<u8>| {
@@ -4660,6 +4683,14 @@ fn exec_digest(
     frame(env!("HALE_TOOLCHAIN_SHA256").as_bytes(), &mut buf);
     frame(env!("CARGO_PKG_VERSION").as_bytes(), &mut buf);
     frame(options_fp.as_bytes(), &mut buf);
+    // GH #476 Change 8: the DISPATCH PLAN is part of what a build
+    // is. Two builds of byte-identical sources by one toolchain
+    // still run different code if the bus lowering differs (an
+    // env-forced all-dynamic plan, a future placement-driven
+    // flavor), and a recording admitted across that boundary would
+    // replay against a program whose bus behaves differently. The
+    // plan's digest is framed here so the boundary is a refusal.
+    frame(&plan_digest.to_le_bytes(), &mut buf);
     buf.extend_from_slice(&(sources.len() as u64).to_le_bytes());
     // Logical (entry-relative) source ids: identical trees checked
     // out under different roots are the same build inputs.
@@ -5176,7 +5207,8 @@ fn run_replay(args: &[String]) -> ExitCode {
         base_options.dev_profile,
         base_options.debug.is_some()
     );
-    let digest = exec_digest(&sources, &prog, &options_fp);
+    let digest =
+        exec_digest(&sources, &prog, &options_fp, dispatch_plan_digest(&bundle));
 
     // GH #296 phase 5b (review round): a binding backend with no
     // replay class cannot be suppressed OR injected — replaying or
@@ -5637,7 +5669,12 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
             base_options.dev_profile,
             base_options.debug.is_some()
         );
-        let digest = exec_digest(&sources, target, &options_fp);
+        let digest = exec_digest(
+            &sources,
+            target,
+            &options_fp,
+            dispatch_plan_digest(&bundle),
+        );
         return compile_and_exec(
             &program, &renames, user_args, model_hash, digest,
         );
@@ -5769,7 +5806,12 @@ fn run_program(target: &Path, user_args: &[String]) -> ExitCode {
         base_options.dev_profile,
         base_options.debug.is_some()
     );
-    let digest = exec_digest(&path_sources, target, &options_fp);
+    let digest = exec_digest(
+        &path_sources,
+        target,
+        &options_fp,
+        dispatch_plan_digest(&bundle),
+    );
     compile_and_exec(&program, &renames, user_args, model_hash, digest)
 }
 

--- a/crates/hale-cli/tests/dispatch_plan_cli.rs
+++ b/crates/hale-cli/tests/dispatch_plan_cli.rs
@@ -1,0 +1,253 @@
+//! GH #476 Change 8 — the dispatch plan, proven against the thing
+//! that actually lowers.
+//!
+//! `DispatchPlan` has two fact sources by design: the model's bus
+//! graph (built over the AUTHORED bundle) and codegen's (built over
+//! the merged, desugared program its own emission uses). The
+//! decision LADDER is shared — `DispatchFlavor::of` — but shared
+//! code proves nothing about facts, so this differential compares
+//! the two plans over the real corpus, through the real binaries:
+//! `hale model dump` prints the model's plan, `HALE_DISPATCH_TRACE`
+//! prints codegen's.
+//!
+//! The second test pins the consequence: the plan is part of the
+//! execution identity, so a build that lowers dispatch differently
+//! is a different build and its recording is not admitted.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn hale() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_hale"))
+}
+
+fn workdir(name: &str) -> PathBuf {
+    let mut d = std::env::temp_dir();
+    d.push(format!("hale_dispatch_cli_{}_{}", std::process::id(), name));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).expect("mkdir");
+    d
+}
+
+fn repo_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.pop();
+    p
+}
+
+/// `subject -> flavor` from `hale model dump`'s plan section.
+fn model_plan(prog: &Path) -> BTreeMap<String, String> {
+    let out = hale()
+        .arg("model")
+        .arg("dump")
+        .arg(prog)
+        .output()
+        .expect("hale model dump");
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut rows = BTreeMap::new();
+    let mut in_plan = false;
+    for line in text.lines() {
+        if line.starts_with("dispatch_plan (") {
+            in_plan = true;
+            continue;
+        }
+        if !in_plan {
+            continue;
+        }
+        let Some(rest) = line.strip_prefix("  ") else { break };
+        let mut it = rest.split(' ');
+        let (Some(subject), Some(flavor)) = (it.next(), it.next()) else {
+            break;
+        };
+        rows.insert(subject.to_string(), flavor.to_string());
+    }
+    rows
+}
+
+/// `subject -> flavor` from the backend's own plan.
+fn codegen_plan(dir: &Path, prog: &str) -> BTreeMap<String, String> {
+    let out = hale()
+        .current_dir(dir)
+        .arg("build")
+        .arg(prog)
+        .env("HALE_DISPATCH_TRACE", "1")
+        .output()
+        .expect("hale build");
+    assert!(
+        out.status.success(),
+        "build of {} failed: {}",
+        prog,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = String::from_utf8_lossy(&out.stderr);
+    let mut rows = BTreeMap::new();
+    for line in text.lines() {
+        let Some(rest) = line.strip_prefix("[hale-dispatch] ") else {
+            continue;
+        };
+        let mut it = rest.split(' ');
+        if let (Some(subject), Some(flavor)) = (it.next(), it.next()) {
+            rows.insert(subject.to_string(), flavor.to_string());
+        }
+    }
+    rows
+}
+
+/// Every subject the MODEL plans must be planned the same way by
+/// codegen. The converse does not hold and must not be asserted:
+/// codegen merges the Hale-source stdlib, so its plan additionally
+/// carries stdlib subjects (`log.**`, `io.tcp.**`) that no user
+/// model has any business naming.
+#[test]
+fn the_model_plan_agrees_with_the_codegen_plan_over_the_corpus() {
+    let corpus =
+        repo_root().join("crates/hale-codegen/tests/fixtures/examples");
+    let mut dirs: Vec<PathBuf> = std::fs::read_dir(&corpus)
+        .expect("corpus")
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.join("main.hl").is_file())
+        .collect();
+    dirs.sort();
+    let work = workdir("differential");
+    let mut compared = 0usize;
+    let mut subjects = 0usize;
+    for d in dirs {
+        let main = d.join("main.hl");
+        let model = model_plan(&main);
+        if model.is_empty() {
+            continue; // no bus surface: nothing to disagree about
+        }
+        // Build in a copy so the corpus tree stays clean.
+        let name = d.file_name().unwrap().to_string_lossy().into_owned();
+        let dst = work.join(&name);
+        let _ = std::fs::create_dir_all(&dst);
+        for e in std::fs::read_dir(&d).unwrap().flatten() {
+            if e.path().is_file() {
+                let _ = std::fs::copy(
+                    e.path(),
+                    dst.join(e.file_name()),
+                );
+            }
+        }
+        let cg = codegen_plan(&dst, "main.hl");
+        assert!(
+            !cg.is_empty(),
+            "{}: codegen printed no plan at all",
+            name
+        );
+        for (subject, flavor) in &model {
+            assert_eq!(
+                cg.get(subject),
+                Some(flavor),
+                "{}: the model plans `{}` as {} but codegen lowers \
+                 it as {:?} — the two fact sources have drifted",
+                name,
+                subject,
+                flavor,
+                cg.get(subject)
+            );
+            subjects += 1;
+        }
+        compared += 1;
+    }
+    assert!(
+        compared >= 15 && subjects >= 15,
+        "differential covered too little to mean anything: \
+         {} programs / {} subjects",
+        compared,
+        subjects
+    );
+    let _ = std::fs::remove_dir_all(&work);
+}
+
+const BUS_PROG: &str = r#"
+type T { n: Int = 0; }
+topic Evt { payload: T; subject: "id.evt"; }
+locus Sub {
+    params { seen: Int = 0; }
+    bus { subscribe Evt as on_e; }
+    fn on_e(t: T) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { s: Sub = Sub { }; }
+    bus { publish Evt; }
+    run() { Evt <- T { n: 1 }; println("done"); }
+}
+fn main() { App { }; }
+"#;
+
+/// The recording header's execution identity (4×u64 at offset 56).
+fn recorded_exec_digest(rec: &Path) -> [u64; 4] {
+    let b = std::fs::read(rec).expect("recording");
+    assert!(b.len() >= 112, "truncated recording");
+    let mut out = [0u64; 4];
+    for (i, part) in out.iter_mut().enumerate() {
+        let o = 56 + i * 8;
+        *part = u64::from_le_bytes(b[o..o + 8].try_into().unwrap());
+    }
+    out
+}
+
+fn record_with(dir: &Path, prog: &Path, tag: &str, devirt: bool) -> PathBuf {
+    let rec = dir.join(format!("{}.halerec", tag));
+    let mut cmd = hale();
+    cmd.arg("run").arg(prog).env("LOTUS_OBS_RECORD", &rec);
+    if !devirt {
+        cmd.env("LOTUS_NO_BUS_DEVIRT", "1");
+    }
+    let out = cmd.output().expect("hale run");
+    assert!(
+        out.status.success(),
+        "recorded run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    rec
+}
+
+/// Same sources, same toolchain, same options — but one build
+/// lowers every subject dynamically and the other devirtualizes.
+/// Those are different executables, so they must not share an
+/// execution identity, and a recording from one must not be
+/// admitted against the other.
+#[test]
+fn a_different_lowering_is_a_different_build_identity() {
+    let dir = workdir("identity");
+    let prog = dir.join("app.hl");
+    std::fs::write(&prog, BUS_PROG).unwrap();
+
+    let devirt = record_with(&dir, &prog, "devirt", true);
+    let dynamic = record_with(&dir, &prog, "dynamic", false);
+    let d1 = recorded_exec_digest(&devirt);
+    let d2 = recorded_exec_digest(&dynamic);
+    assert_ne!(
+        d1, d2,
+        "the all-dynamic control arm and the devirtualized build \
+         stamped the SAME execution identity — the dispatch plan is \
+         not part of what a build is"
+    );
+
+    // And the boundary is enforced, not merely visible: replaying
+    // the all-dynamic recording against the (devirtualized) default
+    // build is refused by name.
+    let out = hale()
+        .arg("replay")
+        .arg(&dynamic)
+        .arg(&prog)
+        // The program prints, so replay's live-effect gate fires
+        // first; accept it explicitly to reach the identity check
+        // this test is about.
+        .arg("--allow-live-effects")
+        .output()
+        .expect("hale replay");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success()
+            && err.contains("recorded from different build inputs"),
+        "replay across the lowering boundary was admitted:\n{}",
+        err
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-cli/tests/dispatch_plan_cli.rs
+++ b/crates/hale-cli/tests/dispatch_plan_cli.rs
@@ -251,3 +251,83 @@ fn a_different_lowering_is_a_different_build_identity() {
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Review round 1, blocker 4: `hale build` artifacts must carry an
+/// execution identity too. The identity plumbing landed on `hale
+/// run` and `hale replay` — whose temporary builds set it — while
+/// the ordinary build path set only the model hash, so the PR's
+/// central claim ("a different lowering is a different build") was
+/// false for exactly the binaries users ship.
+#[test]
+fn hale_build_artifacts_carry_the_plan_in_their_identity() {
+    let dir = workdir("buildident");
+    let seed = dir.join("app");
+    std::fs::create_dir_all(&seed).unwrap();
+    std::fs::write(seed.join("main.hl"), BUS_PROG).unwrap();
+
+    // Build twice from ONE source tree: default lowering, then the
+    // all-dynamic control arm. Separate output dirs so the second
+    // build cannot be mistaken for the first.
+    let build = |tag: &str, devirt: bool| -> PathBuf {
+        let out = dir.join(tag);
+        std::fs::create_dir_all(&out).unwrap();
+        std::fs::copy(seed.join("main.hl"), out.join("main.hl")).unwrap();
+        let mut cmd = hale();
+        cmd.arg("build").arg(&out);
+        if !devirt {
+            cmd.env("LOTUS_NO_BUS_DEVIRT", "1");
+        }
+        let o = cmd.output().expect("hale build");
+        assert!(
+            o.status.success(),
+            "build failed: {}",
+            String::from_utf8_lossy(&o.stderr)
+        );
+        out.join(tag)
+    };
+    let fast = build("fast", true);
+    let slow = build("slow", false);
+
+    let record = |bin: &Path, tag: &str| -> PathBuf {
+        let rec = dir.join(format!("{}.halerec", tag));
+        let o = Command::new(bin)
+            .env("LOTUS_OBS_RECORD", &rec)
+            .output()
+            .expect("run built binary");
+        assert!(
+            o.status.success(),
+            "recorded run failed: {}",
+            String::from_utf8_lossy(&o.stderr)
+        );
+        rec
+    };
+    let d_fast = recorded_exec_digest(&record(&fast, "fast"));
+    let d_slow = recorded_exec_digest(&record(&slow, "slow"));
+    assert_ne!(
+        d_fast, [0; 4],
+        "a `hale build` artifact carries no execution identity at all"
+    );
+    assert_ne!(d_slow, [0; 4]);
+    assert_ne!(
+        d_fast, d_slow,
+        "two `hale build` artifacts that lower dispatch differently \
+         share one execution identity"
+    );
+
+    // Enforced, not merely visible.
+    let out = hale()
+        .arg("replay")
+        .arg(dir.join("slow.halerec"))
+        .arg(seed.join("main.hl"))
+        .arg("--allow-live-effects")
+        .output()
+        .expect("hale replay");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success()
+            && err.contains("recorded from different build inputs"),
+        "replay across the lowering boundary was admitted:\n{}",
+        err
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-cli/tests/obs_entity_ids.rs
+++ b/crates/hale-cli/tests/obs_entity_ids.rs
@@ -1,0 +1,248 @@
+//! GH #476 Change 8 — canonical model entity ids in the live
+//! manifest.
+//!
+//! The observation manifest names entities (`sense.reading`, `W`)
+//! and numbers them in registration order. A consumer holding the
+//! source-derived model could only join the two by matching strings
+//! — a second authority on identity, and the thing this epic
+//! removes. Codegen now stamps the model's own entity id into each
+//! manifest row's `aux_b` (a field that has been in the ABI since v0
+//! and written as 0 by every path, so no consumer's layout moves).
+//!
+//! Pinned here: the ids appear, they are the ids `hale model dump`
+//! reports (+1, since 0 means unstamped), a locus type and a topic
+//! both carry them, and a harness-built binary still reads 0.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+fn workdir(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir()
+        .join(format!("hale_obs_ids_{}_{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+fn build(dir: &Path, src: &str, tag: &str) -> PathBuf {
+    let seed = dir.join(tag);
+    std::fs::create_dir_all(&seed).unwrap();
+    std::fs::write(seed.join("main.hl"), src).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("build")
+        .arg(&seed)
+        .output()
+        .expect("hale build");
+    assert!(
+        out.status.success(),
+        "build failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    seed.join(tag)
+}
+
+/// One manifest row, as a consumer reads it.
+#[derive(Debug, PartialEq, Eq)]
+struct Row {
+    kind: u8,
+    name: String,
+    /// Registration-order id (what events reference).
+    id: u32,
+    /// GH #476 Change 8: canonical model entity id, 0 = unstamped.
+    aux_b: u64,
+}
+
+/// Run the binary under LOTUS_OBS=1 and read its manifest rows out
+/// of the live segment.
+fn manifest_rows(bin: &Path) -> Vec<Row> {
+    let mut child = Command::new(bin)
+        .env("LOTUS_OBS", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    let pid = child.id();
+    let shm = format!("/dev/shm/hale-obs-{}", pid);
+    let mut rows = Vec::new();
+    for _ in 0..80 {
+        std::thread::sleep(Duration::from_millis(25));
+        let Ok(b) = std::fs::read(&shm) else { continue };
+        if b.len() < 0x100 {
+            continue;
+        }
+        let u64at = |o: usize| {
+            u64::from_le_bytes(b[o..o + 8].try_into().unwrap())
+        };
+        let u32at = |o: usize| {
+            u32::from_le_bytes(b[o..o + 4].try_into().unwrap())
+        };
+        // obs_hdr_t: manifest_off is the 2nd of the offset run that
+        // starts at 0x38 (control_off).
+        let manifest_off = u64at(0x40) as usize;
+        if manifest_off == 0 || manifest_off + 16 > b.len() {
+            continue;
+        }
+        // obs_mh_t { entry_count, entry_cap, pool_off, pool_used }
+        let entry_count = u32at(manifest_off) as usize;
+        let pool_off = u32at(manifest_off + 8) as usize;
+        if entry_count == 0 {
+            continue;
+        }
+        // obs_me_t is 32 bytes: shape_hash, aux_b, id, name_off,
+        // name_len, aux_a, kind, flags, _pad.
+        let base = manifest_off + 16;
+        let mut out = Vec::new();
+        for i in 0..entry_count {
+            let e = base + i * 32;
+            if e + 32 > b.len() {
+                break;
+            }
+            let aux_b = u64at(e + 8);
+            let id = u32at(e + 16);
+            let name_off = u32at(e + 20) as usize;
+            let name_len = u16::from_le_bytes(
+                b[e + 24..e + 26].try_into().unwrap(),
+            ) as usize;
+            let kind = b[e + 28];
+            let ns = manifest_off + pool_off + name_off;
+            if ns + name_len > b.len() {
+                continue;
+            }
+            out.push(Row {
+                kind,
+                name: String::from_utf8_lossy(&b[ns..ns + name_len])
+                    .into_owned(),
+                id,
+                aux_b,
+            });
+        }
+        if !out.is_empty() {
+            rows = out;
+            break;
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    rows
+}
+
+const PROG: &str = r#"
+type Tick { n: Int = 0; }
+topic Ticks { payload: Tick; subject: "obs.tick"; }
+// Named so that BIRTH order (Zeta, then Alpha — params field order
+// under the root) is not the model's table order (alphabetical).
+// If the two coincided, this test could not tell a canonical id
+// from a registration-order id.
+locus Zeta {
+    params { seen: Int = 0; }
+    bus { subscribe Ticks as on_t; }
+    fn on_t(t: Tick) { self.seen = self.seen + 1; }
+}
+locus Alpha {
+    params { n: Int = 0; }
+    fn bump() { self.n = self.n + 1; }
+}
+main locus App {
+    params { z: Zeta = Zeta { }; a: Alpha = Alpha { }; }
+    bus { publish Ticks; }
+    run() {
+        self.a.bump();
+        Ticks <- Tick { n: 1 };
+        std::time::sleep(600ms);
+    }
+}
+fn main() { App { }; }
+"#;
+
+/// The model's own ids for the subject and the locus types, as the
+/// dump reports them (the dump prints tables in id order).
+fn model_tables(src_dir: &Path) -> (Vec<String>, Vec<String>) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("model")
+        .arg("dump")
+        .arg(src_dir)
+        .output()
+        .expect("hale model dump");
+    let text = String::from_utf8_lossy(&out.stdout).into_owned();
+    let section = |head: &str| -> Vec<String> {
+        let mut rows = Vec::new();
+        let mut inside = false;
+        for line in text.lines() {
+            if line.starts_with(head) {
+                inside = true;
+                continue;
+            }
+            if !inside {
+                continue;
+            }
+            match line.strip_prefix("  ") {
+                Some(r) => rows.push(
+                    r.split(" -> ").next().unwrap().trim().to_string(),
+                ),
+                None => break,
+            }
+        }
+        rows
+    };
+    (section("subjects ("), section("loci ("))
+}
+
+#[test]
+fn manifest_rows_carry_canonical_model_entity_ids() {
+    let dir = workdir("stamped");
+    let bin = build(&dir, PROG, "app");
+    let (subjects, loci) = model_tables(&dir.join("app"));
+    let rows = manifest_rows(&bin);
+    assert!(!rows.is_empty(), "no manifest rows observed");
+
+    // The topic row for the wire subject carries the model's
+    // SubjectId + 1 (the manifest fuses publishers by subject, so
+    // subject — not topic decl — is the canonical address).
+    let topic = rows
+        .iter()
+        .find(|r| r.kind == 0 && r.name == "obs.tick")
+        .unwrap_or_else(|| panic!("no topic row: {:?}", rows));
+    let want = subjects
+        .iter()
+        .position(|s| s == "obs.tick")
+        .expect("model names the subject")
+        + 1;
+    assert_eq!(
+        topic.aux_b, want as u64,
+        "topic row carries the canonical SubjectId (+1); model \
+         subjects = {:?}",
+        subjects
+    );
+
+    // …and every locus type that registered carries its LocusDeclId.
+    let locus_rows: Vec<&Row> =
+        rows.iter().filter(|r| r.kind == 1).collect();
+    assert!(
+        !locus_rows.is_empty(),
+        "no locus-type rows registered: {:?}",
+        rows
+    );
+    for r in &locus_rows {
+        let want =
+            loci.iter().position(|l| *l == r.name).unwrap_or_else(|| {
+                panic!("manifest names locus `{}`, model has {:?}", r.name, loci)
+            }) + 1;
+        assert_eq!(
+            r.aux_b, want as u64,
+            "locus row `{}` carries the wrong canonical id",
+            r.name
+        );
+    }
+
+    // The registration-order id and the canonical id are different
+    // numbers doing different jobs — this is the whole point, so
+    // assert the manifest still carries its own ordering id.
+    assert!(
+        rows.iter().any(|r| r.aux_b != u64::from(r.id)),
+        "canonical ids are indistinguishable from registration \
+         order in this program — the test proves nothing: {:?}",
+        rows
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-cli/tests/obs_entity_ids.rs
+++ b/crates/hale-cli/tests/obs_entity_ids.rs
@@ -53,6 +53,34 @@ struct Row {
     aux_b: u64,
 }
 
+/// The segment header's two identity fields: `model_hash` (0x80)
+/// and, new at proto 0.3, `entity_id_digest` (0x88).
+fn header_identity(bin: &Path) -> (u64, u64) {
+    let mut child = Command::new(bin)
+        .env("LOTUS_OBS", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    let shm = format!("/dev/shm/hale-obs-{}", child.id());
+    let mut out = (0, 0);
+    for _ in 0..80 {
+        std::thread::sleep(Duration::from_millis(25));
+        let Ok(b) = std::fs::read(&shm) else { continue };
+        if b.len() < 0x90 {
+            continue;
+        }
+        let u64at = |o: usize| {
+            u64::from_le_bytes(b[o..o + 8].try_into().unwrap())
+        };
+        out = (u64at(0x80), u64at(0x88));
+        break;
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    out
+}
+
 /// Run the binary under LOTUS_OBS=1 and read its manifest rows out
 /// of the live segment.
 fn manifest_rows(bin: &Path) -> Vec<Row> {
@@ -243,6 +271,136 @@ fn manifest_rows_carry_canonical_model_entity_ids() {
         "canonical ids are indistinguishable from registration \
          order in this program — the test proves nothing: {:?}",
         rows
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Review round 1, blocker 5a: the ids need an identity that
+/// actually covers the tables they index.
+///
+/// `model_hash` is STRUCTURAL model identity and the arrangement's
+/// binding rows are not part of it — so adding a binding leaves
+/// `model_hash` untouched while renumbering the canonical binding
+/// table. Under the old contract ("meaningful alongside
+/// model_hash") the same `aux_b` would then designate different
+/// entities under one advertised identity, with nothing for a
+/// consumer to check. The header now publishes the id table's own
+/// digest, and it moves when the table moves.
+#[test]
+fn the_entity_id_table_publishes_its_own_identity() {
+    let dir = workdir("identity");
+    const BOUND: &str = r#"
+type Beat { n: Int = 0; }
+topic Heartbeat { payload: Beat; subject: "obs.beat"; }
+main locus App {
+    params { seen: Int = 0; }
+    bus { subscribe Heartbeat as on_beat; }
+    fn on_beat(b: Beat) { self.seen = self.seen + 1; }
+    run() { std::time::sleep(600ms); }
+}
+fn main() { App { }; }
+"#;
+    let with_binding = BOUND.replace(
+        "    run() {",
+        "    bindings { Heartbeat: unix(\"/tmp/hale-c8-ident.sock\"); }\n    run() {",
+    );
+    let plain = build(&dir, BOUND, "plain");
+    let bound = build(&dir, &with_binding, "bound");
+
+    let (m_plain, d_plain) = header_identity(&plain);
+    let (m_bound, d_bound) = header_identity(&bound);
+    assert_ne!(d_plain, 0, "no entity-id identity published");
+    assert_ne!(d_bound, 0);
+    // The premise that makes this a real hazard: structural model
+    // identity does NOT separate these two builds.
+    assert_eq!(
+        m_plain, m_bound,
+        "fixture premise: adding a binding leaves shape_hash alone"
+    );
+    assert_ne!(
+        d_plain, d_bound,
+        "the id table changed (a binding row appeared) but the \
+         published identity did not — a consumer cannot tell which \
+         table its ids index"
+    );
+
+    // And the published value is the one a CONSUMER computes from
+    // the model it holds — that recomputation is the whole join
+    // protocol, so pin it rather than just pinning "it changed".
+    let recompute = |src: &str| -> u64 {
+        let program = hale_syntax::parse_source(src).expect("parse");
+        let mut programs = std::collections::BTreeMap::new();
+        programs.insert("main.hl".to_string(), &program);
+        let bundle = hale_types::Bundle::new(programs);
+        let m = hale_types::model_builder::derive_application_model(
+            &bundle,
+        );
+        hale_model::obs_ids::digest(&hale_model::obs_ids::obs_entity_ids(
+            &m,
+        ))
+    };
+    assert_eq!(
+        d_plain,
+        recompute(BOUND),
+        "the header digest is not the one the model produces"
+    );
+    assert_eq!(d_bound, recompute(&with_binding));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Review round 1, blocker 5b: canonical ids are all-or-nothing.
+/// The mapping table used to be a fixed 512 slots that silently
+/// dropped later entities back to `aux_b == 0` — documented as
+/// "unstamped", so partial canonicalization was indistinguishable
+/// from "this build stamped nothing". A program with more
+/// declarations than any fixed cap must still stamp every one.
+#[test]
+fn a_large_declaration_universe_is_stamped_completely() {
+    let dir = workdir("many");
+    // 300 topics + 300 loci + the root: past 600 canonical
+    // entities, so the old fixed 512-slot table dropped the tail.
+    // Births go in `fn main` — a main locus caps out at 64
+    // locus-typed param fields, and this fixture is about the ID
+    // table's capacity, not that limit.
+    let mut src = String::from("type Tick { n: Int = 0; }\n");
+    for i in 0..300 {
+        src.push_str(&format!(
+            "topic T{i} {{ payload: Tick; subject: \"many.t{i}\"; }}\n\
+             locus L{i} {{\n\
+             \x20   params {{ seen: Int = 0; }}\n\
+             \x20   bus {{ subscribe T{i} as on_t; publish T{i}; }}\n\
+             \x20   fn on_t(t: Tick) {{ self.seen = self.seen + 1; }}\n\
+             }}\n"
+        ));
+    }
+    src.push_str("fn main() {\n");
+    for i in 0..300 {
+        src.push_str(&format!("    L{i} {{ }};\n"));
+    }
+    src.push_str("    std::time::sleep(600ms);\n}\n");
+    let bin = build(&dir, &src, "many");
+    let (_, digest) = header_identity(&bin);
+    assert_ne!(digest, 0, "a complete table publishes an identity");
+
+    // Every entity that actually registered carries a canonical
+    // id. With a capacity cliff, the later-sorted ones came back 0
+    // — indistinguishable from "this build stamped nothing".
+    let rows = manifest_rows(&bin);
+    assert!(
+        rows.len() > 100,
+        "fixture premise: many entities register ({} did)",
+        rows.len()
+    );
+    let unstamped: Vec<&str> = rows
+        .iter()
+        .filter(|r| r.aux_b == 0)
+        .map(|r| r.name.as_str())
+        .collect();
+    assert!(
+        unstamped.is_empty(),
+        "{} registered entities came back unstamped: {:?}",
+        unstamped.len(),
+        unstamped
     );
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/hale-codegen/Cargo.toml
+++ b/crates/hale-codegen/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 description = "Hale codegen targeting LLVM"
 
 [dependencies]
+hale-model = { path = "../hale-model" }
 hale-stdlib = { path = "../hale-stdlib" }
 hale-syntax = { path = "../hale-syntax" }
 hale-types = { path = "../hale-types" }

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -169,6 +169,49 @@ static _Atomic int g_obs_state = 0;
  * any probe can lazily create the segment. */
 static uint64_t g_obs_model_hash = 0;
 void lotus_obs_model_hash_set(uint64_t h) { g_obs_model_hash = h; }
+/* GH #476 Change 8: canonical model entity ids, stamped by the
+ * codegen prelude before any probe can add a manifest entry.
+ *
+ * The manifest identifies entities by NAME and by a
+ * registration-order id, so a consumer joining a live process
+ * against the source-derived model had to match on strings and hope
+ * the two spellings agreed. These rows give the compiler's answer
+ * instead: for each (kind, name) the canonical `ApplicationModel`
+ * entity id, published in the manifest entry's `aux_b` — a field
+ * that has been in the ABI since v0 and written as 0 by every path,
+ * so no consumer's layout moves. `aux_b == 0` still means "no
+ * canonical id" (harness builds, or an entity the model doesn't
+ * name, e.g. a stdlib subject).
+ *
+ * Entity ids are only meaningful WITH the header's `model_hash`:
+ * they are indices into that model's tables, not stable names. */
+#define OBS_MODEL_ID_CAP 512
+static struct {
+  uint8_t kind;
+  char *name;
+  uint64_t model_id;
+} g_model_ids[OBS_MODEL_ID_CAP];
+static int g_model_id_count = 0;
+
+static uint64_t obs_model_id_for(uint8_t kind, const char *name) {
+  for (int i = 0; i < g_model_id_count; i++)
+    if (g_model_ids[i].kind == kind &&
+        strcmp(g_model_ids[i].name, name) == 0)
+      return g_model_ids[i].model_id;
+  return 0;
+}
+
+void lotus_obs_model_id(uint32_t kind, const char *name,
+                        uint64_t model_id) {
+  if (!name || g_model_id_count >= OBS_MODEL_ID_CAP) return;
+  char *copy = strdup(name);
+  if (!copy) return;
+  g_model_ids[g_model_id_count].kind = (uint8_t)kind;
+  g_model_ids[g_model_id_count].name = copy;
+  g_model_ids[g_model_id_count].model_id = model_id;
+  g_model_id_count++;
+}
+
 /* GH #296 review finding 2: shape_hash is structural compatibility,
  * not executable identity. The CLI stamps a digest of the compiler
  * version + every source byte; exact replay admits on THIS. */
@@ -2130,6 +2173,10 @@ static int64_t obs_manifest_add(uint8_t kind, uint8_t flg,
   uint32_t len = (uint32_t)strlen(name);
   uint32_t noff = atomic_fetch_add(&MH->pool_used, len);
   memcpy(POOL + noff, name, len);
+  /* GH #476 Change 8: fill in the canonical model entity id for
+   * this (kind, name), when the build stamped one. Every existing
+   * caller passes aux_b = 0; an explicit value still wins. */
+  if (aux_b == 0) aux_b = obs_model_id_for(kind, name);
   ME[i] = (obs_me_t){ .shape_hash = shape, .aux_b = aux_b,
                       .id = (uint32_t)id, .name_off = noff,
                       .name_len = (uint16_t)len, .aux_a = aux_a,

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -143,6 +143,16 @@ typedef struct {
    * Complementary to the per-topic payload shape_hash rows: model
    * identity deliberately excludes payload field shape. */
   uint64_t model_hash;
+  /* GH #476 Change 8 (proto 0.3): the identity of the CANONICAL
+   * ENTITY ID TABLE whose ids this segment's manifest rows carry in
+   * `aux_b`. `model_hash` is structural model identity and does not
+   * cover every table those ids index (the arrangement's binding
+   * rows, for one, are not in the topology artifact at all), so two
+   * builds could share a model_hash while numbering entities
+   * differently. This digest covers the exact (kind, name, id) rows
+   * the build stamped: a consumer recomputes it from the model it
+   * holds and uses the ids only on a match. 0 = unstamped. */
+  uint64_t entity_id_digest;
 } obs_hdr_t;
 
 typedef struct { _Atomic uint32_t observer_count, sample_n; } obs_ctrl_t;
@@ -185,15 +195,36 @@ void lotus_obs_model_hash_set(uint64_t h) { g_obs_model_hash = h; }
  *
  * Entity ids are only meaningful WITH the header's `model_hash`:
  * they are indices into that model's tables, not stable names. */
-#define OBS_MODEL_ID_CAP 512
-static struct {
+/* The mapping table GROWS: codegen stamps one row per canonical
+ * entity, and a program is free to declare more entities than any
+ * fixed cap would allow. A dropped row is not a smaller table, it
+ * is a row that silently reads back as `aux_b == 0` — documented
+ * as "unstamped" — so partial canonicalization would put a consumer
+ * back to name matching without telling it. There is no cap;
+ * allocation failure is loud and disables the whole channel rather
+ * than publishing a partial one. */
+static struct obs_model_id_row {
   uint8_t kind;
   char *name;
   uint64_t model_id;
-} g_model_ids[OBS_MODEL_ID_CAP];
+} *g_model_ids = NULL;
 static int g_model_id_count = 0;
+static int g_model_id_cap = 0;
+/* Set once the table is known to be incomplete: every id is then
+ * withheld (the digest is zeroed too), because a consumer cannot
+ * tell a missing row from an entity the model never named. */
+static int g_model_ids_broken = 0;
+static uint64_t g_obs_entity_id_digest = 0;
+
+void lotus_obs_entity_id_digest_set(uint64_t d) {
+  /* A broken (partial) table publishes NO identity: the stamps a
+   * consumer would validate against are not all there. */
+  if (g_model_ids_broken) return;
+  g_obs_entity_id_digest = d;
+}
 
 static uint64_t obs_model_id_for(uint8_t kind, const char *name) {
+  if (g_model_ids_broken) return 0;
   for (int i = 0; i < g_model_id_count; i++)
     if (g_model_ids[i].kind == kind &&
         strcmp(g_model_ids[i].name, name) == 0)
@@ -201,11 +232,36 @@ static uint64_t obs_model_id_for(uint8_t kind, const char *name) {
   return 0;
 }
 
+static void obs_model_ids_fail(void) {
+  if (!g_model_ids_broken) {
+    g_model_ids_broken = 1;
+    g_obs_entity_id_digest = 0;
+    fprintf(stderr,
+            "lotus: out of memory registering canonical model entity "
+            "ids; observation manifest rows will carry none "
+            "(consumers must join by name for this process)\n");
+  }
+}
+
 void lotus_obs_model_id(uint32_t kind, const char *name,
                         uint64_t model_id) {
-  if (!name || g_model_id_count >= OBS_MODEL_ID_CAP) return;
+  if (!name || g_model_ids_broken) return;
+  if (g_model_id_count == g_model_id_cap) {
+    int next = g_model_id_cap ? g_model_id_cap * 2 : 64;
+    struct obs_model_id_row *grown = (struct obs_model_id_row *)realloc(
+        g_model_ids, (size_t)next * sizeof(*g_model_ids));
+    if (!grown) {
+      obs_model_ids_fail();
+      return;
+    }
+    g_model_ids = grown;
+    g_model_id_cap = next;
+  }
   char *copy = strdup(name);
-  if (!copy) return;
+  if (!copy) {
+    obs_model_ids_fail();
+    return;
+  }
   g_model_ids[g_model_id_count].kind = (uint8_t)kind;
   g_model_ids[g_model_id_count].name = copy;
   g_model_ids[g_model_id_count].model_id = model_id;
@@ -1819,7 +1875,7 @@ static int obs_create(int64_t rings, int64_t slots) {
   memset(MODE, 2 /* PACKED */, OBS_ENTRY_CAP);
   memset(g_cnt_line_for, -1, sizeof g_cnt_line_for);
 
-  *H = (obs_hdr_t){ .magic = OBS_MAGIC, .proto_major = 0, .proto_minor = 2,
+  *H = (obs_hdr_t){ .magic = OBS_MAGIC, .proto_major = 0, .proto_minor = 3,
     .header_len = sizeof(obs_hdr_t), .total_len = g_seg_len,
     .pid = (uint32_t)getpid(), .ring_count = (uint32_t)rings,
     .ring_slots = (uint32_t)slots, .ts_shift = 4,
@@ -1827,7 +1883,8 @@ static int obs_create(int64_t rings, int64_t slots) {
     .control_off = control_off, .manifest_off = manifest_off,
     .manifest_len = manifest_len, .modemask_off = modemask_off,
     .counters_off = counters_off, .counters_len = counters_len,
-    .rings_off = rings_off, .model_hash = g_obs_model_hash };
+    .rings_off = rings_off, .model_hash = g_obs_model_hash,
+    .entity_id_digest = g_obs_entity_id_digest };
   for (int64_t i = 0; i < rings; i++)
     RD[i] = (obs_rdesc_t){
         .data_off = rings_off + rings_hdr + (uint64_t)i * ring_bytes,

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -594,6 +594,14 @@ pub struct BuildOptions {
     /// builds on this; shape_hash is the structural compatibility
     /// check only.
     pub exec_digest: Option<[u64; 4]>,
+    /// GH #476 Change 8: canonical model entity ids for the
+    /// observation manifest (`hale_model::obs_ids`). Stamped in the
+    /// prelude so a manifest row created later carries the
+    /// compiler's id for the entity — a consumer joining a live
+    /// process to the source-derived model stops matching on
+    /// strings. Meaningful only together with `model_hash`; harness
+    /// callers leave it empty and every row reads 0 as before.
+    pub obs_entity_ids: Vec<hale_model::obs_ids::ObsEntityId>,
 }
 
 /// The per-build source table for DWARF emission: each entry is one
@@ -1450,7 +1458,8 @@ pub fn build_executable_with_options(
         returned_bindings: compute_returned_bindings(&merged),
         assign_moved_bindings: compute_assign_moved_bindings(&merged),
         model_hash: options.model_hash,
-            exec_digest: options.exec_digest,
+        exec_digest: options.exec_digest,
+        obs_entity_ids: options.obs_entity_ids.clone(),
         replica_index_for_next_locus_instantiation: None,
         current_instantiation_replica_index: 0,
         suppress_fresh_temp: false,
@@ -4074,6 +4083,9 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// segment header (None = harness build, header reads 0).
     pub(crate) model_hash: Option<u64>,
     pub(crate) exec_digest: Option<[u64; 4]>,
+    /// GH #476 Change 8: canonical model entity ids, stamped into
+    /// the observation manifest by the prelude.
+    pub(crate) obs_entity_ids: Vec<hale_model::obs_ids::ObsEntityId>,
     /// Replica keys (2026-08-12): the replica index the NEXT locus
     /// instantiation carries — set by the Phase-1c fan-out loop for
     /// replicas 1..K, absent (= replica 0) everywhere else. Consumed
@@ -9018,6 +9030,40 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         "obs.model_hash",
                     )
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            }
+            // GH #476 Change 8: canonical model entity ids. Stamped
+            // here, with the other identity setters, because the
+            // manifest rows they annotate are created LAZILY — the
+            // first publish on a subject, the first birth of a locus
+            // type — and the runtime needs the mapping in hand
+            // before any of that can happen. Only meaningful next to
+            // `model_hash` above: these are indices into that
+            // model's tables.
+            if !self.obs_entity_ids.is_empty() {
+                let id_fn = self
+                    .module
+                    .get_function("lotus_obs_model_id")
+                    .expect("lotus_obs_model_id declared");
+                let i32_t = self.context.i32_type();
+                let i64_t = self.context.i64_type();
+                for e in self.obs_entity_ids.clone() {
+                    let ng = self.global_string(&e.name);
+                    self.builder
+                        .build_call(
+                            id_fn,
+                            &[
+                                i32_t
+                                    .const_int(e.kind as u64, false)
+                                    .into(),
+                                ng.into(),
+                                i64_t.const_int(e.id, false).into(),
+                            ],
+                            "obs.model_id",
+                        )
+                        .map_err(|e2| {
+                            CodegenError::LlvmEmit(e2.to_string())
+                        })?;
+                }
             }
             // GH #296 round 5: eager recording/replay init, AFTER
             // the identity setters — segment creation snapshots

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -8914,23 +8914,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // lotus_bus_register_remote(subject, url, role) per entry
         // in the main locus's bindings { } block. These run BEFORE
         // load_config so an env-var override can layer on top.
-        self.emit_bindings_prelude()?;
-
-        // m58: load the deployment-config map (subject -> transport
-        // URL + role) from the path in $LOTUS_BUS_CONFIG. Emitted
-        // unconditionally — programs without the env var set hit
-        // the C-runtime's `if (!path) return` early-out and pay one
-        // syscall + one branch at startup. Programs with it set
-        // get their cross-process bus routes opened before any
-        // user code runs (so `<- "subj" | ...` calls reach remote
-        // subscribers from the very first publish).
-        // WASM plan (entry inversion): skip the cross-process transport
-        // loader on wasm. `lotus_bus_load_config` opens unix/udp sockets
-        // and spawns reader threads for `listen` routes — its body
-        // references socket/bind/connect/pthread_create, which (being
-        // reachable from `main`) would otherwise survive gc-sections and
-        // become host imports. The browser bus is in-memory / WebSocket-
-        // adapter-driven (a later slice), never cross-process sockets.
+        // GH #476 Change 8 review: the observation IDENTITY is
+        // stamped FIRST — before bindings register, before the
+        // config loader opens routes, before anything else that
+        // can touch a probe. A `bindings { }` entry registers a
+        // manifest row at startup, which CREATES the observation
+        // segment, and segment creation snapshots the identity
+        // fields; stamping afterwards left every bound program
+        // publishing model_hash 0 (and, once they existed,
+        // entity ids with no published identity) for its whole
+        // life. Same failure the GH #296 round-5 eager-init fix
+        // closed for recording processes, on a different path.
         // iris handoff-2 P6: register every declared topic's
         // canonical shape (subject + field structure, never the
         // declaring type's name) before any traffic — two
@@ -9064,24 +9058,63 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                             CodegenError::LlvmEmit(e2.to_string())
                         })?;
                 }
-            }
-            // GH #296 round 5: eager recording/replay init, AFTER
-            // the identity setters — segment creation snapshots
-            // them into the shared header, and a constructor-driven
-            // init published a live segment with model_hash 0 for
-            // its whole life. Still before any user code or probe,
-            // so probe-free programs record. No-op when neither
-            // LOTUS_OBS_RECORD nor LOTUS_REPLAY is set.
-            {
-                let eager_fn = self
+                // …and the table's own identity, since `model_hash`
+                // does not cover every table these ids index. A
+                // consumer recomputes this from its model and joins
+                // only on a match.
+                let d = hale_model::obs_ids::digest(&self.obs_entity_ids);
+                let dig_fn = self
                     .module
-                    .get_function("lotus_obs_eager_init")
-                    .expect("lotus_obs_eager_init declared");
+                    .get_function("lotus_obs_entity_id_digest_set")
+                    .expect("lotus_obs_entity_id_digest_set declared");
                 self.builder
-                    .build_call(eager_fn, &[], "obs.eager_init")
-                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    .build_call(
+                        dig_fn,
+                        &[i64_t.const_int(d, false).into()],
+                        "obs.entity_id_digest",
+                    )
+                    .map_err(|e2| {
+                        CodegenError::LlvmEmit(e2.to_string())
+                    })?;
             }
         }
+
+        self.emit_bindings_prelude()?;
+
+        // GH #296 round 5: eager recording/replay init, AFTER the
+        // identity setters (above) and after the bindings prelude —
+        // its position relative to binding REALIZATION is load
+        // bearing: a backend with no replay class must refuse at its
+        // own seam, naming itself, rather than be pre-empted by a
+        // generic identity refusal. Segment creation snapshots the
+        // identity fields, which the setters have already published.
+        // Still before any user code. No-op when neither
+        // LOTUS_OBS_RECORD nor LOTUS_REPLAY is set.
+        if !self.is_wasm {
+            let eager_fn = self
+                .module
+                .get_function("lotus_obs_eager_init")
+                .expect("lotus_obs_eager_init declared");
+            self.builder
+                .build_call(eager_fn, &[], "obs.eager_init")
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        }
+
+        // m58: load the deployment-config map (subject -> transport
+        // URL + role) from the path in $LOTUS_BUS_CONFIG. Emitted
+        // unconditionally — programs without the env var set hit
+        // the C-runtime's `if (!path) return` early-out and pay one
+        // syscall + one branch at startup. Programs with it set
+        // get their cross-process bus routes opened before any
+        // user code runs (so `<- "subj" | ...` calls reach remote
+        // subscribers from the very first publish).
+        // WASM plan (entry inversion): skip the cross-process transport
+        // loader on wasm. `lotus_bus_load_config` opens unix/udp sockets
+        // and spawns reader threads for `listen` routes — its body
+        // references socket/bind/connect/pthread_create, which (being
+        // reachable from `main`) would otherwise survive gc-sections and
+        // become host imports. The browser bus is in-memory / WebSocket-
+        // adapter-driven (a later slice), never cross-process sockets.
         if !self.is_wasm {
             let load_cfg_fn = self
                 .module

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1059,9 +1059,60 @@ pub fn build_executable_with_options(
     } else {
         let (top, _diags) = hale_types::resolve::build_top_scope(&bundle);
         let graph = hale_types::bus_graph::build_bus_graph(&bundle, &top);
-        // Deterministic ids: eligible subjects sorted by wire string
-        // (BTreeMap iteration order is sorted), 0..N. The direct-call
-        // subset reuses those very ids (its bucket is the same one
+        // GH #476 Change 8: the flavor decision is NOT made here. The
+        // gate facts are bridged into the canonical shape and
+        // `DispatchPlan` — the same procedure the model-side
+        // `DispatchPlan::derive` runs, and whose digest the execution
+        // identity folds in — decides. Codegen's gates come from the
+        // MERGED (user + stdlib, desugared) graph its own lowering
+        // must agree with, so the source of facts is local; only the
+        // ladder is shared. `dispatch_plan_agrees_with_the_model` in
+        // hale-cli pins the two fact sources against each other over
+        // the corpus.
+        let gates: Vec<hale_model::DispatchGate> = graph
+            .subjects
+            .iter()
+            .map(|(subject, info)| hale_model::DispatchGate {
+                subject: subject.clone(),
+                static_eligible: info.eligible,
+                direct_eligible: info.direct_call_eligible,
+                ineligible_reason: info
+                    .ineligible_reason
+                    .as_ref()
+                    .map(|r| r.tag().to_string()),
+                publisher_loci: {
+                    let mut p: Vec<String> = info
+                        .publishers
+                        .iter()
+                        .map(|s| s.locus.clone())
+                        .collect();
+                    p.sort();
+                    p.dedup();
+                    p
+                },
+                subscribers: info
+                    .subscribers
+                    .iter()
+                    .map(|s| (s.locus.clone(), s.handler.clone()))
+                    .collect(),
+            })
+            .collect();
+        let plan = hale_model::dispatch_plan::DispatchPlan::from_gates(
+            &gates,
+            &std::collections::BTreeMap::new(),
+        );
+        if env_flag("HALE_DISPATCH_TRACE") {
+            for s in &plan.subjects {
+                eprintln!(
+                    "[hale-dispatch] {} {}",
+                    s.subject,
+                    s.flavor.as_str()
+                );
+            }
+        }
+        // Deterministic ids: static subjects in wire-string order
+        // (the plan sorts by subject), 0..N. The direct-call subset
+        // reuses those very ids (its bucket is the same one
         // lotus_bus_register_static populates), so we collect both in
         // one pass.
         let mut ids: std::collections::BTreeMap<String, u32> =
@@ -1075,21 +1126,14 @@ pub fn build_executable_with_options(
             String,
             Vec<(String, String)>,
         > = std::collections::BTreeMap::new();
-        let mut next: u32 = 0;
-        for (subject, info) in &graph.subjects {
-            if info.eligible {
-                ids.insert(subject.clone(), next);
-                next += 1;
-                if info.direct_call_eligible {
-                    direct.insert(subject.clone());
-                    direct_subs.insert(
-                        subject.clone(),
-                        info.subscribers
-                            .iter()
-                            .map(|s| (s.locus.clone(), s.handler.clone()))
-                            .collect(),
-                    );
-                }
+        for (next, s) in plan.static_subjects().iter().enumerate() {
+            ids.insert(s.subject.clone(), next as u32);
+            if s.flavor
+                == hale_model::dispatch_plan::DispatchFlavor::StaticDirect
+            {
+                direct.insert(s.subject.clone());
+                direct_subs
+                    .insert(s.subject.clone(), s.subscribers.clone());
             }
         }
         (ids, direct, direct_subs)

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1212,6 +1212,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             ),
             None,
         );
+        // GH #476 Change 8: the identity of the entity-id table
+        // above, published in the segment header so a consumer can
+        // verify the ids index the tables it holds.
+        // declare void @lotus_obs_entity_id_digest_set(i64 d)
+        self.module.add_function(
+            "lotus_obs_entity_id_digest_set",
+            self.context
+                .void_type()
+                .fn_type(&[i64_t2.into()], false),
+            None,
+        );
         // GH #296: build-manifest identity for recording headers,
         // stamped as four u64 parts of a framed SHA-256.
         // declare void @lotus_obs_exec_digest_set(i64 part, i64 v)

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -1195,6 +1195,23 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                 .fn_type(&[i64_t2.into()], false),
             None,
         );
+        // GH #476 Change 8: canonical model entity ids, stamped in
+        // the prelude so a manifest entry created later (lazily, at
+        // first publish or birth) carries the compiler's id for the
+        // entity instead of leaving a consumer to match on names.
+        // declare void @lotus_obs_model_id(i32 kind, ptr name, i64 id)
+        self.module.add_function(
+            "lotus_obs_model_id",
+            self.context.void_type().fn_type(
+                &[
+                    self.context.i32_type().into(),
+                    ptr_t.into(),
+                    i64_t2.into(),
+                ],
+                false,
+            ),
+            None,
+        );
         // GH #296: build-manifest identity for recording headers,
         // stamped as four u64 parts of a framed SHA-256.
         // declare void @lotus_obs_exec_digest_set(i64 part, i64 v)

--- a/crates/hale-codegen/tests/obs_entity_ids_unstamped.rs
+++ b/crates/hale-codegen/tests/obs_entity_ids_unstamped.rs
@@ -1,0 +1,92 @@
+//! GH #476 Change 8, control arm: a build that stamps NO canonical
+//! entity ids leaves the manifest exactly as it was.
+//!
+//! The stamps come from the CLI, which derives them from the
+//! canonical model. Harness callers (`build_executable`, every
+//! codegen test, any embedder) pass none — and their manifest rows
+//! must keep reading `aux_b == 0`, the pre-existing "nothing here"
+//! value, so a consumer written against the old layout is not
+//! silently handed numbers that mean something else.
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+const PROG: &str = r#"
+type Tick { n: Int = 0; }
+topic Ticks { payload: Tick; subject: "unstamped.tick"; }
+locus W {
+    params { seen: Int = 0; }
+    bus { subscribe Ticks as on_t; }
+    fn on_t(t: Tick) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { w: W = W { }; }
+    bus { publish Ticks; }
+    run() { Ticks <- Tick { n: 1 }; std::time::sleep(600ms); }
+}
+fn main() { App { }; }
+"#;
+
+#[test]
+fn a_harness_build_leaves_manifest_entity_ids_zero() {
+    let program = hale_syntax::parse_source(PROG).expect("parse");
+    let bin = harness::unique_bin("lotus_test_obs_ids_unstamped");
+    build_executable(&program, &bin).expect("build");
+
+    let mut child = Command::new(&bin)
+        .env("LOTUS_OBS", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    let pid = child.id();
+    let shm = format!("/dev/shm/hale-obs-{}", pid);
+    let mut seen = 0usize;
+    let mut nonzero = Vec::new();
+    for _ in 0..80 {
+        std::thread::sleep(Duration::from_millis(25));
+        let Ok(b) = std::fs::read(&shm) else { continue };
+        if b.len() < 0x100 {
+            continue;
+        }
+        let u64at =
+            |o: usize| u64::from_le_bytes(b[o..o + 8].try_into().unwrap());
+        let u32at =
+            |o: usize| u32::from_le_bytes(b[o..o + 4].try_into().unwrap());
+        let manifest_off = u64at(0x40) as usize;
+        if manifest_off == 0 || manifest_off + 16 > b.len() {
+            continue;
+        }
+        let entry_count = u32at(manifest_off) as usize;
+        if entry_count == 0 {
+            continue;
+        }
+        seen = entry_count;
+        for i in 0..entry_count {
+            let e = manifest_off + 16 + i * 32;
+            if e + 32 > b.len() {
+                break;
+            }
+            let aux_b = u64at(e + 8);
+            if aux_b != 0 {
+                nonzero.push((i, aux_b));
+            }
+        }
+        break;
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_file(&bin);
+
+    assert!(seen > 0, "no manifest rows observed — test proves nothing");
+    assert!(
+        nonzero.is_empty(),
+        "an unstamped build published canonical entity ids: {:?}",
+        nonzero
+    );
+}

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -1265,7 +1265,18 @@ impl ApplicationModel {
                 Vec<u32>,
             > = std::collections::BTreeMap::new();
             for inst in &e.locus_instances {
-                let Some(open) = inst.path.rfind('[') else {
+                // Replica-ness is a property of the LAST path
+                // component only. A replica's own children keep
+                // being ordinary children — `App.workers[0].leaf`
+                // is a `leaf`, not replica 0 of anything — so an
+                // ancestor's bracket must not make a descendant
+                // answer for it.
+                let last = inst.path.rfind('.').map_or(0, |d| d + 1);
+                let open = inst.path[last..]
+                    .strip_suffix(']')
+                    .and_then(|c| c.rfind('['))
+                    .map(|i| last + i);
+                let Some(open) = open else {
                     // Not a replica path: it must not claim an index.
                     if inst.replica.is_some() {
                         return Err(

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -121,6 +121,24 @@ pub struct Relations {
 /// EXACT membership of legacy serialized sorts that are narrower
 /// than the model's universe, so `TopologyShapeV1` can be projected
 /// from the model alone (no summary/AST side channel). Deleted when
+/// One subject's dispatch-gate facts (GH #476 Change 8) — copied
+/// verbatim from the BusGraph's soundness gates.
+#[derive(Clone, Debug, Default)]
+pub struct DispatchGate {
+    /// The BusGraph's subject key (site spelling).
+    pub subject: String,
+    /// Static-bucket eligible (closed world).
+    pub static_eligible: bool,
+    /// Direct-call eligible (same-thread + quiet + closed world).
+    pub direct_eligible: bool,
+    /// The gate's reason when not static-eligible.
+    pub ineligible_reason: Option<String>,
+    /// Publisher locus displays (site grain, deduped).
+    pub publisher_loci: Vec<String>,
+    /// Subscriber (locus display, handler) pairs.
+    pub subscribers: Vec<(String, String)>,
+}
+
 /// the legacy artifact schema is versioned past.
 #[derive(Clone, Debug, Default)]
 pub struct LegacyProjection {
@@ -139,6 +157,11 @@ pub struct LegacyProjection {
     /// unchanged source. Both endpoints are legacy fns
     /// (∈ `topology_v1_fns`).
     pub topology_v1_calls_via_stdlib: Vec<(FunctionId, FunctionId, bool)>,
+    /// GH #476 Change 8: the BusGraph's per-subject dispatch gates
+    /// — the trusted devirtualization analysis, bridged like every
+    /// other legacy engine. `DispatchPlan::derive` combines these
+    /// facts with the arrangement into the typed lowering plan.
+    pub dispatch_gates: Vec<DispatchGate>,
     /// GH #476 Change 5a: what the evaluator's merged-summary walk
     /// sees INSIDE stdlib bodies reachable from a user fn — interior
     /// fail-closed holes (with the stdlib fn's display for the

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -871,6 +871,13 @@ pub enum ModelError {
     /// A locus instance has no (or more than one) `realizes` row:
     /// the relational projection is not total.
     RealizesIncomplete { instance: usize },
+    /// The replicas of one `replicas = K` field are not a
+    /// contiguous, unique, 0-based index set. Replica indices are
+    /// what codegen bakes and what a keyed subscriber registers
+    /// under, so `[3, 3, 3]` (the count repeated) or a gap is a
+    /// model that names instances the runtime does not have.
+    /// Carries the field's instance-path base.
+    ReplicaIndicesNotContiguous { base: String },
     /// A `binds` row joins a topic and a binding whose subjects
     /// disagree — the entity attribute and the relation repeat one
     /// fact and drifted.
@@ -1242,6 +1249,60 @@ impl ApplicationModel {
                     }
                 }
                 _ => return Err(ModelError::RealizesIncomplete { instance: i }),
+            }
+        }
+        // Replica index law (Change 8): the instances of one
+        // `replicas = K` field are `base[0] … base[K-1]`, each
+        // carrying its OWN index. The runtime pins replica `i` to
+        // one core and a keyed subscriber on that field registers
+        // under `key == i`, so a model that stored the COUNT in
+        // every row (or skipped an index) would name a population
+        // the process does not have. Grouped by the path base, so
+        // two replicated fields cannot patch each other's gaps.
+        {
+            let mut by_base: std::collections::BTreeMap<
+                &str,
+                Vec<u32>,
+            > = std::collections::BTreeMap::new();
+            for inst in &e.locus_instances {
+                let Some(open) = inst.path.rfind('[') else {
+                    // Not a replica path: it must not claim an index.
+                    if inst.replica.is_some() {
+                        return Err(
+                            ModelError::ReplicaIndicesNotContiguous {
+                                base: inst.path.clone(),
+                            },
+                        );
+                    }
+                    continue;
+                };
+                let Some(k) = inst.replica else {
+                    return Err(ModelError::ReplicaIndicesNotContiguous {
+                        base: inst.path[..open].to_string(),
+                    });
+                };
+                // The path and the field are two spellings of ONE
+                // fact; a row whose `base[2]` claims replica 0 is
+                // two answers to "which replica is this".
+                let in_path = inst.path[open + 1..]
+                    .strip_suffix(']')
+                    .and_then(|d| d.parse::<u32>().ok());
+                if in_path != Some(k) {
+                    return Err(ModelError::ReplicaIndicesNotContiguous {
+                        base: inst.path[..open].to_string(),
+                    });
+                }
+                by_base.entry(&inst.path[..open]).or_default().push(k);
+            }
+            for (base, mut ks) in by_base {
+                ks.sort_unstable();
+                let contiguous =
+                    ks.iter().enumerate().all(|(i, k)| *k == i as u32);
+                if !contiguous {
+                    return Err(ModelError::ReplicaIndicesNotContiguous {
+                        base: base.to_string(),
+                    });
+                }
             }
         }
         check_sorted_keys("owns", r.owns.iter().map(|x| (x.parent, x.child)))?;

--- a/crates/hale-model/src/dispatch_plan.rs
+++ b/crates/hale-model/src/dispatch_plan.rs
@@ -133,6 +133,28 @@ impl DispatchPlan {
                     .push(d);
             }
         }
+        // …minus every locus the model admits it does not fully
+        // place. A locus can have an arranged instance AND a
+        // placement hole at the same time: one `Sub` under `App` on
+        // main, another born dynamically inside a pinned locus. The
+        // arranged instance would answer "main" for the whole
+        // population and manufacture a same-domain claim about a
+        // process that has a `Sub` on another thread. A hole hiding
+        // OWNS or PLACED at a locus decl therefore DELETES that
+        // locus's domain answer — incomplete, not partially known.
+        for h in &m.holes {
+            if !h.hides.intersects(
+                crate::hole::RelationSet::OWNS
+                    .union(crate::hole::RelationSet::PLACED),
+            ) {
+                continue;
+            }
+            if let crate::ids::EntityRef::LocusDecl(id) = h.at {
+                if let Some(decl) = m.entities.loci.get(id.index()) {
+                    domains_of.remove(decl.display.as_str());
+                }
+            }
+        }
         DispatchPlan::from_gates(&m.legacy.dispatch_gates, &domains_of)
     }
 
@@ -143,6 +165,11 @@ impl DispatchPlan {
     /// supplies its gates and an empty map — flavors depend only on
     /// the gates, so an absent arrangement costs the `same_domain`
     /// survey field and nothing else.
+    /// `domains_of` is a COMPLETE account per key: a locus present
+    /// in the map has every one of its instances represented, and a
+    /// locus the model cannot fully place must be ABSENT (that is
+    /// what `derive` does with placement holes). A partial entry
+    /// would silently become a same-domain claim.
     pub fn from_gates(
         gates: &[crate::application::DispatchGate],
         domains_of: &std::collections::BTreeMap<&str, Vec<String>>,

--- a/crates/hale-model/src/dispatch_plan.rs
+++ b/crates/hale-model/src/dispatch_plan.rs
@@ -1,0 +1,246 @@
+//! GH #476 Change 8 — `DispatchPlan`: the typed lowering plan.
+//!
+//! Which lowering flavor a subject's dispatch gets (direct call,
+//! static bucket, dynamic queue) is a CONCLUSION derived from the
+//! model, never a model row (`relation.rs`'s rule). This module owns
+//! that conclusion: `DispatchPlan::derive(&ApplicationModel)` turns
+//! the model's dispatch-gate facts (the trusted BusGraph analysis,
+//! bridged through [`crate::application::DispatchGate`] like every
+//! other legacy engine) and the Change-8 arrangement (instances,
+//! placements, thread domains) into one typed plan per subject —
+//! and #464's stage-0 survey question ("how much queued traffic is
+//! same-domain?") becomes a field on each row instead of a bespoke
+//! topology walk.
+//!
+//! The plan participates in EXECUTION IDENTITY: `digest()` is folded
+//! into the exec digest, so two builds whose dispatch decisions
+//! differ can never share a recording identity (#464's
+//! boot-resolved-flag rule, applied from day one).
+
+use crate::application::ApplicationModel;
+
+/// The lowering flavor a subject's dispatch receives.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DispatchFlavor {
+    /// Runtime hash-lookup dispatch — the default, and the only
+    /// sound choice for anything the gates cannot positively clear.
+    Dynamic,
+    /// Compile-time subject id + static bucket walk (dispatch still
+    /// queued; only the lookup devirtualized).
+    StaticBucket,
+    /// Synchronous direct calls to every subscriber handler (the
+    /// quiet/flat/same-thread tier).
+    StaticDirect,
+}
+
+impl DispatchFlavor {
+    /// THE decision ladder — the single place in the toolchain
+    /// where gate booleans become a lowering flavor. Codegen calls
+    /// this rather than open-coding `if eligible { .. if direct
+    /// { .. } }`, so the plan a recording pins and the plan the
+    /// backend emits cannot drift by editing one of two ladders.
+    pub fn of(static_eligible: bool, direct_eligible: bool) -> Self {
+        if direct_eligible {
+            // `direct_call_eligible` is computed as a REFINEMENT of
+            // `eligible` upstream; assert the containment here so a
+            // future gate edit that breaks it fails loudly instead
+            // of silently promoting an ineligible subject.
+            debug_assert!(
+                static_eligible,
+                "direct-call eligibility must refine static eligibility"
+            );
+            DispatchFlavor::StaticDirect
+        } else if static_eligible {
+            DispatchFlavor::StaticBucket
+        } else {
+            DispatchFlavor::Dynamic
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DispatchFlavor::Dynamic => "dynamic",
+            DispatchFlavor::StaticBucket => "static_bucket",
+            DispatchFlavor::StaticDirect => "static_direct",
+        }
+    }
+}
+
+/// One subject's plan row.
+#[derive(Clone, Debug)]
+pub struct SubjectPlan {
+    /// The subject key the gates were computed over (the BusGraph's
+    /// site spelling).
+    pub subject: String,
+    pub flavor: DispatchFlavor,
+    /// The gate's reason when the flavor is `Dynamic`.
+    pub ineligible_reason: Option<String>,
+    /// Subscriber (locus, handler) pairs — what the direct lowering
+    /// bakes.
+    pub subscribers: Vec<(String, String)>,
+    /// The thread domains hosting the subject's PUBLISHER loci
+    /// (every arranged instance of each publishing locus), sorted +
+    /// deduped. Empty when a publisher locus has no arranged
+    /// instance (a dynamic birth) — which also forfeits
+    /// `same_domain`.
+    pub publisher_domains: Vec<String>,
+    /// Likewise for subscriber loci.
+    pub subscriber_domains: Vec<String>,
+    /// #464 stage 0: every publish site and every subscriber of
+    /// this subject sits in ONE thread domain — the precondition
+    /// for the future same-domain flavors (local queue / widened
+    /// direct). Computed conservatively: any unknown domain
+    /// (dynamic birth, unarranged locus) forfeits it.
+    pub same_domain: bool,
+}
+
+/// The whole-program dispatch plan.
+#[derive(Clone, Debug, Default)]
+pub struct DispatchPlan {
+    pub subjects: Vec<SubjectPlan>,
+}
+
+impl DispatchPlan {
+    /// Derive the plan from the model: gate facts × arrangement.
+    pub fn derive(m: &ApplicationModel) -> DispatchPlan {
+        // locus display → the domains of its arranged instances.
+        let domain_name = |id: crate::ids::ThreadDomainId| {
+            m.entities
+                .thread_domains
+                .get(id.index())
+                .map(|d| d.name.clone())
+                .unwrap_or_default()
+        };
+        let mut domains_of: std::collections::BTreeMap<
+            &str,
+            Vec<String>,
+        > = std::collections::BTreeMap::new();
+        for re in &m.relations.realizes {
+            let Some(decl) = m.entities.loci.get(re.decl.index())
+            else {
+                continue;
+            };
+            let domain = m
+                .relations
+                .placed_in
+                .iter()
+                .find(|p| p.instance == re.instance)
+                .map(|p| domain_name(p.domain));
+            if let Some(d) = domain {
+                domains_of
+                    .entry(decl.display.as_str())
+                    .or_default()
+                    .push(d);
+            }
+        }
+        DispatchPlan::from_gates(&m.legacy.dispatch_gates, &domains_of)
+    }
+
+    /// The plan over raw gate facts plus a locus-display → thread
+    /// domains map. `derive` supplies the model's arrangement for
+    /// the map; codegen, which holds the merged (user + stdlib,
+    /// desugared) bus graph its own lowering must agree with,
+    /// supplies its gates and an empty map — flavors depend only on
+    /// the gates, so an absent arrangement costs the `same_domain`
+    /// survey field and nothing else.
+    pub fn from_gates(
+        gates: &[crate::application::DispatchGate],
+        domains_of: &std::collections::BTreeMap<&str, Vec<String>>,
+    ) -> DispatchPlan {
+        let mut subjects: Vec<SubjectPlan> = Vec::new();
+        for g in gates {
+            let flavor =
+                DispatchFlavor::of(g.static_eligible, g.direct_eligible);
+            let collect = |loci: &[String]| -> (Vec<String>, bool) {
+                let mut out: Vec<String> = Vec::new();
+                let mut complete = !loci.is_empty();
+                for l in loci {
+                    match domains_of.get(l.as_str()) {
+                        Some(ds) if !ds.is_empty() => {
+                            out.extend(ds.iter().cloned())
+                        }
+                        _ => complete = false,
+                    }
+                }
+                out.sort();
+                out.dedup();
+                (out, complete)
+            };
+            let sub_loci: Vec<String> = g
+                .subscribers
+                .iter()
+                .map(|(l, _)| l.clone())
+                .collect();
+            let (publisher_domains, pubs_complete) =
+                collect(&g.publisher_loci);
+            let (subscriber_domains, subs_complete) =
+                collect(&sub_loci);
+            let same_domain = pubs_complete
+                && subs_complete
+                && publisher_domains.len() == 1
+                && publisher_domains == subscriber_domains;
+            subjects.push(SubjectPlan {
+                subject: g.subject.clone(),
+                flavor,
+                ineligible_reason: g.ineligible_reason.clone(),
+                subscribers: g.subscribers.clone(),
+                publisher_domains,
+                subscriber_domains,
+                same_domain,
+            });
+        }
+        subjects.sort_by(|a, b| a.subject.cmp(&b.subject));
+        DispatchPlan { subjects }
+    }
+
+    /// The subjects lowered to the static bucket (or stronger), in
+    /// deterministic id order — the codegen id assignment.
+    pub fn static_subjects(&self) -> Vec<&SubjectPlan> {
+        self.subjects
+            .iter()
+            .filter(|s| {
+                !matches!(s.flavor, DispatchFlavor::Dynamic)
+            })
+            .collect()
+    }
+
+    /// #464 stage 0: (same-domain queued subjects, total subjects).
+    /// "Queued" = static-bucket or dynamic — the traffic a future
+    /// same-domain local queue would accelerate.
+    pub fn same_domain_queued(&self) -> (usize, usize) {
+        let same = self
+            .subjects
+            .iter()
+            .filter(|s| {
+                s.same_domain
+                    && !matches!(
+                        s.flavor,
+                        DispatchFlavor::StaticDirect
+                    )
+            })
+            .count();
+        (same, self.subjects.len())
+    }
+
+    /// The plan's identity — folded into the execution digest, so
+    /// dispatch decisions are part of what a recording pins.
+    pub fn digest(&self) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        let mut eat = |bytes: &[u8]| {
+            for b in bytes {
+                h ^= u64::from(*b);
+                h = h.wrapping_mul(0x100000001b3);
+            }
+        };
+        for s in &self.subjects {
+            eat(s.subject.as_bytes());
+            eat(&[0, s.flavor as u8, u8::from(s.same_domain)]);
+            for (l, f) in &s.subscribers {
+                eat(l.as_bytes());
+                eat(&[1]);
+                eat(f.as_bytes());
+            }
+        }
+        h
+    }
+}

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -112,8 +112,14 @@ pub struct LocusInstance {
     /// Canonical instance path, e.g. `App.w` or `App.workers[3]`.
     pub path: String,
     pub decl: LocusDeclId,
-    /// `Some(k)` for a `replicas = K` member; feeds `EqReplica`
-    /// coverage in keyed-delivery judgments.
+    /// This instance's REPLICA INDEX (0-based) when it came from a
+    /// `pinned(..., replicas = K)` field, `None` otherwise. It is
+    /// the index, not the count: the runtime pins replica `i` to
+    /// one core, and a keyed subscriber on a replicated field
+    /// registers under `key == i` — so `EqReplica` coverage in
+    /// keyed-delivery judgments only works if the model names the
+    /// same `i` codegen bakes. `validate` enforces that the
+    /// replicas of one field form a contiguous 0-based set.
     pub replica: Option<u32>,
     pub provenance: ProvenanceId,
 }

--- a/crates/hale-model/src/hole.rs
+++ b/crates/hale-model/src/hole.rs
@@ -192,6 +192,24 @@ pub fn allowed_hole_families(
         (EntityRef::Function(_), K::UnanalyzedBody) => {
             Some((c.union(p).union(e), c.union(p).union(e)))
         }
+        // Change 8: a locus whose method bodies give birth outside
+        // the arrangement — the born instance's owner and
+        // placement resolve at runtime, so the ownership and
+        // placement accounts are both withdrawn.
+        (
+            EntityRef::LocusDecl(_),
+            K::RuntimeInheritedPlacement,
+        ) => Some((
+            RelationSet::OWNS.union(RelationSet::PLACED),
+            RelationSet::OWNS.union(RelationSet::PLACED),
+        )),
+        // Change 8: an adapter-transport binding is a declared
+        // external boundary with opaque internals — the binding
+        // route and its delivery contract are unknown.
+        (EntityRef::Topic(_), K::ExternalOpaque) => Some((
+            RelationSet::BINDS.union(RelationSet::DELIVERY),
+            RelationSet::BINDS.union(RelationSet::DELIVERY),
+        )),
         // Set-level endpoint knowledge: each bit is independently
         // meaningful (publisher-incomplete vs
         // subscriber-incomplete are distinct facts), so nothing

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -131,6 +131,7 @@ pub mod entity;
 pub mod hole;
 pub mod ids;
 pub mod keys;
+pub mod obs_ids;
 pub mod provenance;
 pub mod relation;
 

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -126,6 +126,7 @@
 pub mod application;
 pub mod capability;
 pub mod claim_ir;
+pub mod dispatch_plan;
 pub mod entity;
 pub mod hole;
 pub mod ids;
@@ -138,7 +139,7 @@ pub use application::{
     ApplicationModel, Entities, CertificateEvidence, EvidenceRow, EvidenceTable, LabelRow,
     LegacyProjection, StdlibAbsorption,
     VerdictIr, ModelError, ModelHashKind, ModelHeader,
-    Relations, WeightRow, MODEL_SEMANTICS_V1,
+    Relations, WeightRow, MODEL_SEMANTICS_V1, DispatchGate,
 };
 pub use capability::Capabilities;
 pub use claim_ir::{

--- a/crates/hale-model/src/obs_ids.rs
+++ b/crates/hale-model/src/obs_ids.rs
@@ -48,6 +48,43 @@ pub struct ObsEntityId {
     pub id: u64,
 }
 
+/// The identity of a stamped id table — what the observation
+/// header publishes at `entity_id_digest` (proto 0.3).
+///
+/// The header's `model_hash` is STRUCTURAL model identity, and it
+/// does not cover every table these ids index: the arrangement's
+/// binding rows are not in the topology artifact at all, and an
+/// unused topic's wire subject rides an unhashed section. Two
+/// builds could therefore share a `model_hash` while numbering
+/// entities differently, and `aux_b = 1` would designate different
+/// canonical entities under one advertised identity.
+///
+/// So the ids carry their OWN identity: this digest over the exact
+/// `(kind, name, id)` rows that were stamped. A consumer recomputes
+/// it from the model it holds — `digest(&obs_entity_ids(&model))` —
+/// and uses the ids only on a match. No match, no join; that is a
+/// detectable refusal instead of a silent misattribution.
+pub fn digest(rows: &[ObsEntityId]) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    let mut eat = |bytes: &[u8]| {
+        for b in bytes {
+            h ^= u64::from(*b);
+            h = h.wrapping_mul(0x100000001b3);
+        }
+    };
+    for r in rows {
+        eat(&[r.kind as u8]);
+        eat(r.name.as_bytes());
+        eat(&r.id.to_le_bytes());
+    }
+    // Never 0: that value means "unstamped" in the header.
+    if h == 0 {
+        1
+    } else {
+        h
+    }
+}
+
 /// Project the model's entity tables into manifest stamps, in a
 /// deterministic order (kind, then name).
 pub fn obs_entity_ids(m: &ApplicationModel) -> Vec<ObsEntityId> {

--- a/crates/hale-model/src/obs_ids.rs
+++ b/crates/hale-model/src/obs_ids.rs
@@ -1,0 +1,94 @@
+//! GH #476 Change 8 — canonical entity ids for the observation
+//! manifest.
+//!
+//! A live process's manifest identifies entities by NAME plus a
+//! registration-order id: the topic row for `sense.reading` is
+//! whichever row that subject happened to register into. A consumer
+//! (iris) holding the source-derived model had no way to join the
+//! two except by matching strings and trusting that the compiler's
+//! spelling and the runtime's spelling agree — which is exactly the
+//! kind of second authority this epic exists to delete.
+//!
+//! So the compiler answers instead. This module projects the model
+//! down to `(manifest kind, manifest name, canonical id)` rows; the
+//! CLI hands them to codegen, codegen stamps them in the observation
+//! prelude, and the runtime writes the id into the manifest entry's
+//! `aux_b` when that entry is created. The ids are indices into THIS
+//! model's tables, so they are only meaningful alongside the
+//! header's `model_hash`.
+//!
+//! Encoding: `index + 1`, because `aux_b == 0` is the pre-existing
+//! "nothing here" value and every unstamped build must keep reading
+//! that way.
+
+use crate::application::ApplicationModel;
+
+/// The manifest kinds an entity id can be attached to. Values are
+/// the runtime's `MK_*` constants (`lotus_obs.c`) — this enum is
+/// the Rust half of that shared numbering.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ObsEntityKind {
+    /// `MK_TOPIC` — keyed by WIRE SUBJECT (the manifest fuses every
+    /// publisher of a subject into one row), so the canonical id is
+    /// the model's `SubjectId`, not `TopicId`.
+    Topic = 0,
+    /// `MK_LOCUS_TYPE` — keyed by locus type name; `LocusDeclId`.
+    LocusType = 1,
+    /// `MK_BINDING` — keyed by the bound subject; `BindingId`.
+    Binding = 2,
+}
+
+/// One stamp: "in this model, the manifest row of `kind` named
+/// `name` is entity `id`".
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ObsEntityId {
+    pub kind: ObsEntityKind,
+    pub name: String,
+    /// `index + 1` — see the module note on the zero value.
+    pub id: u64,
+}
+
+/// Project the model's entity tables into manifest stamps, in a
+/// deterministic order (kind, then name).
+pub fn obs_entity_ids(m: &ApplicationModel) -> Vec<ObsEntityId> {
+    let mut out: Vec<ObsEntityId> = Vec::new();
+    for (i, s) in m.entities.subjects.iter().enumerate() {
+        // Wildcard patterns are not manifest rows: the runtime
+        // registers the CONCRETE subject a message was published
+        // on, never the pattern a subscriber matched with.
+        if !s.exact {
+            continue;
+        }
+        out.push(ObsEntityId {
+            kind: ObsEntityKind::Topic,
+            name: s.pattern.clone(),
+            id: i as u64 + 1,
+        });
+    }
+    for (i, l) in m.entities.loci.iter().enumerate() {
+        // The RAW name: what codegen emits as the locus type name
+        // and what `lotus_obs_locus_birth` therefore receives. The
+        // author-facing `display` (alias-qualified for imports) is
+        // never on the wire.
+        out.push(ObsEntityId {
+            kind: ObsEntityKind::LocusType,
+            name: l.name.clone(),
+            id: i as u64 + 1,
+        });
+    }
+    for (i, b) in m.entities.bindings.iter().enumerate() {
+        let Some(s) = m.entities.subjects.get(b.subject.index()) else {
+            continue;
+        };
+        out.push(ObsEntityId {
+            kind: ObsEntityKind::Binding,
+            name: s.pattern.clone(),
+            id: i as u64 + 1,
+        });
+    }
+    out.sort_by(|a, b| {
+        (a.kind as u8, &a.name).cmp(&(b.kind as u8, &b.name))
+    });
+    out.dedup_by(|a, b| a.kind == b.kind && a.name == b.name);
+    out
+}

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -110,7 +110,11 @@ fn tiny_model() -> ApplicationModel {
                 },
             ],
             locus_instances: vec![LocusInstance {
-                path: "App.w".to_string(),
+                // A replica instance: the path carries the index
+                // and `replica` carries the SAME index (Change 8's
+                // contiguity law — an index on a non-replica path,
+                // or a path whose index disagrees, is not a model).
+                path: "App.w[0]".to_string(),
                 decl: LocusDeclId(1),
                 replica: Some(0),
                 provenance: p,

--- a/crates/hale-syntax/src/desugar.rs
+++ b/crates/hale-syntax/src/desugar.rs
@@ -56,8 +56,18 @@ struct TopicEntry {
 pub fn desugar_topics(program: &mut Program) {
     let mut topics: BTreeMap<String, TopicEntry> = BTreeMap::new();
     collect_topics(&program.items, &mut topics);
-    rewrite_items(&mut program.items, &topics);
+    // BEFORE the rewrite: role inference reads `BusSubject::Topic`
+    // ends, and `rewrite_items` turns every one of them into a
+    // literal subject. Running it after (as this did) meant the
+    // publish/subscribe sets were always empty, no role was ever
+    // inferred, and codegen refused every binding that did not
+    // spell `role:` explicitly — the documented inference was
+    // dead code. GH #476 Change 8 review: the canonical model
+    // derives binding roles through the same rule, over the
+    // authored AST where the topic ends are still visible, so the
+    // two must actually agree.
     desugar_binding_roles(program);
+    rewrite_items(&mut program.items, &topics);
 }
 
 /// `--wrap-main` (browser playground): turn a bare-`main` program into a
@@ -171,6 +181,45 @@ fn desugar_binding_roles(program: &mut Program) {
     fill_roles_in_items(&mut program.items, &pubs, &subs);
 }
 
+/// THE binding-role rule, for callers that must agree with the
+/// desugar without mutating a program.
+///
+/// The canonical model (GH #476 Change 8) derives its binding rows
+/// from the AUTHORED bundle — the desugar has not run there, so
+/// `role` is still `None` on every inferred binding. Reading the
+/// syntax field directly would model a publish-only `unix(...)`
+/// binding as whatever the model happened to default to, which is
+/// the second-authority failure this epic exists to remove. Both
+/// callers go through here instead: explicit role wins, otherwise
+/// publish-only is `Connect` and subscribe-only is `Listen`, and
+/// `None` means "not inferable" (typecheck has already diagnosed
+/// it; codegen refuses to lower it).
+pub fn binding_role_for(
+    items: &[TopDecl],
+    topic: &str,
+    explicit: Option<TransportRole>,
+) -> Option<TransportRole> {
+    if explicit.is_some() {
+        return explicit;
+    }
+    role_from_ends(
+        collect_topic_publishers(items).contains(topic),
+        collect_topic_subscribers(items).contains(topic),
+    )
+}
+
+/// The rule itself, over the two ends. One body, two callers (the
+/// desugar's in-place fill and `binding_role_for`).
+fn role_from_ends(p: bool, s: bool) -> Option<TransportRole> {
+    match (p, s) {
+        // Ambiguous (both) and unused (neither) are typecheck
+        // diagnostics, not defaults.
+        (true, false) => Some(TransportRole::Connect),
+        (false, true) => Some(TransportRole::Listen),
+        _ => None,
+    }
+}
+
 fn collect_topic_publishers(items: &[TopDecl]) -> std::collections::BTreeSet<String> {
     let mut out = std::collections::BTreeSet::new();
     fn walk(items: &[TopDecl], out: &mut std::collections::BTreeSet<String>) {
@@ -244,16 +293,17 @@ fn fill_roles_in_items(
                                 &mut entry.transport
                             {
                                 if role.is_none() {
-                                    let p = pubs.contains(&entry.topic.name);
-                                    let s = subs.contains(&entry.topic.name);
-                                    // Typecheck emits a diag for (p && s)
-                                    // and (!p && !s); here we only fill in
-                                    // the unambiguous cases.
-                                    if p && !s {
-                                        *role = Some(TransportRole::Connect);
-                                    } else if s && !p {
-                                        *role = Some(TransportRole::Listen);
-                                    }
+                                    // Typecheck emits a diag for the
+                                    // ambiguous (both) and unused
+                                    // (neither) cases; `role_from_ends`
+                                    // fills in only the unambiguous
+                                    // ones, and the canonical model
+                                    // reads the SAME rule through
+                                    // `binding_role_for`.
+                                    *role = role_from_ends(
+                                        pubs.contains(&entry.topic.name),
+                                        subs.contains(&entry.topic.name),
+                                    );
                                 }
                             }
                         }

--- a/crates/hale-types/src/bus_graph.rs
+++ b/crates/hale-types/src/bus_graph.rs
@@ -629,7 +629,7 @@ pub fn has_offthread_placement(bundle: &Bundle<'_>) -> bool {
 /// path), else `None`. Non-locus field types never appear in a
 /// `placement { }` block (typecheck enforces), so we don't confirm
 /// locus-ness here.
-fn single_named_type(ty: &TypeExpr) -> Option<String> {
+pub(crate) fn single_named_type(ty: &TypeExpr) -> Option<String> {
     match ty {
         TypeExpr::Named { path, .. } => path.segments.last().map(|s| s.name.clone()),
         _ => None,

--- a/crates/hale-types/src/bus_graph.rs
+++ b/crates/hale-types/src/bus_graph.rs
@@ -105,7 +105,21 @@ pub(crate) fn collect_bus_walk(bundle: &Bundle<'_>) -> BusWalk {
         sub_sites: Vec::new(),
     };
 
-    fn walk(items: &[TopDecl], w: &mut BusWalk) {
+    // Wire subjects for every topic decl in the bundle, so a
+    // `bindings { }` entry can be recorded at both grains.
+    let all_items: Vec<TopDecl> = bundle
+        .programs
+        .values()
+        .flat_map(|p| p.items.iter().cloned())
+        .collect();
+    let wire_subjects =
+        crate::topic_identity::topic_wire_subjects(&all_items);
+
+    fn walk(
+        items: &[TopDecl],
+        w: &mut BusWalk,
+        wire_subjects: &BTreeMap<String, String>,
+    ) {
         for item in items {
             match item {
                 TopDecl::Locus(l) => {
@@ -157,20 +171,49 @@ pub(crate) fn collect_bus_walk(bundle: &Bundle<'_>) -> BusWalk {
                             }
                             LocusMember::Bindings(bbk) => {
                                 for entry in &bbk.entries {
+                                    // BOTH spellings of the bound
+                                    // topic: the decl name and the
+                                    // wire subject. A `bindings { }`
+                                    // entry names the topic DECL
+                                    // (`Beat`), but by the time
+                                    // codegen builds this graph the
+                                    // topic references have been
+                                    // desugared to their wire
+                                    // subject (`demo.beat`) — so
+                                    // keying on the decl name alone
+                                    // let a transport-bound subject
+                                    // slip past the eligibility gate
+                                    // there and get devirtualized to
+                                    // a static bucket, cutting the
+                                    // adapter out of its own
+                                    // deliveries. Recording both
+                                    // makes the gate hit whichever
+                                    // grain the graph is keyed at.
+                                    // (GH #476 Change 8 found this:
+                                    // model plan vs codegen plan
+                                    // disagreed on exactly one
+                                    // corpus program.)
                                     w.bound.insert(entry.topic.name.clone());
+                                    if let Some(wire) =
+                                        wire_subjects.get(&entry.topic.name)
+                                    {
+                                        w.bound.insert(wire.clone());
+                                    }
                                 }
                             }
                             _ => {}
                         }
                     }
                 }
-                TopDecl::Module(md) => walk(&md.items, w),
+                TopDecl::Module(md) => {
+                    walk(&md.items, w, wire_subjects)
+                }
                 _ => {}
             }
         }
     }
     for program in bundle.programs.values() {
-        walk(&program.items, &mut w);
+        walk(&program.items, &mut w, &wire_subjects);
     }
     w
 }

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -3053,11 +3053,11 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                     arranged.push(Arranged {
                         path: child_path.clone(),
                         decl: (*ty).to_string(),
-                        replica: if fanout > 1 {
-                            Some(fanout)
-                        } else {
-                            None
-                        },
+                        // The instance's OWN replica index — what
+                        // codegen bakes into replica `i` and what a
+                        // keyed subscriber on this field registers
+                        // under. (`validate` enforces contiguity.)
+                        replica: if fanout > 1 { Some(i) } else { None },
                         domain: child_domain.clone(),
                         parent: Some(path.to_string()),
                         span: *span,
@@ -3108,11 +3108,15 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             .map(|a| a.domain.clone())
             .collect();
         // Bindings (main's `bindings { }` block).
-        let mut binding_entries: Vec<(
-            String,
-            hale_syntax::Span,
-            bool,
-        )> = Vec::new();
+        struct BindingEntry {
+            topic: String,
+            span: hale_syntax::Span,
+            /// `None` for adapter/shm transports — a declared
+            /// external boundary, holed out rather than guessed.
+            unix_role: Option<hale_syntax::ast::TransportRole>,
+            adapter: bool,
+        }
+        let mut binding_entries: Vec<BindingEntry> = Vec::new();
         if let Some((main_name, _)) = &main_decl {
             if let Some(decl) = decls_by_name.get(main_name.as_str())
             {
@@ -3123,11 +3127,29 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                                 e2.transport,
                                 TransportSpec::Unix { .. }
                             );
-                            binding_entries.push((
-                                e2.topic.name.clone(),
-                                e2.span,
+                            // The AUTHORED role, resolved through
+                            // the ONE rule the desugar uses (this
+                            // bundle is not desugared, so the field
+                            // is still `None` on every inferred
+                            // binding — reading it raw would model
+                            // a publish-only `connect` binding as
+                            // whatever the builder defaulted to).
+                            let unix_role = match &e2.transport {
+                                TransportSpec::Unix {
+                                    role, ..
+                                } => hale_syntax::desugar::binding_role_for(
+                                    &all_items,
+                                    &e2.topic.name,
+                                    *role,
+                                ),
+                                _ => None,
+                            };
+                            binding_entries.push(BindingEntry {
+                                topic: e2.topic.name.clone(),
+                                span: e2.span,
+                                unix_role,
                                 adapter,
-                            ));
+                            });
                             domain_names.insert(format!(
                                 "binding:{}",
                                 e2.topic.name
@@ -3208,23 +3230,54 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         // Binding entities + binds rows. Adapter transports are
         // declared external boundaries with opaque internals —
         // they hole out instead of guessing loss semantics.
-        let mut bind_rows: Vec<(
-            hale_model::TopicId,
-            BindingId,
-        )> = Vec::new();
-        for (topic_name, span, adapter) in &binding_entries {
-            let Some(tid) = topic_id.get(topic_name) else {
+        //
+        // Decoded FIRST, sorted canonically SECOND, ids assigned
+        // THIRD. `validate` requires the entity table sorted by
+        // (subject, transport, role); assigning ids in source order
+        // would hand back an invalid model for a perfectly valid
+        // main locus whose two binding entries are authored in
+        // reverse subject order.
+        struct DecodedBinding {
+            topic: hale_model::TopicId,
+            subject: hale_model::SubjectId,
+            transport: TransportKind,
+            role: BindingRole,
+            loss: hale_model::keys::BindingLossBehavior,
+            span: hale_syntax::Span,
+        }
+        let mut decoded: Vec<DecodedBinding> = Vec::new();
+        for entry in &binding_entries {
+            let Some(tid) = topic_id.get(&entry.topic) else {
                 continue;
             };
-            let pid = intern_span(&mut records, *span);
-            if *adapter {
+            let pid = intern_span(&mut records, entry.span);
+            // An adapter transport, or a unix binding whose role
+            // is not inferable (typecheck has diagnosed it; codegen
+            // refuses to lower it), is a boundary the model does
+            // not describe — a hole, never a guessed row.
+            let role = match (entry.adapter, entry.unix_role) {
+                (false, Some(hale_syntax::ast::TransportRole::Listen)) => {
+                    Some(BindingRole::Listen)
+                }
+                (false, Some(hale_syntax::ast::TransportRole::Connect)) => {
+                    Some(BindingRole::Connect)
+                }
+                _ => None,
+            };
+            let Some(role) = role else {
                 holes
                     .entry((
                         EntityRef::Topic(*tid),
                         HoleKind::ExternalOpaque,
-                        "adapter transport: external boundary \
-                         with opaque internals"
-                            .to_string(),
+                        if entry.adapter {
+                            "adapter transport: external boundary \
+                             with opaque internals"
+                                .to_string()
+                        } else {
+                            "binding role is not inferable: the \
+                             route this topic takes is undetermined"
+                                .to_string()
+                        },
                     ))
                     .or_insert((
                         hale_model::RelationSet::BINDS.union(
@@ -3234,16 +3287,52 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                         pid,
                     ));
                 continue;
-            }
-            let bid = BindingId(e.bindings.len() as u32);
-            e.bindings.push(Binding {
+            };
+            // Loss behavior follows the ROLE, because that is what
+            // the runtime does: the connect side is the publish
+            // side, where a send failure marks the entry lost and
+            // `or wait` can park through the reconnect window
+            // (WaitCapable); the listen side re-arms on peer EOF
+            // (peer EOF is not connection loss) and a link it
+            // cannot serve is structural (Fail).
+            let loss = match role {
+                BindingRole::Connect => {
+                    hale_model::keys::BindingLossBehavior::WaitCapable
+                }
+                BindingRole::Listen => {
+                    hale_model::keys::BindingLossBehavior::Fail
+                }
+            };
+            decoded.push(DecodedBinding {
+                topic: *tid,
                 subject: e.topics[tid.index()].subject,
                 transport: TransportKind::Unix,
-                role: BindingRole::Listen,
-                loss: hale_model::keys::BindingLossBehavior::WaitCapable,
+                role,
+                loss,
+                span: entry.span,
+            });
+        }
+        decoded.sort_by_key(|d| {
+            (d.subject, d.transport.clone(), d.role, d.topic)
+        });
+        decoded.dedup_by_key(|d| {
+            (d.subject, d.transport.clone(), d.role)
+        });
+        let mut bind_rows: Vec<(
+            hale_model::TopicId,
+            BindingId,
+        )> = Vec::new();
+        for (i, d) in decoded.iter().enumerate() {
+            let pid = intern_span(&mut records, d.span);
+            let bid = BindingId(i as u32);
+            e.bindings.push(Binding {
+                subject: d.subject,
+                transport: d.transport.clone(),
+                role: d.role,
+                loss: d.loss,
                 provenance: pid,
             });
-            bind_rows.push((*tid, bid));
+            bind_rows.push((d.topic, bid));
         }
         bind_rows.sort();
         for (t, b) in bind_rows {

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -2811,6 +2811,443 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     stdlib_absorption.sort_by_key(|a| (a.from, a.site));
 
     // holes, canonically ordered.
+    // ==== GH #476 Change 8: the ARRANGEMENT — instances,
+    // ownership, placement, thread domains, bindings. These are
+    // the tables Change 2 deliberately left empty ("no current
+    // fragment exports them"); their consumers land here
+    // (#464's DispatchPlan, iris instance IDs). None of this
+    // participates in the artifact's model half, so shape
+    // identity is untouched.
+    {
+        use hale_model::{
+            Binding, BindingId, BindingRole, LocusInstance,
+            LocusInstanceId, Owns, PlacedIn, Realizes,
+            ThreadDomain, ThreadDomainId, TopicBinding,
+            TransportKind,
+        };
+        use hale_syntax::ast::{
+            LocusMember, PlacementSpec, TopDecl, TransportSpec,
+        };
+        // Locus decls by RAW name, with their members, across the
+        // whole bundle (modules included — a module locus can be
+        // arranged like any other).
+        let mut decls_by_name: BTreeMap<
+            &str,
+            &hale_syntax::ast::LocusDecl,
+        > = BTreeMap::new();
+        fn walk_loci<'a>(
+            items: &'a [TopDecl],
+            out: &mut BTreeMap<
+                &'a str,
+                &'a hale_syntax::ast::LocusDecl,
+            >,
+        ) {
+            for item in items {
+                match item {
+                    TopDecl::Locus(l) => {
+                        out.entry(l.name.name.as_str()).or_insert(l);
+                    }
+                    TopDecl::Module(m) => {
+                        walk_loci(&m.items, out)
+                    }
+                    _ => {}
+                }
+            }
+        }
+        for pr in &programs {
+            walk_loci(&pr.items, &mut decls_by_name);
+        }
+        // The recursive arrangement walk. Placement semantics
+        // mirror the runtime invariant: `pinned` owns a thread
+        // (its own domain), `cooperative(pool = X ≠ main)` runs on
+        // pool X's single worker, everything else runs on the
+        // OWNER's thread (inherits the parent's domain; the root
+        // is `main`).
+        struct Arranged {
+            path: String,
+            decl: String,
+            replica: Option<u32>,
+            domain: String,
+            parent: Option<String>,
+            span: hale_syntax::Span,
+        }
+        let mut arranged: Vec<Arranged> = Vec::new();
+        let mut pool_names: BTreeSet<String> = BTreeSet::new();
+        #[allow(clippy::too_many_arguments)]
+        fn walk_arrangement(
+            decl_name: &str,
+            path: &str,
+            domain: &str,
+            decls: &BTreeMap<&str, &hale_syntax::ast::LocusDecl>,
+            stack: &mut Vec<String>,
+            arranged: &mut Vec<Arranged>,
+            pool_names: &mut BTreeSet<String>,
+        ) {
+            if stack.iter().any(|s| s == decl_name)
+                || stack.len() > 32
+            {
+                return; // cycle / depth guard
+            }
+            stack.push(decl_name.to_string());
+            let Some(decl) = decls.get(decl_name) else {
+                stack.pop();
+                return;
+            };
+            // field → (type, span); field → placement spec.
+            let mut field_ty: BTreeMap<
+                &str,
+                (&str, hale_syntax::Span),
+            > = BTreeMap::new();
+            for m in &decl.members {
+                if let LocusMember::Params(pb) = m {
+                    for pa in &pb.params {
+                        if let Some(ty) = &pa.ty {
+                            if let Some(n) =
+                                crate::bus_graph::single_named_type(ty)
+                            {
+                                field_ty.insert(
+                                    pa.name.name.as_str(),
+                                    (
+                                        Box::leak(
+                                            n.into_boxed_str(),
+                                        ),
+                                        pa.name.span,
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            let mut field_place: BTreeMap<
+                &str,
+                &PlacementSpec,
+            > = BTreeMap::new();
+            for m in &decl.members {
+                if let LocusMember::Placement(pb) = m {
+                    for e2 in &pb.entries {
+                        field_place.insert(
+                            e2.field.name.as_str(),
+                            &e2.spec,
+                        );
+                    }
+                }
+            }
+            for (field, (ty, span)) in &field_ty {
+                if !decls.contains_key(ty) {
+                    continue; // not a locus type
+                }
+                let spec = field_place.get(field);
+                let (fanout, pinned, pool) = match spec {
+                    Some(PlacementSpec::Pinned {
+                        replicas,
+                        ..
+                    }) => (
+                        replicas.map(|k| k.max(1)).unwrap_or(1)
+                            as u32,
+                        true,
+                        None,
+                    ),
+                    Some(PlacementSpec::Cooperative {
+                        pool,
+                        ..
+                    }) => (
+                        1,
+                        false,
+                        pool.as_ref()
+                            .filter(|p2| p2.name != "main")
+                            .map(|p2| p2.name.clone()),
+                    ),
+                    None => (1, false, None),
+                };
+                if let Some(p2) = &pool {
+                    pool_names.insert(p2.clone());
+                }
+                for i in 0..fanout {
+                    let child_path = if fanout > 1 {
+                        format!("{}.{}[{}]", path, field, i)
+                    } else {
+                        format!("{}.{}", path, field)
+                    };
+                    let child_domain = if pinned {
+                        format!("pinned:{}", child_path)
+                    } else if let Some(p2) = &pool {
+                        format!("pool:{}", p2)
+                    } else {
+                        domain.to_string()
+                    };
+                    arranged.push(Arranged {
+                        path: child_path.clone(),
+                        decl: (*ty).to_string(),
+                        replica: if fanout > 1 {
+                            Some(fanout)
+                        } else {
+                            None
+                        },
+                        domain: child_domain.clone(),
+                        parent: Some(path.to_string()),
+                        span: *span,
+                    });
+                    walk_arrangement(
+                        ty,
+                        &child_path,
+                        &child_domain,
+                        decls,
+                        stack,
+                        arranged,
+                        pool_names,
+                    );
+                }
+            }
+            stack.pop();
+        }
+        let main_decl =
+            ast.loci.iter().find(|l| l.is_main).map(|l| {
+                (l.name.name.clone(), l.name.span)
+            });
+        if let Some((main_name, main_span)) = &main_decl {
+            arranged.push(Arranged {
+                path: main_name.clone(),
+                decl: main_name.clone(),
+                replica: None,
+                domain: "main".to_string(),
+                parent: None,
+                span: *main_span,
+            });
+            let mut stack = Vec::new();
+            walk_arrangement(
+                main_name,
+                main_name,
+                "main",
+                &decls_by_name,
+                &mut stack,
+                &mut arranged,
+                &mut pool_names,
+            );
+        }
+        // Thread domains, canonical order: every domain any
+        // instance landed in, plus a reader domain per binding
+        // entry (#468: a binding's reader thread is a real
+        // domain).
+        let mut domain_names: BTreeSet<String> = arranged
+            .iter()
+            .map(|a| a.domain.clone())
+            .collect();
+        // Bindings (main's `bindings { }` block).
+        let mut binding_entries: Vec<(
+            String,
+            hale_syntax::Span,
+            bool,
+        )> = Vec::new();
+        if let Some((main_name, _)) = &main_decl {
+            if let Some(decl) = decls_by_name.get(main_name.as_str())
+            {
+                for m in &decl.members {
+                    if let LocusMember::Bindings(bb) = m {
+                        for e2 in &bb.entries {
+                            let adapter = !matches!(
+                                e2.transport,
+                                TransportSpec::Unix { .. }
+                            );
+                            binding_entries.push((
+                                e2.topic.name.clone(),
+                                e2.span,
+                                adapter,
+                            ));
+                            domain_names.insert(format!(
+                                "binding:{}",
+                                e2.topic.name
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        let domain_id: BTreeMap<&String, ThreadDomainId> =
+            domain_names
+                .iter()
+                .enumerate()
+                .map(|(i, n)| (n, ThreadDomainId(i as u32)))
+                .collect();
+        for n in &domain_names {
+            let pid =
+                intern_synth(&mut records, "thread domain");
+            e.thread_domains.push(ThreadDomain {
+                name: n.clone(),
+                provenance: pid,
+            });
+        }
+        // Instances in canonical (path-sorted) order.
+        arranged.sort_by(|a, b| a.path.cmp(&b.path));
+        let inst_id: BTreeMap<&String, LocusInstanceId> =
+            arranged
+                .iter()
+                .enumerate()
+                .map(|(i, a)| {
+                    (&a.path, LocusInstanceId(i as u32))
+                })
+                .collect();
+        for a in &arranged {
+            let pid = intern_span(&mut records, a.span);
+            e.locus_instances.push(LocusInstance {
+                path: a.path.clone(),
+                decl: locus_id[&a.decl],
+                replica: a.replica,
+                provenance: pid,
+            });
+        }
+        for a in &arranged {
+            let pid =
+                intern_synth(&mut records, "arrangement");
+            r.realizes.push(Realizes {
+                instance: inst_id[&a.path],
+                decl: locus_id[&a.decl],
+                provenance: pid,
+            });
+            r.placed_in.push(PlacedIn {
+                instance: inst_id[&a.path],
+                domain: domain_id[&a.domain],
+                provenance: pid,
+            });
+        }
+        let mut own_edges: Vec<(
+            LocusInstanceId,
+            LocusInstanceId,
+        )> = arranged
+            .iter()
+            .filter_map(|a| {
+                a.parent.as_ref().map(|p2| {
+                    (inst_id[p2], inst_id[&a.path])
+                })
+            })
+            .collect();
+        own_edges.sort();
+        for (parent, child) in own_edges {
+            let pid =
+                intern_synth(&mut records, "arrangement");
+            r.owns.push(Owns {
+                parent,
+                child,
+                provenance: pid,
+            });
+        }
+        // Binding entities + binds rows. Adapter transports are
+        // declared external boundaries with opaque internals —
+        // they hole out instead of guessing loss semantics.
+        let mut bind_rows: Vec<(
+            hale_model::TopicId,
+            BindingId,
+        )> = Vec::new();
+        for (topic_name, span, adapter) in &binding_entries {
+            let Some(tid) = topic_id.get(topic_name) else {
+                continue;
+            };
+            let pid = intern_span(&mut records, *span);
+            if *adapter {
+                holes
+                    .entry((
+                        EntityRef::Topic(*tid),
+                        HoleKind::ExternalOpaque,
+                        "adapter transport: external boundary \
+                         with opaque internals"
+                            .to_string(),
+                    ))
+                    .or_insert((
+                        hale_model::RelationSet::BINDS.union(
+                            hale_model::RelationSet::DELIVERY,
+                        ),
+                        None,
+                        pid,
+                    ));
+                continue;
+            }
+            let bid = BindingId(e.bindings.len() as u32);
+            e.bindings.push(Binding {
+                subject: e.topics[tid.index()].subject,
+                transport: TransportKind::Unix,
+                role: BindingRole::Listen,
+                loss: hale_model::keys::BindingLossBehavior::WaitCapable,
+                provenance: pid,
+            });
+            bind_rows.push((*tid, bid));
+        }
+        bind_rows.sort();
+        for (t, b) in bind_rows {
+            let pid = intern_synth(&mut records, "binding");
+            r.binds.push(TopicBinding {
+                topic: t,
+                binding: b,
+                provenance: pid,
+            });
+        }
+        // Dynamic births: a method-body instantiation site's
+        // instance is not in the arrangement — its ownership and
+        // placement are runtime facts. Typed holes keep the
+        // capability account honest (RuntimeInheritedPlacement is
+        // exactly this shape).
+        let og = crate::ownership_graph::build_ownership_graph(
+            bundle, &top,
+        );
+        // Params-default births ARE the arrangement — only sites
+        // outside every params block of their enclosing locus are
+        // dynamic.
+        let params_spans: BTreeMap<
+            &str,
+            Vec<hale_syntax::Span>,
+        > = decls_by_name
+            .iter()
+            .map(|(n, d)| {
+                (
+                    *n,
+                    d.members
+                        .iter()
+                        .filter_map(|m| match m {
+                            LocusMember::Params(pb) => {
+                                Some(pb.span)
+                            }
+                            _ => None,
+                        })
+                        .collect(),
+                )
+            })
+            .collect();
+        for site in &og.sites {
+            let in_arrangement = params_spans
+                .get(site.enclosing_locus.as_str())
+                .is_some_and(|spans| {
+                    spans.iter().any(|ps| {
+                        site.span.start >= ps.start
+                            && site.span.end <= ps.end
+                    })
+                });
+            if in_arrangement {
+                continue;
+            }
+            let pid = intern_span(&mut records, site.span);
+            let Some(lid) =
+                locus_id.get(&site.enclosing_locus)
+            else {
+                continue;
+            };
+            let at = EntityRef::LocusDecl(*lid);
+            holes
+                .entry((
+                    at,
+                    HoleKind::RuntimeInheritedPlacement,
+                    "instance born outside the arrangement: \
+                     owner and placement resolve at runtime"
+                        .to_string(),
+                ))
+                .or_insert((
+                    hale_model::RelationSet::OWNS.union(
+                        hale_model::RelationSet::PLACED,
+                    ),
+                    None,
+                    pid,
+                ));
+        }
+    }
+
     let mut hole_rows: Vec<Hole> = holes
         .into_iter()
         .map(|((at, kind, reason), (hides, site, pid))| Hole {
@@ -2892,6 +3329,15 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         exact_cardinality: !hides_any(
             hale_model::RelationSet::CARDINALITY,
         ),
+        // Change 8: the arrangement tables are populated, so the
+        // ownership/placement/binding accounts are positive unless
+        // a hole (a dynamic birth, an adapter boundary) withdraws
+        // them.
+        exact_ownership: !hides_any(hale_model::RelationSet::OWNS),
+        exact_placement: !hides_any(
+            hale_model::RelationSet::PLACED,
+        ),
+        exact_routes: !hides_any(hale_model::RelationSet::BINDS),
         ..Capabilities::default()
     };
 

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -2511,6 +2511,80 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         }
     }
 
+    // GH #476 Change 8: the BusGraph's per-subject dispatch gates,
+    // bridged verbatim — DispatchPlan::derive combines them with
+    // the arrangement into the typed lowering plan.
+    //
+    // Keyed at WIRE grain, not at `BusSubject::canonical()` grain.
+    // The graph this builder runs over sees the AUTHORED program, so
+    // a topic-addressed site keys by the topic's declaration name
+    // (`Evt`); codegen desugars topics to their wire subject before
+    // building its graph, so the very same dispatch keys by `evt`
+    // there — and the wire string is the identity the runtime, the
+    // artifact (Change 7's route grain), and the static bucket all
+    // use. Mapping here is what makes the two plans comparable at
+    // all.
+    //
+    // A program that addresses one topic BOTH ways (`Evt <- x` in
+    // one locus, `"evt" <- x` in another) has two authored subjects
+    // collapsing onto one wire subject — codegen computes ONE
+    // eligibility over the union of those sites, so the merge is
+    // conjunctive (a subject is static/direct here only if every
+    // authored view of it was) with the site sets unioned. That is
+    // the conservative side: the plan can under-promote relative to
+    // codegen, never over-promote.
+    let mut gate_by_wire: BTreeMap<String, hale_model::DispatchGate> =
+        BTreeMap::new();
+    for (subject, info) in &graph.subjects {
+        let wire = topic_decl_by_name
+            .get(subject.as_str())
+            .map(|t| t.wire.clone())
+            .unwrap_or_else(|| subject.clone());
+        let publisher_loci: Vec<String> =
+            info.publishers.iter().map(|p| p.locus.clone()).collect();
+        let subscribers: Vec<(String, String)> = info
+            .subscribers
+            .iter()
+            .map(|s2| (s2.locus.clone(), s2.handler.clone()))
+            .collect();
+        let reason =
+            info.ineligible_reason.as_ref().map(|r| r.tag().to_string());
+        match gate_by_wire.get_mut(&wire) {
+            Some(g) => {
+                g.static_eligible &= info.eligible;
+                g.direct_eligible &= info.direct_call_eligible;
+                if g.ineligible_reason.is_none() {
+                    g.ineligible_reason = reason;
+                }
+                g.publisher_loci.extend(publisher_loci);
+                g.subscribers.extend(subscribers);
+            }
+            None => {
+                gate_by_wire.insert(
+                    wire.clone(),
+                    hale_model::DispatchGate {
+                        subject: wire,
+                        static_eligible: info.eligible,
+                        direct_eligible: info.direct_call_eligible,
+                        ineligible_reason: reason,
+                        publisher_loci,
+                        subscribers,
+                    },
+                );
+            }
+        }
+    }
+    let dispatch_gates: Vec<hale_model::DispatchGate> = gate_by_wire
+        .into_values()
+        .map(|mut g| {
+            g.publisher_loci.sort();
+            g.publisher_loci.dedup();
+            g.subscribers.sort();
+            g.subscribers.dedup();
+            g
+        })
+        .collect();
+
     // The Change-3 bridge: the legacy artifact's fn sort, recorded
     // so TopologyShapeV1 projects from the model alone.
     let mut legacy_fns: Vec<hale_model::FunctionId> = summary
@@ -3188,6 +3262,8 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         let og = crate::ownership_graph::build_ownership_graph(
             bundle, &top,
         );
+        let free_fn_births =
+            crate::ownership_graph::free_fn_birth_sites(bundle);
         // Params-default births ARE the arrangement — only sites
         // outside every params block of their enclosing locus are
         // dynamic.
@@ -3211,22 +3287,51 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
                 )
             })
             .collect();
-        for site in &og.sites {
+        // Method-body births (the ownership graph's sites) PLUS
+        // free-function births — `fn main() { EchoL { }; }` is the
+        // most common arrangement-free program shape in the corpus,
+        // and it must not read as "no instances, exact placement".
+        let dyn_sites: Vec<(&str, &str, hale_syntax::Span)> = og
+            .sites
+            .iter()
+            .map(|s| {
+                (
+                    s.child_ty.as_str(),
+                    s.enclosing_locus.as_str(),
+                    s.span,
+                )
+            })
+            .chain(
+                free_fn_births
+                    .iter()
+                    .map(|(ty, sp)| (ty.as_str(), "", *sp)),
+            )
+            .collect();
+        for (child_ty, enclosing, span) in dyn_sites {
+            // `fn main() { App { }; }` — the birth of the
+            // arrangement ROOT — is not a dynamic birth: it is how
+            // the arrangement is entered, and the root instance is
+            // already modeled (path `App`, domain `main`). Every
+            // OTHER free-standing birth is outside the arrangement.
+            if main_decl.as_ref().is_some_and(|(n, _)| n == child_ty) {
+                continue;
+            }
             let in_arrangement = params_spans
-                .get(site.enclosing_locus.as_str())
+                .get(enclosing)
                 .is_some_and(|spans| {
                     spans.iter().any(|ps| {
-                        site.span.start >= ps.start
-                            && site.span.end <= ps.end
+                        span.start >= ps.start && span.end <= ps.end
                     })
                 });
             if in_arrangement {
                 continue;
             }
-            let pid = intern_span(&mut records, site.span);
-            let Some(lid) =
-                locus_id.get(&site.enclosing_locus)
-            else {
+            let pid = intern_span(&mut records, span);
+            // Anchored at the BORN locus, not the birthplace: the
+            // fact hidden is "instances of this locus exist that
+            // the arrangement does not name", which is true of the
+            // child whether it was born in a method or a free fn.
+            let Some(lid) = locus_id.get(&child_ty.to_string()) else {
                 continue;
             };
             let at = EntityRef::LocusDecl(*lid);
@@ -3353,6 +3458,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
     let model = ApplicationModel {
         legacy: hale_model::LegacyProjection {
             topology_v1_fns: legacy_fns,
+            dispatch_gates,
             topology_v1_calls_via_stdlib: legacy_via,
             stdlib_absorption,
         },
@@ -3597,5 +3703,35 @@ pub fn render_internal(m: &ApplicationModel) -> String {
         m.capabilities.exact_key_filters,
         m.capabilities.exact_effects
     ));
+    s.push_str(&format!(
+        " ownership={} placement={} routes={}\n",
+        m.capabilities.exact_ownership,
+        m.capabilities.exact_placement,
+        m.capabilities.exact_routes
+    ));
+    // GH #476 Change 8: the derived lowering plan. Not model rows —
+    // a CONCLUSION, printed here because this dump is the survey
+    // surface #464's stage 0 asks its question of ("how much queued
+    // bus traffic is same-thread-domain?").
+    let plan = hale_model::dispatch_plan::DispatchPlan::derive(m);
+    let (same, total) = plan.same_domain_queued();
+    s.push_str(&format!(
+        "dispatch_plan ({} subjects, {} same-domain queued):\n",
+        total, same
+    ));
+    for sp in &plan.subjects {
+        s.push_str(&format!(
+            "  {} {}{} pub[{}] sub[{}]{}\n",
+            sp.subject,
+            sp.flavor.as_str(),
+            sp.ineligible_reason
+                .as_deref()
+                .map(|r| format!(" ({})", r))
+                .unwrap_or_default(),
+            sp.publisher_domains.join(","),
+            sp.subscriber_domains.join(","),
+            if sp.same_domain { " same-domain" } else { "" }
+        ));
+    }
     s
 }

--- a/crates/hale-types/src/ownership_graph.rs
+++ b/crates/hale-types/src/ownership_graph.rs
@@ -764,6 +764,59 @@ fn named_type(ty: &TypeExpr) -> Option<String> {
     }
 }
 
+/// GH #476 Change 8: locus births in FREE functions — `fn main() {
+/// EchoL { }; }` and friends.
+///
+/// The ownership graph deliberately walks locus MEMBER bodies only:
+/// its question is "which owning locus does this child bubble to",
+/// and a free function has no owner to bubble toward. The model's
+/// arrangement asks a different question — "is this instance in the
+/// static arrangement, or does it appear at runtime?" — and a
+/// free-function birth is emphatically the latter. Without this
+/// walk, a whole program whose loci are all born in `fn main` would
+/// model zero instances while claiming exact placement.
+///
+/// Returns `(locus type, literal span)` per site, in source order.
+pub fn free_fn_birth_sites(
+    bundle: &Bundle<'_>,
+) -> Vec<(String, Span)> {
+    let mut locus_types: BTreeSet<String> = BTreeSet::new();
+    fn names(items: &[TopDecl], out: &mut BTreeSet<String>) {
+        for item in items {
+            match item {
+                TopDecl::Locus(l) => {
+                    out.insert(l.name.name.clone());
+                }
+                TopDecl::Module(m) => names(&m.items, out),
+                _ => {}
+            }
+        }
+    }
+    for program in bundle.programs.values() {
+        names(&program.items, &mut locus_types);
+    }
+    let mut out: Vec<RawSite> = Vec::new();
+    fn walk(
+        items: &[TopDecl],
+        locus_types: &BTreeSet<String>,
+        out: &mut Vec<RawSite>,
+    ) {
+        for item in items {
+            match item {
+                TopDecl::Fn(f) => {
+                    collect_sites_block(&f.body, locus_types, out)
+                }
+                TopDecl::Module(m) => walk(&m.items, locus_types, out),
+                _ => {}
+            }
+        }
+    }
+    for program in bundle.programs.values() {
+        walk(&program.items, &locus_types, &mut out);
+    }
+    out.into_iter().map(|s| (s.child_ty, s.span)).collect()
+}
+
 /// Collect every locus-instantiation literal (`I { ... }` where `I` is
 /// a known locus type) reachable from a block, walking every
 /// sub-statement and sub-expression.

--- a/crates/hale-types/tests/dispatch_plan.rs
+++ b/crates/hale-types/tests/dispatch_plan.rs
@@ -1,0 +1,244 @@
+//! GH #476 Change 8 — the derived dispatch plan.
+//!
+//! `DispatchPlan::derive(&ApplicationModel)` is where the lowering
+//! decision lives: gate facts × arrangement → one flavor per
+//! subject, plus #464's stage-0 survey field (`same_domain`). The
+//! obligations pinned here:
+//!
+//!   1. **Wire grain.** Plan subjects are wire subjects, not topic
+//!      decl names — the identity codegen, the runtime, and the
+//!      artifact's routes all use. A plan keyed the other way could
+//!      not be compared to codegen's at all.
+//!   2. **The ladder.** direct ⇒ static_direct, eligible-only ⇒
+//!      static_bucket, otherwise dynamic with the gate's reason.
+//!   3. **Conservatism.** A transport-bound subject is dynamic (the
+//!      adapter is a counterparty no static bucket knows about),
+//!      and a subject whose loci are NOT in the arrangement forfeits
+//!      `same_domain` rather than guessing.
+//!   4. **Identity.** The digest moves when the plan moves.
+
+use std::collections::BTreeMap;
+
+use hale_model::dispatch_plan::{DispatchFlavor, DispatchPlan};
+use hale_types::model_builder::derive_application_model;
+use hale_types::Bundle;
+
+fn plan_of(src: &str) -> DispatchPlan {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let m = derive_application_model(&bundle);
+    m.validate().expect("derived model is lawful");
+    DispatchPlan::derive(&m)
+}
+
+fn flavor(p: &DispatchPlan, subject: &str) -> DispatchFlavor {
+    p.subjects
+        .iter()
+        .find(|s| s.subject == subject)
+        .unwrap_or_else(|| {
+            panic!(
+                "no plan row for `{}` — rows: {:?}",
+                subject,
+                p.subjects.iter().map(|s| &s.subject).collect::<Vec<_>>()
+            )
+        })
+        .flavor
+}
+
+/// A topic-addressed dispatch plans at WIRE grain, and a
+/// single-subscriber closed-world program reaches the direct tier.
+#[test]
+fn topic_subjects_plan_at_wire_grain() {
+    let p = plan_of(
+        r#"
+type T { n: Int = 0; }
+topic Evt { payload: T; subject: "evt"; }
+locus Sub {
+    params { seen: Int = 0; }
+    bus { subscribe Evt as on_e; }
+    fn on_e(t: T) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { s: Sub = Sub { }; }
+    bus { publish Evt; }
+    run() { Evt <- T { n: 1 }; }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        p.subjects.iter().map(|s| s.subject.as_str()).collect::<Vec<_>>(),
+        vec!["evt"],
+        "the plan is keyed by the WIRE subject, never the topic \
+         decl name — codegen desugars topics away before it builds \
+         the graph its own lowering uses"
+    );
+    assert_eq!(flavor(&p, "evt"), DispatchFlavor::StaticDirect);
+    let row = &p.subjects[0];
+    assert_eq!(row.publisher_domains, vec!["main".to_string()]);
+    assert_eq!(row.subscriber_domains, vec!["main".to_string()]);
+    assert!(row.same_domain, "both ends are arranged on main");
+    assert_eq!(row.subscribers, vec![("Sub".into(), "on_e".into())]);
+}
+
+/// A subject whose subscriber lives on its own pool is NOT
+/// same-domain — the stage-0 survey question #464 asks.
+#[test]
+fn a_pooled_subscriber_is_not_same_domain() {
+    let p = plan_of(
+        r#"
+type T { n: Int = 0; }
+topic Evt { payload: T; subject: "evt"; }
+locus Worker {
+    params { seen: Int = 0; }
+    bus { subscribe Evt as on_e; }
+    fn on_e(t: T) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { w: Worker = Worker { }; }
+    placement { w: cooperative(pool = io); }
+    bus { publish Evt; }
+    run() { Evt <- T { n: 1 }; }
+}
+fn main() { App { }; }
+"#,
+    );
+    let row = p.subjects.iter().find(|s| s.subject == "evt").unwrap();
+    assert_eq!(row.publisher_domains, vec!["main".to_string()]);
+    assert_eq!(
+        row.subscriber_domains,
+        vec!["pool:io".to_string()],
+        "a cooperative(pool = X) locus runs on X's worker, not main"
+    );
+    assert!(
+        !row.same_domain,
+        "publisher and subscriber sit in different thread domains"
+    );
+}
+
+/// A transport-bound subject stays dynamic, and says why. This is
+/// also the regression pin for the gate bug Change 8's plan
+/// differential found: `bindings { Beat: unix(..) }` names the topic
+/// DECL, but codegen's graph is keyed by the wire subject, so a
+/// decl-name-only gate let a bound subject be devirtualized into a
+/// static bucket the adapter is not part of.
+#[test]
+fn a_transport_bound_subject_stays_dynamic() {
+    let p = plan_of(
+        r#"
+type Beat { n: Int = 0; }
+topic Heartbeat { payload: Beat; subject: "demo.beat"; }
+locus Watch {
+    params { seen: Int = 0; }
+    bus { subscribe Heartbeat as on_beat; }
+    fn on_beat(b: Beat) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { w: Watch = Watch { }; }
+    bus { publish Heartbeat; }
+    bindings { Heartbeat: unix("/tmp/hale-c8-plan.sock", role: listen); }
+    run() { Heartbeat <- Beat { n: 1 }; }
+}
+fn main() { App { }; }
+"#,
+    );
+    let row =
+        p.subjects.iter().find(|s| s.subject == "demo.beat").unwrap();
+    assert_eq!(row.flavor, DispatchFlavor::Dynamic);
+    assert_eq!(row.ineligible_reason.as_deref(), Some("TransportBound"));
+    let (same, total) = p.same_domain_queued();
+    assert_eq!(total, 1);
+    assert_eq!(
+        same, 1,
+        "queued (not direct) and both ends on main — exactly the \
+         traffic #464's stage 0 counts"
+    );
+}
+
+/// Loci born outside the arrangement have no known domain, so the
+/// survey field is withheld rather than guessed — and the model
+/// says so in its capability account.
+#[test]
+fn unarranged_loci_forfeit_the_survey_field() {
+    let src = r#"
+type T { n: Int = 0; }
+locus Sub {
+    params { seen: Int = 0; }
+    bus { subscribe "evt" as on_e of type T; }
+    fn on_e(t: T) { self.seen = self.seen + 1; }
+}
+locus Pub {
+    bus { publish "evt" of type T; }
+    birth() { "evt" <- T { n: 1 }; }
+}
+fn main() { Sub { }; Pub { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let m = derive_application_model(&bundle);
+    m.validate().expect("lawful");
+    assert!(
+        !m.capabilities.exact_placement && !m.capabilities.exact_ownership,
+        "every instance here is born in `fn main` — the arrangement \
+         names none of them, and the capability account must admit it"
+    );
+    let p = DispatchPlan::derive(&m);
+    let row = p.subjects.iter().find(|s| s.subject == "evt").unwrap();
+    assert!(
+        row.publisher_domains.is_empty()
+            && row.subscriber_domains.is_empty()
+    );
+    assert!(
+        !row.same_domain,
+        "an unknown domain is not evidence of a shared one"
+    );
+    assert_eq!(p.same_domain_queued(), (0, 1));
+}
+
+/// The digest is an identity, not a summary: moving any decision
+/// moves it. Same plan, same digest.
+#[test]
+fn the_digest_tracks_the_plan() {
+    const ONE_SUB: &str = r#"
+type T { n: Int = 0; }
+topic Evt { payload: T; subject: "evt"; }
+locus A {
+    params { seen: Int = 0; }
+    bus { subscribe Evt as on_e; }
+    fn on_e(t: T) { self.seen = self.seen + 1; }
+}
+main locus App {
+    params { a: A = A { }; }
+    bus { publish Evt; }
+    run() { Evt <- T { n: 1 }; }
+}
+fn main() { App { }; }
+"#;
+    // Same program, second derivation: identical.
+    assert_eq!(plan_of(ONE_SUB).digest(), plan_of(ONE_SUB).digest());
+    // A second subscriber changes what the direct lowering bakes.
+    let two_subs = ONE_SUB.replace(
+        "params { a: A = A { }; }",
+        "params { a: A = A { }; b: B = B { }; }",
+    ) + r#"
+locus B {
+    params { seen: Int = 0; }
+    bus { subscribe Evt as on_e; }
+    fn on_e(t: T) { self.seen = self.seen + 1; }
+}
+"#;
+    let two = plan_of(&two_subs);
+    assert_ne!(
+        plan_of(ONE_SUB).digest(),
+        two.digest(),
+        "a different subscriber set is a different lowering"
+    );
+    // The empty plan (the LOTUS_NO_BUS_DEVIRT control arm) is its
+    // own identity — the CLI folds exactly this into the exec
+    // digest when the flag forces all-dynamic lowering.
+    assert_ne!(DispatchPlan::default().digest(), two.digest());
+}

--- a/crates/hale-types/tests/dispatch_plan.rs
+++ b/crates/hale-types/tests/dispatch_plan.rs
@@ -335,6 +335,26 @@ fn main() { App { }; }
         ),
         "validate accepted a replica set that is not 0..K"
     );
+
+    // …and a genuine GAP, with path and field agreeing, so the
+    // contiguity clause is exercised and not just the
+    // path-vs-field agreement clause above.
+    let mut m2 = derive_application_model(&bundle);
+    for inst in m2.entities.locus_instances.iter_mut() {
+        if inst.replica == Some(2) {
+            inst.path = inst.path.replace("[2]", "[7]");
+            inst.replica = Some(7);
+        }
+    }
+    assert!(
+        matches!(
+            m2.validate(),
+            Err(hale_model::ModelError::ReplicaIndicesNotContiguous {
+                ref base
+            }) if base == "App.workers"
+        ),
+        "validate accepted replicas [0, 1, 7]"
+    );
 }
 
 /// Review round 1, blocker 3: a locus can be BOTH arranged and
@@ -519,4 +539,68 @@ fn main() { App { }; }
         );
     }
     assert_eq!(m.relations.binds.len(), 2);
+}
+
+/// Review round 2, blocker 1: a replica's own children are ordinary
+/// children. The arrangement walks into each replica, so a
+/// non-replicated field beneath one is `App.workers[0].leaf` with
+/// no index of its own — correct, and refused by a validator that
+/// decided replica-ness with `path.rfind('[')`, since an ancestor's
+/// bracket is not this row's. Replica-ness is a property of the
+/// LAST path component only.
+#[test]
+fn children_of_replicas_are_not_replicas() {
+    let m = model_of(
+        r#"
+locus Leaf {
+    params { n: Int = 0; }
+}
+locus Worker {
+    params { leaf: Leaf = Leaf { }; }
+}
+main locus App {
+    params { workers: Worker = Worker { }; }
+    placement { workers: pinned(replicas = 2); }
+}
+fn main() { App { }; }
+"#,
+    );
+    let rows: Vec<(&str, Option<u32>)> = m
+        .entities
+        .locus_instances
+        .iter()
+        .map(|i| (i.path.as_str(), i.replica))
+        .collect();
+    assert_eq!(
+        rows,
+        vec![
+            ("App", None),
+            ("App.workers[0]", Some(0)),
+            ("App.workers[0].leaf", None),
+            ("App.workers[1]", Some(1)),
+            ("App.workers[1].leaf", None),
+        ],
+        "each replica is walked into, and what it owns is not \
+         itself a replica"
+    );
+    // The nested leaves are real instances with real placement:
+    // they inherit their replica parent's pinned domain, one
+    // domain per replica.
+    let domains: Vec<&str> = m
+        .relations
+        .placed_in
+        .iter()
+        .map(|p| m.entities.thread_domains[p.domain.index()].name.as_str())
+        .collect();
+    assert_eq!(
+        domains,
+        vec![
+            "main",
+            "pinned:App.workers[0]",
+            "pinned:App.workers[0]",
+            "pinned:App.workers[1]",
+            "pinned:App.workers[1]",
+        ],
+        "a leaf runs on its owner's thread"
+    );
 }

--- a/crates/hale-types/tests/dispatch_plan.rs
+++ b/crates/hale-types/tests/dispatch_plan.rs
@@ -33,6 +33,16 @@ fn plan_of(src: &str) -> DispatchPlan {
     DispatchPlan::derive(&m)
 }
 
+fn model_of(src: &str) -> hale_model::ApplicationModel {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let m = derive_application_model(&bundle);
+    m.validate().expect("derived model is lawful");
+    m
+}
+
 fn flavor(p: &DispatchPlan, subject: &str) -> DispatchFlavor {
     p.subjects
         .iter()
@@ -241,4 +251,272 @@ locus B {
     // own identity — the CLI folds exactly this into the exec
     // digest when the flag forces all-dynamic lowering.
     assert_ne!(DispatchPlan::default().digest(), two.digest());
+}
+
+/// Review round 1, blocker 1: each replica carries its OWN index.
+/// The runtime pins replica `i` to one core and a keyed subscriber
+/// on a replicated field registers under `key == i`, so a model
+/// that stored the fan-out COUNT in every row ([3, 3, 3] for
+/// `replicas = 3`) names a population the process does not have.
+#[test]
+fn replicas_carry_contiguous_zero_based_indices() {
+    let src = r#"
+locus Worker {
+    params { id: Int = 0; }
+    fn tick() { self.id = self.id + 1; }
+}
+main locus App {
+    params { workers: Worker = Worker { }; }
+    placement { workers: pinned(cores = 0..3, replicas = 3); }
+    run() { self.workers.tick(); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let m = derive_application_model(&bundle);
+    m.validate().expect("lawful");
+
+    let replicas: Vec<(String, Option<u32>)> = m
+        .entities
+        .locus_instances
+        .iter()
+        .filter(|i| i.path.contains('['))
+        .map(|i| (i.path.clone(), i.replica))
+        .collect();
+    assert_eq!(
+        replicas,
+        vec![
+            ("App.workers[0]".to_string(), Some(0)),
+            ("App.workers[1]".to_string(), Some(1)),
+            ("App.workers[2]".to_string(), Some(2)),
+        ],
+        "each replica carries its index, not the fan-out count"
+    );
+    // The root and any non-replicated instance claim no index.
+    assert!(m
+        .entities
+        .locus_instances
+        .iter()
+        .filter(|i| !i.path.contains('['))
+        .all(|i| i.replica.is_none()));
+}
+
+/// …and the law is enforced at the model, not merely produced by
+/// the builder: the count-in-every-row shape is refused.
+#[test]
+fn a_non_contiguous_replica_set_is_not_a_model() {
+    let src = r#"
+locus Worker { params { id: Int = 0; } fn tick() { self.id = self.id + 1; } }
+main locus App {
+    params { workers: Worker = Worker { }; }
+    placement { workers: pinned(cores = 0..3, replicas = 3); }
+    run() { self.workers.tick(); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let mut m = derive_application_model(&bundle);
+    // The pre-review shape: every replica stamped with the COUNT.
+    for inst in m.entities.locus_instances.iter_mut() {
+        if inst.replica.is_some() {
+            inst.replica = Some(3);
+        }
+    }
+    assert!(
+        matches!(
+            m.validate(),
+            Err(hale_model::ModelError::ReplicaIndicesNotContiguous { .. })
+        ),
+        "validate accepted a replica set that is not 0..K"
+    );
+}
+
+/// Review round 1, blocker 3: a locus can be BOTH arranged and
+/// dynamically born. The arranged instance answers "main" for the
+/// whole population, but the dynamic sibling is born inside a
+/// pooled locus and runs on that pool's worker — so a plan that
+/// trusted the arranged answer would report a same-domain
+/// optimization opportunity about a process that does not have
+/// one. A placement hole at the locus deletes the answer.
+#[test]
+fn a_partly_dynamic_population_is_not_same_domain() {
+    let src = r#"
+type T { n: Int = 0; }
+topic Evt { payload: T; subject: "evt"; }
+locus Sub {
+    params { seen: Int = 0; }
+    bus { subscribe Evt as on_e; }
+    fn on_e(t: T) { self.seen = self.seen + 1; }
+}
+locus Spawner {
+    params { n: Int = 0; }
+    fn spawn() { Sub { }; }
+}
+main locus App {
+    params { s: Sub = Sub { }; sp: Spawner = Spawner { }; }
+    placement { sp: cooperative(pool = io); }
+    bus { publish Evt; }
+    run() { self.sp.spawn(); Evt <- T { n: 1 }; }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), &program);
+    let bundle = Bundle::new(programs);
+    let m = derive_application_model(&bundle);
+    m.validate().expect("lawful");
+
+    // Premise: the arrangement DOES name a `Sub` on main…
+    assert!(
+        m.entities
+            .locus_instances
+            .iter()
+            .any(|i| i.path == "App.s"),
+        "fixture premise: an arranged Sub exists"
+    );
+    // …and the model admits a second, unplaced one exists.
+    assert!(
+        !m.capabilities.exact_placement,
+        "fixture premise: the dynamic birth is holed out"
+    );
+
+    let p = DispatchPlan::derive(&m);
+    let row = p.subjects.iter().find(|s| s.subject == "evt").unwrap();
+    assert!(
+        row.subscriber_domains.is_empty(),
+        "an incomplete population has no domain answer, not a \
+         partial one: {:?}",
+        row.subscriber_domains
+    );
+    assert!(
+        !row.same_domain,
+        "the plan reported same_domain over a population it \
+         cannot fully place"
+    );
+    assert_eq!(p.same_domain_queued().0, 0);
+}
+
+/// Review round 1, blocker 2: an explicit `role: connect` binding
+/// is a CONNECT binding in the model. The role was hardcoded to
+/// Listen, so a publish-only binding — the shape whose role
+/// codegen infers as Connect — was modeled as its opposite.
+#[test]
+fn a_connect_binding_is_modeled_as_connect() {
+    let m = model_of(
+        r#"
+type Beat { n: Int = 0; }
+topic Heartbeat { payload: Beat; subject: "demo.beat"; }
+main locus App {
+    bus { publish Heartbeat; }
+    bindings { Heartbeat: unix("/tmp/hale-c8-connect.sock", role: connect); }
+    run() { Heartbeat <- Beat { n: 1 }; }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(m.entities.bindings.len(), 1);
+    let b = &m.entities.bindings[0];
+    assert_eq!(b.role, hale_model::BindingRole::Connect);
+    assert_eq!(
+        b.loss,
+        hale_model::keys::BindingLossBehavior::WaitCapable,
+        "the connect side is the publish side: a send failure marks \
+         the entry lost and `or wait` parks through the reconnect \
+         window"
+    );
+}
+
+/// …and the INFERRED role follows the same rule the desugar uses:
+/// subscribe-only is a listener, whose link loss is structural.
+#[test]
+fn an_inferred_listen_binding_is_modeled_as_listen() {
+    let m = model_of(
+        r#"
+type Beat { n: Int = 0; }
+topic Heartbeat { payload: Beat; subject: "demo.beat"; }
+main locus App {
+    params { seen: Int = 0; }
+    bus { subscribe Heartbeat as on_beat; }
+    bindings { Heartbeat: unix("/tmp/hale-c8-listen.sock"); }
+    fn on_beat(b: Beat) { self.seen = self.seen + 1; }
+    run() { }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(m.entities.bindings.len(), 1);
+    assert_eq!(m.entities.bindings[0].role, hale_model::BindingRole::Listen);
+    assert_eq!(
+        m.entities.bindings[0].loss,
+        hale_model::keys::BindingLossBehavior::Fail
+    );
+}
+
+/// Two bindings authored in reverse canonical order still produce a
+/// MODEL: entity ids are assigned after the canonical sort, and the
+/// `binds` relation points at the post-sort ids. Authoring order is
+/// not a model property, and `validate` requires the sort.
+#[test]
+fn bindings_authored_out_of_order_still_validate() {
+    let m = model_of(
+        r#"
+type A { n: Int = 0; }
+type B { n: Int = 0; }
+topic Zed { payload: A; subject: "z.sub"; }
+topic Alpha { payload: B; subject: "a.sub"; }
+main locus App {
+    params { seen: Int = 0; }
+    bus {
+        subscribe Zed as on_z;
+        subscribe Alpha as on_a;
+    }
+    bindings {
+        Zed: unix("/tmp/hale-c8-z.sock");
+        Alpha: unix("/tmp/hale-c8-a.sock");
+    }
+    fn on_z(a: A) { self.seen = self.seen + 1; }
+    fn on_a(b: B) { self.seen = self.seen + 1; }
+    run() { }
+}
+fn main() { App { }; }
+"#,
+    );
+    // validate() ran inside model_of — the canonical-order law is
+    // what used to fail here.
+    let subjects: Vec<&str> = m
+        .entities
+        .bindings
+        .iter()
+        .map(|b| m.entities.subjects[b.subject.index()].pattern.as_str())
+        .collect();
+    assert_eq!(
+        subjects,
+        vec!["a.sub", "z.sub"],
+        "the binding table is canonically sorted, not source-ordered"
+    );
+    // …and `binds` joins each topic to the binding for ITS subject.
+    for row in &m.relations.binds {
+        let topic_subject = m.entities.subjects
+            [m.entities.topics[row.topic.index()].subject.index()]
+        .pattern
+        .clone();
+        let binding_subject = m.entities.subjects[m.entities.bindings
+            [row.binding.index()]
+        .subject
+        .index()]
+        .pattern
+        .clone();
+        assert_eq!(
+            topic_subject, binding_subject,
+            "a binds row points at the wrong post-sort BindingId"
+        );
+    }
+    assert_eq!(m.relations.binds.len(), 2);
 }

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -675,6 +675,7 @@ fn looped_stdlib_entry_with_carrier_is_unbounded() {
         capabilities: Capabilities::default(),
         provenance: prov,
         legacy: LegacyProjection {
+            dispatch_gates: Vec::new(),
             topology_v1_fns: vec![FunctionId(0)],
             topology_v1_calls_via_stdlib: Vec::new(),
             stdlib_absorption: vec![StdlibAbsorption {
@@ -2889,6 +2890,7 @@ fn mixed_dispatch_alternatives_share_one_group() {
         capabilities: Capabilities::default(),
         provenance: prov,
         legacy: LegacyProjection {
+            dispatch_gates: Vec::new(),
             topology_v1_fns: vec![FunctionId(0), FunctionId(1)],
             topology_v1_calls_via_stdlib: Vec::new(),
             // The stdlib alternative of the SAME authored dispatch

--- a/crates/hale-types/tests/model_builder.rs
+++ b/crates/hale-types/tests/model_builder.rs
@@ -552,10 +552,25 @@ fn main() { App { }; }
     assert!(m.capabilities.exact_calls);
     assert!(m.capabilities.exact_publishes && m.capabilities.exact_subscribes);
     assert!(m.capabilities.exact_key_filters);
-    // Never claimed at Change 2 (empty tables, deferred adapters):
-    assert!(!m.capabilities.exact_ownership);
-    assert!(!m.capabilities.exact_placement);
-    assert!(!m.capabilities.exact_routes);
+    // Change 8: the arrangement tables are populated, so a fully
+    // static program claims the ownership/placement/binding
+    // accounts too.
+    assert!(m.capabilities.exact_ownership);
+    assert!(m.capabilities.exact_placement);
+    assert!(m.capabilities.exact_routes);
+    // …and the arrangement itself is modeled: App realizes its
+    // decl on main; App.s is owned by App and co-domained.
+    assert_eq!(m.entities.locus_instances.len(), 2);
+    assert_eq!(m.entities.locus_instances[0].path, "App");
+    assert_eq!(m.entities.locus_instances[1].path, "App.s");
+    assert_eq!(m.relations.owns.len(), 1);
+    assert_eq!(m.relations.placed_in.len(), 2);
+    assert_eq!(
+        m.entities.thread_domains.len(),
+        1,
+        "one domain: main"
+    );
+    assert_eq!(m.entities.thread_domains[0].name, "main");
 }
 
 #[test]

--- a/crates/hale-types/tests/topology_projection.rs
+++ b/crates/hale-types/tests/topology_projection.rs
@@ -618,6 +618,7 @@ fn labels_and_effects_are_restricted_to_the_v1_universe() {
         capabilities: Capabilities::default(),
         provenance: prov,
         legacy: LegacyProjection {
+            dispatch_gates: Vec::new(),
             topology_v1_fns: vec![FunctionId(0)],
             topology_v1_calls_via_stdlib: Vec::new(),
             stdlib_absorption: Vec::new(),

--- a/docs/src/services/bus.md
+++ b/docs/src/services/bus.md
@@ -161,6 +161,24 @@ handler on a closed-world local subject lowers to a direct
 synchronous call — even when the publisher and subscriber are
 distinct locus types.
 
+A topic your deployment binds to a transport keeps the real bus
+path no matter how simple it looks: once a `bindings { }` entry
+names it, an external peer may be the counterparty, and the send
+has to go out the transport rather than into a local call.
+
+You can see what the compiler decided for each subject:
+
+```sh
+hale model dump app.hl        # …then read the dispatch_plan section
+```
+
+Each row names the wire subject, the flavor it lowers to
+(`dynamic`, `static_bucket`, `static_direct`), why — when the
+answer is "dynamic" — and which thread domains the publishers and
+subscribers actually run in. The decision is part of the build's
+identity, so a recording made from one build is never replayed
+against another that dispatches differently.
+
 ## Routing keys: one topic, sharded by a field
 
 By default every subscriber to a topic sees every message. When

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -416,9 +416,31 @@ re-deciding), and the Change-8 arrangement supplies each row's
 publisher/subscriber **thread domains** and `same_domain` — "every
 publish site and every subscriber of this subject sit in one
 domain", the precondition the future placement-driven flavors
-(GH #464) need, withheld rather than guessed whenever a locus has
-no arranged instance. Plan subjects are WIRE subjects; `hale
+(GH #464) need, withheld rather than guessed whenever the model
+cannot place a locus's WHOLE population — a locus with both an
+arranged instance and a dynamic birth is incomplete, and its
+arranged instance does not answer for the instances the model
+admits it cannot see. Plan subjects are WIRE subjects; `hale
 model dump` prints the plan and the same-domain count.
+
+**Binding roles and replica indices in the model.** A binding's
+role is the authored `role:` kwarg when present and otherwise the
+inferred one — publish-only is `connect`, subscribe-only is
+`listen`, and an ambiguous or unused binding is a typecheck
+diagnostic, never a default. One rule serves both the desugar and
+the canonical model (`hale_syntax::desugar::binding_role_for`);
+before GH #476 Change 8 the desugar ran its half AFTER topic
+references were rewritten to literal subjects, so the publish and
+subscribe ends were always empty and no role was ever inferred —
+every binding had to spell `role:` or codegen refused it. Loss
+behavior follows the role, because the runtime does: the connect
+side is the publish side, where a send failure marks the entry lost
+and `or wait` parks through the reconnect window; the listen side
+re-arms on peer EOF and a link it cannot serve is structural.
+A `pinned(..., replicas = K)` field contributes K instances whose
+model rows carry their own 0-based INDEX — the same `i` codegen
+bakes and a keyed subscriber registers under — and the model
+refuses a replica set that is not contiguous from 0.
 
 A subject named by a `bindings { }` entry is never devirtualized:
 an external peer is (or may be) the real counterparty, so the
@@ -1414,21 +1436,45 @@ gauge of the kernel send-queue occupancy sampled at send time),
 `retries` (cell 5, reconnects) — counters-tier, so a consumer
 falling behind shows as depth climbing and block time accruing
 BEFORE anything drops) and the
-**Canonical model entity ids (GH #476 Change 8).** Manifest rows
-name entities and number them in registration order, which is a
-fact about the run, not about the program. Each row's `aux_b` —
-in the entry layout since v0, written as 0 by every path until now
-— carries the canonical `ApplicationModel` entity id for that row,
-stamped by the CLI at build time: `MK_TOPIC` rows carry the
-`SubjectId` (the manifest fuses publishers by wire subject, so the
-address, not the topic decl, is the identity), `MK_LOCUS_TYPE`
+**Canonical model entity ids (GH #476 Change 8, proto 0.3).**
+Manifest rows name entities and number them in registration order,
+which is a fact about the run, not about the program. Each row's
+`aux_b` — in the entry layout since v0, written as 0 by every path
+until now — carries the canonical `ApplicationModel` entity id for
+that row, stamped by the CLI at build time: `MK_TOPIC` rows carry
+the `SubjectId` (the manifest fuses publishers by wire subject, so
+the address, not the topic decl, is the identity), `MK_LOCUS_TYPE`
 rows the `LocusDeclId`, `MK_BINDING` rows the `BindingId`. Values
 are `index + 1`; **0 keeps meaning "unstamped"** (a harness build,
 or an entity the model does not name — a stdlib subject, say).
-The ids are indices into the tables of the model whose
-`shape_hash` sits in the header at `0x80`, so they are meaningful
-only together with it: same `model_hash`, joinable ids. A
-consumer that joined by name still can.
+
+Those ids index tables that `model_hash` does NOT fully cover:
+`shape_hash` is structural model identity, and the arrangement's
+binding rows are not in the topology artifact at all, so two builds
+can share a `model_hash` while numbering entities differently. The
+header therefore publishes the id table's own identity at `0x88`:
+`entity_id_digest`, a digest over the exact `(kind, name, id)` rows
+the build stamped. **A consumer recomputes it from the model it
+holds and uses the ids only on a match** — a detectable refusal
+instead of a silent misattribution. 0 = unstamped. A consumer that
+joined by name still can.
+
+The stamp is all-or-nothing: the mapping table grows with the
+program (no cap), and if it cannot, the process says so on stderr
+and publishes NO ids and NO digest rather than a partial table —
+partial canonicalization is indistinguishable from "unstamped" and
+would put a consumer back on name matching without telling it.
+
+**Identity is stamped before anything can register.** The prelude
+publishes `model_hash`, `exec_digest`, and the entity ids ahead of
+the bindings prelude and the config loader, because registering a
+binding creates the observation segment and segment creation
+snapshots the identity fields — a program with a `bindings { }`
+block used to publish `model_hash 0` for its whole life. Eager
+recording/replay init still runs after binding realization, so a
+backend with no replay class refuses at its own seam, naming
+itself, instead of being pre-empted by a generic identity
+refusal.
 
 The
 runtime's own choke points emit records: `BUS_PUBLISH` /

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -403,6 +403,41 @@ dissolve frame. The replicas are non-addressable — there is no
 `field[i]` surface; they are workers that pull from the bus or run
 their own loop.
 
+**The dispatch plan (GH #476 Change 8).** Which lowering a
+subject's dispatch receives — `dynamic` (runtime hash lookup),
+`static_bucket` (compile-time subject id, dispatch still queued),
+`static_direct` (synchronous direct calls to every subscriber) —
+is a CONCLUSION derived from the canonical model, not a fact
+declared anywhere in the program. `DispatchPlan::derive(
+&ApplicationModel)` owns that derivation: the bus graph's
+per-subject eligibility gates decide the flavor (a single ladder,
+`DispatchFlavor::of`, which the backend calls rather than
+re-deciding), and the Change-8 arrangement supplies each row's
+publisher/subscriber **thread domains** and `same_domain` — "every
+publish site and every subscriber of this subject sit in one
+domain", the precondition the future placement-driven flavors
+(GH #464) need, withheld rather than guessed whenever a locus has
+no arranged instance. Plan subjects are WIRE subjects; `hale
+model dump` prints the plan and the same-domain count.
+
+A subject named by a `bindings { }` entry is never devirtualized:
+an external peer is (or may be) the real counterparty, so the
+dispatch has to go through the transport the binding realizes.
+That exemption is keyed at BOTH grains — the topic decl name a
+binding entry writes and the wire subject a desugared program
+dispatches on — because the backend builds its graph after topic
+desugaring, and a decl-name-only gate silently let a bound subject
+be bucketed past its own adapter.
+
+The plan is part of what a build **is**: its digest is framed into
+the executable identity (`exec_digest`) alongside the toolchain
+hash, the compiler version, the build options, and every source
+byte. Two builds of identical sources that lower dispatch
+differently — notably the all-dynamic `LOTUS_NO_BUS_DEVIRT=1`
+control arm — therefore have different identities, and a recording
+made under one is refused against the other rather than replayed
+against a bus that behaves differently.
+
 **Thread + memory co-location.** A `pinned(node = N)` /
 `pinned(l3 = name)` locus binds not just its thread but its
 *memory*: its arena is created via
@@ -1379,6 +1414,23 @@ gauge of the kernel send-queue occupancy sampled at send time),
 `retries` (cell 5, reconnects) — counters-tier, so a consumer
 falling behind shows as depth climbing and block time accruing
 BEFORE anything drops) and the
+**Canonical model entity ids (GH #476 Change 8).** Manifest rows
+name entities and number them in registration order, which is a
+fact about the run, not about the program. Each row's `aux_b` —
+in the entry layout since v0, written as 0 by every path until now
+— carries the canonical `ApplicationModel` entity id for that row,
+stamped by the CLI at build time: `MK_TOPIC` rows carry the
+`SubjectId` (the manifest fuses publishers by wire subject, so the
+address, not the topic decl, is the identity), `MK_LOCUS_TYPE`
+rows the `LocusDeclId`, `MK_BINDING` rows the `BindingId`. Values
+are `index + 1`; **0 keeps meaning "unstamped"** (a harness build,
+or an entity the model does not name — a stdlib subject, say).
+The ids are indices into the tables of the model whose
+`shape_hash` sits in the header at `0x80`, so they are meaningful
+only together with it: same `model_hash`, joinable ids. A
+consumer that joined by name still can.
+
+The
 runtime's own choke points emit records: `BUS_PUBLISH` /
 `BUS_DELIVER` at every dispatch flavor (dynamic, static-devirt,
 cross-thread wire; deliver is enqueue-time at v0),

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -440,7 +440,11 @@ re-arms on peer EOF and a link it cannot serve is structural.
 A `pinned(..., replicas = K)` field contributes K instances whose
 model rows carry their own 0-based INDEX — the same `i` codegen
 bakes and a keyed subscriber registers under — and the model
-refuses a replica set that is not contiguous from 0.
+refuses a replica set that is not contiguous from 0. Replica-ness
+belongs to the LAST path component: the arrangement walks into each
+replica, so what a replica owns (`App.workers[0].leaf`) is an
+ordinary child that inherits its owner's domain and carries no
+index of its own.
 
 A subject named by a `bindings { }` entry is never devirtualized:
 an external peer is (or may be) the real counterparty, so the


### PR DESCRIPTION
Change 8 of the canonical-model epic (GH #476): the deployment and optimization consumers. Three commits — the arrangement, the dispatch plan, the manifest entity ids.

## The arrangement (commit 1)

Change 2 left `locus_instances` / `realizes` / `owns` / `placed_in` / `thread_domains` / `bindings` / `binds` empty with a note that no consumer exported them. Their consumers land here, so they are populated: the params-default tree rooted at the main locus, `pinned(replicas = K)` fanned to K instances, thread domains by the runtime's own rule (pinned owns a domain, `cooperative(pool = X)` runs on X's worker, everything else inherits its owner, root is `main`, a binding reader is its own domain).

What the arrangement cannot see stays a typed hole rather than silence: instances born outside it hide `OWNS|PLACED` at the born locus, adapter transports hide `BINDS|DELIVERY` at the topic, and the capability account gains `exact_ownership` / `exact_placement` / `exact_routes`.

That closed a fail-open. The ownership graph walks locus member bodies only — its question is which owner a child bubbles to, and a free function has no owner — so `fn main() { W { }; P { }; }`, the corpus's most common program shape, produced zero modeled instances *and* claimed exact placement over them. `free_fn_birth_sites` closes it; the arrangement root itself is exempt, since `fn main() { App { }; }` is how the arrangement is entered.

## The dispatch plan (commit 2)

`DispatchPlan::derive(&ApplicationModel)` owns the lowering decision — a conclusion derived from the model, never a model row. One row per subject: flavor (`dynamic` / `static_bucket` / `static_direct`), the gate's reason, the subscriber list, publisher and subscriber thread domains, and `same_domain` — #464's stage-0 survey question ("how much queued bus traffic is same-thread-domain?") as a model query instead of a bespoke topology walk. `hale model dump` prints the plan and the survey count.

Codegen no longer decides. It still builds its own gate facts, over the merged and desugared program its emission uses — the source of facts must stay local or the lowering could disagree with itself — but the ladder is `DispatchFlavor::of` in hale-model, and the ids, direct set, and direct-subscriber lists come from `plan.static_subjects()`. Same ids, same order, same lowering.

The plan is part of what a build **is**. `exec_digest` frames `DispatchPlan::digest()`, so two builds of byte-identical sources that lower dispatch differently — notably the `LOTUS_NO_BUS_DEVIRT=1` control arm — cannot share a recording identity, and replay across that boundary is refused by name.

**Defect found by the differential.** A subject named by a `bindings { }` entry is exempt from devirtualization: the adapter's peer is (or may be) the real counterparty. The exemption was keyed only by the topic DECL name, but codegen builds its graph after topic desugaring, where subjects are wire strings — so a bound topic could be lowered into a static bucket its own adapter is not part of. The walk now records both grains. One of the 21 bus-carrying corpus programs disagreed; that is what surfaced it.

## Canonical entity ids for iris (commit 3)

Manifest rows name entities and number them in registration order — a fact about the run, not the program — so a consumer joining a live process to the source-derived model had to match on strings. Now the compiler answers: `hale_model::obs_ids` projects the model to `(manifest kind, name, canonical id)`, the CLI hands the rows to codegen with the model hash and exec digest, the prelude stamps them, and the runtime writes the id into the entry's `aux_b` when the row is lazily created.

`aux_b` has been in the entry layout since v0 and written as 0 by every path, so no consumer's layout moves and no protocol version changes. Ids are `index + 1`, keeping 0 as "unstamped" for harness builds and for entities the model does not name. MK_TOPIC carries the `SubjectId` (the manifest fuses publishers by wire subject, so the address is the identity), MK_LOCUS_TYPE the `LocusDeclId`, MK_BINDING the `BindingId` — indices into the model whose `shape_hash` the header already carries.

## Tests

- 5 plan laws in hale-types: wire grain (a plan keyed by decl name could not be compared to codegen's at all), the ladder, a pooled subscriber is not same-domain, a transport-bound subject stays dynamic *and says why*, unarranged loci forfeit the survey field rather than guess, the digest tracks the plan.
- A corpus differential through the real binaries: `hale model dump` vs `HALE_DISPATCH_TRACE=1 hale build`, requiring agreement on every subject the model names, over every bus-carrying corpus program. The converse is deliberately not asserted — codegen additionally carries stdlib subjects no user model names.
- An identity test: the all-dynamic control arm stamps a different exec digest, and replaying its recording against the default build is refused by name.
- A manifest test that reads the live segment and requires every row's `aux_b` to equal the id `hale model dump` reports, over a program whose birth order deliberately differs from the model's table order — otherwise it could not tell a canonical id from a registration-order one.
- A codegen-side control proving a harness build still publishes all-zero `aux_b`.

Full workspace suite green (2864 tests), zero warnings.

## Docs

`spec/runtime.md` gains the dispatch-plan section (flavors as a derived conclusion, the shared ladder, `same_domain`, the plan in execution identity, the transport-bound exemption at both grains) and the canonical-entity-id paragraph. The book's bus chapter tells authors how to read the plan and that a bound topic keeps the real bus path. CHANGELOG carries the Change-8 entry including the devirt fix.

## What Change 8 does not do

Instance-level canonical ids stay out: the runtime's instance table is birth-ordered and the model's instance ids are static-arrangement ids, so joining them needs the arranged path at the birth site — a separate ask, not a prerequisite for the ID join this delivers. Flavors A and B from #464 (same-domain local queue, widened quiet direct) are unchanged; this ships the stage-0 survey they were waiting on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
