### PR TITLE
fix(codegen,types): release runs the accepting owner's own body; @unbounded acknowledges the hot-path advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ behavior.
 
 ## Unreleased
 
+### `release(c)` runs the accept'ing owner's own body (GH #526 F.6)
+
+One child type accepted by two parent types — `Attempt` under both
+`Work` and `WorkSystem` in the DNA core — segfaulted: the reclaim
+spine found "the" release fn by child type alone, so the first parent
+type that declared `release(c: Attempt)` won program-wide and its
+body ran over the other parent's `self`. Minimized, `B accept` was
+followed by `A release` with B's counter incremented. Every locus
+now carries a synthetic `__owner_release` pointer, stored at accept
+dispatch from the accept'ing parent TYPE (null when that parent
+declares no `release` for the child), and reclaim calls through it.
+Whether a type is a flow (run-completion reclaims) stays type-wide;
+which body runs is per owner. Regression:
+`crates/hale-codegen/tests/release_two_parents.rs`.
+
+### `@unbounded` now acknowledges the hot-path advisory (GH #526 F.2)
+
+Every hot-path advisory ended with "or acknowledge an intentional
+shape with `@unbounded` on the enclosing fn/hook", and the walker
+never read the flag, so `hale verify` stayed red on a param-bounded
+fan-out loop. It reads it now; `@hot` still hard-errors.
+
 ### Observation proto 0.4: `aux_b` means one thing (GH #525, iris handoff-14 P31)
 
 Iris's PROTOCOL §4 and its reference emitters had used a manifest

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -6051,6 +6051,15 @@ pub(crate) struct LocusInfo<'ctx> {
     /// routing-gated). Read by a flow child's run-wrapper to fire
     /// `parent.release(owner, child)`. Null when never accept'd.
     pub(crate) owner_self_field_idx: u32,
+    /// GH #526 F.6 (2026-09-05): index of the synthetic
+    /// `__owner_release: ptr` field — the accept'ing PARENT TYPE's
+    /// `release` fn, stored beside `__owner_self` at accept dispatch
+    /// (null when that parent declares no `release` for this child
+    /// type, or the locus was never accept'd). The reclaim spine used
+    /// to find "the" release fn by child type alone, so with two
+    /// parents accepting one child type the first parent's body ran
+    /// over the other parent's self — silent memory corruption.
+    pub(crate) owner_release_field_idx: u32,
     /// Interest-based ownership, artifact #2b — indices of the synthetic
     /// `__owner_for_<I>: ptr` fields, one per interest-type `I` in this
     /// locus's forwarding set (keyed by `I`). Threaded at birth: set to
@@ -7196,6 +7205,15 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             }
             // `release(c)` parent bookend — after drain, before
             // dissolve — for a flow with a non-null owner.
