### PR TITLE
feat(topology): the SVG carries its own theme

### DIFF
--- a/crates/hale-cli/src/topology_graph.rs
+++ b/crates/hale-cli/src/topology_graph.rs
@@ -43,6 +43,7 @@ pub fn run_topology(rest: &[String]) -> ExitCode {
     let mut artifact_path: Option<PathBuf> = None;
     let mut view = "system".to_string();
     let mut format = "svg".to_string();
+    let mut theme = SvgTheme::Auto;
     let mut out_path: Option<PathBuf> = None;
     let mut claim: Option<String> = None;
     let mut config_path: Option<PathBuf> = None;
@@ -57,6 +58,22 @@ pub fn run_topology(rest: &[String]) -> ExitCode {
             "--format" => match it.next() {
                 Some(v) => format = v.clone(),
                 None => return flag_err("--format needs a value"),
+            },
+            // SVG only: the other formats carry no colour of their
+            // own (mermaid and dot are themed by whatever renders
+            // them), so a theme there would be a promise this
+            // command cannot keep.
+            "--theme" => match it.next().map(|v| v.as_str()) {
+                Some("auto") => theme = SvgTheme::Auto,
+                Some("light") => theme = SvgTheme::Light,
+                Some("dark") => theme = SvgTheme::Dark,
+                Some(other) => {
+                    return flag_err(&format!(
+                        "--theme takes auto | light | dark, got `{}`",
+                        other
+                    ))
+                }
+                None => return flag_err("--theme needs a value"),
             },
             "-o" | "--output" => match it.next() {
                 Some(v) => out_path = Some(PathBuf::from(v)),
@@ -147,7 +164,7 @@ pub fn run_topology(rest: &[String]) -> ExitCode {
     let output = match format.as_str() {
         "mermaid" => render_mermaid(&graph),
         "dot" => render_dot(&graph),
-        _ => render_svg(&graph),
+        _ => render_svg(&graph, theme),
     };
     match out_path {
         None => {
@@ -1723,7 +1740,97 @@ struct Placed {
     h: i64,
 }
 
-fn render_svg(g: &RenderGraph) -> String {
+/// The SVG palette, as (light, dark) pairs.
+///
+/// The renderer emits the LIGHT value as an ordinary `fill=` /
+/// `stroke=` attribute, and generates a scoped stylesheet from this
+/// same table that remaps those literals under
+/// `prefers-color-scheme: dark`. Because both sides come from one
+/// array, the attributes and the dark theme cannot drift apart.
+///
+/// That drift is the actual defect this closes: the renderer emitted
+/// a hardcoded light theme, so hale-lang.org re-themed the diagrams
+/// with its own `[fill="#ffffff"] { fill: … }` rules — a copy of this
+/// palette living in a DIFFERENT REPOSITORY, silently wrong the
+/// moment a colour here changed.
+///
+/// Ordered light-to-dark within each role so the mapping reads as an
+/// inversion rather than a lookup table.
+const SVG_PALETTE: &[(&str, &str)] = &[
+    // surfaces
+    ("#ffffff", "#0d1117"), // page
+    ("#f7fafc", "#161b22"), // locus card / info tint
+    ("#ebf8ff", "#12243a"), // topic card
+    ("#f0fff4", "#0f2417"), // ok tint
+    ("#fff5f5", "#2a1215"), // bad tint
+    ("#fffff0", "#241f0d"), // warn tint
+    // ink
+    ("#1a202c", "#e6edf3"), // primary
+    ("#2d3748", "#c9d1d9"), // secondary
+    ("#4a5568", "#8b949e"), // tertiary / call edges
+    ("#718096", "#6e7681"), // muted / dead edges
+    // roles
+    ("#2f855a", "#3fb950"), // publish / ok
+    ("#6b46c1", "#bc8cff"), // subscribe
+    ("#c53030", "#f85149"), // hole / bad
+    ("#d69e2e", "#d29922"), // highlight
+    ("#2b6cb0", "#58a6ff"), // topic
+    ("#b7791f", "#e3b341"), // warn
+    // dark-on-tint card text, which inverts to light-on-dark
+    ("#22543d", "#7ee787"),
+    ("#742a2a", "#ffa198"),
+    ("#744210", "#f2cc60"),
+];
+
+/// How the SVG carries its palette.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SvgTheme {
+    /// Light attributes plus a `prefers-color-scheme: dark` override
+    /// — one artifact that reads correctly in either. The default,
+    /// because a diagram is usually looked at by a person whose
+    /// theme the renderer cannot know.
+    Auto,
+    /// Light only, with no stylesheet — the pre-theming output, for
+    /// embedding somewhere already known to be light.
+    Light,
+    /// Dark unconditionally.
+    Dark,
+}
+
+/// The scoped stylesheet, generated from `SVG_PALETTE`.
+///
+/// Every selector is prefixed with the root's own class, because an
+/// SVG is frequently INLINED into an HTML document — an unscoped
+/// `<style>` here would become page-wide CSS and restyle its host.
+fn svg_theme_style(theme: SvgTheme) -> String {
+    if theme == SvgTheme::Light {
+        return String::new();
+    }
+    let rules = |out: &mut String, indent: &str| {
+        for (light, dark) in SVG_PALETTE {
+            out.push_str(&format!(
+                "{i}.hale-topo [fill=\"{l}\"]{{fill:{d}}}\n\
+                 {i}.hale-topo [stroke=\"{l}\"]{{stroke:{d}}}\n",
+                i = indent,
+                l = light,
+                d = dark
+            ));
+        }
+    };
+    let mut css = String::new();
+    match theme {
+        SvgTheme::Dark => rules(&mut css, ""),
+        SvgTheme::Auto => {
+            css.push_str("@media (prefers-color-scheme: dark){\n");
+            rules(&mut css, "");
+            css.push_str("}\n");
+        }
+        SvgTheme::Light => unreachable!("returned above"),
+    }
+    format!("<style>\n{}</style>\n", css)
+}
+
+fn render_svg(g: &RenderGraph, theme: SvgTheme) -> String {
     // ---- layout: left column of locus boxes, right column of
     // topics, further-right column of unknown nodes, cards top-right.
     let title_h = 2 * LINE_H + PAD;
@@ -1865,14 +1972,20 @@ fn render_svg(g: &RenderGraph) -> String {
     // ---- emit
     let mut s = String::new();
     s.push_str(&format!(
-        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{w}\" \
-         height=\"{h}\" viewBox=\"0 0 {w} {h}\" font-family=\"monospace\" \
-         font-size=\"13\">\n",
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"hale-topo\" \
+         width=\"{w}\" height=\"{h}\" viewBox=\"0 0 {w} {h}\" \
+         font-family=\"monospace\" font-size=\"13\">\n",
         w = width,
         h = height
     ));
+    s.push_str(&svg_theme_style(theme));
     s.push_str(&format!(
-        "<rect x=\"0\" y=\"0\" width=\"{}\" height=\"{}\" fill=\"#ffffff\"/>\n",
+        // Classed so a host can drop the page behind the diagram
+        // (`.hale-topo .bg { fill: transparent }`) without matching
+        // on a colour literal — the one element an embedder almost
+        // always wants to control.
+        "<rect class=\"bg\" x=\"0\" y=\"0\" width=\"{}\" \
+         height=\"{}\" fill=\"#ffffff\"/>\n",
         width, height
     ));
     s.push_str(&format!(

--- a/crates/hale-cli/tests/fixtures/topology/golden-system.svg
+++ b/crates/hale-cli/tests/fixtures/topology/golden-system.svg
@@ -1,5 +1,47 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1196" height="422" viewBox="0 0 1196 422" font-family="monospace" font-size="13">
-<rect x="0" y="0" width="1196" height="422" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" class="hale-topo" width="1196" height="422" viewBox="0 0 1196 422" font-family="monospace" font-size="13">
+<style>
+@media (prefers-color-scheme: dark){
+.hale-topo [fill="#ffffff"]{fill:#0d1117}
+.hale-topo [stroke="#ffffff"]{stroke:#0d1117}
+.hale-topo [fill="#f7fafc"]{fill:#161b22}
+.hale-topo [stroke="#f7fafc"]{stroke:#161b22}
+.hale-topo [fill="#ebf8ff"]{fill:#12243a}
+.hale-topo [stroke="#ebf8ff"]{stroke:#12243a}
+.hale-topo [fill="#f0fff4"]{fill:#0f2417}
+.hale-topo [stroke="#f0fff4"]{stroke:#0f2417}
+.hale-topo [fill="#fff5f5"]{fill:#2a1215}
+.hale-topo [stroke="#fff5f5"]{stroke:#2a1215}
+.hale-topo [fill="#fffff0"]{fill:#241f0d}
+.hale-topo [stroke="#fffff0"]{stroke:#241f0d}
+.hale-topo [fill="#1a202c"]{fill:#e6edf3}
+.hale-topo [stroke="#1a202c"]{stroke:#e6edf3}
+.hale-topo [fill="#2d3748"]{fill:#c9d1d9}
+.hale-topo [stroke="#2d3748"]{stroke:#c9d1d9}
+.hale-topo [fill="#4a5568"]{fill:#8b949e}
+.hale-topo [stroke="#4a5568"]{stroke:#8b949e}
+.hale-topo [fill="#718096"]{fill:#6e7681}
+.hale-topo [stroke="#718096"]{stroke:#6e7681}
+.hale-topo [fill="#2f855a"]{fill:#3fb950}
+.hale-topo [stroke="#2f855a"]{stroke:#3fb950}
+.hale-topo [fill="#6b46c1"]{fill:#bc8cff}
+.hale-topo [stroke="#6b46c1"]{stroke:#bc8cff}
+.hale-topo [fill="#c53030"]{fill:#f85149}
+.hale-topo [stroke="#c53030"]{stroke:#f85149}
+.hale-topo [fill="#d69e2e"]{fill:#d29922}
+.hale-topo [stroke="#d69e2e"]{stroke:#d29922}
+.hale-topo [fill="#2b6cb0"]{fill:#58a6ff}
+.hale-topo [stroke="#2b6cb0"]{stroke:#58a6ff}
+.hale-topo [fill="#b7791f"]{fill:#e3b341}
+.hale-topo [stroke="#b7791f"]{stroke:#e3b341}
+.hale-topo [fill="#22543d"]{fill:#7ee787}
+.hale-topo [stroke="#22543d"]{stroke:#7ee787}
+.hale-topo [fill="#742a2a"]{fill:#ffa198}
+.hale-topo [stroke="#742a2a"]{stroke:#ffa198}
+.hale-topo [fill="#744210"]{fill:#f2cc60}
+.hale-topo [stroke="#744210"]{stroke:#f2cc60}
+}
+</style>
+<rect class="bg" x="0" y="0" width="1196" height="422" fill="#ffffff"/>
 <text x="90" y="18" font-size="15" font-weight="bold" fill="#1a202c">topology · system view</text>
 <text x="90" y="36" fill="#718096">schema 1.17 · shape e7e11084cc75bf03 · verdict clean</text>
 <path d="M 344 97 C 414 97, 414 163, 484 163" fill="none" stroke="#2f855a" stroke-width="1.5"/>

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -3462,3 +3462,148 @@ fn main() { App { }; }
         err
     );
 }
+
+/// Every colour the SVG puts in the document is remapped by its own
+/// dark theme.
+///
+/// The renderer emitted a hardcoded light palette, so hale-lang.org
+/// re-themed the diagrams with its own `[fill="#ffffff"] { … }`
+/// rules — a copy of this palette in a DIFFERENT REPOSITORY, wrong
+/// the moment a colour changed here. The stylesheet now ships inside
+/// the SVG, generated from the same table the attributes come from.
+///
+/// This checks the property that matters and that a new colour would
+/// quietly break: a hex used in the body but absent from the palette
+/// stays light on a dark background, and nothing else would say so.
+#[test]
+fn every_svg_colour_is_remapped_by_the_dark_theme() {
+    let dir = workdir("svgtheme");
+    let src = dir.join("app.hl");
+    // Exercise the tinted/holed paths too, not just the happy graph:
+    // an unresolved call gives the residue view its hole colours.
+    std::fs::write(
+        &src,
+        r#"
+type R { v: Int = 0; }
+topic T { payload: R; subject: "t"; }
+fn apply(f: fn(Int) -> Int, v: Int) -> Int { return f(v); }
+fn scale(v: Int) -> Int { return v * 2; }
+locus Pub {
+    bus { publish T; }
+    params { n: Int = 0; }
+    fn go() { T <- R { v: apply(scale, self.n) }; }
+}
+locus Sub {
+    bus { subscribe T as on_t; }
+    params { seen: Int = 0; }
+    fn on_t(r: R) { self.seen = r.v; }
+}
+main locus App {
+    params { p: Pub = Pub { }; s: Sub = Sub { }; }
+    claims { one: count publishers(topic T) == 1; }
+    run() { self.p.go(); }
+}
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let artifact = dump_artifact(&dir, &src);
+    for view in ["system", "code", "bus", "claim", "residue"] {
+        let mut argv: Vec<&str> =
+            vec!["--view", view, "--format", "svg", "--theme", "dark"];
+        if view == "claim" {
+            argv.extend(["--claim", "one"]);
+        }
+        let svg = render(&artifact, &argv);
+        let (style, body) = svg
+            .split_once("</style>")
+            .expect("a themed svg carries its stylesheet");
+        let mut unthemed: Vec<String> = Vec::new();
+        for (attr, _) in [("fill", 0), ("stroke", 0)] {
+            let needle = format!("{}=\"#", attr);
+            let mut rest = body;
+            while let Some(i) = rest.find(&needle) {
+                rest = &rest[i + needle.len() - 1..];
+                let hex: String =
+                    rest.chars().take_while(|c| *c != '"').collect();
+                let rule = format!("[{}=\"{}\"]{{", attr, hex);
+                if !style.contains(&rule) {
+                    unthemed.push(format!("{} {}", attr, hex));
+                }
+                rest = &rest[1..];
+            }
+        }
+        unthemed.sort();
+        unthemed.dedup();
+        assert!(
+            unthemed.is_empty(),
+            "view `{}` uses colours the dark theme does not remap \
+             (add them to SVG_PALETTE): {:?}",
+            view,
+            unthemed
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The stylesheet is scoped to the SVG's own class.
+///
+/// An SVG is routinely INLINED into an HTML page — hale-lang.org
+/// does exactly that with `set:html`. An unscoped `<style>` here
+/// would stop being the diagram's theme and become the host page's
+/// CSS.
+#[test]
+fn the_svg_stylesheet_cannot_escape_into_a_host_page() {
+    let dir = workdir("svgscope");
+    let src = dir.join("app.hl");
+    std::fs::write(
+        &src,
+        r#"
+topic T { payload: R; subject: "t"; }
+type R { v: Int = 0; }
+locus Pub { bus { publish T; } fn go() { T <- R { v: 1 }; } }
+locus Sub { bus { subscribe T as on_t; } params { n: Int = 0; }
+    fn on_t(r: R) { self.n = r.v; } }
+main locus App { params { p: Pub = Pub { }; s: Sub = Sub { }; }
+    run() { self.p.go(); } }
+fn main() { App { }; }
+"#,
+    )
+    .unwrap();
+    let artifact = dump_artifact(&dir, &src);
+    let svg = render(
+        &artifact,
+        &["--view", "bus", "--format", "svg", "--theme", "dark"],
+    );
+    let style = svg
+        .split_once("</style>")
+        .expect("themed")
+        .0
+        .split_once("<style>")
+        .expect("open tag")
+        .1;
+    for line in style.lines().filter(|l| l.contains('{')) {
+        assert!(
+            line.trim_start().starts_with(".hale-topo "),
+            "every selector must be scoped to the diagram's root; \
+             found `{}`",
+            line
+        );
+    }
+    assert!(
+        svg.contains("class=\"hale-topo\""),
+        "the root carries the class its own stylesheet selects on"
+    );
+
+    // `light` is the pre-theming output: attributes only.
+    let light = render(
+        &artifact,
+        &["--view", "bus", "--format", "svg", "--theme", "light"],
+    );
+    assert!(
+        !light.contains("<style>"),
+        "`--theme light` ships no stylesheet: {:?}",
+        &light[..light.len().min(200)]
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hale-types/tests/fixtures/law_rows_snapshot.txt
+++ b/crates/hale-types/tests/fixtures/law_rows_snapshot.txt
@@ -32,6 +32,7 @@ crates/hale-cli/tests/topology_graph_cli.rs#20	iso	forbid reaches(a_side, b_side
 crates/hale-cli/tests/topology_graph_cli.rs#21	bad	require attributed(all purpose)	Invalid	None
 crates/hale-cli/tests/topology_graph_cli.rs#23	iso	forbid reaches(a_side, b_side)	Holds	None
 crates/hale-cli/tests/topology_graph_cli.rs#23	iso	forbid reaches(b_side, a_side)	Holds	None
+crates/hale-cli/tests/topology_graph_cli.rs#38	one	count publishers(topic T) == 1	Holds	None
 crates/hale-cli/tests/topology_v2.rs#0	iso	forbid reaches(a_side, b_side)	Violated	None
 crates/hale-codegen/tests/fixtures/examples/claim-forms.hl	boundary	only edges planners -> workers { publish Plan }	Holds	None
 crates/hale-codegen/tests/fixtures/examples/claim-forms.hl	isolated	forbid reaches(workers, audit) via { calls }	Holds	None

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -109,6 +109,8 @@ crates/hale-cli/tests/topology_graph_cli.rs#32 7d5cf57defcf548e
 crates/hale-cli/tests/topology_graph_cli.rs#33 7f75bbe0c59b704e
 crates/hale-cli/tests/topology_graph_cli.rs#36 dea7f37538f67e6b
 crates/hale-cli/tests/topology_graph_cli.rs#37 542f43255ecc42a5
+crates/hale-cli/tests/topology_graph_cli.rs#38 66901456f5bcc125
+crates/hale-cli/tests/topology_graph_cli.rs#39 725494b4ad44f749
 crates/hale-cli/tests/topology_graph_cli.rs#4 7d5cf57defcf548e
 crates/hale-cli/tests/topology_graph_cli.rs#5 c09878edd9f20206
 crates/hale-cli/tests/topology_graph_cli.rs#6 37b8850647e390ba


### PR DESCRIPTION
`hale topology graph --format svg` emitted a hardcoded light palette — opaque white page, dark ink, near-white boxes. Anything embedding it in a dark context had to re-theme from outside, and hale-lang.org did: a block of `[fill="#ffffff"] { fill: … }` rules that was **a copy of this palette living in a different repository**, silently wrong the moment a colour moved here.

## What changed

`--theme auto | light | dark`, default `auto`.

- `auto` / `dark` emit a stylesheet **inside** the SVG, generated from the same `SVG_PALETTE` table the attributes are drawn from — so attributes and theme cannot drift.
- `auto` puts it behind `prefers-color-scheme: dark`; `dark` is unconditional (what a dark-only host wants, since `prefers-color-scheme` tracks the OS, not the page).
- `light` is the previous output, byte for byte.

SVG only. Mermaid and dot carry no colour of their own — whatever renders them themes them — so a theme flag there would be a promise this command can't keep.

## Two properties worth pinning

Both would rot silently, so both are tests:

- **Every colour the document uses is remapped by its own dark theme.** A hex emitted but missing from the palette stays light on a dark background, and nothing else would report it. The test reads the *rendered output* rather than the table, so it catches a colour introduced anywhere, in any view.
- **The stylesheet is scoped to the root's own class.** An SVG is routinely inlined into HTML — hale-lang.org does exactly that with `set:html` — and an unscoped `<style>` would stop being the diagram's theme and become the host page's CSS.

## One stable hook

The background rect is classed `bg`. Dropping the page behind the figure is the thing an embedder almost always wants, and `.hale-topo .bg { fill: transparent }` survives a palette change in a way `[fill="#0d1117"]` would not.

## Site side

Prepared in the hale-lang.org repo (separate commit): both committed diagrams regenerated with `--theme dark`, and the cross-repo palette copy deleted down to that single `bg` rule. Verified byte-identical to the previous artifacts modulo the new class attributes — the reproduction was confirmed by shape hash (`2fa360a6be62c813`, `ec4ac714255c5065`) before regenerating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
