### PR TITLE
docs(model): document the model surface, and keep it documented

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - "docs/**"
       - "play/**"
+      - "crates/hale-model/**"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
       - "docs/**"
       - "play/**"
+      - "crates/hale-model/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -64,6 +66,27 @@ jobs:
 
       - name: Build docs
         run: mdbook build docs
+
+      # The model's API reference. `spec/model.md` is the contract and
+      # the book chapter is the explanation; neither says what a given
+      # field holds, and that answer lived only in the source — so a
+      # consumer reading artifacts had to clone the compiler to look
+      # up a row.
+      #
+      # Runs on PRs too, unlike the playground below: hale-model is
+      # deliberately dependency-free, so this is a sub-second build
+      # with no LLVM and no toolchain install. `-D warnings` makes a
+      # broken intra-doc link fail here rather than ship as a dead
+      # link on the site.
+      - name: Build the model API reference
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --no-deps -p hale-model
+
+      - name: Stage the API reference under the docs site (/api)
+        run: |
+          mkdir -p docs/book/api
+          cp -r target/doc/. docs/book/api/
 
       # --- playground: compile the examples + the Hale UI to wasm ---
       # Heavy (LLVM 18 + a compiler build), so skip it on PRs — it runs

--- a/crates/hale-model/src/application.rs
+++ b/crates/hale-model/src/application.rs
@@ -46,6 +46,9 @@ pub enum ModelHashKind {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ModelHeader {
+    /// `ANALYSIS_SEMANTICS_VERSION` at derivation. Bumped when a
+    /// judgment's MEANING changes, so evidence produced under older
+    /// semantics is refused rather than silently reinterpreted.
     pub semantics: u32,
     /// The application entrypoint (main locus name, or `main`).
     pub entrypoint: String,
@@ -54,8 +57,12 @@ pub struct ModelHeader {
 /// A free-form label on an entity (`labels` in the artifact).
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct LabelRow {
+    /// What carries the label.
     pub at: EntityRef,
+    /// The label text — a declared effect class, a marker the frontier
+    /// assigns.
     pub label: String,
+    /// Where the label was attached.
     pub provenance: ProvenanceId,
 }
 
@@ -64,26 +71,46 @@ pub struct LabelRow {
 /// quantitative-judgment migration (Change 5d) closes it.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct WeightRow {
+    /// What the measurement is attributed to.
     pub at: EntityRef,
+    /// Which measurement this is.
     pub metric: String,
+    /// The measurement, in the metric's own unit.
     pub value: u64,
+    /// The site the measurement came from.
     pub provenance: ProvenanceId,
 }
 
 #[derive(Clone, Default, Debug)]
 pub struct Entities {
+    /// Free fns, methods, lifecycle hooks, modes, failure handlers.
     pub functions: Vec<Function>,
+    /// Locus DECLARATIONS — what may exist, not what does.
     pub loci: Vec<LocusDecl>,
+    /// Statically exact instances in the main arrangement (`App.w`,
+    /// `App.workers[3]`).
     pub locus_instances: Vec<LocusInstance>,
+    /// Declared topics.
     pub topics: Vec<Topic>,
+    /// Wire subjects and patterns — delivery identity. A query that
+    /// decides delivery joins here.
     pub subjects: Vec<Subject>,
+    /// Payload contracts. Deliberately a different sort from the
+    /// subject that carries them.
     pub payloads: Vec<PayloadContract>,
+    /// Lifecycle phases.
     pub phases: Vec<Phase>,
+    /// Imported seeds.
     pub seeds: Vec<Seed>,
+    /// Pools and their placement.
     pub thread_domains: Vec<ThreadDomain>,
+    /// Transport bindings, each with a role.
     pub bindings: Vec<Binding>,
+    /// Resolved claim groups.
     pub groups: Vec<Group>,
+    /// Type declarations.
     pub types: Vec<TypeDecl>,
+    /// Interface declarations.
     pub interfaces: Vec<InterfaceDecl>,
     /// Declared/referenced USER effect classes (GH #476 Change 4).
     pub effect_classes: Vec<EffectClassDecl>,
@@ -94,23 +121,41 @@ pub struct Entities {
 
 #[derive(Clone, Default, Debug)]
 pub struct Relations {
+    /// Function → its declaring locus.
     pub member_of: Vec<MemberOf>,
+    /// Function → the lifecycle phase it runs in.
     pub phase_of: Vec<PhaseOf>,
+    /// Entity → the seed declaring it.
     pub declared_in: Vec<DeclaredIn>,
+    /// Instance → the declaration it realizes.
     pub realizes: Vec<Realizes>,
+    /// The lifecycle tree, parent instance → child.
     pub owns: Vec<Owns>,
+    /// SITE-grained call edges. Collapsing these to a set computes
+    /// reachability where the language means executions.
     pub calls: Vec<Call>,
+    /// Dispatches through an interface nothing conforms to — not holes,
+    /// and not edges.
     pub dead_interface_calls: Vec<DeadInterfaceCall>,
+    /// SITE-grained sends, with key domain and loss disposition.
     pub publishes: Vec<Publish>,
     /// Declared publisher ends (`bus { publish T; }`) — the
     /// endpoint grain `require publishes(...)` quantifies over,
     /// distinct from the site-grained sends above.
     pub declares_publish: Vec<DeclaresPublish>,
+    /// Subscriptions with their key predicate and bounds — the filter
+    /// half of delivery.
     pub subscribes: Vec<Subscribe>,
+    /// Instance → thread domain.
     pub placed_in: Vec<PlacedIn>,
+    /// Thread domain → its pinned cores.
     pub affined_to: Vec<AffinedTo>,
+    /// Topic → the transport it crosses a process boundary through.
     pub binds: Vec<TopicBinding>,
+    /// Supervision edges, one row per `on_failure` handler.
     pub supervises: Vec<Supervises>,
+    /// Resolved group membership, globs enumerated. The authored
+    /// spelling lives in `group_selectors`.
     pub group_members: Vec<GroupMember>,
     /// The AUTHORED selector lists (legacy-hash grain), alongside
     /// the resolved `group_members` (judgment grain).
@@ -167,6 +212,8 @@ pub struct Analyses {
 /// must replay the evaluator's order exactly.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StdlibAbsorption {
+    /// The user function whose call site enters the stdlib interior
+    /// this row describes.
     pub from: FunctionId,
     /// The authored site ordinal within `from` (stdlib calls consume
     /// ordinals like every authored site), so the judgment can
@@ -208,6 +255,8 @@ pub struct AbsorbedNode {
     /// an `effects(C)` destination can be satisfied INSIDE a
     /// stdlib body; review: stdlib effect sinks).
     pub direct_effects: Vec<String>,
+    /// What the walk saw in this interior body, in walk order — calls,
+    /// publishes, and the residue where it could not follow.
     pub events: Vec<AbsorbedEvent>,
 }
 
@@ -305,6 +354,7 @@ pub struct CertificateEvidence {
     /// The lowered claim form, display voice — the artifact's
     /// `lowered` row spelling.
     pub form: String,
+    /// This certificate's verdict.
     pub result: VerdictIr,
     /// The engine's diagnostics for this certificate, in emission
     /// order: (message, span provenance).
@@ -346,7 +396,11 @@ pub struct EvidenceTable {
     /// synthetic `Holds` sidecar from validating against a model
     /// for which derivation would have produced no report.
     pub coverage_digest: u64,
+    /// One row per law that generates certificates, keyed by its
+    /// ordinal in the claim table.
     pub rows: Vec<EvidenceRow>,
+    /// Spans for the diagnostics the rows carry. Separate from the
+    /// model's own table because evidence outlives a single derivation.
     pub provenance: ProvenanceTable,
 }
 
@@ -824,18 +878,36 @@ pub struct EvidenceRow {
     pub ordinal: u32,
     /// The annotated fn, as the ClaimIr row resolves it.
     pub subject: Option<FunctionId>,
+    /// The certificates this law generates, in the order its
+    /// `certificate_forms` renders them — the position IS the
+    /// certificate ordinal.
     pub certs: Vec<CertificateEvidence>,
 }
 
 #[derive(Clone, Debug)]
 pub struct ApplicationModel {
+    /// Identity and versioning: what produced this model and under
+    /// which semantics.
     pub header: ModelHeader,
+    /// The fifteen entity tables. A row's id is its index here.
     pub entities: Entities,
+    /// The seventeen relation tables. Read each one's grain before
+    /// counting.
     pub relations: Relations,
+    /// Labels attached to entities — declared effect classes and
+    /// frontier markers.
     pub labels: Vec<LabelRow>,
+    /// Numeric measurements attributed to entities.
     pub weights: Vec<WeightRow>,
+    /// Everything the derivation could not determine, as typed residue.
+    /// Absence of a hole is a positive claim, which is why
+    /// `capabilities` is stated rather than inferred.
     pub holes: Vec<Hole>,
+    /// Which relation families are COMPLETE. The dual of `holes`, and
+    /// stated positively on purpose: a model that never noticed a gap
+    /// does not get to claim exactness by default.
     pub capabilities: Capabilities,
+    /// Source spans every row points into.
     pub provenance: ProvenanceTable,
     /// Analysis products the model carries but does not derive
     /// itself — the bus graph's dispatch gates and the stdlib

--- a/crates/hale-model/src/capability.rs
+++ b/crates/hale-model/src/capability.rs
@@ -13,18 +13,28 @@ use crate::hole::RelationSet;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct Capabilities {
+    /// The call graph is complete: no unresolved callee anywhere
+    /// reachable.
     pub exact_calls: bool,
     /// Publish and subscribe completeness are INDEPENDENT facts
     /// (round 3): a set-level hole can hide one without the other,
     /// and per-family adequacy must not couple them.
     pub exact_publishes: bool,
+    /// Every subscription is known.
     pub exact_subscribes: bool,
+    /// Every key predicate's coverage is decidable.
     pub exact_key_filters: bool,
+    /// The ownership tree is complete.
     pub exact_ownership: bool,
+    /// Every instance's thread domain is known statically.
     pub exact_placement: bool,
+    /// Every transport route is known.
     pub exact_routes: bool,
+    /// Every effect is classified.
     pub exact_effects: bool,
+    /// Instance counts are statically exact.
     pub exact_cardinality: bool,
+    /// Delivery semantics are known for every binding.
     pub exact_delivery_guarantees: bool,
     /// Per-call cost facts (allocation sites, frame sizes, blocking
     /// points) are complete for every analyzed function — what the

--- a/crates/hale-model/src/claim_ir.rs
+++ b/crates/hale-model/src/claim_ir.rs
@@ -108,7 +108,9 @@ pub fn is_builtin_effect_class(name: &str) -> bool {
 /// display. Two spellings, same doctrine as every entity table.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct NameRef {
+    /// The canonical name — the machine join key.
     pub raw: String,
+    /// The author's spelling, for witnesses.
     pub display: String,
 }
 
@@ -119,32 +121,60 @@ pub struct NameRef {
 /// must preserve those primary spans without reopening the AST.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct GroupRef {
+    /// `None` when the operand names nothing in this program. An
+    /// unresolved operand makes its law `Invalid` — never vacuously
+    /// true, which is the whole reason the reference is optional rather
+    /// than dropped.
     pub group: Option<GroupId>,
+    /// The group as written.
     pub name: NameRef,
+    /// The operand's position in the claim, so a diagnostic points at
+    /// the word the author wrote.
     pub provenance: ProvenanceId,
 }
 
 /// A topic reference (`T` / `alias::T`, canonicalized at mangle).
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct TopicIrRef {
+    /// `None` when the operand names nothing in this program. An
+    /// unresolved operand makes its law `Invalid` — never vacuously
+    /// true, which is the whole reason the reference is optional rather
+    /// than dropped.
     pub topic: Option<TopicId>,
+    /// The topic as written.
     pub name: NameRef,
+    /// The operand's position in the claim, so a diagnostic points at
+    /// the word the author wrote.
     pub provenance: ProvenanceId,
 }
 
 /// A phase reference (`during P`).
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct PhaseIrRef {
+    /// `None` when the operand names nothing in this program. An
+    /// unresolved operand makes its law `Invalid` — never vacuously
+    /// true, which is the whole reason the reference is optional rather
+    /// than dropped.
     pub phase: Option<PhaseId>,
+    /// The phase as written.
     pub name: String,
+    /// The operand's position in the claim, so a diagnostic points at
+    /// the word the author wrote.
     pub provenance: ProvenanceId,
 }
 
 /// A seed reference (`in seed(a)`).
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct SeedIrRef {
+    /// `None` when the operand names nothing in this program. An
+    /// unresolved operand makes its law `Invalid` — never vacuously
+    /// true, which is the whole reason the reference is optional rather
+    /// than dropped.
     pub seed: Option<SeedId>,
+    /// The seed as written.
     pub name: String,
+    /// The operand's position in the claim, so a diagnostic points at
+    /// the word the author wrote.
     pub provenance: ProvenanceId,
 }
 
@@ -165,9 +195,16 @@ pub struct SeedIrRef {
 /// resolves to nothing (Change 5's residue).
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct BusSelector {
+    /// The selector as written.
     pub name: String,
+    /// Declared topics it resolves to.
     pub topics: Vec<TopicId>,
+    /// Wire subjects it resolves to. Kept apart from `topics` because
+    /// delivery joins on subjects and declaredness is a separate
+    /// question.
     pub subjects: Vec<SubjectId>,
+    /// The operand's position in the claim, so a diagnostic points at
+    /// the word the author wrote.
     pub provenance: ProvenanceId,
 }
 
@@ -184,7 +221,11 @@ pub struct EffectClassRef {
     pub class: Option<EffectClassId>,
     /// `true` iff the name is a language built-in (`syscall`, …).
     pub builtin: bool,
+    /// The class as written. Resolution is deliberately deferred to the
+    /// class catalog, which knows whether it was ever declared.
     pub name: String,
+    /// The operand's position in the claim, so a diagnostic points at
+    /// the word the author wrote.
     pub provenance: ProvenanceId,
 }
 
@@ -202,6 +243,7 @@ pub struct GrantIr {
     /// `publish T` when true, `subscribe T` when false — both admit
     /// the same edge; the verb names the reviewable declaration.
     pub publish: bool,
+    /// The topic the grant is about.
     pub topic: TopicIrRef,
 }
 
@@ -383,8 +425,12 @@ pub struct ClaimRow {
     /// evaluator attributes them). Annotations and plan rows carry
     /// the annotated declaration's / plan row's name.
     pub name: String,
+    /// Where the law came from — a claims block, a constitution, or an
+    /// annotation. Decides which origins are admissible for the family.
     pub origin: ClaimOrigin,
+    /// The lowered law itself, with every operand typed.
     pub law: ClaimIr,
+    /// The claim's declaration site.
     pub provenance: ProvenanceId,
 }
 
@@ -397,7 +443,9 @@ pub struct ClaimRow {
 /// source.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct LoweringIssue {
+    /// What could not be lowered, in the author's terms.
     pub message: String,
+    /// The claim that could not be lowered.
     pub provenance: ProvenanceId,
     /// Which family's row this issue prevented, when one owns it —
     /// `None` for table-level LAW SELECTION (an unknown or cyclic
@@ -468,6 +516,8 @@ impl GroupSelection {
 /// The lowered law table for one application (or one plan).
 #[derive(Clone, Debug, Default)]
 pub struct ClaimIrTable {
+    /// Every lowered law, in a stable order. A row's index is its
+    /// ordinal, and evidence is keyed by it.
     pub rows: Vec<ClaimRow>,
     /// Law-selection invalidity (see [`LoweringIssue`]).
     pub issues: Vec<LoweringIssue>,

--- a/crates/hale-model/src/dispatch_plan.rs
+++ b/crates/hale-model/src/dispatch_plan.rs
@@ -72,6 +72,8 @@ pub struct SubjectPlan {
     /// The subject key the gates were computed over (the BusGraph's
     /// site spelling).
     pub subject: String,
+    /// The lowering this subject gets. A CONCLUSION derived from the
+    /// model, never an authored fact.
     pub flavor: DispatchFlavor,
     /// The gate's reason when the flavor is `Dynamic`.
     pub ineligible_reason: Option<String>,
@@ -97,6 +99,7 @@ pub struct SubjectPlan {
 /// The whole-program dispatch plan.
 #[derive(Clone, Debug, Default)]
 pub struct DispatchPlan {
+    /// One plan per subject, in subject order.
     pub subjects: Vec<SubjectPlan>,
 }
 

--- a/crates/hale-model/src/entity.rs
+++ b/crates/hale-model/src/entity.rs
@@ -41,6 +41,9 @@ pub struct Function {
     /// Author-facing spelling when it differs (stdlib publics render
     /// their `std::…` path, never the mangled name).
     pub display: String,
+    /// Which executable shape this is. Free fns, methods, hooks, modes
+    /// and failure handlers are one sort because they are all things a
+    /// walk can enter.
     pub kind: FunctionKind,
     /// DERIVED effect classes in declaration order (the stdlib-merged
     /// transitive walk; order is semantic in the existing artifact
@@ -109,12 +112,17 @@ pub struct Function {
     /// coverage and group projection both hang off ownership, so
     /// it is a closed account, never inferable-by-absence.
     pub owner: Option<LocusDeclId>,
+    /// The function's declaration site.
     pub provenance: ProvenanceId,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct LocusDecl {
+    /// The canonical name — the machine join key. Not the author's
+    /// spelling; see `display`.
     pub name: String,
+    /// The author's spelling, for witnesses and diagnostics. Never a
+    /// join key.
     pub display: String,
     /// `@sealed` confinement (GH #436).
     pub sealed: bool,
@@ -135,12 +143,14 @@ pub struct LocusDecl {
     /// only for a statically exact birth, while a param with no
     /// default still declares what this locus may hold.
     pub params: Vec<LocusParam>,
+    /// The `locus` declaration.
     pub provenance: ProvenanceId,
 }
 
 /// One entry of a locus's `params { … }` block.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct LocusParam {
+    /// The param's declared name, as written.
     pub name: String,
     /// Last path segment of the declared type, in author spelling.
     pub type_name: String,
@@ -155,6 +165,7 @@ pub struct LocusParam {
 pub struct LocusInstance {
     /// Canonical instance path, e.g. `App.w` or `App.workers[3]`.
     pub path: String,
+    /// The declaration this instance realizes.
     pub decl: LocusDeclId,
     /// This instance's REPLICA INDEX (0-based) when it came from a
     /// `pinned(..., replicas = K)` field, `None` otherwise. It is
@@ -165,6 +176,7 @@ pub struct LocusInstance {
     /// same `i` codegen bakes. `validate` enforces that the
     /// replicas of one field form a contiguous 0-based set.
     pub replica: Option<u32>,
+    /// The param or literal that gives it birth.
     pub provenance: ProvenanceId,
 }
 
@@ -174,9 +186,13 @@ pub struct LocusInstance {
 /// that fusion; it does not make it the schema).
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Subject {
+    /// The wire subject or wildcard pattern, verbatim — this string IS
+    /// the identity. Two spellings that produce the same wire text are
+    /// one subject.
     pub pattern: String,
     /// False when the pattern contains wildcards.
     pub exact: bool,
+    /// First site naming this subject.
     pub provenance: ProvenanceId,
 }
 
@@ -194,7 +210,11 @@ pub struct PayloadContract {
     /// structural shape `opaque:i` that must not be mistaken for
     /// the sentinel.
     pub opaque: bool,
+    /// Shape digest. Paired with the shape itself so two contracts
+    /// agreeing on one and not the other is a detectable disagreement
+    /// rather than a silent match.
     pub hash: u64,
+    /// The payload type's declaration.
     pub provenance: ProvenanceId,
 }
 
@@ -205,13 +225,18 @@ pub struct Topic {
     /// Author-facing spelling (the alias-qualified form for
     /// imports) — what the artifact's topic sort renders.
     pub display: String,
+    /// The wire subject this topic materializes to. Delivery joins on
+    /// this, never on the topic.
     pub subject: SubjectId,
+    /// The payload contract every endpoint on this topic must agree
+    /// with.
     pub payload: PayloadContractId,
     /// `Some` for `keyed_by` topics.
     pub key: Option<TopicKey>,
     /// `Some` for `bounded(N)` topics — the publisher-facing
     /// capacity + refusal contract (GH #255's topic-level knob).
     pub bound: Option<crate::keys::TopicBound>,
+    /// The `topic` declaration.
     pub provenance: ProvenanceId,
 }
 
@@ -232,6 +257,7 @@ pub struct Group {
     /// checker error (vacuity fail-closed), so the declared intent
     /// is a semantic fact selectors need.
     pub may_be_empty: bool,
+    /// The `group` declaration.
     pub provenance: ProvenanceId,
 }
 
@@ -242,16 +268,26 @@ pub struct Group {
 /// because payload contracts and key types name them.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TypeDecl {
+    /// The canonical name — the machine join key. Not the author's
+    /// spelling; see `display`.
     pub name: String,
+    /// The author's spelling, for witnesses and diagnostics. Never a
+    /// join key.
     pub display: String,
+    /// The `type` declaration.
     pub provenance: ProvenanceId,
 }
 
 /// A declared interface (the F.20 structural contract).
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct InterfaceDecl {
+    /// The canonical name — the machine join key. Not the author's
+    /// spelling; see `display`.
     pub name: String,
+    /// The author's spelling, for witnesses and diagnostics. Never a
+    /// join key.
     pub display: String,
+    /// The `interface` declaration.
     pub provenance: ProvenanceId,
 }
 
@@ -279,15 +315,24 @@ pub enum DeclKind {
 /// An opaque seed-membership-only declaration (see [`DeclKind`]).
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Declaration {
+    /// Which declaration sort this is, so coverage laws can range over
+    /// the declaration universe without joining every table.
     pub kind: DeclKind,
+    /// The canonical name — the machine join key. Not the author's
+    /// spelling; see `display`.
     pub name: String,
+    /// The author's spelling, for witnesses and diagnostics. Never a
+    /// join key.
     pub display: String,
+    /// The declaration site.
     pub provenance: ProvenanceId,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Phase {
+    /// The phase name (`birth`, `run`, `drain`, ...).
     pub name: String,
+    /// Synthetic: phases are a fixed vocabulary, not authored.
     pub provenance: ProvenanceId,
 }
 
@@ -301,6 +346,8 @@ pub struct Phase {
 /// never declared".
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct EffectClassDecl {
+    /// The class name as referenced. Present whether or not the class
+    /// is ever declared — see `definition`.
     pub name: String,
     /// The class's position in the seed's declaration order.
     ///
@@ -314,7 +361,11 @@ pub struct EffectClassDecl {
     pub declaration_index: u32,
     /// `effect NAME;` exists (false = bare reference only).
     pub declared: bool,
+    /// What the class is made of, or that it was only ever referenced.
+    /// A referenced-never-declared class makes a law naming it
+    /// `Invalid`, not vacuously true.
     pub definition: EffectClassDefinition,
+    /// The declaration, or the first reference when there is none.
     pub provenance: ProvenanceId,
 }
 
@@ -340,7 +391,9 @@ pub enum EffectClassDefinition {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Seed {
+    /// The seed's import path.
     pub name: String,
+    /// The `import` that brought it in.
     pub provenance: ProvenanceId,
 }
 
@@ -350,7 +403,9 @@ pub struct Seed {
 /// that enqueues cross-thread.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ThreadDomain {
+    /// The pool name.
     pub name: String,
+    /// The pool declaration.
     pub provenance: ProvenanceId,
 }
 
@@ -371,9 +426,17 @@ pub enum BindingRole {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Binding {
+    /// The wire subject crossing the boundary.
     pub subject: SubjectId,
+    /// Which transport carries it.
     pub transport: TransportKind,
+    /// Which side this binding is. Part of the identity: one subject
+    /// bound in both directions is two bindings, and collapsing them
+    /// loses the direction delivery depends on.
     pub role: BindingRole,
+    /// What the binding declares should happen when the transport
+    /// drops.
     pub loss: crate::keys::BindingLossBehavior,
+    /// The binding declaration.
     pub provenance: ProvenanceId,
 }

--- a/crates/hale-model/src/hole.rs
+++ b/crates/hale-model/src/hole.rs
@@ -106,7 +106,10 @@ pub enum HoleKind {
 /// it hides from judgments.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Hole {
+    /// What the hole sits on. The anchor grain decides which kinds are
+    /// legal — see the closed matrix below.
     pub at: EntityRef,
+    /// Why the model does not know.
     pub kind: HoleKind,
     /// Never empty — a hole that hides nothing is not a hole
     /// (validated; see [`ApplicationModel::validate`]).
@@ -123,6 +126,7 @@ pub struct Hole {
     /// Human-readable reason for witnesses ("call through fn param
     /// `f`").
     pub reason: String,
+    /// The site that could not be resolved.
     pub provenance: ProvenanceId,
 }
 

--- a/crates/hale-model/src/keys.rs
+++ b/crates/hale-model/src/keys.rs
@@ -48,7 +48,9 @@ pub enum KeyValue {
 /// catch-unmatched subscriber).
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TopicKey {
+    /// The payload field carrying the routing key.
     pub field: String,
+    /// What happens to a cell whose key matches no subscription.
     pub on_unmatched: KeyOnUnmatched,
 }
 
@@ -130,6 +132,7 @@ pub enum Capacity {
 pub struct TopicBound {
     /// Must be > 0; validate rejects `0`.
     pub capacity: u64,
+    /// What happens when the bound is reached.
     pub on_full: TopicOnFull,
 }
 

--- a/crates/hale-model/src/obs_ids.rs
+++ b/crates/hale-model/src/obs_ids.rs
@@ -42,7 +42,10 @@ pub enum ObsEntityKind {
 /// `name` is entity `id`".
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ObsEntityId {
+    /// Which entity sort the id refers to.
     pub kind: ObsEntityKind,
+    /// The canonical name, so an observed record joins back to a model
+    /// row.
     pub name: String,
     /// `index + 1` — see the module note on the zero value.
     pub id: u64,

--- a/crates/hale-model/src/provenance.rs
+++ b/crates/hale-model/src/provenance.rs
@@ -40,7 +40,10 @@ pub enum Provenance {
 /// section unprojectable from the model).
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct SourceUnit {
+    /// The file's path as the bundle saw it.
     pub path: String,
+    /// Content digest, so a span can be shown to belong to the text it
+    /// was taken from.
     pub digest: String,
 }
 
@@ -48,6 +51,10 @@ pub struct SourceUnit {
 /// dense IDs from every row in the model.
 #[derive(Clone, Default, Debug)]
 pub struct ProvenanceTable {
+    /// Every source file spans may point into. A `SourceId` is an index
+    /// here.
     pub sources: Vec<SourceUnit>,
+    /// Every span. A `ProvenanceId` is an index here, which is why rows
+    /// carry an id rather than a span.
     pub records: Vec<Provenance>,
 }

--- a/crates/hale-model/src/relation.rs
+++ b/crates/hale-model/src/relation.rs
@@ -23,40 +23,55 @@ use crate::keys::{Capacity, KeyDomain, KeyPredicate, PublishDisposition, ShedPol
 /// `member_of(function, locus)`.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct MemberOf {
+    /// The member.
     pub function: FunctionId,
+    /// The locus declaring it.
     pub locus: LocusDeclId,
+    /// The member's declaration site.
     pub provenance: ProvenanceId,
 }
 
 /// `phase_of(function, phase)`.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct PhaseOf {
+    /// The hook, mode, or handler.
     pub function: FunctionId,
+    /// The lifecycle phase it runs in.
     pub phase: PhaseId,
+    /// The hook's declaration site.
     pub provenance: ProvenanceId,
 }
 
 /// `declared_in(entity, seed)`.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct DeclaredIn {
+    /// The declared entity, in whichever sort it belongs to.
     pub entity: crate::ids::EntityRef,
+    /// The seed that declares it.
     pub seed: SeedId,
+    /// The declaration site, in that seed's file.
     pub provenance: ProvenanceId,
 }
 
 /// `realizes(instance, locus_decl)`.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Realizes {
+    /// The statically exact instance.
     pub instance: LocusInstanceId,
+    /// The declaration it realizes.
     pub decl: LocusDeclId,
+    /// The param or literal that gives the instance birth.
     pub provenance: ProvenanceId,
 }
 
 /// `owns(parent_instance, child_instance)` — the lifecycle tree.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Owns {
+    /// The owning instance.
     pub parent: LocusInstanceId,
+    /// The owned instance. One child has exactly one parent.
     pub child: LocusInstanceId,
+    /// The param or birth expression establishing ownership.
     pub provenance: ProvenanceId,
 }
 
@@ -89,8 +104,12 @@ pub enum DispatchKind {
 /// and `unbounded` OR together, never dropped.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Call {
+    /// The caller.
     pub from: FunctionId,
+    /// The resolved callee. Unresolved callees are holes, never rows.
     pub to: FunctionId,
+    /// How this site reaches the callee. An interface site yields one
+    /// row per conformer, all sharing `site`.
     pub dispatch: DispatchKind,
     /// Source-order site ordinal within `from` (see above).
     pub site: u32,
@@ -100,6 +119,7 @@ pub struct Call {
     /// bounded (the topology model keeps loop and unbounded as
     /// separate facts; so does this schema).
     pub unbounded: bool,
+    /// The call expression — what a witness points at.
     pub provenance: ProvenanceId,
 }
 
@@ -114,7 +134,10 @@ pub struct Call {
 /// sites with DIFFERENT dispositions — each its own row.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Publish {
+    /// The function containing the send.
     pub function: FunctionId,
+    /// The wire subject sent to. This, not `declared_topic`, is what
+    /// delivery joins on.
     pub subject: SubjectId,
     /// `Some` when a declared topic covers this endpoint; its
     /// subject must equal `subject`.
@@ -133,7 +156,10 @@ pub struct Publish {
     /// ways) — an undeclared or unkeyed endpoint has no key domain
     /// to invent.
     pub key_domain: Option<KeyDomain>,
+    /// What the send declared should happen if the cell cannot be
+    /// delivered.
     pub disposition: PublishDisposition,
+    /// The send expression (`T <- v`).
     pub provenance: ProvenanceId,
 }
 
@@ -152,14 +178,20 @@ pub struct Subscribe {
     /// wildcard subscriptions; must agree with a declared topic's
     /// payload).
     pub payload: PayloadContractId,
+    /// The method the delivered cell invokes.
     pub handler: FunctionId,
     /// Source-order ordinal of the subscription declaration within
     /// its locus's bus block — two subscriptions of one topic by
     /// one handler with different filters are two rows.
     pub site: u32,
+    /// The filter half of delivery — which keys this subscription
+    /// accepts.
     pub key_predicate: KeyPredicate,
+    /// The subscription's declared queue bound, if any.
     pub capacity: Capacity,
+    /// What to drop when that bound is reached.
     pub shed: ShedPolicy,
+    /// The `subscribe` clause in the locus's bus block.
     pub provenance: ProvenanceId,
 }
 
@@ -173,8 +205,11 @@ pub struct Subscribe {
 /// shapes.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct GroupMember {
+    /// The group.
     pub group: GroupId,
+    /// One resolved member. Globs arrive here already enumerated.
     pub member: crate::ids::EntityRef,
+    /// The selector that admitted this member.
     pub provenance: ProvenanceId,
 }
 
@@ -198,11 +233,14 @@ pub enum SelectorForm {
 /// `group_selector(group, ordinal)` — the authored selector list.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct GroupSelector {
+    /// The group this selector belongs to.
     pub group: GroupId,
     /// 0-based authored position — the artifact hashes the list
     /// ordered, so order is a semantic fact.
     pub ordinal: u32,
+    /// The selector as authored — named member or unexpanded glob.
     pub selector: SelectorForm,
+    /// The selector's position in the group declaration.
     pub provenance: ProvenanceId,
 }
 
@@ -215,6 +253,7 @@ pub struct GroupSelector {
 /// artifact records it inside the hashed half.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct DeadInterfaceCall {
+    /// The caller holding the uninhabited dispatch.
     pub from: FunctionId,
     /// Source-order site ordinal within `from`.
     pub site: u32,
@@ -222,6 +261,8 @@ pub struct DeadInterfaceCall {
     pub interface: String,
     /// The dispatched method name.
     pub method: String,
+    /// The call expression, retained so a later conformer has a site to
+    /// attach to.
     pub provenance: ProvenanceId,
 }
 
@@ -234,20 +275,27 @@ pub struct DeadInterfaceCall {
 /// `exact_bus_endpoints` was review round 7's catch.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct DeclaresPublish {
+    /// The locus declaring the end.
     pub locus: LocusDeclId,
+    /// The declared wire subject.
     pub subject: SubjectId,
     /// `Some` when a declared topic covers the end; subject and
     /// payload agreement validated exactly as for `Publish`.
     pub declared_topic: Option<TopicId>,
+    /// The end's payload contract.
     pub payload: PayloadContractId,
+    /// The `publish` clause in the bus block.
     pub provenance: ProvenanceId,
 }
 
 /// `placed_in(instance, thread_domain)`.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct PlacedIn {
+    /// The placed instance.
     pub instance: LocusInstanceId,
+    /// The thread domain it runs on.
     pub domain: ThreadDomainId,
+    /// The placement clause, or the inheriting parent's.
     pub provenance: ProvenanceId,
 }
 
@@ -258,8 +306,11 @@ pub struct CoreSet(pub Vec<u32>);
 /// `affined_to(thread_domain, cores)`.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct AffinedTo {
+    /// The thread domain being pinned.
     pub domain: ThreadDomainId,
+    /// The resolved cores, sorted and deduplicated.
     pub cores: CoreSet,
+    /// The affinity clause.
     pub provenance: ProvenanceId,
 }
 
@@ -267,8 +318,11 @@ pub struct AffinedTo {
 /// through this transport.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TopicBinding {
+    /// The topic that crosses the boundary.
     pub topic: TopicId,
+    /// The transport it crosses through.
     pub binding: BindingId,
+    /// The binding declaration.
     pub provenance: ProvenanceId,
 }
 
@@ -277,6 +331,8 @@ pub struct TopicBinding {
 /// serializes this row shape (schema 1.10).
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct SupervisionPolicy {
+    /// The recovery operations the handler body performs, as authored
+    /// (`restart`, `quarantine`, ...), in source order.
     pub ops: Vec<String>,
     /// The literal as WRITTEN — i64 like the legacy artifact, which
     /// serializes any int literal the parser accepted (`for
@@ -305,10 +361,14 @@ pub enum SupervisedRef {
 /// of the row and its canonical key.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Supervises {
+    /// The supervising locus — the one declaring `on_failure`.
     pub parent: LocusDeclId,
+    /// What is supervised. Usually a locus declaration; a supervised
+    /// transport is `External`.
     pub child: SupervisedRef,
     /// The handled error/violation type's canonical name.
     pub error_type: String,
+    /// The recovery vocabulary and retry bound this handler declares.
     pub policy: SupervisionPolicy,
     /// Authored declaration order across the bundle walk. Handler
     /// order is an authored fact the legacy artifact depends on:
@@ -320,6 +380,7 @@ pub struct Supervises {
     /// check-clean and both serialize in the legacy artifact, so
     /// the model must hold both rows (review round 14).
     pub authored_ordinal: u32,
+    /// The `on_failure` declaration.
     pub provenance: ProvenanceId,
 }
 
@@ -334,12 +395,18 @@ pub struct Supervises {
 /// before the judgment throws away the site that saturates.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct CostSite {
+    /// The function the cost is attributed to.
     pub function: FunctionId,
+    /// Which cost this is — and therefore its grain: `Alloc`/`Block`
+    /// are occurrences, `FrameBytes` is one row per function.
     pub dimension: CostDimension,
     /// How much this site costs, in the dimension's own unit.
     pub amount: u64,
     /// Inside a loop — a per-call bound cannot survive it.
     pub in_loop: bool,
+    /// The allocation or blocking site. For `FrameBytes`, the
+    /// function's own declaration. Part of the row's canonical key,
+    /// since cost rows carry no site ordinal.
     pub provenance: ProvenanceId,
 }
 

--- a/crates/hale-model/tests/public_surface_is_documented.rs
+++ b/crates/hale-model/tests/public_surface_is_documented.rs
@@ -1,0 +1,104 @@
+//! Every public field of the model carries a doc comment.
+//!
+//! This crate IS the documentation of the model for anyone writing a
+//! judgment, a consumer, or a downstream tool: `spec/model.md` states
+//! the laws and the grain, and the rustdoc says what each row holds.
+//! The epic that built this crate scoped its documentation as
+//! "design note ships as crate-level rustdoc", and the fields drifted
+//! to 35% covered without anything noticing — a field added in a
+//! review round is exactly the field nobody comes back to describe.
+//!
+//! So it is checked. A public field with no `///` fails here, naming
+//! itself, which is cheaper than discovering years later that the
+//! reference has holes in it.
+//!
+//! Scoped to fields deliberately. Types are covered by
+//! `spec/model.md`'s inventory, and a rule that demanded a comment on
+//! every enum variant would be answered with noise rather than
+//! meaning.
+
+use std::path::PathBuf;
+
+fn src_dir() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("src");
+    p
+}
+
+/// Is this line a `pub <name>:` field declaration?
+///
+/// Struct fields only — `pub fn`, `pub const`, `pub mod` and `pub
+/// use` all fail the trailing-colon test, and tuple-struct members
+/// (`pub Vec<u32>`) have no name to document.
+fn field_name(line: &str) -> Option<&str> {
+    let t = line.trim();
+    let rest = t.strip_prefix("pub ")?;
+    let (name, _) = rest.split_once(':')?;
+    let name = name.trim();
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        return None;
+    }
+    Some(name)
+}
+
+#[test]
+fn every_public_model_field_has_a_doc_comment() {
+    let mut undocumented: Vec<String> = Vec::new();
+    let mut total = 0usize;
+
+    let mut files: Vec<PathBuf> = std::fs::read_dir(src_dir())
+        .expect("src/")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "rs"))
+        .collect();
+    files.sort();
+    assert!(!files.is_empty(), "no sources found — bad test wiring");
+
+    for path in files {
+        let text = std::fs::read_to_string(&path).expect("read");
+        let lines: Vec<&str> = text.lines().collect();
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        for (i, line) in lines.iter().enumerate() {
+            let Some(field) = field_name(line) else { continue };
+            total += 1;
+            // Walk back over attributes and blank lines to the
+            // nearest meaningful line; a doc comment there documents
+            // this field.
+            let mut j = i as isize - 1;
+            while j >= 0 {
+                let prev = lines[j as usize].trim();
+                if prev.starts_with("#[") || prev.is_empty() {
+                    j -= 1;
+                    continue;
+                }
+                break;
+            }
+            let documented = j >= 0
+                && lines[j as usize].trim().starts_with("///");
+            if !documented {
+                undocumented.push(format!("{}:{} {}", name, i + 1, field));
+            }
+        }
+    }
+
+    // The scan itself can rot: a refactor that renames the fields out
+    // from under `field_name` would leave this test passing over
+    // nothing at all, which is worse than failing.
+    assert!(
+        total > 200,
+        "only found {} public fields — the scan is broken, not the docs",
+        total
+    );
+    assert!(
+        undocumented.is_empty(),
+        "{} public field(s) have no doc comment. The model's rustdoc \
+         IS its field reference; a row nobody describes is a row a \
+         consumer has to guess at:\n  {}",
+        undocumented.len(),
+        undocumented.join("\n  ")
+    );
+}

--- a/docs/src/the-model.md
+++ b/docs/src/the-model.md
@@ -168,3 +168,6 @@ The contract — sorts, relations, the hole and capability laws, the
 identity rules, and the discipline a new judgment family follows —
 is in
 [`spec/model.md`](https://github.com/hale-lang/hale/blob/main/spec/model.md).
+
+For what an individual row holds, field by field, the API reference
+is at [`/api/hale_model`](api/hale_model/index.html).

--- a/spec/model.md
+++ b/spec/model.md
@@ -548,9 +548,12 @@ property a consumer of this model is entitled to rely on.
 
 Everything above describes how the model *behaves*. This is what it
 *contains*: every public type, so nothing in the crate is
-reachable-but-undescribed. Field-level documentation is the rustdoc
-— each public field carries a doc comment, and a test fails if one
-lands without.
+reachable-but-undescribed.
+
+Field-level documentation is the rustdoc — every public field
+carries a doc comment, and a test fails if one lands without. It is
+published with the book at **`/api/hale_model`**, so reading a row
+does not require cloning the compiler.
 
 **`application`** — the model itself and its sidecars.
 `ApplicationModel`, `ModelHeader`, `ModelHashKind`, `Entities`,

--- a/spec/model.md
+++ b/spec/model.md
@@ -363,9 +363,12 @@ that no other table holds:
 Absorption is kept as a **graph**, not a flattened summary, and its
 grain matters twice over. One `StdlibAbsorption` row is one
 authored entry site (with `entry_group` marking alternatives of one
-dispatch); its `nodes` form an interior graph whose call events
-carry their own dispatch groups and can target either another
-interior node or a user re-emergence. An interior can publish —
+dispatch); its `nodes` are `AbsorbedNode`s forming an interior
+graph, each carrying `AbsorbedEvent`s in walk order — a `Call`
+(with its own dispatch group, targeting an `AbsorbedTarget`: another
+interior node or a user re-emergence), a `Publish`, or one of the
+three residues: `CallHole`, `PublishHole`, `Truncated`. An interior
+can publish —
 `std::log::Logger.info` computes `log.<path>` and sends from inside
 its own body — so a consumer reading only `relations.publishes`
 misses real publishers.
@@ -540,6 +543,78 @@ property a consumer of this model is entitled to rely on.
    `Function::display` the demangled author spelling; joins take
    the former.
 9. **Move the semantics version when results move.**
+
+## The type inventory
+
+Everything above describes how the model *behaves*. This is what it
+*contains*: every public type, so nothing in the crate is
+reachable-but-undescribed. Field-level documentation is the rustdoc
+— each public field carries a doc comment, and a test fails if one
+lands without.
+
+**`application`** — the model itself and its sidecars.
+`ApplicationModel`, `ModelHeader`, `ModelHashKind`, `Entities`,
+`Relations`, `Analyses`, `LabelRow`, `WeightRow`, `ModelError`.
+Absorption: `StdlibAbsorption`, `AbsorbedNode`, `AbsorbedEvent`,
+`AbsorbedTarget`, `AbsorbedHoleKind`. Evidence: `EvidenceTable`,
+`EvidenceRow`, `CertificateEvidence`, `VerdictIr`. Plus
+`DispatchGate`.
+
+**`entity`** — the fifteen sorts. `Function`, `FunctionKind`,
+`LocusDecl`, `LocusParam`, `LocusInstance`, `Topic`, `Subject`,
+`PayloadContract`, `Phase`, `Seed`, `ThreadDomain`, `Binding`,
+`BindingRole`, `TransportKind`, `Group`, `TypeDecl`,
+`InterfaceDecl`, `EffectClassDecl`, `EffectClassDefinition`,
+`Declaration`, `DeclKind`.
+
+**`relation`** — the seventeen relation row types. Structure:
+`MemberOf`, `PhaseOf`, `DeclaredIn`, `Realizes`, `Owns`. Behaviour:
+`Call`, `DispatchKind`, `DeadInterfaceCall`, `Publish`,
+`Subscribe`, `DeclaresPublish`. Placement: `PlacedIn`, `AffinedTo`,
+`CoreSet`. Wiring: `TopicBinding`. Supervision: `Supervises`,
+`SupervisedRef`, `SupervisionPolicy`. Groups: `GroupMember`,
+`GroupSelector`, `SelectorForm`. Cost: `CostSite`,
+`CostDimension`.
+
+**`keys`** — delivery's typed vocabulary. `KeyDomain`, `KeyValue`,
+`KeyPredicate`, `TopicKey`, `KeyOnUnmatched`, `PublishDisposition`,
+`Capacity`, `ShedPolicy`, `TopicBound`, `TopicOnFull`,
+`BindingLossBehavior`.
+
+**`claim_ir`** — lowered law. `ClaimIrTable`, `ClaimRow`,
+`ClaimIr`, `ClaimOrigin`, `ClaimIrError`, `LoweringIssue`.
+Operands: `NameRef`, `GroupRef`, `TopicIrRef`, `PhaseIrRef`,
+`SeedIrRef`, `EffectClassRef`, `BusSelector`, `GrantIr`, `SetIr`,
+`CountCmpIr`, `QuantDimIr`.
+
+**`hole`** — `Hole`, `HoleKind`, `RelationSet`.
+
+**`capability`** — `Capabilities`.
+
+**`provenance`** — `Provenance`, `ProvenanceTable`, `SourceUnit`.
+
+**`ids`** — the newtype ids and `EntityRef`. A row's id is its
+index in its own table.
+
+**`dispatch_plan`** — `DispatchPlan`, `SubjectPlan`,
+`DispatchFlavor`. Conclusions derived from the model, never
+authored facts.
+
+**`obs_ids`** — `ObsEntityId`, `ObsEntityKind`, the join back from
+an observed record to a model row.
+
+Three of these are easy to mistake for each other, and the
+difference is load-bearing:
+
+- `GroupMember` is resolved membership; `GroupSelector` is the
+  authored selector list. `{ lib::* }` and `{ lib::A, lib::B }` can
+  resolve identically and must still hash differently.
+- `Publish` is a send expression; `DeclaresPublish` is the declared
+  endpoint. A locus that declares an end and never sends still
+  publishes in the endpoint sense.
+- `Call`'s `DispatchKind` is the *fact* of the mechanism;
+  `DispatchFlavor` in the lowering plan is the *conclusion* drawn
+  from it.
 
 ## Known boundaries
 


### PR DESCRIPTION
Finishes the documentation tail of GH #476.

## The gap

The epic scoped its docs as *"design note ships as crate-level rustdoc."* The design note shipped, and `spec/model.md` went well past it — laws, grain, identity, adequacy, versioning. But the field-level reference underneath never did:

| | before | after |
|---|---|---|
| public fields with a doc comment | 108 / 304 (**35%**) | 304 / 304 |
| public types named in `spec/model.md` | 35 / 106 | 106 / 106 |

The undocumented set included `Entities` and `Relations` themselves — the first thing anyone opening the crate reads. The absent types included `KeyPredicate`, `SupervisionPolicy`, `DispatchGate`, `ClaimRow`, `EvidenceRow`, `VerdictIr`.

## Docs that say the thing you'd otherwise get wrong

Not boilerplate restating the type name:

- `Publish.subject` — delivery joins on **this**, not on `declared_topic`
- `CostSite.dimension` — decides the row's grain: `Alloc`/`Block` are occurrences, `FrameBytes` is one per function
- `Binding.role` — part of the identity, so one subject bound both directions is two rows
- every optional operand ref in `claim_ir` — `None` makes the law `Invalid`, never vacuously true
- `provenance` fields say what the span points **at** (the call expression, the declaration, the selector) rather than repeating the type

## The guard

A test walks the crate's own source and fails on any public field with no `///`, naming file and line.

Two things make it a real guard rather than a green tick:

- **Verified red.** Stripping one doc comment fails it with `hole.rs:112 kind`.
- **Floor on the scan.** It asserts it found >200 fields, so a refactor that renames fields out from under the matcher fails instead of passing over nothing — which is the more likely long-run failure and the harder one to notice.

This drifted to 35% because nothing was watching. Now something is.

## Spec

A type inventory grouped by module, plus the three pairs that are easy to confuse and load-bearing when confused: `GroupMember`/`GroupSelector` (resolved vs authored — can resolve identically and must hash differently), `Publish`/`DeclaresPublish` (send vs declared endpoint), `DispatchKind`/`DispatchFlavor` (fact vs conclusion).

The Analyses section is also reconciled with the absorption types as they stand after the publish-confinement work — `AbsorbedNode`, `AbsorbedEvent`, `AbsorbedTarget` and the three residues are named rather than described around.

No functional change. `cargo doc` clean, hale-model tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
