### PR TITLE
feat(syntax): scrutinee-less `match { cond -> … }`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ behavior.
 
 ---
 
+## Unreleased
+
+### `match { cond -> … }` — first-match-wins without a scrutinee
+
+First-match-wins over guards was always expressible: a match arm
+carries a guard, so `match true { _ if cond -> … }` worked. You just
+had to invent a scrutinee you then ignored and write `_ if` on every
+arm.
+
+That shape is a `cond`, and it appears wherever dispatch is a ladder
+of tests rather than a shape match — HTTP routing, protocol
+dispatch, tiered fallbacks:
+
+    return match {
+        std::http::is_route(ctx, "GET", "/users")     -> self.list(),
+        std::http::is_route(ctx, "GET", "/users/:id") -> self.show(id),
+        else                                          -> not_found(),
+    };
+
+`else` is the catch-all. Arms are tried in order and the first true
+one wins.
+
+Parser-only sugar: it desugars into exactly the ignored-scrutinee
+form, so typecheck, codegen, the model and every judgment see the
+match they already saw, and nothing downstream learns a new shape. A
+test pins that the two spellings produce identical programs.
+
+Notably it needs no method references — the arms are ordinary calls
+with `self` in scope, which is why this and not a `routes` block was
+the answer for one-locus-many-endpoints (GH #509 §2).
+
 ## v0.19.0 — check earlier, run faster (2026-09-02)
 
 ### `on_failure` and literal `subscribe` are checked, not just built

--- a/crates/hale-codegen/tests/cond_match.rs
+++ b/crates/hale-codegen/tests/cond_match.rs
@@ -1,0 +1,115 @@
+//! The scrutinee-less `match` — GH #509 §2.
+//!
+//! First-match-wins over guards was always expressible: `MatchArm`
+//! carries a `guard`, so `match true { _ if cond -> … }` worked. You
+//! just had to invent a scrutinee you then ignored and write `_ if`
+//! on every arm.
+//!
+//! That shape is a `cond`, and it turns up wherever dispatch is a
+//! ladder of tests rather than a shape match — HTTP routing, protocol
+//! dispatch, tiered fallbacks. The sugar is parser-only and desugars
+//! into exactly the ignored-scrutinee form, so typecheck, codegen,
+//! the model and every judgment see the match they already saw.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+fn run(name: &str, src: &str) -> String {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(&format!("hale_condmatch_{}", name));
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// Arms are tried in order and the FIRST true one wins — the whole
+/// point of the form. Both guards here are true, so a version that
+/// evaluated them in any other order, or took the last match, gives
+/// a different answer.
+#[test]
+fn arms_are_first_match_wins() {
+    let out = run(
+        "order",
+        r#"
+fn main() {
+    let n = 5;
+    println("r=", match { n > 1 -> "first", n > 2 -> "second", else -> "none" });
+}
+"#,
+    );
+    assert!(out.contains("r=first"), "{:?}", out);
+}
+
+/// `else` is the catch-all, and it is reachable.
+#[test]
+fn else_is_the_fallthrough() {
+    let out = run(
+        "fallthrough",
+        r#"
+fn main() {
+    let n = 0;
+    println("r=", match { n > 1 -> "hi", n < 0 -> "lo", else -> "mid" });
+    println("only=", match { else -> 42 });
+}
+"#,
+    );
+    assert!(out.contains("r=mid"), "{:?}", out);
+    assert!(out.contains("only=42"), "{:?}", out);
+}
+
+/// Both positions, and `self` methods as arm bodies — the routing
+/// shape this exists for, where the arms must be direct calls on the
+/// receiver rather than values.
+#[test]
+fn works_in_statement_position_and_calls_self_methods() {
+    let out = run(
+        "stmt",
+        r#"
+locus L {
+    params { n: Int = 3; }
+    fn a() -> Int { return 10; }
+    fn b() -> Int { return 20; }
+    fn pick() -> Int {
+        return match { self.n == 1 -> self.a(), self.n == 3 -> self.b(), else -> 0 };
+    }
+    fn shout() {
+        match {
+            self.n == 3 -> { println("stmt=three"); },
+            else -> { println("stmt=other"); },
+        }
+    }
+}
+fn main() { let l = L { }; println("pick=", l.pick()); l.shout(); }
+"#,
+    );
+    assert!(out.contains("pick=20"), "{:?}", out);
+    assert!(out.contains("stmt=three"), "{:?}", out);
+}
+
+/// It is SUGAR: the desugared form must behave identically, since
+/// everything downstream is supposed to see the match it always saw.
+#[test]
+fn it_agrees_with_the_ignored_scrutinee_spelling() {
+    let sugar = run(
+        "sugar",
+        r#"fn main() { let n = 7;
+    println("v=", match { n < 5 -> "lo", n < 10 -> "mid", else -> "hi" }); }"#,
+    );
+    let explicit = run(
+        "explicit",
+        r#"fn main() { let n = 7;
+    println("v=", match true { _ if n < 5 -> "lo", _ if n < 10 -> "mid", _ -> "hi" }); }"#,
+    );
+    assert_eq!(sugar, explicit, "the sugar must desugar to the same program");
+    assert!(sugar.contains("v=mid"), "{:?}", sugar);
+}

