### PR TITLE
fix(obs): aux_b carries the canonical entity id; retire the v0 binding/scheduler meaning, proto 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ behavior.
 
 ## Unreleased
 
+### Observation proto 0.4: `aux_b` means one thing (GH #525, iris handoff-14 P31)
+
+Iris's PROTOCOL §4 and its reference emitters had used a manifest
+row's `aux_b` since v0 as *binding → owning topic id, scheduler →
+cpu index*. hale's native emitter, from proto 0.3, wrote the
+canonical model entity id there for every kind — and this file's
+rationale said the field had "been written as 0 by every path",
+which was true of hale's emitter and false of the protocol's. The
+two meanings are not distinguishable from the value; nothing was
+broken only because no consumer read the field yet.
+
+Resolved by retiring the v0 meaning rather than moving the entity
+id: `proto_minor` is now 4, every emitter writes the entity id or
+0, the scheduler cpu index moves to `aux_a`, and the binding →
+topic pairing is dropped (the counter table and the binding name
+carry it). No layout change. A consumer still gates on
+`entity_id_digest != 0`; at minor ≥ 4 it may additionally trust
+that a nonzero `aux_b` was never anything else. The paired iris
+change (protocol.h, synth.c, observe/glue.c, PROTOCOL §4/§13) is
+handed over as `UPSTREAM-NOTE-2026-09-04-aux-b.md` in the iris
+tree. Last open item before the protocol freezes at v0.
+
 ### A second `accept` clause is an error, not a silent overwrite (GH #525)
 
 A locus accepts exactly one child type (`spec/types.md` F.11,

--- a/crates/hale-codegen/runtime/lotus_obs.c
+++ b/crates/hale-codegen/runtime/lotus_obs.c
@@ -187,11 +187,22 @@ void lotus_obs_model_hash_set(uint64_t h) { g_obs_model_hash = h; }
  * against the source-derived model had to match on strings and hope
  * the two spellings agreed. These rows give the compiler's answer
  * instead: for each (kind, name) the canonical `ApplicationModel`
- * entity id, published in the manifest entry's `aux_b` — a field
- * that has been in the ABI since v0 and written as 0 by every path,
- * so no consumer's layout moves. `aux_b == 0` still means "no
- * canonical id" (harness builds, or an entity the model doesn't
- * name, e.g. a stdlib subject).
+ * entity id, published in the manifest entry's `aux_b`. `aux_b == 0`
+ * means "no canonical id" (harness builds, or an entity the model
+ * doesn't name, e.g. a stdlib subject).
+ *
+ * Correction to the original rationale (iris handoff-14 P31,
+ * 2026-08-24): this file claimed `aux_b` had "been written as 0 by
+ * every path". True of THIS emitter, false of the protocol's — iris
+ * PROTOCOL.md §4 and its reference emitters had used the field
+ * since v0 as binding->owning topic id / scheduler->cpu index, so
+ * from 0.3 the same bytes meant two things depending on who wrote
+ * the segment. Resolved at proto 0.4 (GH #525) by retiring the v0
+ * meaning: every emitter writes the entity id or 0, the scheduler
+ * cpu index moves to `aux_a`, and the binding->topic pairing is
+ * dropped (the counter table and the binding name already carry
+ * it). The layout never moved; the meaning did, and a consumer
+ * depends on the meaning.
  *
  * Entity ids are only meaningful WITH the header's `model_hash`:
  * they are indices into that model's tables, not stable names. */
@@ -1875,7 +1886,14 @@ static int obs_create(int64_t rings, int64_t slots) {
   memset(MODE, 2 /* PACKED */, OBS_ENTRY_CAP);
   memset(g_cnt_line_for, -1, sizeof g_cnt_line_for);
 
-  *H = (obs_hdr_t){ .magic = OBS_MAGIC, .proto_major = 0, .proto_minor = 3,
+  /* proto 0.4 (2026-09-04, GH #525 / iris handoff-14 P31): no
+   * layout change. The bump records that `aux_b` now has ONE
+   * meaning across every emitter — canonical entity id, or 0 —
+   * and that v0's binding->topic / scheduler->cpu reading is
+   * retired. A consumer gates on entity_id_digest != 0 as before;
+   * at minor >= 4 it may additionally trust that a nonzero aux_b
+   * was never anything else. */
+  *H = (obs_hdr_t){ .magic = OBS_MAGIC, .proto_major = 0, .proto_minor = 4,
     .header_len = sizeof(obs_hdr_t), .total_len = g_seg_len,
     .pid = (uint32_t)getpid(), .ring_count = (uint32_t)rings,
     .ring_slots = (uint32_t)slots, .ts_shift = 4,

--- a/crates/hale-codegen/tests/obs_entity_ids_unstamped.rs
+++ b/crates/hale-codegen/tests/obs_entity_ids_unstamped.rs
@@ -48,6 +48,7 @@ fn a_harness_build_leaves_manifest_entity_ids_zero() {
     let shm = format!("/dev/shm/hale-obs-{}", pid);
     let mut seen = 0usize;
     let mut nonzero = Vec::new();
+    let mut proto_minor = 0u16;
     for _ in 0..80 {
         std::thread::sleep(Duration::from_millis(25));
         let Ok(b) = std::fs::read(&shm) else { continue };
@@ -58,6 +59,7 @@ fn a_harness_build_leaves_manifest_entity_ids_zero() {
             |o: usize| u64::from_le_bytes(b[o..o + 8].try_into().unwrap());
         let u32at =
             |o: usize| u32::from_le_bytes(b[o..o + 4].try_into().unwrap());
+        proto_minor = u16::from_le_bytes(b[0x0A..0x0C].try_into().unwrap());
         let manifest_off = u64at(0x40) as usize;
         if manifest_off == 0 || manifest_off + 16 > b.len() {
             continue;
@@ -84,6 +86,15 @@ fn a_harness_build_leaves_manifest_entity_ids_zero() {
     let _ = std::fs::remove_file(&bin);
 
     assert!(seen > 0, "no manifest rows observed — test proves nothing");
+    // proto 0.4 (GH #525 / iris handoff-14 P31): the minor at which
+    // `aux_b` has exactly one meaning for every emitter — entity id
+    // or 0. A consumer that sees >= 4 may trust a nonzero aux_b was
+    // never a topic id or a cpu index. Bumping this constant is a
+    // protocol decision, not a test fix.
+    assert_eq!(
+        proto_minor, 4,
+        "segment header proto_minor: aux_b's single meaning is pinned at 0.4"
+    );
     assert!(
         nonzero.is_empty(),
         "an unstamped build published canonical entity ids: {:?}",

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1469,6 +1469,19 @@ and publishes NO ids and NO digest rather than a partial table —
 partial canonicalization is indistinguishable from "unstamped" and
 would put a consumer back on name matching without telling it.
 
+**proto 0.4 (2026-09-04, GH #525 / iris handoff-14 P31).** No
+layout change. Iris's PROTOCOL §4 and its reference emitters had
+used `aux_b` since v0 as *binding → owning topic id, scheduler →
+cpu index*, so from 0.3 a nonzero `aux_b` meant two things
+depending on which emitter wrote the segment. 0.4 retires the v0
+meaning: every emitter writes the canonical entity id or 0, the
+scheduler cpu index moves to `aux_a`, and the binding → topic
+pairing is dropped (the counter table and the binding name carry
+it). A consumer still gates on `entity_id_digest != 0`; at minor
+≥ 4 it may additionally trust that a nonzero `aux_b` was never
+anything else. This was the last open item before the protocol
+freezes at v0.
+
 **Identity is stamped before anything can register.** The prelude
 publishes `model_hash`, `exec_digest`, and the entity ids ahead of
 the bindings prelude and the config loader, because registering a


### PR DESCRIPTION
Track 0 item 3 of #525 (DNA epic #521). Answers iris handoff-14 P31 (`HANDOFF-iris-14-aux-b-collision.md`).

Iris's PROTOCOL §4 and its reference emitters had used a manifest row's `aux_b` since v0 as binding → owning topic id and scheduler → cpu index. hale's native emitter, from proto 0.3, wrote the canonical model entity id there for every kind, and the rationale in `lotus_obs.c` said the field had "been written as 0 by every path", which was true of this emitter and false of the protocol's. The two meanings are not distinguishable from the value. Nothing was broken only because no consumer read the field yet. Handoff-14 asked hale to pick: give the entity id its own field, or retire v0's meaning.

**Retired.** The entity id is the #476 join and what every consumer arriving next (Track B's model-diff perspective, Track C's experience view) will read; v0's use was one binding row and the scheduler rows in `synth.c`. `proto_minor` is now 4 with no layout change, because the meaning moved and a consumer depends on the meaning, not the offset. Every emitter writes the entity id or 0, the scheduler cpu index moves to `aux_a`, and the binding → topic pairing is dropped (the counter table and the binding name carry it). A consumer still gates on `entity_id_digest != 0`; at minor ≥ 4 it may additionally trust a nonzero `aux_b` was never anything else.

- `crates/hale-codegen/runtime/lotus_obs.c`: `proto_minor = 4`, rationale corrected and credited.
- `crates/hale-codegen/tests/obs_entity_ids_unstamped.rs`: pins `proto_minor == 4` in the header so a future bump is a protocol decision, not a test fix.
- `spec/runtime.md` § Native observation emission, CHANGELOG.

**Paired iris change**, not in this PR because the iris worktree carries uncommitted inspector work (item 4 of #525): `UPSTREAM-NOTE-2026-09-04-aux-b.md` plus `aux_b_proto04.patch` are dropped untracked in the iris tree, cut against its current working tree. The patch touches `emitter/protocol.h` (`OBS_PROTO_MINOR 4`, history line, `aux_b` comment), `emitter/synth.c`, `observe/glue.c`, and PROTOCOL §4/§13. Verified in a scratch copy: `git apply --check` clean, `emitter/` and `consumer/` build, `observe/glue.c` compiles with `-Wall`.

Verified here: all 19 `obs_*` integration tests in hale-codegen pass at 0.4.

With this in, PROTOCOL §13 has no open item blocking the v0 freeze on the hale side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
