### PR TITLE
feat(types): perspective designation at a construction site (serves-aware literal override)

### DIFF
--- a/.effects-baseline/corpus.effects
+++ b/.effects-baseline/corpus.effects
@@ -279,6 +279,9 @@ main  does={alloc}
 HashmapAnchorChurn::run  does={syscall,alloc}
 HashmapAnchorChurn::step  does={alloc}
 main  does={alloc}
+### 65-perspective-ctor-override
+App::run  does={syscall}
+main  does={alloc}
 ### 66-self-field-retire
 SelfFieldRetire::alias_literal  does={alloc}
 SelfFieldRetire::alias_struct  does={alloc}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ first clause stays the locus's accept type. Surfaced by the DNA
 Phase 0 design (#521), whose first fixture needs a Step to own
 both Work and delegated Tasks and must fail loudly there.
 
+### A constructor can designate a perspective slot (GH #525)
+
+`App { gw: Gateway { router: RouterV2 { } } }` — where `router` is
+`perspective(Router)` — now typechecks and designates the slot with
+`RouterV2`, overriding the holder's declaration-site default. The
+param-default path already consulted `serves`; the literal-override
+path only knew about interfaces, so a `perspective(P)` field fell
+through to plain assignability and `Router != RouterV2`. Codegen
+had handled the override all along. An override that names a locus
+not serving the perspective is refused with the `serves` clause it
+needs. The slot stays program-global and 1-1: an override picks the
+program's impl, exactly as a default does. Fixture
+`65-perspective-ctor-override`. Asked for by the DNA assembly shape
+in #521 (test assembles a fake, deployment assembles the real one,
+the holder's source never changes).
+
 ## v0.19.2 — helpers get their speed back (2026-09-04)
 
 ### The caller-arena publish is gated on allocation, not on syntax (GH #522)

--- a/crates/hale-codegen/tests/fixtures/examples/65-perspective-ctor-override/main.hl
+++ b/crates/hale-codegen/tests/fixtures/examples/65-perspective-ctor-override/main.hl
@@ -1,0 +1,69 @@
+// 65-perspective-ctor-override — designating a perspective slot
+// from a CONTAINING constructor (GH #525 item 2, 2026-09-04).
+//
+// 60-perspective-slot designates at the declaration site:
+//
+//   locus Gateway { params { router: perspective(Router) = RouterV1 { }; } }
+//
+// The holder's default names an impl. But the locus that assembles
+// a Gateway is the one that knows which impl this program wants —
+// a test assembles a fake, a deployment assembles the real thing —
+// and it should be able to say so where it constructs the holder,
+// the way it already can for an interface-typed field:
+//
+//   App { gw: Gateway { router: RouterV2 { } } }
+//
+// The override designates the slot exactly as the default would
+// have: `RouterV2` is instantiated as an owned child of the
+// Gateway, and the program-global `Router` slot points at it. The
+// slot is 1-1, so this is the program's routing, not this
+// Gateway's — same as a default. The impl must `serves Router`;
+// a locus that does not is refused at the override with a message
+// naming the missing `serves` clause.
+
+perspective Router {
+    fn route(code: Int) -> Int;
+    fn health() -> Int;
+}
+
+locus RouterV1 : serves Router {
+    fn route(code: Int) -> Int {
+        return code + 100;
+    }
+    fn health() -> Int {
+        return 1;
+    }
+}
+
+locus RouterV2 : serves Router {
+    fn route(code: Int) -> Int {
+        return code + 200;
+    }
+    fn health() -> Int {
+        return 2;
+    }
+}
+
+locus Gateway {
+    params {
+        router: perspective(Router) = RouterV1 { };
+    }
+    fn handle(code: Int) -> Int {
+        return self.router.route(code);
+    }
+}
+
+main locus App {
+    params {
+        // The constructor, not the declaration, picks the impl.
+        gw: Gateway = Gateway { router: RouterV2 { } };
+    }
+    run() {
+        println(self.gw.handle(41)); // 241 — V2, not the default V1
+        println(self.gw.router.health()); // 2
+    }
+}
+
+fn main() {
+    App { };
+}

--- a/crates/hale-codegen/tests/perspective_ctor_override_agreement.rs
+++ b/crates/hale-codegen/tests/perspective_ctor_override_agreement.rs
@@ -1,0 +1,82 @@
+//! GH #525 item 2 / PR #531 review: check and build must agree on
+//! perspective designation at a construction site.
+//!
+//! The locus case is accepted by the checker AND lowered by
+//! `lower_locus_instantiation`, so it builds and routes through the
+//! override. The data-type case has no designation path in
+//! `populate_user_type_fields`; the checker must refuse it, because
+//! a program that checks and then fails to build is the worst
+//! failure mode the toolchain has (see corpus_check_build_agreement).
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+use hale_syntax::parse_source;
+use hale_types::check_program;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+const PERSPECTIVE: &str = r#"
+perspective Router {
+    fn route(code: Int) -> Int;
+}
+locus RouterV1 : serves Router {
+    fn route(code: Int) -> Int { return code + 100; }
+}
+locus RouterV2 : serves Router {
+    fn route(code: Int) -> Int { return code + 200; }
+}
+"#;
+
+#[test]
+fn locus_field_override_checks_and_builds() {
+    let src = format!(
+        "{PERSPECTIVE}
+locus Gateway {{
+    params {{ router: perspective(Router) = RouterV1 {{ }}; }}
+    fn handle(code: Int) -> Int {{ return self.router.route(code); }}
+}}
+main locus App {{
+    params {{ gw: Gateway = Gateway {{ router: RouterV2 {{ }} }}; }}
+    run() {{ println(self.gw.handle(1)); }}
+}}
+fn main() {{ App {{ }}; }}
+"
+    );
+    let program = parse_source(&src).expect("parse");
+    let diags = check_program(&program);
+    assert!(
+        diags.iter().all(|d| !d.message.contains("expects `Router`")),
+        "checker refused the locus override: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let bin = harness::unique_bin("hale_test_persp_ctor_locus");
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(out.status.success(), "exit: {:?}", out.status);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("201"), "override not routed: {:?}", stdout);
+}
+
+#[test]
+fn data_type_field_override_is_refused_by_the_checker_not_the_build() {
+    let src = format!(
+        "{PERSPECTIVE}
+type Holder {{ router: perspective(Router); }}
+fn main() {{
+    let holder = Holder {{ router: RouterV2 {{ }} }};
+    println(holder.router.route(1));
+}}
+"
+    );
+    let program = parse_source(&src).expect("parse");
+    let diags = check_program(&program);
+    assert!(
+        diags.iter().any(|d| d.message.contains("type `Holder`")
+            && d.message.contains("field `router` expects `Router`, got `RouterV2`")),
+        "checker must refuse a data-type designation (codegen cannot lower it): {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -13423,7 +13423,69 @@ impl<'a> Checker<'a> {
                     } else {
                         false
                     };
-                    if !interface_satisfied && !want.assignable_from(&got) {
+                    // GH #525 item 2 (2026-09-04): perspective
+                    // designation at a CONSTRUCTION site —
+                    // `App { gw: Gateway { router: RouterV2 { } } }`
+                    // where `router: perspective(Router)`. The
+                    // param-default path already asks `serves`
+                    // (the `conforms` computation in the params
+                    // check); this path only knew about
+                    // interfaces, so `perspective(P)` — a plain
+                    // `Ty::Named(P)` whose symbol is a Perspective,
+                    // not an Interface — fell through to
+                    // `assignable_from` and `P != Impl`. Codegen's
+                    // designation branch already fires for an
+                    // override value, so the checker was the only
+                    // thing refusing it. Note the slot is
+                    // program-global (1-1): an override designates
+                    // the whole program's slot, exactly as a
+                    // default does.
+                    let perspective_designated = if let (
+                        Ty::Named(pname),
+                        Ty::Named(arg_name),
+                    ) = (want, &got)
+                    {
+                        if matches!(
+                            self.top.lookup(pname),
+                            Some(TopSymbol::Perspective(_))
+                        ) {
+                            match self.top.symbols.get(arg_name) {
+                                Some(TopSymbol::Locus(li)) => {
+                                    if !li.serves.iter().any(|sv| sv == pname) {
+                                        self.diags.push(Diag::ty(
+                                            init.value.span(),
+                                            format!(
+                                                "{} `{}`: field `{}` is \
+                                                 `perspective({})`, but `{}` \
+                                                 does not serve it — declare \
+                                                 `locus {} : serves {}`",
+                                                kind_label,
+                                                name,
+                                                init.name.name,
+                                                pname,
+                                                arg_name,
+                                                arg_name,
+                                                pname
+                                            ),
+                                        ));
+                                    }
+                                    // Reported (or fine) — either way
+                                    // the generic mismatch below would
+                                    // only repeat it.
+                                    true
+                                }
+                                _ => false,
+                            }
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    };
+                    if !interface_satisfied
+                        && !perspective_designated
+                        && !want.assignable_from(&got)
+                    {
                         self.diags.push(Diag::ty(
                             init.value.span(),
                             format!(

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -13440,10 +13440,19 @@ impl<'a> Checker<'a> {
                     // program-global (1-1): an override designates
                     // the whole program's slot, exactly as a
                     // default does.
+                    //
+                    // LOCUS literals only. This fn is shared with
+                    // data-type literals, and codegen's
+                    // `populate_user_type_fields` has no designation
+                    // path (`type Holder { r: perspective(P); }` then
+                    // `Holder { r: Impl { } }` fails at build). A
+                    // data-type field keeps the plain mismatch below
+                    // so check and build agree (PR #531 review).
                     let perspective_designated = if let (
+                        "locus",
                         Ty::Named(pname),
                         Ty::Named(arg_name),
-                    ) = (want, &got)
+                    ) = (kind_label, want, &got)
                     {
                         if matches!(
                             self.top.lookup(pname),

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -870,6 +870,7 @@ crates/hale-codegen/tests/parse_float_and_base64_decode.rs#3 865d341109268295
 crates/hale-codegen/tests/parse_float_and_base64_decode.rs#4 f2c1228edb650960
 crates/hale-codegen/tests/parse_float_and_base64_decode.rs#5 f2c1228edb650960
 crates/hale-codegen/tests/parse_float_and_base64_decode.rs#6 f2c1228edb650960
+crates/hale-codegen/tests/perspective_ctor_override_agreement.rs#0 c1eb6094c0eecf4b
 crates/hale-codegen/tests/phase_b_fixes.rs#0 b7a78549e2c4bab4
 crates/hale-codegen/tests/phase_b_fixes.rs#1 f2c1228edb650960
 crates/hale-codegen/tests/phase_b_fixes.rs#10 865d341109268295

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -474,6 +474,7 @@ crates/hale-codegen/tests/fixtures/examples/62-perspective-bus-contract/main.hl 
 crates/hale-codegen/tests/fixtures/examples/63-reperspective-migrate/main.hl 75c7b88e5a182e96
 crates/hale-codegen/tests/fixtures/examples/64-perspective-bus-swap/main.hl e0f296bf12522941
 crates/hale-codegen/tests/fixtures/examples/65-hashmap-anchor-churn/main.hl 92d6843159115d65
+crates/hale-codegen/tests/fixtures/examples/65-perspective-ctor-override/main.hl a534177a38392623
 crates/hale-codegen/tests/fixtures/examples/66-self-field-retire/main.hl 4e9b425623277732
 crates/hale-codegen/tests/fixtures/examples/67-match-expression/main.hl c47d56a3606d2948
 crates/hale-codegen/tests/fixtures/examples/68-hot-certified/main.hl 5845a32f60e45386

--- a/crates/hale-types/tests/perspective_serves.rs
+++ b/crates/hale-types/tests/perspective_serves.rs
@@ -415,3 +415,31 @@ fn ctor_override_with_non_serving_locus_names_the_missing_serves() {
         msgs
     );
 }
+
+#[test]
+fn ctor_override_on_a_data_type_field_is_still_rejected() {
+    // PR #531 review: `check_literal_fields` is shared with data-type
+    // literals, and codegen has no designation path for a `type`
+    // field, so the checker must keep refusing this exactly as the
+    // base did — otherwise `hale check` passes and `hale build` fails.
+    let src = r#"
+perspective Router {
+    fn route(code: Int) -> Int;
+}
+locus RouterV2 : serves Router {
+    fn route(code: Int) -> Int { return code + 2; }
+}
+type Holder { router: perspective(Router); }
+fn main() {
+    let holder = Holder { router: RouterV2 { } };
+    println(holder.router.route(1));
+}
+"#;
+    let msgs = check(src);
+    assert!(
+        msgs.iter().any(|m| m.contains("type `Holder`")
+            && m.contains("field `router` expects `Router`, got `RouterV2`")),
+        "expected the data-type literal to keep its mismatch, got: {:?}",
+        msgs
+    );
+}

--- a/crates/hale-types/tests/perspective_serves.rs
+++ b/crates/hale-types/tests/perspective_serves.rs
@@ -357,3 +357,61 @@ fn main() { App { }; }
         msgs
     );
 }
+
+// GH #525 item 2 (2026-09-04): designation at a CONSTRUCTION site.
+// The param-default path consulted `serves`; the literal-override
+// path only knew interfaces, so a containing constructor could not
+// pick the impl. Codegen already handled the override; the checker
+// was the only refusal.
+
+const CTOR_OVERRIDE: &str = r#"
+perspective Router {
+    fn route(code: Int) -> Int;
+}
+locus RouterV1 : serves Router {
+    fn route(code: Int) -> Int { return code + 1; }
+}
+locus RouterV2 : serves Router {
+    fn route(code: Int) -> Int { return code + 2; }
+}
+locus Plain {
+    fn route(code: Int) -> Int { return code + 3; }
+}
+locus Gateway {
+    params { router: perspective(Router) = RouterV1 { }; }
+}
+main locus App {
+    params { gw: Gateway = Gateway { router: IMPL { } }; }
+    run() { }
+}
+fn main() { App { }; }
+"#;
+
+#[test]
+fn ctor_override_with_serving_locus_clean() {
+    let msgs = check(&CTOR_OVERRIDE.replace("IMPL", "RouterV2"));
+    assert!(
+        msgs.iter().all(|m| !m.contains("expects `Router`")
+            && !m.contains("does not serve")),
+        "expected the override to typecheck clean, got: {:?}",
+        msgs
+    );
+}
+
+#[test]
+fn ctor_override_with_non_serving_locus_names_the_missing_serves() {
+    let msgs = check(&CTOR_OVERRIDE.replace("IMPL", "Plain"));
+    assert!(
+        msgs.iter().any(|m| m.contains("field `router` is `perspective(Router)`")
+            && m.contains("`Plain` does not serve it")
+            && m.contains("locus Plain : serves Router")),
+        "expected a serves-naming diagnostic, got: {:?}",
+        msgs
+    );
+    // And only that one — not the generic mismatch on top of it.
+    assert!(
+        msgs.iter().all(|m| !m.contains("expects `Router`, got `Plain`")),
+        "generic mismatch should be suppressed, got: {:?}",
+        msgs
+    );
+}

--- a/docs/src/services/perspectives.md
+++ b/docs/src/services/perspectives.md
@@ -46,8 +46,9 @@ tier 2` is fine.
 ## Holding and calling through a perspective
 
 A holder programs against `perspective(Router)` — never a concrete
-implementation. It designates the slot with a conforming impl, then
-calls through it:
+implementation. It designates the slot with a conforming impl
+(by default at its own declaration, or from whoever constructs it —
+see below), then calls through it:
 
 ```hale
 locus Gateway {
@@ -59,6 +60,26 @@ locus Gateway {
     }
 }
 ```
+
+The locus that *assembles* a `Gateway` can pick the impl instead of
+taking the declaration's default, the same way it can fill any
+interface-typed field:
+
+```hale
+main locus App {
+    params {
+        gw: Gateway = Gateway { router: RouterV2 { } };  // not RouterV1
+    }
+}
+```
+
+`RouterV2` must `serves Router`; a locus that doesn't is refused
+right there with the `serves` clause it needs. One thing to keep in
+mind: the slot is program-global, so this chooses the *program's*
+router, not this Gateway's — if two holders are constructed with
+different impls, the last designation wins, just as it would with
+two different defaults. Tests assemble a fake, deployments assemble
+the real one, and the holder's source never changes.
 
 `self.router.route(...)` doesn't call `RouterV1` directly — it goes
 through the perspective's **slot**. That indirection is the whole

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -2884,6 +2884,18 @@ P) }` into the global slot. The field itself stores the impl's
 self-pointer for ownership; the slot holds the same pointer plus
 the vtable for dispatch.
 
+A containing constructor may designate instead (2026-09-04, GH
+#525): `App { gw: Gateway { router: RouterV2 { } } }` overrides the
+holder's default with `RouterV2`, which is instantiated as the
+holder's owned child and stored into the slot exactly as the
+default would have been. The override must name a locus that
+`serves P`; one that does not is a typecheck error naming the
+missing `serves` clause. Because the slot is program-global and
+1-1, an override designates the *program's* impl, not a
+per-instance one — two holders constructed with different impls
+race on one slot, last designation wins, the same as two holders
+with different defaults.
+
 **Cost.** Steady state is one load + one predicted indirect call
 per call into a perspective — near-direct. The mechanism is
 Linux/native-agnostic (no new runtime dependency); a program that

--- a/tests/hale/perspective_ctor_override_test.hl
+++ b/tests/hale/perspective_ctor_override_test.hl
@@ -1,0 +1,32 @@
+// GH #525 item 2 (2026-09-04): a containing constructor designates
+// a `perspective(P)` field with a serving locus, overriding the
+// holder's declaration-site default. The override is the impl the
+// program dispatches through — read back through the holder, not
+// just typechecked.
+
+perspective Router {
+    fn route(code: Int) -> Int;
+}
+
+locus RouterV1 : serves Router {
+    fn route(code: Int) -> Int { return code + 100; }
+}
+
+locus RouterV2 : serves Router {
+    fn route(code: Int) -> Int { return code + 200; }
+}
+
+locus Gateway {
+    params { router: perspective(Router) = RouterV1 { }; }
+    fn handle(code: Int) -> Int { return self.router.route(code); }
+}
+
+main locus App {
+    params { gw: Gateway = Gateway { router: RouterV2 { } }; }
+    run() {
+        std::test::assert_eq_int(self.gw.handle(1), 201, "ctor override designates the slot");
+        std::test::assert_eq_int(self.gw.router.route(0), 200, "direct call through the field sees the override");
+    }
+}
+
+fn main() { App { }; }


### PR DESCRIPTION
Track 0 item 2 of #525 (DNA epic #521). Confirms and closes the gap named in the first comment on #521.

`App { gw: Gateway { router: RouterV2 { } } }`, where `router` is `perspective(Router)`, was refused with `locus Gateway: field router expects Router, got RouterV2`, while the same override of an interface-typed field was fine. The param-default path (`conforms` in the params check) already consulted the impl's `serves` list; `check_literal_fields` only knew about interfaces, so a `perspective(P)` field, a plain `Ty::Named(P)` whose symbol is a Perspective, fell through to `assignable_from` and `P != Impl`. Codegen's designation branch in `lower_locus_instantiation` already fires for an override value, so the checker was the only thing in the way.

`check_literal_fields` now mirrors the param path. An override naming a locus that serves the perspective designates the slot. One that does not is refused with the `serves` clause it needs, and the generic mismatch is suppressed so the message is not doubled.

The slot stays program-global and 1-1. An override designates the program's impl exactly as a default does; two holders constructed with different impls are last-wins, the same as two holders with different defaults. Spec and docs say so rather than inventing a per-instance rule.

- `crates/hale-types/src/check.rs`: the `serves`-aware branch.
- `crates/hale-codegen/tests/fixtures/examples/65-perspective-ctor-override/`: runs and prints the V2 result (241, 2).
- `tests/hale/perspective_ctor_override_test.hl`: reads the routed value back through the holder.
- `crates/hale-types/tests/perspective_serves.rs`: override clean; non-serving override names the missing `serves` and suppresses the generic mismatch.
- `crates/hale-types/tests/fixtures/topology_shape_baseline.txt`: one added row for the new fixture.
- `spec/semantics.md` designation paragraph, `docs/src/services/perspectives.md`, CHANGELOG.

Verified: hale-types suite (1159), corpus oracle, syntax examples, hale-native suite, `hale run` on the fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