--- a/crates/hale-syntax/src/parser.rs
+++ b/crates/hale-syntax/src/parser.rs
@@ -6185,16 +6185,38 @@ impl Parser {
 
     fn parse_match_stmt(&mut self) -> Result<MatchStmt, Diag> {
         let kw = self.expect(TokenKind::Match, "match")?;
-        let scrutinee = self.parse_expr()?;
+        // Scrutinee-less form: `match { cond -> a, else -> b }`.
+        //
+        // First-match-wins over guards, which the AST has always been
+        // able to express (`MatchArm::guard`) — you just had to
+        // supply a scrutinee you then ignored and write `_ if` on
+        // every arm. That is a `cond`, and it comes up wherever
+        // dispatch is a ladder of tests rather than a shape match:
+        // HTTP routing, protocol dispatch, tiered fallbacks.
+        //
+        // Pure sugar. It desugars HERE into exactly what the ignored
+        // scrutinee spelling produced, so typecheck, codegen, the
+        // model and every judgment see the match they already saw,
+        // and nothing downstream learns a new form.
+        //
+        // `match {` is unambiguous in practice: matching ON a block
+        // expression is pathological, nothing in the corpus does it,
+        // and it stays writable as `match (…) { … }`.
+        let cond_form = self.at(&TokenKind::LBrace);
+        let scrutinee = if cond_form {
+            Expr::Literal(Literal::Bool(true), kw.span)
+        } else {
+            self.parse_expr()?
+        };
         self.expect(TokenKind::LBrace, "{")?;
         let mut arms = Vec::new();
         if !self.at(&TokenKind::RBrace) {
-            arms.push(self.parse_match_arm()?);
+            arms.push(self.parse_arm(cond_form)?);
             while self.eat(&TokenKind::Comma) {
                 if self.at(&TokenKind::RBrace) {
                     break;
                 }
-                arms.push(self.parse_match_arm()?);
+                arms.push(self.parse_arm(cond_form)?);
             }
         }
         let close = self.expect(TokenKind::RBrace, "}")?;
@@ -6202,6 +6224,46 @@ impl Parser {
             scrutinee,
             arms,
             span: kw.span.merge(close.span),
+        })
+    }
+
+    fn parse_arm(&mut self, cond_form: bool) -> Result<MatchArm, Diag> {
+        if cond_form {
+            self.parse_cond_match_arm()
+        } else {
+            self.parse_match_arm()
+        }
+    }
+
+    /// One arm of the scrutinee-less form: `<cond> -> body` or
+    /// `else -> body`. Lowered to the guarded arm it is sugar for,
+    /// so everything downstream sees an ordinary match.
+    fn parse_cond_match_arm(&mut self) -> Result<MatchArm, Diag> {
+        let start = self.peek_token().span;
+        let guard = if self.eat(&TokenKind::Else) {
+            // The catch-all. `_` with no guard is exactly what an
+            // ignored-scrutinee `_ ->` arm was.
+            None
+        } else {
+            Some(self.parse_expr()?)
+        };
+        self.expect(TokenKind::Arrow, "->")?;
+        let body = if self.at(&TokenKind::LBrace) {
+            MatchArmBody::Block(self.parse_block()?)
+        } else {
+            let e = self.parse_expr()?;
+            self.eat(&TokenKind::Semi);
+            MatchArmBody::Expr(e)
+        };
+        let span = match &body {
+            MatchArmBody::Expr(e) => e.span(),
+            MatchArmBody::Block(b) => b.span,
+        };
+        Ok(MatchArm {
+            pattern: Pattern::Wildcard(start),
+            guard,
+            body,
+            span,
         })
     }
 

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -326,6 +326,11 @@ crates/hale-codegen/tests/closed_world_nested_struct.rs#3 012bd26069e335fa
 crates/hale-codegen/tests/closure_resets_per_epoch.rs#0 1d2bb052909625d0
 crates/hale-codegen/tests/closure_resets_per_epoch.rs#1 ec797c2dbfde2c86
 crates/hale-codegen/tests/compress_tar.rs#0 8069b95a32004c3a
+crates/hale-codegen/tests/cond_match.rs#0 865d341109268295
+crates/hale-codegen/tests/cond_match.rs#1 865d341109268295
+crates/hale-codegen/tests/cond_match.rs#2 d858656cfb6fb882
+crates/hale-codegen/tests/cond_match.rs#3 865d341109268295
+crates/hale-codegen/tests/cond_match.rs#4 865d341109268295
 crates/hale-codegen/tests/coop_pool_basic.rs#0 485e9ef86187f369
 crates/hale-codegen/tests/coop_pool_multi_locus.rs#0 643c2f0569b1b7e7
 crates/hale-codegen/tests/coop_pool_run_dispatch.rs#0 b5d1b9d8b1cac991

