### PR TITLE
dna: PrivateModelRouter's slot is concrete — an interface-typed slot admits every conformer (#533 consequence)

### DIFF
--- a/dna/FRICTION.md
+++ b/dna/FRICTION.md
@@ -327,6 +327,19 @@ absence".
 
 **Reproducer:** `dna/friction/f11-reaches-default-not-override/`.
 
+**Resolution:** FIXED upstream (GH #533, hale PR #538, 2026-09-08).
+A declared interface keeps its own name in the field-type map, so
+the call fans to every conformer in the closed world. Conservative
+by construction, and it has a consequence for the core:
+`PrivateModelRouter.private` had been interface-typed, so after the
+fix the confinement claim saw the external backend through it and
+`confine_pass` failed on merged main. An interface-typed slot admits
+every conformer; a CONCRETE slot admits one; confinement by wiring
+therefore needs the concrete type at the boundary, which is what
+`PrivateModelRouter` now declares. Per-field narrowing (only the
+impls the program actually stores into that field) would give the
+precise answer without the concrete type; filed as a follow-up.
+
 ---
 
 ## Requests and bugs, summarized (2026-09-05)

--- a/dna/core/models.hl
+++ b/dna/core/models.hl
@@ -132,10 +132,13 @@ locus EvidenceAwareSelection {
 
 // A router for CUSTOMER-facing loci: only the local backend is
 // reachable, so `forbid reaches(customer_side, effects(external_model))`
-// holds structurally, not by a runtime check.
+// holds structurally, not by a runtime check. The slot is CONCRETE on
+// purpose: an interface-typed slot admits every conformer in the
+// closed world (GH #533 — a constructor may store any of them), so
+// confinement by wiring needs the concrete type at the boundary.
 locus PrivateModelRouter {
     params {
-        private: ModelBackend = LocalFakeModel { };
+        private: LocalFakeModel = LocalFakeModel { };
         calls: Int = 0;
     }
     fn ask(req: ModelRequest) -> ModelResult {

--- a/dna/tests/law/apply_gate_pass/main.hl
+++ b/dna/tests/law/apply_gate_pass/main.hl
@@ -4,13 +4,13 @@
 // review policy (NoReview) — law is not a constructor flag, so the
 // program still builds only because every apply path passes the gate.
 //
-// Caveat, F.11 (dna/FRICTION.md): `Dna.stage -> self.deployment.apply`
-// goes through the interface-typed `deployment` field whose
-// declaration default is `NoDeployment` (no effect); the constructor
-// override to `LocalApplyDeployment` is what actually runs, and the
-// claims engine resolves the call against the default. So
-// `apply_gated` holds here partly for the wrong reason. The `_fail`
-// sibling uses a concrete handle, which the engine does see.
+// F.11 is fixed (GH #533): `Dna.stage -> self.deployment.apply` goes
+// through the interface-typed `deployment` field, and the claims
+// engine fans that call to every `Deployment` conformer, the
+// `LocalApplyDeployment` carrier included. `apply_gated` holds for
+// the right reason now: the only path to the carrier runs through
+// the Dna gate. The `_fail` sibling adds a concrete handle that
+// bypasses it.
 import "../../../core" as dna;
 
 group organism = { App };


### PR DESCRIPTION
Merged main is red on `dna_law::customer_data_confined_to_local_model`: #533 (in #538) fans a call through an interface-typed field to every conformer, and #539's `PrivateModelRouter.private` was interface-typed, so the confinement claim now sees the external backend through the private router. Each PR was green against its own base; only the combination shows it.

The rule is the honest one: an interface-typed slot admits every conformer, a concrete slot admits one, so confinement by wiring needs the concrete type at the boundary. The slot is `LocalFakeModel` now. The `apply_gate_pass` caveat is rewritten (it holds for the right reason after #533), FRICTION F.11 records the resolution and this consequence, and the precise per-field narrowing that would avoid the concrete type is #540.

Verified on merged main plus this change: `dna_native_suite` and `dna_law` 9/9, `hale verify dna/core` zero findings, fmt gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
