### PR TITLE
perf(codegen): gate the caller-arena publish on allocation, not on syntax (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ behavior.
 
 ---
 
+## Unreleased
+
+### The caller-arena publish is gated on allocation, not on syntax (GH #522)
+
+`fn_modular` — two-deep calls through opaque function pointers —
+has been **29% slower since v0.14.0**, and the bench suite never
+said so: its tolerance band is 30%, so a 29% regression passed
+with a point to spare, at 1% measurement noise.
+
+Bisected across released binaries on one machine, one session:
+
+| build | fn_modular |
+|---|---|
+| v0.11.3 – v0.13.0 | ~18 ms (flat) |
+| **v0.14.0** | **23.25 ms** |
+| v0.18.0 – v0.19.1 | 23.24 ms (flat) |
+
+Disassembling `outer()` from identical source built by each
+compiler showed 5 instructions becoming 15, the difference being
+`call <lotus_set_caller_arena>` — #375's caller-arena publish,
+landing inside a 10M-iteration loop.
+
+#375 fixed a real use-after-free and that trade was right. The
+problem was its gate, which asked whether the body *could* read
+the TLS by substring-searching `{:?}` of the AST for `Call {` or
+`Struct {`. Any call at all armed it, including a call through a
+function pointer that allocates nothing.
+
+The gate now also consults `non_allocating` — the same fixed-point
+classifier that already lets such a fn skip its m49 subregion, and
+one that reasons about function-pointer params instead of giving
+up on them. The TLS exists for allocation sites to read, so a body
+that provably never allocates has no reader to heal. `fn_modular`
+returns to **17.3 ms**, at or below every measurement since
+v0.11.3; no other bench moves.
+
+The safety direction is pinned in both places it can break:
+`caller_arena_tls_unwind.rs` (the #375 reproducer, green under
+`LOTUS_ASAN=1`) and a new `caller_arena_publish_gate.rs` that
+asserts an allocating body still publishes **on entry** — which
+required getting the test right twice, since the first version
+asked about functions LLVM had inlined away and the second counted
+call-site publishes that happen regardless of the prologue.
+
 ## v0.19.1 — print what you meant (2026-09-04)
 
 ### Logging ergonomics (GH #469)

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -13668,7 +13668,28 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // the publish, which otherwise measured +86% on that
         // bench. Same fail-safe direction as the drain-elision
         // gate: over-matching only costs one call.
-        let body_can_read_tls = {
+        //
+        // GH #522: over-matching costs one call PER CALL, not one
+        // call. The syntactic half below is a substring search over
+        // `{:?}` of the body, so ANY call at all arms it — including
+        // a call through a function pointer in a two-deep helper
+        // chain, where the publish lands in a 10M-iteration loop and
+        // measured +29% on `fn_modular` from v0.14.0 onward.
+        //
+        // The TLS exists for allocation sites to read. A body that
+        // provably never allocates therefore has no reader to heal,
+        // and `non_allocating` is exactly that proof — the same
+        // fixed-point classifier that already lets this fn skip its
+        // m49 subregion, and one that reasons about function-pointer
+        // params rather than giving up on them. Consulting it here
+        // keeps the publish wherever an allocation could observe the
+        // TLS and drops it where nothing can.
+        //
+        // This does NOT weaken #375. That was a use-after-free in
+        // `lotus_arena_alloc` — reached only from an allocation.
+        // `caller_arena_tls_unwind.rs` is the standing reproducer
+        // and stays green.
+        let body_can_read_tls = !sig.non_allocating && {
             let dbg = format!("{:?}", f.body);
             dbg.contains("Call {") || dbg.contains("Struct {")
         };

--- a/crates/hale-codegen/tests/caller_arena_publish_gate.rs
+++ b/crates/hale-codegen/tests/caller_arena_publish_gate.rs
@@ -1,0 +1,223 @@
+//! GH #522 — where the caller-arena TLS publish is emitted, both
+//! directions.
+//!
+//! GH #375 fixed a use-after-free by having free-fn prologues
+//! publish their `__caller_arena` param to the TLS. The gate for
+//! "does this body need it" was a substring search over `{:?}` of
+//! the body, so ANY call at all armed it — including a call through
+//! a function pointer in a two-deep helper chain, where the publish
+//! lands inside a 10M-iteration loop.
+//!
+//! That cost `fn_modular` **+29%** from v0.14.0 onward, bisected
+//! across released binaries (v0.13.0 17.99ms → v0.14.0 23.25ms, flat
+//! either side) and confirmed by disassembly: `outer()` went from 5
+//! instructions to 15, the difference being
+//! `call <lotus_set_caller_arena>`.
+//!
+//! The gate now also consults `non_allocating` — the same
+//! fixed-point classifier that already lets such a fn skip its m49
+//! subregion. The TLS exists for allocation sites to read, so a body
+//! that provably never allocates has no reader to heal.
+//!
+//! Both directions are pinned here because only one of them is a
+//! performance question. Dropping a publish that an allocation could
+//! observe is how #375 comes back, and `caller_arena_tls_unwind.rs`
+//! (which runs clean under `LOTUS_ASAN=1`) is the standing
+//! reproducer for that. This file states the narrower structural
+//! claim: the publish is absent exactly where nothing can read it.
+//!
+//! Disassembly-based, so Linux-only — same constraint and same
+//! rationale as `drain_elision.rs`.
+
+#![cfg(target_os = "linux")]
+
+use std::process::Command;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+use hale_codegen::build_executable;
+
+/// Disassemble one function, asserting it survived optimization.
+///
+/// The assert is not defensiveness. The first version of this file
+/// asked about functions LLVM had inlined away, so
+/// `objdump --disassemble=<gone>` printed nothing, every count was
+/// zero, and the test that should have caught a broken gate passed
+/// for exactly the same reason as the one that should have caught a
+/// slow one. A count of zero is only meaningful over code that
+/// exists.
+fn disasm(bin: &std::path::Path, func: &str) -> String {
+    let out = Command::new("objdump")
+        .args(["-d", &format!("--disassemble={}", func)])
+        .arg(bin)
+        .output()
+        .expect("objdump runs");
+    let text = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert!(
+        text.contains(&format!("<{}>:", func)),
+        "`{}` is not in the binary — it was inlined, so this test \
+         would measure nothing. Keep the fn address-taken (assign it \
+         to a `fn` value chosen at runtime).",
+        func
+    );
+    text
+}
+
+/// Whether the fn's PROLOGUE publishes — i.e. the publish precedes
+/// any body work.
+///
+/// Counting publishes anywhere in the body is not enough, and the
+/// first draft of this file got that wrong: call sites publish the
+/// arena before stdlib and method calls independently of the
+/// prologue gate, so an allocating body registers a nonzero count
+/// even with the prologue publish removed entirely. The assertion
+/// held while the property it named did not.
+///
+/// "First call" is not right either — an allocating fn creates its
+/// m49 subregion first, so the publish is genuinely second:
+///
+/// ```text
+///   call <lotus_arena_create_subregion>
+///   call <lotus_set_caller_arena>      <- the prologue publish
+///   call <lotus_obs_locus_birth>       <- body work begins
+/// ```
+///
+/// So: skip arena plumbing, and the next call must be the publish.
+fn publishes_in_prologue(bin: &std::path::Path, func: &str) -> bool {
+    disasm(bin, func)
+        .lines()
+        .filter_map(|l| {
+            let i = l.find("call")?;
+            let sym = l[i..].split('<').nth(1)?.split('>').next()?;
+            Some(sym.to_string())
+        })
+        .find(|sym| !sym.starts_with("lotus_arena_"))
+        .map(|first| first == "lotus_set_caller_arena")
+        .unwrap_or(false)
+}
+
+/// Count `lotus_set_caller_arena` call sites anywhere in one fn.
+fn publish_sites(bin: &std::path::Path, func: &str) -> usize {
+    disasm(bin, func)
+        .lines()
+        .filter(|l| l.contains("call") && l.contains("lotus_set_caller_arena"))
+        .count()
+}
+
+fn build(name: &str, src: &str) -> std::path::PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(name);
+    build_executable(&program, &bin).expect("build");
+    bin
+}
+
+/// The `fn_modular` shape, reduced: a helper that calls another
+/// helper through an OPAQUE function pointer and does arithmetic on
+/// the result. Nothing here allocates, so nothing here can read the
+/// TLS, so the publish is dead code in the hot loop.
+///
+/// The pointer is opaque on purpose — a direct call would let the
+/// optimizer see through it and prove the point for the wrong
+/// reason. This is precisely the shape the old syntactic gate could
+/// not reason about: it saw `Call {` and gave up.
+#[test]
+fn a_non_allocating_body_publishes_nothing_even_through_a_fn_pointer() {
+    const SRC: &str = r#"
+        fn inner(x: Int) -> Int { return x + 1; }
+        fn inner_odd(x: Int) -> Int { return x + 2; }
+        fn outer(x: Int, g: fn(Int) -> Int) -> Int { return g(x) * 3; }
+        fn outer_odd(x: Int, g: fn(Int) -> Int) -> Int { return g(x) * 5; }
+        fn main() {
+            let pid = std::process::pid();
+            let f: fn(Int, fn(Int) -> Int) -> Int =
+                if pid % 2 == 0 { outer } else { outer_odd };
+            let g: fn(Int) -> Int =
+                if pid % 2 == 0 { inner } else { inner_odd };
+            let mut acc = 0;
+            let mut i = 0;
+            while i < 1000 { acc = f(i, g); i = i + 1; }
+            println(acc);
+        }
+    "#;
+    let bin = build("hale_test_ca_nonalloc", SRC);
+    let n = publish_sites(&bin, "outer");
+    let _ = std::fs::remove_file(&bin);
+    assert_eq!(
+        n, 0,
+        "`outer` allocates nothing, so the caller-arena publish is \
+         unreadable work in the caller's loop — got {} site(s)",
+        n
+    );
+}
+
+/// The other direction, and the one that keeps #375 fixed: a body
+/// that DOES allocate keeps its publish. Here the free fn builds a
+/// locus, which is the exact construct whose C-primitive allocation
+/// read the stale TLS in the original report.
+#[test]
+fn an_allocating_body_still_publishes() {
+    const SRC: &str = r#"
+        locus Holder {
+            params { v: Int = 0; }
+            fn read() -> Int { return self.v; }
+        }
+        fn make(seed: Int) -> Int {
+            let h = Holder { v: seed };
+            return h.read();
+        }
+        fn make_odd(seed: Int) -> Int {
+            let h = Holder { v: seed + 1 };
+            return h.read();
+        }
+        fn main() {
+            let f: fn(Int) -> Int =
+                if std::process::pid() % 2 == 0 { make } else { make_odd };
+            println(f(7));
+        }
+    "#;
+    let bin = build("hale_test_ca_alloc", SRC);
+    let prologue = publishes_in_prologue(&bin, "make");
+    let _ = std::fs::remove_file(&bin);
+    assert!(
+        prologue,
+        "a free fn that instantiates a locus must re-heal the TLS on \
+         ENTRY (GH #375) — its first call is not the publish"
+    );
+}
+
+/// A String-building body allocates too, and must keep its publish.
+///
+/// Worth a case of its own because it is the shape where the two
+/// halves of the gate disagree: `non_allocating` correctly calls a
+/// String concat allocating, while the syntactic half sees no
+/// `Call {` at all. The `&&` must not let that through.
+#[test]
+fn a_string_building_body_still_publishes() {
+    const SRC: &str = r#"
+        fn label(n: Int) -> String {
+            let s = "n=" + to_string(n);
+            return s + "!";
+        }
+        fn label_odd(n: Int) -> String {
+            let s = "m=" + to_string(n);
+            return s + "?";
+        }
+        fn main() {
+            let f: fn(Int) -> String =
+                if std::process::pid() % 2 == 0 { label } else { label_odd };
+            println(f(3));
+        }
+    "#;
+    let bin = build("hale_test_ca_string", SRC);
+    let prologue = publishes_in_prologue(&bin, "label");
+    let n = publish_sites(&bin, "label");
+    let _ = std::fs::remove_file(&bin);
+    assert!(
+        prologue,
+        "a String-building free fn allocates and must publish on \
+         entry — its first call is not the publish (saw {} publish \
+         site(s) in total)",
+        n
+    );
+}

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -304,6 +304,9 @@ crates/hale-codegen/tests/bytes_view_type.rs#4 f2c1228edb650960
 crates/hale-codegen/tests/bytes_view_type.rs#5 f2c1228edb650960
 crates/hale-codegen/tests/bytes_xor_find.rs#0 865d341109268295
 crates/hale-codegen/tests/bytes_xor_find.rs#1 f2c1228edb650960
+crates/hale-codegen/tests/caller_arena_publish_gate.rs#0 68a191211a49ee93
+crates/hale-codegen/tests/caller_arena_publish_gate.rs#1 526ddc41dc4e454f
+crates/hale-codegen/tests/caller_arena_publish_gate.rs#2 d21b3a0acc1a8bb5
 crates/hale-codegen/tests/caller_arena_tls_unwind.rs#0 9405c60aa89dc0cf
 crates/hale-codegen/tests/caller_arena_tls_unwind.rs#1 82a19fbf91dc0d88
 crates/hale-codegen/tests/case_fold_and_nested_fstring.rs#0 865d341109268295

--- a/spec/memory.md
+++ b/spec/memory.md
@@ -1040,6 +1040,38 @@ vec without the wrapping locus owning it would still
 dangle — same boundary the cross-seed-segv fix originally
 documented; the fix here doesn't widen or narrow it.
 
+**Free-fn prologue publish (GH #375, gated per GH #522).** The
+caller-arena TLS is a set-and-forget channel, so a callee chain
+that exited down an error edge could leave it pointing at a
+destroyed method scratch; the next TLS reader without its own
+preceding publish then allocated out of freed memory. Free-fn
+prologues therefore publish their `__caller_arena` param to the
+TLS, re-healing it on entry and giving TLS readers the lifetime an
+inlined body would have used.
+
+The publish is emitted only when the body could actually observe
+the TLS. Two conditions must BOTH hold:
+
+  1. the body syntactically contains a call or a struct/locus
+     instantiation — every direct TLS-reading lowering lives under
+     one of those, and a scalar-only leaf fn skips the publish
+     (emitting it measured +86% on the `fn_call` microbench);
+  2. the fn is not classified `non_allocating`. The TLS is read by
+     allocation sites, so a body that provably never allocates has
+     no reader to heal.
+
+Condition 2 exists because condition 1 alone is a syntactic test
+that cannot see through a function pointer: a two-deep helper
+chain calling through an opaque `fn` value armed the publish
+inside the caller's loop and cost 29% on the `fn_modular`
+microbench from v0.14.0 until it was gated.
+
+Neither condition weakens the #375 guarantee, which concerns a
+use-after-free reachable only FROM an allocation. The other two
+layers of that fix — `lotus_arena_destroy` clearing the TLS when
+it points at the dying arena, and method epilogues restoring their
+entry-time snapshot — are unconditional.
+
 **Phase-4 perf follow-ons.** Three substrate
 tunings that fell out of profiling the per-method scratch
 reclaim on a real-world long-running workload:


### PR DESCRIPTION
Closes #522.

## The change

One condition, at `codegen.rs`'s free-fn prologue:

```rust
-let body_can_read_tls = { …substring search over `{:?}` of the body… };
+let body_can_read_tls = !sig.non_allocating && { …same search… };
```

#375 made free-fn prologues publish `__caller_arena` to the TLS, gated on whether the body *could* read it — asked by substring-searching `{:?}` of the AST for `Call {` or `Struct {`. Any call at all armed it, including a call through a function pointer that allocates nothing. In `fn_modular` that put the publish inside a 10M-iteration loop.

The TLS is read by **allocation sites**. A body that provably never allocates has no reader to heal, and `non_allocating` is exactly that proof — the same fixed-point classifier that already lets such a fn skip its m49 subregion, and one that reasons about function-pointer params instead of giving up on them.

## Measurement

| build | fn_modular |
|---|---|
| v0.11.3 | 17.33 ms |
| v0.13.0 | 17.99 ms |
| **v0.14.0** | **23.25 ms** ← #375 landed |
| v0.19.1 | 23.24 ms |
| **this branch** | **17.32 ms** |

Full sweep re-run: no other bench moves outside noise.

## Why this doesn't reopen #375

#375 was a heap-use-after-free in `lotus_arena_alloc`, reachable **only from an allocation**. The gate now drops the publish exactly where no allocation exists to reach it. The fix's other two layers — `lotus_arena_destroy` clearing the TLS when it points at the dying arena, and method epilogues restoring their entry-time snapshot — are untouched and unconditional.

`caller_arena_tls_unwind.rs`, the cross-seed reproducer, is green including under `LOTUS_ASAN=1`.

## The test took three attempts

Worth writing down, because two of the three versions passed while measuring nothing.

1. **Asked about inlined functions.** `objdump --disassemble=make` on a symbol LLVM had inlined prints nothing, so every count was 0 — and the test that should have caught a *broken* gate passed for the same reason as the one that should have caught a *slow* one. `publish_sites` now asserts the symbol exists, and the fixtures keep their functions address-taken (pid-parity `fn` values, mirroring how the bench itself defeats inlining).
2. **Counted publishes anywhere in the body.** Call sites publish the arena before stdlib and method calls independently of the prologue gate, so an allocating body scored nonzero *even with the prologue publish deleted outright*. The assertion held while the property it named did not.
3. **Asks whether the publish precedes body work.** Not "the first call" either — an allocating fn creates its m49 subregion first, so the publish is genuinely second. Skip arena plumbing; the next call must be the publish.

All three cases are verified to fail in the right direction: forcing the gate open fails the perf case, forcing it shut fails both safety cases.

## Also

`spec/memory.md` gains the prologue publish and both of its gate conditions — #375's layer 2 was never specified, only implemented.

And the reason this survived five releases: **`fn_modular`'s tolerance band is 30% and the regression was 29%.** Bands are per-bench guesses unrelated to measured noise (this bench reproduces to 1%), and the baselines are still v0.11.3 from 2026-07-17. Both are noted in #522; neither is fixed here, and re-baselining should wait until they are, or the next one gets absorbed into the floor the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
