### PR TITLE
feat(supervision): lower `restart(c) for N`; exhausting it quarantines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ behavior.
 
 ---
 
+## Unreleased
+
+### `restart(c) for N` lowers, and exhausting it quarantines
+
+The retry-bound modifier checked and modelled — the topology
+artifact has carried `retry_bound` on the supervision row since
+schema 1.10 — but codegen refused it: "unsupported in codegen v0:
+recovery modifier (for/until) not lowered". So the policy a consumer
+was told it could read, "declared cap 3, observed 3 in 40s", was
+unshippable, because no program stating the bound could be built
+(downstream handoff). The workaround was to count failures in the
+handler by hand, which states the same policy somewhere nothing can
+read it.
+
+`restart(c) for N` and `restart_in_place(c) for N` now lower. The
+bound is per child instance and cumulative over its lifetime, and it
+is compared before the restart, so `for N` admits exactly N restarts
+and the next failure **quarantines** the child — a bounded
+supervisor said when to stop, and stopping means the child does not
+run. `for 0` is meaningful: do not restart this one. `N` is an
+expression, not just a literal.
+
+The bound had to become visible to the post-handler rerun check in
+`__birth_closures`, which was a hardcoded `count <= 2`: a declared
+`for 5` would otherwise have silently stopped restarting after two.
+Every locus now carries a `__restart_bound` field seeded to that
+default, so an unbounded `restart(c)` keeps exactly its previous
+behaviour — including that it does NOT quarantine.
+
+Two neighbouring modifiers stay unlowered and now say so precisely
+rather than sharing one generic refusal: `quarantine(c) for d` (a
+duration before an automatic restart — a different `for` from the
+retry count) and `until` on any op. `spec/semantics.md` and the
+failure chapter marked both, and the docs stopped advertising
+`quarantine(child) for d` as if it worked.
+
 ## v0.18.0 — the canonical model (2026-08-30)
 
 ### A computed publish subject is confined to its declaration

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -5951,6 +5951,9 @@ pub(crate) struct LocusInfo<'ctx> {
     /// birth() + birth-epoch closures. Cap is 2 attempts per
     /// locus lifetime (v0 default).
     pub(crate) restart_count_field_idx: u32,
+    /// `__restart_bound`: restarts allowed before the supervisor
+    /// quarantines the child. Default 2; set by `restart(c) for N`.
+    pub(crate) restart_bound_field_idx: u32,
     /// m41: index of the synthetic `__quarantined: i64` flag.
     /// Always present (zero-init at instantiation). The
     /// `quarantine(child)` recovery primitive sets it to 1; the
