### PR TITLE
release: v0.18.0 — the canonical model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.18.0 — the canonical model (2026-08-30)
 
 ### A computed publish subject is confined to its declaration
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "hale-cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "hale-corpus",
  "hale-model",
@@ -103,11 +103,11 @@ dependencies = [
 
 [[package]]
 name = "hale-corpus"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "hale-lsp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "hale-stdlib",
  "hale-syntax",
@@ -117,22 +117,22 @@ dependencies = [
 
 [[package]]
 name = "hale-model"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "hale-stdlib"
-version = "0.17.0"
+version = "0.18.0"
 
 [[package]]
 name = "hale-syntax"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "hale-corpus",
 ]
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "hale-corpus",
  "hale-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Cuts **v0.18.0** from 218 commits since v0.17.0. CHANGELOG heading, workspace version, lockfile — the same three files as the v0.17.0 release.

## Headline: the canonical semantic model (GH #476)

All ten changes plus Track A. One typed, provenance-bearing `ApplicationModel` behind claims, artifacts, fleet and lowering — every judgment family (reachability, boundary, endpoint, bound, certificate, `causes:`, `depends:`, `@budget`) migrated onto it, each held byte-equal against the old evaluator over the whole corpus before the evaluator was deleted. Typed law rows, capabilities and adequacy in the artifact; a typed `FleetModel`; `DispatchPlan` derived from the same model that answers the verification questions.

## Also in this release

- **Computed publish subjects are confined to their declaration**, and the residue they leave is scoped by it. A subject outside the declared wildcard pattern was being delivered to whatever subscribed to it and reinterpreted as that subscriber's type, with `hale check` reporting `ok`.
- **Record & replay phases 5–6** — durable recording, the hermetic wire, feed mode, and `where async_io` pools replaying their recorded schedule (GH #296).
- **Listen-binding ingest no longer loses messages at the edges** (GH #468).
- **Stdlib values get their real types**, closing the fail-open `Ty::Unknown` class (GH #470).
- **`std::http::is_route`** — the one-locus-many-endpoints shape.

## Compatibility

Pre-1.0, and this one is not a quiet minor:

- A program that publishes a computed subject **outside** its declared pattern now panics (`BusPublishUnauthorized`) where it previously delivered. The corpus is clean and the stdlib's own `log_subject` usage is fine, but this is the upgrade note that matters.
- The artifact schema advanced through 1.13 → 1.17 across the epic, and `ANALYSIS_SEMANTICS_VERSION` 3 → 6. Artifacts dumped by older compilers are refused rather than silently trusted; re-dump with this one.

2983/2983 workspace tests pass at the bumped version — worth stating explicitly because the compiler version feeds `inputs_digest`, so the bump itself moves artifact identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
