### PR TITLE
perf(http): literal-head prefilter — route matching ~4x cheaper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ behavior.
 
 ## Unreleased
 
+### HTTP route matching is ~4x cheaper
+
+`__http_match_pattern_into` counted segments in both strings and then
+walked them pairwise — and `__http_seg_at` re-scans from the start and
+allocates a substring, twice per segment. On a route table nearly
+every candidate is a miss, so the whole walk was paid to discover
+that.
+
+Every segment before a pattern's first `:` is literal, so a match
+requires that text to prefix the path. Testing it first — before the
+two segment counts, which scan both strings end to end — rejects a
+miss in one comparison.
+
+Measured over 200k requests, worst case (the request matches the last
+route): 390 -> 91 ns per candidate route; 39.1 -> 9.8 us per request
+at 100 routes; 2.1 -> 1.1 us at five. Both the `Router` and the
+`is_route` ladder go through this matcher, so both benefit.
+
+Behaviour is unchanged, and now pinned: trailing-slash tolerance on
+both sides, a literal head that prefixes without matching segments,
+count mismatches, captures, and the capture-clearing an `if`-ladder
+depends on. The first version of the prefilter broke trailing-slash
+tolerance on the pattern side and nothing in the suite noticed, which
+is why those cases exist.
+
+The remaining cost is that matching is still linear in the route
+count — see GH #509.
+
 ### Element chains take fixed arrays and `bounded[T; N]`
 
 `self.probes.filter(it.live).count()` over a `[Probe; 16]` failed with

