### PR TITLE
fix(check): validate `on_failure` signatures and literal subscribes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ behavior.
 
 ## Unreleased
 
+### `on_failure` and literal `subscribe` are checked, not just built
+
+Two shapes in the language's core vocabulary passed `hale check` and
+failed `hale build`, with no source location:
+
+- `on_failure` with the wrong arity, or a second param that is not
+  `ClosureViolation`. Codegen enforced both; the checker looked at
+  neither.
+- `subscribe "some.subject" as h;` with no `of type T`. A declared
+  topic supplies the payload, but a literal subject has no
+  declaration to take one from, so codegen needs the clause and said
+  so far too late.
+
+Both now report at check time, with a span, and the subscribe
+diagnostic shows the spelling that works. Two test fixtures turned
+out to be invalid Hale that only ever passed because those tests
+check and dump an artifact without building.
+
+This is the first pass against the check/build divergence baseline:
+47 down to 42.
+
 ### Locus param defaults are typechecked
 
 They were not. `check_locus_member` skipped the `params` block with a

--- a/crates/hale-cli/tests/topology_graph_cli.rs
+++ b/crates/hale-cli/tests/topology_graph_cli.rs
@@ -2682,10 +2682,11 @@ fn on_failure_only_locus_admits() {
     std::fs::write(
         &src,
         r#"
+locus Ward { params { k: Int = 0; } }
 @phase_effects(birth: {})
 locus Guard {
     params { n: Int = 0; }
-    on_failure(e: FailureInfo) { self.n = 1; }
+    on_failure(c: Ward, err: ClosureViolation) { self.n = 1; }
 }
 main locus App {
     params { g: Guard = Guard { }; }
@@ -2924,10 +2925,11 @@ fn module_failure_only_locus_admits() {
         &src,
         r#"
 module inner {
+    locus Ward { params { k: Int = 0; } }
     @phase_effects(birth: {})
     locus Guard {
         params { n: Int = 0; }
-        on_failure(e: FailureInfo) {
+        on_failure(c: Ward, err: ClosureViolation) {
             self.n = 1;
         }
     }

--- a/crates/hale-codegen/tests/fixtures/check_build_divergences.txt
+++ b/crates/hale-codegen/tests/fixtures/check_build_divergences.txt
@@ -2,7 +2,6 @@ crates/hale-cli/tests/replay_cli.rs#5
 crates/hale-cli/tests/replay_cli.rs#6
 crates/hale-cli/tests/replay_cli.rs#7
 crates/hale-cli/tests/topology_graph_cli.rs#13
-crates/hale-cli/tests/topology_graph_cli.rs#27
 crates/hale-codegen/tests/cross_seed_imports.rs#1
 crates/hale-codegen/tests/f22_as_parent_for_surface.rs#3
 crates/hale-codegen/tests/f22_capacity_acceptance.rs#4
@@ -26,14 +25,11 @@ crates/hale-codegen/tests/string_escapes.rs#5
 crates/hale-codegen/tests/wasm_target.rs#0
 crates/hale-codegen/tests/wasm_target.rs#1
 crates/hale-codegen/tests/wasm_target.rs#4
-crates/hale-types/tests/artifact_law_projection.rs#12
 crates/hale-types/tests/diag_quality.rs#13
-crates/hale-types/tests/frontier_items.rs#3
 crates/hale-types/tests/generic_call_check.rs#1
 crates/hale-types/tests/generic_call_check.rs#2
 crates/hale-types/tests/generic_call_check.rs#3
 crates/hale-types/tests/generic_call_check.rs#5
-crates/hale-types/tests/judgment_depends.rs#9
 crates/hale-types/tests/model_builder.rs#12
 crates/hale-types/tests/model_builder.rs#15
 crates/hale-types/tests/model_builder.rs#22
@@ -44,4 +40,3 @@ crates/hale-types/tests/placement.rs#18
 crates/hale-types/tests/placement.rs#19
 crates/hale-types/tests/placement.rs#20
 crates/hale-types/tests/placement.rs#22
-crates/hale-types/tests/topology_projection.rs#5

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -8783,7 +8783,37 @@ impl<'a> Checker<'a> {
                     }
                 }
             }
-            LocusMember::Contract(_) | LocusMember::Bus(_) => {
+            LocusMember::Bus(bb) => {
+                // A subscribe on a LITERAL or wildcard subject must
+                // say `of type T`: there is no declaration to take
+                // the payload from, and codegen needs one to pick a
+                // deserializer. Without this the omission passed
+                // `hale check` and failed the build with no span —
+                // the divergence class `corpus_check_build_agreement`
+                // gates. A declared-topic subscribe is exempt: the
+                // topic carries the payload.
+                for bm in &bb.members {
+                    let BusMember::Subscribe { subject, ty, span, .. } = bm
+                    else {
+                        continue;
+                    };
+                    if ty.is_some() {
+                        continue;
+                    }
+                    if !matches!(subject, BusSubject::Literal { .. }) {
+                        continue;
+                    }
+                    self.diags.push(Diag::ty(
+                        *span,
+                        format!(
+                            "subscribe `{}`: a literal subject carries no payload declaration, so the subscription must name one — `subscribe \"{}\" as <handler> of type <T>;`",
+                            subject.canonical(),
+                            subject.canonical()
+                        ),
+                    ));
+                }
+            }
+            LocusMember::Contract(_) => {
                 // Already lowered by the resolver.
             }
             LocusMember::Bindings(_) => {
@@ -8832,6 +8862,47 @@ impl<'a> Checker<'a> {
                 self.in_lifecycle = false;
             }
             LocusMember::Failure(fd) => {
+                // The handler's SIGNATURE, checked here rather than
+                // only in codegen. `on_failure` is the supervision
+                // surface a reader meets early, and getting its shape
+                // wrong used to pass `hale check` and fail the build
+                // with no source location — the divergence class
+                // `corpus_check_build_agreement` gates.
+                //
+                // Same two rules codegen enforces (locus/decl.rs):
+                // exactly (child, err), and the error is
+                // `ClosureViolation`.
+                let locus_name = self
+                    .current_locus
+                    .map(|l| l.name.clone())
+                    .unwrap_or_default();
+                if fd.params.len() != 2 {
+                    self.diags.push(Diag::ty(
+                        fd.span,
+                        format!(
+                            "locus `{}`: `on_failure` takes exactly two params — the failing child and the error — got {}",
+                            locus_name,
+                            fd.params.len()
+                        ),
+                    ));
+                } else {
+                    let err_ty =
+                        resolve_type_expr(&fd.params[1].ty, self.known);
+                    let is_violation = matches!(
+                        &err_ty,
+                        Ty::Named(n) if n == "ClosureViolation"
+                    );
+                    if !is_violation && !matches!(err_ty, Ty::Unknown) {
+                        self.diags.push(Diag::ty(
+                            fd.params[1].name.span,
+                            format!(
+                                "locus `{}`: `on_failure`'s second param is the error and must be `ClosureViolation`, got `{}`",
+                                locus_name,
+                                err_ty.display()
+                            ),
+                        ));
+                    }
+                }
                 self.in_lifecycle = true;
                 self.in_on_failure = true;
                 self.locals.push();

--- a/crates/hale-types/tests/fixtures/claim_diags_snapshot.txt
+++ b/crates/hale-types/tests/fixtures/claim_diags_snapshot.txt
@@ -294,8 +294,6 @@ Claim [409..412] claim `iso` violated: `a_side` reaches `b_side` — witness: `A
 Claim [156..171] claim `iso`: the crossing publish happens here
 Claim [223..247] claim `iso`: delivered at this subscription
 Claim [182..183] claim `iso`: the forbidden destination `B` is declared here
---- crates/hale-types/tests/judgment_reachability.rs#38 ---
-Claim [172..178] claim `tagged` uncertified: a fn makes an indirect or opaque call whose target this check cannot resolve, and names no purpose of its own — so whether a `syscall` boundary is crossed there is unknown. Classify the caller (`@effects(is: {...})`) or bind the callee so it resolves: Sup::on_failure(Violation)
 --- crates/hale-types/tests/judgment_reachability.rs#39 ---
 Claim [358..365] claim `someone` violated: no member of `pubs` subscribes `T`
 --- crates/hale-types/tests/judgment_reachability.rs#41 ---

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -101,10 +101,10 @@ crates/hale-cli/tests/topology_graph_cli.rs#22 40d8994a9613c753
 crates/hale-cli/tests/topology_graph_cli.rs#24 458f00a3d3bd1138
 crates/hale-cli/tests/topology_graph_cli.rs#25 3b07dd3fe7f0d674
 crates/hale-cli/tests/topology_graph_cli.rs#26 bc35382c3565080a
-crates/hale-cli/tests/topology_graph_cli.rs#27 174ce7e0a956f6bc
+crates/hale-cli/tests/topology_graph_cli.rs#27 a61dd10e4262ecb1
 crates/hale-cli/tests/topology_graph_cli.rs#28 7f75bbe0c59b704e
 crates/hale-cli/tests/topology_graph_cli.rs#30 5cec85e61bf600ba
-crates/hale-cli/tests/topology_graph_cli.rs#31 174ce7e0a956f6bc
+crates/hale-cli/tests/topology_graph_cli.rs#31 a61dd10e4262ecb1
 crates/hale-cli/tests/topology_graph_cli.rs#32 7d5cf57defcf548e
 crates/hale-cli/tests/topology_graph_cli.rs#33 7f75bbe0c59b704e
 crates/hale-cli/tests/topology_graph_cli.rs#36 dea7f37538f67e6b
@@ -1178,7 +1178,6 @@ crates/hale-syntax/tests/wrap_main.rs#0 865d341109268295
 crates/hale-syntax/tests/wrap_main.rs#1 80e8e4543ac850e6
 crates/hale-types/tests/artifact_integrity.rs#2 ceb97d5adb719c07
 crates/hale-types/tests/artifact_law_projection.rs#10 a35d4c64d00f5eeb
-crates/hale-types/tests/artifact_law_projection.rs#12 4c84d0dfb2e48da4
 crates/hale-types/tests/artifact_law_projection.rs#13 5b19cc4370a72a2f
 crates/hale-types/tests/artifact_law_projection.rs#2 909347b7987625fc
 crates/hale-types/tests/birth_order_trap.rs#0 c52fb6e0d7e19f18
@@ -1260,7 +1259,6 @@ crates/hale-types/tests/effect_assertions.rs#8 52f5c2d227dbb8b5
 crates/hale-types/tests/effects_through_handles.rs#4 366138d0626a5646
 crates/hale-types/tests/effects_through_handles.rs#9 8d171dcbfe6d26f9
 crates/hale-types/tests/frontier_items.rs#1 440e61c90f2db460
-crates/hale-types/tests/frontier_items.rs#3 d65dcc235af9574f
 crates/hale-types/tests/frontier_items.rs#4 604a68af0451e08c
 crates/hale-types/tests/frontier_items.rs#5 da1afab5cdfd89e6
 crates/hale-types/tests/frontier_items.rs#6 604a68af0451e08c
@@ -1302,7 +1300,6 @@ crates/hale-types/tests/judgment_depends.rs#12 5e52e14006660555
 crates/hale-types/tests/judgment_depends.rs#2 4ebcead20c253595
 crates/hale-types/tests/judgment_depends.rs#4 57b3e718f9ba2b13
 crates/hale-types/tests/judgment_depends.rs#6 1e29a74a1331d44d
-crates/hale-types/tests/judgment_depends.rs#9 2a665aaeccc99a1e
 crates/hale-types/tests/judgment_reachability.rs#12 f7d9fb64200c3e4b
 crates/hale-types/tests/judgment_reachability.rs#14 1b7facc0d6b6d52b
 crates/hale-types/tests/judgment_reachability.rs#22 4362d16e6b2ccfdd
@@ -1430,7 +1427,6 @@ crates/hale-types/tests/topology_projection.rs#13 098d8448db3393fd
 crates/hale-types/tests/topology_projection.rs#14 4df27a79ef60a7b9
 crates/hale-types/tests/topology_projection.rs#3 86ad0bb6f3d1fcae
 crates/hale-types/tests/topology_projection.rs#4 90f1c7ee9e3d1372
-crates/hale-types/tests/topology_projection.rs#5 1da4ace1ebe80e36
 crates/hale-types/tests/topology_projection.rs#7 43fedbac6dfcd680
 crates/hale-types/tests/topology_projection.rs#8 9987dee9f11ab32a
 crates/hale-types/tests/topology_projection.rs#9 e2f9e2e579bb0933


### PR DESCRIPTION
First pass against the check/build divergence baseline (**47 → 42**).

These two are the ones in the language's *core vocabulary* — what a newcomer meets first, and where the divergence hurts most: the error arrives from another layer, without a span, saying a working-looking program can't be built.

**`on_failure`** — codegen requires exactly `(child, err)` and requires the error to be `ClosureViolation`. The checker bound the params into scope and validated neither. Both now report at check time against the same conditions codegen uses.

**Literal `subscribe`** — `subscribe "app.sig" as h;` has no declaration to take a payload from, so codegen needs `of type T`. A declared-topic subscribe is exempt (the topic carries it), and the diagnostic names the spelling that works.

## Two fixtures were invalid Hale all along

`topology_graph_cli`'s `on_failure(e: FailureInfo)` is one param — rejected by codegen since forever. Those tests passed only because they check and dump an artifact without ever building. Corrected to a real signature; what they assert (an on_failure-only locus admits) is unchanged and still passes.

That's the divergence class demonstrating itself: the bug was sitting in our own tests, invisible, because nothing built them.

## Fallout, checked

Six programs leave the harvested corpus — each carried one of these two bugs. Every suite owning one still passes: `frontier_items`, `judgment_depends`, `judgment_reachability`, `artifact_law_projection`, `topology_graph_cli`.

All four baselines regenerated after reading each diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)