### PR TITLE
feat(chains): fixed arrays and `bounded[T; N]` are chain sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ behavior.
 
 ## Unreleased
 
+### Element chains take fixed arrays and `bounded[T; N]`
+
+`self.probes.filter(it.live).count()` over a `[Probe; 16]` failed with
+`no field `get` on `[Probe; 16]``. Chains rewrite — post-parse, before
+typecheck, so with no type to dispatch on — into a loop that fetches
+each element through the source's `get`. A `@form(vec)` is a locus and
+has that method; the two type-level collections are types, whose
+operations are grammar intrinsics (`at(f, i)`), so neither could
+anchor a chain at all. One downstream fleet counted ~11 would-be sites
+in a single component and ~44 hand-rolled index walks across it
+(downstream handoff).
+
+Both now answer `get(Int) -> T fallible(IndexError)` — the accessor
+the rewrite was already built around. `bounded` routes into its own
+`at`, so a chain walks the LIVE slots rather than the capacity and
+shares one bounds check with the intrinsic instead of a second copy
+that could disagree with it. A fixed array's length is static and
+every slot is live, so it gets its own check.
+
+This is a deliberate exception to the types-have-no-methods axiom,
+and the only one: `get` exists so the chain source protocol is
+uniform across locus-form and type-level collections, and `at`
+remains the idiomatic spelling for a direct index.
+
+The diagnostic added earlier for this case — "`[T; N]` is not a
+supported source form yet" — is gone along with the limitation;
+it had become unreachable, and dead advice about a limitation that
+no longer exists is worse than none.
+
 ### `restart(c) for N` lowers, and exhausting it quarantines
 
 The retry-bound modifier checked and modelled — the topology

--- a/crates/hale-codegen/src/channels/mod.rs
+++ b/crates/hale-codegen/src/channels/mod.rs
@@ -2119,6 +2119,17 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         args: &[Expr],
         scope: &Scope<'ctx>,
     ) -> Result<FallibleCallResult<'ctx>, CodegenError> {