+            //
+            // GH #526 F.6: the fn CALLED is the one the accept'ing
+            // parent stored in `__owner_release` at accept dispatch,
+            // not `release_fn` (which is only "some parent releases
+            // this type" — the flow-ness decision). Two parents may
+            // accept one child type; each owner's own body must run
+            // over its own self. A null pointer (this owner declares no
+            // release for the type, or the child was never accept'd)
+            // skips the call.
             if let Some(rfn) = release_fn {
                 let owner_ptr = self
                     .builder
@@ -7211,21 +7229,44 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                     .build_load(ptr_t, owner_ptr, &format!("{}.reclaim.owner", locus_name))
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
                     .into_pointer_value();
+                let rel_slot = self
+                    .builder
+                    .build_struct_gep(
+                        info.struct_ty,
+                        self_arg,
+                        info.owner_release_field_idx,
+                        &format!("{}.reclaim.owner_release.ptr", locus_name),
+                    )
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                let rel_fn_ptr = self
+                    .builder
+                    .build_load(ptr_t, rel_slot, &format!("{}.reclaim.owner_release", locus_name))
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                    .into_pointer_value();
                 let owner_null = self
                     .builder
                     .build_is_null(owner, &format!("{}.reclaim.owner.null", locus_name))
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                let rel_null = self
+                    .builder
+                    .build_is_null(rel_fn_ptr, &format!("{}.reclaim.owner_release.null", locus_name))
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                let skip = self
+                    .builder
+                    .build_or(owner_null, rel_null, &format!("{}.reclaim.release.skip", locus_name))
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                 let fire_bb =
                     self.context.append_basic_block(reclaim, "release.fire");
                 let after_rel_bb =
                     self.context.append_basic_block(reclaim, "release.after");
                 self.builder
-                    .build_conditional_branch(owner_null, after_rel_bb, fire_bb)
+                    .build_conditional_branch(skip, after_rel_bb, fire_bb)
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                 self.builder.position_at_end(fire_bb);
                 self.builder
-                    .build_call(
-                        rfn,
+                    .build_indirect_call(
+                        rfn.get_type(),
+                        rel_fn_ptr,
                         &[owner.into(), self_arg.into()],
                         &format!("{}.reclaim.release.call", locus_name),
                     )

--- a/crates/hale-codegen/src/locus/decl.rs
+++ b/crates/hale-codegen/src/locus/decl.rs
@@ -583,6 +583,13 @@ impl<'ctx, 'p> LocusDeclare<'ctx> for Cx<'ctx, 'p> {
         let owner_self_field_idx = idx;
         llvm_field_tys.push(ptr_field_t.into());
         idx += 1;
+        // GH #526 F.6 (2026-09-05): synthetic `__owner_release: ptr` —
+        // the accept'ing parent TYPE's `release` fn (or null), stored
+        // beside `__owner_self` so the reclaim spine calls the owner's
+        // own body; see LocusInfo::owner_release_field_idx.
+        let owner_release_field_idx = idx;
+        llvm_field_tys.push(ptr_field_t.into());
+        idx += 1;
         // Interest-based ownership, artifact #2b: append one
         // `__owner_for_<I>: ptr` field per interest-type `I` this locus
         // must forward (its entry in the whole-program forwarding sets).
@@ -1188,6 +1195,7 @@ impl<'ctx, 'p> LocusDeclare<'ctx> for Cx<'ctx, 'p> {
                 recpool_release_kind_field_idx,
                 parent_self_field_idx,
                 owner_self_field_idx,
+                owner_release_field_idx,
                 owner_forward_field_idxs,
                 parent_on_failure_field_idx,
                 mailbox_field_idx,

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -2754,6 +2754,23 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                 self.context.ptr_type(AddressSpace::default()).const_null(),
             )
             .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        // GH #526 F.6: `__owner_release` starts null too; accept
+        // dispatch stores the owner type's release fn (or leaves null).
+        let owner_release_slot = self
+            .builder
+            .build_struct_gep(
+                info.struct_ty,
+                self_ptr,
+                info.owner_release_field_idx,
+                &format!("{}.__owner_release.ptr", locus_name),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+        self.builder
+            .build_store(
+                owner_release_slot,
+                self.context.ptr_type(AddressSpace::default()).const_null(),
+            )
+            .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
 
         // Interest-based ownership, artifact #2b: birth-threading — the
         // 3-way write of this child `X`'s `__owner_for_<I>` fields. For
@@ -2939,6 +2956,30 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                     self.builder
                         .build_store(owner_slot, owner_ptr)
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    // GH #526 F.6: THIS owner type's release fn for this
+                    // child type, so reclaim calls the right body even
+                    // when several parent types accept `locus_name`.
+                    let ptr_t = self.context.ptr_type(AddressSpace::default());
+                    let owner_release_val = match &parent_info.release_param {
+                        Some((_, rel_child)) if rel_child == locus_name => parent_info
+                            .methods
+                            .get("release")
+                            .map(|f| f.as_global_value().as_pointer_value())
+                            .unwrap_or(ptr_t.const_null()),
+                        _ => ptr_t.const_null(),
+                    };
+                    let owner_release_slot = self
+                        .builder
+                        .build_struct_gep(
+                            info.struct_ty,
+                            self_ptr,
+                            info.owner_release_field_idx,
+                            &format!("{}.__owner_release.accept.ptr", locus_name),
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    self.builder
+                        .build_store(owner_release_slot, owner_release_val)
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
                     let accept_fn = parent_info
                         .methods

--- a/crates/hale-codegen/tests/release_two_parents.rs
+++ b/crates/hale-codegen/tests/release_two_parents.rs
@@ -1,0 +1,73 @@
+//! GH #526 F.6 (2026-09-05): one child type accepted by TWO parent
+//! types. The reclaim spine found "the" release fn by child type alone
+//! (`user_loci.values().find_map(...)`), so the first parent type that
+//! declared `release(c: Child)` won program-wide and its body ran over
+//! the other parent's `self` — the DNA core segfaulted with `Work`'s
+//! release executing over `WorkSystem`'s layout. Each locus now carries
+//! `__owner_release`, stored at accept dispatch from the accept'ing
+//! parent TYPE, and reclaim calls through it.
+
+use std::process::Command;
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+
+const SRC: &str = r#"
+locus Child {
+    params { tag: String = ""; label: String = ""; }
+    contract { expose label: String; }
+    run() { self.label = "ran:" + self.tag; }
+}
+locus ParentA {
+    params { n: Int = 0; }
+    accept(c: Child) { println("A accept ", c.tag); }
+    release(c: Child) { self.n = self.n + 1; println("A release ", c.label); }
+    run() { Child { tag: "from-A" }; }
+}
+locus ParentB {
+    params { n: Int = 0; seen: String = ""; }
+    accept(c: Child) { println("B accept ", c.tag); }
+    release(c: Child) { self.n = self.n + 1; self.seen = c.label; println("B release ", c.label); }
+    run() { Child { tag: "from-B" }; }
+}
+// A third parent accepts the same type but declares NO release: its
+// child is still a flow (some parent releases the type) and reclaims
+// on run-completion, with no release body called on anybody.
+locus ParentC {
+    params { n: Int = 0; }
+    accept(c: Child) { println("C accept ", c.tag); }
+    run() { Child { tag: "from-C" }; }
+}
+main locus App {
+    params { a: ParentA = ParentA { }; b: ParentB = ParentB { }; c: ParentC = ParentC { }; }
+    run() { println("a.n=", self.a.n, " b.n=", self.b.n, " b.seen=", self.b.seen, " c.n=", self.c.n); }
+}
+fn main() { App { }; }
+"#;
+
+#[test]
+fn each_owner_type_runs_its_own_release_body() {
+    let program = hale_syntax::parse_source(SRC).expect("parse");
+    let bin = harness::unique_bin("hale_test_release_two_parents");
+    build_executable(&program, &bin).expect("build");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(out.status.success(), "exit: {:?}", out.status);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "A accept from-A",
+            "A release ran:from-A",
+            "B accept from-B",
+            "B release ran:from-B",
+            "C accept from-C",
+            "a.n=1 b.n=1 b.seen=ran:from-B c.n=0",
+        ],
+        "each owner's own release body, on its own self: {:?}",
+        stdout
+    );
+}

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -1548,17 +1548,28 @@ struct HotPathCx<'a> {
     /// the stricter perf hints (`snapshot()`/`finish()` in a loop,
     /// whole-struct self-field replace) activate.
     hot: bool,
+    /// GH #526 (2026-09-05): inside an `@unbounded` fn or lifecycle
+    /// hook. Every advisory this lint emits ends with "or acknowledge
+    /// an intentional shape with `@unbounded` on the enclosing
+    /// fn/hook" — and the walker never read the flag, so the
+    /// acknowledgement the message promised did nothing and `hale
+    /// verify` stayed red on a param-bounded fan-out loop. The flag
+    /// silences the ADVISORY only; `@hot` still hard-errors (a hot
+    /// fn that allocates unboundedly is a contradiction, not an
+    /// acknowledgement).
+    unbounded: bool,
 }
 
 impl HotPathCx<'_> {
