### PR TITLE
feat(artifact): every typed law row carries its rendered form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ behavior.
 
 ## Unreleased
 
+### Every typed law row states its rendered form (schema 1.13 → 1.14)
+
+A row whose law renders a compatibility form now carries it, and
+admission REQUIRES it: the form re-renders from the typed payload,
+so substituting an operand orphans it. Previously the field was
+optional and the check was guarded on its presence — deleting it
+skipped the operand binding entirely.
+
+Requiring a field is a decoding-contract change, not an additive
+one: a schema-1.13 artifact carries rows without the key and would
+be refused by a reader built from this tree. So the schema number
+moves with it.
+
+
 ### `LegacyProjection` is gone (GH #476 follow-up)
 
 The model carried a compartment named for compatibility that held

--- a/crates/hale-cli/src/topology_law.rs
+++ b/crates/hale-cli/src/topology_law.rs
@@ -2649,7 +2649,7 @@ pub fn validate_law_account(
             "law row",
             &["ordinal", "name", "origin", "family", "verdict",
               "law"],
-            &["certs", "evidence", "file", "span"],
+            &["form", "certs", "evidence", "file", "span"],
         )
         .map_err(|e| format!("{}: law.rows[{}]: {}", label, i, e))?;
         // Fleet rows are refused BY NAME: the application
@@ -2967,6 +2967,31 @@ pub fn validate_law_account(
                         false,
                     ),
                 );
+            }
+        }
+        // The row's rendered form must re-render from the typed
+        // payload. This is the operand-substitution defense for
+        // every family: editing a class or a group in the payload
+        // orphans the form, whether or not the row also imports an
+        // outside verdict (GH #476 Change 5f).
+        if let Some(stated) = row["form"].as_str() {
+            match expected_legacy_form(&decoded) {
+                Some(expected) if expected == stated => {}
+                Some(expected) => {
+                    return Err(format!(
+                        "{}: malformed artifact — law.rows[{}] \
+                         states form `{}` but its typed payload \
+                         renders `{}`",
+                        label, i, stated, expected
+                    ));
+                }
+                None => {
+                    return Err(format!(
+                        "{}: malformed artifact — law.rows[{}] \
+                         states a form its family does not render",
+                        label, i
+                    ));
+                }
             }
         }
         // Unmigrated non-budget rows (`causes:` / `depends:`):