--- a/docs/src/basics/control-flow.md
+++ b/docs/src/basics/control-flow.md
@@ -107,6 +107,38 @@ shapes), which you'll meet in
 [Records & data](../everyday/records.md). The arms can bind the
 data carried by each variant.
 
+### Matching on conditions instead of a value
+
+Sometimes there's no single value to match on — you just want the
+first true condition out of several. Leave the scrutinee out:
+
+```hale,fragment
+let tier = match {
+    n < 10  -> "small",
+    n < 100 -> "medium",
+    else    -> "large",
+};
+```
+
+Arms are tried top to bottom and the first true one wins, so order
+matters. `else` is the catch-all.
+
+This is the same `match` — it's shorthand for
+`match true { _ if n < 10 -> ..., _ -> ... }` — so everything above
+still applies: it works as a statement or an expression, arms can be
+blocks, and a block-bodied arm still needs its trailing comma.
+
+Reach for it when you're writing a ladder of `if`/`else if` that all
+produce the same kind of answer:
+
+```hale,fragment
+return match {
+    std::http::is_route(ctx, "GET", "/users")     -> self.list(),
+    std::http::is_route(ctx, "GET", "/users/:id") -> self.show(id),
+    else                                          -> not_found(),
+};
+```
+
 ## Blocks have values
 
 A `{ ... }` block's last expression — written without a trailing

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -126,6 +126,35 @@ Phase 2b entry in `spec/stdlib.md`.
   `false` / empty for pointer-shaped types), mirroring the
   statement form's silent-no-op fallthrough.
 
+**Scrutinee-less form.** `match { cond -> body, else -> body }`
+omits the scrutinee and tests guards directly:
+
+```hale
+let tier = match {
+    n < 10   -> "small",
+    n < 100  -> "medium",
+    else     -> "large",
+};
+```
+
+Arms are tried in written order and the first whose condition is
+true wins. `else` is the catch-all and carries no condition.
+
+This is **sugar**, desugared at parse into the guarded form it
+replaces — `match { c -> b, else -> d }` is
+`match true { _ if c -> b, _ -> d }`. Everything downstream sees an
+ordinary match, so both positions, block arm bodies, the trailing
+comma rule, and the all-guards-false fallthrough above behave
+identically.
+
+The form exists because first-match-wins over conditions is common
+where dispatch is a ladder of tests rather than a shape match, and
+the scrutinee in that case is a value the author invents only to
+ignore.
+
+`match {` is not ambiguous with matching on a block expression:
+that shape is written `match (…) { … }`.
+
 ## Binary data — Bytes and conversion
 
 `Bytes` is the binary-safe sibling of `String`. Same


### PR DESCRIPTION
GH #509 §2 — the ergonomic half, done without touching method references.

## What

First-match-wins over guards was always expressible: `MatchArm` carries a `guard`, so `match true { _ if cond -> … }` worked. You just had to invent a scrutinee you then ignored and write `_ if` on every arm.

```hale
return match {
    std::http::is_route(ctx, "GET", "/users")     -> self.list(),
    std::http::is_route(ctx, "GET", "/users/:id") -> self.show(id),
    else                                          -> not_found(),
};
```

`else` is the catch-all; arms are tried in order and the first true one wins.

## Parser-only

It desugars **where it is parsed** into exactly the ignored-scrutinee form, so typecheck, codegen, the model and every judgment see the match they already saw. Nothing downstream learns a new shape. A test pins that both spellings produce byte-identical program output.

## Why this and not a `routes` block or a recognized DSL

The arms are **ordinary calls with `self` in scope** — no closure to represent, no capture modes, no runtime dispatch table, and no method references. That was the wall the one-locus-many-endpoints shape kept hitting from two directions, and this walks around it with parser sugar instead of language surface.

§3 of #509 (a recognized routes form that could compile to a decision tree) stays open, and #510's measurement argues against it: at 91 ns/route a 20-route API spends ~1.8 µs matching.

## Details checked rather than assumed

- **Ambiguity**: `match {` is unambiguous in practice — matching *on* a block expression is pathological, nothing in the corpus does it, and it stays writable as `match (…) { … }`.
- **Consistency**: a block-bodied arm needs a trailing comma, exactly as ordinary match arms do. I verified the existing form behaves the same way rather than assuming my sugar was at fault.
- **Formatter**: round-trips both spellings distinctly; it does not rewrite the sugar into the desugared form. `fmt_corpus` green.

Four tests: ordering, `else` fallthrough, both syntactic positions with `self` method bodies, and sugar-vs-explicit equivalence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)