-    /// Advisory warn by default; hard error inside `@hot`.
+    /// Advisory warn by default; hard error inside `@hot`; silent
+    /// inside `@unbounded` (unless also `@hot`).
     fn emit(&mut self, span: Span, msg: String) {
         if self.hot {
             self.diags.push(Diag::ty(
                 span,
                 format!("@hot: {}", msg),
             ));
-        } else {
+        } else if !self.unbounded {
             self.diags.push(Diag::warn(span, msg));
         }
     }
@@ -2005,17 +2016,18 @@ fn check_hot_path_alloc(bundle: &Bundle<'_>, top: &TopScope, diags: &mut Vec<Dia
                         })
                         .collect();
                     for m in &l.members {
-                        let (body, in_handler, hot) = match m {
+                        let (body, in_handler, hot, unbounded) = match m {
                             LocusMember::Fn(fd) => (
                                 Some(&fd.body),
                                 handler_names
                                     .contains(fd.name.name.as_str()),
                                 fd.hot,
+                                fd.unbounded,
                             ),
                             LocusMember::Lifecycle(ld) => {
-                                (Some(&ld.body), false, false)
+                                (Some(&ld.body), false, false, ld.unbounded)
                             }
-                            _ => (None, false, false),
+                            _ => (None, false, false, false),
                         };
                         if let Some(b) = body {
                             let mut cx = HotPathCx {
@@ -2024,6 +2036,7 @@ fn check_hot_path_alloc(bundle: &Bundle<'_>, top: &TopScope, diags: &mut Vec<Dia
                                 loop_depth: 0,
                                 in_handler,
                                 hot,
+                                unbounded,
                             };
                             hot_walk_block(b, &mut cx);
                         }
@@ -2036,6 +2049,7 @@ fn check_hot_path_alloc(bundle: &Bundle<'_>, top: &TopScope, diags: &mut Vec<Dia
                         loop_depth: 0,
                         in_handler: false,
                         hot: fd.hot,
+                        unbounded: fd.unbounded,
                     };
                     hot_walk_block(&fd.body, &mut cx);
                 }

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -912,6 +912,7 @@ crates/hale-codegen/tests/recv_stamped.rs#0 f21a527aa7a90794
 crates/hale-codegen/tests/recv_timeout_sentinel.rs#0 f21a527aa7a90794
 crates/hale-codegen/tests/recv_timeout_sentinel.rs#1 90900b8058a0b246
 crates/hale-codegen/tests/recv_zero_alloc.rs#0 f21a527aa7a90794
+crates/hale-codegen/tests/release_two_parents.rs#0 ef45ee6209ff2c6e
 crates/hale-codegen/tests/replay_asyncio.rs#0 54fdacb60d7cfd77
 crates/hale-codegen/tests/replay_asyncio.rs#1 0576d42781aa84e9
 crates/hale-codegen/tests/replay_determinism.rs#0 4ff23f87ca9a42ec
@@ -1304,6 +1305,8 @@ crates/hale-types/tests/hot_path_alloc.rs#15 95431874c5a9ae8d
 crates/hale-types/tests/hot_path_alloc.rs#16 93c34d52bcde0cf7
 crates/hale-types/tests/hot_path_alloc.rs#17 b1f059c2b92900ae
 crates/hale-types/tests/hot_path_alloc.rs#18 ab273330600fc920
+crates/hale-types/tests/hot_path_alloc.rs#19 234c5f1f87e43729
+crates/hale-types/tests/hot_path_alloc.rs#20 7e39a961fbd87bc6
 crates/hale-types/tests/hot_path_alloc.rs#4 234c5f1f87e43729
 crates/hale-types/tests/hot_path_alloc.rs#6 234c5f1f87e43729
 crates/hale-types/tests/hot_path_alloc.rs#7 8b5c9b6ca27eb054

--- a/crates/hale-types/tests/hot_path_alloc.rs
+++ b/crates/hale-types/tests/hot_path_alloc.rs
@@ -572,3 +572,60 @@ fn main() {
         "only locus-returning fns allocate an arena per call"
     );
 }
+
+// ---- GH #526 (2026-09-05): `@unbounded` acknowledges the advisory ---
+//
+// Every hot-path advisory ends with "or acknowledge an intentional
+// shape with `@unbounded` on the enclosing fn/hook". The walker never
+// read the flag, so the acknowledgement did nothing and `hale verify`
+// stayed red on a param-bounded fan-out loop (the DNA Phase 0 fixtures
+// birth one flow child per `fan`). `@unbounded` silences the advisory;
+// `@hot` still hard-errors.
+
+#[test]
+fn unbounded_hook_silences_locus_in_loop_advisory() {
+    let src = r#"
+locus Conn { run() { } }
+
+locus Server {
+    params { fan: Int = 4; }
+    @unbounded
+    run() {
+        let mut n = 0;
+        while n < self.fan {
+            Conn { };
+            n = n + 1;
+        }
+    }
+}
+
+fn main() { }
+"#;
+    let w = warnings(src);
+    assert!(w.is_empty(), "@unbounded run() must silence the advisory, got: {:?}", w);
+}
+
+#[test]
+fn unbounded_fn_silences_locus_in_loop_advisory() {
+    let src = r#"
+locus Conn { run() { } }
+
+@unbounded
+fn spawn_many(n: Int) {
+    let mut i = 0;
+    while i < n {
+        let c = Conn { };
+        i = i + 1;
+    }
+}
+
+fn main() { spawn_many(3); }
+"#;
+    let w = warnings(src);
+    assert!(w.is_empty(), "@unbounded fn must silence the advisory, got: {:?}", w);
+}
+
+// (`@hot` and `@unbounded` cannot stack — the parser admits only
+// `@budget` after `@hot` — so "hot still errors under unbounded" has
+// no representable program; the `emit` gate keeps the precedence
+// anyway.)

--- a/docs/src/services/parents-children.md
+++ b/docs/src/services/parents-children.md
@@ -41,7 +41,10 @@ summaries).
 A locus accepts **one** child type. Writing a second `accept` is a
 compile error that points at both clauses; if a parent needs to own
 two kinds of children, one of them belongs under a different owner
