### PR TITLE
release: v0.19.2 — helpers get their speed back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ behavior.
 
 ---
 
-## Unreleased
+## v0.19.2 — helpers get their speed back (2026-09-04)
 
 ### The caller-arena publish is gated on allocation, not on syntax (GH #522)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "hale-cli"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "hale-codegen",
  "hale-lsp",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hale-codegen"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "hale-corpus",
  "hale-model",
@@ -103,11 +103,11 @@ dependencies = [
 
 [[package]]
 name = "hale-corpus"
-version = "0.19.1"
+version = "0.19.2"
 
 [[package]]
 name = "hale-lsp"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "hale-stdlib",
  "hale-syntax",
@@ -117,22 +117,22 @@ dependencies = [
 
 [[package]]
 name = "hale-model"
-version = "0.19.1"
+version = "0.19.2"
 
 [[package]]
 name = "hale-stdlib"
-version = "0.19.1"
+version = "0.19.2"
 
 [[package]]
 name = "hale-syntax"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "hale-corpus",
 ]
 
 [[package]]
 name = "hale-ts-shim"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "tree-sitter",
  "tree-sitter-go",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "hale-types"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "hale-corpus",
  "hale-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.19.1"
+version = "0.19.2"
 edition = "2021"
 authors = ["the Hale authors"]
 license = "Apache-2.0"


### PR DESCRIPTION
Rolls `## Unreleased` to v0.19.2 and bumps the workspace version.

One change since v0.19.1: **#522** — the caller-arena TLS publish is gated on allocation rather than on syntax, recovering a 29% regression in `fn_modular` that had been present since v0.14.0.

Pre-flight: `hale --version` reports 0.19.2, `hale fmt --check .` clean, `grep -c '^## Unreleased' CHANGELOG.md` is 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)