### PR TITLE
docs(spec): bring the verification spec and book up to the merged #476 state

### DIFF
--- a/crates/hale-types/src/judgment.rs
+++ b/crates/hale-types/src/judgment.rs
@@ -11,10 +11,9 @@
 //!
 //! Change 9 finished it: these engines ARE the authority now, for
 //! `hale check` (via [`claim_law_diags`]) as well as for the
-//! artifact. The evaluator in `claims.rs` keeps law SELECTION —
-//! which laws exist at all — and is otherwise a test oracle with no
-//! production callers, enforced by
-//! `tests/legacy_oracle_is_test_only.rs`.
+//! artifact. `claims.rs` keeps law SELECTION — which laws exist at
+//! all — and nothing else: Change 10 deleted the evaluator that
+//! used to sit beside it.
 //!
 //! 5a: reachability (`forbid reaches`) + holes. The walk reuses
 //! `model_graph::search` with a two-kind vertex: user functions

--- a/crates/hale-types/src/topology.rs
+++ b/crates/hale-types/src/topology.rs
@@ -1238,10 +1238,10 @@ pub fn dump_topology_parts(bundle: &Bundle<'_>) -> String {
     // the migrated families the law rows are the judgment's word —
     // stricter than the engine replay in the two documented places
     // (cyclic/undeclared classes ⇒ invalid; attributed-over-hole ⇒
-    // uncertified). Unmigrated rows carry the OLD engines'
-    // authoritative results (`legacy_unmigrated_verdicts`), so
-    // EVERY application-tier row participates: no non-passing law
-    // row can coexist with a `clean` document verdict (round 1).
+    // uncertified). EVERY application-tier row participates — no
+    // family imports an outside verdict any more — so no
+    // non-passing law row can coexist with a `clean` document
+    // verdict (round 1).
     let law_pass = law_rows.iter().all(|r| {
         matches!(r.family, hale_model::JudgmentFamily::Fleet)
             || r.verdict.passed()

--- a/crates/hale-types/tests/artifact_law_projection.rs
+++ b/crates/hale-types/tests/artifact_law_projection.rs
@@ -461,9 +461,8 @@ fn main() { App { }; }
 }
 
 /// Review round 1: NO non-passing law row can coexist with a
-/// `clean` document verdict — over every corpus artifact. The
-/// unmigrated families carry the old engines' authoritative
-/// results (`legacy_unmigrated_verdicts`), so the invariant is
+/// `clean` document verdict — over every corpus artifact. Every
+/// family is judged over the model now, so the invariant is
 /// total: `clean` ⟺ every application-tier law row holds.
 #[test]
 fn clean_verdict_implies_every_law_row_holds() {

--- a/crates/hale-types/tests/constitutions.rs
+++ b/crates/hale-types/tests/constitutions.rs
@@ -619,9 +619,7 @@ main locus App {
     let graph = build_bus_graph(&bundle, &top);
     let progs: Vec<&hale_syntax::ast::Program> =
         bundle.programs.values().copied().collect();
-    let a = hale_types::claims::constitution_identities(
-        &progs, &graph, &[],
-    );
+    let a = constitution_identities(&progs, &graph, &[]);
     assert_eq!(
         a.roots.len(),
         1,

--- a/crates/hale-types/tests/judgment_reachability.rs
+++ b/crates/hale-types/tests/judgment_reachability.rs
@@ -11,7 +11,6 @@
 
 use std::collections::BTreeMap;
 
-use hale_model::ClaimIr;
 use hale_types::claim_lowering::lower_claims;
 use hale_types::judgment::{
     judge_bound, judge_endpoints, judge_forbid_reaches,
@@ -41,28 +40,6 @@ fn bundle_of<'a>(
     b
 }
 
-fn family_names(
-    table: &hale_model::ClaimIrTable,
-) -> Vec<String> {
-    table
-        .rows
-        .iter()
-        .filter(|r| {
-            matches!(
-                r.law,
-                ClaimIr::ForbidReaches { .. }
-                    | ClaimIr::OnlyEdges { .. }
-                    | ClaimIr::RequireEndpoint { .. }
-                    | ClaimIr::RequireSealed { .. }
-                    | ClaimIr::RequireAttributed { .. }
-                    | ClaimIr::Cover { .. }
-                    | ClaimIr::Count { .. }
-                    | ClaimIr::Bound { .. }
-            )
-        })
-        .map(|r| r.name.clone())
-        .collect()
-}
 
 // Change 10: the corpus differential that lived here compared this
 // family's verdicts against the legacy evaluator, claim by claim.

--- a/docs/src/claims.md
+++ b/docs/src/claims.md
@@ -926,8 +926,11 @@ the artifact's canonical catalogs (exact `(name, display)` pairs,
 closed under exact bijection with the public sections), recomputes
 bus-selector candidate sets with the compiler's own matching
 rule, requires the `lowered` evidence and `law.legacy` report to
-project from the typed account, validates every diagnostic and
-requires non-holds verdicts to retain their judgment's evidence,
+project from the typed account, requires each law row that renders
+a compatibility form to STATE it (and re-renders it from the typed
+payload, so substituting an operand orphans the row), validates
+every diagnostic and requires non-holds verdicts to retain their
+judgment's evidence,
 lets static invalidity (unresolved operands, undeclared or cyclic
 classes) dominate every replayed engine result, joins `claims`
 rows to law rows one-to-one in both directions, refuses
@@ -935,11 +938,11 @@ fleet-family rows outright, and recomputes the document verdict.
 A restamped artifact whose sections disagree with each other is
 refused even though its digest verifies.
 
-The artifact shape (schema `1.12`):
+The artifact shape (schema `1.17`):
 
 ```text
 {
-  "schema": "1.12",
+  "schema": "1.17",
   "shape_hash": "<fnv1a-64 over the model half>",
   "sorts":     { "loci": […], "fns": […], "topics": […] },
   "relations": {
@@ -989,9 +992,16 @@ The artifact shape (schema `1.12`):
                  "effect_classes": [ {"name", "declared",
                                       "cyclic"} ],
                  "legacy": [ {"ordinal", "form", "result"} ],
+                 //   ^ EMPTY since 1.17: every family is judged
+                 //     over the model. The section survives so an
+                 //     older artifact still decodes.
                  "issues": [ {"message", "file"?, "span"?} ],
                  "rows": [ {"ordinal", "name", "origin",
                             "family", "verdict",
+                            "form"?,   // REQUIRED when the law
+                                       // renders one; re-rendered
+                                       // from the typed operands
+                                       // at admission
                             "law": {"kind", …typed operand refs,
                                     each with name/display/
                                     resolved and provenance…},
@@ -1003,6 +1013,10 @@ The artifact shape (schema `1.12`):
                             "file"?, "span"?} ] },
   "capabilities": { "exact_calls": bool, … },
   "adequacy":  { "<family>": "exact" | "degraded" },
+  //   families: reachability, boundary, endpoint, bound,
+  //   certificate, causes, depends, budget — every migrated
+  //   family carries an account, and admission requires exactly
+  //   the set its schema version names
   "verdict":   "clean" | "law_failed"
 }
 ```

--- a/docs/src/effects.md
+++ b/docs/src/effects.md
@@ -126,6 +126,23 @@ subscriber *deliveries*, so publishing once to a subject with 200
 subscribers is a fan-out of 200. That's the amplification a per-fn
 count can't show you.
 
+Three details matter once you start relying on it:
+
+- It counts **runtime registrations**, not declarations. One
+  `subscribe` line on a locus arranged with `replicas = 3` is three
+  deliveries.
+- It is **transitive**. If a handler you reach republishes, those
+  deliveries are yours too — a publish reaching one relay that
+  republishes to three sinks is a fan-out of four, not one.
+- One message carries **one key**. A keyed publish reaches the
+  subscriptions whose filter that key satisfies, so
+  `where key == replica` costs one delivery, not one per replica.
+
+Where the compiler cannot know the number — a computed subject, a
+subscriber born outside the arrangement, a topic bound to a
+transport — the answer is *unbounded*, not a guess. A budget cannot
+hold over a count nobody can take.
+
 ## Effects by lifecycle phase
 
 A locus can say which effects each phase may perform:
@@ -385,11 +402,15 @@ anyway, and nothing in the depending locus's source mentions it. The
 diagnostic names the laundering path:
 
 ```
-type error: declared dependence set violated: `StatedCarry` can be
-transitively influenced by subject `Recalled`, which its
+type error: declared dependency set violated: `StatedCarry` can
+transitively depend on `Recalled` through the bus, which its
 `@effects(depends: …)` does not declare. Path: subject `Recalled` ->
 `Launderer` -> subject `SumLookup` -> `StatedCarry`.
 ```
+
+You may name the topic (`Recalled`) or its wire subject
+(`"recalled"`) — they address one endpoint, and the compiler joins
+on that identity rather than on how you spelled it.
 
 It sits on the **locus**, not a fn: dependence enters through
 subscriptions, and those are declared per-locus. A fn-level

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -327,7 +327,8 @@ sections: **`law`** — every lowered `ClaimIr` row with its
 ordinal, origin (`main` / `constitution:<name>` / `library` /
 `annotation`), judgment **family** (`reachability` / `boundary` /
 `endpoint` / `bound` / `causes` / `depends` / `budget` /
-`certificate` / `unmigrated` / `fleet`),
+`certificate` / `unmigrated` / `fleet`; `unmigrated` is now
+unreachable and kept only so an older artifact decodes),
 machine **verdict**, a TYPED **`law` payload** (one tagged object
 per `ClaimIr` variant carrying the law's operands — each reference
 as `{"name": <raw canonical identity>, "display": <author
@@ -341,19 +342,28 @@ consumer checks before trusting external evidence against this
 artifact; **`capabilities`** — the model's positive completeness
 account, typed (`exact_cardinality` is derived: endpoint counts
 come from a closed-world enumeration and are exact unless a hole
-says otherwise); and **`adequacy`** — per migrated judgment
+says otherwise; `exact_costs`, added by Change 5h, vouches the
+per-call COST account — allocation sites, frame estimates and
+blocking points, carried site-grained in `relations.costs`
+because a per-call budget is a statement about one invocation and
+the loop flag is what turns a finite count into an unbounded one.
+The three call-hole kinds REQUIRE the COSTS bit: a call whose
+target the caller chooses is exactly where a quantitative law must
+not certify through); and **`adequacy`** — per migrated judgment
 family, `exact` when capabilities vouch every relation family that
 judgment consumes, else `degraded` (the certificate family
 consumes PUBLISHES — a publish-set contract cannot prove a
-computed subject in-set). The UNMIGRATED families (`causes:`,
-`depends:`, `@budget`) carry the old engines' authoritative
-results in their law rows, so no non-passing law row can coexist
-with a `clean` document verdict. The emitted model half — and
+computed subject in-set). As of schema 1.17 every family is
+judged over the model: `causes:` (Change 5f), `depends:` (5g) and
+`@budget` (5h, through the evidence sidecar) import no outside
+verdict. No non-passing law row can coexist with a `clean`
+document verdict. The emitted model half — and
 `shape_hash` — come from the `ApplicationModel` projection
 (`project_model_half`), and so do the unhashed `sources`,
 `provenance`, and `topics` sections (`project_unhashed_tail`);
-the legacy gathering survives only as the corpus differential's
-comparison arm until Change 9. Bus selectors in the `law` payload
+the legacy gathering is gone: Change 10 deleted the evaluator, and
+the corpus differentials it was the comparison arm of are now
+committed snapshots of its final answers. Bus selectors in the `law` payload
 serialize their resolved CANDIDATE sets (the topic identities and
 wire patterns the selector matched) plus the selector's own
 source location; `capabilities` carries `exact_publishes` and
@@ -398,19 +408,17 @@ generated expectation must be met, so deleting law rows orphans
 their evidence even in an annotation-only artifact — recomputes
 per-row and document verdicts from the evidence, checks the
 one-to-one claims-to-law projection in both directions, requires
-the `law.legacy` report (the old engines' verdicts for the rows
-that are still `unmigrated` — as of schema 1.17 there are NONE, so
-the report is empty for every program; it survives so an artifact
-written by an older toolchain still decodes — keyed by ordinal and by a form FINGERPRINT re-rendered
-that are still `unmigrated` — as of schema 1.17 there are NONE, so
-the report is empty for every program; it survives so an artifact
-written by an older toolchain still decodes — keyed by ordinal and
-by a form FINGERPRINT re-rendered
-from the typed operands; an operand mutation orphans the entry.
-A migrated row imports no outside verdict, so it carries no
-legacy entry and states its own `form` instead, which admission
-re-renders from the typed payload; a `causes:` row naming an
-undeclared or cyclic class still cannot hold), refuses fleet-family
+the `law.legacy` report — the old engines' verdicts for rows that
+are still `unmigrated`, keyed by ordinal and by a form FINGERPRINT
+re-rendered from the typed operands, so an operand mutation
+orphans the entry. As of schema 1.17 NO family is unmigrated, so
+that report is empty for every program; the section survives only
+so an artifact written by an older toolchain still decodes. Every
+row that renders a compatibility form must STATE it, and admission
+re-renders it from the typed payload — that is the operand binding
+for a judged row, which imports no outside verdict at all. A
+`causes:` row naming an undeclared or cyclic class still cannot
+hold — refuses fleet-family
 rows outright (an application artifact does not own a fleet
 account — that is Change 7's), and recomputes `adequacy` from
 `capabilities`. Static invalidity DOMINATES (round 7): an
@@ -433,10 +441,11 @@ overlap, …) admit by RETAINING the judgment's explanation — an
 `invalid` row must carry either a decodable invalidity or its
 judgment's evidence, and an unanalyzed `uncertified` its
 residue. Machine-`invalid` rows may still
-PRESERVE the old engines' reports (`law.legacy`, keyed budget
+PRESERVE an old engine's report (`law.legacy`, keyed budget
 `lowered` rows) — bound by fingerprint as optional evidence,
-never demanded and never overriding the machine verdict, so the
-compiler's own cyclic-class artifacts admit. The catalogs are
+never demanded and never overriding the machine verdict, so an
+older artifact's cyclic-class rows still admit. Nothing the
+current compiler emits populates `law.legacy` any more. The catalogs are
 CLOSED: unique in both halves and in exact bijection with the
 `topics` / `groups` / `sorts.loci` sections (`fn_universe` covers
 `sorts.fns`), so selector recomputation cannot be widened
@@ -555,10 +564,16 @@ fingerprint covers `{issues, rows}`) and in the document verdict
 entry like any diagnostic, and the duplicate-name case is
 recomputed from the rows themselves — no claim error disappears
 between checking and artifact projection. The evidence engine's
-`ANALYSIS_SEMANTICS_VERSION` is 3: round 8's producer/judgment
-changes (synthetic implicit-phase certificates, report-less
-subjects judging `uncertified`) are result-affecting, so pre- and
-post-round-8 evidence cannot share an `inputs_digest`. Both digests are RECOMPUTED at
+`ANALYSIS_SEMANTICS_VERSION` is 6. It moves whenever the
+producer's RESULTS move, because `validate` compares digests and
+never the implementation: v3 was round 8's synthetic
+implicit-phase certificates and report-less subjects judging
+`uncertified`; v4–v6 are GH #476 Change 5h, where `@budget`
+joined the evidence pipeline and its quantitative results changed
+(fan-out became a per-scenario execution count, cross-seed calls
+resolve, an unknown subscriber population stopped reading as an
+absent one). Evidence produced under an earlier version cannot
+share an `inputs_digest` with this one. Both digests are RECOMPUTED at
 admission: `law_digest` is the canonical-JSON fingerprint over
 the law rows (serde-canonical rendering, fnv1a64 — a row edit
 under a stale digest refuses), and `inputs_digest` must equal the
@@ -574,10 +589,11 @@ span lives in a FOREIGN offset space (stdlib parse space, another
 seed) is never re-resolved against bundle sources — the
 projection carries a per-diagnostic discriminator, so numeric
 overlap with a bundle file cannot misfile stdlib evidence as
-application code. Unmigrated rows bridge to the old engines
-only where the old walk demonstrably enumerated the row
-(module-scoped annotations and ambiguous multi-assert anchors
-stay `uncertified`). The legacy `claims` / `lowered` string rows
+application code. No row bridges to an old engine: every
+family is judged over the model, and a subject the judgment
+cannot start from — a module-scoped annotation body, outside the
+analyzable universe — is `uncertified` WITH its reason rather
+than silently absent. The legacy `claims` / `lowered` string rows
 remain, now PROJECTED from the canonical model path; `semantics`
 bumps to 2 because the machine verdicts are stricter in two
 documented places (a certificate naming a cyclically-defined or
@@ -605,13 +621,33 @@ disagree about a law. Two consequences are user-visible:
     silently dropped, which had the effect of evaluating a weaker
     claim than the one written.
 
+Changes 5f–5h then migrated the last three families — `causes:`,
+`depends:` and `@budget` — and Change 10 DELETED the second
+evaluator (about 1900 lines). Its corpus differentials, which
+could only ever hold two implementations equal, are now committed
+snapshots of its final answers: a diff in
+`claim_diags_snapshot.txt` or `law_rows_snapshot.txt` is a
+user-visible change to what `hale check` says or what the artifact
+records. The lowered-certificate comparison stays a live
+differential, because the certificate ENGINES were never what was
+being migrated.
+
+A law that cannot be certified is now LOUD in every family. The
+checker appends diagnostics, not verdicts, so an `uncertified` row
+with no diagnostic used to compile clean while the artifact marked
+the document `law_failed` — the same disagreement this change
+exists to remove — and left the row with no evidence for admission
+to find. Every non-holds row states its reason.
+
 What the claim surface still owns is law SELECTION — which laws
 exist at all: clause enumeration, constitution adoption and
 identity, group resolution, the library/world tier rule. Selection
 is not judgment, and it has exactly one implementation, consumed by
 BOTH the checker and the artifact lowering: a selection refusal
 appears in the document's law-issue account, so the two cannot
-report opposite answers about one program.
+report opposite answers about one program. It does not consult the
+bus graph: deciding which laws exist is a question about clause
+text, adoption and membership.
 
 Selection's verdict on each group declaration is CARRIED with the
 lowered laws, in four states — resolved; intentionally empty
@@ -1648,8 +1684,26 @@ assume the others in a build:
     property no per-fn count reveals: a handler publishing to a
     200-subscriber subject amplifies 200×.
 
+    Counted over RUNTIME REGISTRATIONS, per message, and
+    transitively (GH #476 Change 5h). One `subscribe` declaration
+    on a locus arranged with `replicas = 3` is three deliveries; a
+    publish reaching a relay that republishes is charged its
+    onward deliveries too, multiplied by the number of handler
+    executions that reached it; and because one message carries
+    one KEY, the recipients of a keyed publish are the ones that
+    key selects — `where key == replica` costs one delivery, not
+    one per replica. The maximum is taken over the key values the
+    publish site can produce, and over the conformers of one
+    interface dispatch, each scenario costed whole before any
+    comparison. An unknowable count — a computed subject, a
+    subscriber population the arrangement does not enumerate, a
+    subject bound to a transport, an unknown key filter with a
+    live registration — is *unbounded*, never a guess.
+
   A contributor inside a loop saturates to unbounded, matching
-  `alloc_per_call`'s per-call semantics.
+  `alloc_per_call`'s per-call semantics — except where the
+  contribution is exactly ZERO, since repeating a publish that
+  reaches no registration still reaches none.
 - **Phase-indexed effects — `@phase_effects(...)` on a locus**
   (GH #265 step 6, 2026-07-29). The lifecycle model expresses what a
   function-level effect system cannot:
@@ -1729,6 +1783,21 @@ assume the others in a build:
   effects reached THROUGH the bus are reported; direct effects are
   the `none:` form's job. Actor systems without a declared message
   graph structurally cannot offer this.
+
+  Judged over the canonical model since GH #476 Change 5f, which
+  makes three things true that the earlier walk got wrong. A
+  handler whose effects are not fully classified leaves the law
+  **`uncertified` WITH its reason**, rather than reporting every
+  class it never proved — and uncertified is reported, not silent,
+  so a subject the walk cannot even start from (a module-scoped
+  body, outside the analyzable universe) now says so. A class the
+  walk DID prove survives whatever else is unknown, so a law a
+  known effect already violates reads as violated. And delivery
+  joins on WIRE IDENTITY: a literal `"t" <- …` send is judged
+  exactly like the declared spelling it lowers to, an outbound
+  binding makes the closure uncertified rather than silently
+  ending, and a keyed publish that cannot meet a subscription's
+  predicate is not a reach at all.
 - **Backward causality — `@effects(depends: {…})`** (#330,
   2026-07-31). The dual of `causes:`. `causes:` walks the bus graph
   forward; nothing walked it backward, so an independence claim
@@ -1747,6 +1816,23 @@ assume the others in a build:
   so a mandatory form would be redundant far more often than
   informative. The closure is over the **bus graph**: influence
   travelling outside it (see shared state below) is not part of it.
+
+  Judged over the canonical model since Change 5g. The backward
+  walk is SUBSCRIPTION-grained — it carries the actual `subscribe`
+  rows, so an unrelated wildcard or a disjoint key filter on the
+  same wire cannot manufacture an upstream — and it climbs reverse
+  CALLS, so a publish inside a free helper belongs to every locus
+  that can reach that helper. A stdlib interior that publishes
+  (`std::log::Logger.info` computes `log.<path>` and sends from
+  inside its own body) is a publisher like any other. A
+  declaration may name the topic or its wire subject; they address
+  one endpoint. An operand naming nothing is `invalid` rather than
+  a violation report about the subjects it failed to cover. And
+  where the model cannot complete the walk — an inbound `listen`
+  route, a computed publisher, a caller reached through a call it
+  cannot follow — the law is `uncertified` with that reason,
+  provided the residue is REACHABLE: an unfollowable call in a
+  function nothing executes withdraws nothing.
 - **User-declared effect classes — `effect NAME;` and
   `@effects(is: {…})`** (#345, 2026-08-01). A program may name its own
   effect classes and have them propagated by the same engine, with the


### PR DESCRIPTION
Post-merge sweep for GH #476. Ten changes and four schema transitions landed; the prose did not follow all of them.

### `spec/verification.md`

- **Repairs merge damage** — a `law.legacy` passage was duplicated mid-sentence by one of the round-3 conflict resolutions.
- **The unmigrated families are gone.** The spec still said `causes:` / `depends:` / `@budget` "carry the old engines' authoritative results in their law rows". Every family is judged over the model now, `law.legacy` is empty for every program, and Change 10 deleted the evaluator — its corpus differentials are committed snapshots of its final answers.
- **What the migrations mean for a user**, which is what the spec is for: an uncertified law is loud in every family (including a subject the walk cannot start from, like a module-scoped body); `causes:` keeps a class it proved whatever else is unknown, and joins delivery on wire identity; `depends:` is subscription-grained, climbs reverse calls, sees absorbed stdlib publishers, and counts only *reachable* residue.
- **What `fanout` actually counts** — runtime registrations, per message, transitively, with the maximum taken over key scenarios and dispatch alternatives, and `unbounded` where the count isn't knowable. The old text read as declaration-counting.
- `ANALYSIS_SEMANTICS_VERSION` 3 → 6, and the rule for when it moves.
- `exact_costs` and the site-grained `relations.costs` account.

### `docs/src`

- `claims.md` documented the artifact at **schema 1.12**; it is 1.17. Updated with the required row `form`, the now-empty `law.legacy`, and the eight adequacy families.
- `effects.md` quoted a `depends:` diagnostic that no longer exists (`declared dependence set violated: … transitively influenced by …`). Corrected against the emitter, plus the three fan-out details that decide whether a budget is meaningful.

### Dead code

`family_names` and a `ClaimIr` import left behind when `judgment_reachability`'s differential was deleted, and three comments naming symbols that no longer exist. The remaining workspace warnings (`free_port`, two snake-case test names, three unrelated imports) predate this epic — June and July.

Doc snippets still parse (`hale-syntax --test docs_snippets`); `hale-types` / `hale-model` / `hale-cli` green (1515).

🤖 Generated with [Claude Code](https://claude.com/claude-code)