### PR TITLE
feat(claims): the causes: judgment over the model (GH #476 Change 5f — engine + differential)

### DIFF
--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -45,7 +45,30 @@ pub struct Function {
     /// DERIVED effect classes in declaration order (the stdlib-merged
     /// transitive walk; order is semantic in the existing artifact
     /// and is preserved).
+    ///
+    /// RENDERED, and therefore lossy: when the walk reaches
+    /// something it cannot name, this collapses to the single token
+    /// `unclassified` and every simultaneously-known class is
+    /// discarded. That is fine for the artifact, which reports what
+    /// the old engine reported; it is NOT a basis for judgment. Use
+    /// [`Function::effect_lower_bound`] and
+    /// [`Function::effects_unknown`] for that.
     pub effects: Vec<String>,
+    /// The classes this function is KNOWN to reach, whether or not
+    /// the walk also hit something unnameable — the sound lower
+    /// bound, in canonical order (GH #476 Change 5f review).
+    ///
+    /// Judging over `effects` alone cannot express "definitely
+    /// syscall, and possibly more": a handler that performs a
+    /// syscall AND makes an indirect call renders as exactly
+    /// `unclassified`, so a law that a known effect already
+    /// violates reads as merely uncertain. The pair is the model's
+    /// job to keep, not the judgment's to reconstruct.
+    pub effect_lower_bound: Vec<String>,
+    /// The derived walk reached something it could not name, so
+    /// [`Function::effect_lower_bound`] is a lower bound and not the
+    /// whole answer.
+    pub effects_unknown: bool,
     /// DIRECT effect classes, sorted — what this body itself
     /// performs (carriers, own alloc/publish/spawn sites, ffi and
     /// classified stdlib callees), before propagation. The

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -258,6 +258,16 @@ pub struct Phase {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct EffectClassDecl {
     pub name: String,
+    /// The class's position in the seed's declaration order.
+    ///
+    /// The table is name-sorted (canonical identity), but rendering
+    /// a set of classes is order-SENSITIVE: the language renders
+    /// built-ins in a fixed order and user classes in the order they
+    /// were declared, and a diagnostic naming two of them is
+    /// byte-compared. Sorting the table threw that fact away, so it
+    /// is carried explicitly rather than reconstructed from a side
+    /// channel (GH #476 Change 5f).
+    pub declaration_index: u32,
     /// `effect NAME;` exists (false = bare reference only).
     pub declared: bool,
     pub definition: EffectClassDefinition,

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -65,6 +65,8 @@ fn tiny_model() -> ApplicationModel {
             effect_classes: Vec::new(),
             functions: vec![
                 Function {
+                    effect_lower_bound: Vec::new(),
+                    effects_unknown: false,
                     analyzed: true,
                     summarized: true,
                     owner: Some(LocusDeclId(0)),
@@ -79,6 +81,8 @@ fn tiny_model() -> ApplicationModel {
                     provenance: p,
                 },
                 Function {
+                    effect_lower_bound: Vec::new(),
+                    effects_unknown: false,
                     analyzed: true,
                     summarized: true,
                     owner: Some(LocusDeclId(1)),

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -356,12 +356,49 @@ fn collect_published_subjects(
     }
 }
 
+/// One `causes:` assertion's outcome, keyed so a caller can join it
+/// to the lowered law row it came from.
+///
+/// A function may carry SEVERAL `causes:` clauses, and every one of
+/// them anchors its diagnostic at the same fn-name span — so a span
+/// is not an identity (GH #476 Change 5f, review round 4). The
+/// ordinal is the assertion's position among that function's
+/// `causes:` clauses, in source order, which is exactly the order
+/// the lowering emits rows in.
+pub struct CausesReport {
+    /// The annotated function, as the evaluator displays it.
+    pub function: String,
+    /// 0-based position among this function's `causes:` clauses.
+    pub ordinal: usize,
+    /// `None` when the assertion holds.
+    pub diag: Option<Diag>,
+}
+
+/// Per-assertion `causes:` outcomes — the oracle a differential
+/// joins one law to one law by.
+pub fn causes_reports(
+    programs: &[&Program],
+    graph: &BusGraph,
+) -> Vec<CausesReport> {
+    causes_inner(programs, graph)
+}
+
 /// `@effects(causes: {…})` — check the declared causal set against
 /// what the fn can actually cause through bus edges.
 pub fn causes_diags(
     programs: &[&Program],
     graph: &BusGraph,
 ) -> Vec<Diag> {
+    causes_inner(programs, graph)
+        .into_iter()
+        .filter_map(|r| r.diag)
+        .collect()
+}
+
+fn causes_inner(
+    programs: &[&Program],
+    graph: &BusGraph,
+) -> Vec<CausesReport> {
     // The seed's user effect-class table, so an excess class renders
     // as `money` rather than as nothing at all.
     let names: Vec<String> = programs
@@ -370,13 +407,24 @@ pub fn causes_diags(
         .find(|n| !n.is_empty())
         .cloned()
         .unwrap_or_default();
-    let mut roots: Vec<(FnKey, Vec<EffectClass>, Span)> = Vec::new();
+    // (fn, declared classes, span, per-fn assertion ordinal). A fn
+    // may carry several `causes:` clauses; the ordinal is what makes
+    // each one identifiable, since they share a span.
+    let mut roots: Vec<(FnKey, Vec<EffectClass>, Span, usize)> =
+        Vec::new();
     for p in programs {
         for item in &p.items {
             let mut push = |key: FnKey, fd: &FnDecl| {
+                let mut ordinal = 0usize;
                 for a in &fd.effects {
                     if let EffectAssert::Causes(cs) = a {
-                        roots.push((key.clone(), cs.clone(), fd.name.span));
+                        roots.push((
+                            key.clone(),
+                            cs.clone(),
+                            fd.name.span,
+                            ordinal,
+                        ));
+                        ordinal += 1;
                     }
                 }
             };
@@ -419,8 +467,8 @@ pub fn causes_diags(
         .find(|d| !d.is_empty())
         .cloned()
         .unwrap_or_default();
-    let mut diags = Vec::new();
-    for (key, declared, span) in &roots {
+    let mut reports: Vec<CausesReport> = Vec::new();
+    for (key, declared, span, ordinal) in &roots {
         let (actual, via) = causal_effects(&summary, graph, key, &ffi);
         let mut allowed = EffectSet::PURE;
         for c in declared {
@@ -431,8 +479,8 @@ pub fn causes_diags(
         let direct = infer_effects(&summary, key, &ffi);
         let caused_only = EffectSet(actual.0 & !direct.0);
         let excess = EffectSet(caused_only.0 & !allowed.0);
-        if excess.0 != 0 {
-            diags.push(Diag::ty(
+        let diag = if excess.0 != 0 {
+            Some(Diag::ty(
                 *span,
                 format!(
                     "declared causal set violated: `{}` can transitively \
@@ -448,10 +496,17 @@ pub fn causes_diags(
                         format!(" Path: {}.", via.join("; "))
                     }
                 ),
-            ));
-        }
+            ))
+        } else {
+            None
+        };
+        reports.push(CausesReport {
+            function: key.display(),
+            ordinal: *ordinal,
+            diag,
+        });
     }
-    diags
+    reports
 }
 
 

--- a/crates/hale-types/src/frontier.rs
+++ b/crates/hale-types/src/frontier.rs
@@ -35,6 +35,113 @@ use crate::stdlib_surface::{self, EffectSet};
 
 // ===================== inferred effect sets =====================
 
+/// The KNOWN part of a function's derived effect set, and whether
+/// the walk also reached something it could not name.
+///
+/// [`infer_effects`] saturates: `UNCLASSIFIED` is `u64::MAX`, so one
+/// indirect call turns the whole set into "may do anything" and the
+/// classes the walk had already proven are gone. That is the right
+/// answer to "what might this do"; it is the wrong input to "what
+/// does this definitely do", and a judgment needs both — a handler
+/// that performs a syscall AND makes an indirect call already
+/// violates a law the syscall exceeds, whatever the indirect call
+/// turns out to do (GH #476 Change 5f review).
+///
+/// Same walk, same union rules; the difference is that an
+/// unnameable edge sets the flag instead of saturating the set.
+pub fn infer_effects_lower_bound(
+    summary: &AllocSummary,
+    key: &FnKey,
+    ffi: &BTreeSet<String>,
+) -> (EffectSet, bool) {
+    fn walk(
+        summary: &AllocSummary,
+        key: &FnKey,
+        ffi: &BTreeSet<String>,
+        seen: &mut BTreeSet<FnKey>,
+        steps: &mut u32,
+        unknown: &mut bool,
+    ) -> EffectSet {
+        if !seen.insert(key.clone()) {
+            return EffectSet::PURE;
+        }
+        *steps += 1;
+        if *steps > callgraph::MAX_STEPS {
+            *unknown = true;
+            return EffectSet::PURE;
+        }
+        let Some(fs) = summary.fns.get(key) else {
+            return EffectSet::PURE;
+        };
+        let mut acc = EffectSet::PURE;
+        if let Some(c) = summary.carries.get(key) {
+            if c.is_unclassified() {
+                *unknown = true;
+            } else {
+                acc = acc.union(*c);
+            }
+        }
+        if !fs.sites.is_empty() {
+            acc = acc.union(EffectSet::ALLOC);
+        }
+        for site in &fs.effect_sites {
+            acc = acc.union(match site.kind {
+                alloc_summary::EffectSiteKind::Publish(_) => {
+                    EffectSet::PUBLISH
+                }
+                alloc_summary::EffectSiteKind::Spawn(_) => {
+                    EffectSet::ALLOC
+                }
+            });
+        }
+        for edge in &fs.calls {
+            match &edge.callee {
+                Callee::Resolved(k) => {
+                    if let Some(c) = summary.carries.get(k) {
+                        if c.is_unclassified() {
+                            *unknown = true;
+                        } else {
+                            acc = acc.union(*c);
+                        }
+                    }
+                    if k.locus.is_none() && ffi.contains(&k.fn_name) {
+                        acc = acc.union(EffectSet::SYSCALL);
+                    }
+                    acc = acc.union(walk(
+                        summary, k, ffi, seen, steps, unknown,
+                    ));
+                }
+                Callee::Unresolved(name) => {
+                    // The two shapes that make a set unknowable —
+                    // an indirect call and an untypeable receiver —
+                    // set the flag and contribute nothing, rather
+                    // than swallowing what is already known.
+                    if fs.fn_params.iter().any(|p| p == name)
+                        || edge.opaque_method_call()
+                    {
+                        *unknown = true;
+                        continue;
+                    }
+                    let segs: Vec<&str> = name.split("::").collect();
+                    match stdlib_surface::effects_for(&segs) {
+                        Some(e) if !e.is_unclassified() => {
+                            acc = acc.union(e)
+                        }
+                        Some(_) => *unknown = true,
+                        None => {}
+                    }
+                }
+            }
+        }
+        acc
+    }
+    let mut seen = BTreeSet::new();
+    let mut steps = 0u32;
+    let mut unknown = false;
+    let set = walk(summary, key, ffi, &mut seen, &mut steps, &mut unknown);
+    (set, unknown)
+}
+
 /// The effect set a fn actually performs, transitively — inferred,
 /// never declared. Used by the manifest (a report) and by the
 /// causality check (which needs each subscriber's set).

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -4709,6 +4709,10 @@ pub struct CausesWitness {
     pub incomplete_discovery: Vec<FunctionId>,
     /// The closure left user code through a stdlib interior.
     pub crossed_stdlib_interior: bool,
+    /// A publish on the closure is routed off-process by a typed
+    /// outbound binding — the peer's behaviour is outside this
+    /// model even though the transport is understood.
+    pub crosses_external_route: bool,
     /// The closure took more than one bus hop.
     pub multi_hop: bool,
 }
@@ -4983,6 +4987,27 @@ pub fn judge_causes_witnessed(
                 }) {
                     uncertain = true;
                     witness.incomplete_endpoints.push(subject);
+                }
+                // …and the routes the model DOES understand. A
+                // typed outbound binding is not a hole — the
+                // transport is fully modeled — but the causal
+                // closure still leaves the application at it: a
+                // `connect`-role send is handed to a peer whose
+                // behaviour is not in this model at all. Reading
+                // only `holes` saw an opaque adapter and missed an
+                // ordinary `unix(..., role: connect)` (review round
+                // 4).
+                let outbound = topic_here.is_some_and(|t| {
+                    r.binds.iter().any(|b| {
+                        b.topic == t
+                            && e.bindings[b.binding.index()].role
+                                == hale_model::BindingRole::Connect
+                    })
+                });
+                if outbound {
+                    uncertain = true;
+                    witness.incomplete_endpoints.push(subject);
+                    witness.crosses_external_route = true;
                 }
                 for su in r
                     .subscribes

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -4495,23 +4495,167 @@ fn has_claim_surface(bundle: &crate::symbol::Bundle<'_>) -> bool {
     bundle.programs.values().any(|p| walk(&p.items))
 }
 
+
+// ================= possible delivery (shared) =====================
+
+/// Whether a publish to one endpoint can be DELIVERED to one
+/// subscription, and whether the model is sure.
+///
+/// The join is the model's typed wire identity — `SubjectId` — not
+/// a rendered spelling. `topic Orders { subject: "orders"; }`
+/// published by name and `subscribe "orders"` by literal are the
+/// SAME address and the runtime delivers between them; comparing
+/// display text sees two unrelated strings and certifies the edge
+/// away (GH #476 Change 5f review). `declared_topic` is a link to
+/// the declaration, never the delivery identity.
+///
+/// Wildcards widen it: a subscription whose pattern contains `**`
+/// covers every concrete subject it matches. Key filters are
+/// deliberately NOT consulted — a key predicate can only ever
+/// REMOVE deliveries, so ignoring it over-approximates the reach,
+/// which is the sound direction for any law that asks what a
+/// publish can cause.
+pub fn possibly_delivers(
+    e: &hale_model::Entities,
+    published: hale_model::SubjectId,
+    sub: &hale_model::Subscribe,
+) -> bool {
+    if sub.subject == published {
+        return true;
+    }
+    let pat = e.subjects[sub.subject.index()].pattern.as_str();
+    let wire = e.subjects[published.index()].pattern.as_str();
+    pat.contains("**") && crate::wildcard_match(pat, wire)
+}
+
+/// A class name's ATOMS, with the language's built-in folding
+/// applied: `ffi` is the `syscall` bit (an FFI call is a syscall as
+/// far as every contract is concerned), `spawn` and `recursion` own
+/// no effect bit at all, a composed class means its expansion, and
+/// a cyclic one means nothing. One helper, because a second reading
+/// of "what does this class name mean" is how a contract starts
+/// certifying the wrong set (review: `@effects(causes: {ffi})` was
+/// rejected against an actual set that spells the same bit
+/// `syscall`).
+pub fn effect_class_atoms(
+    e: &hale_model::Entities,
+    name: &str,
+) -> BTreeSet<String> {
+    fn builtin_atom(n: &str) -> Option<&'static str> {
+        Some(match n {
+            "syscall" | "ffi" => "syscall",
+            "block" => "block",
+            "publish" => "publish",
+            "time" => "time",
+            "entropy" => "entropy",
+            "env" => "env",
+            "alloc" => "alloc",
+            "secret_use" => "secret_use",
+            // Own no bit: a contract naming them constrains nothing.
+            "spawn" | "recursion" => return None,
+            _ => return None,
+        })
+    }
+    match e.effect_classes.iter().find(|c| c.name == name) {
+        Some(c) => match &c.definition {
+            hale_model::EffectClassDefinition::Composed { atoms } => {
+                atoms
+                    .iter()
+                    .flat_map(|a| effect_class_atoms(e, a))
+                    .collect()
+            }
+            hale_model::EffectClassDefinition::Atomic => {
+                match builtin_atom(name) {
+                    Some(b) => std::iter::once(b.to_string()).collect(),
+                    None => std::iter::once(name.to_string()).collect(),
+                }
+            }
+            hale_model::EffectClassDefinition::InvalidCycle => {
+                BTreeSet::new()
+            }
+        },
+        None => match builtin_atom(name) {
+            Some(b) => std::iter::once(b.to_string()).collect(),
+            None if name == "spawn" || name == "recursion" => {
+                BTreeSet::new()
+            }
+            // A bare reference to an undeclared user class: its own
+            // atom. (The declaration itself is diagnosed elsewhere.)
+            None => std::iter::once(name.to_string()).collect(),
+        },
+    }
+}
+
+/// Render a set of effect classes in the language's canonical
+/// order: built-ins in their fixed order, then user classes in
+/// DECLARATION order. Diagnostics are byte-compared, so this order
+/// is part of the contract.
+pub fn render_effect_classes(
+    e: &hale_model::Entities,
+    classes: &BTreeSet<String>,
+) -> Vec<String> {
+    const BUILTINS: &[&str] = &[
+        "syscall",
+        "block",
+        "publish",
+        "time",
+        "entropy",
+        "env",
+        "alloc",
+        "secret_use",
+    ];
+    let mut out: Vec<String> = Vec::new();
+    for b in BUILTINS {
+        if classes.contains(*b) {
+            out.push((*b).to_string());
+        }
+    }
+    let mut user: Vec<(u32, &String)> = classes
+        .iter()
+        .filter(|c| !BUILTINS.contains(&c.as_str()))
+        .map(|c| {
+            let idx = e
+                .effect_classes
+                .iter()
+                .find(|ec| ec.name == *c)
+                .map(|ec| ec.declaration_index)
+                .unwrap_or(u32::MAX);
+            (idx, c)
+        })
+        .collect();
+    user.sort();
+    out.extend(user.into_iter().map(|(_, c)| c.clone()));
+    out
+}
+
 /// GH #476 Change 5f — `@effects(causes: {…})` over the model.
 ///
-/// "What can this fn cause ANYWHERE in the system": its own effects,
-/// plus everything the subscribers of every subject it transitively
-/// publishes to perform. Only classes reached THROUGH the bus are
-/// reported — a fn's direct effects are the `none:` form's business,
-/// and subtracting them is what makes this the CAUSAL surface.
+/// "What can this fn cause ANYWHERE in the system": the effects of
+/// every handler a publish it can reach may be delivered to,
+/// following further hops when those handlers publish in turn.
 ///
-/// One divergence from the evaluator, in the fail-CLOSED direction
-/// and carved out in the differential: the evaluator infers effects
-/// from the user-only summary, so a subscriber whose `syscall` comes
-/// from a stdlib call reads as pure to it and its causal
-/// contribution disappears. The model's effect sets are the
-/// stdlib-merged ones, so the class is seen. An undeclared causal
-/// effect is exactly what this law exists to catch; not seeing it
-/// through a stdlib body was an accident of which summary the engine
-/// happened to hold.
+/// Three rules the first draft of this engine got wrong, each of
+/// which certified an absence it could not see:
+///
+///  * **The causal set is accumulated, never subtracted.** It holds
+///    only what DOWNSTREAM handlers do. Seeding it with the root's
+///    own effects and subtracting them back out cannot express
+///    provenance: one `syscall` member subtracted once erases the
+///    downstream occurrence along with the local one, and the
+///    undeclared causal effect disappears. (The evaluator has this
+///    bug; the model is the canonical authority and does not
+///    inherit it.)
+///  * **Incompleteness survives as `Uncertified`.** An unclassified
+///    handler, a computed publish subject, an unfollowable call, a
+///    truncated stdlib interior — each means the causal set is a
+///    lower bound, not an answer. A known excess still wins as
+///    `Violated`; otherwise relevant uncertainty refuses to certify.
+///  * **Delivery is the typed wire identity**, via
+///    [`possibly_delivers`], including wildcard coverage and
+///    publishes that happen inside stdlib bodies (the absorption
+///    interiors). Comparing rendered subject text missed ordinary
+///    deliveries between a topic-name publish and a literal
+///    subscribe on the same wire.
 pub fn judge_causes(
     table: &ClaimIrTable,
     model: &ApplicationModel,
@@ -4522,55 +4666,75 @@ pub fn judge_causes(
     let claim_span = |pid: ProvenanceId| -> Span {
         span_of(&table.provenance, source_bases, pid)
     };
-    // A class's atomic expansion — composed classes own no bit, a
-    // cyclic one expands to nothing (the checker refuses it at the
-    // declaration).
-    let class_atoms = |name: &str| -> BTreeSet<String> {
-        match e.effect_classes.iter().find(|c| c.name == name) {
-            Some(c) => match &c.definition {
-                hale_model::EffectClassDefinition::Composed { atoms } => {
-                    atoms.iter().cloned().collect()
-                }
-                hale_model::EffectClassDefinition::Atomic => {
-                    std::iter::once(name.to_string()).collect()
-                }
-                hale_model::EffectClassDefinition::InvalidCycle => {
-                    BTreeSet::new()
-                }
-            },
-            // Built-ins are their own atom.
-            None => std::iter::once(name.to_string()).collect(),
-        }
-    };
-    // The derived (transitive) classes of a function, as the model
-    // records them. `unclassified` is a residue marker, never a
-    // class a causal set can be measured against.
-    let effects_of = |f: FunctionId| -> BTreeSet<String> {
-        e.functions[f.index()]
+    // A function's DERIVED classes, and whether they are known at
+    // all. `unclassified` is the analysis saying "this body reaches
+    // something I cannot name" — it is not the empty set.
+    let effects_of = |f: FunctionId| -> (BTreeSet<String>, bool) {
+        let row = &e.functions[f.index()];
+        let unknown = row.effects.iter().any(|c| c == "unclassified");
+        let known: BTreeSet<String> = row
             .effects
             .iter()
             .filter(|c| c.as_str() != "unclassified")
-            .cloned()
-            .collect()
+            .flat_map(|c| effect_class_atoms(e, c))
+            .collect();
+        (known, unknown)
     };
-    let is_unclassified = |f: FunctionId| -> bool {
-        e.functions[f.index()]
-            .effects
-            .iter()
-            .any(|c| c == "unclassified")
+    // Which relation families a hole at a function hides.
+    let hole_hides = |f: FunctionId, mask: hale_model::RelationSet| {
+        model.holes.iter().any(|h| {
+            h.at == EntityRef::Function(f) && h.hides.intersects(mask)
+        })
     };
-    // Endpoint spelling: a declared endpoint speaks its topic's
-    // name, a literal one its pattern — the same rule every other
-    // witness renders subjects by.
-    let subject_text = |declared: Option<hale_model::TopicId>,
-                        subject: hale_model::SubjectId|
-     -> String {
-        match declared {
-            Some(t) => e.topics[t.index()].display.clone(),
-            None => e.subjects[subject.index()].pattern.clone(),
+    // Interior stdlib publishes, keyed by the user fn they are
+    // reached from, plus whether that interior is fully explored.
+    let mut interior_pubs: BTreeMap<u32, Vec<hale_model::SubjectId>> =
+        BTreeMap::new();
+    let mut interior_unknown: BTreeSet<u32> = BTreeSet::new();
+    for a in &model.analyses.stdlib_absorption {
+        for node in &a.nodes {
+            for ev in &node.events {
+                match ev {
+                    hale_model::AbsorbedEvent::Publish {
+                        subject,
+                        declared_topic,
+                        ..
+                    } => {
+                        // Interior publishes name a subject by wire
+                        // text (or a declared topic); resolve to the
+                        // typed id the delivery query joins on.
+                        let sid = declared_topic
+                            .map(|t| e.topics[t.index()].subject)
+                            .or_else(|| {
+                                e.subjects
+                                    .iter()
+                                    .position(|s| s.pattern == *subject)
+                                    .map(|i| {
+                                        hale_model::SubjectId(i as u32)
+                                    })
+                            });
+                        match sid {
+                            Some(sid) => interior_pubs
+                                .entry(a.from.0)
+                                .or_default()
+                                .push(sid),
+                            // A subject the model has no row for is
+                            // an address it cannot reason about.
+                            None => {
+                                interior_unknown.insert(a.from.0);
+                            }
+                        }
+                    }
+                    hale_model::AbsorbedEvent::PublishHole
+                    | hale_model::AbsorbedEvent::Truncated
+                    | hale_model::AbsorbedEvent::CallHole(_) => {
+                        interior_unknown.insert(a.from.0);
+                    }
+                    hale_model::AbsorbedEvent::Call { .. } => {}
+                }
+            }
         }
-    };
-    // calls: caller -> callees, for the transitive publish walk.
+    }
     let mut callees: BTreeMap<u32, Vec<FunctionId>> = BTreeMap::new();
     for c in &r.calls {
         callees.entry(c.from.0).or_default().push(c.to);
@@ -4581,18 +4745,11 @@ pub fn judge_causes(
         let ClaimIr::EffectCauses { at, classes } = &row.law else {
             continue;
         };
-        let Some(fid) = at.0 else {
-            // The annotated fn is not in the model's universe —
-            // nothing to judge, and the certificate machinery
-            // reports the unresolved reference.
-            continue;
-        };
+        let Some(fid) = at.0 else { continue };
         let mut diags: Vec<Diag> = Vec::new();
         // A class that resolves to nothing makes the contract
-        // vacuous, so the law is INVALID before evaluation — the
-        // same rule the certificate family applies, and the reason
-        // a cyclic definition is refused at its declaration. No
-        // diagnostic here: the declaration owns that message.
+        // vacuous: invalid before evaluation, as in the certificate
+        // family. The declaration owns the diagnostic.
         if classes.iter().any(|c| {
             c.class.is_some_and(|id| {
                 matches!(
@@ -4609,60 +4766,114 @@ pub fn judge_causes(
             });
             continue;
         }
-        // Subjects this fn transitively publishes to, in the
-        // evaluator's order (subject text, ascending).
-        let mut subjects: BTreeSet<String> = BTreeSet::new();
-        {
-            let mut seen: BTreeSet<u32> = BTreeSet::new();
-            let mut stack = vec![fid];
-            while let Some(f) = stack.pop() {
-                if !seen.insert(f.0) {
-                    continue;
-                }
-                for p in r.publishes.iter().filter(|p| p.function == f) {
-                    subjects.insert(subject_text(p.declared_topic, p.subject));
-                }
-                for next in callees.get(&f.0).into_iter().flatten() {
-                    stack.push(*next);
-                }
-            }
-        }
-        // …and what their subscribers do.
-        let mut actual = effects_of(fid);
+
+        // ---- the causal closure ----
+        // Publishes reachable from the root (through calls), the
+        // handlers they may deliver to, and — because a handler may
+        // publish in turn — onward until it settles.
+        let mut uncertain = false;
+        let mut caused: BTreeSet<String> = BTreeSet::new();
         let mut via: Vec<String> = Vec::new();
-        for subj in &subjects {
-            for s in r.subscribes.iter().filter(|s| {
-                subject_text(s.declared_topic, s.subject) == *subj
-            }) {
-                if is_unclassified(s.handler) {
-                    continue;
+        let mut fn_frontier: Vec<FunctionId> = vec![fid];
+        let mut fn_seen: BTreeSet<u32> = BTreeSet::new();
+        let mut handled: BTreeSet<u32> = BTreeSet::new();
+        while let Some(f) = fn_frontier.pop() {
+            if !fn_seen.insert(f.0) {
+                continue;
+            }
+            // Discovery incompleteness: an unfollowable call or a
+            // computed subject means the publish set is a lower
+            // bound.
+            if hole_hides(
+                f,
+                hale_model::RelationSet::CALLS
+                    .union(hale_model::RelationSet::PUBLISHES),
+            ) || interior_unknown.contains(&f.0)
+            {
+                uncertain = true;
+            }
+            // (subject id, AUTHORED spelling). The join below is on
+            // the id; the witness renders what the author wrote —
+            // `Orders`, not `orders` — because a path a developer
+            // reads must name the declaration they can go look at.
+            let mut published: Vec<(hale_model::SubjectId, String)> = r
+                .publishes
+                .iter()
+                .filter(|p| p.function == f)
+                .map(|p| {
+                    let written = match p.declared_topic {
+                        Some(t) => e.topics[t.index()].display.clone(),
+                        None => e.subjects[p.subject.index()]
+                            .pattern
+                            .clone(),
+                    };
+                    (p.subject, written)
+                })
+                .collect();
+            published.extend(
+                interior_pubs
+                    .get(&f.0)
+                    .into_iter()
+                    .flatten()
+                    .map(|s| {
+                        (*s, e.subjects[s.index()].pattern.clone())
+                    }),
+            );
+            published.sort();
+            published.dedup();
+            for (subject, written) in published {
+                // Delivery incompleteness: the model admits it may
+                // not know every subscriber of this address.
+                if model.holes.iter().any(|h| {
+                    h.hides
+                        .intersects(hale_model::RelationSet::DELIVERY)
+                        && matches!(
+                            h.at,
+                            EntityRef::Topic(_) | EntityRef::Subject(_)
+                        )
+                }) {
+                    uncertain = true;
                 }
-                let eff = effects_of(s.handler);
-                if eff.is_empty() {
-                    continue;
+                for su in r
+                    .subscribes
+                    .iter()
+                    .filter(|su| possibly_delivers(e, subject, su))
+                {
+                    let (eff, unknown) = effects_of(su.handler);
+                    if unknown {
+                        // The handler reaches something unnameable:
+                        // whatever it causes is not measurable here.
+                        uncertain = true;
+                    }
+                    if handled.insert(su.handler.0) && !eff.is_empty() {
+                        via.push(format!(
+                            "`{}` -> subject `{}` -> `{}`",
+                            e.functions[fid.index()].display,
+                            written,
+                            e.functions[su.handler.index()].display
+                        ));
+                    }
+                    caused.extend(eff);
+                    // Onward hops: what this handler publishes is
+                    // also caused by the root.
+                    fn_frontier.push(su.handler);
                 }
-                via.push(format!(
-                    "`{}` -> subject `{}` -> `{}`",
-                    e.functions[fid.index()].display,
-                    subj,
-                    e.functions[s.handler.index()].display
-                ));
-                actual.extend(eff);
+            }
+            for next in callees.get(&f.0).into_iter().flatten() {
+                fn_frontier.push(*next);
             }
         }
+
         let mut allowed: BTreeSet<String> = BTreeSet::new();
         for c in classes {
-            allowed.extend(class_atoms(&c.name));
+            allowed.extend(effect_class_atoms(e, &c.name));
         }
-        let direct = effects_of(fid);
-        let excess: Vec<String> = actual
-            .difference(&direct)
-            .filter(|c| !allowed.contains(*c))
-            .cloned()
+        let excess: BTreeSet<String> = caused
+            .into_iter()
+            .filter(|c| !allowed.contains(c))
             .collect();
-        let verdict = if excess.is_empty() {
-            Verdict::Holds
-        } else {
+        let verdict = if !excess.is_empty() {
+            // A KNOWN excess is an answer, whatever else is unknown.
             diags.push(Diag::ty(
                 claim_span(row.provenance),
                 format!(
@@ -4672,7 +4883,7 @@ pub fn judge_causes(
                      class to the declaration, or route the publish to a \
                      subject whose subscribers don't perform it.",
                     e.functions[fid.index()].display,
-                    excess.join(", "),
+                    render_effect_classes(e, &excess).join(", "),
                     if via.is_empty() {
                         String::new()
                     } else {
@@ -4681,6 +4892,10 @@ pub fn judge_causes(
                 ),
             ));
             Verdict::Violated
+        } else if uncertain {
+            Verdict::Uncertified
+        } else {
+            Verdict::Holds
         };
         out.push(Judged {
             ordinal: row.ordinal,

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -4494,3 +4494,200 @@ fn has_claim_surface(bundle: &crate::symbol::Bundle<'_>) -> bool {
     }
     bundle.programs.values().any(|p| walk(&p.items))
 }
+
+/// GH #476 Change 5f — `@effects(causes: {…})` over the model.
+///
+/// "What can this fn cause ANYWHERE in the system": its own effects,
+/// plus everything the subscribers of every subject it transitively
+/// publishes to perform. Only classes reached THROUGH the bus are
+/// reported — a fn's direct effects are the `none:` form's business,
+/// and subtracting them is what makes this the CAUSAL surface.
+///
+/// One divergence from the evaluator, in the fail-CLOSED direction
+/// and carved out in the differential: the evaluator infers effects
+/// from the user-only summary, so a subscriber whose `syscall` comes
+/// from a stdlib call reads as pure to it and its causal
+/// contribution disappears. The model's effect sets are the
+/// stdlib-merged ones, so the class is seen. An undeclared causal
+/// effect is exactly what this law exists to catch; not seeing it
+/// through a stdlib body was an accident of which summary the engine
+/// happened to hold.
+pub fn judge_causes(
+    table: &ClaimIrTable,
+    model: &ApplicationModel,
+    source_bases: &[u32],
+) -> Vec<Judged> {
+    let e = &model.entities;
+    let r = &model.relations;
+    let claim_span = |pid: ProvenanceId| -> Span {
+        span_of(&table.provenance, source_bases, pid)
+    };
+    // A class's atomic expansion — composed classes own no bit, a
+    // cyclic one expands to nothing (the checker refuses it at the
+    // declaration).
+    let class_atoms = |name: &str| -> BTreeSet<String> {
+        match e.effect_classes.iter().find(|c| c.name == name) {
+            Some(c) => match &c.definition {
+                hale_model::EffectClassDefinition::Composed { atoms } => {
+                    atoms.iter().cloned().collect()
+                }
+                hale_model::EffectClassDefinition::Atomic => {
+                    std::iter::once(name.to_string()).collect()
+                }
+                hale_model::EffectClassDefinition::InvalidCycle => {
+                    BTreeSet::new()
+                }
+            },
+            // Built-ins are their own atom.
+            None => std::iter::once(name.to_string()).collect(),
+        }
+    };
+    // The derived (transitive) classes of a function, as the model
+    // records them. `unclassified` is a residue marker, never a
+    // class a causal set can be measured against.
+    let effects_of = |f: FunctionId| -> BTreeSet<String> {
+        e.functions[f.index()]
+            .effects
+            .iter()
+            .filter(|c| c.as_str() != "unclassified")
+            .cloned()
+            .collect()
+    };
+    let is_unclassified = |f: FunctionId| -> bool {
+        e.functions[f.index()]
+            .effects
+            .iter()
+            .any(|c| c == "unclassified")
+    };
+    // Endpoint spelling: a declared endpoint speaks its topic's
+    // name, a literal one its pattern — the same rule every other
+    // witness renders subjects by.
+    let subject_text = |declared: Option<hale_model::TopicId>,
+                        subject: hale_model::SubjectId|
+     -> String {
+        match declared {
+            Some(t) => e.topics[t.index()].display.clone(),
+            None => e.subjects[subject.index()].pattern.clone(),
+        }
+    };
+    // calls: caller -> callees, for the transitive publish walk.
+    let mut callees: BTreeMap<u32, Vec<FunctionId>> = BTreeMap::new();
+    for c in &r.calls {
+        callees.entry(c.from.0).or_default().push(c.to);
+    }
+
+    let mut out: Vec<Judged> = Vec::new();
+    for row in &table.rows {
+        let ClaimIr::EffectCauses { at, classes } = &row.law else {
+            continue;
+        };
+        let Some(fid) = at.0 else {
+            // The annotated fn is not in the model's universe —
+            // nothing to judge, and the certificate machinery
+            // reports the unresolved reference.
+            continue;
+        };
+        let mut diags: Vec<Diag> = Vec::new();
+        // A class that resolves to nothing makes the contract
+        // vacuous, so the law is INVALID before evaluation — the
+        // same rule the certificate family applies, and the reason
+        // a cyclic definition is refused at its declaration. No
+        // diagnostic here: the declaration owns that message.
+        if classes.iter().any(|c| {
+            c.class.is_some_and(|id| {
+                matches!(
+                    e.effect_classes[id.index()].definition,
+                    hale_model::EffectClassDefinition::InvalidCycle
+                )
+            })
+        }) {
+            out.push(Judged {
+                ordinal: row.ordinal,
+                verdict: Verdict::Invalid,
+                diags,
+                foreign: Vec::new(),
+            });
+            continue;
+        }
+        // Subjects this fn transitively publishes to, in the
+        // evaluator's order (subject text, ascending).
+        let mut subjects: BTreeSet<String> = BTreeSet::new();
+        {
+            let mut seen: BTreeSet<u32> = BTreeSet::new();
+            let mut stack = vec![fid];
+            while let Some(f) = stack.pop() {
+                if !seen.insert(f.0) {
+                    continue;
+                }
+                for p in r.publishes.iter().filter(|p| p.function == f) {
+                    subjects.insert(subject_text(p.declared_topic, p.subject));
+                }
+                for next in callees.get(&f.0).into_iter().flatten() {
+                    stack.push(*next);
+                }
+            }
+        }
+        // …and what their subscribers do.
+        let mut actual = effects_of(fid);
+        let mut via: Vec<String> = Vec::new();
+        for subj in &subjects {
+            for s in r.subscribes.iter().filter(|s| {
+                subject_text(s.declared_topic, s.subject) == *subj
+            }) {
+                if is_unclassified(s.handler) {
+                    continue;
+                }
+                let eff = effects_of(s.handler);
+                if eff.is_empty() {
+                    continue;
+                }
+                via.push(format!(
+                    "`{}` -> subject `{}` -> `{}`",
+                    e.functions[fid.index()].display,
+                    subj,
+                    e.functions[s.handler.index()].display
+                ));
+                actual.extend(eff);
+            }
+        }
+        let mut allowed: BTreeSet<String> = BTreeSet::new();
+        for c in classes {
+            allowed.extend(class_atoms(&c.name));
+        }
+        let direct = effects_of(fid);
+        let excess: Vec<String> = actual
+            .difference(&direct)
+            .filter(|c| !allowed.contains(*c))
+            .cloned()
+            .collect();
+        let verdict = if excess.is_empty() {
+            Verdict::Holds
+        } else {
+            diags.push(Diag::ty(
+                claim_span(row.provenance),
+                format!(
+                    "declared causal set violated: `{}` can transitively \
+                     cause {} through the bus, which its \
+                     `@effects(causes: …)` does not declare.{} Add the \
+                     class to the declaration, or route the publish to a \
+                     subject whose subscribers don't perform it.",
+                    e.functions[fid.index()].display,
+                    excess.join(", "),
+                    if via.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" Path: {}.", via.join("; "))
+                    }
+                ),
+            ));
+            Verdict::Violated
+        };
+        out.push(Judged {
+            ordinal: row.ordinal,
+            verdict,
+            diags,
+            foreign: Vec::new(),
+        });
+    }
+    out
+}

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -4675,11 +4675,61 @@ pub fn render_effect_classes(
 ///    interiors). Comparing rendered subject text missed ordinary
 ///    deliveries between a topic-name publish and a literal
 ///    subscribe on the same wire.
+/// One claim row's own span, in bundle-global offsets — the anchor
+/// both the evaluator and the judgment put a row's diagnostic on,
+/// and therefore the key a differential joins one law to one law by.
+pub fn claim_row_span(
+    table: &ClaimIrTable,
+    source_bases: &[u32],
+    row: &hale_model::ClaimRow,
+) -> Span {
+    span_of(&table.provenance, source_bases, row.provenance)
+}
+
+/// What one `causes:` row's traversal actually reached.
+///
+/// The differential needs this to authorize a divergence against
+/// THIS row rather than against facts anywhere in the program (a
+/// hole on an unrelated topic must not excuse a wrong answer here).
+/// Recomputing the closure inside the test would re-implement the
+/// engine in its own test, which is how a test starts agreeing with
+/// a bug — so the engine reports what it saw.
+#[derive(Clone, Debug, Default)]
+pub struct CausesWitness {
+    /// Handlers a publish on this row's closure may deliver to.
+    pub reached_handlers: Vec<FunctionId>,
+    /// Handlers among those whose effect set is not fully known.
+    pub unknown_handlers: Vec<FunctionId>,
+    /// Endpoints whose downstream is incomplete (subscriber set,
+    /// key filter, or an opaque external boundary).
+    pub incomplete_endpoints: Vec<hale_model::SubjectId>,
+    /// Functions on the closure whose outgoing calls or publish
+    /// sites are not fully known — an unfollowable call or a
+    /// computed subject means the publish set is a lower bound.
+    pub incomplete_discovery: Vec<FunctionId>,
+    /// The closure left user code through a stdlib interior.
+    pub crossed_stdlib_interior: bool,
+    /// The closure took more than one bus hop.
+    pub multi_hop: bool,
+}
+
 pub fn judge_causes(
     table: &ClaimIrTable,
     model: &ApplicationModel,
     source_bases: &[u32],
 ) -> Vec<Judged> {
+    judge_causes_witnessed(table, model, source_bases)
+        .into_iter()
+        .map(|(j, _)| j)
+        .collect()
+}
+
+/// [`judge_causes`], with each row's traversal witness.
+pub fn judge_causes_witnessed(
+    table: &ClaimIrTable,
+    model: &ApplicationModel,
+    source_bases: &[u32],
+) -> Vec<(Judged, CausesWitness)> {
     let e = &model.entities;
     let r = &model.relations;
     let claim_span = |pid: ProvenanceId| -> Span {
@@ -4761,7 +4811,7 @@ pub fn judge_causes(
         callees.entry(c.from.0).or_default().push(c.to);
     }
 
-    let mut out: Vec<Judged> = Vec::new();
+    let mut out: Vec<(Judged, CausesWitness)> = Vec::new();
     for row in &table.rows {
         let ClaimIr::EffectCauses { at, classes } = &row.law else {
             continue;
@@ -4779,12 +4829,15 @@ pub fn judge_causes(
                 )
             })
         }) {
-            out.push(Judged {
-                ordinal: row.ordinal,
-                verdict: Verdict::Invalid,
-                diags,
-                foreign: Vec::new(),
-            });
+            out.push((
+                Judged {
+                    ordinal: row.ordinal,
+                    verdict: Verdict::Invalid,
+                    diags,
+                    foreign: Vec::new(),
+                },
+                CausesWitness::default(),
+            ));
             continue;
         }
 
@@ -4793,6 +4846,7 @@ pub fn judge_causes(
         // handlers they may deliver to, and — because a handler may
         // publish in turn — onward until it settles.
         let mut uncertain = false;
+        let mut witness = CausesWitness::default();
         let mut caused: BTreeSet<String> = BTreeSet::new();
         let mut via: Vec<String> = Vec::new();
         let mut fn_frontier: Vec<FunctionId> = vec![fid];
@@ -4812,6 +4866,15 @@ pub fn judge_causes(
             ) || interior_unknown.contains(&f.0)
             {
                 uncertain = true;
+                witness.incomplete_discovery.push(f);
+            }
+            if interior_pubs.contains_key(&f.0)
+                || interior_unknown.contains(&f.0)
+            {
+                witness.crossed_stdlib_interior = true;
+            }
+            if f != fid {
+                witness.multi_hop = true;
             }
             // (subject id, AUTHORED spelling). The join below is on
             // the id; the witness renders what the author wrote —
@@ -4857,8 +4920,16 @@ pub fn judge_causes(
                     )
                 }),
             );
-            published.sort_by(|a, b| (a.0, &a.1).cmp(&(b.0, &b.1)));
-            published.dedup_by(|a, b| a.0 == b.0 && a.1 == b.1);
+            // NOT deduplicated. Publishes are site-grained on
+            // purpose: one function may publish one subject at
+            // several sites with different key domains, and
+            // collapsing them before the delivery query throws away
+            // the site that actually delivers. Handler facts are
+            // deduplicated AFTER every site has been evaluated
+            // (review round 3).
+            published.sort_by(|a, b| {
+                (a.0, &a.1, a.2.site).cmp(&(b.0, &b.1, b.2.site))
+            });
             for (subject, written, pubrow) in published {
                 // Delivery incompleteness, SCOPED TO THIS ENDPOINT.
                 // A hole somewhere else in the application says
@@ -4872,25 +4943,46 @@ pub fn judge_causes(
                 // DELIVERY (the must-deliver guarantee), plus
                 // KEY_FILTERS, since an unknown filter widens who
                 // may receive.
-                let topic_here = e
-                    .topics
-                    .iter()
-                    .position(|t| t.subject == subject)
-                    .map(|i| hale_model::TopicId(i as u32));
+                // The topic identity comes from the PUBLISH ROW,
+                // not from the first topic that happens to share an
+                // address.
+                let topic_here = pubrow.declared_topic;
+                let wire =
+                    e.subjects[subject.index()].pattern.as_str();
                 if model.holes.iter().any(|h| {
+                    // Three ways this endpoint's downstream can be
+                    // incomplete: the possible handler set is not
+                    // fully known (SUBSCRIBES), a filter that
+                    // decides who receives is not known
+                    // (KEY_FILTERS), or the route leaves the
+                    // program entirely — an adapter-bound topic is
+                    // an ExternalOpaque hole hiding BINDS|DELIVERY,
+                    // and whatever the peer does is not in this
+                    // graph at all.
                     let relevant = h.hides.intersects(
-                        hale_model::RelationSet::SUBSCRIBES.union(
-                            hale_model::RelationSet::KEY_FILTERS,
-                        ),
+                        hale_model::RelationSet::SUBSCRIBES
+                            .union(hale_model::RelationSet::KEY_FILTERS)
+                            .union(hale_model::RelationSet::DELIVERY),
                     );
                     let here = match h.at {
-                        EntityRef::Subject(s) => s == subject,
+                        // Subject-grained residue covers by
+                        // PATTERN: a hole on `orders.**` is
+                        // relevant to a publish on `orders.created`.
+                        EntityRef::Subject(sid) => {
+                            let pat = e.subjects[sid.index()]
+                                .pattern
+                                .as_str();
+                            sid == subject
+                                || (pat.contains("**")
+                                    && crate::wildcard_match(pat, wire))
+                        }
                         EntityRef::Topic(t) => Some(t) == topic_here,
                         _ => false,
                     };
                     relevant && here
                 }) {
                     uncertain = true;
+                    witness.incomplete_endpoints.push(subject);
                 }
                 for su in r
                     .subscribes
@@ -4898,7 +4990,9 @@ pub fn judge_causes(
                     .filter(|su| may_deliver(e, &pubrow, su))
                 {
                     let (eff, unknown) = effects_of(su.handler);
+                    witness.reached_handlers.push(su.handler);
                     if unknown {
+                        witness.unknown_handlers.push(su.handler);
                         // The handler reaches something unnameable:
                         // whatever it causes is not measurable here.
                         uncertain = true;
@@ -4955,12 +5049,23 @@ pub fn judge_causes(
         } else {
             Verdict::Holds
         };
-        out.push(Judged {
-            ordinal: row.ordinal,
-            verdict,
-            diags,
-            foreign: Vec::new(),
-        });
+        witness.reached_handlers.sort();
+        witness.reached_handlers.dedup();
+        witness.unknown_handlers.sort();
+        witness.unknown_handlers.dedup();
+        witness.incomplete_endpoints.sort();
+        witness.incomplete_endpoints.dedup();
+        witness.incomplete_discovery.sort();
+        witness.incomplete_discovery.dedup();
+        out.push((
+            Judged {
+                ordinal: row.ordinal,
+                verdict,
+                diags,
+                foreign: Vec::new(),
+            },
+            witness,
+        ));
     }
     out
 }

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -4947,10 +4947,16 @@ pub fn judge_causes_witnessed(
                 // DELIVERY (the must-deliver guarantee), plus
                 // KEY_FILTERS, since an unknown filter widens who
                 // may receive.
-                // The topic identity comes from the PUBLISH ROW,
-                // not from the first topic that happens to share an
-                // address.
-                let topic_here = pubrow.declared_topic;
+                // Everything below joins on the WIRE SUBJECT.
+                // `declared_topic` is the syntactic link — a literal
+                // `"t" <- …` send carries `None` even when its text
+                // is a declared topic's wire subject, and after
+                // lowering the runtime cannot tell the two spellings
+                // apart. Keying the route or the residue on the
+                // declaration link therefore missed every
+                // literal-spelled send into a bound topic (review
+                // round 5, the same wire-vs-syntax distinction the
+                // delivery join already makes).
                 let wire =
                     e.subjects[subject.index()].pattern.as_str();
                 if model.holes.iter().any(|h| {
@@ -4980,7 +4986,14 @@ pub fn judge_causes_witnessed(
                                 || (pat.contains("**")
                                     && crate::wildcard_match(pat, wire))
                         }
-                        EntityRef::Topic(t) => Some(t) == topic_here,
+                        // A topic-anchored hole is relevant when
+                        // the topic ADDRESSES this wire, however the
+                        // send happened to spell it.
+                        EntityRef::Topic(t) => {
+                            e.topics.get(t.index()).is_some_and(|tp| {
+                                tp.subject == subject
+                            })
+                        }
                         _ => false,
                     };
                     relevant && here
@@ -4997,12 +5010,11 @@ pub fn judge_causes_witnessed(
                 // only `holes` saw an opaque adapter and missed an
                 // ordinary `unix(..., role: connect)` (review round
                 // 4).
-                let outbound = topic_here.is_some_and(|t| {
-                    r.binds.iter().any(|b| {
-                        b.topic == t
-                            && e.bindings[b.binding.index()].role
-                                == hale_model::BindingRole::Connect
-                    })
+                let outbound = r.binds.iter().any(|b| {
+                    let binding = &e.bindings[b.binding.index()];
+                    binding.subject == subject
+                        && binding.role
+                            == hale_model::BindingRole::Connect
                 });
                 if outbound {
                     uncertain = true;

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -4499,33 +4499,52 @@ fn has_claim_surface(bundle: &crate::symbol::Bundle<'_>) -> bool {
 // ================= possible delivery (shared) =====================
 
 /// Whether a publish to one endpoint can be DELIVERED to one
-/// subscription, and whether the model is sure.
+/// subscription.
 ///
 /// The join is the model's typed wire identity — `SubjectId` — not
-/// a rendered spelling. `topic Orders { subject: "orders"; }`
+/// a rendered spelling: `topic Orders { subject: "orders"; }`
 /// published by name and `subscribe "orders"` by literal are the
-/// SAME address and the runtime delivers between them; comparing
-/// display text sees two unrelated strings and certifies the edge
-/// away (GH #476 Change 5f review). `declared_topic` is a link to
-/// the declaration, never the delivery identity.
+/// SAME address and the runtime delivers between them. Wildcards
+/// widen it. `declared_topic` is a link to the declaration, never
+/// the delivery identity.
 ///
-/// Wildcards widen it: a subscription whose pattern contains `**`
-/// covers every concrete subject it matches. Key filters are
-/// deliberately NOT consulted — a key predicate can only ever
-/// REMOVE deliveries, so ignoring it over-approximates the reach,
-/// which is the sound direction for any law that asks what a
-/// publish can cause.
-pub fn possibly_delivers(
+/// KEYS decide the rest. A keyed publish whose domain is statically
+/// exact and a subscription whose predicate is a literal outside it
+/// cannot meet — treating keyed delivery as broadcast is the
+/// failure mode the keyed schema names. Everything unknown widens:
+/// an unknown domain, an unknown predicate, a replica or fallback
+/// filter all leave the edge possible, because over-approximating
+/// reach is the sound direction for a law asking what a publish can
+/// cause.
+pub fn may_deliver(
     e: &hale_model::Entities,
-    published: hale_model::SubjectId,
+    publish: &hale_model::Publish,
     sub: &hale_model::Subscribe,
 ) -> bool {
-    if sub.subject == published {
-        return true;
+    let addressed = sub.subject == publish.subject || {
+        let pat = e.subjects[sub.subject.index()].pattern.as_str();
+        let wire = e.subjects[publish.subject.index()].pattern.as_str();
+        pat.contains("**") && crate::wildcard_match(pat, wire)
+    };
+    if !addressed {
+        return false;
     }
-    let pat = e.subjects[sub.subject.index()].pattern.as_str();
-    let wire = e.subjects[published.index()].pattern.as_str();
-    pat.contains("**") && crate::wildcard_match(pat, wire)
+    use hale_model::keys::{KeyDomain, KeyPredicate};
+    match (&publish.key_domain, &sub.key_predicate) {
+        // Decidable disjointness: an exact produced set and a
+        // literal filter that is not in it.
+        (Some(KeyDomain::Exact(vals)), KeyPredicate::EqLiteral(k)) => {
+            vals.contains(k)
+        }
+        (
+            Some(KeyDomain::IntRange { min, max }),
+            KeyPredicate::EqLiteral(hale_model::keys::KeyValue::Int(k)),
+        ) => k >= min && k <= max,
+        // Everything else is possible: unknown domains, unknown
+        // filters, replica and fallback selection, unkeyed
+        // subscriptions.
+        _ => true,
+    }
 }
 
 /// A class name's ATOMS, with the language's built-in folding
@@ -4669,16 +4688,18 @@ pub fn judge_causes(
     // A function's DERIVED classes, and whether they are known at
     // all. `unclassified` is the analysis saying "this body reaches
     // something I cannot name" — it is not the empty set.
+    // The KNOWN classes and whether anything is unknown — the
+    // typed pair the model carries, not a reading of the rendered
+    // `effects` vector, which collapses to `unclassified` and
+    // discards every simultaneously known class.
     let effects_of = |f: FunctionId| -> (BTreeSet<String>, bool) {
         let row = &e.functions[f.index()];
-        let unknown = row.effects.iter().any(|c| c == "unclassified");
         let known: BTreeSet<String> = row
-            .effects
+            .effect_lower_bound
             .iter()
-            .filter(|c| c.as_str() != "unclassified")
             .flat_map(|c| effect_class_atoms(e, c))
             .collect();
-        (known, unknown)
+        (known, row.effects_unknown)
     };
     // Which relation families a hole at a function hides.
     let hole_hides = |f: FunctionId, mask: hale_model::RelationSet| {
@@ -4796,7 +4817,11 @@ pub fn judge_causes(
             // the id; the witness renders what the author wrote —
             // `Orders`, not `orders` — because a path a developer
             // reads must name the declaration they can go look at.
-            let mut published: Vec<(hale_model::SubjectId, String)> = r
+            let mut published: Vec<(
+                hale_model::SubjectId,
+                String,
+                hale_model::Publish,
+            )> = r
                 .publishes
                 .iter()
                 .filter(|p| p.function == f)
@@ -4807,37 +4832,70 @@ pub fn judge_causes(
                             .pattern
                             .clone(),
                     };
-                    (p.subject, written)
+                    (p.subject, written, p.clone())
                 })
                 .collect();
+            // An interior stdlib publish has no key domain the model
+            // records, so it widens like any unknown one.
             published.extend(
-                interior_pubs
-                    .get(&f.0)
-                    .into_iter()
-                    .flatten()
-                    .map(|s| {
-                        (*s, e.subjects[s.index()].pattern.clone())
-                    }),
+                interior_pubs.get(&f.0).into_iter().flatten().map(|s| {
+                    (
+                        *s,
+                        e.subjects[s.index()].pattern.clone(),
+                        hale_model::Publish {
+                            function: f,
+                            subject: *s,
+                            declared_topic: None,
+                            payload: hale_model::PayloadContractId(0),
+                            site: 0,
+                            in_loop: false,
+                            key_domain: None,
+                            disposition:
+                                hale_model::keys::PublishDisposition::Default,
+                            provenance: hale_model::ProvenanceId(0),
+                        },
+                    )
+                }),
             );
-            published.sort();
-            published.dedup();
-            for (subject, written) in published {
-                // Delivery incompleteness: the model admits it may
-                // not know every subscriber of this address.
+            published.sort_by(|a, b| (a.0, &a.1).cmp(&(b.0, &b.1)));
+            published.dedup_by(|a, b| a.0 == b.0 && a.1 == b.1);
+            for (subject, written, pubrow) in published {
+                // Delivery incompleteness, SCOPED TO THIS ENDPOINT.
+                // A hole somewhere else in the application says
+                // nothing about this causal closure — the model's
+                // hole law is reachability-scoped, and a global
+                // check turns an unrelated adapter binding into
+                // uncertainty about a purely local publish.
+                //
+                // The relation that matters is SUBSCRIBES (is the
+                // set of possible handlers complete?) rather than
+                // DELIVERY (the must-deliver guarantee), plus
+                // KEY_FILTERS, since an unknown filter widens who
+                // may receive.
+                let topic_here = e
+                    .topics
+                    .iter()
+                    .position(|t| t.subject == subject)
+                    .map(|i| hale_model::TopicId(i as u32));
                 if model.holes.iter().any(|h| {
-                    h.hides
-                        .intersects(hale_model::RelationSet::DELIVERY)
-                        && matches!(
-                            h.at,
-                            EntityRef::Topic(_) | EntityRef::Subject(_)
-                        )
+                    let relevant = h.hides.intersects(
+                        hale_model::RelationSet::SUBSCRIBES.union(
+                            hale_model::RelationSet::KEY_FILTERS,
+                        ),
+                    );
+                    let here = match h.at {
+                        EntityRef::Subject(s) => s == subject,
+                        EntityRef::Topic(t) => Some(t) == topic_here,
+                        _ => false,
+                    };
+                    relevant && here
                 }) {
                     uncertain = true;
                 }
                 for su in r
                     .subscribes
                     .iter()
-                    .filter(|su| possibly_delivers(e, subject, su))
+                    .filter(|su| may_deliver(e, &pubrow, su))
                 {
                     let (eff, unknown) = effects_of(su.handler);
                     if unknown {

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -1987,6 +1987,7 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             );
             rows.push(hale_model::EffectClassDecl {
                 name: n.clone(),
+                declaration_index: i as u32,
                 declared: declared.contains(&(i as u16)),
                 definition,
                 provenance: pid,

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -2066,6 +2066,9 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         BTreeMap::new();
     let mut direct_effects: BTreeMap<String, Vec<String>> =
         BTreeMap::new();
+    let mut effect_lower_bounds: BTreeMap<String, Vec<String>> =
+        BTreeMap::new();
+    let mut effects_unknown: BTreeSet<String> = BTreeSet::new();
     for k in merged.fns.keys() {
         if !user_key(k) {
             continue;
@@ -2075,6 +2078,21 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             crate::frontier::render_effects_named(eff, &effect_names);
         if !classes.is_empty() {
             derived_effects.insert(fn_name(k), classes);
+        }
+        // …and the LOWER BOUND, kept apart from the rendering.
+        // `UNCLASSIFIED` is saturation, not a bit, so the known
+        // classes cannot be masked back out of `eff` — they need a
+        // walk that flags an unnameable edge instead of swallowing
+        // the set (GH #476 Change 5f review).
+        let (known, unknown) =
+            crate::frontier::infer_effects_lower_bound(&merged, k, &ffi);
+        let known_classes =
+            crate::frontier::render_effects_named(known, &effect_names);
+        if !known_classes.is_empty() {
+            effect_lower_bounds.insert(fn_name(k), known_classes);
+        }
+        if unknown {
+            effects_unknown.insert(fn_name(k));
         }
     }
     let authored_user_class: BTreeSet<String> =
@@ -2141,6 +2159,11 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
             display: info.display.clone(),
             kind: info.kind,
             effects: derived_effects.get(n).cloned().unwrap_or_default(),
+            effect_lower_bound: effect_lower_bounds
+                .get(n)
+                .cloned()
+                .unwrap_or_default(),
+            effects_unknown: effects_unknown.contains(n),
             direct_effects: direct_effects
                 .get(n)
                 .cloned()

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -1277,7 +1277,9 @@ crates/hale-types/tests/judgment_causes.rs#1 ecb02bdcda68d85d
 crates/hale-types/tests/judgment_causes.rs#11 c81fa6ad060c49cb
 crates/hale-types/tests/judgment_causes.rs#14 cdd341d141c5f482
 crates/hale-types/tests/judgment_causes.rs#17 64c5fba72e9e8d81
+crates/hale-types/tests/judgment_causes.rs#19 cc291c164767f1cb
 crates/hale-types/tests/judgment_causes.rs#2 94b7976c2733d0a0
+crates/hale-types/tests/judgment_causes.rs#20 7a1742d24f862fac
 crates/hale-types/tests/judgment_causes.rs#3 e29c8ecbbd11aea2
 crates/hale-types/tests/judgment_causes.rs#6 09afaf25ad4e9907
 crates/hale-types/tests/judgment_causes.rs#7 9cdb5c4f31c9bea7

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -1276,6 +1276,7 @@ crates/hale-types/tests/interface_dispatch.rs#9 6f2cbe31a3a8633b
 crates/hale-types/tests/judgment_causes.rs#1 ecb02bdcda68d85d
 crates/hale-types/tests/judgment_causes.rs#11 c81fa6ad060c49cb
 crates/hale-types/tests/judgment_causes.rs#14 cdd341d141c5f482
+crates/hale-types/tests/judgment_causes.rs#17 64c5fba72e9e8d81
 crates/hale-types/tests/judgment_causes.rs#2 94b7976c2733d0a0
 crates/hale-types/tests/judgment_causes.rs#3 e29c8ecbbd11aea2
 crates/hale-types/tests/judgment_causes.rs#6 09afaf25ad4e9907

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -1274,6 +1274,7 @@ crates/hale-types/tests/interface_dispatch.rs#3 3e8236394613d0b0
 crates/hale-types/tests/interface_dispatch.rs#6 6d6f6da0dc6377b2
 crates/hale-types/tests/interface_dispatch.rs#9 6f2cbe31a3a8633b
 crates/hale-types/tests/judgment_causes.rs#1 ecb02bdcda68d85d
+crates/hale-types/tests/judgment_causes.rs#11 c81fa6ad060c49cb
 crates/hale-types/tests/judgment_causes.rs#2 94b7976c2733d0a0
 crates/hale-types/tests/judgment_causes.rs#3 e29c8ecbbd11aea2
 crates/hale-types/tests/judgment_causes.rs#6 09afaf25ad4e9907

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -1275,6 +1275,7 @@ crates/hale-types/tests/interface_dispatch.rs#6 6d6f6da0dc6377b2
 crates/hale-types/tests/interface_dispatch.rs#9 6f2cbe31a3a8633b
 crates/hale-types/tests/judgment_causes.rs#1 ecb02bdcda68d85d
 crates/hale-types/tests/judgment_causes.rs#11 c81fa6ad060c49cb
+crates/hale-types/tests/judgment_causes.rs#14 cdd341d141c5f482
 crates/hale-types/tests/judgment_causes.rs#2 94b7976c2733d0a0
 crates/hale-types/tests/judgment_causes.rs#3 e29c8ecbbd11aea2
 crates/hale-types/tests/judgment_causes.rs#6 09afaf25ad4e9907

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -1273,6 +1273,12 @@ crates/hale-types/tests/interface_dispatch.rs#2 970540114cfc4743
 crates/hale-types/tests/interface_dispatch.rs#3 3e8236394613d0b0
 crates/hale-types/tests/interface_dispatch.rs#6 6d6f6da0dc6377b2
 crates/hale-types/tests/interface_dispatch.rs#9 6f2cbe31a3a8633b
+crates/hale-types/tests/judgment_causes.rs#1 ecb02bdcda68d85d
+crates/hale-types/tests/judgment_causes.rs#2 94b7976c2733d0a0
+crates/hale-types/tests/judgment_causes.rs#3 e29c8ecbbd11aea2
+crates/hale-types/tests/judgment_causes.rs#6 09afaf25ad4e9907
+crates/hale-types/tests/judgment_causes.rs#7 9cdb5c4f31c9bea7
+crates/hale-types/tests/judgment_causes.rs#8 0f41594939b4eca0
 crates/hale-types/tests/judgment_certificates.rs#0 48c907513b2f218b
 crates/hale-types/tests/judgment_certificates.rs#11 5b19cc4370a72a2f
 crates/hale-types/tests/judgment_certificates.rs#16 7d5cf57defcf548e

--- a/crates/hale-types/tests/judgment_causes.rs
+++ b/crates/hale-types/tests/judgment_causes.rs
@@ -108,6 +108,7 @@ fn row_premises(
 fn causes_judgment_matches_the_evaluator_over_the_corpus() {
     let mut rows_compared = 0usize;
     let mut strengthened = 0usize;
+    let mut unenumerated = 0usize;
     let mut bad: Vec<String> = Vec::new();
     for p in
         hale_corpus::parseable(|s| hale_syntax::parse_source(s).is_ok())
@@ -137,8 +138,13 @@ fn causes_judgment_matches_the_evaluator_over_the_corpus() {
         let programs_v: Vec<&hale_syntax::ast::Program> = vec![&program];
         let (top, _) = hale_types::resolve::build_top_scope(&bundle);
         let graph = hale_types::bus_graph::build_bus_graph(&bundle, &top);
-        let old: Vec<hale_syntax::Diag> =
-            hale_types::frontier::causes_diags(&programs_v, &graph);
+        // PER-ASSERTION outcomes. A function may carry several
+        // `causes:` clauses and every one of them anchors its
+        // diagnostic at the same fn-name span, so a span is not an
+        // identity — joining on it lets one clause's diagnostic
+        // stand in as another clause's answer (review round 4).
+        let old: Vec<hale_types::frontier::CausesReport> =
+            hale_types::frontier::causes_reports(&programs_v, &graph);
         let bases: Vec<u32> =
             bundle.sources.iter().map(|f| f.base).collect();
         let judged = hale_types::judgment::judge_causes_witnessed(
@@ -156,11 +162,56 @@ fn causes_judgment_matches_the_evaluator_over_the_corpus() {
                 .iter()
                 .find(|r| r.ordinal == j.ordinal)
                 .expect("judged row exists");
-            let row_span = hale_types::judgment::claim_row_span(
-                &table, &bases, row,
-            );
-            let mine: Vec<&hale_syntax::Diag> =
-                old.iter().filter(|d| d.span == row_span).collect();
+            // (function, assertion ordinal) — the key both sides
+            // can produce. The lowering emits one row per `causes:`
+            // clause in source order, which is the order the
+            // evaluator enumerates them in.
+            let hale_model::ClaimIr::EffectCauses { at, .. } = &row.law
+            else {
+                continue;
+            };
+            let fn_display = at
+                .0
+                .map(|f| {
+                    model.entities.functions[f.index()].display.clone()
+                })
+                .unwrap_or_else(|| at.1.display.clone());
+            let assertion_ordinal = table
+                .rows
+                .iter()
+                .filter(|r| {
+                    matches!(
+                        &r.law,
+                        hale_model::ClaimIr::EffectCauses { at: a, .. }
+                            if a.0 == at.0
+                    )
+                })
+                .position(|r| r.ordinal == row.ordinal)
+                .expect("this row is one of its fn's causes rows");
+            let mine: Vec<&hale_syntax::Diag> = old
+                .iter()
+                .filter(|r| {
+                    r.function == fn_display
+                        && r.ordinal == assertion_ordinal
+                })
+                .filter_map(|r| r.diag.as_ref())
+                .collect();
+            let matched = old.iter().any(|r| {
+                r.function == fn_display
+                    && r.ordinal == assertion_ordinal
+            });
+            if !matched {
+                // No oracle for this row. The evaluator's root walk
+                // is non-recursive over modules, so a module-scoped
+                // `causes:` annotation is never enumerated by it —
+                // the documented Change-6 rule that unmigrated rows
+                // bridge to the old engines ONLY where the old walk
+                // demonstrably saw them. Nothing to compare against;
+                // `a_module_scoped_row_has_no_evaluator_outcome`
+                // pins that this is the reason.
+                unenumerated += 1;
+                continue;
+            }
             let old_v = if mine.is_empty() {
                 Verdict::Holds
             } else {
@@ -259,9 +310,9 @@ fn causes_judgment_matches_the_evaluator_over_the_corpus() {
         bad.join("\n")
     );
     eprintln!(
-        "causes differential: {} rows, {} with a documented \
-         divergence",
-        rows_compared, strengthened
+        "causes differential: {} rows compared, {} with a \
+         documented divergence, {} the evaluator never enumerated",
+        rows_compared, strengthened, unenumerated
     );
 }
 
@@ -969,4 +1020,140 @@ fn main() { App { }; }
         "the site that delivers was collapsed away before the \
          delivery query ran"
     );
+}
+
+/// The evaluator's root walk does not recurse into modules, so a
+/// module-scoped `causes:` annotation produces no outcome from it at
+/// all — the documented rule that unmigrated rows bridge to the old
+/// engines only where the old walk demonstrably enumerated them.
+///
+/// This is why the corpus differential SKIPS such rows rather than
+/// treating a missing outcome as `holds`: comparing against silence
+/// that means "never looked" would let anything through.
+#[test]
+fn a_module_scoped_row_has_no_evaluator_outcome() {
+    let src = r#"
+effect money;
+module billing {
+    @effects(causes: { money })
+    fn poke(v: Int) -> Int { return v; }
+}
+main locus App {
+    params { n: Int = 0; }
+    run() { println(1); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let (top, _) = hale_types::resolve::build_top_scope(&bundle);
+    let graph = hale_types::bus_graph::build_bus_graph(&bundle, &top);
+    let reports = hale_types::frontier::causes_reports(
+        &vec![&program],
+        &graph,
+    );
+    assert!(
+        reports.is_empty(),
+        "fixture premise: the evaluator never enumerates a \
+         module-scoped annotation: {:?}",
+        reports.iter().map(|r| &r.function).collect::<Vec<_>>()
+    );
+    // …while the model lowers the row and judges it.
+    let model = derive_application_model(&bundle);
+    let table = hale_types::claim_lowering::lower_claims(&bundle, &model);
+    let bases: Vec<u32> = bundle.sources.iter().map(|f| f.base).collect();
+    assert_eq!(
+        hale_types::judgment::judge_causes(&table, &model, &bases).len(),
+        1,
+        "the model judges what the evaluator could not see"
+    );
+}
+
+/// Review round 4, blocker 1: an ordinary typed outbound binding
+/// takes the causal closure out of the application. The transport
+/// is fully modeled — no hole — but the peer's behaviour is not
+/// here, so the law cannot be certified.
+#[test]
+fn a_connect_binding_leaves_the_application() {
+    let (v, _) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+locus Source {
+    bus { publish T; }
+    @effects(causes: { publish, alloc })
+    fn fire() { T <- Msg { n: 1 }; }
+}
+main locus App {
+    params { p: Source = Source { }; }
+    bindings { T: unix("/tmp/t.sock", role: connect); }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Uncertified,
+        "a connect-role send is handed to a peer this model does \
+         not contain"
+    );
+}
+
+/// Review round 4, blocker 2: two `causes:` clauses on ONE function
+/// share a span, so a span cannot be the join key. One holds and one
+/// is violated; each model row must be matched to its OWN evaluator
+/// outcome.
+#[test]
+fn two_clauses_on_one_fn_are_judged_separately() {
+    let src = r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t; }
+    fn on_t(m: Msg) { println("io"); }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { syscall, publish, alloc }, causes: { publish })
+    fn fire() { T <- Msg { n: 1 }; }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let (top, _) = hale_types::resolve::build_top_scope(&bundle);
+    let graph = hale_types::bus_graph::build_bus_graph(&bundle, &top);
+    let reports =
+        hale_types::frontier::causes_reports(&vec![&program], &graph);
+    assert_eq!(
+        reports.len(),
+        2,
+        "fixture premise: two assertions on one fn: {:?}",
+        reports.iter().map(|r| (&r.function, r.ordinal)).collect::<Vec<_>>()
+    );
+    // Same span on both — which is exactly why the ordinal is the
+    // identity.
+    let spans: Vec<_> = reports
+        .iter()
+        .filter_map(|r| r.diag.as_ref().map(|d| d.span))
+        .collect();
+    assert!(spans.windows(2).all(|w| w[0] == w[1]));
+    // The first clause covers syscall and holds; the second does not.
+    assert!(reports[0].diag.is_none(), "clause 0 holds");
+    assert!(reports[1].diag.is_some(), "clause 1 is violated");
+
+    let model = derive_application_model(&bundle);
+    let table = hale_types::claim_lowering::lower_claims(&bundle, &model);
+    let bases: Vec<u32> = bundle.sources.iter().map(|f| f.base).collect();
+    let judged =
+        hale_types::judgment::judge_causes(&table, &model, &bases);
+    assert_eq!(judged.len(), 2, "the model lowers both clauses");
+    assert_eq!(judged[0].verdict, Verdict::Holds);
+    assert_eq!(judged[1].verdict, Verdict::Violated);
 }

--- a/crates/hale-types/tests/judgment_causes.rs
+++ b/crates/hale-types/tests/judgment_causes.rs
@@ -1,20 +1,31 @@
 //! GH #476 Change 5f — `@effects(causes: …)` over the canonical
 //! model, held against the evaluator over the corpus.
 //!
-//! Same discipline as 5a–5e: the engine reproduces the evaluator's
-//! diagnostics, and the differential is what makes the cutover safe.
-//! One divergence is expected and carved out precisely — the
-//! evaluator infers effects from the USER-ONLY summary, so a
-//! subscriber whose class comes from a stdlib call reads as pure to
-//! it, and the causal contribution vanishes. The model's sets are
-//! stdlib-merged, so it sees the class. That is the fail-closed
-//! direction, and an undeclared causal effect is exactly what this
-//! law exists to catch.
+//! The first version of this differential compared rendered
+//! diagnostics only, never verdicts, and permitted ANY model-only
+//! output as "the documented stdlib divergence" — which would have
+//! blessed a false violation from an unrelated bug (review round 1).
+//! It is strict now:
+//!
+//!   * VERDICTS are compared, not just messages;
+//!   * equal-strength verdicts require byte-equal diagnostics;
+//!   * the model may only be STRICTER (holds < uncertified <
+//!     violated), never weaker — a weakening is always a fail-open;
+//!   * and a strengthening must be explained by a premise the test
+//!     computes from the program itself, not by "the model printed
+//!     more".
+//!
+//! The premises, each a place the evaluator is blind and the model
+//! is not: an unclassified body reachable as a subscriber, a
+//! completeness hole, a publish inside a stdlib interior, a delivery
+//! whose two ends spell the same wire differently, and a second bus
+//! hop.
 
 use std::collections::BTreeMap;
 
 use hale_types::model_builder::derive_application_model;
 use hale_types::symbol::SourceFile;
+use hale_types::verdict::Verdict;
 use hale_types::Bundle;
 
 fn bundle_of<'a>(
@@ -43,12 +54,72 @@ fn render(d: &hale_syntax::Diag) -> String {
     )
 }
 
+/// holds < uncertified < violated; invalid is its own answer and
+/// must match exactly.
+fn strength(v: Verdict) -> u8 {
+    match v {
+        Verdict::Holds => 0,
+        Verdict::Uncertified => 1,
+        Verdict::Violated => 2,
+        Verdict::Invalid => 3,
+    }
+}
+
+/// Why the model may legitimately be stricter than the evaluator on
+/// this program. Computed from the model, never from the output.
+fn divergence_premises(
+    model: &hale_model::ApplicationModel,
+) -> Vec<&'static str> {
+    let e = &model.entities;
+    let r = &model.relations;
+    let mut out = Vec::new();
+    // The evaluator infers effects from the user-only summary, so a
+    // subscriber whose class arrives through a stdlib call reads as
+    // pure to it.
+    if r.subscribes.iter().any(|s| {
+        !e.functions[s.handler.index()].effects.is_empty()
+    }) {
+        out.push("subscriber-effects");
+    }
+    // Unknown downstream behaviour: the model refuses to certify,
+    // the evaluator counts it as nothing.
+    if e.functions.iter().any(|f| {
+        f.effects.iter().any(|c| c == "unclassified")
+    }) {
+        out.push("unclassified-subscriber");
+    }
+    if !model.holes.is_empty() {
+        out.push("completeness-hole");
+    }
+    if !model.analyses.stdlib_absorption.is_empty() {
+        out.push("stdlib-interior");
+    }
+    // A publish and a subscription on ONE wire whose written forms
+    // differ — the join the evaluator does by text misses it.
+    if r.publishes.iter().any(|p| {
+        r.subscribes.iter().any(|s| {
+            s.subject == p.subject
+                && s.declared_topic != p.declared_topic
+        })
+    }) {
+        out.push("wire-vs-text-join");
+    }
+    // A subscriber that publishes: a second hop the evaluator's
+    // one-level walk never takes.
+    if r.subscribes
+        .iter()
+        .any(|s| r.publishes.iter().any(|p| p.function == s.handler))
+    {
+        out.push("second-hop");
+    }
+    out
+}
+
 #[test]
 fn causes_judgment_matches_the_evaluator_over_the_corpus() {
-    let mut compared = 0usize;
     let mut with_rows = 0usize;
-    let mut divergences: Vec<String> = Vec::new();
-    let mut mismatches: Vec<String> = Vec::new();
+    let mut strengthened = 0usize;
+    let mut bad: Vec<String> = Vec::new();
     for p in
         hale_corpus::parseable(|s| hale_syntax::parse_source(s).is_ok())
     {
@@ -56,7 +127,6 @@ fn causes_judgment_matches_the_evaluator_over_the_corpus() {
             continue;
         };
         let bundle = bundle_of(&p.source, &program);
-        // The model describes CHECKED programs only.
         if hale_types::check_bundle_opts(&bundle, false)
             .iter()
             .any(|d| {
@@ -69,54 +139,99 @@ fn causes_judgment_matches_the_evaluator_over_the_corpus() {
         let model = derive_application_model(&bundle);
         let table =
             hale_types::claim_lowering::lower_claims(&bundle, &model);
-        let has_causes = table.rows.iter().any(|r| {
+        if !table.rows.iter().any(|r| {
             matches!(r.law, hale_model::ClaimIr::EffectCauses { .. })
-        });
-        if !has_causes {
+        }) {
             continue;
         }
-        compared += 1;
         with_rows += 1;
 
         let programs_v: Vec<&hale_syntax::ast::Program> = vec![&program];
         let (top, _) = hale_types::resolve::build_top_scope(&bundle);
         let graph = hale_types::bus_graph::build_bus_graph(&bundle, &top);
-        let old: Vec<String> =
+        let old_diags: Vec<String> =
             hale_types::frontier::causes_diags(&programs_v, &graph)
                 .iter()
                 .map(render)
                 .collect();
         let bases: Vec<u32> =
             bundle.sources.iter().map(|f| f.base).collect();
-        let new: Vec<String> =
-            hale_types::judgment::judge_causes(&table, &model, &bases)
-                .iter()
-                .flat_map(|j| j.diags.iter())
-                .map(render)
-                .collect();
-        if old == new {
+        let judged =
+            hale_types::judgment::judge_causes(&table, &model, &bases);
+        let new_diags: Vec<String> = judged
+            .iter()
+            .flat_map(|j| j.diags.iter())
+            .map(render)
+            .collect();
+
+        // The evaluator has no verdict channel: a diagnostic is a
+        // violation, silence is a pass. Compare at that grain.
+        let old_v = if old_diags.is_empty() {
+            Verdict::Holds
+        } else {
+            Verdict::Violated
+        };
+        // How each side expresses "I don't know". The evaluator
+        // SATURATES: the unclassified bit unions in as every class
+        // at once, so its message asserts `can transitively cause
+        // syscall, block, time, entropy, env, secret_use` — a
+        // definite claim about classes nobody observed, built on the
+        // absence of information. The model answers `Uncertified`,
+        // which is the vocabulary this epic settled on for exactly
+        // that evidence (Change 6: uncertified is a state distinct
+        // from violated). Neither certifies; they differ in what
+        // they are willing to assert.
+        //
+        // Read off the MODEL, not the message: an unclassified body
+        // sits on a delivered-to path.
+        let premises_here = divergence_premises(&model);
+        let evaluator_guessed =
+            premises_here.contains(&"unclassified-subscriber");
+        for j in &judged {
+            let weaker = strength(j.verdict) < strength(old_v);
+            let honest_uncertified = evaluator_guessed
+                && j.verdict == Verdict::Uncertified;
+            if weaker && !honest_uncertified {
+                bad.push(format!(
+                    "{}: model is WEAKER ({:?} vs evaluator {:?}) — a \
+                     fail-open",
+                    p.origin, j.verdict, old_v
+                ));
+            }
+        }
+        if evaluator_guessed
+            && judged.iter().all(|j| j.verdict == Verdict::Uncertified)
+        {
+            strengthened += 1;
             continue;
         }
-        // The documented divergence: the model may only ADD a
-        // violation the user-only summary could not see.
-        let old_only: Vec<&String> =
-            old.iter().filter(|l| !new.contains(l)).collect();
-        if old_only.is_empty() && !new.is_empty() {
-            divergences.push(p.origin.clone());
+        let model_v = judged
+            .iter()
+            .map(|j| j.verdict)
+            .max_by_key(|v| strength(*v))
+            .unwrap_or(Verdict::Holds);
+        if strength(model_v) == strength(old_v) {
+            if old_diags != new_diags {
+                bad.push(format!(
+                    "{}: same verdict, different diagnostics:\n  \
+                     evaluator: {:?}\n  model:     {:?}",
+                    p.origin, old_diags, new_diags
+                ));
+            }
             continue;
         }
-        mismatches.push(format!(
-            "--- {} ---\n  evaluator:\n{}\n  model:\n{}",
-            p.origin,
-            old.iter()
-                .map(|l| format!("    {}", l))
-                .collect::<Vec<_>>()
-                .join("\n"),
-            new.iter()
-                .map(|l| format!("    {}", l))
-                .collect::<Vec<_>>()
-                .join("\n"),
-        ));
+        // Stricter: allowed only with a premise, and the premise is
+        // read off the model.
+        let premises = premises_here;
+        if premises.is_empty() {
+            bad.push(format!(
+                "{}: model is stricter ({:?} vs {:?}) with NO premise \
+                 that explains it:\n  evaluator: {:?}\n  model:     {:?}",
+                p.origin, model_v, old_v, old_diags, new_diags
+            ));
+            continue;
+        }
+        strengthened += 1;
     }
     assert!(
         with_rows > 0,
@@ -124,15 +239,354 @@ fn causes_judgment_matches_the_evaluator_over_the_corpus() {
          would pass vacuously"
     );
     assert!(
-        mismatches.is_empty(),
-        "{} of {} programs diverge outside the documented class:\n{}",
-        mismatches.len(),
-        compared,
-        mismatches.join("\n")
+        bad.is_empty(),
+        "{} programs disagree:\n{}",
+        bad.len(),
+        bad.join("\n")
     );
     eprintln!(
-        "causes differential: {} programs, {} documented divergences",
-        compared,
-        divergences.len()
+        "causes differential: {} programs, {} strengthened",
+        with_rows, strengthened
     );
+}
+
+// ===================== negative controls =========================
+//
+// Each drops or perturbs ONE relation the engine claims to read and
+// requires the verdict to move. A judgment that ignores a relation
+// cannot fail these.
+
+fn judge(src: &str) -> (Verdict, String) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let model = derive_application_model(&bundle);
+    let table = hale_types::claim_lowering::lower_claims(&bundle, &model);
+    let bases: Vec<u32> = bundle.sources.iter().map(|f| f.base).collect();
+    let judged = hale_types::judgment::judge_causes(&table, &model, &bases);
+    let j = judged.first().expect("a causes row was judged");
+    (
+        j.verdict,
+        j.diags.iter().map(|d| d.message.clone()).collect::<Vec<_>>().join(" | "),
+    )
+}
+
+/// The reviewer's fixture: an unclassified subscriber is UNKNOWN
+/// behaviour, not absent behaviour.
+#[test]
+fn an_unclassified_subscriber_is_uncertified_not_holds() {
+    let (v, _) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+fn does_syscall(x: Int) -> Int { println("side effect"); return x; }
+fn apply(f: fn (Int) -> Int, x: Int) -> Int { return f(x); }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t; }
+    fn on_t(m: Msg) { self.n = apply(does_syscall, m.n); }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { publish, alloc })
+    fn fire() { T <- Msg { n: 1 }; }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Uncertified,
+        "an indirect call the analysis cannot follow makes the \
+         causal set a lower bound, not an answer"
+    );
+}
+
+/// The reviewer's second fixture: publisher and subscriber name ONE
+/// wire in two spellings. Delivery is real, so the downstream
+/// syscall is caused.
+#[test]
+fn a_wire_identity_join_finds_the_delivery() {
+    let (v, msg) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic Orders { payload: Msg; subject: "orders"; }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe "orders" as on_order of type Msg; }
+    fn on_order(m: Msg) { println("received"); }
+}
+locus Source {
+    bus { publish Orders; }
+    @effects(causes: { publish, alloc })
+    fn fire() { Orders <- Msg { n: 1 }; }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Violated,
+        "a topic-name publish and a literal subscribe on the same \
+         wire deliver; comparing rendered text certified it away"
+    );
+    assert!(
+        msg.contains("syscall"),
+        "the downstream syscall is the excess: {}",
+        msg
+    );
+}
+
+/// The reviewer's third fixture: a class occurring BOTH locally and
+/// downstream is still caused downstream. Set subtraction erased it.
+#[test]
+fn a_local_occurrence_does_not_erase_the_downstream_one() {
+    let (v, msg) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t; }
+    fn on_t(m: Msg) { println("downstream syscall"); }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { publish, alloc })
+    fn fire() { println("local syscall"); T <- Msg { n: 1 }; }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Violated,
+        "the downstream syscall is caused whether or not the same \
+         class also occurs locally"
+    );
+    assert!(msg.contains("syscall"), "{}", msg);
+}
+
+/// `ffi` IS the syscall bit. A declaration naming it must satisfy an
+/// actual set that spells the same bit `syscall` — the false
+/// rejection the old differential would have blessed.
+#[test]
+fn ffi_declares_the_syscall_bit() {
+    let (v, msg) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t; }
+    fn on_t(m: Msg) { println("io"); }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { ffi, publish, alloc })
+    fn fire() { T <- Msg { n: 1 }; }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Holds,
+        "`causes: {{ffi}}` covers a downstream syscall: {}",
+        msg
+    );
+}
+
+/// Canonical rendering: built-ins in the language's fixed order,
+/// then user classes in DECLARATION order — not the lexical order a
+/// set iterates in.
+#[test]
+fn excess_classes_render_in_canonical_order() {
+    let (v, msg) = judge(
+        r#"
+effect zeta;
+effect alpha;
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+@effects(is: { zeta })
+fn z(v: Int) -> Int { return v; }
+@effects(is: { alpha })
+fn a(v: Int) -> Int { return v; }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t; }
+    fn on_t(m: Msg) { self.n = z(m.n) + a(m.n); println("io"); }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { publish, alloc })
+    fn fire() { T <- Msg { n: 1 }; }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(v, Verdict::Violated);
+    let at = |c: &str| msg.find(c).unwrap_or(usize::MAX);
+    assert!(
+        at("syscall") < at("zeta"),
+        "built-ins render before user classes: {}",
+        msg
+    );
+    assert!(
+        at("zeta") < at("alpha"),
+        "user classes render in DECLARATION order (zeta declared \
+         first), not lexically: {}",
+        msg
+    );
+}
+
+/// The engine reads the CALLS relation: a publish reached only
+/// through a call is still the root's doing.
+#[test]
+fn a_publish_behind_a_call_is_still_caused() {
+    let (v, _) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t; }
+    fn on_t(m: Msg) { println("io"); }
+}
+locus Source {
+    bus { publish T; }
+    fn emit() { T <- Msg { n: 1 }; }
+    @effects(causes: { publish, alloc })
+    fn fire() { self.emit(); }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Violated,
+        "the causal walk follows calls to find publish sites"
+    );
+}
+
+/// …and it follows a SECOND hop: a handler that publishes carries
+/// the root's causality onward.
+#[test]
+fn a_second_bus_hop_is_caused_too() {
+    let (v, _) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic First { payload: Msg; subject: "first"; }
+topic Second { payload: Msg; subject: "second"; }
+locus Relay {
+    params { n: Int = 0; }
+    bus { subscribe First as on_first; publish Second; }
+    fn on_first(m: Msg) { Second <- m; }
+}
+locus Deep {
+    params { n: Int = 0; }
+    bus { subscribe Second as on_second; }
+    fn on_second(m: Msg) { println("io"); }
+}
+locus Source {
+    bus { publish First; }
+    @effects(causes: { publish, alloc })
+    fn fire() { First <- Msg { n: 1 }; }
+}
+main locus App {
+    params { r: Relay = Relay { }; d: Deep = Deep { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Violated,
+        "`causes` asks what this fn can cause ANYWHERE — the walk \
+         does not stop at the first delivery"
+    );
+}
+
+/// A wildcard subscription covers the concrete subject published.
+#[test]
+fn a_wildcard_subscriber_receives_the_publish() {
+    let (v, _) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic Created { payload: Msg; subject: "orders.created"; }
+locus Audit {
+    params { n: Int = 0; }
+    bus { subscribe "orders.**" as on_any of type Msg; }
+    fn on_any(m: Msg) { println("io"); }
+}
+locus Source {
+    bus { publish Created; }
+    @effects(causes: { publish, alloc })
+    fn fire() { Created <- Msg { n: 1 }; }
+}
+main locus App {
+    params { a: Audit = Audit { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Violated,
+        "`orders.**` covers `orders.created`"
+    );
+}
+
+/// The control that keeps the rest honest: a genuinely pure
+/// downstream still HOLDS. Without it, an engine that answered
+/// `violated` unconditionally would pass every test above.
+#[test]
+fn a_pure_downstream_holds() {
+    let (v, msg) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t; }
+    fn on_t(m: Msg) { self.n = m.n + 1; }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { publish, alloc })
+    fn fire() { T <- Msg { n: 1 }; }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(v, Verdict::Holds, "nothing undeclared is caused: {}", msg);
 }

--- a/crates/hale-types/tests/judgment_causes.rs
+++ b/crates/hale-types/tests/judgment_causes.rs
@@ -65,59 +65,48 @@ fn strength(v: Verdict) -> u8 {
     }
 }
 
-/// Why the model may legitimately be stricter than the evaluator on
-/// this program. Computed from the model, never from the output.
-fn divergence_premises(
+/// Why the model may legitimately differ from the evaluator ON THIS
+/// ROW — read from the row's own traversal witness, never from
+/// facts elsewhere in the program. A hole on an unrelated topic, an
+/// unclassified function nothing delivers to, a stdlib interior
+/// another law crosses: none of them excuse a different answer
+/// here.
+fn row_premises(
     model: &hale_model::ApplicationModel,
+    w: &hale_types::judgment::CausesWitness,
 ) -> Vec<&'static str> {
-    let e = &model.entities;
-    let r = &model.relations;
     let mut out = Vec::new();
-    // The evaluator infers effects from the user-only summary, so a
-    // subscriber whose class arrives through a stdlib call reads as
-    // pure to it.
-    if r.subscribes.iter().any(|s| {
-        !e.functions[s.handler.index()].effects.is_empty()
-    }) {
-        out.push("subscriber-effects");
+    if !w.unknown_handlers.is_empty() {
+        out.push("unclassified-handler-on-path");
     }
-    // Unknown downstream behaviour: the model refuses to certify,
-    // the evaluator counts it as nothing.
-    if e.functions.iter().any(|f| {
-        f.effects.iter().any(|c| c == "unclassified")
-    }) {
-        out.push("unclassified-subscriber");
+    if !w.incomplete_endpoints.is_empty() {
+        out.push("incomplete-endpoint-on-path");
     }
-    if !model.holes.is_empty() {
-        out.push("completeness-hole");
+    if !w.incomplete_discovery.is_empty() {
+        out.push("incomplete-discovery-on-path");
     }
-    if !model.analyses.stdlib_absorption.is_empty() {
-        out.push("stdlib-interior");
+    if w.crossed_stdlib_interior {
+        out.push("stdlib-interior-on-path");
     }
-    // A publish and a subscription on ONE wire whose written forms
-    // differ — the join the evaluator does by text misses it.
-    if r.publishes.iter().any(|p| {
-        r.subscribes.iter().any(|s| {
-            s.subject == p.subject
-                && s.declared_topic != p.declared_topic
-        })
-    }) {
-        out.push("wire-vs-text-join");
-    }
-    // A subscriber that publishes: a second hop the evaluator's
-    // one-level walk never takes.
-    if r.subscribes
-        .iter()
-        .any(|s| r.publishes.iter().any(|p| p.function == s.handler))
-    {
+    if w.multi_hop {
         out.push("second-hop");
+    }
+    // The evaluator infers effects from the user-only summary, so a
+    // handler this row reaches whose classes come through a stdlib
+    // call reads as pure to it.
+    if w.reached_handlers.iter().any(|h| {
+        !model.entities.functions[h.index()]
+            .effect_lower_bound
+            .is_empty()
+    }) {
+        out.push("reached-handler-effects");
     }
     out
 }
 
 #[test]
 fn causes_judgment_matches_the_evaluator_over_the_corpus() {
-    let mut with_rows = 0usize;
+    let mut rows_compared = 0usize;
     let mut strengthened = 0usize;
     let mut bad: Vec<String> = Vec::new();
     for p in
@@ -144,136 +133,135 @@ fn causes_judgment_matches_the_evaluator_over_the_corpus() {
         }) {
             continue;
         }
-        with_rows += 1;
 
         let programs_v: Vec<&hale_syntax::ast::Program> = vec![&program];
         let (top, _) = hale_types::resolve::build_top_scope(&bundle);
         let graph = hale_types::bus_graph::build_bus_graph(&bundle, &top);
-        let old_diags: Vec<String> =
-            hale_types::frontier::causes_diags(&programs_v, &graph)
-                .iter()
-                .map(render)
-                .collect();
+        let old: Vec<hale_syntax::Diag> =
+            hale_types::frontier::causes_diags(&programs_v, &graph);
         let bases: Vec<u32> =
             bundle.sources.iter().map(|f| f.base).collect();
-        let judged =
-            hale_types::judgment::judge_causes(&table, &model, &bases);
-        let new_diags: Vec<String> = judged
-            .iter()
-            .flat_map(|j| j.diags.iter())
-            .map(render)
-            .collect();
+        let judged = hale_types::judgment::judge_causes_witnessed(
+            &table, &model, &bases,
+        );
 
-        // The evaluator has no verdict channel: a diagnostic is a
-        // violation, silence is a pass. Compare at that grain.
-        let old_v = if old_diags.is_empty() {
-            Verdict::Holds
-        } else {
-            Verdict::Violated
-        };
-        // How each side expresses "I don't know". The evaluator
-        // SATURATES: the unclassified bit unions in as every class
-        // at once, so its message asserts `can transitively cause
-        // syscall, block, time, entropy, env, secret_use` — a
-        // definite claim about classes nobody observed, built on the
-        // absence of information. The model answers `Uncertified`,
-        // which is the vocabulary this epic settled on for exactly
-        // that evidence (Change 6: uncertified is a state distinct
-        // from violated). Neither certifies; they differ in what
-        // they are willing to assert.
-        //
-        // Read off the MODEL, not the message: an unclassified body
-        // sits on a delivered-to path.
-        let premises_here = divergence_premises(&model);
-        let evaluator_guessed =
-            premises_here.contains(&"unclassified-subscriber");
-        for j in &judged {
-            let weaker = strength(j.verdict) < strength(old_v);
-            let honest_uncertified = evaluator_guessed
-                && j.verdict == Verdict::Uncertified;
-            if weaker && !honest_uncertified {
-                bad.push(format!(
-                    "{}: model is WEAKER ({:?} vs evaluator {:?}) — a \
-                     fail-open",
-                    p.origin, j.verdict, old_v
-                ));
+        // ONE LAW TO ONE LAW. Both sides anchor a causes diagnostic
+        // at the annotated fn's name span, which is also the row's
+        // provenance — so the rows and the evaluator's outcomes join
+        // on span. A program-wide "any diagnostic means violated"
+        // compares row B against row A's answer.
+        for (j, w) in &judged {
+            let row = table
+                .rows
+                .iter()
+                .find(|r| r.ordinal == j.ordinal)
+                .expect("judged row exists");
+            let row_span = hale_types::judgment::claim_row_span(
+                &table, &bases, row,
+            );
+            let mine: Vec<&hale_syntax::Diag> =
+                old.iter().filter(|d| d.span == row_span).collect();
+            let old_v = if mine.is_empty() {
+                Verdict::Holds
+            } else {
+                Verdict::Violated
+            };
+            rows_compared += 1;
+            let premises = row_premises(&model, w);
+            // The evaluator SATURATES on unknown: it unions the
+            // unclassified marker as every class at once and asserts
+            // them. `Uncertified` is this epic's vocabulary for that
+            // same evidence, so it is not a weakening — but only
+            // when an unknown handler is actually on THIS row's
+            // path.
+            let saturating = premises
+                .contains(&"unclassified-handler-on-path");
+            let mine_text: String = mine
+                .iter()
+                .map(|d| d.message.clone())
+                .collect::<Vec<_>>()
+                .join(" ");
+            let new_text: String = j
+                .diags
+                .iter()
+                .map(|d| d.message.clone())
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            if strength(j.verdict) < strength(old_v) {
+                if !(saturating && j.verdict == Verdict::Uncertified) {
+                    bad.push(format!(
+                        "{} ordinal {}: model is WEAKER ({:?} vs {:?}) \
+                         — a fail-open",
+                        p.origin, j.ordinal, j.verdict, old_v
+                    ));
+                }
+                strengthened += 1;
+                continue;
             }
-        }
-        if evaluator_guessed
-            && judged.iter().all(|j| j.verdict == Verdict::Uncertified)
-        {
-            strengthened += 1;
-            continue;
-        }
-        let model_v = judged
-            .iter()
-            .map(|j| j.verdict)
-            .max_by_key(|v| strength(*v))
-            .unwrap_or(Verdict::Holds);
-        if strength(model_v) == strength(old_v) {
-            // When the evaluator saturated, its message lists every
-            // class at once and the model's lists only what it
-            // knows. Comparable as a SUBSET, not byte-for-byte: the
-            // model may name fewer classes, never a class the
-            // evaluator did not.
-            if evaluator_guessed {
-                let evaluator_text = old_diags.join(" ");
+            if strength(j.verdict) > strength(old_v) {
+                if premises.is_empty() {
+                    bad.push(format!(
+                        "{} ordinal {}: model is stricter ({:?} vs \
+                         {:?}) with NO premise on this row's path\n  \
+                         evaluator: {}\n  model: {}",
+                        p.origin, j.ordinal, j.verdict, old_v,
+                        mine_text, new_text
+                    ));
+                }
+                strengthened += 1;
+                continue;
+            }
+            // Equal strength: byte-equal messages, except that a
+            // saturated evaluator message is compared as a SUPERSET
+            // of the model's class list.
+            if saturating {
                 let invented: Vec<&str> = [
                     "syscall", "block", "publish", "time", "entropy",
                     "env", "alloc", "secret_use",
                 ]
                 .into_iter()
                 .filter(|c| {
-                    new_diags.iter().any(|d| d.contains(c))
-                        && !evaluator_text.contains(c)
+                    new_text.contains(c) && !mine_text.contains(c)
                 })
                 .collect();
                 if !invented.is_empty() {
                     bad.push(format!(
-                        "{}: the model names classes the evaluator \
-                         did not: {:?}",
-                        p.origin, invented
+                        "{} ordinal {}: the model names classes the \
+                         evaluator did not: {:?}",
+                        p.origin, j.ordinal, invented
                     ));
                 }
-                strengthened += 1;
                 continue;
             }
-            if old_diags != new_diags {
+            let old_rendered: Vec<String> =
+                mine.iter().map(|d| render(d)).collect();
+            let new_rendered: Vec<String> =
+                j.diags.iter().map(render).collect();
+            if old_rendered != new_rendered {
                 bad.push(format!(
-                    "{}: same verdict, different diagnostics:\n  \
-                     evaluator: {:?}\n  model:     {:?}",
-                    p.origin, old_diags, new_diags
+                    "{} ordinal {}: same verdict, different \
+                     diagnostics:\n  evaluator: {:?}\n  model: {:?}",
+                    p.origin, j.ordinal, old_rendered, new_rendered
                 ));
             }
-            continue;
         }
-        // Stricter: allowed only with a premise, and the premise is
-        // read off the model.
-        let premises = premises_here;
-        if premises.is_empty() {
-            bad.push(format!(
-                "{}: model is stricter ({:?} vs {:?}) with NO premise \
-                 that explains it:\n  evaluator: {:?}\n  model:     {:?}",
-                p.origin, model_v, old_v, old_diags, new_diags
-            ));
-            continue;
-        }
-        strengthened += 1;
     }
     assert!(
-        with_rows > 0,
+        rows_compared > 0,
         "the corpus must exercise `causes:` — the differential \
          would pass vacuously"
     );
     assert!(
         bad.is_empty(),
-        "{} programs disagree:\n{}",
+        "{} rows disagree:\n{}",
         bad.len(),
         bad.join("\n")
     );
     eprintln!(
-        "causes differential: {} programs, {} strengthened",
-        with_rows, strengthened
+        "causes differential: {} rows, {} with a documented \
+         divergence",
+        rows_compared, strengthened
     );
 }
 
@@ -876,4 +864,109 @@ fn main() { App { }; }
 "#,
     );
     assert_eq!(v, Verdict::Violated);
+}
+
+/// Review round 3, blocker 2: a binding on the PUBLISHED topic is
+/// an opaque boundary. The publish leaves the program; whatever the
+/// adapter or its peer does is not in this graph, so the law cannot
+/// be certified — the mirror of the unrelated-binding control,
+/// which must stay `Holds`.
+#[test]
+fn a_binding_on_the_published_topic_is_uncertified() {
+    let (v, _) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+locus MyAdapter {
+    params { n: Int = 0; }
+    fn send(subject: String, bytes: Bytes) { self.n = self.n + 1; }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { publish, alloc })
+    fn fire() { T <- Msg { n: 1 }; }
+}
+main locus App {
+    params { p: Source = Source { }; }
+    bindings { T: MyAdapter { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Uncertified,
+        "the publish crosses an opaque external boundary"
+    );
+}
+
+/// Review round 3, blocker 1: publish SITES survive the delivery
+/// query. Two sites on one subject with different exact key
+/// domains — only one of which reaches the `key == 2` subscriber —
+/// must not collapse before `may_deliver` runs.
+///
+/// The builder records `AnyOfType` for a literal send, so the exact
+/// domains are set on the derived model (a lawful state `validate`
+/// accepts) to reach the shape the engine must handle.
+#[test]
+fn publish_sites_survive_the_delivery_query() {
+    use hale_model::keys::{KeyDomain, KeyValue};
+    let src = r#"
+type Msg { shard: Int = 0; }
+topic T { payload: Msg; subject: "t"; keyed_by shard; }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t where key == 2; }
+    fn on_t(m: Msg) { println("io"); }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { publish, alloc })
+    fn fire() {
+        T <- Msg { shard: 1 };
+        T <- Msg { shard: 2 };
+    }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let mut model = derive_application_model(&bundle);
+    // Two sites, distinct exact domains: site 0 produces key 1
+    // (never delivered), site 1 produces key 2 (delivered).
+    let mut sites: Vec<usize> = model
+        .relations
+        .publishes
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| p.key_domain.is_some())
+        .map(|(i, _)| i)
+        .collect();
+    sites.sort();
+    assert_eq!(
+        sites.len(),
+        2,
+        "fixture premise: two keyed publish sites"
+    );
+    model.relations.publishes[sites[0]].key_domain =
+        Some(KeyDomain::Exact(vec![KeyValue::Int(1)]));
+    model.relations.publishes[sites[1]].key_domain =
+        Some(KeyDomain::Exact(vec![KeyValue::Int(2)]));
+    model.validate().expect("still a lawful model");
+
+    let table = hale_types::claim_lowering::lower_claims(&bundle, &model);
+    let bases: Vec<u32> = bundle.sources.iter().map(|f| f.base).collect();
+    let judged =
+        hale_types::judgment::judge_causes(&table, &model, &bases);
+    assert_eq!(
+        judged.first().expect("a row").verdict,
+        Verdict::Violated,
+        "the site that delivers was collapsed away before the \
+         delivery query ran"
+    );
 }

--- a/crates/hale-types/tests/judgment_causes.rs
+++ b/crates/hale-types/tests/judgment_causes.rs
@@ -1,0 +1,138 @@
+//! GH #476 Change 5f — `@effects(causes: …)` over the canonical
+//! model, held against the evaluator over the corpus.
+//!
+//! Same discipline as 5a–5e: the engine reproduces the evaluator's
+//! diagnostics, and the differential is what makes the cutover safe.
+//! One divergence is expected and carved out precisely — the
+//! evaluator infers effects from the USER-ONLY summary, so a
+//! subscriber whose class comes from a stdlib call reads as pure to
+//! it, and the causal contribution vanishes. The model's sets are
+//! stdlib-merged, so it sees the class. That is the fail-closed
+//! direction, and an undeclared causal effect is exactly what this
+//! law exists to catch.
+
+use std::collections::BTreeMap;
+
+use hale_types::model_builder::derive_application_model;
+use hale_types::symbol::SourceFile;
+use hale_types::Bundle;
+
+fn bundle_of<'a>(
+    src: &str,
+    program: &'a hale_syntax::ast::Program,
+) -> Bundle<'a> {
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), program);
+    let mut b = Bundle::new(programs);
+    b.sources = vec![SourceFile {
+        id: 0,
+        path: "app.hl".to_string(),
+        digest: "0".to_string(),
+        base: 0,
+        len: src.len() as u32,
+    }];
+    b
+}
+
+fn render(d: &hale_syntax::Diag) -> String {
+    format!(
+        "[{}..{}] {}",
+        d.span.start.as_usize(),
+        d.span.end.as_usize(),
+        d.message
+    )
+}
+
+#[test]
+fn causes_judgment_matches_the_evaluator_over_the_corpus() {
+    let mut compared = 0usize;
+    let mut with_rows = 0usize;
+    let mut divergences: Vec<String> = Vec::new();
+    let mut mismatches: Vec<String> = Vec::new();
+    for p in
+        hale_corpus::parseable(|s| hale_syntax::parse_source(s).is_ok())
+    {
+        let Ok(program) = hale_syntax::parse_source(&p.source) else {
+            continue;
+        };
+        let bundle = bundle_of(&p.source, &program);
+        // The model describes CHECKED programs only.
+        if hale_types::check_bundle_opts(&bundle, false)
+            .iter()
+            .any(|d| {
+                d.is_error()
+                    && d.kind != hale_syntax::error::DiagKind::Claim
+            })
+        {
+            continue;
+        }
+        let model = derive_application_model(&bundle);
+        let table =
+            hale_types::claim_lowering::lower_claims(&bundle, &model);
+        let has_causes = table.rows.iter().any(|r| {
+            matches!(r.law, hale_model::ClaimIr::EffectCauses { .. })
+        });
+        if !has_causes {
+            continue;
+        }
+        compared += 1;
+        with_rows += 1;
+
+        let programs_v: Vec<&hale_syntax::ast::Program> = vec![&program];
+        let (top, _) = hale_types::resolve::build_top_scope(&bundle);
+        let graph = hale_types::bus_graph::build_bus_graph(&bundle, &top);
+        let old: Vec<String> =
+            hale_types::frontier::causes_diags(&programs_v, &graph)
+                .iter()
+                .map(render)
+                .collect();
+        let bases: Vec<u32> =
+            bundle.sources.iter().map(|f| f.base).collect();
+        let new: Vec<String> =
+            hale_types::judgment::judge_causes(&table, &model, &bases)
+                .iter()
+                .flat_map(|j| j.diags.iter())
+                .map(render)
+                .collect();
+        if old == new {
+            continue;
+        }
+        // The documented divergence: the model may only ADD a
+        // violation the user-only summary could not see.
+        let old_only: Vec<&String> =
+            old.iter().filter(|l| !new.contains(l)).collect();
+        if old_only.is_empty() && !new.is_empty() {
+            divergences.push(p.origin.clone());
+            continue;
+        }
+        mismatches.push(format!(
+            "--- {} ---\n  evaluator:\n{}\n  model:\n{}",
+            p.origin,
+            old.iter()
+                .map(|l| format!("    {}", l))
+                .collect::<Vec<_>>()
+                .join("\n"),
+            new.iter()
+                .map(|l| format!("    {}", l))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        ));
+    }
+    assert!(
+        with_rows > 0,
+        "the corpus must exercise `causes:` — the differential \
+         would pass vacuously"
+    );
+    assert!(
+        mismatches.is_empty(),
+        "{} of {} programs diverge outside the documented class:\n{}",
+        mismatches.len(),
+        compared,
+        mismatches.join("\n")
+    );
+    eprintln!(
+        "causes differential: {} programs, {} documented divergences",
+        compared,
+        divergences.len()
+    );
+}

--- a/crates/hale-types/tests/judgment_causes.rs
+++ b/crates/hale-types/tests/judgment_causes.rs
@@ -211,6 +211,33 @@ fn causes_judgment_matches_the_evaluator_over_the_corpus() {
             .max_by_key(|v| strength(*v))
             .unwrap_or(Verdict::Holds);
         if strength(model_v) == strength(old_v) {
+            // When the evaluator saturated, its message lists every
+            // class at once and the model's lists only what it
+            // knows. Comparable as a SUBSET, not byte-for-byte: the
+            // model may name fewer classes, never a class the
+            // evaluator did not.
+            if evaluator_guessed {
+                let evaluator_text = old_diags.join(" ");
+                let invented: Vec<&str> = [
+                    "syscall", "block", "publish", "time", "entropy",
+                    "env", "alloc", "secret_use",
+                ]
+                .into_iter()
+                .filter(|c| {
+                    new_diags.iter().any(|d| d.contains(c))
+                        && !evaluator_text.contains(c)
+                })
+                .collect();
+                if !invented.is_empty() {
+                    bad.push(format!(
+                        "{}: the model names classes the evaluator \
+                         did not: {:?}",
+                        p.origin, invented
+                    ));
+                }
+                strengthened += 1;
+                continue;
+            }
             if old_diags != new_diags {
                 bad.push(format!(
                     "{}: same verdict, different diagnostics:\n  \
@@ -589,4 +616,264 @@ fn main() { App { }; }
 "#,
     );
     assert_eq!(v, Verdict::Holds, "nothing undeclared is caused: {}", msg);
+}
+
+/// Review round 2, blocker 1: a KNOWN excess beats uncertainty.
+///
+/// The handler definitely performs a syscall AND makes an indirect
+/// call. The declaration does not cover syscall, so the law is
+/// already violated whatever the indirect call turns out to do —
+/// monotone, and the reason the model must keep a lower bound
+/// rather than a rendered `unclassified` token that discards it.
+#[test]
+fn a_known_excess_beats_uncertainty() {
+    let (v, msg) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+fn id(x: Int) -> Int { return x; }
+fn apply(f: fn (Int) -> Int, x: Int) -> Int { return f(x); }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t; }
+    fn on_t(m: Msg) {
+        println("definite syscall");
+        self.n = apply(id, m.n);
+    }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { publish, alloc })
+    fn fire() { T <- Msg { n: 1 }; }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Violated,
+        "a known syscall already exceeds the declaration: {}",
+        msg
+    );
+    assert!(msg.contains("syscall"), "{}", msg);
+}
+
+/// …and the anti-control: the SAME indirect call with nothing known
+/// beyond the declaration stays `Uncertified`. Without this, an
+/// engine that answered `Violated` on any uncertainty would pass
+/// the test above.
+#[test]
+fn uncertainty_without_a_known_excess_is_uncertified() {
+    let (v, _) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+fn id(x: Int) -> Int { return x; }
+fn apply(f: fn (Int) -> Int, x: Int) -> Int { return f(x); }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t; }
+    fn on_t(m: Msg) { self.n = apply(id, m.n); }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { publish, alloc })
+    fn fire() { T <- Msg { n: 1 }; }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(v, Verdict::Uncertified);
+}
+
+/// Review round 2, blocker 2: uncertainty is RELEVANCE-SCOPED. An
+/// unrelated adapter-bound topic is a hole somewhere else in the
+/// application; nothing on this causal closure reaches it, so it
+/// must not turn a local `Holds` into `Uncertified`.
+#[test]
+fn an_unrelated_binding_does_not_poison_the_law() {
+    let (v, _) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+topic Unrelated { payload: Msg; subject: "unrelated"; }
+locus MyAdapter {
+    params { n: Int = 0; }
+    fn send(subject: String, bytes: Bytes) { self.n = self.n + 1; }
+}
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t; }
+    fn on_t(m: Msg) { self.n = m.n + 1; }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { publish, alloc })
+    fn fire() { T <- Msg { n: 1 }; }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    bindings { Unrelated: MyAdapter { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Holds,
+        "a hole on an unrelated topic says nothing about this \
+         causal closure"
+    );
+}
+
+/// Keyed delivery widens when the produced key is not statically
+/// known. The builder records this publish's domain as
+/// `AnyOfType(Int)` — it does not read `1` out of the literal — so
+/// the edge is possible and the law is violated. The conservative
+/// direction, and the reviewer's "unknown domain still creates the
+/// possible edge" control.
+#[test]
+fn an_unknown_key_domain_widens_conservatively() {
+    let (v, _) = judge(
+        r#"
+type Msg { shard: Int = 0; }
+topic T { payload: Msg; subject: "t"; keyed_by shard; }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t where key == 2; }
+    fn on_t(m: Msg) { println("io"); }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { publish, alloc })
+    fn fire() { T <- Msg { shard: 1 }; }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Violated,
+        "an unknown produced key cannot rule the delivery out"
+    );
+}
+
+/// …and the disjointness rule itself, pinned where it lives. A
+/// lawful model CAN carry an exact domain (`validate` accepts it as
+/// a first-class fact); the builder simply does not infer one from
+/// a literal today, so the rule is exercised on the query directly
+/// rather than through a program that cannot reach the state.
+#[test]
+fn may_deliver_decides_exact_key_domains() {
+    use hale_model::keys::{KeyDomain, KeyPredicate, KeyValue};
+    let e = hale_model::Entities {
+        subjects: vec![hale_model::Subject {
+            pattern: "t".to_string(),
+            exact: true,
+            provenance: hale_model::ProvenanceId(0),
+        }],
+        ..Default::default()
+    };
+    let sid = hale_model::SubjectId(0);
+    let publish = |domain: Option<KeyDomain>| hale_model::Publish {
+        function: hale_model::FunctionId(0),
+        subject: sid,
+        declared_topic: None,
+        payload: hale_model::PayloadContractId(0),
+        site: 0,
+        in_loop: false,
+        key_domain: domain,
+        disposition: hale_model::keys::PublishDisposition::Default,
+        provenance: hale_model::ProvenanceId(0),
+    };
+    let sub = |pred: KeyPredicate| hale_model::Subscribe {
+        subject: sid,
+        declared_topic: None,
+        payload: hale_model::PayloadContractId(0),
+        handler: hale_model::FunctionId(0),
+        site: 0,
+        key_predicate: pred,
+        capacity: hale_model::keys::Capacity::Unbounded,
+        shed: hale_model::keys::ShedPolicy::None,
+        provenance: hale_model::ProvenanceId(0),
+    };
+    let exact_one =
+        Some(KeyDomain::Exact(vec![KeyValue::Int(1)]));
+    assert!(
+        !hale_types::judgment::may_deliver(
+            &e,
+            &publish(exact_one.clone()),
+            &sub(KeyPredicate::EqLiteral(KeyValue::Int(2)))
+        ),
+        "an exact key set of {{1}} never reaches a `key == 2` filter"
+    );
+    assert!(hale_types::judgment::may_deliver(
+        &e,
+        &publish(exact_one.clone()),
+        &sub(KeyPredicate::EqLiteral(KeyValue::Int(1)))
+    ));
+    // Ranges decide the same way…
+    assert!(!hale_types::judgment::may_deliver(
+        &e,
+        &publish(Some(KeyDomain::IntRange { min: 0, max: 3 })),
+        &sub(KeyPredicate::EqLiteral(KeyValue::Int(9)))
+    ));
+    // …and everything unknown widens: an unknown domain, an
+    // unkeyed subscription, a replica filter, an unknown filter.
+    assert!(hale_types::judgment::may_deliver(
+        &e,
+        &publish(Some(KeyDomain::Unknown)),
+        &sub(KeyPredicate::EqLiteral(KeyValue::Int(2)))
+    ));
+    assert!(hale_types::judgment::may_deliver(
+        &e,
+        &publish(exact_one.clone()),
+        &sub(KeyPredicate::Any)
+    ));
+    assert!(hale_types::judgment::may_deliver(
+        &e,
+        &publish(exact_one),
+        &sub(KeyPredicate::EqReplica)
+    ));
+}
+
+/// A matching literal filter delivers — the keyed path is not an
+/// unconditional "keyed means no edge".
+#[test]
+fn a_matching_key_filter_creates_the_edge() {
+    let (v, _) = judge(
+        r#"
+type Msg { shard: Int = 0; }
+topic T { payload: Msg; subject: "t"; keyed_by shard; }
+locus Sink {
+    params { n: Int = 0; }
+    bus { subscribe T as on_t where key == 1; }
+    fn on_t(m: Msg) { println("io"); }
+}
+locus Source {
+    bus { publish T; }
+    @effects(causes: { publish, alloc })
+    fn fire() { T <- Msg { shard: 1 }; }
+}
+main locus App {
+    params { s: Sink = Sink { }; p: Source = Source { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(v, Verdict::Violated);
 }

--- a/crates/hale-types/tests/judgment_causes.rs
+++ b/crates/hale-types/tests/judgment_causes.rs
@@ -1157,3 +1157,69 @@ fn main() { App { }; }
     assert_eq!(judged[0].verdict, Verdict::Holds);
     assert_eq!(judged[1].verdict, Verdict::Violated);
 }
+
+/// Review round 5: the route query joins on the WIRE, not on the
+/// syntactic declaration link. A literal `"t" <- …` send carries
+/// `declared_topic: None` even though its text is the bound topic's
+/// wire subject, and after lowering the runtime cannot tell the two
+/// spellings apart — the send reaches the binding installed for
+/// that wire.
+#[test]
+fn a_literal_send_into_a_connect_bound_wire_leaves_the_application() {
+    let (v, _) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+locus Source {
+    bus { publish "t" of type Msg; }
+    @effects(causes: { publish, alloc })
+    fn fire() { "t" <- Msg { n: 1 }; }
+}
+main locus App {
+    params { p: Source = Source { }; }
+    bindings { T: unix("/tmp/t.sock", role: connect); }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Uncertified,
+        "a literal send on the bound wire reaches the peer just as \
+         a topic-spelled one does"
+    );
+}
+
+/// …and the same for an opaque adapter boundary, whose hole is
+/// anchored at the TOPIC while the publish names the wire.
+#[test]
+fn a_literal_send_into_an_adapter_bound_wire_is_uncertified() {
+    let (v, _) = judge(
+        r#"
+type Msg { n: Int = 0; }
+topic T { payload: Msg; subject: "t"; }
+locus MyAdapter {
+    params { n: Int = 0; }
+    fn send(subject: String, bytes: Bytes) { self.n = self.n + 1; }
+}
+locus Source {
+    bus { publish "t" of type Msg; }
+    @effects(causes: { publish, alloc })
+    fn fire() { "t" <- Msg { n: 1 }; }
+}
+main locus App {
+    params { p: Source = Source { }; }
+    bindings { T: MyAdapter { }; }
+    run() { self.p.fire(); }
+}
+fn main() { App { }; }
+"#,
+    );
+    assert_eq!(
+        v,
+        Verdict::Uncertified,
+        "the ExternalOpaque hole is anchored at the topic; the \
+         publish names the wire; they are one address"
+    );
+}

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -650,6 +650,8 @@ fn looped_stdlib_entry_with_carrier_is_unbounded() {
     });
     let p = ProvenanceId(0);
     let f = |name: &str| Function {
+        effect_lower_bound: Vec::new(),
+        effects_unknown: false,
         analyzed: true,
         summarized: true,
         owner: None,
@@ -2860,6 +2862,8 @@ fn mixed_dispatch_alternatives_share_one_group() {
     });
     let p = ProvenanceId(0);
     let f = |name: &str| Function {
+        effect_lower_bound: Vec::new(),
+        effects_unknown: false,
         analyzed: true,
         summarized: true,
         owner: None,

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -677,6 +677,7 @@ fn looped_stdlib_entry_with_carrier_is_unbounded() {
                 provenance: p,
             }],
             effect_classes: vec![EffectClassDecl {
+                declaration_index: 0,
                 name: "money".to_string(),
                 declared: true,
                 definition: EffectClassDefinition::Atomic,
@@ -2886,6 +2887,7 @@ fn mixed_dispatch_alternatives_share_one_group() {
                 provenance: p,
             }],
             effect_classes: vec![EffectClassDecl {
+                declaration_index: 0,
                 name: "money".to_string(),
                 declared: true,
                 definition: EffectClassDefinition::Atomic,

--- a/crates/hale-types/tests/topology_projection.rs
+++ b/crates/hale-types/tests/topology_projection.rs
@@ -616,6 +616,8 @@ fn labels_and_effects_are_restricted_to_the_v1_universe() {
     // `summarized` IS the V1 universe now (it always was the same
     // set; the model used to carry a second copy of it).
     let f = |name: &str, effects: Vec<&str>, summarized: bool| Function {
+        effect_lower_bound: Vec::new(),
+        effects_unknown: false,
         analyzed: summarized,
         summarized,
         owner: None,


### PR DESCRIPTION
Stage 1 of migrating the three remaining claim families and retiring `claims.rs`. This lands the `causes:` **engine and its proof**, not the cutover — see "Why the cutover is not here".

## The engine

`judge_causes` computes the causal surface from model rows: transitive publish sites over `calls`, each subject's subscribers from `subscribes`, and what those handlers perform from `Function.effects`. It subtracts the fn's own direct effects, because a fn's own behavior is the `none:` form's business — subtracting it is what makes this the *causal* surface rather than a restatement of the fn's effects. A class that resolves to nothing (a cyclic definition) makes the contract vacuous, so the row is `Invalid` before evaluation, matching the rule the certificate family already applies.

## The proof

A corpus differential holds it byte-equal to `frontier::causes_diags` — message, span, order — on every corpus program carrying the family. **Zero divergences.**

One divergence is anticipated and bounded in the differential rather than waited for: the evaluator infers effects from the **user-only** summary, so a subscriber whose `syscall` arrives through a stdlib call reads as pure to it and its causal contribution disappears. The model's effect sets are stdlib-merged, so the class is seen. That is the fail-closed direction, and an undeclared causal effect is precisely what this law exists to catch — not seeing it through a stdlib body was an accident of which summary the old engine happened to hold. The differential permits the model to *add* a violation and nothing else.

## Why the cutover is not here

I implemented it, ran it, and backed it out, because it surfaced something that deserves its own decision.

Promoting `causes` out of `JudgmentFamily::Unmigrated` means the row stops importing an old-engine verdict, which means it stops carrying a `law.legacy` report entry. That entry is what `causes_operand_swap_is_refused` relies on: swap one declared effect class for another declared one in the typed law payload, restamp the digests, and the legacy fingerprint no longer re-renders, so admission refuses. Remove the import and that tamper is admitted.

The uncomfortable part is that this is not special to `causes`. That defense exists *because* the row imports an outside verdict, so every already-migrated family looks like it has the same gap for `holds` rows — which are unbacked by evidence across all of them, by design (Change 6's rule is that non-holds verdicts retain evidence). I did not finish proving that on a reachability row, and I would rather say so than assert it.

Three possible answers, none of which should be bolted onto a migration commit:

1. give `holds` rows evidence for the families where a payload operand is otherwise unanchored;
2. recompute the operand at admission against the artifact's own tables (catches substitution of a *declared* class, which the catalog rule does not);
3. accept a uniform posture — `law_digest` plus catalogs plus evidence-for-non-holds — and retire the family-specific fingerprint knowingly, updating the test to pin what actually defends migrated rows.

## Remaining stages

- **5f cutover** — after the question above is settled.
- **5g `depends:`** — same shape; the backward dual.
- **5h `@budget`** — alloc + quantitative, over the model's `weights`.
- **Delete `claims.rs`** — note this is larger than "delete the evaluator": the module still owns law SELECTION (clause enumeration, constitution adoption and identities, group resolution) which check and lowering both consume, plus vocabulary helpers the model builder calls. Those move; the evaluator and the differentials that use it as an oracle go.

Full suite green at 2890, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
