### PR TITLE
dna: Phase 0 domain proof — dna/core, eight fixtures, friction log (#526)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,29 @@ shape with `@unbounded` on the enclosing fn/hook", and the walker
 never read the flag, so `hale verify` stayed red on a param-bounded
 fan-out loop. It reads it now; `@hot` still hard-errors.
 
+### `dna/core`: the DNA Phase 0 domain proof (GH #526)
+
+A library seed under `dna/core` and seven Hale-native fixtures under
+`dna/tests` (plus six law fixtures gated from Rust) prove the #521
+process domain in today's Hale: the single-accept chain
+`Metabolism > Task > Workflow > Step > Work > Attempt`, delegation by
+interest-based bubbling with settlement over a keyed topic, fan-out
+and join, typed and structural failure-up, cancellation, executor-
+neutral Work routed to assembly-owned performers, model routing that
+returns data, Review with a pinned candidate and independence,
+AutonomyBoundary with a vector disposition, a sha256-chained JSONL
+journal with compare-and-append, fencing tokens and idempotent
+effects, Knowledge with direction-derived bindings and reviewed
+distillation, and a constructor-shaped `Dna { ... }` assembly.
+`dna/FRICTION.md` records ten findings with minimized reproducers;
+two were compiler bugs fixed above, three are candidate language
+requests (F.4 hold-without-designation, F.7 fallible interface
+methods, and the multi-accept question #521 predicted, which the
+fixtures answered by bubbling instead), the rest are open compiler
+bugs (F.1, F.8, F.9, F.10) with reproducers under `dna/friction/`.
+Wired into CI by `crates/hale-cli/tests/dna_native_suite.rs` and
+`dna_law.rs`.
+
 ### Observation proto 0.4: `aux_b` means one thing (GH #525, iris handoff-14 P31)
 
 Iris's PROTOCOL §4 and its reference emitters had used a manifest

--- a/crates/hale-cli/tests/dna_law.rs
+++ b/crates/hale-cli/tests/dna_law.rs
@@ -1,0 +1,95 @@
+//! #526 fixture 8: DNA law. Assertions about COMPILER OUTPUT —
+//! refused builds and their witnesses — stay in Rust (CLAUDE.md), so
+//! each fixture under `dna/tests/law/<name>/` is checked here and its
+//! diagnostics matched. `*_pass` fixtures must check clean; `*_fail`
+//! fixtures must be refused naming the claim and the witness.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn law_dir(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.pop();
+    p.join("dna/tests/law").join(name)
+}
+
+fn check(name: &str) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("check")
+        .arg(".")
+        .current_dir(law_dir(name))
+        .output()
+        .expect("invoke hale check");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), text)
+}
+
+fn passes(name: &str) {
+    let (ok, text) = check(name);
+    assert!(ok, "{name} must check clean:\n{text}");
+}
+
+fn refused(name: &str, needles: &[&str]) {
+    let (ok, text) = check(name);
+    assert!(!ok, "{name} must be refused:\n{text}");
+    for n in needles {
+        assert!(text.contains(n), "{name}: expected `{n}` in:\n{text}");
+    }
+}
+
+/// Customer-side loci wired to the private router never reach an
+/// external model: a structural fact, not a runtime `allows()` check.
+#[test]
+fn customer_data_confined_to_local_model() {
+    passes("confine_pass");
+}
+
+/// The same locus wired to the full router: the witness names the
+/// path into `effects(external_model)`, whatever runtime policy says.
+#[test]
+fn customer_data_reaching_external_model_is_refused_with_a_witness() {
+    refused(
+        "confine_fail",
+        &[
+            "claim `no_leak` violated",
+            "effects(external_model)",
+            "CustomerTriage::triage",
+            "dna::ModelRouter::ask",
+        ],
+    );
+}
+
+/// Every apply path passes the Dna gate; constructing a permissive
+/// review policy does not weaken the adopted constitution.
+#[test]
+fn apply_gated_through_the_assembly_holds() {
+    passes("apply_gate_pass");
+}
+
+/// A concrete bypass of the gate is refused naming the carrier.
+#[test]
+fn apply_bypassing_the_gate_is_refused() {
+    refused(
+        "apply_gate_fail",
+        &[
+            "claim `apply_gated` violated",
+            "effects(genome_apply)",
+            "dna::LocalApplyDeployment::apply",
+        ],
+    );
+}
+
+#[test]
+fn credential_sources_sealed_holds() {
+    passes("sealed_pass");
+}
+
+#[test]
+fn unsealed_credential_holder_is_refused_by_name() {
+    refused("sealed_fail", &["claim `confined` violated", "LeakyCreds"]);
+}

--- a/crates/hale-cli/tests/dna_native_suite.rs
+++ b/crates/hale-cli/tests/dna_native_suite.rs
@@ -1,0 +1,80 @@
+//! Runs the DNA Phase 0 domain proof (`dna/tests/`, GH #526) through
+//! `hale test`, and `hale verify` over its core, so a compiler change
+//! that breaks the domain shapes fails the build here rather than in
+//! a friction log. `dna/core` is a library seed (imported by the
+//! tests); every fixture is an ordinary Hale program that exits 0.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.pop();
+    p
+}
+
+#[test]
+fn dna_fixtures_pass() {
+    let dir = repo_root().join("dna/tests");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("test")
+        .arg(&dir)
+        .output()
+        .expect("invoke hale test dna/tests");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "the DNA fixtures failed.\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+    assert!(stdout.contains(", 0 failed"), "expected a passing summary, got:\n{}", stdout);
+}
+
+#[test]
+fn dna_core_verifies_clean() {
+    let dir = repo_root().join("dna/core");
+    let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .arg("verify")
+        .arg(&dir)
+        .output()
+        .expect("invoke hale verify dna/core");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "hale verify dna/core must report zero findings.\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+}
+
+/// A suite that quietly emptied would pass the check above by
+/// running nothing. #526 names eight programs; seven are Hale-native.
+#[test]
+fn dna_fixture_set_is_complete() {
+    let dir = repo_root().join("dna/tests");
+    let mut names: Vec<String> = std::fs::read_dir(&dir)
+        .expect("dna/tests exists")
+        .flatten()
+        .filter_map(|e| {
+            let n = e.file_name().to_string_lossy().to_string();
+            n.ends_with("_test.hl").then_some(n)
+        })
+        .collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec![
+            "assembly_test.hl",
+            "fanout_join_test.hl",
+            "journal_test.hl",
+            "knowledge_test.hl",
+            "performers_test.hl",
+            "recursion_settlement_test.hl",
+            "review_authority_test.hl",
+        ]
+    );
+}

--- a/dna/.gitignore
+++ b/dna/.gitignore
@@ -1,0 +1,19 @@
+# `hale build <dir>` writes the binary at <dir>/<dir>; reproducers and
+# law fixtures get built ad hoc while investigating. Never commit them.
+friction/*/app/app
+friction/*/app2/app2
+friction/*/lib/lib
+friction/*/lib2/lib2
+friction/f3-interface-value-into-field/f3-interface-value-into-field
+friction/f4-perspective-must-designate/f4-perspective-must-designate
+friction/f5-bus-reply-at-drain/f5-bus-reply-at-drain
+friction/f6-two-parents-release/f6-two-parents-release
+friction/f7-interface-fallible/f7-interface-fallible
+friction/f8-or-on-infallible-stdlib/f8-or-on-infallible-stdlib
+friction/f9-write-append-unit/f9-write-append-unit
+tests/law/*/apply_gate_pass
+tests/law/*/apply_gate_fail
+tests/law/*/confine_pass
+tests/law/*/confine_fail
+tests/law/*/sealed_pass
+tests/law/*/sealed_fail