--- a/crates/hale-codegen/tests/http_route_matching.rs
+++ b/crates/hale-codegen/tests/http_route_matching.rs
@@ -1,0 +1,147 @@
+//! Pattern-matching semantics for `std::http::is_route`, pinned
+//! against a prefilter that made the matcher ~4x cheaper.
+//!
+//! `__http_match_pattern_into` used to walk both strings segment by
+//! segment before it could reject — re-scanning and allocating a
+//! substring twice per segment, ~390ns per candidate route. On a
+//! route table nearly every candidate is a miss, so the whole walk
+//! was being paid to discover that.
+//!
+//! It now tests the pattern's literal head as a prefix first, which
+//! is implied by the per-segment equality the walk enforces, so it
+//! can only reject where the walk would.
+//!
+//! "Can only reject where the walk would" is the entire safety
+//! argument, and the first version of it was WRONG: matching is
+//! trailing-slash tolerant on both sides, so pattern `/users/` must
+//! match path `/users` — and testing the slash as part of the prefix
+//! rejected exactly that pair. Nothing in the suite caught it. These
+//! are the cases that would have.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+/// Every case is `(path, pattern, expected)`, run through the real
+/// `build_context` + `is_route` surface rather than the internals,
+/// so this pins the behaviour a user sees.
+const CASES: &[(&str, &str, bool)] = &[
+    // Trailing slash is tolerated on BOTH sides. The prefilter's
+    // first version broke the first of these and kept the second,
+    // which is exactly the asymmetry to guard.
+    ("/users", "/users/", true),
+    ("/users/", "/users", true),
+    ("/users/", "/users/", true),
+    ("/users", "/users", true),
+    // Captures.
+    ("/users/42", "/users/:id", true),
+    ("/users/42/", "/users/:id", true),
+    ("/u", "/:id", true),
+    ("/a/b", "/:x/:y", true),
+    // A literal head that PREFIXES the path but is not a segment
+    // match: the prefilter passes it and the walk must still reject.
+    ("/usersXYZ", "/users", false),
+    ("/users/42", "/user/:id", false),
+    // Segment-count mismatch, both directions.
+    ("/users/42/extra", "/users/:id", false),
+    ("/users", "/users/:id", false),
+    // The query half is split off before matching.
+    ("/users/42?q=1", "/users/:id", true),
+    // A miss in the literal head — the case the prefilter exists for.
+    ("/orders/42", "/users/:id", false),
+];
+
+#[test]
+fn route_patterns_match_exactly_as_documented() {
+    let checks: String = CASES
+        .iter()
+        .map(|(path, pat, _)| {
+            format!(
+                "    t(\"{}\", \"{}\");\n",
+                path, pat
+            )
+        })
+        .collect();
+    let src = format!(
+        r#"
+fn t(path: String, pat: String) {{
+    let req = std::http::Request {{
+        method: "GET", path: path, body: "", conn_fd: 0 - 1
+    }};
+    let ctx = std::http::build_context(req);
+    println(path, " ", pat, " ", std::http::is_route(ctx, "GET", pat));
+}}
+fn main() {{
+{}}}
+"#,
+        checks
+    );
+    let program = hale_syntax::parse_source(&src).expect("parse");
+    let bin = harness::unique_bin("hale_test_route_matching");
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let got: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(got.len(), CASES.len(), "output:\n{}", stdout);
+
+    let mut wrong = Vec::new();
+    for ((path, pat, want), line) in CASES.iter().zip(got.iter()) {
+        let actual = line.ends_with("true");
+        if actual != *want {
+            wrong.push(format!(
+                "  {} vs {} -> {} (want {})",
+                path, pat, actual, want
+            ));
+        }
+    }
+    assert!(
+        wrong.is_empty(),
+        "route matching changed:\n{}",
+        wrong.join("\n")
+    );
+}
+
+/// The method compare rejects before any pattern work, and the
+/// captures are cleared on that path — an if-ladder is first-match
+/// wins, so a miss must not leave the previous check's captures
+/// visible to the next arm.
+#[test]
+fn a_method_miss_clears_captures() {
+    let src = r#"
+fn main() {
+    let req = std::http::Request {
+        method: "GET", path: "/users/42", body: "", conn_fd: 0 - 1
+    };
+    let ctx = std::http::build_context(req);
+    // Matches, filling a capture.
+    println("hit=", std::http::is_route(ctx, "GET", "/users/:id"));
+    println("id=", std::http::path_param(ctx.params, "id"));
+    // Method miss: must clear, so the stale `id` is not readable.
+    println("miss=", std::http::is_route(ctx, "POST", "/users/:id"));
+    println("after=", std::http::path_param(ctx.params, "id"));
+}
+"#;
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin("hale_test_route_clear");
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("hit=true"), "{:?}", stdout);
+    assert!(stdout.contains("id=42"), "{:?}", stdout);
+    assert!(stdout.contains("miss=false"), "{:?}", stdout);
+    assert!(
+        stdout.contains("after=") && !stdout.contains("after=42"),
+        "a method miss must not leave the previous capture readable: {:?}",
+        stdout
+    );
+}

