### PR TITLE
release: v0.19.0 — check earlier, run faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.19.0 — check earlier, run faster (2026-09-02)
 
 ### `on_failure` and literal `subscribe` are checked, not just built
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "hale-cli"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "hale-corpus",
  "hale-model",
@@ -103,11 +103,11 @@ dependencies = [
 
 [[package]]
 name = "hale-corpus"
-version = "0.18.0"
+version = "0.19.0"
 
 [[package]]
 name = "hale-lsp"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "hale-stdlib",
  "hale-syntax",
@@ -117,22 +117,22 @@ dependencies = [
 
 [[package]]
 name = "hale-model"
-version = "0.18.0"
+version = "0.19.0"
 
 [[package]]
 name = "hale-stdlib"
-version = "0.18.0"
+version = "0.19.0"
 
 [[package]]
 name = "hale-syntax"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "hale-corpus",
 ]
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "hale-corpus",
  "hale-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Cuts **v0.19.0** from 8 commits since v0.18.0.

## Headline: errors move to `hale check`, where they have a span

`hale check` accepting what `hale build` refuses is the worst failure mode the toolchain has — late, from another layer, usually spanless, telling the author their working program is broken.

The ~1300 programs embedded in Rust test strings were typechecked but **never compiled**, so the class had a hiding place. It's now gated by a ratchet, and the first pass took it **47 → 42**. Three shapes moved to check time: locus param defaults, `on_failure` signatures, and literal `subscribe` payload types.

## Also in this release

- **`restart(c) for N` lowers**, and exhausting the bound quarantines the child — unblocking supervision adoption downstream
- **Element chains take `[T; N]` and `bounded[T; N]`**
- **HTTP route matching ~4x cheaper** — 390 → 91 ns per candidate route

## Upgrade note

The three new checks are **new `hale check` errors** on programs that previously passed check and failed at build. Strictly better errors in a better place, but they are new failures on first upgrade. Two of our own test fixtures turned out to be invalid Hale that only ever passed because those tests never built.

Verified after the version bump, since the compiler version feeds `inputs_digest`: all three pinned baselines and the supervision suite still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)