+        // `src.get(i)` where src is a type-level collection (a fixed
+        // array or a `bounded[T; N]`) rather than a form locus. This
+        // is what the element-chain desugar emits, and it is checked
+        // before the locus resolution below because these receivers
+        // have no locus to resolve to — they used to fall straight
+        // into "fallible method call on non-locus value".
+        if let Some(result) =
+            self.try_lower_collection_get(receiver, method_name, args, scope)?
+        {
+            return Ok(result);
+        }
         let (info, self_ptr, locus_name) =
             if matches!(receiver, Expr::KwSelf(_)) {
                 let cs = self.current_self.as_ref().cloned().ok_or_else(

--- a/crates/hale-codegen/src/form/bounded.rs
+++ b/crates/hale-codegen/src/form/bounded.rs
@@ -205,6 +205,136 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// push(f, x) / at(f, i) — the fallible pair, dispatched from
     /// `lower_fallible_call`'s Ident arm. Returns None when args[0]
     /// isn't bounded (the caller falls through to user fns).
+    /// `src.get(i)` on a type-level collection — the accessor the
+    /// element-chain desugar rides.
+    ///
+    /// Chains desugar before typecheck into a loop that fetches
+    /// through the source's `get`, so a source must answer that name
+    /// to be chainable at all. A `@form(vec)` is a locus and has the
+    /// method; a `bounded[T; N]` and a fixed array are types whose
+    /// operations are free intrinsics, so chains could not anchor on
+    /// them (downstream handoff).
+    ///
+    /// `bounded` routes straight into its own `at`, which already
+    /// has exactly this signature and semantics — one bounds check,
+    /// not a second copy that could disagree with it. A fixed array
+    /// has no length field (every one of its N slots is live and N is
+    /// static), so it gets the check here.
+    pub(crate) fn try_lower_collection_get(
+        &mut self,
+        receiver: &Expr,
+        method_name: &str,
+        args: &[Expr],
+        scope: &Scope<'ctx>,
+    ) -> Result<Option<FallibleCallResult<'ctx>>, CodegenError> {
+        if method_name != "get" || args.len() != 1 {
+            return Ok(None);
+        }
+        let recv_ty = match self.static_expr_codegen_ty(receiver, scope) {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+        let (elem, len) = match recv_ty {
+            CodegenTy::Bounded(..) => {
+                // Rebuild the free-call shape `at(recv, i)`.
+                let mut at_args = Vec::with_capacity(2);
+                at_args.push(receiver.clone());
+                at_args.push(args[0].clone());
+                return self.try_lower_bounded_fallible_intrinsic(
+                    "at", &at_args, scope,
+                );
+            }
+            CodegenTy::Array(elem, n) => (*elem, n),
+            _ => return Ok(None),
+        };
+        let i64_t = self.context.i64_type();
+        let func = self.current_fn.expect("array get in fn body");
+        let (recv_val, _) = self.lower_expr(receiver, scope)?;
+        let data_ptr = recv_val.into_pointer_value();
+        let (iv, ity) = self.lower_expr(&args[0], scope)?;
+        if ity != CodegenTy::Int {
+            return Err(CodegenError::Unsupported(format!(
+                "get(i) on an array: index must be Int, got {:?}",
+                ity
+            )));
+        }
+        let idx = iv.into_int_value();
+        let neg = self
+            .builder
+            .build_int_compare(
+                inkwell::IntPredicate::SLT,
+                idx,
+                i64_t.const_zero(),
+                "array.get.neg",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let past = self
+            .builder
+            .build_int_compare(
+                inkwell::IntPredicate::SGE,
+                idx,
+                i64_t.const_int(len, false),
+                "array.get.past",
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let oob = self
+            .builder
+            .build_or(neg, past, "array.get.oob")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        let ok_bb = self.context.append_basic_block(func, "array.get.ok");
+        let err_bb = self.context.append_basic_block(func, "array.get.err");
+        let join_bb =
+            self.context.append_basic_block(func, "array.get.join");
+        let out_val_slot = self.alloca_for(&elem, "array.get.val.slot")?;
+        let out_err_slot = self.alloca_for(
+            &CodegenTy::TypeRef("IndexError".into()),
+            "array.get.err.slot",
+        )?;
+        self.builder
+            .build_conditional_branch(oob, err_bb, ok_bb)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+
+        self.builder.position_at_end(ok_bb);
+        let elem_llvm = self.llvm_basic_type(&elem);
+        let slot_ptr = unsafe {
+            self.builder
+                .build_gep(elem_llvm, data_ptr, &[idx], "array.get.slot")
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+        };
+        let v = self
+            .builder
+            .build_load(elem_llvm, slot_ptr, "array.get.val")
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_store(out_val_slot, v)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_unconditional_branch(join_bb)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+
+        self.builder.position_at_end(err_bb);
+        let err_ptr = self.emit_index_error_alloc(
+            "out_of_bounds",
+            idx,
+            i64_t.const_int(len, false),
+        )?;
+        self.builder
+            .build_store(out_err_slot, err_ptr)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_unconditional_branch(join_bb)
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+
+        self.builder.position_at_end(join_bb);
+        Ok(Some(FallibleCallResult {
+            i1_path: oob,
+            out_val_slot: Some(out_val_slot),
+            out_err_slot,
+            success_ty: Some(elem),
+            payload_ty: CodegenTy::TypeRef("IndexError".into()),
+        }))
+    }
+
     pub(crate) fn try_lower_bounded_fallible_intrinsic(
         &mut self,
         name: &str,

--- a/crates/hale-codegen/tests/chain_array_sources.rs
+++ b/crates/hale-codegen/tests/chain_array_sources.rs
@@ -1,0 +1,161 @@
+//! Element chains over the type-level collections: `[T; N]` and
+//! `bounded[T; N]`.
+//!
+//! Chains desugar — before typecheck, so with no type to dispatch on
+//! — into a loop that fetches each element through the source's
+//! `get`. A `@form(vec)` is a locus and has that method; a fixed
+//! array and a `bounded` are types, whose operations are free
+//! intrinsics (`at(f, i)`), so the desugared loop hit "no field
+//! `get`" and chains could not anchor on them at all. A downstream
+//! fleet counted ~11 would-be sites in one component and ~44
+//! hand-rolled index walks across the whole thing.
+//!
+//! `get(Int) -> T fallible(IndexError)` now answers on both, which
+//! is the accessor the desugar was already built around.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+fn run_src(name: &str, source: &str) -> String {
+    let program = hale_syntax::parse_source(source).expect("parse");
+    let bin = harness::unique_bin(&format!("hale_test_chainsrc_{}", name));
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(
+        out.status.success(),
+        "program must run: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// The acceptance test the friction report asked for: a fixed array
+/// `.filter(…).count()` compiles and counts.
+#[test]
+fn a_fixed_array_is_a_chain_source() {
+    let out = run_src(
+        "array",
+        r#"
+type Probe { live: Bool = false; id: Int = 0; }
+locus Fleet {
+    params {
+        ps: [Probe; 4] = [
+            Probe { live: true,  id: 1 },
+            Probe { live: false, id: 2 },
+            Probe { live: true,  id: 3 },
+            Probe { live: true,  id: 4 },
+        ];
+    }
+    run {
+        println("live=", self.ps.filter(it.live).count());
+        println("sum=", self.ps.map(it.id).sum(0));
+        println("any=", self.ps.any(it.id == 3));
+        println("all=", self.ps.all(it.id > 0));
+    }
+}
+fn main() { let f = Fleet { }; }
+"#,
+    );
+    assert!(out.contains("live=3"), "{:?}", out);
+    // Every slot of a fixed array is live, so the walk must cover
+    // all N — a chain that stopped early would still look plausible
+    // on `count` alone.
+    assert!(out.contains("sum=10"), "1+2+3+4: {:?}", out);
+    assert!(out.contains("any=true"), "{:?}", out);
+    assert!(out.contains("all=true"), "{:?}", out);
+}
+
+/// `bounded` walks its LIVE slots, not its capacity. It routes into
+/// the same `at` the free intrinsic uses, which is bounded by `len`
+/// — a second bounds check written here could have used the
+/// capacity and silently read uninitialized slots.
+#[test]
+fn a_bounded_chain_walks_live_slots_not_capacity() {
+    let out = run_src(
+        "bounded",
+        r#"
+locus Fleet {
+    params { xs: bounded[Int; 8]; }
+    birth() {
+        push(self.xs, 5) or discard;
+        push(self.xs, 7) or discard;
+        push(self.xs, 9) or discard;
+    }
+    run {
+        println("count=", self.xs.filter(it > 5).count());
+        println("sum=", self.xs.map(it).sum(0));
+        println("any=", self.xs.any(it == 7));
+    }
+}
+fn main() { let f = Fleet { }; }
+"#,
+    );
+    assert!(out.contains("count=2"), "7 and 9: {:?}", out);
+    assert!(
+        out.contains("sum=21"),
+        "5+7+9 and nothing from the 5 unused slots: {:?}",
+        out
+    );
+    assert!(out.contains("any=true"), "{:?}", out);
+}
+
+/// An empty `bounded` has zero live slots; the chain must terminate
+/// immediately rather than read capacity.
+#[test]
+fn an_empty_bounded_chains_to_zero() {
+    let out = run_src(
+        "boundedempty",
+        r#"
+locus Fleet {
+    params { xs: bounded[Int; 4]; }
+    run {
+        println("count=", self.xs.filter(it > 0).count());
+        println("sum=", self.xs.map(it).sum(0));
+        println("any=", self.xs.any(it == 1));
+    }
+}
+fn main() { let f = Fleet { }; }
+"#,
+    );
+    assert!(out.contains("count=0"), "{:?}", out);
+    assert!(out.contains("sum=0"), "{:?}", out);
+    assert!(out.contains("any=false"), "{:?}", out);
+}
+
+/// `get` is the accessor the desugar rides, and it is also directly
+/// callable — it is fallible, so an out-of-range index takes the
+/// `or` arm rather than reading past the end.
+#[test]
+fn get_is_fallible_on_both_source_forms() {
+    let out = run_src(
+        "getdirect",
+        r#"
+locus Fleet {
+    params { ps: [Int; 3] = [10, 20, 30]; xs: bounded[Int; 4]; }
+    birth() { push(self.xs, 42) or discard; }
+    run {
+        println("a=", self.ps.get(1) or 0);
+        println("b=", self.ps.get(9) or -1);
+        println("c=", self.ps.get(0 - 1) or -2);
+        println("d=", self.xs.get(0) or 0);
+        println("e=", self.xs.get(3) or -1);
+    }
+}
+fn main() { let f = Fleet { }; }
+"#,
+    );
+    assert!(out.contains("a=20"), "{:?}", out);
+    assert!(out.contains("b=-1"), "past the end: {:?}", out);
+    assert!(out.contains("c=-2"), "negative index: {:?}", out);
+    assert!(out.contains("d=42"), "{:?}", out);
+    assert!(
+        out.contains("e=-1"),
+        "past the live count, inside capacity: {:?}",
+        out
+    );
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -10829,6 +10829,37 @@ impl<'a> Checker<'a> {
                 _ => None,
             }
             }
+            // `get(i) -> T fallible(IndexError)` on the two
+            // type-level collections.
+            //
+            // Element chains desugar — before typecheck, so with no
+            // type to dispatch on — into a loop that fetches through
+            // the source's `get`. A `@form(vec)` is a locus and has
+            // that method; a fixed array and a `bounded[T; N]` are
+            // types, whose operations are grammar intrinsics
+            // (`at(f, i)`, `count(f)`), so the desugared loop hit
+            // "no field `get`" and chains simply could not anchor on
+            // them (downstream handoff: ~11 would-be sites in one
+            // fleet, ~44 hand-rolled walks across it).
+            //
+            // This is the one method-position operation on these
+            // types, and it exists so the chain source protocol is
+            // uniform across locus-form and type-level collections.
+            // Same signature and semantics as `at`, which stays the
+            // idiomatic spelling for a direct index.
+            Ty::Array(elem, _) | Ty::Bounded(elem, _)
+                if name == "get" =>
+            {
+                Some(Ty::Function {
+                    params: vec![Ty::Prim(PrimType::Int)],
+                    ret: Box::new(Ty::Fallible {
+                        success: elem.clone(),
+                        payload: Box::new(Ty::Named(
+                            "IndexError".into(),
+                        )),
+                    }),
+                })
+            }
             Ty::Unknown => Some(Ty::Unknown),
             _ => None,
         }
@@ -11957,39 +11988,18 @@ impl<'a> Checker<'a> {
                                     _ => {}
                                 }
                             }
-                            // Element chains desugar (pre-typecheck) to a
-                            // loop that fetches each element through the
-                            // source's `get` / `entry_at`. On a source form
-                            // that has neither — a fixed array or a
-                            // `bounded[T; N]` — the failure surfaces here as
-                            // a bare "no field `get`", with no hint that a
-                            // chain was even involved or which forms a chain
-                            // supports. Name it, so the reader doesn't have
-                            // to bisect the desugar (downstream handoff).
-                            let is_chain_accessor =
-                                name.name == "get" || name.name == "entry_at";
-                            let unsupported_chain_source = is_chain_accessor
-                                && matches!(
-                                    rt,
-                                    Ty::Array(..) | Ty::Bounded(..)
-                                );
-                            let hint = if unsupported_chain_source {
-                                format!(
-                                    " — if this is an element chain \
-                                     (`.filter(…).count()` and the like), \
-                                     `{}` is not a supported source form yet; \
-                                     chains anchor on a `@form(vec)` directly \
-                                     or a `@form(hashmap)` via `.entries`",
-                                    rt.display()
-                                )
-                            } else {
-                                crate::stdlib_surface::nearest_name(
-                                    &name.name,
-                                    candidates.iter().map(|s| s.as_str()),
-                                )
-                                .map(|s| format!(" — did you mean `{}`?", s))
-                                .unwrap_or_default()
-                            };
+                            // (An element-chain source that cannot
+                            // answer `get` used to be hinted here.
+                            // Both type-level collections answer it
+                            // now, so the hint was unreachable —
+                            // dead advice about a limitation that no
+                            // longer exists is worse than none.)
+                            let hint = crate::stdlib_surface::nearest_name(
+                                &name.name,
+                                candidates.iter().map(|s| s.as_str()),
+                            )
+                            .map(|s| format!(" — did you mean `{}`?", s))
+                            .unwrap_or_default();
                             self.diags.push(Diag::ty(
                                 *span,
                                 format!(

--- a/crates/hale-types/tests/diag_quality.rs
+++ b/crates/hale-types/tests/diag_quality.rs
@@ -102,12 +102,16 @@ fn field_typo_gets_did_you_mean() {
 }
 
 #[test]
-fn chain_over_unsupported_source_names_the_chain() {
-    // An element chain desugars to a loop fetching each element through
-    // the source's `get`. A fixed array / `bounded[T; N]` has no such
-    // accessor, so it failed with a bare "no field `get`" that never
-    // mentioned chains or the supported source forms (downstream
-    // handoff). Both the array and the bounded case now say so.
+fn a_fixed_array_and_a_bounded_are_chain_sources() {
+    // These two used to fail with "no field `get`": chains desugar
+    // to a loop fetching each element through the source's `get`,
+    // and the type-level collections had no such accessor, so they
+    // could not anchor a chain at all. They answer `get` now, so the
+    // programs below are ordinary (downstream handoff).
+    //
+    // Kept as a DIAGNOSTIC test rather than only a codegen one: the
+    // failure mode was a confusing message on a reasonable program,
+    // and the fix is that there is no message.
     for src in [
         r#"
             locus L {
@@ -125,13 +129,9 @@ fn chain_over_unsupported_source_names_the_chain() {
     ] {
         let ds = diags(src);
         assert!(
-            ds.iter().any(|m| {
-                m.contains("element chain")
-                    && m.contains("@form(vec)")
-                    && m.contains("`.entries`")
-            }),
-            "expected a chain-source diagnostic naming the supported \
-             forms; got: {:?}",
+            ds.is_empty(),
+            "a chain over a type-level collection should check clean; \
+             got: {:?}",
             ds
         );
     }

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -310,6 +310,10 @@ crates/hale-codegen/tests/case_fold_and_nested_fstring.rs#2 865d341109268295
 crates/hale-codegen/tests/case_fold_and_nested_fstring.rs#3 865d341109268295
 crates/hale-codegen/tests/case_fold_and_nested_fstring.rs#4 f2c1228edb650960
 crates/hale-codegen/tests/case_fold_and_nested_fstring.rs#5 f2c1228edb650960
+crates/hale-codegen/tests/chain_array_sources.rs#0 5b8eccc1b3947077
+crates/hale-codegen/tests/chain_array_sources.rs#1 c70a96d9e23bc5e6
+crates/hale-codegen/tests/chain_array_sources.rs#2 5b8eccc1b3947077
+crates/hale-codegen/tests/chain_array_sources.rs#3 c70a96d9e23bc5e6
 crates/hale-codegen/tests/children_count_sugar.rs#0 4d984294b3fc41b3
 crates/hale-codegen/tests/children_growable.rs#0 2d4c43412163d81b
 crates/hale-codegen/tests/children_growable.rs#1 2d4c43412163d81b
@@ -1230,6 +1234,8 @@ crates/hale-types/tests/contract_expose_check.rs#5 68571438548b5b78
 crates/hale-types/tests/depends_set.rs#1 e6d019967d07bc80
 crates/hale-types/tests/depends_set.rs#2 7eb747ab2594f71d
 crates/hale-types/tests/diag_quality.rs#2 865d341109268295
+crates/hale-types/tests/diag_quality.rs#5 d6325a0b5e9d93db
+crates/hale-types/tests/diag_quality.rs#6 9340303665f67845
 crates/hale-types/tests/dispatch_plan.rs#0 fe4628dffcd0e1c9
 crates/hale-types/tests/dispatch_plan.rs#1 f9df46108bfdfb03
 crates/hale-types/tests/dispatch_plan.rs#10 8831f70364306fc6

--- a/docs/src/everyday/collections.md
+++ b/docs/src/everyday/collections.md
@@ -192,6 +192,19 @@ let n = users.filter(it.active).count();
 users.filter(it.active).into(actives);
 ```
 
+This works on any of the collections in this chapter — a
+`@form(vec)`, a `@form(hashmap)` (via `.entries`), a `bounded[T; N]`,
+and a plain fixed array:
+
+```hale,fragment
+let live = self.probes.filter(it.live).count();   // probes: [Probe; 16]
+let hot  = self.recent.filter(it > 90).count();   // recent: bounded[Int; 8]
+```
+
+A `bounded` chain walks the elements you actually pushed, not its
+capacity — an empty one answers zero rather than reading unused
+slots.
+
 `it` is the current element. Chain as many stages as you like; they
 run in a single pass:
 

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -2422,6 +2422,28 @@ silently wrong comparison).
 | `reverse_into(target)` | push survivors, then swap ends inward on the caller's vec (2026-08-11) |
 | `group_count_into(target, key?)` | one hashmap `bump(key)` per survivor — increment-or-init tallying into the caller's `@form(hashmap)`; the bare form keys on the element itself (2026-08-11) |
 
+**Chain sources.** A chain rewrites to a loop that fetches each
+element through the source's `get(Int) -> T fallible(IndexError)`,
+so answering that name is exactly what makes a form chainable:
+
+| source | accessor |
+|---|---|
+| `@form(vec)` | its synthesized `get` |
+| `@form(hashmap)` via `.entries` | `entry_at`, same shape |
+| `[T; N]` | `get`, over all `N` slots |
+| `bounded[T; N]` | `get`, over the **live** slots (not capacity) |
+
+The two type-level collections are a deliberate exception to the
+types-have-no-methods axiom, and the only one: their operations are
+otherwise grammar intrinsics (`at(f, i)`, `count(f)`), and `at`
+remains the idiomatic spelling for a direct index. `get` exists so
+the chain source protocol is uniform, and is identical to `at` in
+signature and semantics — on `bounded` it *is* `at`.
+
+The rewrite happens post-parse, before typecheck, so it cannot
+dispatch on the source's type; a form that does not answer `get`
+fails with an ordinary no-method diagnostic at the chain's site.
+
 **Fallible terminals ride the source's own `get`.** `first` / `find`
 / `min` / `max` lower to an index search whose value is
 `src.get(idx)` — an empty result is the ordinary `IndexError`, so

--- a/spec/types.md
+++ b/spec/types.md
@@ -435,7 +435,17 @@ count(f)         -> Int
 clear(f)                                          // len = 0
 truncate(f, n)   -> Int                           // len = clamp; returns it
 for x in f { }                                    // iterate live slots
+f.get(i)         -> T   fallible(IndexError)      // = at(f, i); see below
 ```
+
+`get` is the one operation in method position, and the same is true
+of `[T; N]`. Element chains rewrite to a loop that fetches through
+the source's `get`, so answering that name is what makes a form
+chainable at all — without it, `f.filter(…).count()` failed with
+"no field `get`" and the type-level collections could not anchor a
+chain. It is identical to `at` in signature and semantics (on
+`bounded` it *is* `at`, bounded by the live count rather than the
+capacity); `at` remains the idiomatic spelling for a direct index.
 
 Semantics:
 - Fields auto-initialize EMPTY. Literal init and whole-field


### PR DESCRIPTION
Closes the last of four items in a downstream friction report.

## The gap

`self.probes.filter(it.live).count()` over a `[Probe; 16]` failed with `no field `get` on `[Probe; 16]``.

Chains rewrite post-parse, **before typecheck** — so with no type to dispatch on — into a loop that fetches each element through the source's `get`. A `@form(vec)` is a locus and has that method; `[T; N]` and `bounded[T; N]` are *types*, whose operations are grammar intrinsics (`at(f, i)`, `count(f)`), so neither could anchor a chain at all.

One downstream fleet counted ~11 would-be sites in a single component and ~44 hand-rolled index walks across the whole thing.

## The fix

Both source forms now answer `get(Int) -> T fallible(IndexError)` — the accessor the rewrite was already built around, so the desugar is untouched.

| source | accessor | walks |
|---|---|---|
| `@form(vec)` | synthesized `get` | all elements |
| `@form(hashmap)` via `.entries` | `entry_at` | occupied slots |
| `[T; N]` | `get` | all `N` slots (static length) |
| `bounded[T; N]` | `get` → its own `at` | **live** slots, not capacity |

`bounded` routing into `at` is the part that matters: one bounds check shared with the intrinsic rather than a second copy that could disagree with it. A hand-written check here could easily have used the capacity and read uninitialized storage — hence the empty-`bounded` test.

## The axiom

This is a deliberate exception to types-have-no-methods, and the only one. `get` exists so the chain source protocol is uniform across locus-form and type-level collections; `at` remains the idiomatic spelling for a direct index, and on `bounded` `get` **is** `at`. Both `spec/types.md` and `spec/semantics.md` say so explicitly rather than leaving the exception implicit.

## A diagnostic that outlived its bug

The hint added earlier for exactly this case — "`[T; N]` is not a supported source form yet; chains anchor on a `@form(vec)`" — is removed along with the limitation. Once both forms answer `get`, it was unreachable, and dead advice about a limitation that no longer exists is worse than none. Its test now asserts the opposite: those two programs check clean.

## Tests

- both source forms end to end (`filter`/`map`/`any`/`all`/`sum`/`count`)
- an empty `bounded` — zero live slots, must not read capacity
- full coverage of a fixed array's N slots, asserted via `sum` as well as `count`, since a walk that stopped early would still look right on `count` alone
- `get` used directly: in range, past the end, negative, and past the live count but inside capacity

Six baseline additions, all new corpus programs (including the two diag_quality programs, which now compile and so enter the corpus for the first time). No existing artifact identity moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