--- a/crates/hale-stdlib/hl/http.hl
+++ b/crates/hale-stdlib/hl/http.hl
@@ -894,6 +894,39 @@ fn __http_seg_at(p: String, idx: Int) -> String {
 // because match failure is the COMMON path. Trailing-slash
 // tolerant on both sides; no implicit wildcard suffix.
 fn __http_match_pattern_into(pattern: String, path: String, p: std::http::RouteParams) -> Bool {
+    // Literal-head prefilter, BEFORE the segment counts: those
+    // scan both strings end to end, and on a route table nearly
+    // every candidate is rejected, so paying two full scans to
+    // discover it is the wrong order. Every segment before the pattern's
+    // first `:` is literal, so a successful match REQUIRES that
+    // text to prefix the path — one memcmp instead of the
+    // segment walk below, which re-scans and allocates a
+    // substring twice per segment.
+    //
+    // Sound because it only rejects where the walk would: it is
+    // implied by the per-segment equality the walk enforces. It
+    // never accepts anything extra — a pass still falls through
+    // to the full walk.
+    //
+    // This is the hot path for a route TABLE, where nearly every
+    // candidate differs in its first segment and pays the whole
+    // walk to discover it (measured ~385ns/route before this).
+    let colon = std::str::index_of(pattern, ":");
+    let raw_head = if colon < 0 { pattern } else { std::str::substring(pattern, 0, colon) };
+    // Drop a trailing `/` before testing. Matching is
+    // trailing-slash tolerant ON BOTH SIDES, so pattern `/users/`
+    // must still match path `/users` — testing the slash as part
+    // of the prefix rejected exactly that pair. Dropping it makes
+    // the filter weaker and still sound; the walk decides.
+    let hl = len(raw_head);
+    let head = if hl > 0 && raw_head[hl - 1..hl] == "/" {
+        std::str::substring(raw_head, 0, hl - 1)
+    } else {
+        raw_head
+    };
+    if len(head) > 0 && !std::str::starts_with(path, head) {
+        return false;
+    }
     let pn = __http_seg_count(pattern);
     let rn = __http_seg_count(path);
     if pn != rn {

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -642,6 +642,7 @@ crates/hale-codegen/tests/http_request_headers.rs#1 865d341109268295
 crates/hale-codegen/tests/http_request_headers.rs#2 865d341109268295
 crates/hale-codegen/tests/http_response_headers.rs#2 f2c1228edb650960
 crates/hale-codegen/tests/http_response_headers.rs#3 865d341109268295
+crates/hale-codegen/tests/http_route_matching.rs#1 f2c1228edb650960
 crates/hale-codegen/tests/http_router.rs#0 d57a225f18d70f1a
 crates/hale-codegen/tests/http_router.rs#2 b5782caf934f5fa8
 crates/hale-codegen/tests/http_server_bus_logging.rs#0 eb5ed69dd85d3434


### PR DESCRIPTION
Delivers the first of the three pieces in #509 — the one that needed no design decision.

## Measured first

200k iterations of `build_context` + a guarded-`match` ladder of `is_route` arms, request matching the **last** route (worst case):

| routes | before | after | |
|---|---|---|---|
| 5 | 2,089 | 1,130 ns/req | 1.9x |
| 100 | 39,127 | 9,798 ns/req | **4.0x** |
| mixed methods, 100 | 12,061 | 4,908 ns/req | 2.5x |
| **marginal** | **390** | **91 ns/route** | **4.3x** |

## What was wrong

`__http_match_pattern_into` counted segments in *both* strings, then walked them pairwise — and `__http_seg_at` re-scans from the start and allocates a substring, twice per segment. On a route table nearly every candidate is a miss, so the whole walk was paid just to discover that.

Every segment before the pattern's first `:` is literal, so a successful match **requires** that text to prefix the path. Testing it first is one comparison instead of the walk — and it runs *before* the two segment counts, which scan both strings end to end and are the wrong thing to pay on a miss.

Sound because it can only reject where the walk would: the prefix is implied by the per-segment equality the walk enforces, and a pass still falls through to the full walk. It never accepts anything extra.

## That argument was wrong the first time

Matching is trailing-slash tolerant **on both sides**, so pattern `/users/` must match path `/users` — and testing the slash as part of the prefix rejected exactly that pair.

**Nothing in the existing suite caught it.** I found it by diffing 10 matcher cases against the pre-change binary, which is the only reason it isn't in this PR.

So the trailing slash is dropped from the head before the test — a weaker filter, still sound — and `http_route_matching.rs` pins 15 cases through the public `build_context` + `is_route` surface, including:

- trailing slash in both directions (the pair I broke)
- a literal head that prefixes the path but isn't a segment match (`/usersXYZ` vs `/users`) — the prefilter passes it, the walk must still reject
- segment-count mismatch both ways
- captures, including in the first segment
- the capture-clearing contract an if-ladder depends on: a method miss must not leave the previous check's capture readable

Verified red against the broken version: `/users vs /users/ -> false (want true)`.

## Scope

This does **not** address the deeper cost — `is_route` still walks the table linearly, which is #509's remaining two pieces (scrutinee-less `match` for ergonomics, and a recognized form that could compile to a decision tree). Both need decisions; this one didn't.

Worth noting the crossover moved: at 91ns/route, a 20-route API spends ~1.8µs matching, which makes the case for compiled dispatch weaker than the original 390ns figure suggested. That's the measurement #509 says should gate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
