### PR TITLE
test(types): pin GH #476's demand gate

### DIFF
--- a/crates/hale-types/tests/demand_gate.rs
+++ b/crates/hale-types/tests/demand_gate.rs
@@ -1,0 +1,109 @@
+//! GH #476 acceptance criterion 1: *"One demand-gated model
+//! derivation entry point; no-claims LSP path **provably** skips
+//! it."*
+//!
+//! The gate shipped (`has_claim_surface`, an early return in
+//! `claim_law_diags`) and so did the instrumentation
+//! (`model_builder::builds()`, whose doc comment says "The no-claims
+//! check path must leave this at zero"). Nothing asserted it. A
+//! refactor that hoisted the derivation above the gate — or a new
+//! claim surface that forgot to extend it — would pass CI silently
+//! while every keystroke in the editor paid for a model.
+//!
+//! That is the whole point of the criterion, so it is checked here.
+//!
+//! **This file is deliberately a lone test in its own binary.**
+//! `builds()` is a process-global counter and Rust runs a test
+//! binary's tests in parallel by default, so a sibling test deriving
+//! a model would make this either flaky or vacuous.
+
+/// The editor path: a program that swears to nothing must not build
+/// a model — and one that does must build exactly one, so the test
+/// cannot pass by the gate simply never opening.
+#[test]
+fn the_no_claims_check_path_derives_no_model() {
+    let no_claims = hale_syntax::parse_source(
+        r#"
+type Order { id: Int = 0; }
+topic Placed { payload: Order; }
+
+locus Desk {
+    params { seen: Int = 0; }
+    bus { subscribe Placed as on_placed; }
+    fn on_placed(o: Order) { self.seen = o.id; }
+}
+
+locus Feed {
+    bus { publish Placed; }
+    fn go() { Placed <- Order { id: 1 }; }
+}
+
+main locus App {
+    params { d: Desk = Desk { }; f: Feed = Feed { }; }
+}
+fn main() { App { }; }
+"#,
+    )
+    .expect("parse");
+
+    let before = hale_types::model_builder::builds();
+    let diags = hale_types::check_program(&no_claims);
+    let after = hale_types::model_builder::builds();
+
+    assert!(
+        !diags.iter().any(|d| d.is_error()),
+        "the fixture must be a CLEAN program, or the checker may bail \
+         before reaching the gate and the test proves nothing: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        after, before,
+        "a program with no claims, no constitution, and no judged \
+         annotation must not derive an ApplicationModel — this is the \
+         LSP's path, and it runs on every keystroke"
+    );
+
+    // The other half: the gate must actually open. Without this the
+    // assertion above is satisfied by a gate that never lets anything
+    // through, which would be a silent loss of all claim checking.
+    let with_claim = hale_syntax::parse_source(
+        r#"
+type Order { id: Int = 0; }
+topic Placed { payload: Order; }
+
+locus Desk {
+    params { seen: Int = 0; }
+    bus { subscribe Placed as on_placed; }
+    fn on_placed(o: Order) { self.seen = o.id; }
+}
+
+locus Feed {
+    bus { publish Placed; }
+    fn go() { Placed <- Order { id: 1 }; }
+}
+
+main locus App {
+    params { d: Desk = Desk { }; f: Feed = Feed { }; }
+    claims { one_writer: count publishers(topic Placed) == 1; }
+}
+fn main() { App { }; }
+"#,
+    )
+    .expect("parse");
+
+    let before = hale_types::model_builder::builds();
+    let diags = hale_types::check_program(&with_claim);
+    let after = hale_types::model_builder::builds();
+
+    assert!(
+        !diags.iter().any(|d| d.is_error()),
+        "the claim-bearing fixture must also be clean: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert!(
+        after > before,
+        "a program carrying a claim MUST derive a model — a gate that \
+         never opens would satisfy the first assertion while silently \
+         checking no law at all"
+    );
+}

--- a/crates/hale-types/tests/fixtures/law_rows_snapshot.txt
+++ b/crates/hale-types/tests/fixtures/law_rows_snapshot.txt
@@ -115,6 +115,7 @@ crates/hale-types/tests/constitutions.rs#5	shared	count publishers(topic Settled
 crates/hale-types/tests/constitutions.rs#6	one	count publishers(topic Settled) == 1	Invalid	Some("A")
 crates/hale-types/tests/constitutions.rs#6	two	count subscribers(topic Settled) == 0	Invalid	Some("B")
 crates/hale-types/tests/constitutions.rs#8	two	count subscribers(topic Settled) == 0	Invalid	Some("Core")
+crates/hale-types/tests/demand_gate.rs#1	one_writer	count publishers(topic Placed) == 1	Holds	None
 crates/hale-types/tests/interface_dispatch.rs#10	one_call	bound llm <= 1 on paths from planners	Violated	None
 crates/hale-types/tests/interface_dispatch.rs#4	iso	forbid reaches(a_side, sinks)	Violated	None
 crates/hale-types/tests/interface_dispatch.rs#5	iso	forbid reaches(a_side, sinks)	Uncertified	None

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -1229,6 +1229,8 @@ crates/hale-types/tests/constitutions.rs#0 2a2f5fd182496fe2
 crates/hale-types/tests/contract_expose_check.rs#2 c9f68cd1c70737ed
 crates/hale-types/tests/contract_expose_check.rs#3 5406bf60d39ac690
 crates/hale-types/tests/contract_expose_check.rs#5 68571438548b5b78
+crates/hale-types/tests/demand_gate.rs#0 a476bae0f7b173fe
+crates/hale-types/tests/demand_gate.rs#1 a476bae0f7b173fe
 crates/hale-types/tests/depends_set.rs#1 e6d019967d07bc80
 crates/hale-types/tests/depends_set.rs#2 7eb747ab2594f71d
 crates/hale-types/tests/diag_quality.rs#10 b6f5c37a20862edb


### PR DESCRIPTION
Closes the last unproven acceptance criterion of #476.

> **1.** One demand-gated model derivation entry point; no-claims LSP path **provably** skips it.

The gate shipped (`has_claim_surface`, an early return in `claim_law_diags`) and so did the instrumentation — `model_builder::builds()`, whose doc comment already said *"The no-claims check path must leave this at zero."*

**Nothing ever asserted it.** So "provably" wasn't backed by anything: a refactor hoisting the derivation above the gate, or a new claim surface that forgot to extend `has_claim_surface`, would pass CI while every keystroke in the editor paid for a full model derivation.

## Both directions, because either alone is worthless

- a clean program with no claims, no constitution, no judged annotation → `builds()` unchanged
- a clean program carrying a claim → `builds()` increases

Without the second, a gate that never opens satisfies the first while silently checking no law at all.

## Verified against the actual failure modes

Not assumed:

| injected fault | result |
|---|---|
| derivation hoisted above the gate | fails assertion 1 |
| gate forced always-closed | fails assertion 2 |
| restored | green |

Deliberately a lone test in its own binary — `builds()` is process-global and test binaries run their tests in parallel, so a sibling deriving a model would make this flaky or vacuous. It also asserts its fixtures are error-free, so the checker can't bail early and pass it for the wrong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)