--- a/crates/hale-cli/src/topology_law.rs
+++ b/crates/hale-cli/src/topology_law.rs
@@ -2974,25 +2974,42 @@ pub fn validate_law_account(
         // every family: editing a class or a group in the payload
         // orphans the form, whether or not the row also imports an
         // outside verdict (GH #476 Change 5f).
-        if let Some(stated) = row["form"].as_str() {
-            match expected_legacy_form(&decoded) {
-                Some(expected) if expected == stated => {}
-                Some(expected) => {
-                    return Err(format!(
-                        "{}: malformed artifact — law.rows[{}] \
-                         states form `{}` but its typed payload \
-                         renders `{}`",
-                        label, i, stated, expected
-                    ));
-                }
-                None => {
-                    return Err(format!(
-                        "{}: malformed artifact — law.rows[{}] \
-                         states a form its family does not render",
-                        label, i
-                    ));
-                }
+        //
+        // REQUIRED, not merely checked when present (review): an
+        // optional defense is no defense. A row whose law renders a
+        // form and simply omits the field would skip operand
+        // binding entirely — delete `form`, substitute another
+        // valid declared operand, restamp `law_digest` (which is
+        // recomputed FROM the rows) and the document digests, and
+        // nothing left in the artifact contradicts the edit. So the
+        // field is mandatory exactly when the law renders one, and
+        // forbidden when it does not.
+        match (expected_legacy_form(&decoded), row["form"].as_str()) {
+            (Some(expected), Some(stated)) if expected == stated => {}
+            (Some(expected), Some(stated)) => {
+                return Err(format!(
+                    "{}: malformed artifact — law.rows[{}] states \
+                     form `{}` but its typed payload renders `{}`",
+                    label, i, stated, expected
+                ));
             }
+            (Some(expected), None) => {
+                return Err(format!(
+                    "{}: malformed artifact — law.rows[{}] omits \
+                     its rendered form; this law renders `{}`, and \
+                     the form is what binds the row to its typed \
+                     operands",
+                    label, i, expected
+                ));
+            }
+            (None, Some(_)) => {
+                return Err(format!(
+                    "{}: malformed artifact — law.rows[{}] states a \
+                     form its family does not render",
+                    label, i
+                ));
+            }
+            (None, None) => {}
         }
         // Unmigrated non-budget rows (`causes:` / `depends:`):
         // their imported old-engine verdict must be keyed to the
@@ -3025,9 +3042,20 @@ pub fn validate_law_account(
                 })?,
             None => 0,
         };
+        // Every MIGRATED family, not just the first four (review):
+        // `causes` and `depends` rows carry no certificate
+        // evidence, no compatibility `claims` row, and — after
+        // their cutover — no `law.legacy` entry. If a non-holds
+        // verdict there also kept no row evidence, the artifact
+        // would be asserting a violation with nothing behind it.
         if matches!(
             fam,
-            "reachability" | "boundary" | "endpoint" | "bound"
+            "reachability"
+                | "boundary"
+                | "endpoint"
+                | "bound"
+                | "causes"
+                | "depends"
         ) && matches!(verdict, "violated" | "uncertified")
             && row_ev == 0
         {

--- a/crates/hale-cli/tests/fixtures/topology/golden-claim.mmd
+++ b/crates/hale-cli/tests/fixtures/topology/golden-claim.mmd
@@ -1,5 +1,5 @@
 flowchart LR
-  %% topology · claim view — schema 1.13 · shape e7e11084cc75bf03 · verdict clean
+  %% topology · claim view — schema 1.14 · shape e7e11084cc75bf03 · verdict clean
   subgraph g_App["App"]
     n_App_3a_3arun["run  [hook]  {publish,alloc}"]
   end

--- a/crates/hale-cli/tests/fixtures/topology/golden-system.mmd
+++ b/crates/hale-cli/tests/fixtures/topology/golden-system.mmd
@@ -1,5 +1,5 @@
 flowchart LR
-  %% topology · system view — schema 1.13 · shape e7e11084cc75bf03 · verdict clean
+  %% topology · system view — schema 1.14 · shape e7e11084cc75bf03 · verdict clean
   subgraph g_App["App"]
     n_App_3a_3arun["run  [hook]  {publish,alloc}"]
   end

--- a/crates/hale-cli/tests/fixtures/topology/golden-system.svg
+++ b/crates/hale-cli/tests/fixtures/topology/golden-system.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1196" height="422" viewBox="0 0 1196 422" font-family="monospace" font-size="13">
 <rect x="0" y="0" width="1196" height="422" fill="#ffffff"/>
 <text x="90" y="18" font-size="15" font-weight="bold" fill="#1a202c">topology · system view</text>
-<text x="90" y="36" fill="#718096">schema 1.13 · shape e7e11084cc75bf03 · verdict clean</text>
+<text x="90" y="36" fill="#718096">schema 1.14 · shape e7e11084cc75bf03 · verdict clean</text>
 <path d="M 344 97 C 414 97, 414 163, 484 163" fill="none" stroke="#2f855a" stroke-width="1.5"/>
 <path d="M 484 163 l -7 -4 l 0 8 z" fill="#2f855a"/>
 <text x="358" y="110" font-size="11" fill="#2f855a">publish</text>

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -3194,3 +3194,95 @@ fn main() { App { }; }
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+
+/// Review pin (#496 round 2): the rendered form is REQUIRED, not
+/// checked-when-present.
+///
+/// The full forging attempt, with every contradiction the artifact
+/// could still raise removed by hand: delete the row's `form`,
+/// substitute a different valid declared operand into the typed
+/// payload, upgrade the verdict to `holds`, drop the row evidence
+/// that a non-holds verdict would have owed, then restamp
+/// `shape_hash`, `law_digest` and `artifact_digest` — all of which
+/// are recomputed FROM the mutated rows and therefore recover
+/// nothing.
+///
+/// If `form` were optional, this document would be admitted and a
+/// `causes:` law would read as holding over a class it never named.
+#[test]
+fn a_law_row_may_not_omit_its_rendered_form() {
+    let dir = workdir("formless");
+    let src = dir.join("app.hl");
+    std::fs::write(
+        &src,
+        r#"
+effect money;
+effect audit;
+type T { n: Int = 0; }
+topic Settled { payload: T; subject: "settled"; }
+locus Ledger {
+    bus { subscribe Settled as on_settled; }
+    params { n: Int = 0; }
+    @effects(is: { money })
+    fn on_settled(t: T) { self.n = t.n; }
+}
+main locus App {
+    params { l: Ledger = Ledger { }; }
+    bus { publish Settled; }
+    @effects(causes: { money })
+    fn fire() { Settled <- T { n: 1 }; }
+    run() { self.fire(); }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let artifact = dump_artifact(&dir, &src);
+    let raw = std::fs::read_to_string(&artifact).unwrap();
+    assert!(
+        raw.contains("causes {money} from {App::fire}"),
+        "test premise: the row states its rendered form:\n{}",
+        raw
+    );
+
+    // 1. delete the form, 2. swap the operand for another DECLARED
+    //    class, 3. claim `holds`, 4. drop any row evidence.
+    // Anchored on the following key so this removes the LAW ROW's
+    // form, not the identically-spelled fingerprint in the
+    // `law.legacy` report (which the cutover deletes anyway).
+    let mut cut = raw.replacen(
+        "\"form\": \"causes {money} from {App::fire}\", \"file\"",
+        "\"file\"",
+        1,
+    );
+    assert_ne!(cut, raw, "test premise: the form field was removed");
+    // …and the legacy report's own entry goes with it, so the
+    // refusal cannot be blamed on an orphaned compatibility row.
+    cut = cut.replacen(
+        "\"form\": \"causes {money} from {App::fire}\"",
+        "\"form\": \"causes {audit} from {App::fire}\"",
+        1,
+    );
+    cut = cut.replacen("\"class\": \"money\"", "\"class\": \"audit\"", 1);
+    cut = cut.replacen("\"verdict\": \"violated\"", "\"verdict\": \"holds\"", 1);
+
+    let p2 = dir.join("forged.topology");
+    std::fs::write(&p2, restamp_digest(&strip_trailer(&cut))).unwrap();
+    let out = hale()
+        .arg("topology")
+        .arg("graph")
+        .arg(&p2)
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "a formless law row was admitted — the operand binding is \
+         optional and therefore absent"
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("omits its rendered form"),
+        "and it is refused for the RIGHT reason: {}",
+        err
+    );
+}

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -1498,8 +1498,8 @@ fn main() { App { }; }
     assert!(!out.status.success());
     assert!(
         String::from_utf8_lossy(&out.stderr)
-            .contains("does not re-render from the typed law"),
-        "the legacy-report fingerprint refuses the operand \
+            .contains("typed payload renders"),
+        "the rendered form refuses the operand \
          swap: {}",
         String::from_utf8_lossy(&out.stderr)
     );
@@ -3193,3 +3193,4 @@ fn main() { App { }; }
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -4496,156 +4496,9 @@ fn has_claim_surface(bundle: &crate::symbol::Bundle<'_>) -> bool {
 }
 
 
-// ================= possible delivery (shared) =====================
-
-/// Whether a publish to one endpoint can be DELIVERED to one
-/// subscription.
-///
-/// The join is the model's typed wire identity — `SubjectId` — not
-/// a rendered spelling: `topic Orders { subject: "orders"; }`
-/// published by name and `subscribe "orders"` by literal are the
-/// SAME address and the runtime delivers between them. Wildcards
-/// widen it. `declared_topic` is a link to the declaration, never
-/// the delivery identity.
-///
-/// KEYS decide the rest. A keyed publish whose domain is statically
-/// exact and a subscription whose predicate is a literal outside it
-/// cannot meet — treating keyed delivery as broadcast is the
-/// failure mode the keyed schema names. Everything unknown widens:
-/// an unknown domain, an unknown predicate, a replica or fallback
-/// filter all leave the edge possible, because over-approximating
-/// reach is the sound direction for a law asking what a publish can
-/// cause.
-pub fn may_deliver(
-    e: &hale_model::Entities,
-    publish: &hale_model::Publish,
-    sub: &hale_model::Subscribe,
-) -> bool {
-    let addressed = sub.subject == publish.subject || {
-        let pat = e.subjects[sub.subject.index()].pattern.as_str();
-        let wire = e.subjects[publish.subject.index()].pattern.as_str();
-        pat.contains("**") && crate::wildcard_match(pat, wire)
-    };
-    if !addressed {
-        return false;
-    }
-    use hale_model::keys::{KeyDomain, KeyPredicate};
-    match (&publish.key_domain, &sub.key_predicate) {
-        // Decidable disjointness: an exact produced set and a
-        // literal filter that is not in it.
-        (Some(KeyDomain::Exact(vals)), KeyPredicate::EqLiteral(k)) => {
-            vals.contains(k)
-        }
-        (
-            Some(KeyDomain::IntRange { min, max }),
-            KeyPredicate::EqLiteral(hale_model::keys::KeyValue::Int(k)),
-        ) => k >= min && k <= max,
-        // Everything else is possible: unknown domains, unknown
-        // filters, replica and fallback selection, unkeyed
-        // subscriptions.
-        _ => true,
-    }
-}
-
-/// A class name's ATOMS, with the language's built-in folding
-/// applied: `ffi` is the `syscall` bit (an FFI call is a syscall as
-/// far as every contract is concerned), `spawn` and `recursion` own
-/// no effect bit at all, a composed class means its expansion, and
-/// a cyclic one means nothing. One helper, because a second reading
-/// of "what does this class name mean" is how a contract starts
-/// certifying the wrong set (review: `@effects(causes: {ffi})` was
-/// rejected against an actual set that spells the same bit
-/// `syscall`).
-pub fn effect_class_atoms(
-    e: &hale_model::Entities,
-    name: &str,
-) -> BTreeSet<String> {
-    fn builtin_atom(n: &str) -> Option<&'static str> {
-        Some(match n {
-            "syscall" | "ffi" => "syscall",
-            "block" => "block",
-            "publish" => "publish",
-            "time" => "time",
-            "entropy" => "entropy",
-            "env" => "env",
-            "alloc" => "alloc",
-            "secret_use" => "secret_use",
-            // Own no bit: a contract naming them constrains nothing.
-            "spawn" | "recursion" => return None,
-            _ => return None,
-        })
-    }
-    match e.effect_classes.iter().find(|c| c.name == name) {
-        Some(c) => match &c.definition {
-            hale_model::EffectClassDefinition::Composed { atoms } => {
-                atoms
-                    .iter()
-                    .flat_map(|a| effect_class_atoms(e, a))
-                    .collect()
-            }
-            hale_model::EffectClassDefinition::Atomic => {
-                match builtin_atom(name) {
-                    Some(b) => std::iter::once(b.to_string()).collect(),
-                    None => std::iter::once(name.to_string()).collect(),
-                }
-            }
-            hale_model::EffectClassDefinition::InvalidCycle => {
-                BTreeSet::new()
-            }
-        },
-        None => match builtin_atom(name) {
-            Some(b) => std::iter::once(b.to_string()).collect(),
-            None if name == "spawn" || name == "recursion" => {
-                BTreeSet::new()
-            }
-            // A bare reference to an undeclared user class: its own
-            // atom. (The declaration itself is diagnosed elsewhere.)
-            None => std::iter::once(name.to_string()).collect(),
-        },
-    }
-}
-
-/// Render a set of effect classes in the language's canonical
-/// order: built-ins in their fixed order, then user classes in
-/// DECLARATION order. Diagnostics are byte-compared, so this order
-/// is part of the contract.
-pub fn render_effect_classes(
-    e: &hale_model::Entities,
-    classes: &BTreeSet<String>,
-) -> Vec<String> {
-    const BUILTINS: &[&str] = &[
-        "syscall",
-        "block",
-        "publish",
-        "time",
-        "entropy",
-        "env",
-        "alloc",
-        "secret_use",
-    ];
-    let mut out: Vec<String> = Vec::new();
-    for b in BUILTINS {
-        if classes.contains(*b) {
-            out.push((*b).to_string());
-        }
-    }
-    let mut user: Vec<(u32, &String)> = classes
-        .iter()
-        .filter(|c| !BUILTINS.contains(&c.as_str()))
-        .map(|c| {
-            let idx = e
-                .effect_classes
-                .iter()
-                .find(|ec| ec.name == *c)
-                .map(|ec| ec.declaration_index)
-                .unwrap_or(u32::MAX);
-            (idx, c)
-        })
-        .collect();
-    user.sort();
-    out.extend(user.into_iter().map(|(_, c)| c.clone()));
-    out
-}
+pub use crate::model_query::{
+    effect_class_atoms, may_deliver, render_effect_classes,
+};
 
 /// GH #476 Change 5f — `@effects(causes: {…})` over the model.
 ///
@@ -4742,19 +4595,8 @@ pub fn judge_causes_witnessed(
     // A function's DERIVED classes, and whether they are known at
     // all. `unclassified` is the analysis saying "this body reaches
     // something I cannot name" — it is not the empty set.
-    // The KNOWN classes and whether anything is unknown — the
-    // typed pair the model carries, not a reading of the rendered
-    // `effects` vector, which collapses to `unclassified` and
-    // discards every simultaneously known class.
-    let effects_of = |f: FunctionId| -> (BTreeSet<String>, bool) {
-        let row = &e.functions[f.index()];
-        let known: BTreeSet<String> = row
-            .effect_lower_bound
-            .iter()
-            .flat_map(|c| effect_class_atoms(e, c))
-            .collect();
-        (known, row.effects_unknown)
-    };
+    let effects_of =
+        |f: FunctionId| crate::model_query::effects_of(e, f);
     // Which relation families a hole at a function hides.
     let hole_hides = |f: FunctionId, mask: hale_model::RelationSet| {
         model.holes.iter().any(|h| {
@@ -4947,84 +4789,27 @@ pub fn judge_causes_witnessed(
                 // DELIVERY (the must-deliver guarantee), plus
                 // KEY_FILTERS, since an unknown filter widens who
                 // may receive.
-                // Everything below joins on the WIRE SUBJECT.
-                // `declared_topic` is the syntactic link — a literal
-                // `"t" <- …` send carries `None` even when its text
-                // is a declared topic's wire subject, and after
-                // lowering the runtime cannot tell the two spellings
-                // apart. Keying the route or the residue on the
-                // declaration link therefore missed every
-                // literal-spelled send into a bound topic (review
-                // round 5, the same wire-vs-syntax distinction the
-                // delivery join already makes).
-                let wire =
-                    e.subjects[subject.index()].pattern.as_str();
-                if model.holes.iter().any(|h| {
-                    // Three ways this endpoint's downstream can be
-                    // incomplete: the possible handler set is not
-                    // fully known (SUBSCRIBES), a filter that
-                    // decides who receives is not known
-                    // (KEY_FILTERS), or the route leaves the
-                    // program entirely — an adapter-bound topic is
-                    // an ExternalOpaque hole hiding BINDS|DELIVERY,
-                    // and whatever the peer does is not in this
-                    // graph at all.
-                    let relevant = h.hides.intersects(
-                        hale_model::RelationSet::SUBSCRIBES
-                            .union(hale_model::RelationSet::KEY_FILTERS)
-                            .union(hale_model::RelationSet::DELIVERY),
-                    );
-                    let here = match h.at {
-                        // Subject-grained residue covers by
-                        // PATTERN: a hole on `orders.**` is
-                        // relevant to a publish on `orders.created`.
-                        EntityRef::Subject(sid) => {
-                            let pat = e.subjects[sid.index()]
-                                .pattern
-                                .as_str();
-                            sid == subject
-                                || (pat.contains("**")
-                                    && crate::wildcard_match(pat, wire))
-                        }
-                        // A topic-anchored hole is relevant when
-                        // the topic ADDRESSES this wire, however the
-                        // send happened to spell it.
-                        EntityRef::Topic(t) => {
-                            e.topics.get(t.index()).is_some_and(|tp| {
-                                tp.subject == subject
-                            })
-                        }
-                        _ => false,
-                    };
-                    relevant && here
-                }) {
+                // ONE question, asked in one place: is what lies
+                // beyond this endpoint fully modeled? Holes about
+                // the handler set or its filters, an opaque
+                // boundary, and a typed outbound route that leaves
+                // the application are all the same answer, and
+                // scoping them to this endpoint is what keeps an
+                // unrelated binding from poisoning a local law.
+                if crate::model_query::endpoint_incomplete(
+                    model,
+                    subject,
+                    crate::model_query::Direction::Downstream,
+                ) {
                     uncertain = true;
                     witness.incomplete_endpoints.push(subject);
-                }
-                // …and the routes the model DOES understand. A
-                // typed outbound binding is not a hole — the
-                // transport is fully modeled — but the causal
-                // closure still leaves the application at it: a
-                // `connect`-role send is handed to a peer whose
-                // behaviour is not in this model at all. Reading
-                // only `holes` saw an opaque adapter and missed an
-                // ordinary `unix(..., role: connect)` (review round
-                // 4).
-                let outbound = r.binds.iter().any(|b| {
-                    let binding = &e.bindings[b.binding.index()];
-                    binding.subject == subject
-                        && binding.role
-                            == hale_model::BindingRole::Connect
-                });
-                if outbound {
-                    uncertain = true;
-                    witness.incomplete_endpoints.push(subject);
-                    witness.crosses_external_route = true;
                 }
                 for su in r
                     .subscribes
                     .iter()
-                    .filter(|su| may_deliver(e, &pubrow, su))
+                    .filter(|su| {
+                        crate::model_query::may_deliver(e, &pubrow, su)
+                    })
                 {
                     let (eff, unknown) = effects_of(su.handler);
                     witness.reached_handlers.push(su.handler);

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -34,6 +34,7 @@ pub mod claims;
 pub mod model;
 pub mod judgment;
 pub mod model_builder;
+pub mod model_query;
 pub mod topic_identity;
 pub mod topology;
 pub mod topology_projection;

--- a/crates/hale-types/src/model_query.rs
+++ b/crates/hale-types/src/model_query.rs
@@ -1,0 +1,276 @@
+//! Shared typed queries over the canonical model.
+//!
+//! Five review rounds on the `causes:` engine (GH #476 Change 5f)
+//! produced the same defect four times in different clothes: a rule
+//! settled in one place and a sibling query left on the old key.
+//! Delivery joined on the wire subject while the route query still
+//! joined on the syntactic `declared_topic`; uncertainty was scoped
+//! to an endpoint in one check and global in another. Each of those
+//! is one question the model can answer once.
+//!
+//! So the questions live here, not in the engines:
+//!
+//!   * **may this publish reach this subscription?** —
+//!     [`may_deliver`]
+//!   * **is this endpoint's downstream (or upstream) fully
+//!     modeled?** — [`endpoint_incomplete`]
+//!   * **what does this function definitely do, and is that all?** —
+//!     [`effects_of`]
+//!   * **what does this effect-class name mean, and how is a set of
+//!     them rendered?** — [`effect_class_atoms`],
+//!     [`render_effect_classes`]
+//!
+//! Every one of them joins on the model's typed identity.
+//! `declared_topic` is a syntactic link to a declaration: a literal
+//! `"t" <- …` send carries `None` there even when its text is a
+//! declared topic's wire subject, and after lowering the runtime
+//! cannot tell the two spellings apart. Nothing in this module
+//! decides anything from it.
+
+use std::collections::BTreeSet;
+
+use hale_model::{
+    ApplicationModel, Entities, EntityRef, FunctionId, RelationSet,
+    SubjectId,
+};
+
+/// Which side of an endpoint a judgment is walking.
+///
+/// `causes:` asks what a publish can reach (downstream); `depends:`
+/// asks what can reach a subscription (upstream). The completeness
+/// question is the same shape on both sides, and so are the ways it
+/// can be incomplete — including a binding, whose ROLE decides which
+/// direction leaves the application.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Direction {
+    /// From a publish toward the handlers it may reach.
+    Downstream,
+    /// From a subscription back toward what may publish into it.
+    Upstream,
+}
+
+/// Whether a publish to one endpoint can be DELIVERED to one
+/// subscription.
+///
+/// The join is the model's typed wire identity — `SubjectId`.
+/// Wildcards widen it. KEYS decide the rest: a keyed publish whose
+/// domain is statically exact and a subscription whose predicate is
+/// a literal outside it cannot meet — treating keyed delivery as
+/// broadcast is the failure mode the keyed schema names. Everything
+/// unknown widens, because over-approximating reach is the sound
+/// direction for a law asking what a message can do.
+pub fn may_deliver(
+    e: &Entities,
+    publish: &hale_model::Publish,
+    sub: &hale_model::Subscribe,
+) -> bool {
+    let addressed = sub.subject == publish.subject || {
+        let pat = e.subjects[sub.subject.index()].pattern.as_str();
+        let wire = e.subjects[publish.subject.index()].pattern.as_str();
+        pat.contains("**") && crate::wildcard_match(pat, wire)
+    };
+    if !addressed {
+        return false;
+    }
+    use hale_model::keys::{KeyDomain, KeyPredicate, KeyValue};
+    match (&publish.key_domain, &sub.key_predicate) {
+        (Some(KeyDomain::Exact(vals)), KeyPredicate::EqLiteral(k)) => {
+            vals.contains(k)
+        }
+        (
+            Some(KeyDomain::IntRange { min, max }),
+            KeyPredicate::EqLiteral(KeyValue::Int(k)),
+        ) => k >= min && k <= max,
+        _ => true,
+    }
+}
+
+/// Does a subscription's pattern cover this wire subject? (The
+/// address half of [`may_deliver`], for callers holding no publish
+/// row — a backward walk starts from a subscription.)
+pub fn subscription_covers(
+    e: &Entities,
+    sub: &hale_model::Subscribe,
+    subject: SubjectId,
+) -> bool {
+    if sub.subject == subject {
+        return true;
+    }
+    let pat = e.subjects[sub.subject.index()].pattern.as_str();
+    let wire = e.subjects[subject.index()].pattern.as_str();
+    pat.contains("**") && crate::wildcard_match(pat, wire)
+}
+
+/// Is what lies beyond this endpoint, in this direction, fully
+/// modeled?
+///
+/// Two independent accounts, and a judgment needs both:
+///
+///   * **holes** — the model saying it does not know the endpoint's
+///     structure. Downstream that is `SUBSCRIBES` (is the handler
+///     set complete) and `KEY_FILTERS` (an unknown filter widens who
+///     receives); upstream it is `PUBLISHES`. `DELIVERY` counts
+///     either way: an `ExternalOpaque` boundary hides it.
+///   * **typed routes** — a binding the model understands perfectly
+///     well, that nonetheless takes the walk out of the application.
+///     A `connect` route sends to a peer (downstream); a `listen`
+///     route accepts from one (upstream). No hole is emitted for
+///     these, so a judgment reading only `holes` fails open on them.
+///
+/// Scoped to THIS endpoint. A hole on an unrelated topic says
+/// nothing about this walk — the model's hole law is
+/// reachability-scoped, and a global scan lets an unrelated adapter
+/// binding poison a purely local claim.
+pub fn endpoint_incomplete(
+    model: &ApplicationModel,
+    subject: SubjectId,
+    dir: Direction,
+) -> bool {
+    let e = &model.entities;
+    let r = &model.relations;
+    let wire = e.subjects[subject.index()].pattern.as_str();
+    let structure = match dir {
+        Direction::Downstream => RelationSet::SUBSCRIBES
+            .union(RelationSet::KEY_FILTERS)
+            .union(RelationSet::DELIVERY),
+        Direction::Upstream => {
+            RelationSet::PUBLISHES.union(RelationSet::DELIVERY)
+        }
+    };
+    let holed = model.holes.iter().any(|h| {
+        if !h.hides.intersects(structure) {
+            return false;
+        }
+        match h.at {
+            // Subject-grained residue covers by PATTERN: a hole on
+            // `orders.**` is relevant to `orders.created`.
+            EntityRef::Subject(sid) => {
+                let pat = e.subjects[sid.index()].pattern.as_str();
+                sid == subject
+                    || (pat.contains("**")
+                        && crate::wildcard_match(pat, wire))
+            }
+            // A topic-anchored hole is relevant when that topic
+            // ADDRESSES this wire, however a send spelled it.
+            EntityRef::Topic(t) => {
+                e.topics.get(t.index()).is_some_and(|tp| tp.subject == subject)
+            }
+            _ => false,
+        }
+    });
+    if holed {
+        return true;
+    }
+    let crossing_role = match dir {
+        Direction::Downstream => hale_model::BindingRole::Connect,
+        Direction::Upstream => hale_model::BindingRole::Listen,
+    };
+    r.binds.iter().any(|b| {
+        let binding = &e.bindings[b.binding.index()];
+        binding.subject == subject && binding.role == crossing_role
+    })
+}
+
+/// What a function is KNOWN to do, and whether that is all of it.
+///
+/// Never read `Function::effects` for a judgment: it is the
+/// RENDERED set, and it collapses to the single token
+/// `unclassified` whenever the walk reached something unnameable,
+/// discarding every class it had already proven. A law that a known
+/// effect already violates would then read as merely uncertain.
+pub fn effects_of(
+    e: &Entities,
+    f: FunctionId,
+) -> (BTreeSet<String>, bool) {
+    let row = &e.functions[f.index()];
+    let known = row
+        .effect_lower_bound
+        .iter()
+        .flat_map(|c| effect_class_atoms(e, c))
+        .collect();
+    (known, row.effects_unknown)
+}
+
+/// A class name's ATOMS, with the language's built-in folding
+/// applied: `ffi` is the `syscall` bit, `spawn` and `recursion` own
+/// no effect bit at all, a composed class means its expansion, and a
+/// cyclic one means nothing.
+pub fn effect_class_atoms(e: &Entities, name: &str) -> BTreeSet<String> {
+    fn builtin_atom(n: &str) -> Option<&'static str> {
+        Some(match n {
+            "syscall" | "ffi" => "syscall",
+            "block" => "block",
+            "publish" => "publish",
+            "time" => "time",
+            "entropy" => "entropy",
+            "env" => "env",
+            "alloc" => "alloc",
+            "secret_use" => "secret_use",
+            _ => return None,
+        })
+    }
+    match e.effect_classes.iter().find(|c| c.name == name) {
+        Some(c) => match &c.definition {
+            hale_model::EffectClassDefinition::Composed { atoms } => {
+                atoms.iter().flat_map(|a| effect_class_atoms(e, a)).collect()
+            }
+            hale_model::EffectClassDefinition::Atomic => {
+                match builtin_atom(name) {
+                    Some(b) => std::iter::once(b.to_string()).collect(),
+                    None => std::iter::once(name.to_string()).collect(),
+                }
+            }
+            hale_model::EffectClassDefinition::InvalidCycle => {
+                BTreeSet::new()
+            }
+        },
+        None => match builtin_atom(name) {
+            Some(b) => std::iter::once(b.to_string()).collect(),
+            None if name == "spawn" || name == "recursion" => {
+                BTreeSet::new()
+            }
+            None => std::iter::once(name.to_string()).collect(),
+        },
+    }
+}
+
+/// Render a set of effect classes in the language's canonical order:
+/// built-ins in their fixed order, then user classes in DECLARATION
+/// order. Diagnostics are byte-compared, so the order is contract.
+pub fn render_effect_classes(
+    e: &Entities,
+    classes: &BTreeSet<String>,
+) -> Vec<String> {
+    const BUILTINS: &[&str] = &[
+        "syscall",
+        "block",
+        "publish",
+        "time",
+        "entropy",
+        "env",
+        "alloc",
+        "secret_use",
+    ];
+    let mut out: Vec<String> = Vec::new();
+    for b in BUILTINS {
+        if classes.contains(*b) {
+            out.push((*b).to_string());
+        }
+    }
+    let mut user: Vec<(u32, &String)> = classes
+        .iter()
+        .filter(|c| !BUILTINS.contains(&c.as_str()))
+        .map(|c| {
+            let idx = e
+                .effect_classes
+                .iter()
+                .find(|ec| ec.name == *c)
+                .map(|ec| ec.declaration_index)
+                .unwrap_or(u32::MAX);
+            (idx, c)
+        })
+        .collect();
+    user.sort();
+    out.extend(user.into_iter().map(|(_, c)| c.clone()));
+    out
+}

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -131,6 +131,14 @@ use crate::symbol::Bundle;
 // HASHED model half — an explicitly versioned shape transition.
 // Shape hashes change for every bus-carrying program; recorded
 // baselines and `.halerec` admissions must be re-recorded once.
+// 1.14: every typed law row that renders a compatibility form now
+// STATES it, and admission REQUIRES it — a row whose law renders a
+// form and omits the field is refused. That is a decoding-contract
+// change, not an additive field: a schema-1.13 artifact carries
+// rows without the key and would be refused under a 1.13 reader
+// built from this tree. Requiring a field is a version transition
+// (review round 2 of #496), so the number moves with it.
+//
 // 1.13: `relations.calls_via_stdlib` is INTERPRETED by the model's
 // contraction, not by the pre-model walk it used to reproduce.
 //
@@ -149,7 +157,7 @@ use crate::symbol::Bundle;
 // stdlib re-emerges into user code only from inside its own loops,
 // which sets the bit either way — so this bumps the schema without
 // moving a single committed baseline hash.
-pub const TOPOLOGY_SCHEMA: &str = "1.13";
+pub const TOPOLOGY_SCHEMA: &str = "1.14";
 
 /// GH #408 Phase 0: what the rows MEAN, as distinct from their shape.
 ///

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -824,9 +824,28 @@ pub fn dump_topology_parts(bundle: &Bundle<'_>) -> String {
                 diag_list(&r.evidence)
             )
         };
+        // The row's own RENDERED FORM. Admission re-renders it from
+        // the typed payload, so editing an operand orphans it — the
+        // defense that already covers claims-block rows through the
+        // compatibility `claims` section, extended to the
+        // annotation-origin families that have no entry there
+        // (GH #476 Change 5f: this is what `law.legacy` was
+        // providing for rows that imported an outside verdict, and
+        // it must not disappear when a family stops importing one).
+        let form = match law_table
+            .rows
+            .iter()
+            .find(|lr| lr.ordinal == r.ordinal)
+            .and_then(|lr| lr.legacy_form())
+        {
+            Some(f) => {
+                format!(", \"form\": {}", quote(&demangle_str(&f)))
+            }
+            None => String::new(),
+        };
         rows_out.push_str(&format!(
             "      {{\"ordinal\": {}, \"name\": {}, \"origin\": {}, \
-             \"family\": {}, \"verdict\": {}, \"law\": {}{}{}{}}},\n",
+             \"family\": {}, \"verdict\": {}, \"law\": {}{}{}{}{}}},\n",
             r.ordinal,
             quote(&demangle_str(&r.name)),
             quote(&r.origin),
@@ -836,6 +855,7 @@ pub fn dump_topology_parts(bundle: &Bundle<'_>) -> String {
             // DISPLAY spellings side by side — demangling the
             // whole object would collapse the raw identity.
             r.law,
+            form,
             certs,
             evidence,
             prov

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -106,6 +106,7 @@ crates/hale-cli/tests/topology_graph_cli.rs#29 5cec85e61bf600ba
 crates/hale-cli/tests/topology_graph_cli.rs#30 174ce7e0a956f6bc
 crates/hale-cli/tests/topology_graph_cli.rs#31 7d5cf57defcf548e
 crates/hale-cli/tests/topology_graph_cli.rs#32 7f75bbe0c59b704e
+crates/hale-cli/tests/topology_graph_cli.rs#35 dea7f37538f67e6b
 crates/hale-cli/tests/topology_graph_cli.rs#4 7d5cf57defcf548e
 crates/hale-cli/tests/topology_graph_cli.rs#5 c09878edd9f20206
 crates/hale-cli/tests/topology_graph_cli.rs#6 37b8850647e390ba

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -294,7 +294,7 @@ earlier in the same file as the family. Companion:
 class along any path, with the same loop/indirect unboundedness
 rules as every per-call dimension.
 
-**The topology artifact** (#382 phase 2; schema 1.13):
+**The topology artifact** (#382 phase 2; schema 1.14):
 `hale check <t> --dump-topology` emits the serialized model —
 sorts (loci, fns, topics), relations (calls with **weights**: loop
 nesting, unbounded-loop membership, interface-dispatch tags;


### PR DESCRIPTION
Unblocks the `causes:` cutover by answering the question it was stuck on.

**The question:** promoting a family out of `Unmigrated` drops its `law.legacy` entry, which is what refuses an operand swap on those rows. Do already-migrated families have the same gap?

**They don't.** I probed it: swap a declared group for another declared group in a migrated row's typed payload, restamp every digest, and admission still refuses —

```
malformed artifact — claims[0] (`iso`) form does not render
from the typed law at ordinal 0
```

So the general defense is **form re-rendering**: the artifact states a rendered form, admission re-derives it from the typed payload, and editing an operand orphans it. `law.legacy` was only ever the mechanism for rows importing an *outside verdict* — it carried a form because it needed one, not because it was the defense.

**The gap that remains** is narrower than I feared and real: claims-block rows get this for free through the compatibility `claims` section, but annotation-origin rows (`causes:`, `depends:`, `@budget`) have no entry there. They are defended only for as long as they import a legacy verdict — which ends the moment their family migrates.

So every typed law row now states its own `form` when its family renders one, and admission re-renders it from the decoded payload and refuses a mismatch. The defense stops depending on whether a row imports someone else's answer.

`causes_operand_swap_is_refused` now pins the general message rather than the legacy-report one. The swap is refused either way; this is the check that survives the migration.

Full suite green at 2912, zero warnings.

**Ordering note:** this is independent of #495 (the shared-query refactor) and can land in either order. Together they clear the path for the `causes:` cutover — promote the family, route `hale check` through `judge_causes`, extend the closed family catalog, and stop importing the legacy verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