@@ -17236,16 +17239,57 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             Stmt::Block(b) => self.lower_block(b, scope),
             Stmt::Return(expr_opt, _) => self.lower_return(expr_opt.as_ref(), scope),
             Stmt::Recovery { op, args, modifier, .. } => {
-                if modifier.is_some() {
-                    return Err(CodegenError::Unsupported(
-                        "recovery modifier (for/until) not lowered".into(),
-                    ));
-                }
+                // `for N` bounds how many times this child is
+                // restarted; on the failure that exhausts it the
+                // supervisor quarantines instead. It is only
+                // meaningful on the restart ops — there is nothing to
+                // repeat about quarantining or bubbling.
+                let bound = match modifier {
+                    None => None,
+                    Some(RecoveryModifier::For(e)) => match op {
+                        RecoveryOp::Restart
+                        | RecoveryOp::RestartInPlace => Some(e),
+                        // `quarantine(c) for d` is a DIFFERENT
+                        // modifier — a duration after which the child
+                        // is automatically restarted (spec/semantics
+                        // § quarantine). Specified, never lowered;
+                        // say that rather than implying `for` belongs
+                        // only to restart.
+                        RecoveryOp::Quarantine => {
+                            return Err(CodegenError::Unsupported(
+                                "`quarantine(c) for d` (auto-restart \
+                                 after a duration) is specified but not \
+                                 lowered; `restart(c) for N` — a retry \
+                                 bound — is"
+                                    .into(),
+                            ))
+                        }
+                        other => {
+                            return Err(CodegenError::Unsupported(
+                                format!(
+                                    "`for` bounds how many times a child \
+                                     is restarted, so it does not apply \
+                                     to `{:?}`",
+                                    other
+                                ),
+                            ))
+                        }
+                    },
+                    Some(RecoveryModifier::Until(_)) => {
+                        return Err(CodegenError::Unsupported(
+                            "`until` (restart while a condition holds) is \
+                             not lowered; `for N` is"
+                                .into(),
+                        ))
+                    }
+                };
                 match op {
                     RecoveryOp::Bubble => self.lower_bubble_call(args, scope),
-                    RecoveryOp::Restart => self.lower_restart_call(args, scope),
+                    RecoveryOp::Restart => {
+                        self.lower_restart_call(args, bound, scope)
+                    }
                     RecoveryOp::RestartInPlace => {
-                        self.lower_restart_in_place_call(args, scope)
+                        self.lower_restart_in_place_call(args, bound, scope)
                     }
                     RecoveryOp::Quarantine => {
                         self.lower_quarantine_call(args, scope)
@@ -28614,9 +28658,10 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     fn lower_restart_call(
         &mut self,
         args: &[Expr],
+        bound: Option<&Expr>,
         scope: &Scope<'ctx>,
     ) -> Result<BlockEnd, CodegenError> {
-        self.lower_restart_call_kind(args, scope, false)
+        self.lower_restart_call_kind(args, bound, scope, false)
     }
 
     /// m45: lower `restart_in_place(c);`. Same shape as
@@ -28629,14 +28674,16 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     fn lower_restart_in_place_call(
         &mut self,
         args: &[Expr],
+        bound: Option<&Expr>,
         scope: &Scope<'ctx>,
     ) -> Result<BlockEnd, CodegenError> {
-        self.lower_restart_call_kind(args, scope, true)
+        self.lower_restart_call_kind(args, bound, scope, true)
     }
 
     fn lower_restart_call_kind(
         &mut self,
         args: &[Expr],
+        bound: Option<&Expr>,
         scope: &Scope<'ctx>,
         in_place: bool,
     ) -> Result<BlockEnd, CodegenError> {
@@ -28665,6 +28712,93 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             .expect("LocusRef points to a declared locus");
         let child_ptr = val.into_pointer_value();
         let i64_t = self.context.i64_type();
+        // `restart(c) for N`: this child gets N restarts, and the
+        // failure that exhausts them quarantines it instead.
+        //
+        // The bound is recorded on the child before the branch,
+        // because the post-handler rerun check in `__birth_closures`
+        // reads it — the handler decides whether to restart, but a
+        // different function decides whether to re-run birth, and the
+        // two must agree on the same N.
+        //
+        // Compared BEFORE the bump: `__restart_count` is how many
+        // restarts have already happened, so `count < N` admits
+        // exactly N of them, and the (N+1)th failure quarantines.
+        let cont_bb = match bound {
+            None => None,
+            Some(expr) => {
+                let (nval, nty) = self.lower_expr(expr, scope)?;
+                if !matches!(nty, CodegenTy::Int) {
+                    return Err(CodegenError::Unsupported(format!(
+                        "`{} for N`: the bound must be an Int; got {:?}",
+                        kind, nty
+                    )));
+                }
+                let n = nval.into_int_value();
+                let rb_ptr = self
+                    .builder
+                    .build_struct_gep(
+                        info.struct_ty,
+                        child_ptr,
+                        info.restart_bound_field_idx,
+                        "restart.bound.ptr",
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                self.builder
+                    .build_store(rb_ptr, n)
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                let cnt_ptr = self
+                    .builder
+                    .build_struct_gep(
+                        info.struct_ty,
+                        child_ptr,
+                        info.restart_count_field_idx,
+                        "restart.bound.count.ptr",
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                let cnt = self
+                    .builder
+                    .build_load(i64_t, cnt_ptr, "restart.bound.count")
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                    .into_int_value();
+                let may_restart = self
+                    .builder
+                    .build_int_compare(
+                        inkwell::IntPredicate::SLT,
+                        cnt,
+                        n,
+                        "restart.bound.may",
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                let func = self
+                    .builder
+                    .get_insert_block()
+                    .and_then(|bb| bb.get_parent())
+                    .expect("inside a function");
+                let do_bb = self
+                    .context
+                    .append_basic_block(func, "restart.bound.restart");
+                let spent_bb = self
+                    .context
+                    .append_basic_block(func, "restart.bound.spent");
+                let join_bb = self
+                    .context
+                    .append_basic_block(func, "restart.bound.cont");
+                self.builder
+                    .build_conditional_branch(may_restart, do_bb, spent_bb)
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                // Bound spent: quarantine, exactly as `quarantine(c)`
+                // would — including the bus deregistration and the
+                // accumulator reset for the quarantine event.
+                self.builder.position_at_end(spent_bb);
+                self.emit_quarantine(&info, child_ptr, &locus_name)?;
+                self.builder
+                    .build_unconditional_branch(join_bb)
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                self.builder.position_at_end(do_bb);
+                Some(join_bb)
+            }
+        };
         let rc_ptr = self
             .builder
             .build_struct_gep(
@@ -28710,6 +28844,14 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         self.emit_accumulator_reset_for_event(
             &info, child_ptr, kind, &locus_name,
         )?;
+        // Rejoin the quarantine branch when a bound was declared, so
+        // whatever follows the recovery statement sees one successor.
+        if let Some(join_bb) = cont_bb {
+            self.builder
+                .build_unconditional_branch(join_bb)
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder.position_at_end(join_bb);
+        }
         Ok(BlockEnd::Open)
     }
 
@@ -28750,6 +28892,21 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             .cloned()
             .expect("LocusRef points to a declared locus");
         let child_ptr = val.into_pointer_value();
+        self.emit_quarantine(&info, child_ptr, &locus_name)?;
+        Ok(BlockEnd::Open)
+    }
+
+    /// The quarantine effect on an already-resolved child. Split out
+    /// of `lower_quarantine_call` so `restart(c) for N` can reach it
+    /// on the branch where the bound is spent — exhausting a declared
+    /// retry bound quarantines the child, and that must be the SAME
+    /// effect an explicit `quarantine(c)` has, not a near-copy.
+    fn emit_quarantine(
+        &mut self,
+        info: &LocusInfo<'ctx>,
+        child_ptr: inkwell::values::PointerValue<'ctx>,
+        locus_name: &str,
+    ) -> Result<(), CodegenError> {
         let i64_t = self.context.i64_type();
         let q_ptr = self
             .builder
@@ -28786,9 +28943,9 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // m46: zero each closure's accumulators unless its
         // `persists_through(...)` clause names "quarantine".
         self.emit_accumulator_reset_for_event(
-            &info, child_ptr, "quarantine", &locus_name,
+            info, child_ptr, "quarantine", locus_name,
         )?;
-        Ok(BlockEnd::Open)
+        Ok(())
     }
 
     /// m44: lower a `check_closures();` builtin call. Fires

--- a/crates/hale-codegen/src/lib.rs
+++ b/crates/hale-codegen/src/lib.rs
@@ -30,6 +30,15 @@
 //! lowered.
 
 pub(crate) mod bus;
+/// Restarts a supervised child gets before its supervisor gives up,
+/// when the `on_failure` handler does not say. `restart(c) for N`
+/// overrides it per child.
+///
+/// Was a bare `2` inline in the post-handler rerun check; named here
+/// because two places have to agree — the instantiation that seeds
+/// `__restart_bound` and the check that reads it.
+pub const DEFAULT_RESTART_BOUND: u64 = 2;
+
 pub mod deployment;
 pub(crate) mod channels;
 pub mod codegen;

--- a/crates/hale-codegen/src/locus/closure.rs
+++ b/crates/hale-codegen/src/locus/closure.rs
@@ -398,7 +398,27 @@ impl<'ctx, 'p> LocusClosure<'ctx> for Cx<'ctx, 'p> {
                     "restart.bumped",
                 )
                 .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
-            let cap = i64_t.const_int(2, false);
+            // The cap is the child's `__restart_bound`, not a baked
+            // constant: it seeds to DEFAULT_RESTART_BOUND and
+            // `restart(c) for N` overwrites it. Reading the field is
+            // what lets a declared bound above the default actually
+            // rerun that many times — as a literal `2` this silently
+            // stopped restarting after two, whatever the handler
+            // declared.
+            let cap_ptr = self
+                .builder
+                .build_struct_gep(
+                    cs_struct_ty,
+                    child_self,
+                    info.restart_bound_field_idx,
+                    "restart.bound.ptr",
+                )
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let cap = self
+                .builder
+                .build_load(i64_t, cap_ptr, "restart.bound")
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                .into_int_value();
             let under_cap = self
                 .builder
                 .build_int_compare(

--- a/crates/hale-codegen/src/locus/decl.rs
+++ b/crates/hale-codegen/src/locus/decl.rs
@@ -457,6 +457,24 @@ impl<'ctx, 'p> LocusDeclare<'ctx> for Cx<'ctx, 'p> {
         let restart_count_field_idx = idx;
         llvm_field_tys.push(i64_t_struct.into());
         idx += 1;
+        // Synthetic `__restart_bound: i64` — how many restarts this
+        // child gets before the supervisor gives up on it.
+        //
+        // Initialized to the default cap (2) at instantiation, so a
+        // plain `restart(c)` behaves exactly as before. A
+        // `restart(c) for N` writes N here before restarting, which
+        // is what lets the declared bound govern the post-handler
+        // rerun check — that check was a hardcoded `count <= 2`, so
+        // without this a declared `for 5` would silently stop
+        // restarting after 2.
+        //
+        // A field rather than a baked constant because the bound is
+        // an expression, not necessarily a literal, and because the
+        // rerun check runs in `__birth_closures` — a different
+        // function from the handler that declared it.
+        let restart_bound_field_idx = idx;
+        llvm_field_tys.push(i64_t_struct.into());
+        idx += 1;
         // m41: synthetic `__quarantined: i64` flag, always
         // appended to every locus struct. Zero-initialized at
         // instantiation; set to 1 by the `quarantine(child)`
@@ -1158,6 +1176,7 @@ impl<'ctx, 'p> LocusDeclare<'ctx> for Cx<'ctx, 'p> {
                 child_cap_field_idx,
                 arena_field_idx,
                 restart_count_field_idx,
+                restart_bound_field_idx,
                 quarantined_field_idx,
                 restart_in_place_pending_field_idx,
                 drain_requested_field_idx,

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -2480,6 +2480,27 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
         self.builder
             .build_store(rc_ptr, zero)
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        // Init `__restart_bound` to the DEFAULT cap, so a locus
+        // supervised by a plain `restart(c)` keeps exactly its
+        // previous behaviour. `restart(c) for N` overwrites this
+        // before restarting.
+        let rb_ptr = self
+            .builder
+            .build_struct_gep(
+                info.struct_ty,
+                self_ptr,
+                info.restart_bound_field_idx,
+                &format!("{}.__restart_bound.ptr", locus_name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_store(
+                rb_ptr,
+                self.context
+                    .i64_type()
+                    .const_int(crate::DEFAULT_RESTART_BOUND, false),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
         // m41: zero-init the synthetic __quarantined flag.
         let q_ptr = self
             .builder

--- a/crates/hale-codegen/tests/restart_bound.rs
+++ b/crates/hale-codegen/tests/restart_bound.rs
@@ -1,0 +1,206 @@
+//! `restart(c) for N` — the bounded restart, and what happens when
+//! the bound is spent.
+//!
+//! The retry-bound modifier checked and modelled (the topology
+//! artifact carries `retry_bound`) but codegen refused to lower it:
+//! "unsupported in codegen v0: recovery modifier (for/until) not
+//! lowered". So the policy a consumer was promised it could read —
+//! "declared cap 3, observed 3" — was unshippable, because any
+//! program stating the bound could not be built (downstream
+//! handoff). The workaround was to move the bound into the handler
+//! body (`if self.fired <= 3 { restart(c); } else { quarantine(c); }`),
+//! which states the same policy where nothing can read it.
+//!
+//! Exhausting the bound QUARANTINES the child: the supervisor tried
+//! N times and is done with it. That is a real difference from an
+//! unbounded `restart(c)`, which stops re-running at the default cap
+//! but leaves the child live.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+fn build_hale(name: &str, source: &str) -> std::path::PathBuf {
+    let program = hale_syntax::parse_source(source).expect("parse");
+    let bin = harness::unique_bin(&format!("hale_test_restartbound_{}", name));
+    build_executable(&program, &bin).expect("build");
+    bin
+}
+
+/// A child whose birth-epoch closure can never pass, so every
+/// attempt fails and the only thing that stops the loop is the
+/// bound. `run()` prints, so its ABSENCE is the quarantine
+/// observation.
+fn src(recovery: &str) -> String {
+    format!(
+        r#"
+locus Worker {{
+    params {{ attempts: Int = 0; target: Int = 99; }}
+    closure reached {{ self.attempts ~~ self.target within 0; epoch birth; }}
+    birth() {{
+        self.attempts = self.attempts + 1;
+        println("birth ", self.attempts);
+    }}
+    run() {{ println("RUN"); }}
+}}
+locus Coordinator {{
+    params {{ fired: Int = 0; }}
+    on_failure(c: Worker, err: ClosureViolation) {{
+        self.fired = self.fired + 1;
+        println("fail ", self.fired);
+        {recovery}
+    }}
+    run() {{ Worker {{ target: 99 }}; }}
+}}
+fn main() {{ let c = Coordinator {{ }}; }}
+"#,
+        recovery = recovery
+    )
+}
+
+fn run(tag: &str, recovery: &str) -> String {
+    let bin = build_hale(tag, &src(recovery));
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(
+        out.status.success(),
+        "program must run: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn count(hay: &str, needle: &str) -> usize {
+    hay.matches(needle).count()
+}
+
+#[test]
+fn a_declared_bound_allows_exactly_that_many_restarts() {
+    // `for 3`: birth, then three restarts — four attempts, four
+    // failures. Notably ABOVE the default cap of 2, which is the
+    // case a hardcoded cap silently clamped.
+    let out = run("for3", "restart(c) for 3;");
+    assert_eq!(count(&out, "birth "), 4, "3 restarts + the first birth: {:?}", out);
+    assert_eq!(count(&out, "fail "), 4, "{:?}", out);
+}
+
+#[test]
+fn exhausting_the_bound_quarantines_the_child() {
+    let out = run("quar", "restart(c) for 3;");
+    assert!(
+        !out.contains("RUN"),
+        "the supervisor gave up on this child, so it must not run: {:?}",
+        out
+    );
+}
+
+#[test]
+fn a_bound_of_one_restarts_once() {
+    let out = run("for1", "restart(c) for 1;");
+    assert_eq!(count(&out, "birth "), 2, "{:?}", out);
+    assert!(!out.contains("RUN"), "{:?}", out);
+}
+
+/// `for 0` is not a degenerate case to reject — it says "do not
+/// restart this child," which is a coherent policy and must
+/// quarantine on the first failure rather than restart once.
+#[test]
+fn a_bound_of_zero_quarantines_without_restarting() {
+    let out = run("for0", "restart(c) for 0;");
+    assert_eq!(count(&out, "birth "), 1, "no restart at all: {:?}", out);
+    assert_eq!(count(&out, "fail "), 1, "{:?}", out);
+    assert!(!out.contains("RUN"), "{:?}", out);
+}
+
+/// The bound is a ceiling, not a schedule: a child that recovers
+/// stops failing, keeps its remaining budget, and runs.
+#[test]
+fn a_bound_that_is_not_exhausted_lets_the_child_run() {
+    let src = r#"
+locus Worker {
+    params { attempts: Int = 0; target: Int = 3; }
+    closure reached { self.attempts ~~ self.target within 0; epoch birth; }
+    birth() {
+        self.attempts = self.attempts + 1;
+        println("birth ", self.attempts);
+    }
+    run() { println("RUN"); }
+}
+locus Coordinator {
+    on_failure(c: Worker, err: ClosureViolation) {
+        println("fail");
+        restart(c) for 5;
+    }
+    run() { Worker { target: 3 }; }
+}
+fn main() { let c = Coordinator { }; }
+"#;
+    let bin = build_hale("ok", src);
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(count(&stdout, "birth "), 3, "{:?}", stdout);
+    assert_eq!(count(&stdout, "fail"), 2, "{:?}", stdout);
+    assert!(stdout.contains("RUN"), "the closure passed: {:?}", stdout);
+}
+
+/// An unbounded `restart(c)` keeps the behaviour it had before the
+/// modifier lowered: it stops re-running at the default cap, and the
+/// child is NOT quarantined. Pinned because the bound is carried in
+/// the same field the default seeds, so a mistake there would
+/// silently change every existing supervisor.
+#[test]
+fn an_unbounded_restart_is_unchanged_and_does_not_quarantine() {
+    let out = run("default", "restart(c);");
+    assert_eq!(
+        count(&out, "birth "),
+        3,
+        "default cap is 2 restarts: {:?}",
+        out
+    );
+    assert!(
+        out.contains("RUN"),
+        "an unbounded restart does not quarantine: {:?}",
+        out
+    );
+}
+
+/// `quarantine(c) for d` carries a DIFFERENT modifier — a duration
+/// after which the child is automatically restarted
+/// (`spec/semantics.md` § quarantine). It is specified and still not
+/// lowered, so it must refuse in terms of what it actually is,
+/// rather than implying `for` belongs to restart alone.
+#[test]
+fn quarantine_for_a_duration_refuses_as_the_unlowered_feature_it_is() {
+    let program = hale_syntax::parse_source(&src("quarantine(c) for 3;"))
+        .expect("parse");
+    let bin = harness::unique_bin("hale_test_restartbound_quarfor");
+    let err = build_executable(&program, &bin).expect_err("must refuse");
+    let msg = format!("{:?}", err);
+    assert!(
+        msg.contains("quarantine") && msg.contains("not lowered"),
+        "should name the unlowered quarantine-duration form: {}",
+        msg
+    );
+    let _ = std::fs::remove_file(&bin);
+}
+
+/// `until` is the other recovery modifier and remains unlowered;
+/// its diagnostic should point at what does work.
+#[test]
+fn until_refuses_and_points_at_the_bound_that_works() {
+    let program =
+        hale_syntax::parse_source(&src("restart(c) until 3;")).expect("parse");
+    let bin = harness::unique_bin("hale_test_restartbound_until");
+    let err = build_executable(&program, &bin).expect_err("must refuse");
+    let msg = format!("{:?}", err);
+    assert!(
+        msg.contains("until") && msg.contains("for N"),
+        "should name `for N` as the shipped alternative: {}",
+        msg
+    );
+    let _ = std::fs::remove_file(&bin);
+}

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -906,6 +906,7 @@ crates/hale-codegen/tests/replay_recording.rs#1 1f253806d6a36078
 crates/hale-codegen/tests/replay_truncated.rs#0 c2a81f93ab151f59
 crates/hale-codegen/tests/replica_keys.rs#0 3339627819e66a48
 crates/hale-codegen/tests/replica_keys.rs#1 27ea505efcac4821
+crates/hale-codegen/tests/restart_bound.rs#1 d4dabe7a57f79bfa
 crates/hale-codegen/tests/self_field_alias.rs#0 cc87392098879459
 crates/hale-codegen/tests/self_field_alias.rs#1 cc87392098879459
 crates/hale-codegen/tests/self_field_alias.rs#2 00a0c7a19f9e4446

--- a/docs/src/services/failure.md
+++ b/docs/src/services/failure.md
@@ -57,7 +57,7 @@ locus Bank {
 
     on_failure(a: Account, err: Error) {
         match err {
-            Error::ClosureViolation(v) -> { quarantine(a) for 60s; },
+            Error::ClosureViolation(v) -> { quarantine(a); },
             _                          -> { bubble(err); },
         }
     }
@@ -69,10 +69,39 @@ The recovery primitives:
 - **absorb** — just return; the failure is noted and contained.
 - **`restart(child)`** — dissolve and re-create it fresh.
 - **`restart_in_place(child)`** — reset it, keeping its region.
-- **`quarantine(child) for d`** — pause it, preserving state for
-  inspection, optionally auto-restarting after `d`.
+- **`quarantine(child)`** — pause it, preserving state for
+  inspection.
 - **`bubble(err)`** — pass it up to *this* locus's parent.
 - **`dissolve(child)`** — force it down.
+
+### Saying how many times: `restart(child) for N`
+
+Restarting forever is rarely what you want. A child that fails
+for a structural reason will keep failing, and a supervisor that
+keeps retrying just turns a broken child into a busy loop.
+
+```hale,fragment
+on_failure(c: Book, err: ClosureViolation) {
+    restart(c) for 3;
+}
+```
+
+That gives this child three restarts. The fourth failure
+**quarantines** it instead: you said when to stop trying, so
+stopping means the child no longer runs. The count is per child
+and cumulative over its life, so a child that recovers keeps
+whatever budget it had left. `for 0` is a legitimate policy — do
+not restart this one at all.
+
+Write the bound here rather than counting failures by hand in the
+handler. Both do the same thing at runtime, but the declared form
+is the one the topology artifact records (`retry_bound`), so the
+policy you wrote and the restarts actually observed can be
+compared. A counter in a param is invisible to everything outside
+the handler.
+
+Without the modifier, `restart(child)` stops re-running after a
+default of two attempts and leaves the child live.
 
 If a failure bubbles past the root with no one absorbing it, the
 process exits non-zero with a structured report. That's the only

--- a/spec/precedence.md
+++ b/spec/precedence.md
@@ -119,7 +119,8 @@ precedence table. They appear in the form:
 
 ```
 restart(child);
-quarantine(child) for 30s;
+restart(child) for 3;
+quarantine(child);
 bubble(err);
 violate fatal_io;             // F.27, v1.x-VIOLATE
 violate fatal_io with detail; // optional payload

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -2841,12 +2841,34 @@ torn read possible.
 
 ## Recovery primitives
 
-### `restart(child)`
+### `restart(child)` / `restart(child) for N`
 
 1. Schedule child for dissolution.
 2. Once dissolved, instantiate a new child with the same
    declared params.
 3. New child's birth runs; old child's state is gone.
+
+**The retry bound.** `restart(c) for N` gives this child at most
+`N` restarts. The count is per child instance and cumulative over
+its lifetime, and it is compared *before* the restart, so `for N`
+admits exactly `N` restarts and the failure that follows the last
+one **quarantines** the child instead — the supervisor tried `N`
+times and is done with it. `for 0` is meaningful and quarantines
+on the first failure without restarting.
+
+Exhaustion quarantines rather than falling through: a bounded
+supervisor has stated when to stop, and stopping means the child
+does not run. This is the difference from an unbounded
+`restart(c)`, which stops re-running at the default cap of 2 but
+leaves the child live.
+
+`N` is an expression, evaluated at the recovery site. Without the
+modifier the bound is the default 2, so an unbounded `restart(c)`
+is unchanged.
+
+The bound is recorded in the topology artifact as `retry_bound`
+on the supervision row (schema 1.10), so the declared policy and
+the observed restarts are comparable.
 
 ### `restart_in_place(child)`
 
@@ -2868,6 +2890,14 @@ fine; just had a bad message).
 2. Preserve arena and state.
 3. If `for d` clause given, automatically restart after `d`.
 4. Otherwise wait until parent explicitly resolves.
+
+**Not lowered:** the `for d` duration clause. `quarantine(c)`
+itself ships; `quarantine(c) for d` is refused by codegen. Note
+that this `for` is a *duration* before an automatic restart — a
+different modifier from `restart(c) for N`, which is a retry
+count.
+
+Also not lowered: the `until` modifier on any recovery op.
 
 ### `reorganize(child, ...)`
 

--- a/spec/types.md
+++ b/spec/types.md
@@ -916,7 +916,8 @@ or error value as argument:
 
 ```
 restart(child);
-quarantine(child) for 30s;
+restart(child) for 3;
+quarantine(child);
 bubble(err);
 ```
 


### PR DESCRIPTION
Closes the third of four items in a downstream friction report.

## The gap

`restart(c) for N` checked and modelled — the topology artifact has carried `retry_bound` on the supervision row since schema 1.10 — but codegen refused it: `unsupported in codegen v0: recovery modifier (for/until) not lowered`.

So the annotation a consumer was told it could read ("declared cap 3, observed 3 in 40s") was unshippable, because no program stating the bound could be built. The workaround was counting failures by hand in the handler, which states the same policy somewhere nothing outside the handler can read it.

## Semantics

`for N` gives the child at most N restarts; the failure after the last one **quarantines** it. Per child instance, cumulative over its lifetime, compared *before* the restart. `N` is an expression, not just a literal.

| | births | restarts | child runs after? |
|---|---|---|---|
| `restart(c)` (default) | 3 | 2 | **yes** — unchanged |
| `restart(c) for 3` | 4 | 3 | no — quarantined |
| `restart(c) for 1` | 2 | 1 | no — quarantined |
| `restart(c) for 0` | 1 | 0 | no — immediate quarantine |
| `for 5`, closure recovers | 3 | 2 | yes, budget unspent |

Quarantine-on-exhaustion is the point: a bounded supervisor has said when to stop, and stopping means the child does not run. That is the difference from an unbounded `restart(c)`, which stops re-running at the default cap of 2 but leaves the child live.

## The part that would have shipped silently wrong

Lowering the statement alone gives a **wrong** `for N` above 2. The post-handler rerun check in `__birth_closures` was a hardcoded `count <= 2`, and it runs in a different function from the handler that declares the bound — so `for 5` would have restarted twice and stopped, with nothing to signal the declared policy wasn't being honoured.

Every locus now carries a synthetic `__restart_bound`, seeded at instantiation to that same default (named `DEFAULT_RESTART_BOUND`, since two places must agree) and overwritten by `for N`. Because the default and the bound now share a field, "unbounded `restart(c)` is unchanged" gets its own test rather than an assumption.

The quarantine path calls the same `emit_quarantine` an explicit `quarantine(c)` does — bus deregistration and the quarantine-event accumulator reset included — rather than a near-copy that could drift.

## Docs advertised two forms codegen refuses

`quarantine(c) for d` is a *duration* before an automatic restart — a different modifier from the retry count — and is specified but still not lowered. Neither is `until`. They shared one generic refusal that implied `for` belonged to restart alone; each now says what it actually is.

The failure chapter listed `quarantine(child) for d` in its recovery menu **and** used `quarantine(a) for 60s` in a worked `on_failure` example, and two spec grammar blocks used the same form. All moved to shipped forms; `spec/semantics.md` now states the lowering status of both.

## Verification

2991/2991 workspace tests pass. 8 new tests: the bound honoured above the old cap, exhaustion quarantining, `for 1`, `for 0`, a bound that is not exhausted, the unchanged unbounded default, and the two refusals. One baseline line added for the new corpus program; no existing artifact identity moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
