### PR TITLE
release: v0.19.1 — print what you meant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.19.1 — print what you meant (2026-09-04)
 
 ### Logging ergonomics (GH #469)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "hale-cli"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "hale-corpus",
  "hale-model",
@@ -103,11 +103,11 @@ dependencies = [
 
 [[package]]
 name = "hale-corpus"
-version = "0.19.0"
+version = "0.19.1"
 
 [[package]]
 name = "hale-lsp"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "hale-stdlib",
  "hale-syntax",
@@ -117,22 +117,22 @@ dependencies = [
 
 [[package]]
 name = "hale-model"
-version = "0.19.0"
+version = "0.19.1"
 
 [[package]]
 name = "hale-stdlib"
-version = "0.19.0"
+version = "0.19.1"
 
 [[package]]
 name = "hale-syntax"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "hale-corpus",
 ]
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "hale-corpus",
  "hale-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Rolls `## Unreleased` to v0.19.1 and bumps the workspace version.

Two changes have accumulated on main since v0.19.0:

- **Logging ergonomics** (#469, PR #517) — f-strings surfaced in the spec, book and corpus; composite debug rendering; format specs; interpolation diagnostic spans; the plain-string lint; and `std::log`'s structured half.
- **Scrutinee-less `match { cond -> … }`** (#516) — which merged about an hour *after* v0.19.0 was tagged, so it has been unreachable to anyone installing a release. That is the main reason to roll now.

Verified before pushing: `hale --version` reports 0.19.1, `hale fmt --check .` is clean, and `grep -c '^## Unreleased' CHANGELOG.md` is 0 (no orphaned heading below the new version, the v0.11.23 failure mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)