### PR TITLE
feat(model): judge `depends:` over the canonical model (GH #476 Change 5g)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ behavior.
 
 ## Unreleased
 
+### `depends:` is judged over the canonical model (GH #476 Change 5g)
+
+`@effects(depends: {…})` on a locus (RFC #330) is the backward dual
+of `causes:` — the COMPLETE set of subjects that can transitively
+reach any handler the locus owns. It is now judged over the
+canonical model, by the same shared queries the forward walk uses.
+That is the point: if the two walks disagreed about whether a
+publish and a subscription meet, one of them was wrong.
+
+Three corrections fall out of the shared join:
+
+- **A declaration may name the wire subject.**
+  `@effects(depends: { "evt" })` and `{ Evt }` address one
+  endpoint. The old engine compared names and reported the wire
+  spelling as an omission.
+- **An operand naming nothing is `invalid`, not `violated`.** The
+  old engine matched declared entries by name, so a typo covered
+  nothing and every subject that reached the locus came back as an
+  omission — a violation report about the subjects, when the defect
+  is the typo. The diagnostic now names the unresolved entry.
+- **An inbound route is uncertainty, not silence.** A `listen`
+  binding on a reached subject means a peer this application does
+  not model can publish into it, so the closure cannot be certified.
+  An outbound `connect` route on the same locus does not taint it —
+  the completeness query takes a direction.
+
+The `sync`-discipline refusal (#340) is unchanged: a locus holding
+a `@form(…, sync = …)` param is reachable by another pool's writes
+with no bus edge recording it, and `depends:` closes over the
+message graph only.
+
+Diagnostics for the family are now `Claim`-kind, matching the other
+law families.
+
+**Artifact schema 1.14 → 1.15.** `depends:` rows carry
+`"family": "depends"` with their own rendered `form` and no
+`law.legacy` entry; that report now covers `@budget` alone.
+
 ### `causes:` is judged over the canonical model (GH #476 Change 5f)
 
 `@effects(causes: …)` was the last effect law still answered by a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ Diagnostics for the family are now `Claim`-kind, matching the other
 law families.
 
 **Artifact schema 1.14 → 1.15.** `depends:` rows carry
-`"family": "depends"` with their own rendered `form` and no
-`law.legacy` entry; that report now covers `@budget` alone.
+`"family": "depends"` with their own rendered `form`, an
+`adequacy.depends` entry, and no `law.legacy` entry; that report now covers `@budget` alone.
 
 ### `causes:` is judged over the canonical model (GH #476 Change 5f)
 

--- a/crates/hale-cli/src/topology_law.rs
+++ b/crates/hale-cli/src/topology_law.rs
@@ -3310,8 +3310,18 @@ pub fn validate_law_account(
         ("certificate", JF::Certificate),
         ("causes", JF::Causes),
     ];
+    const MIGRATED_115: &[(&str, JF)] = &[
+        ("reachability", JF::Reachability),
+        ("boundary", JF::Boundary),
+        ("endpoint", JF::Endpoint),
+        ("bound", JF::Bound),
+        ("certificate", JF::Certificate),
+        ("causes", JF::Causes),
+        ("depends", JF::Depends),
+    ];
     let schema = v["schema"].as_str().unwrap_or_default();
     let migrated: &[(&str, JF)] = match schema {
+        "1.15" => MIGRATED_115,
         "1.14" => MIGRATED_114,
         _ => MIGRATED_113,
     };

--- a/crates/hale-cli/src/topology_law.rs
+++ b/crates/hale-cli/src/topology_law.rs
@@ -2215,8 +2215,8 @@ pub fn family_of(law: &Law) -> &'static str {
         | Law::NoPanic { .. }
         | Law::PhaseEffects { .. } => "certificate",
         Law::EffectCauses { .. } => "causes",
-        Law::DependsSet { .. }
-        | Law::AllocBudget { .. }
+        Law::DependsSet { .. } => "depends",
+        Law::AllocBudget { .. }
         | Law::QuantBudget { .. } => "unmigrated",
     }
 }
@@ -2473,6 +2473,7 @@ pub fn validate_law_account(
         "bound",
         "certificate",
         "causes",
+        "depends",
         "unmigrated",
     ];
     const VERDICTS: &[&str] =
@@ -2541,7 +2542,10 @@ pub fn validate_law_account(
         .map_err(|e| format!("{}: {}", label, e))?;
     let origin_ok = |origin: &str, family: &str| -> bool {
         match family {
-            "certificate" | "causes" | "unmigrated" => {
+            // `depends:` is an annotation on a LOCUS, `causes:` one
+            // on a function; neither can arrive from a claims block
+            // or a constitution.
+            "certificate" | "causes" | "depends" | "unmigrated" => {
                 origin == "annotation"
             }
             _ => {

--- a/crates/hale-cli/tests/fixtures/topology/golden-claim.mmd
+++ b/crates/hale-cli/tests/fixtures/topology/golden-claim.mmd
@@ -1,5 +1,5 @@
 flowchart LR
-  %% topology · claim view — schema 1.14 · shape e7e11084cc75bf03 · verdict clean
+  %% topology · claim view — schema 1.15 · shape e7e11084cc75bf03 · verdict clean
   subgraph g_App["App"]
     n_App_3a_3arun["run  [hook]  {publish,alloc}"]
   end

--- a/crates/hale-cli/tests/fixtures/topology/golden-system.mmd
+++ b/crates/hale-cli/tests/fixtures/topology/golden-system.mmd
@@ -1,5 +1,5 @@
 flowchart LR
-  %% topology · system view — schema 1.14 · shape e7e11084cc75bf03 · verdict clean
+  %% topology · system view — schema 1.15 · shape e7e11084cc75bf03 · verdict clean
   subgraph g_App["App"]
     n_App_3a_3arun["run  [hook]  {publish,alloc}"]
   end

--- a/crates/hale-cli/tests/fixtures/topology/golden-system.svg
+++ b/crates/hale-cli/tests/fixtures/topology/golden-system.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1196" height="422" viewBox="0 0 1196 422" font-family="monospace" font-size="13">
 <rect x="0" y="0" width="1196" height="422" fill="#ffffff"/>
 <text x="90" y="18" font-size="15" font-weight="bold" fill="#1a202c">topology · system view</text>
-<text x="90" y="36" fill="#718096">schema 1.14 · shape e7e11084cc75bf03 · verdict clean</text>
+<text x="90" y="36" fill="#718096">schema 1.15 · shape e7e11084cc75bf03 · verdict clean</text>
 <path d="M 344 97 C 414 97, 414 163, 484 163" fill="none" stroke="#2f855a" stroke-width="1.5"/>
 <path d="M 484 163 l -7 -4 l 0 8 z" fill="#2f855a"/>
 <text x="358" y="110" font-size="11" fill="#2f855a">publish</text>

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -3232,7 +3232,7 @@ fn main() { App { }; }
     let artifact = dump_artifact(&dir, &src);
     let raw = std::fs::read_to_string(&artifact).unwrap();
     let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
-    assert_eq!(v["schema"], "1.14");
+    assert_eq!(v["schema"], "1.15");
     let adequacy =
         v["adequacy"].as_object().expect("adequacy object");
     assert!(
@@ -3242,10 +3242,11 @@ fn main() { App { }; }
     );
     assert_eq!(
         adequacy.len(),
-        6,
-        "five older families plus causes: {:?}",
+        7,
+        "five older families plus causes and depends: {:?}",
         adequacy
     );
+    assert!(adequacy.contains_key("depends"), "{:?}", adequacy);
 
     // …and an artifact that omits it is refused, restamped or not.
     let cut = raw.replacen(",\n    \"causes\": \"exact\"", "", 1);

--- a/crates/hale-model/src/claim_ir.rs
+++ b/crates/hale-model/src/claim_ir.rs
@@ -503,8 +503,11 @@ pub enum JudgmentFamily {
     /// `@effects(causes: …)` — the cross-actor causal surface
     /// (Change 5f).
     Causes,
-    /// Lowered but its engine has not migrated (`depends:`,
-    /// `@budget`) — judged at minimum `uncertified`.
+    /// `@effects(depends: …)` — the backward dual of `causes:`
+    /// (Change 5g).
+    Depends,
+    /// Lowered but its engine has not migrated (`@budget`) —
+    /// judged at minimum `uncertified`.
     Unmigrated,
     /// Fleet plan rows — Change 7's `FleetModel`.
     Fleet,
@@ -519,6 +522,7 @@ impl JudgmentFamily {
             JudgmentFamily::Bound => "bound",
             JudgmentFamily::Certificate => "certificate",
             JudgmentFamily::Causes => "causes",
+            JudgmentFamily::Depends => "depends",
             JudgmentFamily::Unmigrated => "unmigrated",
             JudgmentFamily::Fleet => "fleet",
         }
@@ -556,6 +560,15 @@ impl JudgmentFamily {
                 .union(R::PUBLISHES)
                 .union(R::DELIVERY)
                 .union(R::EFFECTS),
+            // `depends` walks the same graph BACKWARD, and owes
+            // nothing to EFFECTS: the claim is reachability of a
+            // subject, not what anything does with it. OWNS is how
+            // a locus's handler set is found, and losing it means
+            // the subscription set is not known to be complete.
+            JudgmentFamily::Depends => R::PUBLISHES
+                .union(R::SUBSCRIBES)
+                .union(R::DELIVERY)
+                .union(R::OWNS),
             JudgmentFamily::Unmigrated | JudgmentFamily::Fleet => {
                 crate::hole::RelationSet(0)
             }
@@ -1046,8 +1059,8 @@ impl ClaimRow {
                 JudgmentFamily::Certificate
             }
             ClaimIr::EffectCauses { .. } => JudgmentFamily::Causes,
-            ClaimIr::DependsSet { .. }
-            | ClaimIr::AllocBudget { .. }
+            ClaimIr::DependsSet { .. } => JudgmentFamily::Depends,
+            ClaimIr::AllocBudget { .. }
             | ClaimIr::QuantBudget { .. } => {
                 JudgmentFamily::Unmigrated
             }

--- a/crates/hale-model/src/claim_ir.rs
+++ b/crates/hale-model/src/claim_ir.rs
@@ -581,9 +581,19 @@ impl JudgmentFamily {
             // subject, not what anything does with it. OWNS is how
             // a locus's handler set is found, and losing it means
             // the subscription set is not known to be complete.
-            JudgmentFamily::Depends => R::PUBLISHES
+            // Round 2: CALLS joins the list. The backward walk
+            // climbs reverse call edges from a publish site to
+            // every locus that can reach it — a publish inside a
+            // free helper belongs to its callers — so an incomplete
+            // call account is an incomplete dependency account.
+            // ROUTES for the same reason it appears under `causes`:
+            // an inbound binding is an upstream the model cannot
+            // see past.
+            JudgmentFamily::Depends => R::CALLS
+                .union(R::PUBLISHES)
                 .union(R::SUBSCRIBES)
                 .union(R::DELIVERY)
+                .union(R::ROUTES)
                 .union(R::OWNS),
             JudgmentFamily::Unmigrated | JudgmentFamily::Fleet => {
                 crate::hole::RelationSet(0)

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -124,7 +124,28 @@ pub struct LocusDecl {
     /// sets it from its declaration walk; the evidence layer and
     /// the artifact emitter read it here, never re-walking source.
     pub analyzable: bool,
+    /// This locus's own `@form(…, sync)` discipline (#340). A locus
+    /// holding one as a param is reachable by another pool's WRITES,
+    /// with no bus edge recording it — an input channel the message
+    /// graph cannot see, which is why `depends:` must refuse to
+    /// certify over it.
+    pub sync_form: bool,
+    /// Declared `params { … }`, at DECLARATION grain. Deliberately
+    /// not the same fact as [`LocusInstance`]: an instance exists
+    /// only for a statically exact birth, while a param with no
+    /// default still declares what this locus may hold.
+    pub params: Vec<LocusParam>,
     pub provenance: ProvenanceId,
+}
+
+/// One entry of a locus's `params { … }` block.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct LocusParam {
+    pub name: String,
+    /// Last path segment of the declared type, in author spelling.
+    pub type_name: String,
+    /// Resolved when the type names a locus in this application.
+    pub decl: Option<LocusDeclId>,
 }
 
 /// A statically exact instance in the main arrangement, e.g. the

--- a/crates/hale-model/src/lib.rs
+++ b/crates/hale-model/src/lib.rs
@@ -154,7 +154,7 @@ pub use claim_ir::{
 };
 pub use entity::{
     Binding, BindingRole, DeclKind, Declaration, EffectClassDecl, EffectClassDefinition, Function, FunctionKind, Group, InterfaceDecl,
-    LocusDecl, LocusInstance, PayloadContract, Phase, Seed, Subject, ThreadDomain, Topic,
+    LocusDecl, LocusInstance, LocusParam, PayloadContract, Phase, Seed, Subject, ThreadDomain, Topic,
     TransportKind, TypeDecl,
 };
 pub use hole::{allowed_hole_families, hole_site_shaped, Hole, HoleKind, RelationSet};

--- a/crates/hale-model/tests/architecture.rs
+++ b/crates/hale-model/tests/architecture.rs
@@ -103,6 +103,8 @@ fn tiny_model() -> ApplicationModel {
                     display: "App".to_string(),
                     sealed: false,
                     analyzable: true,
+                    sync_form: false,
+                    params: Vec::new(),
                     provenance: p,
                 },
                 LocusDecl {
@@ -110,6 +112,8 @@ fn tiny_model() -> ApplicationModel {
                     display: "Worker".to_string(),
                     sealed: false,
                     analyzable: true,
+                    sync_form: false,
+                    params: Vec::new(),
                     provenance: p,
                 },
             ],

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -465,11 +465,9 @@ pub fn check_bundle(
             };
             // GH #265 frontier: cross-actor causality (needs the
             // bus graph), supervision coverage, and secret taint.
-            // GH #476 Change 5f: `causes:` is judged over the model
-            // with the other migrated families — see
-            // `check_bundle_opts`.
-            // RFC #330: the backward dual.
-            diags.extend(crate::frontier::depends_diags(&programs_vec, &graph));
+            // GH #476 Change 5f/5g: `causes:` and its backward dual
+            // `depends:` (RFC #330) are judged over the model with
+            // the other migrated families — see `check_bundle_opts`.
             // GH #382 phase 1: bundle-level claims — group
             // resolution (unknown name = error, vacuity) and
             // `forbid reaches` evaluation with countermodel

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -4965,6 +4965,66 @@ pub fn judge_depends_witnessed(
     for m in &r.member_of {
         fns_of.entry(m.locus.0).or_default().push(m.function);
     }
+    // Reverse CALLS. A publish inside a free helper belongs to
+    // every locus that can reach that helper, so the backward walk
+    // has to climb the call graph before it can ask "whose inputs
+    // are these?".
+    let mut callers_of: BTreeMap<u32, Vec<FunctionId>> =
+        BTreeMap::new();
+    for c in &r.calls {
+        callers_of.entry(c.to.0).or_default().push(c.from);
+    }
+    // …and through the stdlib: a user fn that reaches a user fn
+    // through a stdlib interior is still a caller.
+    for a in &model.analyses.stdlib_absorption {
+        for node in &a.nodes {
+            for ev in &node.events {
+                if let hale_model::AbsorbedEvent::Call {
+                    target: hale_model::AbsorbedTarget::User(u),
+                    ..
+                } = ev
+                {
+                    callers_of.entry(u.0).or_default().push(a.from);
+                }
+            }
+        }
+    }
+    let owner_of: BTreeMap<u32, hale_model::LocusDeclId> = r
+        .member_of
+        .iter()
+        .map(|m| (m.function.0, m.locus))
+        .collect();
+    // Every locus that owns a function which can transitively reach
+    // `f` — including `f`'s own owner.
+    // Functions whose publish set the model could not resolve.
+    let computed_publishers: BTreeSet<u32> = model
+        .holes
+        .iter()
+        .filter(|h| h.hides.intersects(hale_model::RelationSet::PUBLISHES))
+        .filter_map(|h| match h.at {
+            EntityRef::Function(f) => Some(f.0),
+            _ => None,
+        })
+        .collect();
+    let owning_loci = |f: FunctionId| -> Vec<hale_model::LocusDeclId> {
+        let mut seen_fn: BTreeSet<u32> = BTreeSet::new();
+        let mut out: BTreeSet<u32> = BTreeSet::new();
+        let mut frontier = vec![f];
+        while let Some(cur) = frontier.pop() {
+            if !seen_fn.insert(cur.0) {
+                continue;
+            }
+            if let Some(l) = owner_of.get(&cur.0) {
+                out.insert(l.0);
+                // A method's own locus is an answer; its callers
+                // still matter (another locus may call into it).
+            }
+            for up in callers_of.get(&cur.0).into_iter().flatten() {
+                frontier.push(*up);
+            }
+        }
+        out.into_iter().map(hale_model::LocusDeclId).collect()
+    };
 
     let mut out = Vec::new();
     for row in table.rows.iter() {
@@ -5076,6 +5136,23 @@ pub fn judge_depends_witnessed(
                 uncertain = true;
                 witness.incomplete_endpoints.push(subject);
             }
+            // Function-grained publisher residue (round 2). A
+            // COMPUTED publish is recorded as a PUBLISHES hole at
+            // its function, not as a `Publish` row and not anchored
+            // to any subject — so neither the endpoint query (which
+            // reads subject- and topic-anchored holes) nor the row
+            // walk below can see it. A publisher whose subject the
+            // model could not name might name THIS wire, and a
+            // backward completeness claim cannot be certified over
+            // it.
+            //
+            // Deliberately not scoped to this subject: the hole
+            // exists precisely because the subject is unknown, so
+            // there is nothing narrower to scope it to. It
+            // downgrades to `uncertified`, never to a violation.
+            if !computed_publishers.is_empty() {
+                uncertain = true;
+            }
             // Who can publish INTO a subscription on this subject?
             // The join is delivery, not the syntactic topic link: a
             // literal `"t" <- …` send reaches a `t` subscriber, and
@@ -5091,31 +5168,26 @@ pub fn judge_depends_witnessed(
                     if !crate::model_query::may_deliver(e, p, su) {
                         continue;
                     }
-                    let Some(m) =
-                        r.member_of.iter().find(|m| m.function == p.function)
-                    else {
-                        // A publisher owned by no locus is a free
-                        // function: its subject still reaches here,
-                        // but there is no locus to walk on from.
-                        let pl = p.subject;
-                        if !seen.contains_key(&pl.0) {
-                            queue.push((
-                                pl,
-                                Some((
-                                    e.functions[p.function.index()]
-                                        .display
-                                        .clone(),
-                                    shown(subject.0),
-                                )),
-                            ));
+                    // Every LOCUS this publish can be reached FROM,
+                    // not just the one that owns the publishing
+                    // function.
+                    //
+                    // Round 2: the walk used to stop at a free
+                    // function, recording its subject and giving up
+                    // because there was no owner locus to inspect.
+                    // But a handler that calls a free helper which
+                    // publishes is a real path — `Secret ->
+                    // Relay::on_secret -> emit_clean() -> Clean ->
+                    // Target::on_clean` — and stopping there let a
+                    // locus certify `depends: {Clean}` while
+                    // `Secret` reached it. The publish site's
+                    // CALLERS are part of the backward walk.
+                    for owner in owning_loci(p.function) {
+                        let plocus = &e.loci[owner.index()];
+                        if !seen_locus.insert(owner.0) {
+                            continue;
                         }
-                        continue;
-                    };
-                    let plocus = &e.loci[m.locus.index()];
-                    // The publishing locus's OWN inputs are inputs
-                    // of this one, transitively.
-                    if seen_locus.insert(m.locus.0) {
-                        for up in subs_of(m.locus.0) {
+                        for up in subs_of(owner.0) {
                             queue.push((
                                 up.subject,
                                 Some((
@@ -5124,6 +5196,20 @@ pub fn judge_depends_witnessed(
                                 )),
                             ));
                         }
+                    }
+                    // A publish no locus can be reached from still
+                    // delivers here — record the subject even when
+                    // the walk cannot continue past it.
+                    if !seen.contains_key(&p.subject.0) {
+                        queue.push((
+                            p.subject,
+                            Some((
+                                e.functions[p.function.index()]
+                                    .display
+                                    .clone(),
+                                shown(subject.0),
+                            )),
+                        ));
                     }
                 }
             }

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -4453,6 +4453,7 @@ pub fn claim_law_diags(bundle: &crate::symbol::Bundle<'_>) -> Vec<Diag> {
                 | hale_model::JudgmentFamily::Endpoint
                 | hale_model::JudgmentFamily::Bound
                 | hale_model::JudgmentFamily::Causes
+                | hale_model::JudgmentFamily::Depends
         ) {
             continue;
         }
@@ -4477,10 +4478,11 @@ pub fn claim_law_diags(bundle: &crate::symbol::Bundle<'_>) -> Vec<Diag> {
 /// judge — a `claims { }` block (world tier or library tier) or a
 /// `constitution` to adopt one from?
 ///
-/// …plus `@effects(causes: …)`, which is annotation-carried but
-/// judged here since Change 5f. Other annotations are deliberately
-/// NOT a claim surface: their rows are the certificate family,
-/// whose diagnostics belong to the effects engine.
+/// …plus `@effects(causes: …)` on a function and
+/// `@effects(depends: …)` on a locus, which are annotation-carried
+/// but judged here since Changes 5f and 5g. Other annotations are
+/// deliberately NOT a claim surface: their rows are the certificate
+/// family, whose diagnostics belong to the effects engine.
 fn has_claim_surface(bundle: &crate::symbol::Bundle<'_>) -> bool {
     use hale_syntax::ast::{EffectAssert, FnDecl, LocusMember, TopDecl};
     fn causes(fd: &FnDecl) -> bool {
@@ -4492,11 +4494,14 @@ fn has_claim_surface(bundle: &crate::symbol::Bundle<'_>) -> bool {
         items.iter().any(|item| match item {
             TopDecl::Claims(_) | TopDecl::Constitution(_) => true,
             TopDecl::Fn(f) => causes(f),
-            TopDecl::Locus(l) => l.members.iter().any(|m| match m {
-                LocusMember::Claims(_) => true,
-                LocusMember::Fn(f) => causes(f),
-                _ => false,
-            }),
+            TopDecl::Locus(l) => {
+                l.depends.is_some()
+                    || l.members.iter().any(|m| match m {
+                        LocusMember::Claims(_) => true,
+                        LocusMember::Fn(f) => causes(f),
+                        _ => false,
+                    })
+            }
             TopDecl::Module(m) => walk(&m.items),
             _ => false,
         })
@@ -4888,6 +4893,339 @@ pub fn judge_causes_witnessed(
         witness.incomplete_endpoints.dedup();
         witness.incomplete_discovery.sort();
         witness.incomplete_discovery.dedup();
+        out.push((
+            Judged {
+                ordinal: row.ordinal,
+                verdict,
+                diags,
+                foreign: Vec::new(),
+            },
+            witness,
+        ));
+    }
+    out
+}
+
+/// The traversal witness a `depends:` row leaves behind — what the
+/// backward walk reached, and everywhere it could not see.
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct DependsWitness {
+    /// Every subject that can reach this locus, in the order the
+    /// walk settled them.
+    pub reached_subjects: Vec<hale_model::SubjectId>,
+    /// Reached subjects whose upstream is not fully modeled.
+    pub incomplete_endpoints: Vec<hale_model::SubjectId>,
+    /// Params typed as a `sync`-discipline form: input channels
+    /// outside the message graph entirely.
+    pub sync_form_params: Vec<String>,
+}
+
+/// GH #476 Change 5g — `@effects(depends: {A, B})` on a locus,
+/// judged over the canonical model.
+///
+/// The backward dual of [`judge_causes`], and deliberately built
+/// from the same shared queries: `causes:` asks what a publish can
+/// REACH, `depends:` asks what can reach a subscription. Running
+/// them on different joins is exactly the defect
+/// [`crate::model_query`] exists to prevent — a dependence routed
+/// through one republishing intermediary is invisible in the
+/// depending locus's own `bus {}` block, so the walk has to be
+/// transitive and it has to agree with delivery.
+///
+/// It is a COMPLETE declaration: every subject that can transitively
+/// reach any handler this locus owns must be named. Reachability,
+/// not dataflow — a locus subscribing to a laundered republish of S
+/// depends on S whether or not it reads the field.
+pub fn judge_depends(
+    table: &ClaimIrTable,
+    model: &ApplicationModel,
+    source_bases: &[u32],
+) -> Vec<Judged> {
+    judge_depends_witnessed(table, model, source_bases)
+        .into_iter()
+        .map(|(j, _)| j)
+        .collect()
+}
+
+/// [`judge_depends`], with each row's traversal witness.
+pub fn judge_depends_witnessed(
+    table: &ClaimIrTable,
+    model: &ApplicationModel,
+    source_bases: &[u32],
+) -> Vec<(Judged, DependsWitness)> {
+    let e = &model.entities;
+    let r = &model.relations;
+    let claim_span = |pid: ProvenanceId| -> Span {
+        span_of(&table.provenance, source_bases, pid)
+    };
+    // locus -> the functions it owns. `depends:` is a claim about a
+    // LOCUS, but subscription is a fact about a FUNCTION, and
+    // `member_of` is the only bridge.
+    let mut fns_of: BTreeMap<u32, Vec<FunctionId>> = BTreeMap::new();
+    for m in &r.member_of {
+        fns_of.entry(m.locus.0).or_default().push(m.function);
+    }
+
+    let mut out = Vec::new();
+    for row in table.rows.iter() {
+        let ClaimIr::DependsSet { locus, entries } = &row.law else {
+            continue;
+        };
+        let mut witness = DependsWitness::default();
+        let mut diags: Vec<Diag> = Vec::new();
+
+        // Static invalidity DOMINATES: an operand that names
+        // nothing cannot be certified against, and a replayed
+        // engine result is never an alternative.
+        let Some(lid) = locus.0 else {
+            out.push((
+                Judged {
+                    ordinal: row.ordinal,
+                    verdict: Verdict::Invalid,
+                    diags,
+                    foreign: Vec::new(),
+                },
+                witness,
+            ));
+            continue;
+        };
+        let decl = &e.loci[lid.index()];
+
+        // Obligation 1 (#340): a param typed as a form carrying a
+        // `sync` discipline. Another pool writes it, this locus
+        // reads it, and NO bus edge records the transfer — so the
+        // message graph, which is all this walk can see, cannot
+        // support a completeness claim at all.
+        for prm in &decl.params {
+            let holds_sync = prm
+                .decl
+                .is_some_and(|d| e.loci[d.index()].sync_form);
+            if !holds_sync {
+                continue;
+            }
+            witness.sync_form_params.push(prm.name.clone());
+            diags.push(Diag::ty(
+                claim_span(row.provenance),
+                format!(
+                    "declared dependency set is incomplete: `{}` holds \
+                     `{}` as `{}`, a form carrying a `sync` discipline \
+                     — shared state another pool can write. That is an \
+                     input channel outside the bus graph, and \
+                     `depends:` closes over the message graph only.",
+                    decl.display, prm.type_name, prm.name
+                ),
+            ));
+        }
+
+        // Author spelling for a wire subject: the topic that
+        // declares it, when exactly one does. Identity stays the
+        // `SubjectId` — this is only how it is SHOWN, the same
+        // raw/display duality the topics section carries.
+        let shown = |sid: u32| -> String {
+            let subject = &e.subjects[sid as usize];
+            let mut named = e
+                .topics
+                .iter()
+                .filter(|t| t.subject.0 == sid)
+                .map(|t| t.display.clone());
+            match (named.next(), named.next()) {
+                (Some(one), None) => one,
+                _ => subject.pattern.clone(),
+            }
+        };
+        // Obligation 2: the backward closure. BFS over LOCI,
+        // remembering how each subject was reached so the
+        // diagnostic can name the path and not only the verdict.
+        let mut uncertain = false;
+        // subject -> (via locus display, into subject display)
+        let mut seen: BTreeMap<u32, Option<(String, String)>> =
+            BTreeMap::new();
+        let mut seen_locus: BTreeSet<u32> = BTreeSet::new();
+        seen_locus.insert(lid.0);
+        // (subject reaching the frontier locus, how it got there)
+        let mut queue: Vec<(hale_model::SubjectId, Option<(String, String)>)> =
+            Vec::new();
+        let subs_of = |l: u32| -> Vec<hale_model::Subscribe> {
+            let owned = fns_of.get(&l).cloned().unwrap_or_default();
+            r.subscribes
+                .iter()
+                .filter(|su| owned.contains(&su.handler))
+                .cloned()
+                .collect()
+        };
+        for su in subs_of(lid.0) {
+            queue.push((su.subject, None));
+        }
+        while let Some((subject, via)) = queue.pop() {
+            if seen.contains_key(&subject.0) {
+                continue;
+            }
+            seen.insert(subject.0, via);
+            witness.reached_subjects.push(subject);
+            // Is this endpoint's UPSTREAM fully modeled? Holes over
+            // who publishes it, an opaque delivery boundary, and a
+            // `listen` binding that accepts from a peer are all the
+            // same answer — and scoping the question to THIS
+            // subject is what keeps an unrelated adapter from
+            // poisoning a purely local claim.
+            if crate::model_query::endpoint_incomplete(
+                model,
+                subject,
+                crate::model_query::Direction::Upstream,
+            ) {
+                uncertain = true;
+                witness.incomplete_endpoints.push(subject);
+            }
+            // Who can publish INTO a subscription on this subject?
+            // The join is delivery, not the syntactic topic link: a
+            // literal `"t" <- …` send reaches a `t` subscriber, and
+            // a keyed publish that cannot meet this predicate is
+            // not an upstream at all.
+            for su in r.subscribes.iter() {
+                if !crate::model_query::subscription_covers(
+                    e, su, subject,
+                ) {
+                    continue;
+                }
+                for p in r.publishes.iter() {
+                    if !crate::model_query::may_deliver(e, p, su) {
+                        continue;
+                    }
+                    let Some(m) =
+                        r.member_of.iter().find(|m| m.function == p.function)
+                    else {
+                        // A publisher owned by no locus is a free
+                        // function: its subject still reaches here,
+                        // but there is no locus to walk on from.
+                        let pl = p.subject;
+                        if !seen.contains_key(&pl.0) {
+                            queue.push((
+                                pl,
+                                Some((
+                                    e.functions[p.function.index()]
+                                        .display
+                                        .clone(),
+                                    shown(subject.0),
+                                )),
+                            ));
+                        }
+                        continue;
+                    };
+                    let plocus = &e.loci[m.locus.index()];
+                    // The publishing locus's OWN inputs are inputs
+                    // of this one, transitively.
+                    if seen_locus.insert(m.locus.0) {
+                        for up in subs_of(m.locus.0) {
+                            queue.push((
+                                up.subject,
+                                Some((
+                                    plocus.display.clone(),
+                                    shown(subject.0),
+                                )),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Which reached subjects the declaration does NOT name. A
+        // selector resolves to typed ids at lowering, so this is an
+        // id comparison — no name matching, and no second answer to
+        // "what does this selector mean".
+        let declared: BTreeSet<u32> = entries
+            .iter()
+            .flat_map(|sel| {
+                sel.subjects
+                    .iter()
+                    .map(|s| s.0)
+                    .chain(sel.topics.iter().map(|t| {
+                        e.topics[t.index()].subject.0
+                    }))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        // An entry that resolved to nothing names no subject in
+        // this application. Static invalidity DOMINATES: the old
+        // engine matched declared entries by NAME, so an unresolved
+        // one silently covered nothing and every reached subject
+        // came back as an omission — a violation report about the
+        // subjects, when the actual defect is the typo. A law whose
+        // operands do not resolve cannot be certified against, and
+        // it cannot be violated either.
+        let unresolved: Vec<&hale_model::BusSelector> = entries
+            .iter()
+            .filter(|sel| sel.subjects.is_empty() && sel.topics.is_empty())
+            .collect();
+        if !unresolved.is_empty() {
+            let names: Vec<String> =
+                unresolved.iter().map(|s| s.name.clone()).collect();
+            diags.push(Diag::ty(
+                claim_span(row.provenance),
+                format!(
+                    "declared dependency set is invalid: `{}` names `{}`, which is not a topic or subject in this application — so the set constrains nothing and cannot be judged. Name a declared topic, or remove the entry.",
+                    decl.display,
+                    names.join("`, `")
+                ),
+            ));
+            out.push((
+                Judged {
+                    ordinal: row.ordinal,
+                    verdict: Verdict::Invalid,
+                    diags,
+                    foreign: Vec::new(),
+                },
+                witness,
+            ));
+            continue;
+        }
+
+        let mut undeclared: Vec<(u32, Option<(String, String)>)> = seen
+            .iter()
+            .filter(|(sid, _)| !declared.contains(sid))
+            .map(|(sid, via)| (*sid, via.clone()))
+            .collect();
+        undeclared.sort_by_key(|(sid, _)| *sid);
+        for (sid, via) in &undeclared {
+            let path = match via {
+                Some((locus, into)) => format!(
+                    " Path: subject `{}` -> `{}` -> subject `{}` -> `{}`.",
+                    shown(*sid),
+                    locus,
+                    into,
+                    decl.display
+                ),
+                None => format!(
+                    " It is subscribed directly by `{}`.",
+                    decl.display
+                ),
+            };
+            diags.push(Diag::ty(
+                claim_span(row.provenance),
+                format!(
+                    "declared dependency set violated: `{}` can \
+                     transitively depend on `{}` through the bus, which \
+                     its `@effects(depends: …)` does not declare.{} Add \
+                     the subject to the set, or route the input through \
+                     a subject this locus doesn't reach.",
+                    decl.display,
+                    shown(*sid),
+                    path
+                ),
+            ));
+        }
+
+        // A KNOWN excess is an answer, whatever else is unknown —
+        // the same precedence `causes:` settled on in round 2.
+        let verdict = if !diags.is_empty() {
+            Verdict::Violated
+        } else if uncertain {
+            Verdict::Uncertified
+        } else {
+            Verdict::Holds
+        };
+        witness.incomplete_endpoints.sort();
+        witness.incomplete_endpoints.dedup();
         out.push((
             Judged {
                 ordinal: row.ordinal,

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -5017,6 +5017,14 @@ pub struct DependsWitness {
     /// Params typed as a `sync`-discipline form: input channels
     /// outside the message graph entirely.
     pub sync_form_params: Vec<String>,
+    /// A publish whose SUBJECT the model could not name — it might
+    /// name a wire this locus subscribes to.
+    pub unknown_publishers: bool,
+    /// A publishing function whose CALLERS the model could not
+    /// enumerate: an indirect call, an untypeable receiver, or an
+    /// absorbed stdlib interior. Their inputs are inputs of this
+    /// locus, and the reverse graph has no edge to find them by.
+    pub unknown_callers: bool,
 }
 
 /// GH #476 Change 5g — `@effects(depends: {A, B})` on a locus,
@@ -5105,7 +5113,28 @@ pub fn judge_depends_witnessed(
             _ => None,
         })
         .collect();
-    let owning_loci = |f: FunctionId| -> Vec<hale_model::LocusDeclId> {
+    // Functions whose INBOUND call edges the model could not
+    // enumerate: an indirect call or an untypeable receiver at some
+    // call site means the reverse graph is missing edges, and a
+    // truncated or hole-bearing stdlib interior means an absorbed
+    // path could re-emerge anywhere.
+    let call_residue_anywhere = model.holes.iter().any(|h| {
+        h.hides.intersects(hale_model::RelationSet::CALLS)
+    }) || model.analyses.stdlib_absorption.iter().any(|a| {
+        a.nodes.iter().any(|n| {
+            n.events.iter().any(|ev| {
+                matches!(
+                    ev,
+                    hale_model::AbsorbedEvent::CallHole(_)
+                        | hale_model::AbsorbedEvent::Truncated
+                )
+            })
+        })
+    });
+    // Every locus that owns a function which can transitively reach
+    // `f` — including `f`'s own owner — and whether that search was
+    // COMPLETE.
+    let owning_loci = |f: FunctionId| -> (Vec<hale_model::LocusDeclId>, bool) {
         let mut seen_fn: BTreeSet<u32> = BTreeSet::new();
         let mut out: BTreeSet<u32> = BTreeSet::new();
         let mut frontier = vec![f];
@@ -5122,7 +5151,10 @@ pub fn judge_depends_witnessed(
                 frontier.push(*up);
             }
         }
-        out.into_iter().map(hale_model::LocusDeclId).collect()
+        (
+            out.into_iter().map(hale_model::LocusDeclId).collect(),
+            call_residue_anywhere,
+        )
     };
 
     let mut out = Vec::new();
@@ -5192,18 +5224,40 @@ pub fn judge_depends_witnessed(
                 _ => subject.pattern.clone(),
             }
         };
-        // Obligation 2: the backward closure. BFS over LOCI,
-        // remembering how each subject was reached so the
-        // diagnostic can name the path and not only the verdict.
+        // Obligation 2: the backward closure, SUBSCRIPTION-grained
+        // (round 3).
+        //
+        // A frontier of bare `SubjectId`s loses the wildcard and the
+        // key predicate — the two things that decide delivery. The
+        // walk then scanned every subscription in the application
+        // whose ADDRESS covered the subject, so an unrelated `**`
+        // subscriber, or one filtering `key == 2` while the target
+        // filters `key == 1`, could manufacture an upstream edge for
+        // a locus those publishes never reach. The frontier holds
+        // the actual `Subscribe` rows, and a publisher must satisfy
+        // `may_deliver` against THAT row.
         let mut uncertain = false;
         // subject -> (via locus display, into subject display)
         let mut seen: BTreeMap<u32, Option<(String, String)>> =
             BTreeMap::new();
         let mut seen_locus: BTreeSet<u32> = BTreeSet::new();
         seen_locus.insert(lid.0);
-        // (subject reaching the frontier locus, how it got there)
-        let mut queue: Vec<(hale_model::SubjectId, Option<(String, String)>)> =
-            Vec::new();
+        // Author spelling for a wire subject: the topic that
+        // declares it, when exactly one does. Identity stays the
+        // `SubjectId` — this is only how it is SHOWN, the same
+        // raw/display duality the topics section carries.
+        let shown = |sid: u32| -> String {
+            let subject = &e.subjects[sid as usize];
+            let mut named = e
+                .topics
+                .iter()
+                .filter(|t| t.subject.0 == sid)
+                .map(|t| t.display.clone());
+            match (named.next(), named.next()) {
+                (Some(one), None) => one,
+                _ => subject.pattern.clone(),
+            }
+        };
         let subs_of = |l: u32| -> Vec<hale_model::Subscribe> {
             let owned = fns_of.get(&l).cloned().unwrap_or_default();
             r.subscribes
@@ -5212,21 +5266,35 @@ pub fn judge_depends_witnessed(
                 .cloned()
                 .collect()
         };
-        for su in subs_of(lid.0) {
-            queue.push((su.subject, None));
-        }
-        while let Some((subject, via)) = queue.pop() {
-            if seen.contains_key(&subject.0) {
+        let mut queue: Vec<(
+            hale_model::Subscribe,
+            Option<(String, String)>,
+        )> = subs_of(lid.0)
+            .into_iter()
+            .map(|su| (su, None))
+            .collect();
+        // Deduplicate by SUBSCRIPTION identity (handler + site), not
+        // by subject: one locus may hold two filters on one wire and
+        // they have different upstreams.
+        let mut seen_sub: BTreeSet<(u32, u32)> = BTreeSet::new();
+        while let Some((sub, via)) = queue.pop() {
+            if !seen_sub.insert((sub.handler.0, sub.site)) {
                 continue;
             }
-            seen.insert(subject.0, via);
-            witness.reached_subjects.push(subject);
-            // Is this endpoint's UPSTREAM fully modeled? Holes over
+            let subject = sub.subject;
+            // The subject-level dependency is recorded once a real
+            // subscription is on the frontier — that is what the
+            // declaration must name.
+            if !seen.contains_key(&subject.0) {
+                seen.insert(subject.0, via.clone());
+                witness.reached_subjects.push(subject);
+            }
+            // Is this endpoint's UPSTREAM fully modelled? Holes over
             // who publishes it, an opaque delivery boundary, and a
             // `listen` binding that accepts from a peer are all the
-            // same answer — and scoping the question to THIS
-            // subject is what keeps an unrelated adapter from
-            // poisoning a purely local claim.
+            // same answer — and scoping the question to THIS subject
+            // is what keeps an unrelated adapter from poisoning a
+            // purely local claim.
             if crate::model_query::endpoint_incomplete(
                 model,
                 subject,
@@ -5236,76 +5304,44 @@ pub fn judge_depends_witnessed(
                 witness.incomplete_endpoints.push(subject);
             }
             // Function-grained publisher residue (round 2). A
-            // COMPUTED publish is recorded as a PUBLISHES hole at
-            // its function, not as a `Publish` row and not anchored
-            // to any subject — so neither the endpoint query (which
-            // reads subject- and topic-anchored holes) nor the row
-            // walk below can see it. A publisher whose subject the
-            // model could not name might name THIS wire, and a
-            // backward completeness claim cannot be certified over
-            // it.
-            //
-            // Deliberately not scoped to this subject: the hole
-            // exists precisely because the subject is unknown, so
-            // there is nothing narrower to scope it to. It
-            // downgrades to `uncertified`, never to a violation.
+            // COMPUTED publish is a PUBLISHES hole at its function,
+            // anchored to no subject — invisible to both the
+            // endpoint query and the publish-row walk below. It
+            // might name this wire.
             if !computed_publishers.is_empty() {
                 uncertain = true;
+                witness.unknown_publishers = true;
             }
-            // Who can publish INTO a subscription on this subject?
-            // The join is delivery, not the syntactic topic link: a
-            // literal `"t" <- …` send reaches a `t` subscriber, and
-            // a keyed publish that cannot meet this predicate is
-            // not an upstream at all.
-            for su in r.subscribes.iter() {
-                if !crate::model_query::subscription_covers(
-                    e, su, subject,
-                ) {
+            // Who can publish into THIS subscription?
+            for p in r.publishes.iter() {
+                if !crate::model_query::may_deliver(e, p, &sub) {
                     continue;
                 }
-                for p in r.publishes.iter() {
-                    if !crate::model_query::may_deliver(e, p, su) {
+                // Every LOCUS this publish can be reached FROM (a
+                // free helper's publish belongs to its callers),
+                // plus whether that caller search was COMPLETE.
+                let (owners, caller_residue) = owning_loci(p.function);
+                // Round 3: if the publishing function is reached
+                // through an indirect call or an absorbed stdlib
+                // hole, the known reverse graph has no edge and the
+                // caller's inputs silently vanish. Monotone, like
+                // the publisher residue: it can only turn a
+                // would-be `holds` into `uncertified`, never a
+                // proven omission into a pass.
+                if caller_residue {
+                    uncertain = true;
+                    witness.unknown_callers = true;
+                }
+                for owner in owners {
+                    let plocus = &e.loci[owner.index()];
+                    if !seen_locus.insert(owner.0) {
                         continue;
                     }
-                    // Every LOCUS this publish can be reached FROM,
-                    // not just the one that owns the publishing
-                    // function.
-                    //
-                    // Round 2: the walk used to stop at a free
-                    // function, recording its subject and giving up
-                    // because there was no owner locus to inspect.
-                    // But a handler that calls a free helper which
-                    // publishes is a real path — `Secret ->
-                    // Relay::on_secret -> emit_clean() -> Clean ->
-                    // Target::on_clean` — and stopping there let a
-                    // locus certify `depends: {Clean}` while
-                    // `Secret` reached it. The publish site's
-                    // CALLERS are part of the backward walk.
-                    for owner in owning_loci(p.function) {
-                        let plocus = &e.loci[owner.index()];
-                        if !seen_locus.insert(owner.0) {
-                            continue;
-                        }
-                        for up in subs_of(owner.0) {
-                            queue.push((
-                                up.subject,
-                                Some((
-                                    plocus.display.clone(),
-                                    shown(subject.0),
-                                )),
-                            ));
-                        }
-                    }
-                    // A publish no locus can be reached from still
-                    // delivers here — record the subject even when
-                    // the walk cannot continue past it.
-                    if !seen.contains_key(&p.subject.0) {
+                    for up in subs_of(owner.0) {
                         queue.push((
-                            p.subject,
+                            up,
                             Some((
-                                e.functions[p.function.index()]
-                                    .display
-                                    .clone(),
+                                plocus.display.clone(),
                                 shown(subject.0),
                             )),
                         ));
@@ -5405,6 +5441,59 @@ pub fn judge_depends_witnessed(
         let verdict = if !diags.is_empty() {
             Verdict::Violated
         } else if uncertain {
+            // Round 3: never silent. `claim_law_diags` appends
+            // diagnostics, not verdicts, so an unexplained
+            // `Uncertified` compiled clean while the artifact
+            // marked the document `law_failed` — and left the row
+            // with no evidence for admission to find.
+            let mut why: Vec<String> = Vec::new();
+            if !witness.incomplete_endpoints.is_empty() {
+                let subs: Vec<String> = witness
+                    .incomplete_endpoints
+                    .iter()
+                    .map(|s| format!("`{}`", shown(s.0)))
+                    .collect();
+                why.push(format!(
+                    "{} can be published into from outside this \
+                     application (an inbound route or an opaque \
+                     boundary)",
+                    subs.join(", ")
+                ));
+            }
+            if witness.unknown_publishers {
+                why.push(
+                    "a publish whose subject the compiler could not \
+                     name may address a wire this locus subscribes \
+                     to"
+                        .to_string(),
+                );
+            }
+            if witness.unknown_callers {
+                why.push(
+                    "a publishing function is reachable through a \
+                     call the compiler cannot follow, so its \
+                     callers' own inputs cannot be enumerated"
+                        .to_string(),
+                );
+            }
+            if why.is_empty() {
+                why.push(
+                    "part of the backward closure is not modelled"
+                        .to_string(),
+                );
+            }
+            diags.push(Diag::ty(
+                claim_span(row.provenance),
+                format!(
+                    "declared dependency set cannot be certified: \
+                     `{}` is reached from a closure this model does \
+                     not fully know — {}. The law is neither kept \
+                     nor broken here; close the endpoint, resolve \
+                     the call, or name the subject.",
+                    decl.display,
+                    why.join("; ")
+                ),
+            ));
             Verdict::Uncertified
         } else {
             Verdict::Holds

--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -5103,7 +5103,122 @@ pub fn judge_depends_witnessed(
         .collect();
     // Every locus that owns a function which can transitively reach
     // `f` — including `f`'s own owner.
-    // Functions whose publish set the model could not resolve.
+    // ---- what is REACHABLE, and therefore relevant ----
+    //
+    // Round 4: residue used to be a program-global boolean. An
+    // uncalled free function containing an indirect call, or a
+    // computed publish in a fn nothing executes, made every
+    // `depends:` row in the document uncertified. That inverts the
+    // model's hole rule: REACHABLE relevant residue withdraws a
+    // proof; residue anywhere in the document authorizes nothing.
+    //
+    // Executable roots are the locus members (a locus's methods and
+    // lifecycle hooks) and `main`. A free function is relevant only
+    // if something executable can reach it.
+    let reachable_fns: BTreeSet<u32> = {
+        let mut out: BTreeSet<u32> = BTreeSet::new();
+        let mut frontier: Vec<FunctionId> = e
+            .functions
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| {
+                f.owner.is_some() || f.name == "main"
+            })
+            .map(|(i, _)| FunctionId(i as u32))
+            .collect();
+        let mut callees: BTreeMap<u32, Vec<FunctionId>> =
+            BTreeMap::new();
+        for c in &r.calls {
+            callees.entry(c.from.0).or_default().push(c.to);
+        }
+        for a in &model.analyses.stdlib_absorption {
+            for node in &a.nodes {
+                for ev in &node.events {
+                    if let hale_model::AbsorbedEvent::Call {
+                        target: hale_model::AbsorbedTarget::User(u),
+                        ..
+                    } = ev
+                    {
+                        callees.entry(a.from.0).or_default().push(*u);
+                    }
+                }
+            }
+        }
+        while let Some(cur) = frontier.pop() {
+            if !out.insert(cur.0) {
+                continue;
+            }
+            for next in callees.get(&cur.0).into_iter().flatten() {
+                frontier.push(*next);
+            }
+        }
+        out
+    };
+
+    // ---- the ABSORBED publisher account (round 4) ----
+    //
+    // A stdlib interior is a first-class part of the model, and it
+    // can publish: `std::log::Logger.info` computes `log.<path>`
+    // and sends from inside its own body. Reading only
+    // `r.publishes` meant a subscriber to `log.**` saw no matching
+    // publisher, no call hole and no function-level publish hole —
+    // and could return `Holds` while a whole upstream sat behind
+    // the absorption boundary.
+    //
+    // Attributed to the USER fn the interior is reached from
+    // (`StdlibAbsorption::from`), which is where the reverse-caller
+    // walk can pick it up.
+    let mut interior_pubs: BTreeMap<u32, Vec<hale_model::SubjectId>> =
+        BTreeMap::new();
+    let mut interior_unknown: BTreeSet<u32> = BTreeSet::new();
+    for a in &model.analyses.stdlib_absorption {
+        for node in &a.nodes {
+            for ev in &node.events {
+                match ev {
+                    hale_model::AbsorbedEvent::Publish {
+                        subject,
+                        declared_topic,
+                        ..
+                    } => {
+                        let sid = declared_topic
+                            .map(|t| e.topics[t.index()].subject)
+                            .or_else(|| {
+                                e.subjects
+                                    .iter()
+                                    .position(|s| s.pattern == *subject)
+                                    .map(|i| {
+                                        hale_model::SubjectId(i as u32)
+                                    })
+                            });
+                        match sid {
+                            Some(sid) => interior_pubs
+                                .entry(a.from.0)
+                                .or_default()
+                                .push(sid),
+                            // A subject the model has no row for is
+                            // an address it cannot reason about.
+                            None => {
+                                interior_unknown.insert(a.from.0);
+                            }
+                        }
+                    }
+                    // A computed interior publish, an unexplored
+                    // frontier, or an unfollowable interior call:
+                    // the publisher set beyond it is incomplete.
+                    hale_model::AbsorbedEvent::PublishHole
+                    | hale_model::AbsorbedEvent::Truncated
+                    | hale_model::AbsorbedEvent::CallHole(_) => {
+                        interior_unknown.insert(a.from.0);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    // Functions whose publish set the model could not resolve —
+    // function-grained PUBLISHES holes plus absorbed publisher
+    // residue — RESTRICTED to the ones something can execute.
     let computed_publishers: BTreeSet<u32> = model
         .holes
         .iter()
@@ -5112,25 +5227,37 @@ pub fn judge_depends_witnessed(
             EntityRef::Function(f) => Some(f.0),
             _ => None,
         })
+        .chain(interior_unknown.iter().copied())
+        .filter(|f| reachable_fns.contains(f))
         .collect();
     // Functions whose INBOUND call edges the model could not
     // enumerate: an indirect call or an untypeable receiver at some
     // call site means the reverse graph is missing edges, and a
     // truncated or hole-bearing stdlib interior means an absorbed
     // path could re-emerge anywhere.
-    let call_residue_anywhere = model.holes.iter().any(|h| {
-        h.hides.intersects(hale_model::RelationSet::CALLS)
-    }) || model.analyses.stdlib_absorption.iter().any(|a| {
-        a.nodes.iter().any(|n| {
-            n.events.iter().any(|ev| {
-                matches!(
-                    ev,
-                    hale_model::AbsorbedEvent::CallHole(_)
-                        | hale_model::AbsorbedEvent::Truncated
-                )
-            })
+    // Round 4: RESTRICTED to reachable functions. An unfollowable
+    // call in a fn nothing executes cannot invoke anything, so it
+    // cannot hide a caller of any publisher.
+    let call_residue_relevant = model
+        .holes
+        .iter()
+        .filter(|h| h.hides.intersects(hale_model::RelationSet::CALLS))
+        .any(|h| match h.at {
+            EntityRef::Function(f) => reachable_fns.contains(&f.0),
+            _ => false,
         })
-    });
+        || model.analyses.stdlib_absorption.iter().any(|a| {
+            reachable_fns.contains(&a.from.0)
+                && a.nodes.iter().any(|n| {
+                    n.events.iter().any(|ev| {
+                        matches!(
+                            ev,
+                            hale_model::AbsorbedEvent::CallHole(_)
+                                | hale_model::AbsorbedEvent::Truncated
+                        )
+                    })
+                })
+        });
     // Every locus that owns a function which can transitively reach
     // `f` — including `f`'s own owner — and whether that search was
     // COMPLETE.
@@ -5153,7 +5280,7 @@ pub fn judge_depends_witnessed(
         }
         (
             out.into_iter().map(hale_model::LocusDeclId).collect(),
-            call_residue_anywhere,
+            call_residue_relevant,
         )
     };
 
@@ -5208,22 +5335,6 @@ pub fn judge_depends_witnessed(
             ));
         }
 
-        // Author spelling for a wire subject: the topic that
-        // declares it, when exactly one does. Identity stays the
-        // `SubjectId` — this is only how it is SHOWN, the same
-        // raw/display duality the topics section carries.
-        let shown = |sid: u32| -> String {
-            let subject = &e.subjects[sid as usize];
-            let mut named = e
-                .topics
-                .iter()
-                .filter(|t| t.subject.0 == sid)
-                .map(|t| t.display.clone());
-            match (named.next(), named.next()) {
-                (Some(one), None) => one,
-                _ => subject.pattern.clone(),
-            }
-        };
         // Obligation 2: the backward closure, SUBSCRIPTION-grained
         // (round 3).
         //
@@ -5312,8 +5423,35 @@ pub fn judge_depends_witnessed(
                 uncertain = true;
                 witness.unknown_publishers = true;
             }
-            // Who can publish into THIS subscription?
-            for p in r.publishes.iter() {
+            // Who can publish into THIS subscription? Ordinary
+            // publish rows, plus the ABSORBED publishes a stdlib
+            // interior performs on behalf of the user fn that
+            // reached it — both are first-class publishers and both
+            // join the same delivery query.
+            let absorbed: Vec<hale_model::Publish> = interior_pubs
+                .iter()
+                .flat_map(|(from, subjects)| {
+                    subjects.iter().map(move |sid| {
+                        hale_model::Publish {
+                            function: FunctionId(*from),
+                            subject: *sid,
+                            // An interior publish carries no
+                            // declared-topic link and no key domain
+                            // the model records, so it widens like
+                            // any unknown one.
+                            declared_topic: None,
+                            payload: hale_model::PayloadContractId(0),
+                            site: 0,
+                            in_loop: false,
+                            key_domain: None,
+                            disposition:
+                                hale_model::keys::PublishDisposition::Default,
+                            provenance: hale_model::ProvenanceId(0),
+                        }
+                    })
+                })
+                .collect();
+            for p in r.publishes.iter().chain(absorbed.iter()) {
                 if !crate::model_query::may_deliver(e, p, &sub) {
                     continue;
                 }

--- a/crates/hale-types/src/model_builder.rs
+++ b/crates/hale-types/src/model_builder.rs
@@ -451,11 +451,42 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
 
     // ---- entity tables (canonical order via BTree keys, RAW) ----
     // Loci.
-    let mut locus_rows: BTreeMap<String, (bool, hale_syntax::Span)> =
-        BTreeMap::new();
+    struct LocusRow {
+        sealed: bool,
+        span: hale_syntax::Span,
+        sync_form: bool,
+        /// (param name, declared type's last segment)
+        params: Vec<(String, String)>,
+    }
+    let mut locus_rows: BTreeMap<String, LocusRow> = BTreeMap::new();
     for l in &ast.loci {
-        locus_rows
-            .insert(l.name.name.clone(), (l.sealed, l.name.span));
+        // #340: the `sync` discipline is read off the form's own
+        // declaration. There is no annotation for it, and there
+        // should not be — it is a property of how the form is
+        // shared, not a claim about it.
+        let sync_form = l.form.as_ref().is_some_and(|f| {
+            f.args.iter().any(|a| a.name.name == "sync")
+        });
+        let mut params = Vec::new();
+        for m in &l.members {
+            let LocusMember::Params(pb) = m else { continue };
+            for prm in &pb.params {
+                let Some(TypeExpr::Named { path, .. }) = &prm.ty else {
+                    continue;
+                };
+                let Some(seg) = path.segments.last() else { continue };
+                params.push((prm.name.name.clone(), seg.name.clone()));
+            }
+        }
+        locus_rows.insert(
+            l.name.name.clone(),
+            LocusRow {
+                sealed: l.sealed,
+                span: l.name.span,
+                sync_form,
+                params,
+            },
+        );
     }
     let locus_id: BTreeMap<&String, LocusDeclId> = locus_rows
         .keys()
@@ -2047,13 +2078,23 @@ pub fn derive_application_model(bundle: &Bundle<'_>) -> ApplicationModel {
         }
         out
     };
-    for (n, (sealed, sp)) in &locus_rows {
-        let pid = intern_span(&mut records, *sp);
+    for (n, row) in &locus_rows {
+        let pid = intern_span(&mut records, row.span);
         e.loci.push(LocusDecl {
             name: n.clone(),
             display: name(n),
-            sealed: *sealed,
+            sealed: row.sealed,
             analyzable: !module_loci.contains(n),
+            sync_form: row.sync_form,
+            params: row
+                .params
+                .iter()
+                .map(|(pn, ty)| hale_model::LocusParam {
+                    name: pn.clone(),
+                    type_name: ty.clone(),
+                    decl: locus_id.get(ty).copied(),
+                })
+                .collect(),
             provenance: pid,
         });
     }

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -131,6 +131,10 @@ use crate::symbol::Bundle;
 // HASHED model half — an explicitly versioned shape transition.
 // Shape hashes change for every bus-carrying program; recorded
 // baselines and `.halerec` admissions must be re-recorded once.
+// 1.15: `depends:` joins it (Change 5g), on the same terms —
+// `"family": "depends"`, its own rendered form, no legacy entry.
+// `law.legacy` now covers `@budget` alone.
+//
 // 1.14: `causes:` is a judged family (GH #476 Change 5f), not an
 // unmigrated row importing an outside verdict. Its rows now carry
 // `"family": "causes"` and their own rendered `form`, and they no
@@ -156,7 +160,7 @@ use crate::symbol::Bundle;
 // stdlib re-emerges into user code only from inside its own loops,
 // which sets the bit either way — so this bumps the schema without
 // moving a single committed baseline hash.
-pub const TOPOLOGY_SCHEMA: &str = "1.14";
+pub const TOPOLOGY_SCHEMA: &str = "1.15";
 
 /// GH #408 Phase 0: what the rows MEAN, as distinct from their shape.
 ///

--- a/crates/hale-types/src/topology_projection.rs
+++ b/crates/hale-types/src/topology_projection.rs
@@ -906,8 +906,14 @@ pub fn legacy_unmigrated_verdicts(
         }
     }
 
-    // ---- causes / depends: span-attributed, single-assert
-    // subjects only ----
+    // ---- span-attributed, single-assert subjects only ----
+    //
+    // `causes:` (Change 5f) and `depends:` (Change 5g) used to be
+    // imported here by matching the old engines' diagnostics back
+    // to a row by span. Both are judged families now: they state
+    // their own form and import no outside verdict, so this block
+    // covers `@budget` alone until 5h retires it entirely.
+    #[allow(unused)]
     let span_of_row =
         |row: &hale_model::ClaimRow| -> Option<(usize, usize)> {
             match table
@@ -933,48 +939,6 @@ pub fn legacy_unmigrated_verdicts(
                 _ => None,
             }
         };
-    let causes_diags =
-        crate::frontier::causes_diags(&programs, graph);
-    let depends_diags =
-        crate::frontier::depends_diags(&programs, graph);
-    for row in &table.rows {
-        let (diags, enumerated, unambiguous) = match &row.law {
-            ClaimIr::EffectCauses { .. } => (
-                &causes_diags,
-                vis_causes.contains_key(&row.name),
-                vis_causes.get(&row.name) == Some(&1),
-            ),
-            ClaimIr::DependsSet { .. } => (
-                &depends_diags,
-                vis_depends.contains(&row.name),
-                true,
-            ),
-            _ => continue,
-        };
-        if !enumerated {
-            continue; // never evaluated — stays uncertified
-        }
-        let Some((a, b)) = span_of_row(row) else {
-            continue;
-        };
-        let hit = diags.iter().any(|d| {
-            d.span.start.as_usize() == a
-                && d.span.end.as_usize() == b
-        });
-        if hit && !unambiguous {
-            // Two asserts share one anchor — the diagnostic
-            // cannot be attributed to a row.
-            continue;
-        }
-        out.insert(
-            row.ordinal,
-            if hit {
-                crate::verdict::Verdict::Violated
-            } else {
-                crate::verdict::Verdict::Holds
-            },
-        );
-    }
     out
 }
 
@@ -1024,6 +988,9 @@ pub fn judge_all(
         judged.insert(j.ordinal, j);
     }
     for j in crate::judgment::judge_causes(table, model, source_bases) {
+        judged.insert(j.ordinal, j);
+    }
+    for j in crate::judgment::judge_depends(table, model, source_bases) {
         judged.insert(j.ordinal, j);
     }
     (pre, judged)

--- a/crates/hale-types/src/topology_projection.rs
+++ b/crates/hale-types/src/topology_projection.rs
@@ -1363,6 +1363,8 @@ pub fn family_adequacy(
         // artifact that could not state whether the model is exact
         // or degraded there would be internally contradictory.
         F::Causes,
+        // Change 5g, same contract.
+        F::Depends,
     ]
     .into_iter()
     .map(|f| (f, vouched.contains(f.required_relations())))

--- a/crates/hale-types/tests/claim_diags_differential.rs
+++ b/crates/hale-types/tests/claim_diags_differential.rs
@@ -69,9 +69,9 @@ fn legacy_arm(bundle: &Bundle<'_>) -> Vec<String> {
         bundle.programs.values().copied().collect();
     let (top, _) = hale_types::resolve::build_top_scope(bundle);
     let graph = hale_types::bus_graph::build_bus_graph(bundle, &top);
-    // Since Change 5f the check path also judges `causes:`, whose
-    // evaluator lives in `frontier` rather than in `claims.rs` —
-    // the legacy arm is both engines.
+    // Since Changes 5f and 5g the check path also judges `causes:`
+    // and `depends:`, whose evaluators live in `frontier` rather
+    // than in `claims.rs` — the legacy arm is all three engines.
     let mut d = hale_types::claims::claims_diags(
         &programs,
         &graph,
@@ -86,11 +86,12 @@ fn legacy_arm(bundle: &Bundle<'_>) -> Vec<String> {
     for diag in &mut d {
         diag.kind = hale_syntax::error::DiagKind::Claim;
     }
-    let mut causes = hale_types::frontier::causes_diags(&programs, &graph);
-    for diag in &mut causes {
+    let mut migrated = hale_types::frontier::causes_diags(&programs, &graph);
+    migrated.extend(hale_types::frontier::depends_diags(&programs, &graph));
+    for diag in &mut migrated {
         diag.kind = hale_syntax::error::DiagKind::Claim;
     }
-    d.extend(causes);
+    d.extend(migrated);
     d.iter().map(render).collect()
 }
 
@@ -110,6 +111,62 @@ fn model_arm(bundle: &Bundle<'_>) -> Vec<String> {
     out.iter().map(render).collect()
 }
 
+
+/// The two ways the migrated `depends:` engine parts company with
+/// the evaluator, each admitted only when the ROW's own verdict is
+/// the explanation.
+///
+/// **Invalid operands.** The evaluator matched declared entries by
+/// NAME. An entry naming nothing therefore covered nothing, and
+/// every subject that reached the locus came back as an omission —
+/// a violation report about the subjects, when the defect is the
+/// typo. The model refuses: an unresolved operand makes `invalid`
+/// the only admissible verdict, the same rule the artifact's
+/// admission already enforced.
+///
+/// **Wire identity.** `@effects(depends: { "evt" })` names the WIRE
+/// SUBJECT of a topic spelled `Evt`. Those are one endpoint, and
+/// the evaluator's name comparison said they were two — the same
+/// defect the `causes:` rounds settled, in the backward direction.
+fn depends_divergence_is_explained(
+    bundle: &Bundle<'_>,
+    legacy_only: &[&String],
+    model_only: &[&String],
+) -> bool {
+    if legacy_only.is_empty()
+        || !legacy_only
+            .iter()
+            .all(|l| l.contains("declared dependency set violated"))
+    {
+        return false;
+    }
+    let model = hale_types::model_builder::derive_application_model(bundle);
+    let table = hale_types::claim_lowering::lower_claims(bundle, &model);
+    let bases: Vec<u32> = bundle.sources.iter().map(|f| f.base).collect();
+    let judged =
+        hale_types::judgment::judge_depends_witnessed(&table, &model, &bases);
+    if judged.is_empty() {
+        return false;
+    }
+    // Class A: the row is INVALID, and that is exactly what the
+    // model said instead.
+    let invalid = judged.iter().any(|(j, _)| {
+        j.verdict == hale_types::verdict::Verdict::Invalid
+    });
+    if invalid {
+        return model_only.iter().all(|l| {
+            l.contains("declared dependency set is invalid")
+        });
+    }
+    // Class B: the row HOLDS, adding nothing, because every subject
+    // the walk reached is named — by wire subject where the
+    // evaluator wanted the topic's spelling.
+    model_only.is_empty()
+        && judged.iter().all(|(j, _)| {
+            j.verdict == hale_types::verdict::Verdict::Holds
+        })
+}
+
 #[test]
 fn claim_diagnostics_match_the_evaluator_over_the_corpus() {
     let mut compared = 0usize;
@@ -117,8 +174,9 @@ fn claim_diagnostics_match_the_evaluator_over_the_corpus() {
     let mut mismatches: Vec<String> = Vec::new();
     let mut documented_divergences = 0usize;
     for program in hale_corpus::all() {
-        // `judgment_causes.rs` is the control suite for the migrated
-        // `causes:` engine, and several of its fixtures exist
+        // `judgment_causes.rs` and `judgment_depends.rs` are the
+        // control suites for the migrated engines, and several of
+        // their fixtures exist
         // PRECISELY to pin a place where the model engine is right
         // and the evaluator was wrong: a saturated walk that used to
         // report every class it had never proven, and a known
@@ -126,7 +184,9 @@ fn claim_diagnostics_match_the_evaluator_over_the_corpus() {
         // two there asserts the bug. Each of those fixtures already
         // asserts the model's verdict directly, in the control that
         // owns it.
-        if program.origin.contains("judgment_causes.rs") {
+        if program.origin.contains("judgment_causes.rs")
+            || program.origin.contains("judgment_depends.rs")
+        {
             continue;
         }
         let Ok(parsed) = hale_syntax::parse_source(&program.source) else {
@@ -170,6 +230,17 @@ fn claim_diagnostics_match_the_evaluator_over_the_corpus() {
                     .iter()
                     .all(|l| l.contains("uncertified:"))
             {
+                documented_divergences += 1;
+                continue;
+            }
+            // Change 5g. `depends:` diverges in two places, and
+            // each premise is ROW-LOCAL — read off the judgment's
+            // own verdict for the row, never off the program.
+            if depends_divergence_is_explained(
+                &bundle,
+                &legacy_only,
+                &model_only,
+            ) {
                 documented_divergences += 1;
                 continue;
             }

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -1290,6 +1290,10 @@ crates/hale-types/tests/judgment_certificates.rs#5 5b19cc4370a72a2f
 crates/hale-types/tests/judgment_certificates.rs#6 5b19cc4370a72a2f
 crates/hale-types/tests/judgment_certificates.rs#8 7d5cf57defcf548e
 crates/hale-types/tests/judgment_certificates.rs#9 5b19cc4370a72a2f
+crates/hale-types/tests/judgment_depends.rs#2 4ebcead20c253595
+crates/hale-types/tests/judgment_depends.rs#3 6bd28037e4d97c71
+crates/hale-types/tests/judgment_depends.rs#4 57b3e718f9ba2b13
+crates/hale-types/tests/judgment_depends.rs#6 1e29a74a1331d44d
 crates/hale-types/tests/judgment_reachability.rs#12 f7d9fb64200c3e4b
 crates/hale-types/tests/judgment_reachability.rs#14 1b7facc0d6b6d52b
 crates/hale-types/tests/judgment_reachability.rs#22 4362d16e6b2ccfdd

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -1286,9 +1286,9 @@ crates/hale-types/tests/judgment_certificates.rs#6 5b19cc4370a72a2f
 crates/hale-types/tests/judgment_certificates.rs#8 7d5cf57defcf548e
 crates/hale-types/tests/judgment_certificates.rs#9 5b19cc4370a72a2f
 crates/hale-types/tests/judgment_depends.rs#2 4ebcead20c253595
-crates/hale-types/tests/judgment_depends.rs#3 6bd28037e4d97c71
 crates/hale-types/tests/judgment_depends.rs#4 57b3e718f9ba2b13
 crates/hale-types/tests/judgment_depends.rs#6 1e29a74a1331d44d
+crates/hale-types/tests/judgment_depends.rs#9 2a665aaeccc99a1e
 crates/hale-types/tests/judgment_reachability.rs#12 f7d9fb64200c3e4b
 crates/hale-types/tests/judgment_reachability.rs#14 1b7facc0d6b6d52b
 crates/hale-types/tests/judgment_reachability.rs#22 4362d16e6b2ccfdd

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -1285,6 +1285,7 @@ crates/hale-types/tests/judgment_certificates.rs#5 5b19cc4370a72a2f
 crates/hale-types/tests/judgment_certificates.rs#6 5b19cc4370a72a2f
 crates/hale-types/tests/judgment_certificates.rs#8 7d5cf57defcf548e
 crates/hale-types/tests/judgment_certificates.rs#9 5b19cc4370a72a2f
+crates/hale-types/tests/judgment_depends.rs#12 5e52e14006660555
 crates/hale-types/tests/judgment_depends.rs#2 4ebcead20c253595
 crates/hale-types/tests/judgment_depends.rs#4 57b3e718f9ba2b13
 crates/hale-types/tests/judgment_depends.rs#6 1e29a74a1331d44d

--- a/crates/hale-types/tests/judgment_depends.rs
+++ b/crates/hale-types/tests/judgment_depends.rs
@@ -1,0 +1,317 @@
+//! GH #476 Change 5g — `@effects(depends: {…})` over the canonical
+//! model (RFC #330).
+//!
+//! The backward dual of `causes:`, and these controls are mostly
+//! about the places the two must AGREE. `causes:` asks what a
+//! publish reaches; `depends:` asks what can reach a subscription.
+//! If those two walks disagree about whether a publish and a
+//! subscription meet, one of them is wrong — so both call the same
+//! `model_query` joins, and the cases below are the ones where the
+//! evaluator's name comparison and the model's typed identity gave
+//! different answers.
+
+use std::collections::BTreeMap;
+
+use hale_types::model_builder::derive_application_model;
+use hale_types::symbol::SourceFile;
+use hale_types::verdict::Verdict;
+use hale_types::Bundle;
+
+fn bundle_of<'a>(
+    src: &str,
+    program: &'a hale_syntax::ast::Program,
+) -> Bundle<'a> {
+    let mut programs = BTreeMap::new();
+    programs.insert("app.hl".to_string(), program);
+    let mut b = Bundle::new(programs);
+    b.sources = vec![SourceFile {
+        id: 0,
+        path: "app.hl".to_string(),
+        digest: "0".to_string(),
+        base: 0,
+        len: src.len() as u32,
+    }];
+    b
+}
+
+/// The row verdict plus its diagnostics, which is what every
+/// control below asserts on.
+fn judge(src: &str) -> (Verdict, Vec<String>) {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bundle = bundle_of(src, &program);
+    let model = derive_application_model(&bundle);
+    let table = hale_types::claim_lowering::lower_claims(&bundle, &model);
+    let bases: Vec<u32> = bundle.sources.iter().map(|f| f.base).collect();
+    let judged =
+        hale_types::judgment::judge_depends(&table, &model, &bases);
+    assert_eq!(
+        judged.len(),
+        1,
+        "expected exactly one depends row, got {}",
+        judged.len()
+    );
+    let j = &judged[0];
+    (
+        j.verdict,
+        j.diags.iter().map(|d| d.message.clone()).collect(),
+    )
+}
+
+const BASE: &str = r#"
+type Act { mag: Float; pos: Int; }
+topic SumLookup { payload: Act; subject: "sum.lookup"; }
+topic Recalled  { payload: Act; subject: "recalled"; }
+
+locus Relay {
+    bus { subscribe SumLookup as on_sum; publish Recalled; }
+    fn on_sum(a: Act) { Recalled <- Act { mag: a.mag, pos: a.pos }; }
+}
+@effects(depends: {DECLARED})
+locus Carry {
+    bus { subscribe Recalled as on_recalled; }
+    params { recalled: Float = 0.0; }
+    fn on_recalled(a: Act) { self.recalled = a.mag; }
+}
+locus Compute {
+    bus { publish SumLookup; }
+    fn go() { SumLookup <- Act { mag: 7.0, pos: 1 }; }
+}
+main locus App {
+    params {
+        r: Relay = Relay { }; c: Carry = Carry { };
+        k: Compute = Compute { };
+    }
+}
+fn main() { App { }; }
+"#;
+
+fn with(declared: &str) -> String {
+    BASE.replace("DECLARED", declared)
+}
+
+#[test]
+fn the_full_backward_closure_holds() {
+    let (v, ds) = judge(&with("Recalled, SumLookup"));
+    assert_eq!(v, Verdict::Holds, "{:?}", ds);
+}
+
+#[test]
+fn a_laundered_second_hop_is_a_violation() {
+    // `Carry` names only what it directly subscribes. The whole
+    // point of the law: `SumLookup` reaches it through `Relay`.
+    let (v, ds) = judge(&with("Recalled"));
+    assert_eq!(v, Verdict::Violated);
+    assert!(
+        ds.iter().any(|m| m.contains("SumLookup")
+            && m.contains("-> `Relay` ->")),
+        "the diagnostic must name the laundering path: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn the_declaration_may_name_the_wire_subject() {
+    // `"recalled"` IS topic `Recalled` — one endpoint, two
+    // spellings. The evaluator compared names and called this an
+    // omission; the model joins on `SubjectId`.
+    let (v, ds) = judge(&with("\"recalled\", \"sum.lookup\""));
+    assert_eq!(
+        v,
+        Verdict::Holds,
+        "wire subject and topic name address the same endpoint: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn an_operand_naming_nothing_is_invalid_not_violated() {
+    // The evaluator matched by NAME, so a typo covered nothing and
+    // every reached subject came back as an omission — a violation
+    // report about the subjects, when the defect is the typo.
+    let (v, ds) = judge(&with("Recaled, SumLookup"));
+    assert_eq!(v, Verdict::Invalid);
+    assert!(
+        ds.iter().any(|m| m.contains("is invalid")
+            && m.contains("Recaled")),
+        "the diagnostic must name the unresolved entry: {:?}",
+        ds
+    );
+    assert!(
+        !ds.iter().any(|m| m.contains("violated")),
+        "an invalid law is not a violated one: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn a_sync_form_param_refuses_the_whole_claim() {
+    // #340. Another pool writes the form, this locus reads it, and
+    // NO bus edge records the transfer — so the message graph, all
+    // this walk can see, cannot support a completeness claim.
+    let src = r#"
+type Act { mag: Float; pos: Int; }
+topic Recalled { payload: Act; subject: "recalled"; }
+@form(hashmap, sync = lockfree)
+locus Shared {
+    params { n: Int = 0; }
+    fn get() -> Int { return self.n; }
+}
+@effects(depends: {Recalled})
+locus Carry {
+    bus { subscribe Recalled as on_recalled; }
+    params { shared: Shared = Shared { }; recalled: Float = 0.0; }
+    fn on_recalled(a: Act) { self.recalled = a.mag; }
+}
+main locus App {
+    params { c: Carry = Carry { }; }
+}
+fn main() { App { }; }
+"#;
+    let (v, ds) = judge(src);
+    assert_eq!(v, Verdict::Violated);
+    assert!(
+        ds.iter().any(|m| m.contains("sync") && m.contains("shared")),
+        "the diagnostic must name the param and the discipline: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn an_ordinary_child_locus_is_not_a_sync_form() {
+    // The premise of the control above: it is the FORM's `sync`
+    // argument that matters, not merely holding another locus.
+    let src = r#"
+type Act { mag: Float; pos: Int; }
+topic Recalled { payload: Act; subject: "recalled"; }
+locus Plain {
+    params { n: Int = 0; }
+    fn get() -> Int { return self.n; }
+}
+@effects(depends: {Recalled})
+locus Carry {
+    bus { subscribe Recalled as on_recalled; }
+    params { plain: Plain = Plain { }; recalled: Float = 0.0; }
+    fn on_recalled(a: Act) { self.recalled = a.mag; }
+}
+main locus App {
+    params { c: Carry = Carry { }; }
+}
+fn main() { App { }; }
+"#;
+    let (v, ds) = judge(src);
+    assert_eq!(v, Verdict::Holds, "{:?}", ds);
+}
+
+#[test]
+fn an_inbound_route_makes_the_upstream_uncertified() {
+    // A `listen` binding accepts from a peer this application does
+    // not model. Nothing local publishes `Recalled`, so a walk
+    // reading only local publishes would report a clean `holds` —
+    // the fail-open the direction-aware endpoint query exists to
+    // close.
+    let src = r#"
+type Act { mag: Float; pos: Int; }
+topic Recalled { payload: Act; subject: "recalled"; }
+@effects(depends: {Recalled})
+locus Carry {
+    bus { subscribe Recalled as on_recalled; }
+    params { recalled: Float = 0.0; }
+    fn on_recalled(a: Act) { self.recalled = a.mag; }
+}
+main locus App {
+    params { c: Carry = Carry { }; }
+    bindings { Recalled: unix("/tmp/hale-depends-in.sock", role: listen); }
+}
+fn main() { App { }; }
+"#;
+    let (v, ds) = judge(src);
+    assert_eq!(
+        v,
+        Verdict::Uncertified,
+        "a peer can publish into this subject: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn an_outbound_route_does_not_taint_the_backward_walk() {
+    // The dual of the control above, and the reason the query takes
+    // a DIRECTION: a `connect` route is where messages LEAVE. It
+    // says nothing about what can reach this locus.
+    let src = r#"
+type Act { mag: Float; pos: Int; }
+topic Recalled { payload: Act; subject: "recalled"; }
+topic Outbound { payload: Act; subject: "outbound"; }
+locus Src {
+    bus { publish Recalled; }
+    fn go() { Recalled <- Act { mag: 1.0, pos: 1 }; }
+}
+@effects(depends: {Recalled})
+locus Carry {
+    bus { subscribe Recalled as on_recalled; publish Outbound; }
+    params { recalled: Float = 0.0; }
+    fn on_recalled(a: Act) {
+        self.recalled = a.mag;
+        Outbound <- Act { mag: a.mag, pos: a.pos };
+    }
+}
+main locus App {
+    params { s: Src = Src { }; c: Carry = Carry { }; }
+    bindings { Outbound: unix("/tmp/hale-depends-out.sock", role: connect); }
+}
+fn main() { App { }; }
+"#;
+    let (v, ds) = judge(src);
+    assert_eq!(v, Verdict::Holds, "{:?}", ds);
+}
+
+#[test]
+fn a_free_function_publisher_still_counts_as_an_upstream() {
+    // Ownership is how the walk hops from a subject to a locus's
+    // own inputs; a publisher owned by no locus has no inputs to
+    // walk on to, but its subject reaches here all the same.
+    let src = r#"
+type Act { mag: Float; pos: Int; }
+topic Recalled { payload: Act; subject: "recalled"; }
+fn shout() { Recalled <- Act { mag: 1.0, pos: 1 }; }
+@effects(depends: {})
+locus Carry {
+    bus { subscribe Recalled as on_recalled; }
+    params { recalled: Float = 0.0; }
+    fn on_recalled(a: Act) { self.recalled = a.mag; }
+}
+main locus App {
+    params { c: Carry = Carry { }; }
+    run() { shout(); }
+}
+fn main() { App { }; }
+"#;
+    let (v, ds) = judge(src);
+    assert_eq!(v, Verdict::Violated);
+    assert!(
+        ds.iter().any(|m| m.contains("Recalled")
+            || m.contains("recalled")),
+        "{:?}",
+        ds
+    );
+}
+
+#[test]
+fn a_pure_publisher_depends_on_nothing() {
+    let src = r#"
+type Act { mag: Float; pos: Int; }
+topic Recalled { payload: Act; subject: "recalled"; }
+@effects(depends: {})
+locus Src {
+    bus { publish Recalled; }
+    fn go() { Recalled <- Act { mag: 1.0, pos: 1 }; }
+}
+main locus App {
+    params { s: Src = Src { }; }
+    run() { self.s.go(); }
+}
+fn main() { App { }; }
+"#;
+    let (v, ds) = judge(src);
+    assert_eq!(v, Verdict::Holds, "{:?}", ds);
+}

--- a/crates/hale-types/tests/judgment_depends.rs
+++ b/crates/hale-types/tests/judgment_depends.rs
@@ -536,3 +536,128 @@ fn main() { App { }; }
         ds
     );
 }
+
+/// Review pin (round 4): a stdlib interior can PUBLISH, and the
+/// backward walk has to see it.
+///
+/// `std::log::Logger.info` computes `log.<path>` and sends from
+/// inside its own body. Reading only `relations.publishes` meant a
+/// subscriber to `log.**` found no matching publisher, no call hole
+/// and no function-level publish hole — and could return `Holds`
+/// while an entire upstream sat behind the absorption boundary.
+#[test]
+fn an_absorbed_computed_publish_is_not_invisible() {
+    let src = r#"
+type Msg { n: Int = 0; }
+topic Secret { payload: Msg; subject: "secret"; }
+
+locus Relay {
+    bus { subscribe Secret as on_secret; }
+    params { log: std::log::Logger = std::log::Logger { }; }
+    fn on_secret(m: Msg) { self.log.info("relayed"); }
+}
+@effects(depends: {"log.**"})
+locus Target {
+    bus { subscribe "log.**" as on_log of type std::log::LogEvent; }
+    params { n: Int = 0; }
+    fn on_log(ev: std::log::LogEvent) { self.n = 1; }
+}
+locus Src {
+    bus { publish Secret; }
+    fn go() { Secret <- Msg { n: 7 }; }
+}
+main locus App {
+    params {
+        r: Relay = Relay { }; t: Target = Target { };
+        s: Src = Src { };
+    }
+}
+fn main() { App { }; }
+"#;
+    let (v, ds) = judge(src);
+    assert_ne!(
+        v,
+        Verdict::Holds,
+        "the absorbed publish hides an upstream: {:?}",
+        ds
+    );
+}
+
+/// Review pin (round 4): residue must be REACHABLE to matter.
+///
+/// The model's hole rule is that reachable relevant residue
+/// withdraws a proof — not that residue anywhere in the document
+/// authorizes a refusal. A program-global flag made an uncalled
+/// helper's indirect call uncertify every `depends:` row.
+#[test]
+fn a_dead_indirect_call_does_not_uncertify_an_exact_law() {
+    let src = r#"
+type Msg { n: Int = 0; }
+topic Clean { payload: Msg; subject: "clean"; }
+
+// Never called by anything executable.
+fn dead_apply(f: fn(Int) -> Int, x: Int) -> Int { return f(x); }
+
+locus Source {
+    bus { publish Clean; }
+    fn go() { Clean <- Msg { n: 1 }; }
+}
+@effects(depends: {Clean})
+locus Target {
+    bus { subscribe Clean as on_clean; }
+    params { n: Int = 0; }
+    fn on_clean(m: Msg) { self.n = m.n; }
+}
+main locus App {
+    params { s: Source = Source { }; t: Target = Target { }; }
+    run() { self.s.go(); }
+}
+fn main() { App { }; }
+"#;
+    let (v, ds) = judge(src);
+    assert_eq!(
+        v,
+        Verdict::Holds,
+        "`dead_apply` is on no caller path to `Source::go`: {:?}",
+        ds
+    );
+}
+
+/// The publisher-side twin: a computed publish in a function nothing
+/// executes cannot address anything.
+#[test]
+fn a_dead_computed_publish_does_not_uncertify_an_exact_law() {
+    let src = r#"
+type Msg { n: Int = 0; }
+topic Clean { payload: Msg; subject: "clean"; }
+
+fn pick(n: Int) -> String { if n > 0 { return "x"; } return "y"; }
+// Never called.
+fn dead_shout(n: Int) { pick(n) <- Msg { n: n }; }
+
+locus Source {
+    bus { publish Clean; publish "z.**" of type Msg; }
+    fn go() { Clean <- Msg { n: 1 }; }
+}
+@effects(depends: {Clean})
+locus Target {
+    bus { subscribe Clean as on_clean; }
+    params { n: Int = 0; }
+    fn on_clean(m: Msg) { self.n = m.n; }
+}
+main locus App {
+    params { s: Source = Source { }; t: Target = Target { }; }
+    run() { self.s.go(); }
+}
+fn main() { App { }; }
+"#;
+    let (v, ds) = judge(src);
+    assert_eq!(
+        v,
+        Verdict::Holds,
+        "`dead_shout` is unreachable, so its computed subject \
+         addresses nothing: {:?}",
+        ds
+    );
+}
+

--- a/crates/hale-types/tests/judgment_depends.rs
+++ b/crates/hale-types/tests/judgment_depends.rs
@@ -414,3 +414,125 @@ fn main() { App { }; }
         ds
     );
 }
+
+/// Review pin (round 3): the backward frontier is
+/// SUBSCRIPTION-grained.
+///
+/// With a queue of bare subjects, the walk scanned every
+/// subscription whose ADDRESS covered the subject — so an unrelated
+/// wildcard subscriber let a publish that never reaches this locus
+/// drag its publisher's inputs in as dependencies.
+#[test]
+fn an_unrelated_wildcard_subscriber_is_not_an_upstream() {
+    let src = r#"
+type Msg { n: Int = 0; }
+topic Secret   { payload: Msg; subject: "secret"; }
+topic Clean    { payload: Msg; subject: "clean"; }
+topic OtherWire { payload: Msg; subject: "other"; }
+
+locus Relay {
+    bus { subscribe Secret as on_secret; publish OtherWire; }
+    params { n: Int = 0; }
+    fn on_secret(m: Msg) { OtherWire <- Msg { n: m.n }; }
+}
+locus Nosy {
+    bus { subscribe "**" as on_any; }
+    params { n: Int = 0; }
+    fn on_any(m: Msg) { self.n = m.n; }
+}
+locus Feeder {
+    bus { publish Clean; }
+    fn go() { Clean <- Msg { n: 1 }; }
+}
+@effects(depends: {Clean})
+locus Target {
+    bus { subscribe Clean as on_clean; }
+    params { n: Int = 0; }
+    fn on_clean(m: Msg) { self.n = m.n; }
+}
+locus Src {
+    bus { publish Secret; }
+    fn go() { Secret <- Msg { n: 7 }; }
+}
+main locus App {
+    params {
+        r: Relay = Relay { }; y: Nosy = Nosy { };
+        f: Feeder = Feeder { }; t: Target = Target { };
+        s: Src = Src { };
+    }
+}
+fn main() { App { }; }
+"#;
+    let (v, ds) = judge(src);
+    assert_eq!(
+        v,
+        Verdict::Holds,
+        "`Nosy`'s `**` covers `clean`, but `Relay`'s `other` publish \
+         reaches Nosy, not Target: {:?}",
+        ds
+    );
+    assert!(
+        !ds.iter().any(|m| m.contains("Secret")),
+        "`Secret` is upstream of Nosy, not of Target: {:?}",
+        ds
+    );
+}
+
+// The KEYED version of the same defect — two disjoint filters on one
+// wire have different upstreams — is the same fix: the frontier
+// carries the subscription, so `may_deliver` sees its predicate.
+// It is not restated as a control here because it needs a
+// statically EXACT publish key domain to be provable, and
+// `may_deliver`'s exact-domain arm is pinned directly in
+// `judgment_causes::may_deliver_respects_exact_key_domains`. With an
+// unknown key domain the walk widens, which is the sound direction.
+
+/// Review pin (round 3): caller discovery that CANNOT be completed
+/// downgrades the verdict rather than passing unnoticed.
+#[test]
+fn an_unfollowable_caller_makes_the_law_uncertified() {
+    let src = r#"
+type Msg { n: Int = 0; }
+topic Secret { payload: Msg; subject: "secret"; }
+topic Clean  { payload: Msg; subject: "clean"; }
+
+fn emit_clean() { Clean <- Msg { n: 1 }; }
+fn apply(f: fn() -> Unit) { f(); }
+
+locus Relay {
+    bus { subscribe Secret as on_secret; publish Clean; }
+    params { n: Int = 0; }
+    fn on_secret(m: Msg) { apply(emit_clean); }
+}
+@effects(depends: {Clean})
+locus Target {
+    bus { subscribe Clean as on_clean; }
+    params { n: Int = 0; }
+    fn on_clean(m: Msg) { self.n = m.n; }
+}
+locus Src {
+    bus { publish Secret; }
+    fn go() { Secret <- Msg { n: 7 }; }
+}
+main locus App {
+    params {
+        r: Relay = Relay { }; t: Target = Target { };
+        s: Src = Src { };
+    }
+}
+fn main() { App { }; }
+"#;
+    let (v, ds) = judge(src);
+    assert_eq!(
+        v,
+        Verdict::Uncertified,
+        "the reverse graph has no edge from `Relay` to \
+         `emit_clean`, so `Secret` would silently vanish: {:?}",
+        ds
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("cannot follow")),
+        "and it says which knowledge is missing: {:?}",
+        ds
+    );
+}

--- a/crates/hale-types/tests/judgment_depends.rs
+++ b/crates/hale-types/tests/judgment_depends.rs
@@ -315,3 +315,102 @@ fn main() { App { }; }
     let (v, ds) = judge(src);
     assert_eq!(v, Verdict::Holds, "{:?}", ds);
 }
+
+/// Review pin (round 2): the backward walk climbs reverse CALLS.
+///
+/// The walk used to stop at a free-function publisher, recording
+/// its subject and giving up because there was no owner locus to
+/// inspect. But a handler that calls a free helper which publishes
+/// is a real path, and stopping there let a locus certify a
+/// dependency set that omitted the subject driving it.
+const LAUNDERED_VIA_HELPER: &str = r#"
+type Msg { n: Int = 0; }
+topic Secret { payload: Msg; subject: "secret"; }
+topic Clean  { payload: Msg; subject: "clean"; }
+
+fn emit_clean() { Clean <- Msg { n: 1 }; }
+
+locus Relay {
+    bus { subscribe Secret as on_secret; publish Clean; }
+    params { n: Int = 0; }
+    fn on_secret(m: Msg) { emit_clean(); }
+}
+@effects(depends: {DECLARED})
+locus Target {
+    bus { subscribe Clean as on_clean; }
+    params { n: Int = 0; }
+    fn on_clean(m: Msg) { self.n = m.n; }
+}
+locus Source {
+    bus { publish Secret; }
+    fn go() { Secret <- Msg { n: 7 }; }
+}
+main locus App {
+    params {
+        r: Relay = Relay { };
+        t: Target = Target { };
+        s: Source = Source { };
+    }
+}
+fn main() { App { }; }
+"#;
+
+#[test]
+fn a_free_helper_publish_carries_its_callers_inputs() {
+    // `Secret -> Relay::on_secret -> emit_clean() -> Clean ->
+    //  Target::on_clean`. Declaring only `Clean` is incomplete.
+    let (v, ds) =
+        judge(&LAUNDERED_VIA_HELPER.replace("DECLARED", "Clean"));
+    assert_eq!(
+        v,
+        Verdict::Violated,
+        "the helper's publish belongs to the loci that can reach \
+         it: {:?}",
+        ds
+    );
+    assert!(
+        ds.iter().any(|m| m.contains("Secret")),
+        "and the omitted subject is named: {:?}",
+        ds
+    );
+}
+
+#[test]
+fn declaring_the_helper_mediated_closure_holds() {
+    let (v, ds) = judge(
+        &LAUNDERED_VIA_HELPER.replace("DECLARED", "Clean, Secret"),
+    );
+    assert_eq!(v, Verdict::Holds, "{:?}", ds);
+}
+
+#[test]
+fn a_computed_publisher_upstream_is_uncertified() {
+    // A publish whose subject the model could not name is a
+    // function-grained PUBLISHES hole, anchored to no subject at
+    // all — so neither the endpoint query nor the publish-row walk
+    // can see it. It might name this wire.
+    let src = r#"
+type Msg { n: Int = 0; }
+topic Clean { payload: Msg; subject: "clean"; }
+fn pick(n: Int) -> String { if n > 0 { return "clean"; } return "other"; }
+fn shout(n: Int) { pick(n) <- Msg { n: n }; }
+@effects(depends: {Clean})
+locus Target {
+    bus { subscribe Clean as on_clean; }
+    params { n: Int = 0; }
+    fn on_clean(m: Msg) { self.n = m.n; }
+}
+main locus App {
+    params { t: Target = Target { }; }
+    run() { shout(1); }
+}
+fn main() { App { }; }
+"#;
+    let (v, ds) = judge(src);
+    assert_eq!(
+        v,
+        Verdict::Uncertified,
+        "an unnameable publisher cannot be certified around: {:?}",
+        ds
+    );
+}

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -326,8 +326,8 @@ topology under different law keeps one shape). Schema 1.11+
 sections: **`law`** — every lowered `ClaimIr` row with its
 ordinal, origin (`main` / `constitution:<name>` / `library` /
 `annotation`), judgment **family** (`reachability` / `boundary` /
-`endpoint` / `bound` / `causes` / `certificate` / `unmigrated` /
-`fleet`),
+`endpoint` / `bound` / `causes` / `depends` / `certificate` /
+`unmigrated` / `fleet`),
 machine **verdict**, a TYPED **`law` payload** (one tagged object
 per `ClaimIr` variant carrying the law's operands — each reference
 as `{"name": <raw canonical identity>, "display": <author
@@ -399,9 +399,9 @@ their evidence even in an annotation-only artifact — recomputes
 per-row and document verdicts from the evidence, checks the
 one-to-one claims-to-law projection in both directions, requires
 the `law.legacy` report (the old engines' verdicts for the rows
-that are still `unmigrated` — as of schema 1.14 that is
-`depends:` and `@budget`, `causes:` having become its own judged
-family — keyed by ordinal and by a form FINGERPRINT re-rendered
+that are still `unmigrated` — as of schema 1.15 that is `@budget`
+alone, `causes:` and `depends:` having become judged families —
+keyed by ordinal and by a form FINGERPRINT re-rendered
 from the typed operands; an operand mutation orphans the entry.
 A migrated row imports no outside verdict, so it carries no
 legacy entry and states its own `form` instead, which admission


### PR DESCRIPTION
Stacked on #497 (Change 5f). RFC #330's `@effects(depends: {…})` is the backward dual of `causes:` — the COMPLETE set of subjects that can transitively reach any handler a locus owns — and it is now judged over the canonical model.

The point of doing it right after 5f is that both walks call the same `model_query` joins. If the forward walk and the backward walk disagreed about whether a publish and a subscription meet, one of them was wrong.

### Two new model facts, both decl-level

- **`LocusDecl.sync_form`** — the locus's own `@form(…, sync = X)` discipline (#340), read off the form declaration. There is no annotation for it and there should not be: it is a property of how the form is shared, not a claim about it.
- **`LocusDecl.params`** — declared `params { }` at DECLARATION grain. Deliberately not the same fact as `LocusInstance`: an instance exists only for a statically exact birth, while a param with no default still declares what the locus may hold.

### Corrections

- **A declaration may name the wire subject.** `depends: { "evt" }` and `depends: { Evt }` address one endpoint; the old engine compared names and called the wire spelling an omission.
- **An operand naming nothing is `invalid`, not `violated`.** Matching by name meant a typo covered nothing, so every subject that reached the locus came back as an omission — a violation report about the subjects, when the defect is the typo. The diagnostic now names the unresolved entry.
- **A `listen` binding on a reached subject is uncertainty.** A peer this application does not model can publish into it, so the closure cannot be certified. A `connect` route on the same locus does not taint the backward walk — the completeness query takes a direction, and that is the whole reason `Direction` exists.

The `sync`-discipline refusal is unchanged in meaning: a locus holding a `sync` form is reachable by another pool's writes with no bus edge recording it, and `depends:` closes over the message graph only.

Diagnostics name the author's topic spelling where exactly one topic declares the subject, and fall back to the wire pattern otherwise — the same raw/display duality the `topics` section carries.

### Schema 1.14 → 1.15

`depends:` rows carry `"family": "depends"` with their own rendered `form` and no `law.legacy` entry. That report now covers `@budget` alone.

### On the differential

The corpus differential keeps the old walk as its comparison arm. It diverges in exactly two places, and each is admitted only by a **row-local** premise read off the judgment's own verdict for that row — `Invalid` for the unresolved operand, `Holds` for the wire-identity spelling. Never a whole-program property; that was the round-3 blocker on #494 and the rule holds here.

Ten new controls in `judgment_depends.rs`, including the two directions of a binding, an ordinary child locus that is *not* a sync form (the premise of the sync-form control), and a free-function publisher.

Full workspace suite green (2922 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)