### PR TITLE
fix(codegen): seed mangler leaves member-position names alone — perspective contract methods and bus handlers (#542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ behavior.
 
 ## Unreleased
 
+### A perspective contract method keeps its name under `import` (GH #542)
+
+A library free fn that shared its name with a perspective contract
+method (`fn pick()` beside `perspective P { fn pick(); }`) broke the
+perspective once imported: every `serves` impl was "missing contract
+method" because the seed mangler had renamed the contract method to
+the free fn's mangled name while the impls' own methods correctly
+kept theirs. Contract methods live in member position exactly like
+locus methods (the pond P1 rule) and are walked that way now. Same
+fix for bus handler references: `subscribe Tick as tick;` names a
+member method, and a free fn `tick` in the seed used to move the
+reference to the mangled free-fn name.
+
 ### `dna/core` takes its enum and its routing perspective back (GH #534 follow-through)
 
 With enums and perspectives crossing seed boundaries, `Disposition`

--- a/crates/hale-codegen/src/mangle.rs
+++ b/crates/hale-codegen/src/mangle.rs
@@ -878,9 +878,13 @@ impl<'a> Mangler<'a> {
                             if let BusSubject::Topic(ident) = subject {
                                 self.rewrite_ident(&mut ident.name);
                             }
-                            // Handler resolves against top-level fns in
-                            // the seed; rewrite if it's one of ours.
-                            self.rewrite_ident(&mut handler.name);
+                            // GH #542: the handler names a MEMBER method
+                            // of this locus (kept unrenamed by
+                            // walk_method_decl), never a top-level fn.
+                            // Rewriting it when a free fn shared the
+                            // name pointed the subscription at a method
+                            // that does not exist.
+                            let _ = &handler;
                             if let Some(t) = ty {
                                 self.walk_type_expr(t);
                             }
@@ -990,7 +994,15 @@ impl<'a> Mangler<'a> {
                 }
                 PerspectiveMember::StableWhen(b) => self.walk_block(b),
                 PerspectiveMember::SerializeAs(t) => self.walk_type_expr(t),
-                PerspectiveMember::Fn(f) => self.walk_fn_decl(f),
+                // GH #542: a contract method's name lives in member
+                // position, exactly like a locus method's (pond P1
+                // below) — looked up on the perspective by its
+                // authored name, never through the seed rename map.
+                // `walk_fn_decl` renamed it when a top-level fn shared
+                // the name, so every `serves` impl (whose own method
+                // correctly kept its name) was "missing" the contract
+                // method once imported.
+                PerspectiveMember::Fn(f) => self.walk_method_decl(f),
                 // Phase 2c: contract bus surface.
                 PerspectiveMember::Bus(bb) => {
                     for bm in &mut bb.members {
@@ -999,7 +1011,9 @@ impl<'a> Mangler<'a> {
                                 if let BusSubject::Topic(id) = subject {
                                     self.rewrite_ident(&mut id.name);
                                 }
-                                self.rewrite_ident(&mut handler.name);
+                                // GH #542: a contract handler is a member
+                                // method name; see the locus case.
+                                let _ = &handler;
                                 if let Some(t) = ty {
                                     self.walk_type_expr(t);
                                 }

--- a/crates/hale-codegen/tests/cross_seed_imports.rs
+++ b/crates/hale-codegen/tests/cross_seed_imports.rs
@@ -519,6 +519,7 @@ fn perspective_contract_method_shadowed_by_top_level_fn_resolves() {
         fn pick() -> String { return "free"; }
     "#;
     let consumer_src = r#"
+        import "../lib" as lib;
         fn main() {
             let h = lib::Holder { };
             println(h.which(), " ", lib::pick());
@@ -577,6 +578,7 @@ fn bus_handler_name_shadowed_by_top_level_fn_resolves() {
         fn tick() -> Int { return 42; }
     "#;
     let consumer_src = r#"
+        import "../lib" as lib;
         main locus App {
             params { c: lib::Counter = lib::Counter { }; p: lib::Pub = lib::Pub { }; }
             run() { println("seen=", self.c.seen, " free=", lib::tick()); }

--- a/crates/hale-codegen/tests/cross_seed_imports.rs
+++ b/crates/hale-codegen/tests/cross_seed_imports.rs
@@ -501,3 +501,107 @@ fn library_enum_match_and_perspective_serves_survive_import() {
         assert!(stdout.contains(needle), "missing {needle}: {stdout:?}");
     }
 }
+
+/// GH #542: a free fn that shares its name with a PERSPECTIVE contract
+/// method. The seed mangler renamed the contract method (member
+/// position, like a locus method) to the free fn's mangled name, so
+/// every `serves` impl -- whose own method correctly kept its name --
+/// was "missing contract method" once imported.
+#[test]
+fn perspective_contract_method_shadowed_by_top_level_fn_resolves() {
+    let lib_src = r#"
+        perspective P { fn pick() -> String; }
+        locus Impl : serves P { fn pick() -> String { return "impl"; } }
+        locus Holder {
+            params { p: perspective(P) = Impl { }; }
+            fn which() -> String { return self.p.pick(); }
+        }
+        fn pick() -> String { return "free"; }
+    "#;
+    let consumer_src = r#"
+        fn main() {
+            let h = lib::Holder { };
+            println(h.which(), " ", lib::pick());
+        }
+    "#;
+    let alias = "lib";
+    let mut lib_prog = parse_source(lib_src).expect("parse lib");
+    let seed_renames = {
+        let stem_refs: Vec<(String, &Program)> = vec![("thing".to_string(), &lib_prog)];
+        mangle::build_seed_renames(&stem_refs, alias)
+    };
+    let renames: Vec<(Vec<String>, String)> = seed_renames
+        .iter()
+        .map(|(name, mangled)| (vec![alias.to_string(), name.clone()], mangled.clone()))
+        .collect();
+    mangle::mangle_with_renames(&mut lib_prog, &seed_renames);
+    // The contract method kept its authored name; the free fn moved.
+    for item in &lib_prog.items {
+        if let TopDecl::Perspective(p) = item {
+            for m in &p.members {
+                if let hale_syntax::ast::PerspectiveMember::Fn(f) = m {
+                    assert_eq!(f.name.name, "pick", "contract method must keep its name");
+                }
+            }
+        }
+        if let TopDecl::Fn(f) = item {
+            assert!(f.name.name.starts_with("__lib_"), "free fn must be mangled: {}", f.name.name);
+        }
+    }
+    let mut consumer = parse_source(consumer_src).expect("parse consumer");
+    consumer.imports.clear();
+    consumer.items.extend(lib_prog.items);
+    let bin = harness::unique_bin(&format!("hale_persp_method_shadow_{}", std::process::id()));
+    build_executable_with_imports(&consumer, &bin, &renames).expect("build consumer + lib");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(out.status.success(), "exit: {:?} stderr={}", out.status, String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("impl free"), "got: {stdout:?}");
+}
+
+/// GH #542, the bus-handler face: `subscribe Tick as tick;` names a
+/// member method; a free fn `tick` in the same seed moved the
+/// REFERENCE to the mangled free-fn name while the method kept its.
+#[test]
+fn bus_handler_name_shadowed_by_top_level_fn_resolves() {
+    let lib_src = r#"
+        type Beat { n: Int = 0; }
+        topic Tick { payload: Beat; subject: "c.tick"; }
+        locus Counter {
+            params { seen: Int = 0; }
+            bus { subscribe Tick as tick; }
+            fn tick(b: Beat) { self.seen = self.seen + b.n; }
+        }
+        locus Pub { bus { publish Tick; } run() { Tick <- Beat { n: 5 }; } }
+        fn tick() -> Int { return 42; }
+    "#;
+    let consumer_src = r#"
+        main locus App {
+            params { c: lib::Counter = lib::Counter { }; p: lib::Pub = lib::Pub { }; }
+            run() { println("seen=", self.c.seen, " free=", lib::tick()); }
+        }
+        fn main() { App { }; }
+    "#;
+    let alias = "lib";
+    let mut lib_prog = parse_source(lib_src).expect("parse lib");
+    let seed_renames = {
+        let stem_refs: Vec<(String, &Program)> = vec![("thing".to_string(), &lib_prog)];
+        mangle::build_seed_renames(&stem_refs, alias)
+    };
+    let renames: Vec<(Vec<String>, String)> = seed_renames
+        .iter()
+        .map(|(name, mangled)| (vec![alias.to_string(), name.clone()], mangled.clone()))
+        .collect();
+    mangle::mangle_with_renames(&mut lib_prog, &seed_renames);
+    let mut consumer = parse_source(consumer_src).expect("parse consumer");
+    consumer.imports.clear();
+    consumer.items.extend(lib_prog.items);
+    let bin = harness::unique_bin(&format!("hale_handler_shadow_{}", std::process::id()));
+    build_executable_with_imports(&consumer, &bin, &renames).expect("build consumer + lib");
+    let out = Command::new(&bin).output().expect("run");
+    let _ = std::fs::remove_file(&bin);
+    assert!(out.status.success(), "exit: {:?} stderr={}", out.status, String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("seen=5 free=42"), "got: {stdout:?}");
+}

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -349,6 +349,10 @@ crates/hale-codegen/tests/cross_locus_from_method.rs#6 4dc3ef9029ded8d0
 crates/hale-codegen/tests/cross_locus_from_method.rs#7 fcd7b15eda245808
 crates/hale-codegen/tests/cross_seed_imports.rs#0 19c45840adcf5be3
 crates/hale-codegen/tests/cross_seed_imports.rs#1 7ba49c53bd84fd5d
+crates/hale-codegen/tests/cross_seed_imports.rs#2 89a7431e3e28532a
+crates/hale-codegen/tests/cross_seed_imports.rs#3 f2c1228edb650960
+crates/hale-codegen/tests/cross_seed_imports.rs#4 d4e741f73d4026f0
+crates/hale-codegen/tests/cross_seed_imports.rs#5 7d5cf57defcf548e
 crates/hale-codegen/tests/cross_seed_locus_arg.rs#0 0bf5244b2cba771c
 crates/hale-codegen/tests/cross_seed_locus_arg.rs#1 0bf5244b2cba771c
 crates/hale-codegen/tests/cross_seed_locus_arg.rs#2 a3ae8b631fccba11


### PR DESCRIPTION
Fixes #542.

A library free fn sharing its name with a perspective contract method broke the perspective under `import`: the contract method was renamed to the free fn's mangled name while every `serves` impl's own method correctly kept its name, so each impl was "missing contract method". Contract methods live in member position exactly like locus methods (the pond P1 rule) and are walked that way now.

Same class in bus blocks, found by probing while fixing this: `subscribe Tick as tick;` names a member method, and both the locus and perspective walkers rewrote the handler reference through the top-level rename map, so a free fn `tick` in the seed pointed the subscription at a method that does not exist.

Two regressions in `cross_seed_imports.rs`, each building and running an importer. Verified: hale-codegen 1333, hale-types 1172, hale-cli 359, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
