### PR TITLE
dna: take the enum and the routing perspective back (#534 follow-through); checker recognises aliased enum arms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ behavior.
 
 ## Unreleased
 
+### `dna/core` takes its enum and its routing perspective back (GH #534 follow-through)
+
+With enums and perspectives crossing seed boundaries, `Disposition`
+is an enum again (matched on the importer's side in
+`review_authority_test.hl`) and `WorkRouting` is a perspective the
+assembly designates at construction and the `WorkSystem` re-points
+live with `reperspective`. The swap preserves state by design, so
+each policy lives in its impl's code and the shared footprint holds
+only the decision counter; `assembly_test.hl` swaps policies mid-run
+and reads the counter across both. The checker's match
+exhaustiveness now recognises an importer's `alias::Enum::Variant`
+arm against the seed-mangled scrutinee type, which the #534 codegen
+fix alone had not covered.
+
 ### `or` on an infallible stdlib call is refused where it is written; `write_file_append` is Unit in the `or` form (GH #535)
 
 The json flat-object readers (`find_string_field`, `find_int_field`,

--- a/crates/hale-cli/tests/cross_seed_enum_persp.rs
+++ b/crates/hale-cli/tests/cross_seed_enum_persp.rs
@@ -43,7 +43,7 @@ fn consumer_of_enum_and_perspective_library_checks_builds_and_runs() {
     let _ = std::fs::remove_file(&bin);
     assert!(out.status.success(), "consumer exit: {:?}", out.status);
     let stdout = String::from_utf8_lossy(&out.stdout);
-    for needle in ["first=red", "green=true", "which=second", "after=second", "label=b"] {
+    for needle in ["first=red", "green=true", "which=second", "after=second", "label=b", "picked=g"] {
         assert!(stdout.contains(needle), "missing {needle}: {stdout:?}");
     }
 }

--- a/crates/hale-codegen/tests/cross_seed_imports.rs
+++ b/crates/hale-codegen/tests/cross_seed_imports.rs
@@ -497,7 +497,7 @@ fn library_enum_match_and_perspective_serves_survive_import() {
     let _ = std::fs::remove_file(&bin);
     assert!(out.status.success(), "non-zero exit: {:?} stderr={}", out.status, String::from_utf8_lossy(&out.stderr));
     let stdout = String::from_utf8_lossy(&out.stdout);
-    for needle in ["first=red", "green=true", "which=second", "after=second", "label=b"] {
+    for needle in ["first=red", "green=true", "which=second", "after=second", "label=b", "picked=g"] {
         assert!(stdout.contains(needle), "missing {needle}: {stdout:?}");
     }
 }

--- a/crates/hale-codegen/tests/fixtures/import-enum-persp-consumer/main.hl
+++ b/crates/hale-codegen/tests/fixtures/import-enum-persp-consumer/main.hl
@@ -22,6 +22,14 @@ main locus App {
             lib::Color::Blue -> "b",
         };
         println("label=", label);
+        // a TYPED scrutinee (the lib's enum as a return type): the
+        // checker's exhaustiveness must recognise the aliased arms
+        let picked = match lib::pick_color() {
+            lib::Color::Red -> "r",
+            lib::Color::Green -> "g",
+            lib::Color::Blue -> "b",
+        };
+        println("picked=", picked);
     }
 }
 

--- a/crates/hale-codegen/tests/fixtures/lib-enum-persp/lib.hl
+++ b/crates/hale-codegen/tests/fixtures/lib-enum-persp/lib.hl
@@ -18,6 +18,10 @@ fn first() -> String {
     return name(Color::Red);
 }
 
+fn pick_color() -> Color {
+    return Color::Green;
+}
+
 fn is_green(c: Color) -> Bool {
     return match c {
         Color::Green -> true,

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -108,14 +108,30 @@ fn match_is_exhaustive(scrut_ty: &Ty, arms: &[MatchArm], top: &TopScope) -> bool
             // `<template>_<arg>_<arg>...` so the prefix check
             // is unambiguous.
             let mangle_prefix = format!("{}_", name);
+            // GH #534: an importer's arm is `alias::Enum::Variant` —
+            // three segments whose middle is the enum's authored name,
+            // while the scrutinee is typed by the seed-mangled name
+            // `__lib_<id>_<stem>_Enum`. The checker holds no alias
+            // table (the same limitation the `__lib_` tail matching
+            // elsewhere documents), so match on the mangled tail.
             for arm in arms.iter().filter(unguarded) {
                 if let Pattern::Constructor { path, .. } = &arm.pattern {
-                    if let [enum_seg, variant_seg] = path.segments.as_slice() {
+                    let segs: Vec<&str> =
+                        path.segments.iter().map(|s| s.name.as_str()).collect();
+                    let (enum_seg, variant_seg) = match segs.as_slice() {
+                        [e, v] => (*e, *v),
+                        [_, e, v]
+                            if name.starts_with("__lib_")
+                                && name.ends_with(&format!("_{}", e)) =>
+                        {
+                            (name.as_str(), *v)
+                        }
+                        _ => continue,
+                    };
+                    {
                         let matches_template_or_monomorph =
-                            enum_seg.name == *name
-                                || enum_seg
-                                    .name
-                                    .starts_with(&mangle_prefix);
+                            enum_seg == *name
+                                || enum_seg.starts_with(&mangle_prefix);
                         if matches_template_or_monomorph {
                             // m47-payloads: a Constructor arm
                             // covers its variant whether the
@@ -127,7 +143,7 @@ fn match_is_exhaustive(scrut_ty: &Ty, arms: &[MatchArm], top: &TopScope) -> bool
                             // variant; we still treat them as
                             // covering for v0.1 — same permissive
                             // policy the Bool literal arms get.
-                            covered.insert(variant_seg.name.as_str());
+                            covered.insert(variant_seg);
                         }
                     }
                 }

--- a/dna/FRICTION.md
+++ b/dna/FRICTION.md
@@ -47,9 +47,12 @@ passes, `hale build` fails). `hale check lib` alone is clean.
 `dna/core/types.hl`. The enum is the shape we want back; strings cross
 the seed boundary today.
 
-**Resolution:** pending. Two distinct bugs: (1) exhaustiveness over a
-path-renamed enum; (2) codegen's constructor-pattern arm resolves the
-enum by bare name after the import prefix was applied.
+**Resolution:** FIXED upstream (GH #534, hale PR #538, 2026-09-08):
+the seed mangler now rewrites two-segment `Enum::Variant` paths in
+expression and pattern position, and an importer can spell
+`lib::Enum::Variant` in both. `Disposition` is an enum again in
+`dna/core/types.hl`; `review_authority_test.hl` matches it on the
+importer's side.
 
 ## F.2 — `@unbounded` did not acknowledge the hot-path advisory
 
@@ -290,10 +293,18 @@ interfaces cross the seed boundary. This is the same class as F.1
 
 **Reproducer:** `dna/friction/f10-perspective-across-seeds/`.
 
-**Workaround:** `WorkSelection` is an interface in the core;
-substitution happens at construction only (#525 item 2 proved the
-constructor-site designation in-seed, fixture
-`65-perspective-ctor-override`).
+**Resolution:** FIXED upstream (GH #534, hale PR #538, 2026-09-08):
+`serves` lists are renamed with their perspective. `WorkRouting` is a
+perspective again in `dna/core/work_system.hl`; the assembly
+designates it at construction (#525 item 2, now across a seed
+boundary) and `WorkSystem` re-points it live with `reperspective` —
+`assembly_test.hl` swaps policies mid-run. One thing the swap taught:
+`reperspective` swaps CODE and preserves STATE (the footprint), so a
+policy expressed as params (`default_order: String = ...`) does not
+change when the slot is re-pointed — the new impl's methods ran over
+the old impl's orders. Policies now live in their impls' methods and
+the shared footprint holds only the decision counter, which the test
+reads across both policies through the contract.
 
 ## F.11 — `forbid reaches` follows the declaration default, not the constructor override
 

--- a/dna/core/assembly.hl
+++ b/dna/core/assembly.hl
@@ -126,20 +126,30 @@ locus Dna {
     // policy, and NEVER applied by this assembly's deployment.
     fn stage(change_class: String, candidate_digest: String, m: Magnitude, e: Evidence) -> String {
         let d = self.boundary.assess(change_class, m, e);
-        let r = self.journal.append(self.journal.revision(), "mutation." + d, candidate_digest, change_class);
-        if d == DISP_RELEASE {
-            // the grant would allow it; the deployment gateway decides
-            // whether expression is possible here at all
-            if !self.deployment.apply(candidate_digest) {
-                self.membrane.notify("mutation", "staged (no deployment): " + candidate_digest);
-                return DISP_STAGE;
-            }
-            return "applied";
-        }
-        if d == DISP_REVIEW || d == DISP_STAGE {
-            self.membrane.notify("review", self.review_policy.required_authority(change_class, m) + " needed for " + candidate_digest);
-        }
-        return d;
+        let name = disposition_name(d);
+        let r = self.journal.append(self.journal.revision(), "mutation." + name, candidate_digest, change_class);
+        return match d {
+            Disposition::Release -> {
+                // the grant would allow it; the deployment gateway
+                // decides whether expression is possible here at all
+                if self.deployment.apply(candidate_digest) {
+                    "applied"
+                } else {
+                    self.membrane.notify("mutation", "staged (no deployment): " + candidate_digest);
+                    "stage"
+                }
+            },
+            Disposition::Review -> {
+                self.membrane.notify("review", self.review_policy.required_authority(change_class, m) + " needed for " + candidate_digest);
+                name
+            },
+            Disposition::Stage -> {
+                self.membrane.notify("review", self.review_policy.required_authority(change_class, m) + " needed for " + candidate_digest);
+                name
+            },
+            Disposition::Escalate -> name,
+            Disposition::Deny -> name,
+        };
     }
     fn status() -> String {
         let b = std::json::Builder { };

--- a/dna/core/review.hl
+++ b/dna/core/review.hl
@@ -107,12 +107,13 @@ locus AutonomyBoundary {
     }
     fn current_grant() -> Grant { return self.grant; }
     // The disposition of a proposed change under the current grant.
-    fn assess(change_class: String, m: Magnitude, e: Evidence) -> String {
+    fn assess(change_class: String, m: Magnitude, e: Evidence) -> Disposition {
         let d = dispose(self.grant, change_class, m, e);
         self.decisions = self.decisions + 1;
         self.audit.push(AuditRow {
             seq: self.decisions, change_class: change_class,
-            magnitude: magnitude_sum(m), evidence: evidence_score(e), disposition: d
+            magnitude: magnitude_sum(m), evidence: evidence_score(e),
+            disposition: disposition_name(d)
         });
         return d;
     }

--- a/dna/core/types.hl
+++ b/dna/core/types.hl
@@ -91,16 +91,23 @@ type Evidence {
     rollback_rehearsed: Bool = false;
 }
 
-// Dispositions are STRINGS, not an enum: F.1 (dna/FRICTION.md) — a
-// `match` over an enum declared in an imported seed fails the
-// importer's exhaustiveness check, and with a `_` arm fails codegen
-// ("constructor pattern: unknown enum"). Strings cross the seed
-// boundary today; the enum is the shape we want back.
-const DISP_RELEASE: String = "release";
-const DISP_STAGE: String = "stage";
-const DISP_REVIEW: String = "review";
-const DISP_ESCALATE: String = "escalate";
-const DISP_DENY: String = "deny";
+// The disposition of a proposed change (#521): release inside an
+// already-granted envelope; stage = prepare and verify but do not
+// apply; review = block on a named reviewer; escalate = the current
+// parent cannot decide; deny = outside policy or evidence. An enum
+// again since GH #534 (dna/FRICTION.md F.1): a library's own enum
+// now crosses the seed boundary in expression and pattern position.
+type Disposition = enum { Release, Stage, Review, Escalate, Deny };
+
+fn disposition_name(d: Disposition) -> String {
+    return match d {
+        Disposition::Release -> "release",
+        Disposition::Stage -> "stage",
+        Disposition::Review -> "review",
+        Disposition::Escalate -> "escalate",
+        Disposition::Deny -> "deny",
+    };
+}
 
 fn magnitude_sum(m: Magnitude) -> Int {
     let mut s = m.loci + m.external_blast + m.novelty;
@@ -141,15 +148,15 @@ fn evidence_score(e: Evidence) -> Int {
 // reversibility, boundary crossings, inherited law); proceed only if
 // the grant permits the class AND no hard boundary is crossed AND
 // evidence satisfies required assurance.
-fn dispose(g: Grant, change_class: String, m: Magnitude, e: Evidence) -> String {
-    if crosses_hard_boundary(m) { return DISP_REVIEW; }
+fn dispose(g: Grant, change_class: String, m: Magnitude, e: Evidence) -> Disposition {
+    if crosses_hard_boundary(m) { return Disposition::Review; }
     let permitted = std::str::contains(g.classes, change_class);
-    if !permitted { return DISP_ESCALATE; }
+    if !permitted { return Disposition::Escalate; }
     let mag = magnitude_sum(m);
-    if mag > g.max_magnitude { return DISP_ESCALATE; }
+    if mag > g.max_magnitude { return Disposition::Escalate; }
     let required = mag + m.novelty * 2;
     let have = evidence_score(e);
-    if have < required { return DISP_STAGE; }
-    if g.review == "pre" { return DISP_REVIEW; }
-    return DISP_RELEASE;
+    if have < required { return Disposition::Stage; }
+    if g.review == "pre" { return Disposition::Review; }
+    return Disposition::Release;
 }

--- a/dna/core/work_system.hl
+++ b/dna/core/work_system.hl
@@ -11,17 +11,19 @@
 // never gains the right to settle a decision by being selected
 // (that lives with the Review/AutonomyBoundary).
 
-// Routing policy WANTS to be a perspective (#521 comment 1: "live
-// selection may become a perspective") — one program-global slot the
-// assembly designates at construction (#525 item 2) and the owning
-// WorkSystem re-points with `reperspective`. F.10 (dna/FRICTION.md):
-// a perspective declared in an imported seed does not resolve for
-// `serves` or for the holder's default, so the core ships the
-// interface form; substitution happens at construction only.
-interface WorkSelection {
+// Routing policy is a PERSPECTIVE (#521 comment 1: "live selection
+// may become a perspective"): one program-global slot the assembly
+// designates at construction (#525 item 2) and the owning WorkSystem
+// re-points with `reperspective` — a routing-policy mutation without
+// replacing or restarting its owner. Every impl shares one footprint
+// (the three order params), the perspective soundness rule. Back as
+// a perspective since GH #534 (dna/FRICTION.md F.10).
+perspective WorkRouting {
     // Returns a performer CLASS: "human" | "agent" | "software" | "service".
     fn select(req: WorkRequest, attempt_no: Int, last: String) -> String;
     fn policy_name() -> String;
+    // the shared state every policy continues on
+    fn decisions() -> Int;
 }
 
 // The n-th comma-separated class; past the end, the last one keeps trying.
@@ -40,35 +42,36 @@ fn nth_class(order: String, n: Int) -> String {
     return last;
 }
 
+// `reperspective` swaps CODE and preserves STATE (spec/semantics.md
+// "state-preserving"), so a policy lives in its impl's methods, and
+// the shared footprint holds only the state every policy continues
+// on — here, how many selections have been made.
+
 // Capability first, then the cheapest; escalates to a person only
 // after the cheaper performers declined or failed.
-locus CapabilityFirstSelection {
-    params {
-        default_order: String = "software,agent,human";
-        judgment_order: String = "agent,human";
-        service_order: String = "service,agent";
-    }
+locus CapabilityFirstSelection : serves WorkRouting {
+    params { decisions: Int = 0; }
     fn policy_name() -> String { return "capability-first"; }
+    fn decisions() -> Int { return self.decisions; }
     fn select(req: WorkRequest, attempt_no: Int, last: String) -> String {
-        if std::str::contains(req.requires, "judgment") { return nth_class(self.judgment_order, attempt_no); }
-        if std::str::contains(req.requires, "analysis") { return nth_class(self.service_order, attempt_no); }
-        return nth_class(self.default_order, attempt_no);
+        self.decisions = self.decisions + 1;
+        if std::str::contains(req.requires, "judgment") { return nth_class("agent,human", attempt_no); }
+        if std::str::contains(req.requires, "analysis") { return nth_class("service,agent", attempt_no); }
+        return nth_class("software,agent,human", attempt_no);
     }
 }
 
 // A person first, everywhere: the conservative posture an assembly
 // can designate, or a WorkSystem can swap to under pressure.
-locus HumanFirstSelection {
-    params {
-        default_order: String = "human,software";
-        judgment_order: String = "human,agent";
-        service_order: String = "human,service";
-    }
+locus HumanFirstSelection : serves WorkRouting {
+    params { decisions: Int = 0; }
     fn policy_name() -> String { return "human-first"; }
+    fn decisions() -> Int { return self.decisions; }
     fn select(req: WorkRequest, attempt_no: Int, last: String) -> String {
-        if std::str::contains(req.requires, "judgment") { return nth_class(self.judgment_order, attempt_no); }
-        if std::str::contains(req.requires, "analysis") { return nth_class(self.service_order, attempt_no); }
-        return nth_class(self.default_order, attempt_no);
+        self.decisions = self.decisions + 1;
+        if std::str::contains(req.requires, "judgment") { return nth_class("human,agent", attempt_no); }
+        if std::str::contains(req.requires, "analysis") { return nth_class("human,service", attempt_no); }
+        return nth_class("human,software", attempt_no);
     }
 }
 
@@ -159,7 +162,7 @@ locus WorkSystem {
         agent: Performer = AgentPerformer { };
         software: Performer = ScriptedPerformer { name: "software" };
         service: Performer = ServicePerformer { };
-        selection: WorkSelection = CapabilityFirstSelection { };
+        selection: perspective(WorkRouting) = CapabilityFirstSelection { };
         max_attempts: Int = 3;
         requests: Int = 0;
         attempts_made: Int = 0;
@@ -174,6 +177,11 @@ locus WorkSystem {
         self.attempts_made = self.attempts_made + 1;
     }
     fn policy() -> String { return self.selection.policy_name(); }
+    // A routing-policy mutation: re-point the program's WorkRouting
+    // slot. Only the slot's owner may (the ownership tree is the
+    // redeploy authority); the swap is one store, state preserved.
+    fn route_human_first() { reperspective self.selection as HumanFirstSelection; }
+    fn route_capability_first() { reperspective self.selection as CapabilityFirstSelection; }
     fn perform_as(kind: String, req: WorkRequest) -> WorkResult {
         if kind == "human" { return self.human.perform(req); }
         if kind == "agent" { return self.agent.perform(req); }

--- a/dna/tests/assembly_test.hl
+++ b/dna/tests/assembly_test.hl
@@ -84,6 +84,20 @@ main locus App {
         std::test::assert_eq_str(rv, "review", "law touched -> review");
         let s1 = self.dna.status();
         std::test::assert(std::str::contains(s1, "\"tasks_settled\": 1"), "status reflects the run: " + s1);
+
+        // routing policy is a perspective: the assembly designated
+        // human-first at construction (#525), and the WorkSystem can
+        // re-point the program's slot live (GH #534 closed F.10)
+        self.dna.work.route_capability_first();
+        std::test::assert_eq_str(self.dna.work.policy(), "capability-first", "live routing-policy swap");
+        let t2 = self.dna.ask(dna::Intent { id: "i2", outcome: "format the tree", from: "human" }, dna::Knobs { routed: true });
+        let settled2 = self.dna.metabolism.find(t2);
+        std::test::assert(std::str::contains(settled2.detail, "a0:software:done"), "the swapped policy routed software first: " + settled2.detail);
+        // the swap preserved the slot's STATE: the decision counter kept
+        // counting across both policies (the footprint they share)
+        std::test::assert_eq_int(self.dna.work.selection.decisions(), 2, "state survives the swap: one decision under each policy");
+        self.dna.work.route_human_first();
+        std::test::assert_eq_str(self.dna.work.policy(), "human-first", "swapped back");
     }
 }
 

--- a/dna/tests/review_authority_test.hl
+++ b/dna/tests/review_authority_test.hl
@@ -63,28 +63,38 @@ main locus App {
         std::test::assert_eq_int(self.review.verdict_count(), 2, "abstain + approve kept in lineage");
 
         // ---- Disposition is a vector policy -------------------------
+        // The disposition is the library's own enum, matched here on the
+        // importer's side (GH #534 closed dna/FRICTION.md F.1).
+        let lens = match self.boundary.assess("refactor", dna::Magnitude { loci: 1, law_touched: true }, dna::Evidence { }) {
+            dna::Disposition::Review -> "blocked-on-a-reviewer",
+            dna::Disposition::Release -> "released",
+            dna::Disposition::Stage -> "staged",
+            dna::Disposition::Escalate -> "escalated",
+            dna::Disposition::Deny -> "denied",
+        };
+        std::test::assert_eq_str(lens, "blocked-on-a-reviewer", "importer-side match over the library enum");
         let small = dna::Magnitude { loci: 2 };
         let strong = dna::Evidence { check_clean: true, verify_clean: true, tests_pass: true, replay_ok: true, rollback_rehearsed: true, independent_reviews: 3 };
         let weak = dna::Evidence { check_clean: true };
         // 6. Permitted class, small magnitude, strong evidence, post-review grant -> release.
-        std::test::assert_eq_str(self.boundary.assess("refactor", small, strong), "release", "release inside the envelope");
+        std::test::assert_eq_str(dna::disposition_name(self.boundary.assess("refactor", small, strong)), "release", "release inside the envelope");
         // 7. Same change, weak evidence -> stage (prepare, do not apply).
-        std::test::assert_eq_str(self.boundary.assess("refactor", small, weak), "stage", "insufficient evidence stages");
+        std::test::assert_eq_str(dna::disposition_name(self.boundary.assess("refactor", small, weak)), "stage", "insufficient evidence stages");
         // 8. A class outside the grant -> escalate, however strong the evidence.
-        std::test::assert_eq_str(self.boundary.assess("deploy", small, strong), "escalate", "class not granted escalates");
+        std::test::assert_eq_str(dna::disposition_name(self.boundary.assess("deploy", small, strong)), "escalate", "class not granted escalates");
         // 9. Hard boundaries: law touched / effects widened / ownership crossed
         //    -> review, and NO evidence score cancels that.
         let law = dna::Magnitude { loci: 1, law_touched: true };
-        std::test::assert_eq_str(self.boundary.assess("refactor", law, strong), "review", "law touched: review regardless of evidence");
+        std::test::assert_eq_str(dna::disposition_name(self.boundary.assess("refactor", law, strong)), "review", "law touched: review regardless of evidence");
         let widen = dna::Magnitude { loci: 1, effects_widened: true };
-        std::test::assert_eq_str(self.boundary.assess("refactor", widen, strong), "review", "effects widened: review regardless of evidence");
+        std::test::assert_eq_str(dna::disposition_name(self.boundary.assess("refactor", widen, strong)), "review", "effects widened: review regardless of evidence");
         let cross = dna::Magnitude { loci: 1, ownership_crossed: true };
-        std::test::assert_eq_str(self.boundary.assess("docs", cross, strong), "review", "ownership crossed: review");
+        std::test::assert_eq_str(dna::disposition_name(self.boundary.assess("docs", cross, strong)), "review", "ownership crossed: review");
         let blast = dna::Magnitude { loci: 1, irreversible: true, external_blast: 3 };
-        std::test::assert_eq_str(self.boundary.assess("docs", blast, strong), "review", "irreversible external blast: review");
+        std::test::assert_eq_str(dna::disposition_name(self.boundary.assess("docs", blast, strong)), "review", "irreversible external blast: review");
         // 10. Magnitude over the ceiling escalates even for a permitted class.
         let big = dna::Magnitude { loci: 40 };
-        std::test::assert_eq_str(self.boundary.assess("refactor", big, strong), "escalate", "magnitude ceiling escalates");
+        std::test::assert_eq_str(dna::disposition_name(self.boundary.assess("refactor", big, strong)), "escalate", "magnitude ceiling escalates");
 
         // ---- Autonomy evolution is asymmetric ------------------------
         // 11. The child cannot expand its own grant.
@@ -94,14 +104,14 @@ main locus App {
         // 12. The parent can.
         std::test::assert(self.boundary.expand("Product", "Product", 20, "deploy"), "parent expansion admitted");
         std::test::assert_eq_int(self.boundary.current_grant().max_magnitude, 20, "ceiling raised by the parent");
-        std::test::assert_eq_str(self.boundary.assess("deploy", small, strong), "release", "newly granted class releases");
+        std::test::assert_eq_str(dna::disposition_name(self.boundary.assess("deploy", small, strong)), "release", "newly granted class releases");
         // 13. Repeated failure contracts the grant automatically.
         self.boundary.note_outcome(false);
         self.boundary.note_outcome(false);
         std::test::assert_eq_int(self.boundary.contractions, 1, "contracted after two failures");
         std::test::assert_eq_int(self.boundary.current_grant().max_magnitude, 10, "ceiling halved");
         std::test::assert_eq_str(self.boundary.current_grant().review, "pre", "review tightened to pre");
-        std::test::assert(self.boundary.audit_count() >= 12, "every decision is in the audit trail");
+        std::test::assert(self.boundary.audit_count() >= 13, "every decision is in the audit trail");
     }
 }
 


### PR DESCRIPTION
Item 2 from the post-Track-A list. With #534 on main, `dna/core` drops its two workarounds and one checker gap the codegen-side fix had left surfaces and is closed.

- **Enum back.** `Disposition` is an enum: `dispose` and `AutonomyBoundary.assess` return it, `Dna.stage` matches on it, and `review_authority_test.hl` matches it on the importer's side as `dna::Disposition::Review`.
- **Perspective back.** `WorkRouting` is a perspective the assembly designates at construction (across the seed boundary) and the `WorkSystem` re-points live with `reperspective`; `assembly_test.hl` swaps policies mid-run. The swap preserves state by design, so each policy lives in its impl's code and the shared footprint holds only the decision counter, read across both policies through the contract. FRICTION F.1 and F.10 carry the resolutions and that lesson.
- **Checker.** `match_is_exhaustive` accepts an `alias::Enum::Variant` arm against a scrutinee typed by the seed-mangled enum. The #534 codegen fix left a typed scrutinee (a library fn returning its own enum) refused at check time; the consumer fixture gains that case.
- **Filed, not fixed:** a free fn named like a perspective contract method gets the method renamed by the seed mangler (#542).

Verified: hale-types 1172, hale-cli 359, hale-codegen 1331, `hale test dna/tests` 7/7, `hale verify dna/core` zero findings, fmt gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
