### PR TITLE
fix(types): reject a second accept clause on one locus instead of silently overwriting the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ behavior.
 
 ---
 
+## Unreleased
+
+### A second `accept` clause is an error, not a silent overwrite (GH #525)
+
+A locus accepts exactly one child type (`spec/types.md` F.11,
+single-accept-type per parent). The checker stored that type in a
+singular slot and a second `accept(c: U)` clause simply replaced
+the first — no diagnostic, and the parent written to own two child
+types quietly owned one. It is now a typecheck error naming both
+clauses (the second carries the first as a related span), and the
+first clause stays the locus's accept type. Surfaced by the DNA
+Phase 0 design (#521), whose first fixture needs a Step to own
+both Work and delegated Tasks and must fail loudly there.
+
 ## v0.19.2 — helpers get their speed back (2026-09-04)
 
 ### The caller-arena publish is gated on allocation, not on syntax (GH #522)

--- a/crates/hale-types/src/resolve.rs
+++ b/crates/hale-types/src/resolve.rs
@@ -777,6 +777,13 @@ fn register_locus(
     let mut bus_publishes: Vec<BusPublishInfo> = Vec::new();
     let mut bus_subscribes: Vec<BusSubscribeInfo> = Vec::new();
     let mut accept_param: Option<(String, Ty)> = None;
+    // GH #525 item 1: a locus accepts exactly one child type
+    // (`spec/types.md`, single-accept-type per parent). The
+    // singular `accept_param` used to be overwritten by a second
+    // `accept` clause with no diagnostic, so the first clause
+    // silently stopped existing. Remember where the first one was
+    // so the second can name it.
+    let mut accept_span: Option<Span> = None;
     let mut mode_returns: BTreeMap<ModeKind, Ty> = BTreeMap::new();
     let mut annotations = Annotations::default();
     let mut contract_expose: Vec<ContractEntry> = Vec::new();
@@ -877,9 +884,28 @@ fn register_locus(
                 }
             }
             LocusMember::Lifecycle(lc) if matches!(lc.kind, LifecycleKind::Accept) => {
-                if let Some(p) = lc.params.first() {
-                    let ty = resolve_type_expr(&p.ty, known);
-                    accept_param = Some((p.name.name.clone(), ty));
+                if let Some(first) = accept_span {
+                    // The first clause stays the locus's accept type;
+                    // the second is an error, not a replacement.
+                    diags.push(
+                        Diag::ty(
+                            lc.span,
+                            format!(
+                                "locus `{}` declares `accept` twice: a locus \
+                                 accepts exactly one child type. Keep one \
+                                 `accept(c: T)` here and give the other child \
+                                 type a different owner.",
+                                decl.name.name
+                            ),
+                        )
+                        .with_related(first, "first `accept` declared here"),
+                    );
+                } else {
+                    accept_span = Some(lc.span);
+                    if let Some(p) = lc.params.first() {
+                        let ty = resolve_type_expr(&p.ty, known);
+                        accept_param = Some((p.name.name.clone(), ty));
+                    }
                 }
             }
             LocusMember::Mode(md) => {

--- a/crates/hale-types/tests/duplicate_accept.rs
+++ b/crates/hale-types/tests/duplicate_accept.rs
@@ -1,0 +1,78 @@
+//! GH #525 item 1 (2026-09-04): a locus accepts exactly one child
+//! type (`spec/types.md`, single-accept-type per parent). A second
+//! `accept` clause used to overwrite the first with no diagnostic,
+//! so a parent written to own two child types silently owned one.
+//! It is now an error naming both clauses; the first stays the
+//! locus's accept type.
+
+use hale_syntax::parse_source;
+use hale_types::check_program;
+
+const TWO_ACCEPTS: &str = r#"
+locus Work { params { id: Int = 0; } run() { } }
+locus Task { params { id: Int = 0; } run() { } }
+
+locus Step {
+    params { n: Int = 0; }
+    accept(w: Work) { }
+    accept(t: Task) { }
+    run() {
+        Work { id: 1 };
+    }
+}
+
+main locus App {
+    params { s: Step = Step { }; }
+    run() { }
+}
+fn main() { App { }; }
+"#;
+
+#[test]
+fn a_second_accept_clause_is_an_error_naming_both() {
+    let prog = parse_source(TWO_ACCEPTS).expect("parse");
+    let diags = check_program(&prog);
+    let hit = diags
+        .iter()
+        .find(|d| d.message.contains("declares `accept` twice"))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a duplicate-accept diagnostic, got: {:?}",
+                diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+            )
+        });
+    assert!(
+        hit.message.contains("locus `Step`"),
+        "names the locus: {}",
+        hit.message
+    );
+    assert!(
+        hit.related
+            .iter()
+            .any(|(_, label)| label.contains("first `accept` declared here")),
+        "carries the first clause as related: {:?}",
+        hit.related
+    );
+    // The FIRST clause is the one that survives: `Work` is still
+    // accepted, so the `Work { }` literal inside `run()` resolves
+    // an owner and raises nothing of its own.
+    let (first_span, _) = hit.related[0];
+    assert!(
+        first_span.start < hit.span.start,
+        "related span points at the earlier clause: {:?} vs {:?}",
+        first_span,
+        hit.span
+    );
+}
+
+#[test]
+fn one_accept_clause_is_clean() {
+    let src = TWO_ACCEPTS.replace("    accept(t: Task) { }\n", "");
+    let prog = parse_source(&src).expect("parse");
+    let diags = check_program(&prog);
+    assert!(
+        diags.iter().all(|d| !d.message.contains("declares `accept` twice")),
+        "got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/docs/src/services/parents-children.md
+++ b/docs/src/services/parents-children.md
@@ -38,6 +38,11 @@ parent's `self.children` holds its accepted children (with
 `self.children.count` and `self.children.is_empty` for quick
 summaries).
 
+A locus accepts **one** child type. Writing a second `accept` is a
+compile error that points at both clauses; if a parent needs to own
+two kinds of children, one of them belongs under a different owner
+(or the same owner one level down).
+
 ## Bubbling: the nearest accepting ancestor collects the child
 
 `accept` isn't limited to *direct* children. If you instantiate a

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -829,6 +829,13 @@ Receives c's declared params (not its running state). Can:
 After accept returns normally, child registers in
 `self.children` (per F.11).
 
+A locus declares **at most one** `accept` (single-accept-type per
+parent, `types.md` F.11). A second `accept` clause is a typecheck
+error naming both clauses; the first clause remains the locus's
+accept type. A parent that must own two child types gives one of
+them a different owner. (2026-09-04, GH #525: a second clause used
+to overwrite the first silently.)
+
 ### `run()`
 
 Runs continuously until drain is requested or run returns


### PR DESCRIPTION
Track 0 item 1 of #525 (DNA epic #521).

A locus accepts exactly one child type (`spec/types.md` F.11, single-accept-type per parent). `resolve.rs` stored that type in a singular `Option` and every `LifecycleKind::Accept` member assigned it, so a second `accept(c: U)` clause replaced the first with no diagnostic. A parent written to own two child types quietly owned one, and the child literal inside it still found an owner, so nothing downstream noticed either.

It is now a typecheck error naming both clauses (the second carries the first as a related span), and the first clause stays the locus's accept type so the rest of the check sees the same program it always did.

Surfaced by the DNA Phase 0 design: its first fixture needs a Step to own both Work and delegated Tasks, and that has to fail loudly rather than compile into something else.

- `crates/hale-types/src/resolve.rs`: track the first clause's span, diagnose the second.
- `crates/hale-types/tests/duplicate_accept.rs`: two clauses error with related span pointing at the earlier one; one clause is clean.
- `spec/semantics.md` `accept(c)` section, `docs/src/services/parents-children.md`, CHANGELOG.

Verified: `cargo nextest run --release -p hale-types` (1159 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