-(or the same owner one level down).
+(or the same owner one level down). The other direction is fine:
+several parent types may accept the *same* child type, and each
+child's `release` fires on the parent that actually accepted it,
+running that parent's own `release` body.
 
 ## Bubbling: the nearest accepting ancestor collects the child
 

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -463,6 +463,16 @@ parent has two effects:
    flow-typed locus is instantiated outside an accept context
    (no owner).
 
+Several parent types may accept the same child type; each child
+carries its accept'ing owner AND that owner type's `release` fn
+(stored at accept dispatch), so the body that fires is the actual
+owner's own, never another parent type's (2026-09-05, GH #526 F.6:
+the reclaim spine used to pick the first declared `release(c: T)`
+program-wide). Whether `T` is a flow remains a type-wide fact: if
+any parent declares `release(c: T)`, every `T` reclaims on
+run-completion, and an owner that declares no `release` simply has
+no bookend called.
+
 `release` has the same shape as `accept` — one typed child
 param — and the same fn signature `(parent_self, child_self)`.
 


### PR DESCRIPTION
Two compiler bugs the DNA Phase 0 fixtures (#526) hit on their first day. The domain seed (next PR) stacks on this one.

**F.6, release dispatch keyed by child type alone.** One child type accepted by two parent types (`Attempt` under both `Work` and `WorkSystem`) segfaulted. The reclaim spine found "the" release fn with `user_loci.values().find_map(release_param == child)`, so the first parent type that declared `release(c: Attempt)` won program-wide and its body ran over the other parent's `self`. Minimized, `B accept` was followed by `A release` with B's counter incremented. Every locus now carries a synthetic `__owner_release` pointer beside `__owner_self`, stored at accept dispatch from the accepting parent type's release fn (null when that parent declares none), and the reclaim spine calls through it. Whether a type is a flow stays type-wide; which body runs is per owner. Regression `release_two_parents.rs` covers three parents, one release-less.

**F.2, `@unbounded` ignored by the hot-path lint.** Every advisory ends with "or acknowledge an intentional shape with `@unbounded` on the enclosing fn/hook", and the walker never read the flag, so `hale verify` stayed red on a param-bounded fan-out loop. `HotPathCx` carries `unbounded`; `emit` skips the advisory, never the `@hot` error.

Spec and docs record the per-owner release rule. Corpus baseline gains the harvested program.

Verified: full `hale-codegen` (1330), `hale-types` (1164), `hale-cli` (358) suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