--- a/dna/FRICTION.md
+++ b/dna/FRICTION.md
@@ -1,0 +1,386 @@
+# dna — friction log
+
+Gaps met while building the DNA Phase 0 domain proof (GH #526)
+against today's Hale. Format follows iris / pond / brained: one entry
+per gap — tag, severity, what happened, the minimized reproducer, the
+workaround in `dna/core`, and the resolution once there is one.
+Entries are never removed when a gap closes; they get a "Resolved"
+line, because tomorrow's reader needs to know which workaround in the
+source dates from which era.
+
+A language REQUEST leaves this file only when the reproducer shows the
+invariant cannot be expressed with loci, types, interfaces,
+perspectives, topics and claims, and the proposed primitive's
+semantics are specified (#521 "prove each before adding syntax").
+Compiler BUGS found on the way are fixed upstream and noted here.
+
+---
+
+## F.1 — `match` on an enum declared in an imported seed
+
+**Tag:** `import-enum-match`
+**Severity:** blocking for any library that matches its own enum.
+**Status:** open (compiler bug); workaround in `dna/core/types.hl`.
+
+`dna/core/types.hl` declared `type Disposition = enum { Release,
+Stage, Review, Escalate, Deny }` and a `match` over it. `hale check
+dna/core` is clean. Any importer of the seed fails:
+
+```
+type error: match is not exhaustive; add a `_` arm or cover all
+cases of `__lib_dna_core_types_Disposition`
+```
+
+so the importer's exhaustiveness pass does not see the mangled enum's
+variants. Adding the `_` arm moves the failure to codegen:
+
+```
+codegen error: unsupported in codegen v0: constructor pattern:
+unknown enum `Disposition`
+```
+
+**Reproducer:** `dna/friction/f1-import-enum-match/` — `lib/` +
+`app/` (checker refusal), `lib2/` + `app2/` (with `_` arm: check
+passes, `hale build` fails). `hale check lib` alone is clean.
+
+**Workaround:** dispositions are `String` constants (`DISP_*`) in
+`dna/core/types.hl`. The enum is the shape we want back; strings cross
+the seed boundary today.
+
+**Resolution:** pending. Two distinct bugs: (1) exhaustiveness over a
+path-renamed enum; (2) codegen's constructor-pattern arm resolves the
+enum by bare name after the import prefix was applied.
+
+## F.2 — `@unbounded` did not acknowledge the hot-path advisory
+
+**Tag:** `unbounded-not-honored-by-hot-path-lint`
+**Severity:** blocks `hale verify` (the discipline gate) on any
+param-bounded fan-out loop.
+**Status:** FIXED upstream (hale, 2026-09-05, this track).
+
+Every hot-path advisory ends with "or acknowledge an intentional
+shape with `@unbounded` on the enclosing fn/hook". `Workflow::run`
+births one `Step` per `steps` and `Work::run` one `Attempt` per try;
+both carried `@unbounded` and the advisory still fired, so `hale
+verify dna/core` stayed at 2 findings. `check_hot_path_alloc` in
+`crates/hale-types/src/check.rs` walked lifecycle hooks with a
+hard-coded `false` and fns with only `hot`; the flag the message named
+was never read.
+
+**Fix:** `HotPathCx` carries `unbounded`; `emit` skips the advisory
+(never the `@hot` error) when set. Regression tests in
+`crates/hale-types/tests/hot_path_alloc.rs`.
+
+**Note:** `@hot` and `@unbounded` cannot stack (the parser admits only
+`@budget` after `@hot`), which is fine — a hot fn that allocates
+unboundedly is a contradiction, not an acknowledgement.
+
+## F.3 — an interface-typed VALUE cannot flow into an interface-typed field
+
+**Tag:** `interface-value-into-interface-field`
+**Severity:** shapes the whole performer design.
+**Status:** open (language gap, or a missing identity coercion).
+
+`Work` holds `performer: Performer` (assembly-substitutable) and
+wanted to hand it to each `Attempt { performer: self.performer }`.
+Refused:
+
+```
+type error: type `Performer` cannot satisfy interface `Performer`
+— only loci satisfy interfaces
+```
+
+Only a concrete locus literal coerces into an interface-typed field.
+An interface-typed value is a fat pointer that already IS the field's
+type, so the identity case is simply missing from the coercion table
+(`spec/types.md` lists eight positions; "interface → same interface"
+is not one). Even if it were admitted, the ownership question is
+open: the field and the frame that produced the value would both
+claim the impl (the same ambiguity the locus-typed-field guard
+rejects, which returns early for interfaces — `check.rs:9540`).
+
+**Reproducer:** `dna/friction/f3-interface-value-into-field/`.
+
+**Consequence:** a dynamically created child cannot be given an
+assembly-supplied implementation by its creator, because the creator
+is library code and must name a concrete locus in the literal.
+Assembly-time substitution reaches only statically-owned params.
+
+## F.4 — a `perspective(P)` field must designate; a holder cannot just dispatch
+
+**Tag:** `perspective-hold-without-designation`
+**Severity:** closes the other route to F.3's problem.
+**Status:** open — the first candidate language REQUEST from this
+track (see "Requests" below).
+
+The obvious answer to F.3 is the program-global slot: the assembly
+designates `perspective(Performing)` once (`#525` item 2 made that
+possible from a constructor), and every dynamic `Attempt` holds
+`performer: perspective(Performing)` and dispatches through the slot.
+But a perspective field with no initializer is a REQUIRED param:
+
+```
+type error: locus `Attempt`: missing field `performer`
+```
+
+and a default initializer re-designates the global slot at every
+birth, clobbering the assembly's choice (last designation wins).
+There is no way to say "hold the slot, dispatch through whatever the
+program designated".
+
+**Reproducer:** `dna/friction/f4-perspective-must-designate/`.
+
+**Request shape:** `p: perspective(P);` with no initializer means
+*hold, do not designate*; `hale check` errors if no locus in the
+program designates `P`. Semantics are already those of the slot
+(`spec/semantics.md` "One global slot"); only the designation rule
+changes, and it is the constructor-shaped assembly of #521 comment 1
+made to reach dynamic children.
+
+## F.5 — a bus reply reaches a flow child at drain, after its `run()`
+
+**Tag:** `bus-reply-delivered-at-drain`
+**Severity:** informational; it fixes the routed-work shape.
+**Status:** by design (cooperative queue), recorded so nobody fights it.
+
+Routing work over the bus (`WorkRequested` out, `WorkDone` back keyed
+by `work_id`) works, but the reply is delivered during the child's
+DRAIN — after `run()` returned, before `release(c)` fires:
+
+```
+w1 out=-1        <- inside Work::run, after the publish
+released 42      <- the parent, in release(w)
+```
+
+So a flow child can ask and its OWNER can read the answer, but the
+child cannot act on it inside `run()`. The routed shape therefore
+puts the retry/reassignment loop in the locus that owns the
+performers (`WorkSystem`), not in `Work`; `Work` asks once and
+settles with whatever came back.
+
+**Reproducer:** `dna/friction/f5-bus-reply-at-drain/`.
+
+## F.6 — a child type accepted by two parents: `release` runs the wrong parent's body
+
+**Tag:** `release-dispatch-keyed-by-child-only`
+**Severity:** memory corruption (SIGSEGV in the DNA core: `Work`'s
+release body ran over `WorkSystem`'s layout).
+**Status:** compiler bug; see resolution line.
+
+`Attempt` was accepted by `Work` (in-tower attempts) AND by
+`WorkSystem` (routed attempts). The routed program segfaulted inside
+the first `Attempt::run` with a `String` field slot holding `0x1`.
+Minimized: two plain parents that both `accept(c: Child)` and
+`release(c: Child)`, each birthing one child in `run()`:
+
+```
+A accept from-A
+A release ran:from-A
+A run done n=1
+B accept from-B
+A release ran:from-B      <- A's release BODY, on B's self (b.n became 1)
+B run done n=1
+```
+
+`accept` dispatches to the right parent; `release` dispatches by
+child type alone, so the first parent type that declares
+`release(c: Child)` wins program-wide and its body executes with the
+actual owner's `self`. With different field layouts that is silent
+corruption, which is what the core hit.
+
+**Reproducer:** `dna/friction/f6-two-parents-release/`.
+
+**Resolution:** FIXED upstream (hale, 2026-09-05, this track). Every
+locus carries a synthetic `__owner_release` pointer, stored at accept
+dispatch from the accept'ing parent TYPE's `release` fn (null when
+that parent declares none), and the reclaim spine calls through it.
+"Is this type a flow" stays a type-wide property (any parent releases
+it → run-completion reclaims); WHICH body runs is now per owner.
+Regression: `crates/hale-codegen/tests/release_two_parents.rs`. The
+core keeps one `Attempt` concept accepted by both `Work` and
+`WorkSystem`.
+
+## F.7 — an interface method cannot be `fallible(E)`
+
+**Tag:** `interface-method-fallible`
+**Severity:** shapes every storage contract.
+**Status:** open — second candidate language REQUEST.
+
+`interface Journal { fn append(expected: Int, ...) -> Int fallible(JournalError); }`
+is a parse error (`expected ;, got Ident("fallible")`): the interface
+member grammar admits a return type but no error channel. A locus
+method CAN be fallible, so an implementation can fail where its
+contract cannot say so — the caller through the interface never
+learns the error, and `or` addressing (the whole point of
+`fallible`) is unavailable at the one place substitution happens.
+
+**Reproducer:** `dna/friction/f7-interface-fallible/`.
+
+**Workaround:** result structs (`AppendResult { ok, revision, error }`)
+on every interface that can fail. That is exactly the shape
+`fallible(E)` exists to replace.
+
+**Request shape:** `interface_member` admits `fallible(E)`; a locus
+satisfies the method only if its own signature declares the same
+error type (or none — infallible satisfies fallible, not the
+reverse). Call sites through the interface address the error with
+`or` like any other.
+
+## F.8 — `or` on an infallible stdlib call checks clean and fails at build
+
+**Tag:** `or-on-infallible-stdlib-path`
+**Severity:** minor; check/build disagreement.
+**Status:** open (compiler bug; known class — multi-segment stdlib
+paths type as `Unknown`, so fallibility is invisible to the checker).
+
+`std::json::find_int_field(line, "seq") or 0` — the reader is
+infallible (returns 0 on a missing field), so the `or` is meaningless;
+`hale check` says nothing and `hale build` refuses with
+`` `or` over unknown path call ``. The checker should reject the `or`
+where the build does, with the fn named.
+
+**Reproducer:** `dna/friction/f8-or-on-infallible-stdlib/`.
+**Workaround:** no `or` on the flat-object readers.
+
+## F.9 — `write_file_append` is `Int` to the spec and `Unit` to codegen
+
+**Tag:** `write-file-append-unit-vs-int`
+**Severity:** blocked the file-backed journal for an hour; misleading
+diagnostics.
+**Status:** open (compiler bug, three faces).
+
+`spec/stdlib.md` and `stdlib_surface.rs` declare
+`write_file_append(path, s) -> Int fallible(IoError)`. Codegen lowers
+the call as Unit, so:
+
+- `let n = std::io::fs::write_file_append(p, s) or 0;` fails at build
+  with `expression statement other than locus literal or builtin
+  call` — a message about something else entirely;
+- `... or neg_one()` fails with `` `or` expression in value position
+  has Unit success type `` — the honest message;
+- `let n = std::io::fs::write_file_append(p, s);` with NO `or` is
+  accepted by check AND build, an unaddressed fallible call, because
+  the multi-segment path types as `Unknown` (the F.8 class).
+
+**Reproducer:** `dna/friction/f9-write-append-unit/`.
+
+**Workaround:** statement position with an error-check fn:
+`write_file_append(p, s) or self.io_failed(err);` and read a counter.
+
+## F.10 — a perspective declared in an imported seed does not resolve
+
+**Tag:** `perspective-across-seeds`
+**Severity:** blocks the routing-policy-as-perspective design in a
+library.
+**Status:** open (compiler bug: the import path-rename pass misses
+`serves` lists and `perspective(P)` field types).
+
+`perspective WorkRouting`, two `: serves WorkRouting` impls and a
+`selection: perspective(WorkRouting) = CapabilityFirstSelection { }`
+holder are clean in-seed. Through `import`:
+
+```
+locus `__lib_..._CapabilityFirstSelection` serves unknown perspective `WorkRouting`
+param `selection`: declared `__lib_..._WorkRouting`, default is `__lib_..._CapabilityFirstSelection`
+```
+
+so a library cannot offer a live-rebindable policy slot at all; only
+interfaces cross the seed boundary. This is the same class as F.1
+(enums): a name family the mangler does not rewrite.
+
+**Reproducer:** `dna/friction/f10-perspective-across-seeds/`.
+
+**Workaround:** `WorkSelection` is an interface in the core;
+substitution happens at construction only (#525 item 2 proved the
+constructor-site designation in-seed, fixture
+`65-perspective-ctor-override`).
+
+## F.11 — `forbid reaches` follows the declaration default, not the constructor override
+
+**Tag:** `reaches-through-interface-field-default`
+**Severity:** SOUNDNESS — fail-open on the exact shape #521's assembly
+is built from.
+**Status:** open; filed upstream from this track.
+
+`Dna { deployment: LocalApplyDeployment { } }` overrides the
+`deployment: Deployment = NoDeployment { }` default. `Dna.stage`
+calls `self.deployment.apply(...)`. The constitution
+`forbid reaches(organism, effects(genome_apply))` passed although
+`LocalApplyDeployment::apply` (the `genome_apply` carrier) is what
+runs. Minimized in-seed:
+
+- default `Noop`, override `Real` (carrier): check PASSES — fail-open;
+- default `Real`, override `Noop`: check REFUSES through `Real::apply`,
+  which never runs — false positive.
+
+One-hop and two-hop, in-seed and cross-seed, all resolve the same way:
+against the declaration-site default. Concrete-typed fields are
+resolved correctly, which is why `apply_gate_fail` uses a concrete
+bypass handle and `apply_gate_pass` holds partly for the wrong reason.
+
+The rule the engine should follow is the one the spec states for
+unknowns: an interface-typed field's callee set is every impl the
+closed world stores into that field (every instantiation site's
+literal, the default included), or, failing that analysis, every
+locus that satisfies the interface — "a hole beats a false proof of
+absence".
+
+**Reproducer:** `dna/friction/f11-reaches-default-not-override/`.
+
+---
+
+## Requests and bugs, summarized (2026-09-05)
+
+Eleven entries. What the fixtures established, against #521's prediction
+that the first language request would be multiple `accept` clauses:
+
+**The multi-accept request did not materialize.** A Step that must own
+Work and delegated Tasks writes the `Task { }` literal anyway; interest-
+based ownership bubbles it to `Metabolism`, lineage rides as data, and
+settlement comes back over a keyed topic published by the mediating
+supersystem. That is H9 in the letter, it compiles, it reclaims, and
+`recursion_settlement_test.hl` proves it. Single-accept-type per parent
+stands, for now, as a design that pushed the domain toward a better
+shape than the one the issue drew.
+
+**Candidate language requests** (each with a reproducer; none filed
+yet — the fixtures should sit for a while first):
+
+1. F.4 — `p: perspective(P);` with no initializer means *hold, do not
+   designate*. Without it, a dynamic child cannot dispatch through the
+   slot its assembly designated, and the constructor-shaped assembly
+   of #521 stops at statically-owned params. This is the one that
+   changes the DNA design most.
+2. F.7 — `fallible(E)` on interface method signatures. Without it every
+   storage contract is a result struct, which is the shape `fallible`
+   exists to replace.
+3. F.3 — an interface-typed value flowing into an interface-typed
+   field (the identity coercion), WITH an ownership rule. Probably
+   subsumed by F.4 for the performer case.
+
+**Compiler bugs fixed in this track:** F.2 (`@unbounded` ignored by the
+hot-path lint), F.6 (release dispatch by child type alone — memory
+corruption).
+
+**Compiler bugs open, reproducers under `dna/friction/`:** F.11
+(SOUNDNESS: `forbid reaches` through an interface-typed field follows
+the declaration default, not the constructor override — fail-open on
+the assembly shape itself; fix this first), F.1 (enum match across
+seeds: checker and codegen), F.10 (perspectives do not cross seeds),
+F.8 (`or` on an infallible stdlib path accepted by check), F.9
+(`write_file_append` Int vs Unit, misleading diagnostics). F.1 and
+F.10 share a cause — name families the import mangler does not
+rewrite: a library cannot use its own enums or perspectives until they
+are.
+
+**Recorded, by design:** F.5 (a bus reply reaches a flow child at
+drain, so the retry loop lives with whoever owns the performers).
+
+**Things the survey said to verify, now verified:** `adopt` of a
+constitution declared in an imported seed was not needed — the app's
+own `constitution DnaCore { ... }` plus groups naming `dna::*` loci
+works and is what the law fixtures use; reassigning an interface-typed
+field was never exercised because F.3 forbids the value flow before
+reassignment is reached; String-keyed settlement topics carried every
+delegated Task in the fixtures without visible cost, though nothing
+here is at scale.

--- a/dna/core/assembly.hl
+++ b/dna/core/assembly.hl
@@ -16,7 +16,7 @@
 // ---- the human/external membrane -----------------------------------
 
 interface Membrane {
-    fn offer(i: Intent) -> String;       // "accepted" | "refused: ..."
+    fn offer(i: Intent) -> String; // "accepted" | "refused: ..."
     fn notify(kind: String, msg: String);
     fn notifications() -> Int;
 }

--- a/dna/core/assembly.hl
+++ b/dna/core/assembly.hl
@@ -1,0 +1,160 @@
+// dna/core/assembly.hl — the Dna locus a project constructs (#521
+// comment 1: constructor-shaped assembly).
+//
+// "Configuration" is Hale source: a project writes `Dna { memory:
+// ..., work: ..., governance: ..., membrane: ... }` in its main's
+// params, supplying concrete children behind the core's interfaces.
+// The assembly is visible to the ApplicationModel, claims can reason
+// about its reachability and effects, and changing it is an ordinary
+// reviewed genome diff. Nothing here is a config-file loader.
+//
+// Four things stay distinct: construction (which concrete stores,
+// models, gateways exist), genome (evolvable policy loci), law
+// (constitutions adopted by the main, never a constructor flag), and
+// durable state (behind the constructed stores, never a literal).
+
+// ---- the human/external membrane -----------------------------------
+
+interface Membrane {
+    fn offer(i: Intent) -> String;       // "accepted" | "refused: ..."
+    fn notify(kind: String, msg: String);
+    fn notifications() -> Int;
+}
+
+// The local human: intent enters through `hale dna ask`, review
+// requests and status leave through the terminal / Iris. The person
+// is outside the root; this locus owns the boundary.
+locus LocalHumanMembrane {
+    params { who: String = "operator"; offered: Int = 0; notified: Int = 0; last: String = ""; }
+    fn offer(i: Intent) -> String {
+        if i.outcome == "" { return "refused: empty intent"; }
+        self.offered = self.offered + 1;
+        return "accepted";
+    }
+    fn notify(kind: String, msg: String) {
+        self.notified = self.notified + 1;
+        self.last = kind + ": " + msg;
+    }
+    fn notifications() -> Int { return self.notified; }
+}
+
+// ---- governance policy (evolvable genome, bounded by law) -----------
+
+interface ReviewPolicy {
+    fn required_authority(change_class: String, m: Magnitude) -> String;
+    fn blocking(change_class: String) -> Bool;
+    fn name() -> String;
+}
+
+// The safe baseline (#521 open question 15): every application,
+// deployment, external-effect, process-policy and constitutional
+// mutation blocks on a human.
+locus HumanBeforeApply {
+    fn required_authority(change_class: String, m: Magnitude) -> String { return "maintainer"; }
+    fn blocking(change_class: String) -> Bool { return true; }
+    fn name() -> String { return "human-before-apply"; }
+}
+
+// Post-review for reversible internal refactors; everything else blocks.
+locus PostReviewRefactors {
+    fn required_authority(change_class: String, m: Magnitude) -> String {
+        if m.law_touched || m.effects_widened { return "maintainer"; }
+        return "reviewer";
+    }
+    fn blocking(change_class: String) -> Bool { return change_class != "refactor"; }
+    fn name() -> String { return "post-review-refactors"; }
+}
+
+// ---- deployment gateway (an EFFECT, behind an attributed gate) -----
+
+interface Deployment {
+    fn apply(candidate_digest: String) -> Bool;
+    fn kind() -> String;
+    fn applied() -> Int;
+}
+
+// A deployment that DOES apply (simulated): the one method carries
+// `genome_apply`, which the law gates behind the Dna assembly.
+locus LocalApplyDeployment {
+    params { applied_n: Int = 0; last: String = ""; }
+    @effects(is: { genome_apply })
+    fn apply(candidate_digest: String) -> Bool { self.applied_n = self.applied_n + 1; self.last = candidate_digest; return true; }
+    fn kind() -> String { return "local-apply"; }
+    fn applied() -> Int { return self.applied_n; }
+}
+
+// Phase 1: every mutation stops at stage. This gateway refuses.
+locus NoDeployment {
+    params { refused: Int = 0; }
+    fn apply(candidate_digest: String) -> Bool { self.refused = self.refused + 1; return false; }
+    fn kind() -> String { return "none"; }
+    fn applied() -> Int { return 0; }
+}
+
+// ---- Dna --------------------------------------------------------------
+
+locus Dna {
+    params {
+        journal: Journal = MemJournal { };
+        leases: Coordination = MemLeases { };
+        knowledge: Knowledge = Knowledge { };
+        work: WorkSystem = WorkSystem { };
+        metabolism: Metabolism = Metabolism { };
+        boundary: AutonomyBoundary = AutonomyBoundary { child: "app" };
+        review_policy: ReviewPolicy = HumanBeforeApply { };
+        deployment: Deployment = NoDeployment { };
+        membrane: Membrane = LocalHumanMembrane { };
+        asked: Int = 0;
+    }
+    // Intent enters through the membrane and births a durable Task;
+    // its birth and its settlement are Journal events (the causal
+    // authority), the live locus is the expression.
+    fn ask(i: Intent, k: Knobs) -> String {
+        let gate = self.membrane.offer(i);
+        if gate != "accepted" { return gate; }
+        self.asked = self.asked + 1;
+        let born = self.journal.append(self.journal.revision(), "intent.offered", i.id, i.outcome);
+        if !born.ok { return "refused: journal " + born.error; }
+        let id = self.metabolism.offer(i, k);
+        let s = self.metabolism.find(id);
+        let r = self.journal.append(self.journal.revision(), "task.born", id, i.outcome);
+        let r2 = self.journal.append(self.journal.revision(), "task." + s.disposition, id, s.detail);
+        if !r.ok || !r2.ok { self.membrane.notify("journal", "append failed"); }
+        return id;
+    }
+    // A staged mutation: assessed under the boundary, reviewed per
+    // policy, and NEVER applied by this assembly's deployment.
+    fn stage(change_class: String, candidate_digest: String, m: Magnitude, e: Evidence) -> String {
+        let d = self.boundary.assess(change_class, m, e);
+        let r = self.journal.append(self.journal.revision(), "mutation." + d, candidate_digest, change_class);
+        if d == DISP_RELEASE {
+            // the grant would allow it; the deployment gateway decides
+            // whether expression is possible here at all
+            if !self.deployment.apply(candidate_digest) {
+                self.membrane.notify("mutation", "staged (no deployment): " + candidate_digest);
+                return DISP_STAGE;
+            }
+            return "applied";
+        }
+        if d == DISP_REVIEW || d == DISP_STAGE {
+            self.membrane.notify("review", self.review_policy.required_authority(change_class, m) + " needed for " + candidate_digest);
+        }
+        return d;
+    }
+    fn status() -> String {
+        let b = std::json::Builder { };
+        b.begin_object();
+        b.int_field("asked", self.asked);
+        b.int_field("journal_revision", self.journal.revision());
+        b.int_field("tasks_settled", self.metabolism.settled_count());
+        b.int_field("work_requests", self.work.requests);
+        b.int_field("attempts", self.work.attempts_made);
+        b.string_field("routing", self.work.policy());
+        b.string_field("review_policy", self.review_policy.name());
+        b.string_field("deployment", self.deployment.kind());
+        b.int_field("knowledge_revision", self.knowledge.revision);
+        b.int_field("notifications", self.membrane.notifications());
+        b.end_object();
+        return b.result();
+    }
+}

--- a/dna/core/journal.hl
+++ b/dna/core/journal.hl
@@ -1,0 +1,313 @@
+// dna/core/journal.hl — the append-only causal authority (#521 comment 1).
+//
+// The Journal is the causal authority; Task status, pending reviews,
+// and retrieval indexes are PROJECTIONS rebuilt from it. Storage is
+// assembled by semantic capability: `Journal` (ordered append with an
+// expected revision, idempotency, durable identity), `Coordination`
+// (leases with fencing tokens), and a rebuildable `RetrievalIndex`.
+// Two implementations of each: in-memory, and a file-backed JSONL
+// journal with a sha256 chain, using only stdlib (no FFI in the core;
+// sqlite arrives as a pond adapter).
+
+type Event {
+    seq: Int = 0;
+    kind: String = "";        // "task.born" | "effect.requested" | ...
+    entity: String = "";      // durable id the event is about
+    body: String = "";
+    prev: String = "";        // digest of the previous event
+    digest: String = "";      // sha256(prev + kind + entity + body)
+}
+
+// F.7 (dna/FRICTION.md): interface methods cannot be `fallible(E)`,
+// so the append contract carries its failure in a result struct.
+type AppendResult {
+    ok: Bool = false;
+    revision: Int = 0;        // the revision after a successful append
+    error: String = "";       // "stale_revision" | "io"
+    expected: Int = 0;
+    actual: Int = 0;
+}
+
+interface Journal {
+    fn revision() -> Int;
+    fn head() -> String;
+    fn append(expected: Int, kind: String, entity: String, body: String) -> AppendResult;
+    fn read(i: Int) -> Event;
+    fn verify_chain() -> Bool;
+}
+
+fn hex(b: Bytes) -> String {
+    let digits = "0123456789abcdef";
+    let mut out = "";
+    let mut i = 0;
+    let n = len(b);
+    while i < n {
+        let v = std::bytes::at(b, i) or 0;
+        out = out + digits[(v / 16)..(v / 16 + 1)] + digits[(v % 16)..(v % 16 + 1)];
+        i = i + 1;
+    }
+    return out;
+}
+
+fn event_digest(prev: String, kind: String, entity: String, body: String) -> String {
+    return hex(std::crypto::sha256(std::bytes::from_string(prev + "|" + kind + "|" + entity + "|" + body)));
+}
+
+@form(vec)
+locus EventRows {
+    capacity { heap rows of Event; }
+}
+
+// ---- in-memory journal --------------------------------------------
+
+locus MemJournal {
+    params { rows: EventRows = EventRows { }; }
+    fn revision() -> Int { return self.rows.len(); }
+    fn head() -> String {
+        if self.rows.len() == 0 { return "genesis"; }
+        let e = self.rows.get(self.rows.len() - 1) or Event { };
+        return e.digest;
+    }
+    // Compare-and-append: two writers holding the same expected
+    // revision cannot both advance the same entity from the same state.
+    fn append(expected: Int, kind: String, entity: String, body: String) -> AppendResult {
+        let rev = self.rows.len();
+        if expected != rev { return AppendResult { error: "stale_revision", expected: expected, actual: rev }; }
+        let prev = self.head();
+        self.rows.push(Event { seq: rev, kind: kind, entity: entity, body: body, prev: prev, digest: event_digest(prev, kind, entity, body) });
+        return AppendResult { ok: true, revision: rev + 1 };
+    }
+    fn read(i: Int) -> Event { return self.rows.get(i) or Event { }; }
+    fn verify_chain() -> Bool { return chain_ok(self.rows); }
+}
+
+fn chain_ok(rows: EventRows) -> Bool {
+    let mut prev = "genesis";
+    let mut i = 0;
+    while i < rows.len() {
+        let e = rows.get(i) or Event { };
+        if e.prev != prev { return false; }
+        if e.digest != event_digest(e.prev, e.kind, e.entity, e.body) { return false; }
+        prev = e.digest;
+        i = i + 1;
+    }
+    return true;
+}
+
+// ---- file-backed journal (JSONL, sha256-chained) ---------------------
+
+locus FileJournal {
+    params {
+        path: String = ".hale/dna/journal.jsonl";
+        rows: EventRows = EventRows { };
+        loaded: Int = 0;           // rows rehydrated at birth
+        io_errors: Int = 0;
+        last_io_error: String = "";
+    }
+    // Rehydrate: the file is the durable form; the rows are its
+    // in-memory projection. A missing file is an empty journal.
+    birth() { self.load(); }
+    @effects(is: { journal_io })
+    fn load() {
+        let text = std::io::fs::read_file(self.path) or "";
+        let mut rest = text;
+        while len(rest) > 0 {
+            let nl = std::str::index_of(rest, "\n");
+            let line = if nl < 0 { rest } else { rest[0..nl] };
+            if len(line) > 0 {
+                // F.8 (dna/FRICTION.md): these readers are infallible
+                // ("" / 0 on a missing field); an `or` here typechecks
+                // and then fails codegen.
+                self.rows.push(Event {
+                    seq: std::json::find_int_field(line, "seq"),
+                    kind: std::json::find_string_field(line, "kind"),
+                    entity: std::json::find_string_field(line, "entity"),
+                    body: std::json::find_string_field(line, "body"),
+                    prev: std::json::find_string_field(line, "prev"),
+                    digest: std::json::find_string_field(line, "digest")
+                });
+                self.loaded = self.loaded + 1;
+            }
+            if nl < 0 { rest = ""; } else { rest = rest[(nl + 1)..len(rest)]; }
+        }
+    }
+    fn revision() -> Int { return self.rows.len(); }
+    fn head() -> String {
+        if self.rows.len() == 0 { return "genesis"; }
+        let e = self.rows.get(self.rows.len() - 1) or Event { };
+        return e.digest;
+    }
+    @effects(is: { journal_io })
+    fn append(expected: Int, kind: String, entity: String, body: String) -> AppendResult {
+        let rev = self.rows.len();
+        if expected != rev { return AppendResult { error: "stale_revision", expected: expected, actual: rev }; }
+        let prev = self.head();
+        let d = event_digest(prev, kind, entity, body);
+        let b = std::json::Builder { };
+        b.begin_object();
+        b.int_field("seq", rev);
+        b.string_field("kind", kind);
+        b.string_field("entity", entity);
+        b.string_field("body", body);
+        b.string_field("prev", prev);
+        b.string_field("digest", d);
+        b.end_object();
+        // The durable write happens BEFORE the in-memory projection
+        // moves: a crash between them loses nothing that was promised.
+        // F.9 (dna/FRICTION.md): `write_file_append` is Unit-typed in
+        // codegen (Int per spec), so the error is caught by an
+        // error-check fn, not an `or <value>` substitute.
+        let before = self.io_errors;
+        let line = b.result() + "\n";
+        std::io::fs::write_file_append(self.path, line) or self.io_failed(err);
+        if self.io_errors > before { return AppendResult { error: "io", expected: expected, actual: rev }; }
+        self.rows.push(Event { seq: rev, kind: kind, entity: entity, body: body, prev: prev, digest: d });
+        return AppendResult { ok: true, revision: rev + 1 };
+    }
+    fn io_failed(e: IoError) {
+        self.io_errors = self.io_errors + 1;
+        self.last_io_error = e.kind;
+    }
+    fn read(i: Int) -> Event { return self.rows.get(i) or Event { }; }
+    fn verify_chain() -> Bool { return chain_ok(self.rows); }
+}
+
+// ---- coordination: leases with fencing tokens -----------------------
+
+type Lease {
+    key: String = "";
+    holder: String = "";
+    token: Int = 0;           // fencing token; monotonically increasing per key
+    expires: Int = 0;
+    present: Bool = false;
+}
+
+// F.7 again: `acquire` reports "held by someone else" as a Lease with
+// `present == false` and `holder` naming the current holder.
+interface Coordination {
+    fn acquire(key: String, holder: String, now: Int, ttl: Int) -> Lease;
+    fn complete(key: String, token: Int, now: Int) -> Bool;
+    fn holder_of(key: String) -> String;
+}
+
+@form(hashmap)
+locus LeaseRows {
+    capacity { pool rows of Lease indexed_by key; }
+}
+
+locus MemLeases {
+    params { rows: LeaseRows = LeaseRows { }; next_token: Int = 1; }
+    fn acquire(key: String, holder: String, now: Int, ttl: Int) -> Lease {
+        let cur = self.rows.get(key) or Lease { };
+        if cur.present && cur.expires > now && cur.holder != holder {
+            return Lease { key: key, holder: cur.holder, token: 0, expires: cur.expires, present: false };
+        }
+        let t = self.next_token;
+        self.next_token = self.next_token + 1;
+        let l = Lease { key: key, holder: holder, token: t, expires: now + ttl, present: true };
+        self.rows.set(l);
+        return l;
+    }
+    // A late writer whose lease expired and was re-acquired holds a
+    // stale token; its completion is refused, never applied.
+    fn complete(key: String, token: Int, now: Int) -> Bool {
+        let cur = self.rows.get(key) or Lease { };
+        if !cur.present { return false; }
+        if cur.token != token { return false; }
+        self.rows.set(Lease { key: key, holder: cur.holder, token: cur.token, expires: 0, present: false });
+        return true;
+    }
+    fn holder_of(key: String) -> String {
+        let cur = self.rows.get(key) or Lease { };
+        if cur.present { return cur.holder; }
+        return "";
+    }
+}
+
+// ---- idempotent effects over the journal --------------------------
+
+// An effect request is committed BEFORE dispatch under a durable key;
+// a retry after a crash finds the key and does not dispatch again;
+// the result is appended once. Both facts are Journal events, so the
+// ledger is a projection and can be rebuilt.
+type EffectStatus { requested: Bool = false; done: Bool = false; ok: Bool = false; }
+
+fn effect_status(j: Journal, key: String) -> EffectStatus {
+    let mut st = EffectStatus { };
+    let mut i = 0;
+    let n = j.revision();
+    while i < n {
+        let e = j.read(i);
+        if e.entity == key {
+            if e.kind == "effect.requested" { st.requested = true; }
+            if e.kind == "effect.result" { st.done = true; st.ok = e.body == "ok"; }
+        }
+        i = i + 1;
+    }
+    return st;
+}
+
+// Returns true if THIS call should dispatch the effect (first time),
+// false if it was already requested (a retry) — the caller then only
+// waits for / records the result.
+fn effect_request(j: Journal, key: String, body: String) -> Bool {
+    let st = effect_status(j, key);
+    if st.requested { return false; }
+    let r = j.append(j.revision(), "effect.requested", key, body);
+    return r.ok;
+}
+
+fn effect_result(j: Journal, key: String, ok: Bool) -> Bool {
+    let st = effect_status(j, key);
+    if st.done { return false; }
+    let r = j.append(j.revision(), "effect.result", key, if ok { "ok" } else { "failed" });
+    return r.ok;
+}
+
+// ---- projections --------------------------------------------------
+
+// Task status is the last task.* event for the id — reconstructed,
+// never stored as the authority.
+fn task_status(j: Journal, task_id: String) -> String {
+    let mut st = "unknown";
+    let mut i = 0;
+    let n = j.revision();
+    while i < n {
+        let e = j.read(i);
+        if e.entity == task_id && std::str::starts_with(e.kind, "task.") {
+            st = e.kind[5..len(e.kind)];
+        }
+        i = i + 1;
+    }
+    return st;
+}
+
+// A derived, disposable retrieval index: term -> count. Delete it and
+// rebuild it from the journal; the journal never changes.
+type TermRow { term: String = ""; count: Int = 0; }
+
+@form(hashmap)
+locus TermRows {
+    capacity { pool rows of TermRow indexed_by term; }
+}
+
+locus RetrievalIndex {
+    params { rows: TermRows = TermRows { }; indexed: Int = 0; }
+    @unbounded
+    fn rebuild(j: Journal) {
+        self.indexed = 0;
+        let mut i = 0;
+        let n = j.revision();
+        while i < n {
+            let e = j.read(i);
+            let cur = self.rows.get(e.kind) or TermRow { term: e.kind };
+            self.rows.set(TermRow { term: e.kind, count: cur.count + 1 });
+            self.indexed = self.indexed + 1;
+            i = i + 1;
+        }
+    }
+    fn count(term: String) -> Int {
+        let r = self.rows.get(term) or TermRow { };
+        return r.count;
+    }
+}

--- a/dna/core/journal.hl
+++ b/dna/core/journal.hl
@@ -11,19 +11,19 @@
 
 type Event {
     seq: Int = 0;
-    kind: String = "";        // "task.born" | "effect.requested" | ...
-    entity: String = "";      // durable id the event is about
+    kind: String = ""; // "task.born" | "effect.requested" | ...
+    entity: String = ""; // durable id the event is about
     body: String = "";
-    prev: String = "";        // digest of the previous event
-    digest: String = "";      // sha256(prev + kind + entity + body)
+    prev: String = ""; // digest of the previous event
+    digest: String = ""; // sha256(prev + kind + entity + body)
 }
 
 // F.7 (dna/FRICTION.md): interface methods cannot be `fallible(E)`,
 // so the append contract carries its failure in a result struct.
 type AppendResult {
     ok: Bool = false;
-    revision: Int = 0;        // the revision after a successful append
-    error: String = "";       // "stale_revision" | "io"
+    revision: Int = 0; // the revision after a successful append
+    error: String = ""; // "stale_revision" | "io"
     expected: Int = 0;
     actual: Int = 0;
 }
@@ -100,7 +100,7 @@ locus FileJournal {
     params {
         path: String = ".hale/dna/journal.jsonl";
         rows: EventRows = EventRows { };
-        loaded: Int = 0;           // rows rehydrated at birth
+        loaded: Int = 0; // rows rehydrated at birth
         io_errors: Int = 0;
         last_io_error: String = "";
     }
@@ -177,7 +177,7 @@ locus FileJournal {
 type Lease {
     key: String = "";
     holder: String = "";
-    token: Int = 0;           // fencing token; monotonically increasing per key
+    token: Int = 0; // fencing token; monotonically increasing per key
     expires: Int = 0;
     present: Bool = false;
 }

--- a/dna/core/knowledge.hl
+++ b/dna/core/knowledge.hl
@@ -13,10 +13,10 @@
 
 type Idea {
     id: String = "";
-    kind: String = "idea";      // "idea" | "concept" | "practice" | "task_concept"
+    kind: String = "idea"; // "idea" | "concept" | "practice" | "task_concept"
     text: String = "";
-    author: String = "";        // a locus path, e.g. "app/support"
-    provenance: String = "";    // "declared" | "observed" | "inferred" | "proposed" | "ratified"
+    author: String = ""; // a locus path, e.g. "app/support"
+    provenance: String = ""; // "declared" | "observed" | "inferred" | "proposed" | "ratified"
     revision: Int = 0;
     accepted: Bool = false;
 }
@@ -25,18 +25,18 @@ type KnowledgeEdge { from: String = ""; to: String = ""; rel: String = ""; }
 
 type KnowledgeBinding {
     idea: String = "";
-    target: String = "";        // locus path the idea is bound to
-    author: String = "";        // who bound it
-    class: String = "";         // derived: "goal" | "concern" | "initiative"
+    target: String = ""; // locus path the idea is bound to
+    author: String = ""; // who bound it
+    class: String = ""; // derived: "goal" | "concern" | "initiative"
 }
 
 type ContextPackage {
     target: String = "";
     revision: Int = 0;
     digest: String = "";
-    included: String = "";      // idea ids, space-separated
+    included: String = ""; // idea ids, space-separated
     included_n: Int = 0;
-    omitted_n: Int = 0;         // what this projection left out, stated
+    omitted_n: Int = 0; // what this projection left out, stated
     data_class: String = "";
 }
 
@@ -49,7 +49,7 @@ fn classify_binding(author: String, target: String) -> String {
     if author == target { return "initiative"; }
     if is_ancestor(author, target) { return "goal"; }
     if is_ancestor(target, author) { return "concern"; }
-    return "lateral";           // siblings do not privately coordinate (H9)
+    return "lateral"; // siblings do not privately coordinate (H9)
 }
 
 @form(vec)

--- a/dna/core/knowledge.hl
+++ b/dna/core/knowledge.hl
@@ -1,0 +1,152 @@
+// dna/core/knowledge.hl — semantic memory (#521 comment 1).
+//
+// `Knowledge` is a locus that owns domain data: ideas, edges, bindings
+// and revisions are pure cells in its forms, in exactly one tower
+// (I4). Authorship direction IS the classification — parent-authored
+// knowledge bound to a child is a GOAL, child-authored bound to a
+// parent is a CONCERN, self-authored bound locally is an INITIATIVE —
+// computed from the tower, never a tag that can contradict it. Task
+// history never becomes knowledge by itself: an Attempt PROPOSES, and
+// only the distillation/review path commits a revision. A performer
+// receives a bounded ContextPackage with a digest and a revision, not
+// the store.
+
+type Idea {
+    id: String = "";
+    kind: String = "idea";      // "idea" | "concept" | "practice" | "task_concept"
+    text: String = "";
+    author: String = "";        // a locus path, e.g. "app/support"
+    provenance: String = "";    // "declared" | "observed" | "inferred" | "proposed" | "ratified"
+    revision: Int = 0;
+    accepted: Bool = false;
+}
+
+type KnowledgeEdge { from: String = ""; to: String = ""; rel: String = ""; }
+
+type KnowledgeBinding {
+    idea: String = "";
+    target: String = "";        // locus path the idea is bound to
+    author: String = "";        // who bound it
+    class: String = "";         // derived: "goal" | "concern" | "initiative"
+}
+
+type ContextPackage {
+    target: String = "";
+    revision: Int = 0;
+    digest: String = "";
+    included: String = "";      // idea ids, space-separated
+    included_n: Int = 0;
+    omitted_n: Int = 0;         // what this projection left out, stated
+    data_class: String = "";
+}
+
+fn is_ancestor(a: String, b: String) -> Bool {
+    // "app" is an ancestor of "app/support/intake"
+    return len(b) > len(a) && std::str::starts_with(b, a + "/");
+}
+
+fn classify_binding(author: String, target: String) -> String {
+    if author == target { return "initiative"; }
+    if is_ancestor(author, target) { return "goal"; }
+    if is_ancestor(target, author) { return "concern"; }
+    return "lateral";           // siblings do not privately coordinate (H9)
+}
+
+@form(vec)
+locus IdeaRows { capacity { heap rows of Idea; } }
+@form(vec)
+locus EdgeRows { capacity { heap rows of KnowledgeEdge; } }
+@form(vec)
+locus BindingRows { capacity { heap rows of KnowledgeBinding; } }
+
+locus Knowledge {
+    params {
+        ideas: IdeaRows = IdeaRows { };
+        edges: EdgeRows = EdgeRows { };
+        bindings: BindingRows = BindingRows { };
+        proposals: IdeaRows = IdeaRows { };
+        revision: Int = 0;
+        refused_lateral: Int = 0;
+        refused_distill: Int = 0;
+    }
+    // Declared knowledge enters as an accepted revision with its
+    // provenance kept.
+    fn declare(i: Idea) -> Int {
+        self.revision = self.revision + 1;
+        self.ideas.push(Idea { id: i.id, kind: i.kind, text: i.text, author: i.author, provenance: i.provenance, revision: self.revision, accepted: true });
+        return self.revision;
+    }
+    // An Attempt may PROPOSE; it cannot write.
+    fn propose(i: Idea) -> Int {
+        self.proposals.push(Idea { id: i.id, kind: i.kind, text: i.text, author: i.author, provenance: "proposed", revision: 0, accepted: false });
+        return self.proposals.len() - 1;
+    }
+    fn proposal_count() -> Int { return self.proposals.len(); }
+    // Distillation: an independent reviewer accepts a proposal into a
+    // revision. The proposer cannot ratify their own proposal.
+    fn distill(proposal: Int, reviewer: String, verdict: String) -> Bool {
+        let p = self.proposals.get(proposal) or Idea { };
+        if p.id == "" || p.accepted { self.refused_distill = self.refused_distill + 1; return false; }
+        if reviewer == p.author { self.refused_distill = self.refused_distill + 1; return false; }
+        if verdict != "approve" { return false; }
+        self.revision = self.revision + 1;
+        self.ideas.push(Idea { id: p.id, kind: p.kind, text: p.text, author: p.author, provenance: "ratified", revision: self.revision, accepted: true });
+        self.proposals.set(proposal, Idea { id: p.id, kind: p.kind, text: p.text, author: p.author, provenance: "proposed", revision: self.revision, accepted: true }) or discard;
+        return true;
+    }
+    fn link(from: String, to: String, rel: String) {
+        self.edges.push(KnowledgeEdge { from: from, to: to, rel: rel });
+    }
+    // Binding direction is the classification; lateral is refused.
+    fn bind(idea: String, target: String, author: String) -> String {
+        let c = classify_binding(author, target);
+        if c == "lateral" { self.refused_lateral = self.refused_lateral + 1; return c; }
+        self.bindings.push(KnowledgeBinding { idea: idea, target: target, author: author, class: c });
+        return c;
+    }
+    fn accepted_count() -> Int { return self.ideas.len(); }
+    // Bounded by the store's size; one substitute struct per row scanned.
+    @unbounded
+    fn find(id: String) -> Idea {
+        let mut i = 0;
+        while i < self.ideas.len() {
+            let x = self.ideas.get(i) or Idea { };
+            if x.id == id { return x; }
+            i = i + 1;
+        }
+        return Idea { };
+    }
+    // The bounded projection a performer receives: ideas bound to the
+    // target or to any of its ancestors (goals flow down, initiatives
+    // stay local), capped by `budget`, with the omission counted.
+    @unbounded
+    fn context_for(target: String, budget: Int, data_class: String) -> ContextPackage {
+        let mut included = "";
+        let mut omitted_ids = "";
+        let mut n = 0;
+        let mut omitted = 0;
+        let mut i = 0;
+        while i < self.bindings.len() {
+            let b = self.bindings.get(i) or KnowledgeBinding { };
+            let relevant = b.target == target || is_ancestor(b.target, target);
+            // The same idea may be bound in several places; the package
+            // carries it once.
+            let seen = std::str::contains(included, b.idea + " ") || std::str::contains(omitted_ids, b.idea + " ");
+            if relevant && !seen {
+                let idea = self.find(b.idea);
+                if idea.accepted {
+                    if n < budget {
+                        included = included + idea.id + " ";
+                        n = n + 1;
+                    } else {
+                        omitted = omitted + 1;
+                        omitted_ids = omitted_ids + idea.id + " ";
+                    }
+                }
+            }
+            i = i + 1;
+        }
+        let d = hex(std::crypto::sha256(std::bytes::from_string(target + "@" + to_string(self.revision) + ":" + included)));
+        return ContextPackage { target: target, revision: self.revision, digest: d, included: included, included_n: n, omitted_n: omitted, data_class: data_class };
+    }
+}

--- a/dna/core/models.hl
+++ b/dna/core/models.hl
@@ -11,12 +11,12 @@
 
 type ModelRequest {
     attempt_id: String = "";
-    role: String = "";             // "classify" | "synthesize" | "review" | ...
+    role: String = ""; // "classify" | "synthesize" | "review" | ...
     prompt_digest: String = "";
     context_bytes: Int = 0;
     data_class: String = "internal";
     needs_tools: Bool = false;
-    assurance: Int = 0;            // 0 quick .. 2 independent/deep
+    assurance: Int = 0; // 0 quick .. 2 independent/deep
     cost_ceiling_micros: Int = 0;
 }
 
@@ -27,7 +27,7 @@ type ModelResult {
     output: String = "";
     tokens: Int = 0;
     cost_micros: Int = 0;
-    refused: String = "";          // why, when !ok
+    refused: String = ""; // why, when !ok
 }
 
 interface ModelBackend {
@@ -118,7 +118,7 @@ locus EvidenceAwareSelection {
     fn select(req: ModelRequest, quick_ok: Bool, deep_ok: Bool, private_ok: Bool) -> String {
         if req.data_class == "customer" {
             if private_ok { return "private"; }
-            return "";                 // no permitted backend: refuse, never leak
+            return ""; // no permitted backend: refuse, never leak
         }
         if req.assurance >= 2 || req.role == "review" {
             if deep_ok { return "deep"; }
@@ -168,8 +168,8 @@ locus ModelRouter {
         self.calls = self.calls + 1;
         self.last_backend = cls;
         let r = if cls == "deep" { self.deep.complete(req) }
-                else if cls == "private" { self.private.complete(req) }
-                else { self.quick.complete(req) };
+        else if cls == "private" { self.private.complete(req) }
+        else { self.quick.complete(req) };
         self.spent_micros = self.spent_micros + r.cost_micros;
         return r;
     }

--- a/dna/core/models.hl
+++ b/dna/core/models.hl
@@ -1,0 +1,176 @@
+// dna/core/models.hl — model routing (#521 comment 1 & 2).
+//
+// A model is one resource an AGENT performer uses; it is not the
+// organism's unit of agency. `ModelRouter` owns backends behind the
+// structural `ModelBackend` interface and a selection policy behind
+// `ModelSelection`, and returns pure results — never a backend locus
+// (the CQRS rule). Availability (construction) and policy (selection)
+// are distinct from LAW: a backend that must never see customer data
+// is refused by `allows()` and, at the program level, by an effect
+// class the claims can forbid (dna/tests/dna_law.rs).
+
+type ModelRequest {
+    attempt_id: String = "";
+    role: String = "";             // "classify" | "synthesize" | "review" | ...
+    prompt_digest: String = "";
+    context_bytes: Int = 0;
+    data_class: String = "internal";
+    needs_tools: Bool = false;
+    assurance: Int = 0;            // 0 quick .. 2 independent/deep
+    cost_ceiling_micros: Int = 0;
+}
+
+type ModelResult {
+    ok: Bool = false;
+    backend: String = "";
+    model: String = "";
+    output: String = "";
+    tokens: Int = 0;
+    cost_micros: Int = 0;
+    refused: String = "";          // why, when !ok
+}
+
+interface ModelBackend {
+    fn identity() -> String;
+    fn model_name() -> String;
+    fn allows(data_class: String) -> Bool;
+    fn capacity_bytes() -> Int;
+    fn complete(req: ModelRequest) -> ModelResult;
+}
+
+interface ModelSelection {
+    // Returns a backend CLASS name: "quick" | "deep" | "private".
+    fn select(req: ModelRequest, quick_ok: Bool, deep_ok: Bool, private_ok: Bool) -> String;
+}
+
+fn fake_answer(name: String, model: String, req: ModelRequest, max_bytes: Int, price: Int) -> ModelResult {
+    if req.context_bytes > max_bytes {
+        return ModelResult { ok: false, backend: name, model: model, refused: "context too large" };
+    }
+    return ModelResult {
+        ok: true,
+        backend: name,
+        model: model,
+        output: name + ":" + req.role + ":" + req.prompt_digest,
+        tokens: req.context_bytes / 4 + 32,
+        cost_micros: price
+    };
+}
+
+// A deterministic EXTERNAL backend for the proof: its `complete`
+// carries the `external_model` effect class, so the law can forbid a
+// customer-data path from ever reaching it — statically, whatever
+// `allows()` says at runtime. Runtime policy and law must not collapse.
+locus FakeModel {
+    params {
+        name: String = "fake";
+        model: String = "fake-1";
+        max_bytes: Int = 100000;
+        price_micros: Int = 10;
+        calls: Int = 0;
+    }
+    fn identity() -> String { return self.name; }
+    fn model_name() -> String { return self.model; }
+    fn allows(data_class: String) -> Bool { return data_class != "customer"; }
+    fn capacity_bytes() -> Int { return self.max_bytes; }
+    @effects(is: { external_model })
+    fn complete(req: ModelRequest) -> ModelResult {
+        self.calls = self.calls + 1;
+        if !self.allows(req.data_class) {
+            return ModelResult { ok: false, backend: self.name, model: self.model, refused: "data class " + req.data_class };
+        }
+        return fake_answer(self.name, self.model, req, self.max_bytes, self.price_micros);
+    }
+}
+
+// A deterministic LOCAL backend: no effect class, any data class.
+locus LocalFakeModel {
+    params {
+        name: String = "private";
+        model: String = "local-1";
+        max_bytes: Int = 100000;
+        price_micros: Int = 1;
+        calls: Int = 0;
+    }
+    fn identity() -> String { return self.name; }
+    fn model_name() -> String { return self.model; }
+    fn allows(data_class: String) -> Bool { return true; }
+    fn capacity_bytes() -> Int { return self.max_bytes; }
+    fn complete(req: ModelRequest) -> ModelResult {
+        self.calls = self.calls + 1;
+        return fake_answer(self.name, self.model, req, self.max_bytes, self.price_micros);
+    }
+}
+
+// Key material the DNA tree never holds: a sealed source that reports
+// presence and a fingerprint, never bytes (the std::secret shape).
+@sealed locus CredentialSource {
+    params { source: String = ""; loaded: Bool = false; }
+    fn present() -> Bool { return self.source != ""; }
+    fn fingerprint() -> String { return "fp:" + self.source; }
+}
+
+// Evidence-aware selection: private for customer data, deep for
+// review/high assurance, quick otherwise; falls back only to a
+// backend that is actually permitted.
+locus EvidenceAwareSelection {
+    params { default_class: String = "quick"; }
+    fn select(req: ModelRequest, quick_ok: Bool, deep_ok: Bool, private_ok: Bool) -> String {
+        if req.data_class == "customer" {
+            if private_ok { return "private"; }
+            return "";                 // no permitted backend: refuse, never leak
+        }
+        if req.assurance >= 2 || req.role == "review" {
+            if deep_ok { return "deep"; }
+        }
+        if quick_ok { return self.default_class; }
+        if deep_ok { return "deep"; }
+        if private_ok { return "private"; }
+        return "";
+    }
+}
+
+// A router for CUSTOMER-facing loci: only the local backend is
+// reachable, so `forbid reaches(customer_side, effects(external_model))`
+// holds structurally, not by a runtime check.
+locus PrivateModelRouter {
+    params {
+        private: ModelBackend = LocalFakeModel { };
+        calls: Int = 0;
+    }
+    fn ask(req: ModelRequest) -> ModelResult {
+        self.calls = self.calls + 1;
+        return self.private.complete(req);
+    }
+}
+
+locus ModelRouter {
+    params {
+        quick: ModelBackend = FakeModel { name: "quick", model: "quick-1", price_micros: 5 };
+        deep: ModelBackend = FakeModel { name: "deep", model: "deep-1", price_micros: 50 };
+        private: ModelBackend = LocalFakeModel { };
+        selection: ModelSelection = EvidenceAwareSelection { };
+        daily_cost_ceiling_micros: Int = 25000000;
+        spent_micros: Int = 0;
+        calls: Int = 0;
+        last_backend: String = "";
+    }
+    // The router returns DATA. Which backend answered is recorded, not hidden.
+    fn ask(req: ModelRequest) -> ModelResult {
+        let quick_ok = self.quick.allows(req.data_class) && self.quick.capacity_bytes() >= req.context_bytes;
+        let deep_ok = self.deep.allows(req.data_class) && self.deep.capacity_bytes() >= req.context_bytes;
+        let private_ok = self.private.allows(req.data_class) && self.private.capacity_bytes() >= req.context_bytes;
+        let cls = self.selection.select(req, quick_ok, deep_ok, private_ok);
+        if cls == "" { return ModelResult { ok: false, refused: "no permitted backend for " + req.data_class }; }
+        if self.spent_micros >= self.daily_cost_ceiling_micros {
+            return ModelResult { ok: false, refused: "cost ceiling" };
+        }
+        self.calls = self.calls + 1;
+        self.last_backend = cls;
+        let r = if cls == "deep" { self.deep.complete(req) }
+                else if cls == "private" { self.private.complete(req) }
+                else { self.quick.complete(req) };
+        self.spent_micros = self.spent_micros + r.cost_micros;
+        return r;
+    }
+}

--- a/dna/core/performers.hl
+++ b/dna/core/performers.hl
@@ -1,0 +1,45 @@
+// dna/core/performers.hl — who does a unit of Work.
+//
+// Work is executor-neutral (#521 comment 2). A performer is the human,
+// agent, software, or service currently assigned to one Attempt; the
+// backend it uses (a model endpoint, a person's inbox, a binary) is
+// below it. `Performer` is a structural interface, so an Attempt holds
+// whichever concrete locus the assembly hands it, and the compiler
+// checks the contract rather than a registry.
+
+interface Performer {
+    fn kind() -> String;
+    fn identity() -> String;
+    fn perform(req: WorkRequest) -> WorkResult;
+}
+
+// A deterministic performer for the domain proof: scripted outcomes,
+// scripted failures for the first `fail_first` attempts, so retry and
+// reassignment are exercised without a model or a person.
+locus ScriptedPerformer {
+    params {
+        name: String = "script";
+        performer_kind: String = "software";
+        outcome: String = "done";
+        fail_first: Int = 0;
+    }
+    fn kind() -> String { return self.performer_kind; }
+    fn identity() -> String { return self.name; }
+    // One result per attempt; bounded by the caller's attempt cap.
+    @unbounded
+    fn perform(req: WorkRequest) -> WorkResult {
+        if req.attempt_no < self.fail_first {
+            return WorkResult {
+                disposition: "failed",
+                narrative: "scripted failure on attempt " + to_string(req.attempt_no),
+                performer: self.name
+            };
+        }
+        return WorkResult {
+            disposition: self.outcome,
+            result: "ok:" + req.objective,
+            narrative: "scripted " + self.outcome,
+            performer: self.name
+        };
+    }
+}

--- a/dna/core/process.hl
+++ b/dna/core/process.hl
@@ -102,7 +102,7 @@ locus Work {
         attempts: Int = 0;
         disposition: String = "";
         result: String = "";
-        history: String = "";     // "a0:failed a1:done "
+        history: String = ""; // "a0:failed a1:done "
     }
     contract {
         expose work_id: String;
@@ -128,7 +128,7 @@ locus Work {
         self.history = s.history;
     }
     accept(a: Attempt) { }
-    release(a: Attempt) {
+    release (a: Attempt) {
         // The typed settlement signal: fires after the child drains,
         // before it dissolves; we read its final state here.
         self.attempts = self.attempts + 1;
@@ -188,8 +188,8 @@ locus Step {
         task_id: String = "";
         workflow_id: String = "";
         objective: String = "";
-        fan: Int = 1;              // Work children to fan out
-        delegate: Bool = false;    // also spawn a child Task
+        fan: Int = 1; // Work children to fan out
+        delegate: Bool = false; // also spawn a child Task
         routed: Bool = false;
         requires: String = "";
         data_class: String = "internal";
@@ -222,9 +222,9 @@ locus Step {
     on_failure(w: Work, err: ClosureViolation) {
         self.works_violated = self.works_violated + 1;
         self.works_failed = self.works_failed + 1;
-        self.detail = self.detail + "violated:" + err.closure + " ";
+        self.detail = self.detail + "violated:" + err.closure +" ";
     }
-    release(w: Work) {
+    release (w: Work) {
         if w.disposition == "done" { self.works_done = self.works_done + 1; }
         else { self.works_failed = self.works_failed + 1; }
         self.detail = self.detail + w.work_id + "=" + w.disposition + "[" + w.history + "] ";
@@ -281,12 +281,12 @@ locus Workflow {
     params {
         workflow_id: String = "";
         task_id: String = "";
-        revision: Int = 1;         // definition revision bound at birth
+        revision: Int = 1; // definition revision bound at birth
         objective: String = "";
         steps: Int = 1;
         fan: Int = 1;
-        delegate_at: Int = -1;     // which step (if any) delegates a child Task
-        cancel_at: Int = -1;       // the owning Task cancels before this step activates
+        delegate_at: Int = -1; // which step (if any) delegates a child Task
+        cancel_at: Int = -1; // the owning Task cancels before this step activates
         routed: Bool = false;
         requires: String = "";
         data_class: String = "internal";
@@ -294,7 +294,7 @@ locus Workflow {
         escalate: Bool = false;
         steps_done: Int = 0;
         steps_failed: Int = 0;
-        steps_skipped: Int = 0;    // dependents that never activated
+        steps_skipped: Int = 0; // dependents that never activated
         disposition: String = "";
         detail: String = "";
     }
@@ -308,7 +308,7 @@ locus Workflow {
         expose detail: String;
     }
     accept(s: Step) { }
-    release(s: Step) {
+    release (s: Step) {
         if s.disposition == "done" { self.steps_done = self.steps_done + 1; }
         else { self.steps_failed = self.steps_failed + 1; }
         self.detail = self.detail + s.step_id + "=" + s.disposition + " {" + s.detail + "} ";
@@ -357,7 +357,7 @@ locus Workflow {
 locus Task {
     params {
         task_id: String = "";
-        parent_task: String = "";  // "" at the root
+        parent_task: String = ""; // "" at the root
         spawning_step: String = "";
         intent: Intent = Intent { };
         revision: Int = 1;
@@ -382,7 +382,7 @@ locus Task {
         expose detail: String;
     }
     accept(w: Workflow) { }
-    release(w: Workflow) {
+    release (w: Workflow) {
         // One outcome upward, not every internal event.
         self.disposition = w.disposition;
         self.detail = w.detail;
@@ -416,7 +416,7 @@ locus Metabolism {
     }
     bus { publish TaskSettled; }
     accept(t: Task) { }
-    release(t: Task) {
+    release (t: Task) {
         self.log.push(Settled {
             id: t.task_id,
             kind: "task",

--- a/dna/core/process.hl
+++ b/dna/core/process.hl
@@ -1,0 +1,466 @@
+// dna/core/process.hl — the process recursion, in ordinary Hale.
+//
+//   Metabolism                 flat Task pool; the supersystem that mediates
+//   └── Task                   bounded intention; binds a workflow revision
+//       └── Workflow           dependency topology; mediates sibling Steps
+//           └── Step           synchronization barrier: fan-out / join
+//               └── Work       executor-neutral outcome; survives reassignment
+//                   └── Attempt one performer, one context, one grant
+//
+// Every parent `accept`s exactly ONE concrete child type (spec/types.md
+// F.11, single-accept-type per parent). A Step therefore owns Work and
+// nothing else. Delegation — a Step that needs a child TASK — writes a
+// `Task { }` literal anyway: interest-based ownership bubbles it past
+// Step, Workflow and Task (none accept `Task`) to Metabolism, the
+// nearest ancestor that does. Lineage (`parent_task`, `spawning_step`)
+// is DATA on the child; settlement comes back to the waiting Step over
+// `TaskSettled`, keyed by the parent task, published by Metabolism.
+// That is supersystem mediation in the letter of H9, and it is the
+// honest today-shape for #521 open question 1.
+//
+// Retries never `restart(c)`: restart reuses identity, and #521 wants
+// every Attempt to be its own locus with its own lifetime. A failed
+// Attempt settles as failed; Work births the next one with a new id.
+
+// Proof knobs: how a Task's workflow should behave in a fixture.
+type Knobs {
+    steps: Int = 1;
+    fan: Int = 1;
+    delegate_at: Int = -1;
+    cancel_at: Int = -1;
+    routed: Bool = false;
+    requires: String = "";
+    data_class: String = "internal";
+    fail_first: Int = 0;
+    escalate: Bool = false;
+}
+
+// ---- the settled log (data collection + facade) -------------------
+
+@form(vec)
+locus SettledRows {
+    capacity { heap rows of Settled; }
+}
+
+// ---- Attempt: one allocation of agency ----------------------------
+
+// One assignment of one performer to one Work request, with its own
+// lifetime. F.3 (dna/FRICTION.md): a performer cannot be handed into
+// a child literal, so the locus that OWNS the performer performs and
+// births the Attempt carrying the request and the result. The Attempt
+// is the durable record of the allocation; a retry is a new one.
+locus Attempt {
+    params {
+        attempt_id: String = "";
+        work_id: String = "";
+        attempt_no: Int = 0;
+        performer_kind: String = "";
+        req: WorkRequest = WorkRequest { };
+        outcome: WorkResult = WorkResult { };
+        disposition: String = "";
+        result: String = "";
+        performer_name: String = "";
+    }
+    contract {
+        expose attempt_id: String;
+        expose attempt_no: Int;
+        expose disposition: String;
+        expose result: String;
+        expose performer_name: String;
+        expose performer_kind: String;
+    }
+    run() {
+        self.disposition = self.outcome.disposition;
+        self.result = self.outcome.result;
+        self.performer_name = self.outcome.performer;
+    }
+}
+
+// ---- Work: executor-neutral outcome ---------------------------------
+
+locus Work {
+    params {
+        work_id: String = "";
+        task_id: String = "";
+        step_id: String = "";
+        objective: String = "";
+        requires: String = "";
+        data_class: String = "internal";
+        max_attempts: Int = 3;
+        // When attempts are exhausted: settle as "failed" (typed
+        // settlement through release) or VIOLATE (structural failure
+        // through the parent's on_failure). Both are failure-up; the
+        // second is the ↑ channel proper.
+        escalate: Bool = false;
+        // In-tower shape: the library names its performer (a
+        // deterministic one for the proof). Routed shape: `routed`
+        // sends the request to the assembly-owned WorkSystem, which
+        // owns real performers and the Attempts (F.3/F.5).
+        routed: Bool = false;
+        performer: ScriptedPerformer = ScriptedPerformer { };
+        fail_first: Int = 0;
+        attempts: Int = 0;
+        disposition: String = "";
+        result: String = "";
+        history: String = "";     // "a0:failed a1:done "
+    }
+    contract {
+        expose work_id: String;
+        expose attempts: Int;
+        expose disposition: String;
+        expose result: String;
+        expose history: String;
+    }
+    bus {
+        publish WorkRequested;
+        subscribe WorkDone as on_done where key == self.work_id;
+    }
+    closure attempts_exhausted {
+        captures: work_id, attempts;
+        epoch inline;
+    }
+    // Routed settlement arrives at drain (F.5) — after run(), before
+    // the owner's release(w) reads us.
+    fn on_done(s: WorkSettlement) {
+        self.disposition = s.disposition;
+        self.result = s.result;
+        self.attempts = s.attempts;
+        self.history = s.history;
+    }
+    accept(a: Attempt) { }
+    release(a: Attempt) {
+        // The typed settlement signal: fires after the child drains,
+        // before it dissolves; we read its final state here.
+        self.attempts = self.attempts + 1;
+        self.history = self.history + a.attempt_id + ":" + a.disposition + " ";
+        self.disposition = a.disposition;
+        self.result = a.result;
+    }
+    // Bounded by a param (`max_attempts` / `fan` / `steps`), which the
+    // advisory cannot see; the children are flow children reclaimed by
+    // `release`, only their literal arguments live in this region.
+    @unbounded
+    run() {
+        if self.routed {
+            WorkRequested <- WorkRequest {
+                work_id: self.work_id,
+                task_id: self.task_id,
+                step_id: self.step_id,
+                objective: self.objective,
+                requires: self.requires,
+                data_class: self.data_class
+            };
+        } else {
+            self.performer.fail_first = self.fail_first;
+            let mut n = 0;
+            let mut settled = false;
+            while !settled && n < self.max_attempts {
+                let req = WorkRequest {
+                    work_id: self.work_id,
+                    task_id: self.task_id,
+                    step_id: self.step_id,
+                    objective: self.objective,
+                    attempt_no: n
+                };
+                let r = self.performer.perform(req);
+                // A NEW Attempt per try — never restart(c).
+                Attempt {
+                    attempt_id: self.work_id + "/a" + to_string(n),
+                    work_id: self.work_id,
+                    attempt_no: n,
+                    performer_kind: self.performer.kind(),
+                    req: req,
+                    outcome: r
+                };
+                if self.disposition == "done" { settled = true; }
+                n = n + 1;
+            }
+            if !settled && self.escalate { violate attempts_exhausted; }
+        }
+    }
+}
+
+// ---- Step: the synchronization barrier -------------------------------
+
+locus Step {
+    params {
+        step_id: String = "";
+        task_id: String = "";
+        workflow_id: String = "";
+        objective: String = "";
+        fan: Int = 1;              // Work children to fan out
+        delegate: Bool = false;    // also spawn a child Task
+        routed: Bool = false;
+        requires: String = "";
+        data_class: String = "internal";
+        fail_first: Int = 0;
+        escalate: Bool = false;
+        works_done: Int = 0;
+        works_failed: Int = 0;
+        works_violated: Int = 0;
+        child_tasks_settled: Int = 0;
+        disposition: String = "";
+        detail: String = "";
+    }
+    contract {
+        expose step_id: String;
+        expose works_done: Int;
+        expose works_failed: Int;
+        expose works_violated: Int;
+        expose child_tasks_settled: Int;
+        expose disposition: String;
+        expose detail: String;
+    }
+    bus {
+        // Only THIS task's delegated children reach this Step: the bus
+        // is the routing table, keyed by the parent task id.
+        subscribe TaskSettled as on_child_task where key == self.task_id;
+    }
+    accept(w: Work) { }
+    // ↑ (H8): a Work that violated `attempts_exhausted` collapses; its
+    // owner absorbs and records. Failures never flow laterally.
+    on_failure(w: Work, err: ClosureViolation) {
+        self.works_violated = self.works_violated + 1;
+        self.works_failed = self.works_failed + 1;
+        self.detail = self.detail + "violated:" + err.closure + " ";
+    }
+    release(w: Work) {
+        if w.disposition == "done" { self.works_done = self.works_done + 1; }
+        else { self.works_failed = self.works_failed + 1; }
+        self.detail = self.detail + w.work_id + "=" + w.disposition + "[" + w.history + "] ";
+    }
+    // One concat per delegated child; bounded by the Step's delegation
+    // count, which the advisory cannot see.
+    @unbounded
+    fn on_child_task(s: TaskSettlement) {
+        self.child_tasks_settled = self.child_tasks_settled + 1;
+        self.detail = self.detail + "child " + s.task_id + "=" + s.disposition + " ";
+    }
+    // Bounded by a param (`max_attempts` / `fan` / `steps`), which the
+    // advisory cannot see; the children are flow children reclaimed by
+    // `release`, only their literal arguments live in this region.
+    @unbounded
+    run() {
+        // fan-out belongs inside a Step
+        let mut i = 0;
+        while i < self.fan {
+            Work {
+                work_id: self.step_id + "/w" + to_string(i),
+                task_id: self.task_id,
+                step_id: self.step_id,
+                objective: self.objective,
+                routed: self.routed,
+                requires: self.requires,
+                data_class: self.data_class,
+                fail_first: self.fail_first,
+                escalate: self.escalate
+            };
+            i = i + 1;
+        }
+        if self.delegate {
+            // Delegation recurses. Step does not accept Task, so this
+            // literal bubbles up to Metabolism; lineage rides as data.
+            Task {
+                task_id: self.task_id + ".sub",
+                parent_task: self.task_id,
+                spawning_step: self.step_id,
+                intent: Intent { outcome: "delegated: " + self.objective, from: self.step_id },
+                steps: 1
+            };
+        }
+        // join at the Step boundary
+        let delegated_ok = !self.delegate || self.child_tasks_settled > 0;
+        if self.works_failed == 0 && delegated_ok { self.disposition = "done"; }
+        else { self.disposition = "failed"; }
+    }
+}
+
+// ---- Workflow: current organization of the work ----------------------
+
+locus Workflow {
+    params {
+        workflow_id: String = "";
+        task_id: String = "";
+        revision: Int = 1;         // definition revision bound at birth
+        objective: String = "";
+        steps: Int = 1;
+        fan: Int = 1;
+        delegate_at: Int = -1;     // which step (if any) delegates a child Task
+        cancel_at: Int = -1;       // the owning Task cancels before this step activates
+        routed: Bool = false;
+        requires: String = "";
+        data_class: String = "internal";
+        fail_first: Int = 0;
+        escalate: Bool = false;
+        steps_done: Int = 0;
+        steps_failed: Int = 0;
+        steps_skipped: Int = 0;    // dependents that never activated
+        disposition: String = "";
+        detail: String = "";
+    }
+    contract {
+        expose workflow_id: String;
+        expose revision: Int;
+        expose steps_done: Int;
+        expose steps_failed: Int;
+        expose steps_skipped: Int;
+        expose disposition: String;
+        expose detail: String;
+    }
+    accept(s: Step) { }
+    release(s: Step) {
+        if s.disposition == "done" { self.steps_done = self.steps_done + 1; }
+        else { self.steps_failed = self.steps_failed + 1; }
+        self.detail = self.detail + s.step_id + "=" + s.disposition + " {" + s.detail + "} ";
+    }
+    // Bounded by a param (`max_attempts` / `fan` / `steps`), which the
+    // advisory cannot see; the children are flow children reclaimed by
+    // `release`, only their literal arguments live in this region.
+    @unbounded
+    run() {
+        // The step DAG is a chain here: step i depends on step i-1.
+        // Readiness travels through the Workflow — a failed step
+        // means its dependents never activate.
+        let mut i = 0;
+        let mut cancelled = false;
+        while i < self.steps && self.steps_failed == 0 && !cancelled {
+            if i == self.cancel_at {
+                // Cancellation is a Task-owned transition; the Workflow
+                // stops activating dependents and says so.
+                cancelled = true;
+            } else {
+                Step {
+                    step_id: self.workflow_id + "/s" + to_string(i),
+                    task_id: self.task_id,
+                    workflow_id: self.workflow_id,
+                    objective: self.objective,
+                    fan: self.fan,
+                    delegate: i == self.delegate_at,
+                    routed: self.routed,
+                    requires: self.requires,
+                    data_class: self.data_class,
+                    fail_first: self.fail_first,
+                    escalate: self.escalate
+                };
+                i = i + 1;
+            }
+        }
+        self.steps_skipped = self.steps - self.steps_done - self.steps_failed;
+        if cancelled { self.disposition = "cancelled"; }
+        else if self.steps_failed == 0 && self.steps_done == self.steps { self.disposition = "done"; }
+        else { self.disposition = "failed"; }
+    }
+}
+
+// ---- Task: bounded intention -----------------------------------------
+
+locus Task {
+    params {
+        task_id: String = "";
+        parent_task: String = "";  // "" at the root
+        spawning_step: String = "";
+        intent: Intent = Intent { };
+        revision: Int = 1;
+        steps: Int = 1;
+        fan: Int = 1;
+        delegate_at: Int = -1;
+        cancel_at: Int = -1;
+        routed: Bool = false;
+        requires: String = "";
+        data_class: String = "internal";
+        fail_first: Int = 0;
+        escalate: Bool = false;
+        disposition: String = "";
+        detail: String = "";
+    }
+    contract {
+        expose task_id: String;
+        expose parent_task: String;
+        expose spawning_step: String;
+        expose revision: Int;
+        expose disposition: String;
+        expose detail: String;
+    }
+    accept(w: Workflow) { }
+    release(w: Workflow) {
+        // One outcome upward, not every internal event.
+        self.disposition = w.disposition;
+        self.detail = w.detail;
+    }
+    run() {
+        Workflow {
+            workflow_id: self.task_id + "/wf" + to_string(self.revision),
+            task_id: self.task_id,
+            revision: self.revision,
+            objective: self.intent.outcome,
+            steps: self.steps,
+            fan: self.fan,
+            delegate_at: self.delegate_at,
+            cancel_at: self.cancel_at,
+            routed: self.routed,
+            requires: self.requires,
+            data_class: self.data_class,
+            fail_first: self.fail_first,
+            escalate: self.escalate
+        };
+    }
+}
+
+// ---- Metabolism: the Task pool and the mediating supersystem ---------
+
+locus Metabolism {
+    params {
+        log: SettledRows = SettledRows { };
+        minted: Int = 0;
+        last_id: String = "";
+    }
+    bus { publish TaskSettled; }
+    accept(t: Task) { }
+    release(t: Task) {
+        self.log.push(Settled {
+            id: t.task_id,
+            kind: "task",
+            parent: t.parent_task,
+            disposition: t.disposition,
+            detail: t.detail
+        });
+        if t.parent_task != "" {
+            // Mediation: the child settled; tell the tower that is
+            // waiting, and only that tower (keyed by parent_task).
+            TaskSettled <- TaskSettlement {
+                task_id: t.task_id,
+                parent_task: t.parent_task,
+                spawning_step: t.spawning_step,
+                disposition: t.disposition,
+                detail: t.detail
+            };
+        }
+    }
+    // Intent enters here; accepting it births a durable Task.
+    fn offer(i: Intent, k: Knobs) -> String {
+        self.minted = self.minted + 1;
+        let id = "t" + to_string(self.minted);
+        self.last_id = id;
+        Task {
+            task_id: id, intent: i, steps: k.steps, fan: k.fan,
+            delegate_at: k.delegate_at, cancel_at: k.cancel_at,
+            routed: k.routed, requires: k.requires, data_class: k.data_class,
+            fail_first: k.fail_first, escalate: k.escalate
+        };
+        return id;
+    }
+    fn settled_count() -> Int { return self.log.len(); }
+    fn settled_at(i: Int) -> Settled { return self.log.get(i) or Settled { }; }
+    // Bounded by the log's length; the `or Settled { }` substitute is
+    // one struct per row scanned.
+    @unbounded
+    fn find(id: String) -> Settled {
+        let mut i = 0;
+        while i < self.log.len() {
+            let s = self.log.get(i) or Settled { };
+            if s.id == id { return s; }
+            i = i + 1;
+        }
+        return Settled { };
+    }
+}

--- a/dna/core/review.hl
+++ b/dna/core/review.hl
@@ -25,15 +25,15 @@ locus Review {
     params {
         review_id: String = "";
         question: String = "";
-        subject_digest: String = "";      // the candidate, pinned
+        subject_digest: String = ""; // the candidate, pinned
         required_authority: String = ""; // e.g. "maintainer", "operator"
-        author: String = "";              // the Attempt/performer that authored the candidate
+        author: String = ""; // the Attempt/performer that authored the candidate
         blocking: Bool = true;
         verdicts: VerdictRows = VerdictRows { };
         settled: Bool = false;
-        outcome: String = "";             // "approve" | "revise" | "reject" | ""
+        outcome: String = ""; // "approve" | "revise" | "reject" | ""
         decided_by: String = "";
-        refused: Int = 0;                 // verdicts refused (wrong digest / authority / independence)
+        refused: Int = 0; // verdicts refused (wrong digest / authority / independence)
         last_refusal: String = "";
     }
     contract {

--- a/dna/core/review.hl
+++ b/dna/core/review.hl
@@ -1,0 +1,153 @@
+// dna/core/review.hl — judgment with provenance, and autonomy as a
+// boundary grant (#521 "Review", "Autonomy is a boundary grant").
+//
+// A Review is a locus, not a Boolean: it owns the exact question, the
+// candidate's digest at decision time, the authority required, and
+// the verdicts it received with their provenance. It settles only when
+// a verdict (a) names the exact candidate digest under review, (b)
+// comes from a reviewer whose claimed authority satisfies the
+// requirement, and (c) is independent of the authoring Attempt. A
+// capable performer with the wrong authority does not settle it.
+//
+// The AutonomyBoundary is owned by the PARENT for one child
+// relationship. It computes the disposition from the grant, the
+// magnitude vector and the evidence (pure fn `dispose` in types.hl),
+// contracts on failure, and never expands on the child's say-so.
+
+// ---- Review -------------------------------------------------------
+
+@form(vec)
+locus VerdictRows {
+    capacity { heap rows of Verdict; }
+}
+
+locus Review {
+    params {
+        review_id: String = "";
+        question: String = "";
+        subject_digest: String = "";      // the candidate, pinned
+        required_authority: String = ""; // e.g. "maintainer", "operator"
+        author: String = "";              // the Attempt/performer that authored the candidate
+        blocking: Bool = true;
+        verdicts: VerdictRows = VerdictRows { };
+        settled: Bool = false;
+        outcome: String = "";             // "approve" | "revise" | "reject" | ""
+        decided_by: String = "";
+        refused: Int = 0;                 // verdicts refused (wrong digest / authority / independence)
+        last_refusal: String = "";
+    }
+    contract {
+        expose review_id: String;
+        expose settled: Bool;
+        expose outcome: String;
+        expose decided_by: String;
+        expose refused: Int;
+        expose last_refusal: String;
+    }
+    // A verdict is admitted only if it names THIS candidate, carries the
+    // required authority, and is independent of the author.
+    fn consider(v: Verdict) -> Bool {
+        if self.settled { self.last_refusal = "already settled"; self.refused = self.refused + 1; return false; }
+        if v.subject_digest != self.subject_digest {
+            self.last_refusal = "digest mismatch: " + v.subject_digest + " != " + self.subject_digest;
+            self.refused = self.refused + 1;
+            return false;
+        }
+        if !std::str::contains(v.authority, self.required_authority) {
+            self.last_refusal = "authority " + v.authority + " does not satisfy " + self.required_authority;
+            self.refused = self.refused + 1;
+            return false;
+        }
+        if v.reviewer == self.author {
+            self.last_refusal = "reviewer " + v.reviewer + " authored the candidate";
+            self.refused = self.refused + 1;
+            return false;
+        }
+        self.verdicts.push(v);
+        if v.verdict == "abstain" { return true; }
+        self.settled = true;
+        self.outcome = v.verdict;
+        self.decided_by = v.reviewer;
+        return true;
+    }
+    fn verdict_count() -> Int { return self.verdicts.len(); }
+}
+
+// ---- AutonomyBoundary ---------------------------------------------
+
+@form(vec)
+locus AuditRows {
+    capacity { heap rows of AuditRow; }
+}
+
+type AuditRow {
+    seq: Int = 0;
+    change_class: String = "";
+    magnitude: Int = 0;
+    evidence: Int = 0;
+    disposition: String = "";
+    note: String = "";
+}
+
+locus AutonomyBoundary {
+    params {
+        child: String = "";
+        grant: Grant = Grant { };
+        audit: AuditRows = AuditRows { };
+        decisions: Int = 0;
+        contractions: Int = 0;
+        expansions_refused: Int = 0;
+        failures_in_row: Int = 0;
+    }
+    contract {
+        expose child: String;
+        expose decisions: Int;
+        expose contractions: Int;
+        expose expansions_refused: Int;
+    }
+    fn current_grant() -> Grant { return self.grant; }
+    // The disposition of a proposed change under the current grant.
+    fn assess(change_class: String, m: Magnitude, e: Evidence) -> String {
+        let d = dispose(self.grant, change_class, m, e);
+        self.decisions = self.decisions + 1;
+        self.audit.push(AuditRow {
+            seq: self.decisions, change_class: change_class,
+            magnitude: magnitude_sum(m), evidence: evidence_score(e), disposition: d
+        });
+        return d;
+    }
+    // Autonomy evolution is asymmetric: failure contracts automatically...
+    fn note_outcome(ok: Bool) {
+        if ok { self.failures_in_row = 0; return; }
+        self.failures_in_row = self.failures_in_row + 1;
+        if self.failures_in_row >= 2 && self.grant.max_magnitude > 0 {
+            self.grant = Grant {
+                child: self.grant.child, classes: self.grant.classes,
+                max_magnitude: self.grant.max_magnitude / 2,
+                review: "pre", may_expand_self: false
+            };
+            self.contractions = self.contractions + 1;
+            self.audit.push(AuditRow { seq: self.decisions, disposition: "contract", note: "repeated failure" });
+        }
+    }
+    // ...and expansion needs the PARENT. A request from the child (or
+    // anyone who is not the owning parent) is refused and recorded.
+    fn expand(requested_by: String, parent: String, new_max: Int, add_classes: String) -> Bool {
+        if requested_by != parent || self.grant.may_expand_self {
+            self.expansions_refused = self.expansions_refused + 1;
+            self.audit.push(AuditRow { seq: self.decisions, disposition: "refuse-expand", note: "requested by " + requested_by });
+            return false;
+        }
+        self.grant = Grant {
+            child: self.grant.child,
+            classes: self.grant.classes + " " + add_classes,
+            max_magnitude: new_max,
+            review: self.grant.review,
+            may_expand_self: false
+        };
+        self.audit.push(AuditRow { seq: self.decisions, disposition: "expand", note: "by " + parent });
+        return true;
+    }
+    fn audit_count() -> Int { return self.audit.len(); }
+    fn audit_at(i: Int) -> AuditRow { return self.audit.get(i) or AuditRow { }; }
+}

--- a/dna/core/topics.hl
+++ b/dna/core/topics.hl
@@ -1,0 +1,76 @@
+// dna/core/topics.hl — facts that cross a real boundary.
+//
+// Most transitions stay inside the owning locus and are read by the
+// owner through `release(c)`. Topics exist only where a fact must
+// cross an ownership tower, a placement, persistence, observation, or
+// the external membrane (#521 "domain facts and topic families").
+
+// Human/external intent entering the organism's membrane.
+type IntentOffer { intent_id: String = ""; outcome: String = ""; from: String = ""; to: String = ""; }
+topic IntentOffered { payload: IntentOffer; subject: "dna.intent.offered"; }
+
+// A delegated child Task settled. Published by the Task pool owner
+// (Metabolism) on behalf of the spawning Step, keyed by the PARENT
+// task so only the waiting Step's tower hears it — supersystem
+// mediation, not sibling chatter (H9).
+type TaskSettlement {
+    task_id: String = "";
+    parent_task: String = "";
+    spawning_step: String = "";
+    disposition: String = "";
+    detail: String = "";
+}
+topic TaskSettled { payload: TaskSettlement; subject: "dna.task.settled"; keyed_by parent_task; }
+
+// Upward-only signals (child -> supersystem).
+type Pressure { source: String = ""; what: String = ""; count: Int = 0; }
+topic PressureRaised { payload: Pressure; subject: "dna.pressure.raised"; }
+
+type Concern { source: String = ""; what: String = ""; severity: Int = 0; }
+topic ConcernRaised { payload: Concern; subject: "dna.concern.raised"; }
+
+// Review requests and verdicts cross the membrane (a human answers).
+type ReviewRequest {
+    review_id: String = "";
+    question: String = "";
+    subject_digest: String = "";   // exact candidate under review (TOCTOU pin)
+    required_authority: String = "";
+}
+topic ReviewRequested { payload: ReviewRequest; subject: "dna.review.requested"; }
+
+type Verdict {
+    review_id: String = "";
+    subject_digest: String = "";   // must equal the request's, or the verdict is refused
+    verdict: String = "";          // "approve" | "revise" | "reject" | "abstain"
+    reviewer: String = "";
+    authority: String = "";        // the authority the reviewer claims
+    comment: String = "";
+}
+topic ReviewVerdict { payload: Verdict; subject: "dna.review.verdict"; keyed_by review_id; }
+
+// Work routed to the assembly-owned WorkSystem (F.3/F.4/F.5 in
+// dna/FRICTION.md: a dynamic child cannot be handed an assembly
+// implementation, so the implementations own the Attempts and the
+// bus carries the request and the settlement, keyed by work id).
+topic WorkRequested { payload: WorkRequest; subject: "dna.work.requested"; }
+
+type WorkSettlement {
+    work_id: String = "";
+    disposition: String = "";
+    result: String = "";
+    attempts: Int = 0;
+    history: String = "";      // "a0:human:declined a1:agent:done "
+}
+topic WorkDone { payload: WorkSettlement; subject: "dna.work.done"; keyed_by work_id; }
+
+// A recorded model call (inside an Attempt; never a Work of its own).
+type ModelCall {
+    attempt_id: String = "";
+    backend: String = "";
+    model: String = "";
+    prompt_digest: String = "";
+    data_class: String = "";
+    tokens: Int = 0;
+    cost_micros: Int = 0;
+    ok: Bool = false;
+}

--- a/dna/core/topics.hl
+++ b/dna/core/topics.hl
@@ -33,17 +33,17 @@ topic ConcernRaised { payload: Concern; subject: "dna.concern.raised"; }
 type ReviewRequest {
     review_id: String = "";
     question: String = "";
-    subject_digest: String = "";   // exact candidate under review (TOCTOU pin)
+    subject_digest: String = ""; // exact candidate under review (TOCTOU pin)
     required_authority: String = "";
 }
 topic ReviewRequested { payload: ReviewRequest; subject: "dna.review.requested"; }
 
 type Verdict {
     review_id: String = "";
-    subject_digest: String = "";   // must equal the request's, or the verdict is refused
-    verdict: String = "";          // "approve" | "revise" | "reject" | "abstain"
+    subject_digest: String = ""; // must equal the request's, or the verdict is refused
+    verdict: String = ""; // "approve" | "revise" | "reject" | "abstain"
     reviewer: String = "";
-    authority: String = "";        // the authority the reviewer claims
+    authority: String = ""; // the authority the reviewer claims
     comment: String = "";
 }
 topic ReviewVerdict { payload: Verdict; subject: "dna.review.verdict"; keyed_by review_id; }
@@ -59,7 +59,7 @@ type WorkSettlement {
     disposition: String = "";
     result: String = "";
     attempts: Int = 0;
-    history: String = "";      // "a0:human:declined a1:agent:done "
+    history: String = ""; // "a0:human:declined a1:agent:done "
 }
 topic WorkDone { payload: WorkSettlement; subject: "dna.work.done"; keyed_by work_id; }
 

--- a/dna/core/types.hl
+++ b/dna/core/types.hl
@@ -1,0 +1,155 @@
+// dna/core/types.hl — pure facts (Σ in proto-form, no lifecycle).
+//
+// Everything here is passed or persisted by value. Identity is a
+// String id minted by the owner that births the thing; durable
+// identity outlives any locus instance (a Task survives a restart
+// as its Journal events, not as its arena).
+
+// ---- effect classes the law reasons about ----------------------------
+// Declared once here; user classes cross seed boundaries. A backend or
+// gateway that performs the effect carries `@effects(is: { ... })` on
+// the one method that does; the app's claims forbid or gate reach.
+effect external_model;   // a prompt leaves the process for a hosted model
+effect genome_apply;     // a candidate becomes the genome (commit/merge/deploy)
+effect journal_io;       // the durable journal's own file I/O
+
+// A bounded outcome offered downward (supersystem -> subsystem).
+type Intent {
+    id: String = "";
+    outcome: String = "";
+    constraints: String = "";
+    from: String = "";       // who offered it: "human", a locus name, ...
+}
+
+// What a settled child hands its owner through `release(c)`.
+// `disposition`: "done" | "failed" | "cancelled" | "declined" |
+// "timeout" | "escalated".
+type Settled {
+    id: String = "";
+    kind: String = "";       // "task" | "workflow" | "step" | "work" | "attempt"
+    parent: String = "";
+    disposition: String = "";
+    detail: String = "";
+    attempts: Int = 0;
+}
+
+// Executor-neutral unit of work: the METHOD is open, the envelope is
+// typed (#521 comment 2).
+type WorkRequest {
+    work_id: String = "";
+    task_id: String = "";
+    step_id: String = "";
+    objective: String = "";
+    context_digest: String = "";   // ContextPackage digest, never the bytes
+    output_contract: String = "";  // e.g. "ReviewVerdict", "Patch", "Assessment"
+    data_class: String = "internal";  // "public" | "internal" | "customer"
+    requires: String = "";         // capability words, space-separated
+    cost_ceiling: Int = 0;
+    attempt_no: Int = 0;
+}
+
+type WorkResult {
+    disposition: String = "";      // "done" | "failed" | "declined" | "timeout"
+    result: String = "";           // structured result (JSON or a value)
+    narrative: String = "";
+    evidence: String = "";         // content digests, space-separated
+    concerns: String = "";
+    performer: String = "";        // performer identity, recorded not hidden
+}
+
+// Autonomy is a property of the parent -> child relationship. The
+// grant is authored by the parent; the child cannot enlarge it.
+type Grant {
+    child: String = "";
+    classes: String = "";          // change classes the child may apply unreviewed
+    max_magnitude: Int = 0;        // scalar ceiling on the SUM of the vector, never a cancel
+    review: String = "pre";        // "pre" | "post" | "sampled" | "audit"
+    may_expand_self: Bool = false; // always false; here so a test can prove it stays false
+}
+
+// Magnitude stays a vector (#521 "do not reduce risk to one score").
+type Magnitude {
+    loci: Int = 0;                 // affected subtree size
+    contract_change: Bool = false; // parent-facing contract changes
+    effects_widened: Bool = false; // new capability / effect class reached
+    law_touched: Bool = false;     // claims / constitution / review policy
+    placement_change: Bool = false;
+    ownership_crossed: Bool = false;
+    state_migration: Bool = false;
+    external_blast: Int = 0;       // 0 none .. 3 customer/financial
+    irreversible: Bool = false;
+    novelty: Int = 0;              // 0 seen-before .. 3 unprecedented
+}
+
+// Evidence-shaped confidence, never an LLM self-rating.
+type Evidence {
+    check_clean: Bool = false;
+    verify_clean: Bool = false;
+    tests_pass: Bool = false;
+    replay_ok: Bool = false;
+    independent_reviews: Int = 0;
+    rollback_rehearsed: Bool = false;
+}
+
+// Dispositions are STRINGS, not an enum: F.1 (dna/FRICTION.md) — a
+// `match` over an enum declared in an imported seed fails the
+// importer's exhaustiveness check, and with a `_` arm fails codegen
+// ("constructor pattern: unknown enum"). Strings cross the seed
+// boundary today; the enum is the shape we want back.
+const DISP_RELEASE: String = "release";
+const DISP_STAGE: String = "stage";
+const DISP_REVIEW: String = "review";
+const DISP_ESCALATE: String = "escalate";
+const DISP_DENY: String = "deny";
+
+fn magnitude_sum(m: Magnitude) -> Int {
+    let mut s = m.loci + m.external_blast + m.novelty;
+    if m.contract_change { s = s + 4; }
+    if m.effects_widened { s = s + 4; }
+    if m.law_touched { s = s + 6; }
+    if m.placement_change { s = s + 2; }
+    if m.ownership_crossed { s = s + 3; }
+    if m.state_migration { s = s + 3; }
+    if m.irreversible { s = s + 5; }
+    return s;
+}
+
+// A hard boundary is any dimension the grant can never cover, no
+// matter what the evidence says: touching law or review policy,
+// widening effects, crossing ownership, or an irreversible external
+// blast. Confidence cannot cancel these (#521).
+fn crosses_hard_boundary(m: Magnitude) -> Bool {
+    if m.law_touched { return true; }
+    if m.effects_widened { return true; }
+    if m.ownership_crossed { return true; }
+    if m.irreversible && m.external_blast > 0 { return true; }
+    return false;
+}
+
+fn evidence_score(e: Evidence) -> Int {
+    let mut s = 0;
+    if e.check_clean { s = s + 1; }
+    if e.verify_clean { s = s + 1; }
+    if e.tests_pass { s = s + 2; }
+    if e.replay_ok { s = s + 2; }
+    if e.rollback_rehearsed { s = s + 2; }
+    s = s + e.independent_reviews * 2;
+    return s;
+}
+
+// required_assurance = policy(class, magnitude vector, novelty,
+// reversibility, boundary crossings, inherited law); proceed only if
+// the grant permits the class AND no hard boundary is crossed AND
+// evidence satisfies required assurance.
+fn dispose(g: Grant, change_class: String, m: Magnitude, e: Evidence) -> String {
+    if crosses_hard_boundary(m) { return DISP_REVIEW; }
+    let permitted = std::str::contains(g.classes, change_class);
+    if !permitted { return DISP_ESCALATE; }
+    let mag = magnitude_sum(m);
+    if mag > g.max_magnitude { return DISP_ESCALATE; }
+    let required = mag + m.novelty * 2;
+    let have = evidence_score(e);
+    if have < required { return DISP_STAGE; }
+    if g.review == "pre" { return DISP_REVIEW; }
+    return DISP_RELEASE;
+}

--- a/dna/core/types.hl
+++ b/dna/core/types.hl
@@ -9,16 +9,16 @@
 // Declared once here; user classes cross seed boundaries. A backend or
 // gateway that performs the effect carries `@effects(is: { ... })` on
 // the one method that does; the app's claims forbid or gate reach.
-effect external_model;   // a prompt leaves the process for a hosted model
-effect genome_apply;     // a candidate becomes the genome (commit/merge/deploy)
-effect journal_io;       // the durable journal's own file I/O
+effect external_model; // a prompt leaves the process for a hosted model
+effect genome_apply; // a candidate becomes the genome (commit/merge/deploy)
+effect journal_io; // the durable journal's own file I/O
 
 // A bounded outcome offered downward (supersystem -> subsystem).
 type Intent {
     id: String = "";
     outcome: String = "";
     constraints: String = "";
-    from: String = "";       // who offered it: "human", a locus name, ...
+    from: String = ""; // who offered it: "human", a locus name, ...
 }
 
 // What a settled child hands its owner through `release(c)`.
@@ -26,7 +26,7 @@ type Intent {
 // "timeout" | "escalated".
 type Settled {
     id: String = "";
-    kind: String = "";       // "task" | "workflow" | "step" | "work" | "attempt"
+    kind: String = ""; // "task" | "workflow" | "step" | "work" | "attempt"
     parent: String = "";
     disposition: String = "";
     detail: String = "";
@@ -40,45 +40,45 @@ type WorkRequest {
     task_id: String = "";
     step_id: String = "";
     objective: String = "";
-    context_digest: String = "";   // ContextPackage digest, never the bytes
-    output_contract: String = "";  // e.g. "ReviewVerdict", "Patch", "Assessment"
-    data_class: String = "internal";  // "public" | "internal" | "customer"
-    requires: String = "";         // capability words, space-separated
+    context_digest: String = ""; // ContextPackage digest, never the bytes
+    output_contract: String = ""; // e.g. "ReviewVerdict", "Patch", "Assessment"
+    data_class: String = "internal"; // "public" | "internal" | "customer"
+    requires: String = ""; // capability words, space-separated
     cost_ceiling: Int = 0;
     attempt_no: Int = 0;
 }
 
 type WorkResult {
-    disposition: String = "";      // "done" | "failed" | "declined" | "timeout"
-    result: String = "";           // structured result (JSON or a value)
+    disposition: String = ""; // "done" | "failed" | "declined" | "timeout"
+    result: String = ""; // structured result (JSON or a value)
     narrative: String = "";
-    evidence: String = "";         // content digests, space-separated
+    evidence: String = ""; // content digests, space-separated
     concerns: String = "";
-    performer: String = "";        // performer identity, recorded not hidden
+    performer: String = ""; // performer identity, recorded not hidden
 }
 
 // Autonomy is a property of the parent -> child relationship. The
 // grant is authored by the parent; the child cannot enlarge it.
 type Grant {
     child: String = "";
-    classes: String = "";          // change classes the child may apply unreviewed
-    max_magnitude: Int = 0;        // scalar ceiling on the SUM of the vector, never a cancel
-    review: String = "pre";        // "pre" | "post" | "sampled" | "audit"
+    classes: String = ""; // change classes the child may apply unreviewed
+    max_magnitude: Int = 0; // scalar ceiling on the SUM of the vector, never a cancel
+    review: String = "pre"; // "pre" | "post" | "sampled" | "audit"
     may_expand_self: Bool = false; // always false; here so a test can prove it stays false
 }
 
 // Magnitude stays a vector (#521 "do not reduce risk to one score").
 type Magnitude {
-    loci: Int = 0;                 // affected subtree size
+    loci: Int = 0; // affected subtree size
     contract_change: Bool = false; // parent-facing contract changes
     effects_widened: Bool = false; // new capability / effect class reached
-    law_touched: Bool = false;     // claims / constitution / review policy
+    law_touched: Bool = false; // claims / constitution / review policy
     placement_change: Bool = false;
     ownership_crossed: Bool = false;
     state_migration: Bool = false;
-    external_blast: Int = 0;       // 0 none .. 3 customer/financial
+    external_blast: Int = 0; // 0 none .. 3 customer/financial
     irreversible: Bool = false;
-    novelty: Int = 0;              // 0 seen-before .. 3 unprecedented
+    novelty: Int = 0; // 0 seen-before .. 3 unprecedented
 }
 
 // Evidence-shaped confidence, never an LLM self-rating.

--- a/dna/core/work_system.hl
+++ b/dna/core/work_system.hl
@@ -1,0 +1,217 @@
+// dna/core/work_system.hl — Work routed to performers (#521 comment 2).
+//
+// The assembly owns this locus and hands it the performers it wants
+// (interface-typed params, substitutable at construction). Work asks
+// over the bus (WorkRequested), the WorkSystem selects a performer per
+// attempt, performs, births one Attempt per assignment (its own
+// lifetime, its own id), and settles the Work over WorkDone keyed by
+// work id. Reassignment is a new Attempt; a completed result is never
+// re-attributed. Selection compares capability, capacity, trust,
+// independence and cost — AUTHORITY is not among them: a performer
+// never gains the right to settle a decision by being selected
+// (that lives with the Review/AutonomyBoundary).
+
+// Routing policy WANTS to be a perspective (#521 comment 1: "live
+// selection may become a perspective") — one program-global slot the
+// assembly designates at construction (#525 item 2) and the owning
+// WorkSystem re-points with `reperspective`. F.10 (dna/FRICTION.md):
+// a perspective declared in an imported seed does not resolve for
+// `serves` or for the holder's default, so the core ships the
+// interface form; substitution happens at construction only.
+interface WorkSelection {
+    // Returns a performer CLASS: "human" | "agent" | "software" | "service".
+    fn select(req: WorkRequest, attempt_no: Int, last: String) -> String;
+    fn policy_name() -> String;
+}
+
+// The n-th comma-separated class; past the end, the last one keeps trying.
+fn nth_class(order: String, n: Int) -> String {
+    let mut rest = order;
+    let mut i = 0;
+    let mut last = "";
+    while len(rest) > 0 {
+        let c = std::str::index_of(rest, ",");
+        let head = if c < 0 { rest } else { rest[0..c] };
+        if i == n { return head; }
+        last = head;
+        if c < 0 { rest = ""; } else { rest = rest[(c + 1)..len(rest)]; }
+        i = i + 1;
+    }
+    return last;
+}
+
+// Capability first, then the cheapest; escalates to a person only
+// after the cheaper performers declined or failed.
+locus CapabilityFirstSelection {
+    params {
+        default_order: String = "software,agent,human";
+        judgment_order: String = "agent,human";
+        service_order: String = "service,agent";
+    }
+    fn policy_name() -> String { return "capability-first"; }
+    fn select(req: WorkRequest, attempt_no: Int, last: String) -> String {
+        if std::str::contains(req.requires, "judgment") { return nth_class(self.judgment_order, attempt_no); }
+        if std::str::contains(req.requires, "analysis") { return nth_class(self.service_order, attempt_no); }
+        return nth_class(self.default_order, attempt_no);
+    }
+}
+
+// A person first, everywhere: the conservative posture an assembly
+// can designate, or a WorkSystem can swap to under pressure.
+locus HumanFirstSelection {
+    params {
+        default_order: String = "human,software";
+        judgment_order: String = "human,agent";
+        service_order: String = "human,service";
+    }
+    fn policy_name() -> String { return "human-first"; }
+    fn select(req: WorkRequest, attempt_no: Int, last: String) -> String {
+        if std::str::contains(req.requires, "judgment") { return nth_class(self.judgment_order, attempt_no); }
+        if std::str::contains(req.requires, "analysis") { return nth_class(self.service_order, attempt_no); }
+        return nth_class(self.default_order, attempt_no);
+    }
+}
+
+// ---- performers -----------------------------------------------------
+
+// The human is OUTSIDE the root. This is the in-process gateway that
+// owns delivery, response capture, timeout and the typed boundary
+// back into Work — not a fictional human locus.
+locus HumanWorkGateway {
+    params {
+        operator: String = "operator";
+        // scripted answers for the proof: "done" | "declined" | "timeout"
+        answer: String = "done";
+        delivered: Int = 0;
+    }
+    fn kind() -> String { return "human"; }
+    fn identity() -> String { return self.operator; }
+    fn perform(req: WorkRequest) -> WorkResult {
+        self.delivered = self.delivered + 1;
+        if self.answer == "timeout" {
+            return WorkResult { disposition: "timeout", narrative: "no answer within the window", performer: self.operator };
+        }
+        if self.answer == "declined" {
+            return WorkResult { disposition: "declined", narrative: "operator declined", performer: self.operator };
+        }
+        return WorkResult { disposition: "done", result: "human:" + req.objective, narrative: "operator answered", performer: self.operator };
+    }
+}
+
+// One agent Attempt may make several model calls — classify on the
+// quick class, synthesize on whatever the router permits — and it
+// stays ONE performer; the calls nest inside the Attempt's history.
+locus AgentPerformer {
+    params {
+        name: String = "agent";
+        models: ModelRouter = ModelRouter { };
+        calls_made: Int = 0;
+        last_backends: String = "";
+    }
+    fn kind() -> String { return "agent"; }
+    fn identity() -> String { return self.name; }
+    fn perform(req: WorkRequest) -> WorkResult {
+        self.last_backends = "";
+        let c = self.models.ask(ModelRequest {
+            attempt_id: req.work_id + "/a" + to_string(req.attempt_no),
+            role: "classify", prompt_digest: req.context_digest, context_bytes: 400,
+            data_class: req.data_class
+        });
+        self.calls_made = self.calls_made + 1;
+        if !c.ok { return WorkResult { disposition: "failed", narrative: "classify refused: " + c.refused, performer: self.name }; }
+        self.last_backends = c.backend;
+        let s = self.models.ask(ModelRequest {
+            attempt_id: req.work_id + "/a" + to_string(req.attempt_no),
+            role: "synthesize", prompt_digest: req.context_digest, context_bytes: 4000,
+            data_class: req.data_class, assurance: 2
+        });
+        self.calls_made = self.calls_made + 1;
+        if !s.ok { return WorkResult { disposition: "failed", narrative: "synthesize refused: " + s.refused, performer: self.name }; }
+        self.last_backends = self.last_backends + "," + s.backend;
+        return WorkResult {
+            disposition: "done",
+            result: s.output,
+            narrative: "agent: " + c.output + " then " + s.output,
+            evidence: "calls=2 backends=" + self.last_backends,
+            performer: self.name
+        };
+    }
+}
+
+// An external API is a performer only when it fulfils the Work
+// contract (an assessment). Anything that changes the world stays an
+// effect behind a gateway — see dna/tests/dna_law.rs.
+locus ServicePerformer {
+    params { name: String = "analysis-service"; calls: Int = 0; }
+    fn kind() -> String { return "service"; }
+    fn identity() -> String { return self.name; }
+    fn perform(req: WorkRequest) -> WorkResult {
+        self.calls = self.calls + 1;
+        return WorkResult { disposition: "done", result: "assessment:" + req.objective, performer: self.name };
+    }
+}
+
+// ---- the router -------------------------------------------------------
+
+locus WorkSystem {
+    params {
+        human: Performer = HumanWorkGateway { };
+        agent: Performer = AgentPerformer { };
+        software: Performer = ScriptedPerformer { name: "software" };
+        service: Performer = ServicePerformer { };
+        selection: WorkSelection = CapabilityFirstSelection { };
+        max_attempts: Int = 3;
+        requests: Int = 0;
+        attempts_made: Int = 0;
+        last_history: String = "";
+    }
+    bus {
+        subscribe WorkRequested as on_request;
+        publish WorkDone;
+    }
+    accept(a: Attempt) { }
+    release(a: Attempt) {
+        self.attempts_made = self.attempts_made + 1;
+    }
+    fn policy() -> String { return self.selection.policy_name(); }
+    fn perform_as(kind: String, req: WorkRequest) -> WorkResult {
+        if kind == "human" { return self.human.perform(req); }
+        if kind == "agent" { return self.agent.perform(req); }
+        if kind == "service" { return self.service.perform(req); }
+        return self.software.perform(req);
+    }
+    // Bounded by max_attempts; one Attempt literal per try.
+    @unbounded
+    fn on_request(req: WorkRequest) {
+        self.requests = self.requests + 1;
+        let mut n = 0;
+        let mut last = "";
+        let mut history = "";
+        let mut result = "";
+        while n < self.max_attempts && last != "done" {
+            let kind = self.selection.select(req, n, last);
+            let r = self.perform_as(kind, req);
+            let aid = req.work_id + "/a" + to_string(n);
+            Attempt {
+                attempt_id: aid,
+                work_id: req.work_id,
+                attempt_no: n,
+                performer_kind: kind,
+                req: req,
+                outcome: r
+            };
+            history = history + "a" + to_string(n) + ":" + kind + ":" + r.disposition + " ";
+            last = r.disposition;
+            result = r.result;
+            n = n + 1;
+        }
+        self.last_history = history;
+        WorkDone <- WorkSettlement {
+            work_id: req.work_id,
+            disposition: if last == "done" { "done" } else { "failed" },
+            result: result,
+            attempts: n,
+            history: history
+        };
+    }
+}

--- a/dna/core/work_system.hl
+++ b/dna/core/work_system.hl
@@ -170,7 +170,7 @@ locus WorkSystem {
         publish WorkDone;
     }
     accept(a: Attempt) { }
-    release(a: Attempt) {
+    release (a: Attempt) {
         self.attempts_made = self.attempts_made + 1;
     }
     fn policy() -> String { return self.selection.policy_name(); }

--- a/dna/friction/f1-import-enum-match/app/main.hl
+++ b/dna/friction/f1-import-enum-match/app/main.hl
@@ -1,0 +1,7 @@
+// Minimized: `hale check ../lib` is clean; `hale check .` (which
+// imports it) reports "match is not exhaustive ... `__lib_lib_Color`".
+import "../lib" as lib;
+
+fn main() {
+    println(lib::name(lib::Color::Red));
+}

--- a/dna/friction/f1-import-enum-match/app2/main.hl
+++ b/dna/friction/f1-import-enum-match/app2/main.hl
@@ -1,0 +1,7 @@
+// Minimized: `hale check ../lib` is clean; `hale check .` passes with the `_` arm but `hale build .` (which
+// imports it) reports "match is not exhaustive ... `__lib_lib_Color`".
+import "../lib2" as lib;
+
+fn main() {
+    println(lib::name(lib::Color::Red));
+}

--- a/dna/friction/f1-import-enum-match/lib/lib.hl
+++ b/dna/friction/f1-import-enum-match/lib/lib.hl
@@ -1,0 +1,8 @@
+type Color = enum { Red, Green };
+
+fn name(c: Color) -> String {
+    return match c {
+        Color::Red -> "red",
+        Color::Green -> "green",
+    };
+}

--- a/dna/friction/f1-import-enum-match/lib2/lib.hl
+++ b/dna/friction/f1-import-enum-match/lib2/lib.hl
@@ -1,0 +1,9 @@
+type Color = enum { Red, Green };
+
+fn name(c: Color) -> String {
+    return match c {
+        Color::Red -> "red",
+        Color::Green -> "green",
+        _ -> "?",
+    };
+}

--- a/dna/friction/f10-perspective-across-seeds/app/main.hl
+++ b/dna/friction/f10-perspective-across-seeds/app/main.hl
@@ -1,0 +1,9 @@
+// Minimized: `hale check ../lib` is clean; importing it fails:
+//   type error: locus `__lib_lib_First` serves unknown perspective `Routing`
+//   type error: param `policy`: declared `__lib_lib_Routing`, default is `__lib_lib_First`
+import "../lib" as lib;
+main locus App {
+    params { r: lib::Router = lib::Router { policy: lib::Second { } }; }
+    run() { println(self.r.which()); }
+}
+fn main() { App { }; }

--- a/dna/friction/f10-perspective-across-seeds/lib/lib.hl
+++ b/dna/friction/f10-perspective-across-seeds/lib/lib.hl
@@ -1,0 +1,7 @@
+perspective Routing { fn pick() -> String; }
+locus First : serves Routing { fn pick() -> String { return "first"; } }
+locus Second : serves Routing { fn pick() -> String { return "second"; } }
+locus Router {
+    params { policy: perspective(Routing) = First { }; }
+    fn which() -> String { return self.policy.pick(); }
+}

--- a/dna/friction/f11-reaches-default-not-override/README.md
+++ b/dna/friction/f11-reaches-default-not-override/README.md
@@ -1,0 +1,10 @@
+Two single-file programs (check each on its own with `hale check <file>`):
+
+- `fail_open.hl` — default `Noop`, constructor override `Real` (the
+  carrier). `hale check` passes. It should refuse: `Real::apply` runs.
+- `false_positive.hl` — default `Real`, override `Noop`. `hale check`
+  refuses with a witness through `Real::apply`, which never runs.
+
+The claims engine resolves a call through an interface-typed field
+against the field's declaration-site default impl, not the impl the
+constructor actually stored (nor the set of all satisfying impls).

--- a/dna/friction/f11-reaches-default-not-override/fail_open.hl
+++ b/dna/friction/f11-reaches-default-not-override/fail_open.hl
@@ -1,0 +1,15 @@
+// Probe i: the interface has TWO impls; the holder's declaration-site
+// default is the harmless one (Noop) and the CONSTRUCTOR overrides it
+// with the carrier (Real). Does `forbid reaches` see the override?
+effect apply_it;
+interface Gate { fn apply(x: String) -> Bool; }
+locus Real { @effects(is: { apply_it }) fn apply(x: String) -> Bool { return true; } }
+locus Noop { fn apply(x: String) -> Bool { return false; } }
+locus Holder { params { dep: Gate = Noop { }; } }
+group organism = { App };
+main locus App {
+    params { h: Holder = Holder { dep: Real { } }; }
+    claims { gated: forbid reaches(organism, effects(apply_it)); }
+    run() { let ok = self.h.dep.apply("i"); }
+}
+fn main() { App { }; }

--- a/dna/friction/f11-reaches-default-not-override/false_positive.hl
+++ b/dna/friction/f11-reaches-default-not-override/false_positive.hl
@@ -1,0 +1,15 @@
+// Probe i: the interface has TWO impls; the holder's declaration-site
+// default is the harmless one (Noop) and the CONSTRUCTOR overrides it
+// with the carrier (Real). Does `forbid reaches` see the override?
+effect apply_it;
+interface Gate { fn apply(x: String) -> Bool; }
+locus Real { @effects(is: { apply_it }) fn apply(x: String) -> Bool { return true; } }
+locus Noop { fn apply(x: String) -> Bool { return false; } }
+locus Holder { params { dep: Gate = Real { }; } }
+group organism = { App };
+main locus App {
+    params { h: Holder = Holder { dep: Noop { } }; }
+    claims { gated: forbid reaches(organism, effects(apply_it)); }
+    run() { let ok = self.h.dep.apply("i"); }
+}
+fn main() { App { }; }

--- a/dna/friction/f3-interface-value-into-field/main.hl
+++ b/dna/friction/f3-interface-value-into-field/main.hl
@@ -1,0 +1,25 @@
+// Probe: can a parent hand ITS interface-typed param child to a
+// dynamically accepted child's interface-typed field? (#526 "verify
+// first": ownership semantics of an interface-typed locus value.)
+interface Performer { fn perform(x: Int) -> Int; fn name() -> String; }
+
+locus Doubler { params { calls: Int = 0; } fn perform(x: Int) -> Int { self.calls = self.calls + 1; return x * 2; } fn name() -> String { return "doubler"; } }
+
+locus Attempt {
+    params { performer: Performer; out: Int = 0; }
+    contract { expose out: Int; }
+    run() { self.out = self.performer.perform(21); }
+}
+
+locus Work {
+    params { performer: Performer = Doubler { }; total: Int = 0; }
+    accept(a: Attempt) { }
+    release(a: Attempt) { self.total = self.total + a.out; }
+    run() {
+        Attempt { performer: self.performer };
+        Attempt { performer: self.performer };
+        println("total=", self.total, " name=", self.performer.name());
+    }
+}
+
+fn main() { Work { }; }

--- a/dna/friction/f3-interface-value-into-field/main.hl
+++ b/dna/friction/f3-interface-value-into-field/main.hl
@@ -14,7 +14,7 @@ locus Attempt {
 locus Work {
     params { performer: Performer = Doubler { }; total: Int = 0; }
     accept(a: Attempt) { }
-    release(a: Attempt) { self.total = self.total + a.out; }
+    release (a: Attempt) { self.total = self.total + a.out; }
     run() {
         Attempt { performer: self.performer };
         Attempt { performer: self.performer };

--- a/dna/friction/f4-perspective-must-designate/main.hl
+++ b/dna/friction/f4-perspective-must-designate/main.hl
@@ -1,0 +1,33 @@
+// Probe: a DYNAMIC child holds `perspective(P)` with no default and
+// dispatches through the program-global slot the ASSEMBLY designated.
+perspective Performing { fn perform(x: Int) -> Int; fn name() -> String; }
+
+locus Doubler : serves Performing { fn perform(x: Int) -> Int { return x * 2; } fn name() -> String { return "doubler"; } }
+locus Tripler : serves Performing { fn perform(x: Int) -> Int { return x * 3; } fn name() -> String { return "tripler"; } }
+
+locus Attempt {
+    params { performer: perspective(Performing); out: Int = 0; }
+    contract { expose out: Int; }
+    run() { self.out = self.performer.perform(21); }
+}
+
+locus Work {
+    params { total: Int = 0; }
+    accept(a: Attempt) { }
+    release(a: Attempt) { self.total = self.total + a.out; }
+    run() {
+        Attempt { };
+        Attempt { };
+        println("total=", self.total);
+    }
+}
+
+main locus App {
+    params {
+        // the assembly designates the program's performer
+        performer: perspective(Performing) = Tripler { };
+        w: Work = Work { };
+    }
+    run() { println("app performer=", self.performer.name()); }
+}
+fn main() { App { }; }

--- a/dna/friction/f4-perspective-must-designate/main.hl
+++ b/dna/friction/f4-perspective-must-designate/main.hl
@@ -14,7 +14,7 @@ locus Attempt {
 locus Work {
     params { total: Int = 0; }
     accept(a: Attempt) { }
-    release(a: Attempt) { self.total = self.total + a.out; }
+    release (a: Attempt) { self.total = self.total + a.out; }
     run() {
         Attempt { };
         Attempt { };

--- a/dna/friction/f5-bus-reply-at-drain/main.hl
+++ b/dna/friction/f5-bus-reply-at-drain/main.hl
@@ -1,0 +1,41 @@
+// Probe: route Work to an assembly-owned performer over the bus,
+// keyed by work id, with a synchronous round trip.
+interface Performer { fn perform(x: Int) -> Int; }
+locus Doubler { fn perform(x: Int) -> Int { return x * 2; } }
+
+type WorkReq { work_id: String = ""; x: Int = 0; }
+type WorkRes { work_id: String = ""; out: Int = 0; }
+topic WorkRequested { payload: WorkReq; subject: "dna.work.requested"; }
+topic WorkDone { payload: WorkRes; subject: "dna.work.done"; keyed_by work_id; }
+
+locus WorkSystem {
+    params { performer: Performer = Doubler { }; served: Int = 0; }
+    bus { subscribe WorkRequested as on_req; publish WorkDone; }
+    fn on_req(r: WorkReq) {
+        self.served = self.served + 1;
+        WorkDone <- WorkRes { work_id: r.work_id, out: self.performer.perform(r.x) };
+    }
+}
+
+locus Work {
+    params { work_id: String = ""; out: Int = -1; }
+    contract { expose out: Int; }
+    bus { publish WorkRequested; subscribe WorkDone as on_done where key == self.work_id; }
+    fn on_done(r: WorkRes) { self.out = r.out; }
+    run() {
+        WorkRequested <- WorkReq { work_id: self.work_id, x: 21 };
+        println(self.work_id, " out=", self.out);
+    }
+}
+
+locus Step {
+    accept(w: Work) { }
+    release(w: Work) { println("released ", w.out); }
+    run() { Work { work_id: "w1" }; Work { work_id: "w2" }; }
+}
+
+main locus App {
+    params { ws: WorkSystem = WorkSystem { }; s: Step = Step { }; }
+    run() { println("served=", self.ws.served); }
+}
+fn main() { App { }; }

--- a/dna/friction/f5-bus-reply-at-drain/main.hl
+++ b/dna/friction/f5-bus-reply-at-drain/main.hl
@@ -30,7 +30,7 @@ locus Work {
 
 locus Step {
     accept(w: Work) { }
-    release(w: Work) { println("released ", w.out); }
+    release (w: Work) { println("released ", w.out); }
     run() { Work { work_id: "w1" }; Work { work_id: "w2" }; }
 }
 

--- a/dna/friction/f6-two-parents-release/main.hl
+++ b/dna/friction/f6-two-parents-release/main.hl
@@ -1,0 +1,24 @@
+// Probe 7: one child type, two accepting parents, no bus. Which
+// parent's release fires?
+locus Child {
+    params { tag: String = ""; label: String = ""; }
+    contract { expose label: String; }
+    run() { self.label = "ran:" + self.tag; }
+}
+locus ParentA {
+    params { n: Int = 0; }
+    accept(c: Child) { println("A accept ", c.tag); }
+    release(c: Child) { self.n = self.n + 1; println("A release ", c.label); }
+    run() { Child { tag: "from-A" }; println("A run done n=", self.n); }
+}
+locus ParentB {
+    params { n: Int = 0; }
+    accept(c: Child) { println("B accept ", c.tag); }
+    release(c: Child) { self.n = self.n + 1; println("B release ", c.label); }
+    run() { Child { tag: "from-B" }; println("B run done n=", self.n); }
+}
+main locus App {
+    params { a: ParentA = ParentA { }; b: ParentB = ParentB { }; }
+    run() { println("a.n=", self.a.n, " b.n=", self.b.n); }
+}
+fn main() { App { }; }

--- a/dna/friction/f6-two-parents-release/main.hl
+++ b/dna/friction/f6-two-parents-release/main.hl
@@ -8,13 +8,13 @@ locus Child {
 locus ParentA {
     params { n: Int = 0; }
     accept(c: Child) { println("A accept ", c.tag); }
-    release(c: Child) { self.n = self.n + 1; println("A release ", c.label); }
+    release (c: Child) { self.n = self.n + 1; println("A release ", c.label); }
     run() { Child { tag: "from-A" }; println("A run done n=", self.n); }
 }
 locus ParentB {
     params { n: Int = 0; }
     accept(c: Child) { println("B accept ", c.tag); }
-    release(c: Child) { self.n = self.n + 1; println("B release ", c.label); }
+    release (c: Child) { self.n = self.n + 1; println("B release ", c.label); }
     run() { Child { tag: "from-B" }; println("B run done n=", self.n); }
 }
 main locus App {

--- a/dna/friction/f7-interface-fallible/main.hl
+++ b/dna/friction/f7-interface-fallible/main.hl
@@ -1,0 +1,8 @@
+// Minimized: an interface method cannot declare `fallible(E)`.
+//   parse error: expected ;, got Ident("fallible")
+type E { kind: String = ""; }
+interface Store {
+    fn put(k: String) -> Int fallible(E);
+}
+locus Mem { fn put(k: String) -> Int fallible(E) { if k == "" { fail E { kind: "empty" }; } return 1; } }
+fn main() { let m = Mem { }; println(m.put("a") or 0); }

--- a/dna/friction/f8-or-on-infallible-stdlib/main.hl
+++ b/dna/friction/f8-or-on-infallible-stdlib/main.hl
@@ -1,0 +1,8 @@
+// Minimized: `hale check` accepts `or` on an INFALLIBLE stdlib path
+// call (the multi-segment path types as Unknown, so fallibility is
+// invisible to the checker); `hale build` refuses:
+//   codegen error: Unsupported("`or` over unknown path call `std::json::find_int_field`")
+fn main() {
+    let n = std::json::find_int_field("{\"seq\": 3}", "seq") or 0;
+    println(n);
+}

--- a/dna/friction/f9-write-append-unit/main.hl
+++ b/dna/friction/f9-write-append-unit/main.hl
@@ -1,0 +1,16 @@
+// Minimized: spec and the typecheck surface say
+//   write_file_append(path, s) -> Int fallible(IoError)
+// but codegen lowers it as Unit, so `let n = ... or 0;` fails with the
+// misleading "expression statement other than locus literal or builtin
+// call", and `or neg_one()` says "`or` expression in value position has
+// Unit success type". Without `or`, the unaddressed fallible call is
+// accepted by BOTH check and build (the path types as Unknown).
+locus W {
+    params { path: String = "/tmp/dna-probe-w.txt"; }
+    fn put(s: String) -> Int {
+        let wrote = std::io::fs::write_file_append(self.path, s) or 0;
+        return wrote;
+    }
+}
+fn neg_one() -> Int { return 0 - 1; }
+fn main() { let w = W { }; println(w.put("x")); }

--- a/dna/tests/assembly_test.hl
+++ b/dna/tests/assembly_test.hl
@@ -1,0 +1,90 @@
+// dna/tests/assembly_test.hl — #526 fixture 7.
+//
+// One `Dna { ... }` is assembled directly in a main's params with
+// every child replaceable through interface substitution: a fake
+// journal, a human-first router, a post-review policy, a deployment
+// that refuses. Model routing returns data, never a locus; intent
+// enters through the membrane; a staged mutation stops at stage.
+// Construction, genome (policy), law (the app's claims) and durable
+// state (the journal) stay four different things.
+
+import "../core" as dna;
+
+// A fake journal: counts appends, keeps nothing (the in-memory fake the
+// issue asks for, proving DNA's owning logic does not change).
+locus CountingJournal {
+    params { appends: Int = 0; }
+    fn revision() -> Int { return self.appends; }
+    fn head() -> String { return "fake"; }
+    fn append(expected: Int, kind: String, entity: String, body: String) -> dna::AppendResult {
+        if expected != self.appends { return dna::AppendResult { error: "stale_revision", expected: expected, actual: self.appends }; }
+        self.appends = self.appends + 1;
+        return dna::AppendResult { ok: true, revision: self.appends };
+    }
+    fn read(i: Int) -> dna::Event { return dna::Event { }; }
+    fn verify_chain() -> Bool { return true; }
+}
+
+main locus App {
+    params {
+        dna: dna::Dna = dna::Dna {
+            journal: CountingJournal { },
+            work: dna::WorkSystem {
+                human: dna::HumanWorkGateway { operator: "riley", answer: "done" },
+                selection: dna::HumanFirstSelection { }
+            },
+            review_policy: dna::PostReviewRefactors { },
+            boundary: dna::AutonomyBoundary {
+                child: "app",
+                grant: dna::Grant { child: "app", classes: "refactor", max_magnitude: 8, review: "post" }
+            },
+            deployment: dna::NoDeployment { }
+        };
+    }
+    run() {
+        // substitution is visible in the status projection
+        let s0 = self.dna.status();
+        std::test::assert(std::str::contains(s0, "\"routing\": \"human-first\""), "assembled router policy: " + s0);
+        std::test::assert(std::str::contains(s0, "\"review_policy\": \"post-review-refactors\""), "assembled review policy: " + s0);
+        std::test::assert(std::str::contains(s0, "\"deployment\": \"none\""), "assembled deployment: " + s0);
+
+        // intent through the membrane -> durable task -> journal events on the FAKE journal
+        let refused = self.dna.ask(dna::Intent { id: "i0", outcome: "" }, dna::Knobs { });
+        std::test::assert_eq_str(refused, "refused: empty intent", "the membrane gates intent");
+        let t = self.dna.ask(dna::Intent { id: "i1", outcome: "answer the audit", from: "human" }, dna::Knobs { routed: true });
+        std::test::assert_eq_str(t, "t1", "task minted");
+        std::test::assert_eq_int(self.dna.journal.revision(), 3, "intent.offered, task.born, task.done on the substituted journal");
+        let settled = self.dna.metabolism.find(t);
+        std::test::assert_eq_str(settled.disposition, "done", "human-first routing served it: " + settled.detail);
+        std::test::assert(std::str::contains(settled.detail, "a0:human:done"), "the human took attempt 0: " + settled.detail);
+
+        // model routing returns DATA
+        let r = dna::ModelRouter { };
+        let quick = r.ask(dna::ModelRequest { role: "classify", prompt_digest: "d1", context_bytes: 100 });
+        std::test::assert(quick.ok && quick.backend == "quick", "quick class by default: " + quick.backend);
+        let deep = r.ask(dna::ModelRequest { role: "review", prompt_digest: "d2", context_bytes: 100, assurance: 2 });
+        std::test::assert(deep.ok && deep.backend == "deep", "review goes deep: " + deep.backend);
+        let priv = r.ask(dna::ModelRequest { role: "classify", prompt_digest: "d3", context_bytes: 100, data_class: "customer" });
+        std::test::assert(priv.ok && priv.backend == "private", "customer data stays private: " + priv.backend);
+        let too_big = r.ask(dna::ModelRequest { role: "classify", prompt_digest: "d4", context_bytes: 10000000, data_class: "customer" });
+        std::test::assert(!too_big.ok, "no permitted backend -> refused, never leaked: " + too_big.refused);
+        std::test::assert_eq_int(r.calls, 3, "three calls recorded, one refusal not counted as a call");
+        std::test::assert_eq_int(r.spent_micros, 56, "cost recorded: 5 + 50 + 1");
+
+        // a mutation stops at stage: the grant would release a small
+        // refactor, the deployment refuses, the membrane is told
+        let d = self.dna.stage("refactor", "sha256:cand-1",
+            dna::Magnitude { loci: 2 },
+            dna::Evidence { check_clean: true, verify_clean: true, tests_pass: true, replay_ok: true, rollback_rehearsed: true, independent_reviews: 2 });
+        std::test::assert_eq_str(d, "stage", "released by the grant, staged by the deployment");
+        std::test::assert_eq_int(self.dna.deployment.applied(), 0, "nothing applied");
+        std::test::assert(self.dna.membrane.notifications() > 0, "membrane notified");
+        // a law-touching change goes to review regardless
+        let rv = self.dna.stage("refactor", "sha256:cand-2", dna::Magnitude { loci: 1, law_touched: true }, dna::Evidence { tests_pass: true });
+        std::test::assert_eq_str(rv, "review", "law touched -> review");
+        let s1 = self.dna.status();
+        std::test::assert(std::str::contains(s1, "\"tasks_settled\": 1"), "status reflects the run: " + s1);
+    }
+}
+
+fn main() { App { }; }

--- a/dna/tests/fanout_join_test.hl
+++ b/dna/tests/fanout_join_test.hl
@@ -1,0 +1,61 @@
+// dna/tests/fanout_join_test.hl — #526 fixture 2.
+//
+// Step fans out N Work; the Workflow activates dependents only when
+// the prior Step settled; cancellation stops activation and is
+// recorded; a failed Attempt is absorbed and Work births a new Attempt
+// with a new id; exceeding the retry bound fails upward — as a typed
+// settlement through release, or structurally through on_failure.
+//
+// Phase 0 runs on one cooperative pool, so children run inline and
+// there is nothing "in flight" to dissolve at cancellation: the
+// cancelled Workflow reports the dependents it never activated. That
+// is the honest single-pool shape; async fan-out is a placement
+// question, not a domain one.
+
+import "../core" as dna;
+
+main locus App {
+    params { m: dna::Metabolism = dna::Metabolism { }; }
+    run() {
+        // 1. Fan-out and retry: three Works, each fails its first attempt
+        //    (scripted), so every Work settles done on attempt a1.
+        let t1 = self.m.offer(dna::Intent { outcome: "fan", from: "test" },
+            dna::Knobs { steps: 1, fan: 3, fail_first: 1 });
+        let s1 = self.m.find(t1);
+        std::test::assert_eq_str(s1.disposition, "done", "retries recover: " + s1.detail);
+        std::test::assert(std::str::contains(s1.detail, "t1/wf1/s0/w0=done[t1/wf1/s0/w0/a0:failed t1/wf1/s0/w0/a1:done ]"),
+            "a failed Attempt is followed by a NEW Attempt id: " + s1.detail);
+        std::test::assert(std::str::contains(s1.detail, "t1/wf1/s0/w2=done"), "all three fanned Works settled: " + s1.detail);
+
+        // 2. Retry bound exceeded: fail_first beyond max_attempts (3).
+        //    Typed failure-up: Work failed -> Step failed -> Workflow
+        //    stops activating -> Task failed. Step 1 never runs.
+        let t2 = self.m.offer(dna::Intent { outcome: "exhaust", from: "test" },
+            dna::Knobs { steps: 3, fan: 1, fail_first: 9 });
+        let s2 = self.m.find(t2);
+        std::test::assert_eq_str(s2.disposition, "failed", "exhausted retries fail upward: " + s2.detail);
+        std::test::assert(std::str::contains(s2.detail, "t2/wf1/s0=failed"), "step 0 failed: " + s2.detail);
+        std::test::assert(!std::str::contains(s2.detail, "t2/wf1/s1"), "dependent step 1 never activated: " + s2.detail);
+        std::test::assert(std::str::contains(s2.detail, "a2:failed"), "three attempts were made before giving up: " + s2.detail);
+
+        // 3. Structural failure-up: the same exhaustion, but the Work
+        //    VIOLATES `attempts_exhausted`; the Step's on_failure absorbs
+        //    it and records the closure by name.
+        let t3 = self.m.offer(dna::Intent { outcome: "violate", from: "test" },
+            dna::Knobs { steps: 2, fan: 1, fail_first: 9, escalate: true });
+        let s3 = self.m.find(t3);
+        std::test::assert_eq_str(s3.disposition, "failed", "violated Work fails the tower: " + s3.detail);
+        std::test::assert(std::str::contains(s3.detail, "violated:attempts_exhausted"), "on_failure named the closure: " + s3.detail);
+
+        // 4. Cancellation before step 1 activates.
+        let t4 = self.m.offer(dna::Intent { outcome: "cancel", from: "test" },
+            dna::Knobs { steps: 3, fan: 1, cancel_at: 1 });
+        let s4 = self.m.find(t4);
+        std::test::assert_eq_str(s4.disposition, "cancelled", "cancelled is its own disposition: " + s4.detail);
+        std::test::assert(std::str::contains(s4.detail, "t4/wf1/s0=done"), "step 0 ran before the cancel: " + s4.detail);
+        std::test::assert(!std::str::contains(s4.detail, "t4/wf1/s1"), "step 1 never activated: " + s4.detail);
+        std::test::assert_eq_int(self.m.settled_count(), 4, "four tasks settled, none leaked");
+    }
+}
+
+fn main() { App { }; }

--- a/dna/tests/journal_test.hl
+++ b/dna/tests/journal_test.hl
@@ -1,0 +1,102 @@
+// dna/tests/journal_test.hl — #526 fixture 5.
+//
+// The Journal is the causal authority. Compare-and-append rejects a
+// stale expected revision; the sha256 chain verifies; a lease carries
+// a fencing token and a late writer is refused; an effect request is
+// committed before dispatch and survives a simulated crash/retry
+// without dispatching twice; task status is a projection; a retrieval
+// index can be deleted and rebuilt with no loss. The file-backed
+// journal rehydrates from disk with the same chain.
+
+import "../core" as dna;
+
+// A fresh path per run (pid-unique); left behind on purpose — F.9
+// forbids `unlink(path) or discard;` as a statement.
+fn scratch_path() -> String {
+    return "/tmp/dna-journal-" + to_string(std::process::pid()) + ".jsonl";
+}
+
+main locus App {
+    params {
+        mem: dna::MemJournal = dna::MemJournal { };
+        leases: dna::MemLeases = dna::MemLeases { };
+        index: dna::RetrievalIndex = dna::RetrievalIndex { };
+    }
+    run() {
+        // ---- compare-and-append ------------------------------------
+        let a = self.mem.append(0, "task.born", "t1", "reduce checkout failures");
+        std::test::assert(a.ok, "first append at revision 0");
+        std::test::assert_eq_int(a.revision, 1, "revision advances");
+        // two writers read revision 1 and both try to advance from it
+        let w1 = self.mem.append(1, "task.running", "t1", "");
+        let w2 = self.mem.append(1, "task.cancelled", "t1", "");
+        std::test::assert(w1.ok, "the first writer wins");
+        std::test::assert(!w2.ok, "the second writer is refused");
+        std::test::assert_eq_str(w2.error, "stale_revision", "named as stale");
+        std::test::assert_eq_int(w2.actual, 2, "told the actual revision");
+        std::test::assert(self.mem.verify_chain(), "digest chain intact");
+        let e1 = self.mem.read(1);
+        std::test::assert_eq_str(e1.prev, self.mem.read(0).digest, "each event names its predecessor");
+        std::test::assert_eq_int(len(e1.digest), 64, "sha256 hex digest");
+
+        // ---- projections ---------------------------------------------
+        std::test::assert_eq_str(dna::task_status(self.mem, "t1"), "running", "status is rebuilt from events");
+        let done = self.mem.append(2, "task.done", "t1", "");
+        std::test::assert(done.ok, "append");
+        std::test::assert_eq_str(dna::task_status(self.mem, "t1"), "done", "status follows the last event");
+        std::test::assert_eq_str(dna::task_status(self.mem, "t9"), "unknown", "unknown id");
+
+        // ---- fencing ---------------------------------------------------
+        let l1 = self.leases.acquire("work:w1", "attempt-a", 100, 50);
+        std::test::assert(l1.present, "lease acquired");
+        let l2 = self.leases.acquire("work:w1", "attempt-b", 120, 50);
+        std::test::assert(!l2.present, "held lease refused while live");
+        std::test::assert_eq_str(l2.holder, "attempt-a", "names the holder");
+        // attempt-a's lease expires; attempt-b takes over with a new token
+        let l3 = self.leases.acquire("work:w1", "attempt-b", 200, 50);
+        std::test::assert(l3.present && l3.token > l1.token, "re-acquired with a higher fencing token");
+        // the late writer wakes up and tries to complete with its stale token
+        std::test::assert(!self.leases.complete("work:w1", l1.token, 210), "stale token cannot record a late success");
+        std::test::assert(self.leases.complete("work:w1", l3.token, 210), "current token completes");
+        std::test::assert_eq_str(self.leases.holder_of("work:w1"), "", "lease released on completion");
+
+        // ---- idempotent effects across crash/retry ---------------------
+        let first = dna::effect_request(self.mem, "email:welcome:42", "send welcome to 42");
+        std::test::assert(first, "first request dispatches");
+        // crash before the result was recorded; the retry finds the key
+        let retry = dna::effect_request(self.mem, "email:welcome:42", "send welcome to 42");
+        std::test::assert(!retry, "retry does NOT dispatch again");
+        std::test::assert(dna::effect_result(self.mem, "email:welcome:42", true), "result recorded once");
+        std::test::assert(!dna::effect_result(self.mem, "email:welcome:42", true), "a second result is refused");
+        let st = dna::effect_status(self.mem, "email:welcome:42");
+        std::test::assert(st.requested && st.done && st.ok, "ledger projection reads back");
+
+        // ---- retrieval index: delete and rebuild -----------------------
+        self.index.rebuild(self.mem);
+        std::test::assert_eq_int(self.index.count("effect.requested"), 1, "indexed one request");
+        std::test::assert_eq_int(self.index.count("task.born"), 1, "indexed the birth");
+        let fresh = dna::RetrievalIndex { };
+        fresh.rebuild(self.mem);
+        std::test::assert_eq_int(fresh.indexed, self.index.indexed, "a fresh index rebuilds to the same size");
+        std::test::assert_eq_int(fresh.count("task.done"), 1, "same content");
+        std::test::assert(self.mem.verify_chain(), "the journal never changed");
+
+        // ---- file-backed journal rehydrates --------------------------
+        let path = scratch_path();
+        let f1 = dna::FileJournal { path: path };
+        let r1 = f1.append(0, "task.born", "t1", "durable");
+        let r2 = f1.append(1, "task.done", "t1", "");
+        std::test::assert(r1.ok && r2.ok, "two durable appends");
+        std::test::assert(!f1.append(1, "task.x", "t1", "").ok, "stale refused on the file journal too");
+        let head = f1.head();
+        let f2 = dna::FileJournal { path: path };
+        std::test::assert_eq_int(f2.loaded, 2, "rehydrated both events from disk");
+        std::test::assert_eq_str(f2.head(), head, "same chain head after restart");
+        std::test::assert(f2.verify_chain(), "chain verifies after rehydration");
+        std::test::assert_eq_str(dna::task_status(f2, "t1"), "done", "projection survives restart");
+        let r3 = f2.append(2, "task.retained", "t1", "");
+        std::test::assert(r3.ok, "the rehydrated journal continues the chain");
+    }
+}
+
+fn main() { App { }; }

--- a/dna/tests/knowledge_test.hl
+++ b/dna/tests/knowledge_test.hl
@@ -1,0 +1,57 @@
+// dna/tests/knowledge_test.hl — #526 fixture 6.
+//
+// Goal / concern / initiative are DERIVED from binding direction, never
+// tagged; a lateral binding is refused (H9). A Task event can propose an
+// insight but only the distillation/review path commits a revision, and
+// the proposer cannot ratify their own. A ContextPackage carries digest,
+// revision, included bindings and what it omitted.
+
+import "../core" as dna;
+
+main locus App {
+    params { k: dna::Knowledge = dna::Knowledge { }; }
+    run() {
+        // declared knowledge, provenance kept
+        let r1 = self.k.declare(dna::Idea { id: "i1", kind: "practice", text: "review before apply", author: "app", provenance: "declared" });
+        let r2 = self.k.declare(dna::Idea { id: "i2", kind: "idea", text: "checkout fails under load", author: "app/support", provenance: "observed" });
+        std::test::assert_eq_int(r2, 2, "each acceptance is a revision");
+        std::test::assert_eq_str(self.k.find("i2").provenance, "observed", "provenance is kept, not flattened");
+
+        // binding direction is the classification
+        std::test::assert_eq_str(self.k.bind("i1", "app/support", "app"), "goal", "parent-authored, bound to child = goal");
+        std::test::assert_eq_str(self.k.bind("i2", "app", "app/support"), "concern", "child-authored, bound to parent = concern");
+        std::test::assert_eq_str(self.k.bind("i2", "app/support", "app/support"), "initiative", "self-authored, bound locally = initiative");
+        std::test::assert_eq_str(self.k.bind("i2", "app/billing", "app/support"), "lateral", "sibling binding refused");
+        std::test::assert_eq_int(self.k.refused_lateral, 1, "refusal counted");
+
+        // proposals do not write; distillation does, and not by the author
+        let p = self.k.propose(dna::Idea { id: "i3", kind: "idea", text: "retry the payment gateway once", author: "app/support/attempt-7" });
+        std::test::assert_eq_int(self.k.accepted_count(), 2, "a proposal is not knowledge yet");
+        std::test::assert(!self.k.distill(p, "app/support/attempt-7", "approve"), "the proposer cannot ratify");
+        std::test::assert(!self.k.distill(p, "app", "reject"), "a rejection commits nothing");
+        std::test::assert_eq_int(self.k.accepted_count(), 2, "still two");
+        std::test::assert(self.k.distill(p, "app", "approve"), "an independent reviewer ratifies");
+        std::test::assert_eq_int(self.k.accepted_count(), 3, "now three");
+        std::test::assert_eq_str(self.k.find("i3").provenance, "ratified", "ratified provenance");
+        std::test::assert_eq_int(self.k.find("i3").revision, 3, "revision 3");
+        std::test::assert(!self.k.distill(p, "app", "approve"), "cannot ratify twice");
+
+        // a bounded ContextPackage
+        // F.9 (dna/FRICTION.md): a value-returning call cannot stand as a statement.
+        let c3 = self.k.bind("i3", "app/support", "app");
+        std::test::assert_eq_str(c3, "goal", "i3 bound as a goal");
+        let full = self.k.context_for("app/support/intake", 10, "internal");
+        std::test::assert_eq_int(full.included_n, 3, "goals flow down to the descendant: i1, i2 (initiative on support), i3: " + full.included);
+        std::test::assert_eq_int(full.omitted_n, 0, "nothing omitted at budget 10");
+        std::test::assert_eq_int(full.revision, 3, "package names the knowledge revision");
+        std::test::assert_eq_int(len(full.digest), 64, "package is content-addressed");
+        let small = self.k.context_for("app/support/intake", 1, "internal");
+        std::test::assert_eq_int(small.included_n, 1, "budget respected");
+        std::test::assert_eq_int(small.omitted_n, 2, "the package states what it omitted");
+        std::test::assert(small.digest != full.digest, "a different projection has a different digest");
+        let again = self.k.context_for("app/support/intake", 10, "internal");
+        std::test::assert_eq_str(again.digest, full.digest, "same revision, same projection, same digest");
+    }
+}
+
+fn main() { App { }; }

--- a/dna/tests/law/apply_gate_fail/main.hl
+++ b/dna/tests/law/apply_gate_fail/main.hl
@@ -1,0 +1,46 @@
+// #526 fixture 8d: the app reaches the apply gateway DIRECTLY, avoiding
+// the Dna gate. The constitution refuses the build with a witness.
+//
+// F.11 (dna/FRICTION.md): the direct call goes through a CONCRETE
+// `LocalApplyDeployment` param. Through the interface-typed
+// `self.dna.deployment` the same call is invisible to `forbid reaches`
+// today, which is the soundness gap that entry records. The constitution
+// says so; the assembly below deliberately constructs a permissive
+// review policy (NoReview) — law is not a constructor flag, so the
+// program still builds only because every apply path passes the gate.
+import "../../../core" as dna;
+
+group organism = { App };
+group dna_gate = { dna::Dna };
+group performers = { dna::AgentPerformer, dna::HumanWorkGateway, dna::ServicePerformer, dna::ScriptedPerformer };
+group credentials = { dna::CredentialSource };
+
+constitution DnaCore {
+    apply_gated: forbid reaches(organism, effects(genome_apply)) avoiding dna_gate;
+    performers_never_apply: forbid reaches(performers, effects(genome_apply));
+    credentials_sealed: require sealed(all credentials);
+}
+
+// A policy that never blocks. Constructing it does not weaken the law.
+locus NoReview {
+    fn required_authority(change_class: String, m: dna::Magnitude) -> String { return ""; }
+    fn blocking(change_class: String) -> Bool { return false; }
+    fn name() -> String { return "no-review"; }
+}
+
+main locus App {
+    params {
+        dna: dna::Dna = dna::Dna {
+            review_policy: NoReview { },
+            deployment: dna::LocalApplyDeployment { }
+        };
+        // a second, concrete handle on the gateway — the bypass
+        bypass: dna::LocalApplyDeployment = dna::LocalApplyDeployment { };
+    }
+    claims { adopt DnaCore; }
+    run() {
+        // bypasses Dna.stage: a path from App to genome_apply avoiding the gate
+        let ok = self.bypass.apply("sha256:c1");
+    }
+}
+fn main() { App { }; }

--- a/dna/tests/law/apply_gate_pass/main.hl
+++ b/dna/tests/law/apply_gate_pass/main.hl
@@ -1,0 +1,46 @@
+// #526 fixture 8c: the apply gateway is reachable only THROUGH the Dna
+// assembly (the gate), and never from a performer. The constitution
+// says so; the assembly below deliberately constructs a permissive
+// review policy (NoReview) — law is not a constructor flag, so the
+// program still builds only because every apply path passes the gate.
+//
+// Caveat, F.11 (dna/FRICTION.md): `Dna.stage -> self.deployment.apply`
+// goes through the interface-typed `deployment` field whose
+// declaration default is `NoDeployment` (no effect); the constructor
+// override to `LocalApplyDeployment` is what actually runs, and the
+// claims engine resolves the call against the default. So
+// `apply_gated` holds here partly for the wrong reason. The `_fail`
+// sibling uses a concrete handle, which the engine does see.
+import "../../../core" as dna;
+
+group organism = { App };
+group dna_gate = { dna::Dna };
+group performers = { dna::AgentPerformer, dna::HumanWorkGateway, dna::ServicePerformer, dna::ScriptedPerformer };
+group credentials = { dna::CredentialSource };
+
+constitution DnaCore {
+    apply_gated: forbid reaches(organism, effects(genome_apply)) avoiding dna_gate;
+    performers_never_apply: forbid reaches(performers, effects(genome_apply));
+    credentials_sealed: require sealed(all credentials);
+}
+
+// A policy that never blocks. Constructing it does not weaken the law.
+locus NoReview {
+    fn required_authority(change_class: String, m: dna::Magnitude) -> String { return ""; }
+    fn blocking(change_class: String) -> Bool { return false; }
+    fn name() -> String { return "no-review"; }
+}
+
+main locus App {
+    params {
+        dna: dna::Dna = dna::Dna {
+            review_policy: NoReview { },
+            deployment: dna::LocalApplyDeployment { }
+        };
+    }
+    claims { adopt DnaCore; }
+    run() {
+        let d = self.dna.stage("refactor", "sha256:c1", dna::Magnitude { loci: 1 }, dna::Evidence { tests_pass: true });
+    }
+}
+fn main() { App { }; }

--- a/dna/tests/law/confine_fail/main.hl
+++ b/dna/tests/law/confine_fail/main.hl
@@ -1,0 +1,25 @@
+// #526 fixture 8b: customer-side loci reach only the local model.
+// `forbid reaches(customer_side, effects(external_model))` FAILS
+// because CustomerTriage is wired to ModelRouter, whose external backends are reachable — the router's
+// runtime `allows()` refusal is policy, not law; the witness names the path.
+import "../../../core" as dna;
+
+group customer_side = { CustomerTriage };
+
+locus CustomerTriage {
+    params { models: dna::ModelRouter = dna::ModelRouter { }; handled: Int = 0; }
+    fn triage(report_digest: String) -> String {
+        let r = self.models.ask(dna::ModelRequest { role: "classify", prompt_digest: report_digest, context_bytes: 200, data_class: "customer" });
+        self.handled = self.handled + 1;
+        return r.output;
+    }
+}
+
+main locus App {
+    params { triage: CustomerTriage = CustomerTriage { }; }
+    claims {
+        no_leak: forbid reaches(customer_side, effects(external_model));
+    }
+    run() { let o = self.triage.triage("d1"); }
+}
+fn main() { App { }; }

--- a/dna/tests/law/confine_pass/main.hl
+++ b/dna/tests/law/confine_pass/main.hl
@@ -1,0 +1,25 @@
+// #526 fixture 8a: customer-side loci reach only the local model.
+// `forbid reaches(customer_side, effects(external_model))` HOLDS
+// because CustomerTriage is wired to PrivateModelRouter — a structural
+// fact, not a runtime `allows()` check.
+import "../../../core" as dna;
+
+group customer_side = { CustomerTriage };
+
+locus CustomerTriage {
+    params { models: dna::PrivateModelRouter = dna::PrivateModelRouter { }; handled: Int = 0; }
+    fn triage(report_digest: String) -> String {
+        let r = self.models.ask(dna::ModelRequest { role: "classify", prompt_digest: report_digest, context_bytes: 200, data_class: "customer" });
+        self.handled = self.handled + 1;
+        return r.output;
+    }
+}
+
+main locus App {
+    params { triage: CustomerTriage = CustomerTriage { }; }
+    claims {
+        no_leak: forbid reaches(customer_side, effects(external_model));
+    }
+    run() { let o = self.triage.triage("d1"); }
+}
+fn main() { App { }; }

--- a/dna/tests/law/sealed_fail/main.hl
+++ b/dna/tests/law/sealed_fail/main.hl
@@ -1,0 +1,11 @@
+// #526 fixture 8f: an app-side credential holder that is NOT sealed
+// joins the group; the build fails naming it.
+import "../../../core" as dna;
+group credentials = { dna::CredentialSource, LeakyCreds };
+locus LeakyCreds { params { key: String = "hunter2"; } fn present() -> Bool { return self.key != ""; } }
+main locus App {
+    params { c: dna::CredentialSource = dna::CredentialSource { source: "X" }; l: LeakyCreds = LeakyCreds { }; }
+    claims { confined: require sealed(all credentials); }
+    run() { let p = self.l.present(); }
+}
+fn main() { App { }; }

--- a/dna/tests/law/sealed_pass/main.hl
+++ b/dna/tests/law/sealed_pass/main.hl
@@ -1,0 +1,9 @@
+// #526 fixture 8e: every credential source is @sealed.
+import "../../../core" as dna;
+group credentials = { dna::CredentialSource };
+main locus App {
+    params { c: dna::CredentialSource = dna::CredentialSource { source: "PROVIDER_A_API_KEY" }; }
+    claims { confined: require sealed(all credentials); }
+    run() { let p = self.c.present(); }
+}
+fn main() { App { }; }

--- a/dna/tests/performers_test.hl
+++ b/dna/tests/performers_test.hl
@@ -1,0 +1,76 @@
+// dna/tests/performers_test.hl — #526 fixture 3.
+//
+// Human, Agent, Software and Service performers satisfy one parent-
+// facing contract with no shared state; an Agent Attempt makes several
+// model calls under ONE attempt identity; a human timeout/decline is a
+// typed outcome that triggers reassignment; every reassignment is a
+// new Attempt with the Work identity preserved; a service performer
+// fulfils an assessment but never touches a world-changing gateway
+// (that half is law — dna_law.rs).
+//
+// Routed shape (dna/FRICTION.md F.3/F.5): the assembly owns the
+// WorkSystem and its performers; Work asks over the bus and its owner
+// reads the settlement.
+
+import "../core" as dna;
+
+main locus App {
+    params {
+        // The assembly chooses the performers. Here: an operator who
+        // declines, so judgment work reassigns from agent -> human ->
+        // (agent again) and the history shows every assignment.
+        ws: dna::WorkSystem = dna::WorkSystem {
+            human: dna::HumanWorkGateway { operator: "riley", answer: "declined" },
+            // a cost ceiling the fourth task will trip mid-attempt
+            agent: dna::AgentPerformer {
+                name: "architect",
+                models: dna::ModelRouter { daily_cost_ceiling_micros: 60 }
+            },
+            max_attempts: 3
+        };
+        m: dna::Metabolism = dna::Metabolism { };
+    }
+    run() {
+        // 1. Default order: software first, and software succeeds.
+        let t1 = self.m.offer(dna::Intent { outcome: "format the tree", from: "test" },
+            dna::Knobs { routed: true });
+        let s1 = self.m.find(t1);
+        std::test::assert_eq_str(s1.disposition, "done", "routed work settles through the owner: " + s1.detail);
+        std::test::assert(std::str::contains(s1.detail, "[a0:software:done ]"), "software took it on attempt 0: " + s1.detail);
+
+        // 2. Judgment work: agent first. The agent makes two model calls
+        //    (classify on quick, synthesize on deep) inside ONE Attempt.
+        let t2 = self.m.offer(dna::Intent { outcome: "assess the storage migration", from: "test" },
+            dna::Knobs { routed: true, requires: "judgment" });
+        let s2 = self.m.find(t2);
+        std::test::assert_eq_str(s2.disposition, "done", "agent settles judgment work: " + s2.detail);
+        std::test::assert(std::str::contains(s2.detail, "[a0:agent:done ]"), "one Attempt, one performer: " + s2.detail);
+        std::test::assert_eq_int(self.ws.attempts_made, 2, "two Attempt loci so far (t1 a0, t2 a0)");
+
+        // 3. Customer data: the agent's model calls are refused by every
+        //    external backend; the private backend takes them (router
+        //    policy), so the agent still completes on ONE attempt.
+        let t3 = self.m.offer(dna::Intent { outcome: "triage a customer report", from: "test" },
+            dna::Knobs { routed: true, requires: "judgment", data_class: "customer" });
+        let s3 = self.m.find(t3);
+        std::test::assert_eq_str(s3.disposition, "done", "customer-class work routes to the private model: " + s3.detail);
+
+        // 4. Reassignment. The router's ceiling (60 micros) is crossed
+        //    during this task's second model call, so the agent Attempt
+        //    fails; selection moves to the human, who declines (a typed
+        //    outcome, not an error); the cap is reached with the human
+        //    still declining. Every assignment is its own Attempt, the
+        //    Work identity never changes, and nothing is re-attributed.
+        let t4 = self.m.offer(dna::Intent { outcome: "decide the rollout", from: "test" },
+            dna::Knobs { routed: true, requires: "judgment" });
+        let s4 = self.m.find(t4);
+        std::test::assert_eq_str(s4.disposition, "failed", "declined twice after an agent failure: " + s4.detail);
+        std::test::assert(std::str::contains(s4.detail, "a0:agent:failed a1:human:declined a2:human:declined"),
+            "reassignment history, one Attempt per assignment: " + s4.detail);
+        std::test::assert_eq_int(self.m.settled_count(), 4, "four routed tasks settled");
+        std::test::assert_eq_int(self.ws.requests, 4, "the WorkSystem served every request");
+        std::test::assert_eq_int(self.ws.attempts_made, 6, "1 + 1 + 1 + 3 Attempt loci were born and reclaimed");
+    }
+}
+
+fn main() { App { }; }

--- a/dna/tests/recursion_settlement_test.hl
+++ b/dna/tests/recursion_settlement_test.hl
@@ -1,0 +1,48 @@
+// dna/tests/recursion_settlement_test.hl — #526 fixture 1.
+//
+// The single-accept chain Metabolism > Task > Workflow > Step > Work >
+// Attempt births, runs, settles, and reclaims; a delegated child Task
+// bubbles to Metabolism; the spawning Step observes settlement over
+// the keyed TaskSettled topic; lineage survives in the settled record.
+
+import "../core" as dna;
+
+main locus App {
+    params {
+        m: dna::Metabolism = dna::Metabolism { };
+    }
+    run() {
+        // 1. A plain intent: two steps, each fanning out two Works.
+        let t1 = self.m.offer(
+            dna::Intent { outcome: "reduce checkout failures", from: "human" },
+            dna::Knobs { steps: 2, fan: 2 });
+        std::test::assert_eq_str(t1, "t1", "first task id is minted by the pool");
+        let s1 = self.m.find(t1);
+        std::test::assert_eq_str(s1.kind, "task", "settled record is a task row");
+        std::test::assert_eq_str(s1.disposition, "done", "chain settles done: " + s1.detail);
+        std::test::assert_eq_str(s1.parent, "", "root task has no parent");
+        std::test::assert(std::str::contains(s1.detail, "t1/wf1/s0=done"), "step 0 settled through release: " + s1.detail);
+        std::test::assert(std::str::contains(s1.detail, "t1/wf1/s1=done"), "step 1 settled through release: " + s1.detail);
+        std::test::assert(std::str::contains(s1.detail, "t1/wf1/s1/w1=done[t1/wf1/s1/w1/a0:done ]"), "work history names the attempt: " + s1.detail);
+
+        // 2. Delegation: step 0 spawns a child Task. Step does not
+        //    accept Task; the literal bubbles to Metabolism, which
+        //    releases it and publishes TaskSettled keyed by parent.
+        let t2 = self.m.offer(
+            dna::Intent { outcome: "delegating intent", from: "human" },
+            dna::Knobs { steps: 1, fan: 1, delegate_at: 0 });
+        std::test::assert_eq_int(self.m.settled_count(), 3, "root + child + t1 are three settled rows");
+        let child = self.m.find(t2 + ".sub");
+        std::test::assert_eq_str(child.kind, "task", "delegated child is a Task in the pool");
+        std::test::assert_eq_str(child.parent, t2, "lineage: child records its parent task");
+        std::test::assert_eq_str(child.disposition, "done", "child settles done");
+        let root = self.m.find(t2);
+        std::test::assert_eq_str(root.disposition, "done", "parent settles after the child: " + root.detail);
+        std::test::assert(std::str::contains(root.detail, "child t2.sub=done"), "the spawning Step heard TaskSettled over the keyed topic: " + root.detail);
+        // the child settled BEFORE the parent (its row comes first)
+        std::test::assert_eq_str(self.m.settled_at(1).id, "t2.sub", "child row precedes the parent row");
+        std::test::assert_eq_str(self.m.settled_at(2).id, "t2", "parent row is last");
+    }
+}
+
+fn main() { App { }; }

--- a/dna/tests/review_authority_test.hl
+++ b/dna/tests/review_authority_test.hl
@@ -1,0 +1,108 @@
+// dna/tests/review_authority_test.hl — #526 fixture 4.
+//
+// A Review owns its question, the pinned candidate digest, and the
+// authority it requires; a verdict settles it only if it names the
+// exact candidate, carries the authority, and is independent of the
+// author. The AutonomyBoundary's disposition is a pure function over a
+// magnitude VECTOR and evidence; no confidence cancels a hard boundary;
+// a child cannot widen its own grant; failure contracts the grant.
+
+import "../core" as dna;
+
+main locus App {
+    params {
+        review: dna::Review = dna::Review {
+            review_id: "r1",
+            question: "apply mutation m7 to Support?",
+            subject_digest: "sha256:m7-candidate",
+            required_authority: "maintainer",
+            author: "architect"
+        };
+        boundary: dna::AutonomyBoundary = dna::AutonomyBoundary {
+            child: "Support",
+            grant: dna::Grant { child: "Support", classes: "refactor docs", max_magnitude: 12, review: "post" }
+        };
+    }
+    run() {
+        // ---- Review ---------------------------------------------------
+        // 1. A capable performer without the authority cannot settle.
+        let agent = self.review.consider(dna::Verdict {
+            review_id: "r1", subject_digest: "sha256:m7-candidate",
+            verdict: "approve", reviewer: "review-agent", authority: "agent"
+        });
+        std::test::assert(!agent, "authority-less verdict refused");
+        std::test::assert(!self.review.settled, "still open");
+        std::test::assert(std::str::contains(self.review.last_refusal, "authority agent does not satisfy maintainer"), self.review.last_refusal);
+        // 2. The author cannot review their own candidate, even with authority.
+        let selfie = self.review.consider(dna::Verdict {
+            review_id: "r1", subject_digest: "sha256:m7-candidate",
+            verdict: "approve", reviewer: "architect", authority: "maintainer"
+        });
+        std::test::assert(!selfie, "author's verdict refused (independence)");
+        // 3. A verdict for a candidate that changed after the reviewer looked is refused (TOCTOU pin).
+        let stale = self.review.consider(dna::Verdict {
+            review_id: "r1", subject_digest: "sha256:m7-candidate-v2",
+            verdict: "approve", reviewer: "riley", authority: "maintainer"
+        });
+        std::test::assert(!stale, "digest mismatch refused");
+        std::test::assert_eq_int(self.review.refused, 3, "three refusals recorded");
+        // 4. Abstention is admitted but does not settle.
+        let abst = self.review.consider(dna::Verdict {
+            review_id: "r1", subject_digest: "sha256:m7-candidate",
+            verdict: "abstain", reviewer: "riley", authority: "maintainer"
+        });
+        std::test::assert(abst && !self.review.settled, "abstain admitted, not settled");
+        // 5. The right verdict settles it, with provenance.
+        let ok = self.review.consider(dna::Verdict {
+            review_id: "r1", subject_digest: "sha256:m7-candidate",
+            verdict: "approve", reviewer: "riley", authority: "maintainer operator"
+        });
+        std::test::assert(ok && self.review.settled, "settled");
+        std::test::assert_eq_str(self.review.outcome, "approve", "outcome recorded");
+        std::test::assert_eq_str(self.review.decided_by, "riley", "reviewer recorded");
+        std::test::assert_eq_int(self.review.verdict_count(), 2, "abstain + approve kept in lineage");
+
+        // ---- Disposition is a vector policy -------------------------
+        let small = dna::Magnitude { loci: 2 };
+        let strong = dna::Evidence { check_clean: true, verify_clean: true, tests_pass: true, replay_ok: true, rollback_rehearsed: true, independent_reviews: 3 };
+        let weak = dna::Evidence { check_clean: true };
+        // 6. Permitted class, small magnitude, strong evidence, post-review grant -> release.
+        std::test::assert_eq_str(self.boundary.assess("refactor", small, strong), "release", "release inside the envelope");
+        // 7. Same change, weak evidence -> stage (prepare, do not apply).
+        std::test::assert_eq_str(self.boundary.assess("refactor", small, weak), "stage", "insufficient evidence stages");
+        // 8. A class outside the grant -> escalate, however strong the evidence.
+        std::test::assert_eq_str(self.boundary.assess("deploy", small, strong), "escalate", "class not granted escalates");
+        // 9. Hard boundaries: law touched / effects widened / ownership crossed
+        //    -> review, and NO evidence score cancels that.
+        let law = dna::Magnitude { loci: 1, law_touched: true };
+        std::test::assert_eq_str(self.boundary.assess("refactor", law, strong), "review", "law touched: review regardless of evidence");
+        let widen = dna::Magnitude { loci: 1, effects_widened: true };
+        std::test::assert_eq_str(self.boundary.assess("refactor", widen, strong), "review", "effects widened: review regardless of evidence");
+        let cross = dna::Magnitude { loci: 1, ownership_crossed: true };
+        std::test::assert_eq_str(self.boundary.assess("docs", cross, strong), "review", "ownership crossed: review");
+        let blast = dna::Magnitude { loci: 1, irreversible: true, external_blast: 3 };
+        std::test::assert_eq_str(self.boundary.assess("docs", blast, strong), "review", "irreversible external blast: review");
+        // 10. Magnitude over the ceiling escalates even for a permitted class.
+        let big = dna::Magnitude { loci: 40 };
+        std::test::assert_eq_str(self.boundary.assess("refactor", big, strong), "escalate", "magnitude ceiling escalates");
+
+        // ---- Autonomy evolution is asymmetric ------------------------
+        // 11. The child cannot expand its own grant.
+        std::test::assert(!self.boundary.expand("Support", "Product", 50, "deploy"), "child self-expansion refused");
+        std::test::assert_eq_int(self.boundary.expansions_refused, 1, "refusal audited");
+        std::test::assert_eq_int(self.boundary.current_grant().max_magnitude, 12, "grant unchanged");
+        // 12. The parent can.
+        std::test::assert(self.boundary.expand("Product", "Product", 20, "deploy"), "parent expansion admitted");
+        std::test::assert_eq_int(self.boundary.current_grant().max_magnitude, 20, "ceiling raised by the parent");
+        std::test::assert_eq_str(self.boundary.assess("deploy", small, strong), "release", "newly granted class releases");
+        // 13. Repeated failure contracts the grant automatically.
+        self.boundary.note_outcome(false);
+        self.boundary.note_outcome(false);
+        std::test::assert_eq_int(self.boundary.contractions, 1, "contracted after two failures");
+        std::test::assert_eq_int(self.boundary.current_grant().max_magnitude, 10, "ceiling halved");
+        std::test::assert_eq_str(self.boundary.current_grant().review, "pre", "review tightened to pre");
+        std::test::assert(self.boundary.audit_count() >= 12, "every decision is in the audit trail");
+    }
+}
+
+fn main() { App { }; }


### PR DESCRIPTION
Track A of the DNA epic (#526, umbrella #521): the Phase 0 domain proof in today's Hale, no language change. Stacks on the compiler-fix PR (base branch `fix/release-owner-dispatch`).

**What lands**
- `dna/core`: a library seed of ten files, `hale verify` clean. Types and effect classes, topics, the process chain, performers, the routed WorkSystem, model routing, Review and AutonomyBoundary, the journal (MemJournal, sha256-chained JSONL FileJournal, leases with fencing, idempotent effects, rebuildable projections), Knowledge, and the `Dna { ... }` assembly.
- `dna/tests`: the seven Hale-native fixtures from #526 (recursion and settlement, fan-out and join, performers, review and authority, journal, knowledge, assembly), run by `crates/hale-cli/tests/dna_native_suite.rs`, which also gates `hale verify dna/core`.
- `dna/tests/law`: six law fixtures (confine customer data to the local model, gate `genome_apply` behind the Dna assembly, seal credential sources), each pass/fail pair asserted from `crates/hale-cli/tests/dna_law.rs` with the witness text.
- `dna/FRICTION.md`: eleven findings, every one with a minimized reproducer under `dna/friction/`.

**What the fixtures established**
- The single-accept chain works, and #521's predicted multi-accept request did not materialize: a Step that delegates writes the `Task` literal anyway, interest-based ownership bubbles it to `Metabolism`, lineage rides as data, and settlement returns over `TaskSettled` keyed by the parent task. Bubbling was the better shape.
- A dynamic child cannot be handed an assembly-supplied implementation (F.3: interface values do not flow into interface fields; F.4: a perspective field must designate; F.5: a bus reply reaches a flow child at drain). So the routed shape puts performers and Attempts under the assembly-owned `WorkSystem`, and the bus carries the request and the settlement. That is the one design change from the issue text.
- Law is call-graph confinement and it composes with the assembly: the same `CustomerTriage` locus passes wired to `PrivateModelRouter` and is refused with a witness wired to `ModelRouter`, whatever the runtime `allows()` check says.

**Friction outcome**
- Fixed in the parent PR: F.2, F.6.
- Filed as bugs: #533 (F.11, `forbid reaches` follows the declaration default, not the constructor override; fail-open on the assembly shape), #534 (F.1/F.10, enums and perspectives do not cross seeds), #535 (F.8/F.9, stdlib path fallibility and `write_file_append` Int vs Unit).
- Candidate language requests, not filed yet: F.4 (`p: perspective(P);` meaning hold-without-designating) and F.7 (`fallible(E)` on interface methods). The fixtures should sit for a while first.

Verified: `hale test dna/tests` 7/7, `hale verify dna/core` 0 findings, the two new hale-cli test binaries 9/9, and the full hale-cli suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
