### PR TITLE
model diff: what a dry run of the kill test found (GH #529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ behavior.
 
 ## Unreleased
 
+### Bindings: a listener serves many peers, and keyed topics keep their routing across the socket (DNA F.12 + F.13, GH #529 prep)
+
+- **F.13 — a listen binding serves many peers.** The unix serve loop was accept → read until EOF → re-arm: one peer held the socket until it hung up, and a second connector (an observer holding the membrane, then a CLI publishing one fact) sat in the backlog with its message never read. The loop now polls the listener beside every accepted peer (up to 64), admits connections as they arrive, keeps a framed seq space per peer, closes only the peer that hangs up, and — once the listener is shut at exit — drains every connected peer to EOF, so the exit quiesce still delivers the kernel-queued tail. Listen backlog 1 → 16. `hale dna ask` / `review` connect directly beside an attached iris; the `.hale/dna/iris.port` detour is gone. Test: `binding_multi_peer` (two publishers connected together, both deliver, no seq gaps).
+- **F.12 — keyed subscriptions hear wire deliveries.** Remote fanout carries no key material, and the receive side dispatched unkeyed, so `subscribe T as h where key == self.k` behind a binding received nothing. Codegen now synthesizes one `__key_extract_*` per keyed wire subject (the publish site's exact computation over the deserialized payload: scalars through the same pair packing, String keys as FNV hash + pointer) and registers it at the main prelude; the runtime derives the key on every inbound path (unix serve loop, boot-window flush, UDP reader, adapter inbound) and takes the keyed dispatch. The DNA core's Review subscribes `where key == self.review_id` again. Test: `binding_keyed_over_wire` (Int and String keys; an unmatched key reaches no filtered subscriber). Spec: `semantics.md` (String keys), `runtime.md` (the serve loop).
+
 ### DNA: mutations stop at stage; the organism is visible in iris (GH #528 PR 28, #527 B7)
 
 - **Observation names imported loci by their author-facing names.** The manifest recorded the mangled symbol (`__lib_vendor_dna_assembly_Dna`), which iris hides as runtime-internal and which never joined with the artifact's `dna::Dna` — every cross-seed tower was invisible and unjoinable. Codegen now emits the same demangled display the artifact uses (imports ∪ stdlib renames).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ behavior.
 
 ## Unreleased
 
+### DNA: the kill test for Track D (GH #529)
+
+- `dna/kill-test/`: the falsification test the track puts before its apply path. `before/` and `after/` are one small application (a support desk) around a proposed change that does five different things to the model (a second publisher that flips a law to violated, a locus gaining `outbound_email`, a parent-facing contract change, a pure rename, a new law); `run.sh` prints the git diff and `hale model diff --text` over the same change (and opens iris [4] with `--iris`); `WALKTHROUGH.md` is the protocol and scoring for a reviewer who does not care about Hale. If the semantic diff is not visibly better than the git diff for deciding, Track D is reordered or stopped.
+
 ### Bindings: a listener serves many peers, and keyed topics keep their routing across the socket (DNA F.12 + F.13, GH #529 prep)
 
 - **F.13 — a listen binding serves many peers.** The unix serve loop was accept → read until EOF → re-arm: one peer held the socket until it hung up, and a second connector (an observer holding the membrane, then a CLI publishing one fact) sat in the backlog with its message never read. The loop now polls the listener beside every accepted peer (up to 64), admits connections as they arrive, keeps a framed seq space per peer, closes only the peer that hangs up, and — once the listener is shut at exit — drains every connected peer to EOF, so the exit quiesce still delivers the kernel-queued tail. Listen backlog 1 → 16. `hale dna ask` / `review` connect directly beside an attached iris; the `.hale/dna/iris.port` detour is gone. Test: `binding_multi_peer` (two publishers connected together, both deliver, no seq gaps).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ behavior.
 
 ## Unreleased
 
+### `hale model diff`: what a dry run of the kill test found (GH #529)
+
+- Two reviewers who did not know the language read the kill test's views. Both decided from the semantic diff (a law flipping to violated is one line) and wrote their revision comments from the git diff. Four things they could not read in the semantic view are fixed: a persisted topic whose payload shape or wire subject moved now has a `contracts` row (`! topic QueueStats shape: …` — a wider payload is a contract change for every locus on it); a param rename no longer echoes as ownership and placement rows (those facets are by owner and thread domain now, not by instance path); the text view carries a legend for `+ - ~ > * ? !` and labels source sites as byte offsets; a claim whose result and verdict move together is stated once. Not fixed, stated in `dna/kill-test/WALKTHROUGH.md`: an effect class reached through a bus edge shows only as `gains publish` on the sender, wire values are outside the model, and an added-but-unread field looks like a used one.
+
 ### DNA: the kill test for Track D (GH #529)
 
 - `dna/kill-test/`: the falsification test the track puts before its apply path. `before/` and `after/` are one small application (a support desk) around a proposed change that does five different things to the model (a second publisher that flips a law to violated, a locus gaining `outbound_email`, a parent-facing contract change, a pure rename, a new law); `run.sh` prints the git diff and `hale model diff --text` over the same change (and opens iris [4] with `--iris`); `WALKTHROUGH.md` is the protocol and scoring for a reviewer who does not care about Hale. If the semantic diff is not visibly better than the git diff for deciding, Track D is reordered or stopped.

--- a/crates/hale-cli/src/dna.rs
+++ b/crates/hale-cli/src/dna.rs
@@ -494,8 +494,6 @@ fn run_organism(args: &[String]) -> ExitCode {
     };
     let mut observer: Option<std::process::Child> = None;
     let status_path = dna_dir.join("status.json");
-    let port_file = dna_dir.join("iris.port");
-    let _ = fs::remove_file(&port_file);
     if bound {
         eprintln!("hale dna run: membrane bound at {}", dna_dir.display());
         // the status projection, written before iris reads it
@@ -512,10 +510,6 @@ fn run_organism(args: &[String]) -> ExitCode {
             match cmd.spawn() {
                 Ok(c) => {
                     eprintln!("hale dna run: iris at http://127.0.0.1:{port}/  (l law · 4 review vs baseline · 5 organism · m membrane)");
-                    // F.13 (dna/FRICTION.md): a listen binding serves one
-                    // peer at a time, and iris holds the membrane while it
-                    // runs — so `hale dna ask` / `review` go through iris.
-                    let _ = fs::write(&port_file, format!("{port}\n"));
                     observer = Some(c);
                 }
                 Err(e) => eprintln!("hale dna run: could not launch hale iris: {e}"),
@@ -536,7 +530,6 @@ fn run_organism(args: &[String]) -> ExitCode {
         write_status(&root, &status_path);
         std::thread::sleep(std::time::Duration::from_secs(1));
     };
-    let _ = fs::remove_file(&port_file);
     if let Some(mut o) = observer {
         let _ = o.kill();
         let _ = o.wait();
@@ -812,41 +805,12 @@ fn ask(args: &[String]) -> Result<Vec<String>, String> {
     }
 }
 
-/// Publish one typed fact on the membrane. While `hale dna run` has
-/// iris attached, iris HOLDS the organism's listen sockets (a listen
-/// binding serves one peer at a time — F.13 in dna/FRICTION.md), so
-/// the fact goes through iris's `/ctl` endpoint, which publishes the
-/// same declaration on the same socket. Otherwise the embedded
-/// membrane client connects directly.
+/// Publish one typed fact on the membrane: build (once, in the
+/// toolchain cache beside the core it imports) and exec the membrane
+/// client with routes to this project's sockets. A listen binding
+/// serves many peers (F.13, fixed), so this connects beside an
+/// attached iris.
 fn publish_on_membrane(root: &Path, kind: &str, body: &str) -> Result<(), String> {
-    if let Ok(p) = fs::read_to_string(root.join(".hale/dna/iris.port")) {
-        if let Ok(port) = p.trim().parse::<u16>() {
-            let path = if kind == "intent" { "/ctl/intent" } else { "/ctl/review" };
-            match post_local(port, path, body) {
-                Ok(status) if status == 200 => return Ok(()),
-                Ok(status) => return Err(format!("iris refused the {kind} (HTTP {status})")),
-                Err(e) => eprintln!("hale dna: iris at :{port} did not answer ({e}); publishing directly"),
-            }
-        }
-    }
-    publish_directly(root, kind, body)
-}
-
-fn post_local(port: u16, path: &str, body: &str) -> Result<u16, String> {
-    use std::io::{Read, Write};
-    let mut s = std::net::TcpStream::connect(("127.0.0.1", port)).map_err(|e| e.to_string())?;
-    s.set_read_timeout(Some(std::time::Duration::from_secs(5))).map_err(|e| e.to_string())?;
-    s.write_all(format!("POST {path} HTTP/1.0\r\nHost: x\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}", body.len()).as_bytes())
-        .map_err(|e| e.to_string())?;
-    let mut out = String::new();
-    let _ = s.read_to_string(&mut out);
-    out.split_whitespace().nth(1).and_then(|c| c.parse().ok()).ok_or_else(|| "no HTTP status".to_string())
-}
-
-/// Build (once, in the toolchain cache beside the core it imports)
-/// and exec the membrane client with routes to this project's
-/// sockets.
-fn publish_directly(root: &Path, kind: &str, body: &str) -> Result<(), String> {
     let cache = hale_iris::materialize().map_err(|e| format!("cannot materialize the toolchain cache: {e}"))?;
     let bin = cache.join(hale_dna::MEMBRANE_BIN);
     let me = std::env::current_exe().map_err(|e| e.to_string())?;

--- a/crates/hale-cli/tests/dna_run.rs
+++ b/crates/hale-cli/tests/dna_run.rs
@@ -91,8 +91,8 @@ fn run_hosts_the_organism_with_iris_and_the_membrane_and_holds_no_state() {
     let body = r#"{"intent_id":"i1","outcome":"write the changelog","from":"test"}"#;
     let r = http(port, &format!("POST /ctl/intent HTTP/1.0\r\nHost: x\r\nContent-Length: {}\r\n\r\n{body}", body.len()));
     assert!(r.contains("200"), "{r}");
-    // …and so does `hale dna ask` WHILE iris holds the membrane (F.13:
-    // it goes through iris's /ctl, and the answer comes from the Journal)
+    // …and so does `hale dna ask` while iris is attached to the same
+    // sockets (F.13, fixed: a listen binding serves many peers)
     let ask = Command::new(env!("CARGO_BIN_EXE_hale"))
         .args(["dna", "ask", "also", "tag", "the", "release"])
         .current_dir(&app)
@@ -131,7 +131,6 @@ fn run_hosts_the_organism_with_iris_and_the_membrane_and_holds_no_state() {
     assert!(grew, "the organism journaled intent.offered + task.born");
     assert!(ask.status.success() && ask_out.contains("task t2 born"), "ask through iris: {ask_out}");
     assert!(status_ok, "status.json re-projected from the Journal");
-    assert!(!app.join(".hale/dna/iris.port").exists(), "the port file is gone with the host");
     let _ = std::fs::remove_dir_all(&d);
 }
 

--- a/crates/hale-cli/tests/dna_run.rs
+++ b/crates/hale-cli/tests/dna_run.rs
@@ -44,14 +44,24 @@ fn run_hosts_the_organism_with_iris_and_the_membrane_and_holds_no_state() {
         .spawn()
         .expect("spawn hale dna run");
     // iris comes up with the membrane, the current artifact and the review view
+    // The observer discovers EVERY LOTUS_OBS=1 process on the machine
+    // (a CI shard runs other observed tests beside this one), so wait
+    // for and assert on the organism's own process by name.
+    let organism_loci = |s: &str| -> Option<Vec<String>> {
+        let json = s.find("{\"ts\"")?;
+        let v: serde_json::Value = serde_json::from_str(&s[json..]).ok()?;
+        let p = v["processes"].as_array()?.iter().find(|p| p["name"] == "orgrun")?;
+        Some(p["loci"].as_array()?.iter().map(|l| l["type"].as_str().unwrap_or("").to_string()).collect())
+    };
     let deadline = Instant::now() + Duration::from_secs(90);
     let mut snap = String::new();
     while Instant::now() < deadline {
         let s = http(port, "GET /snapshot HTTP/1.0\r\nHost: x\r\n\r\n");
         // the diff AND the organism's status both report loaded, the law
-        // verified, and the organism's locus tree replayed (a process
+        // verified, and the organism's own locus tree replayed (a process
         // attaches before its births are replayed, so wait for a type)
-        if s.contains("\"membrane\"") && s.matches("\"state\":\"loaded\"").count() >= 2 && s.contains("\"digest\":\"verified\"") && s.contains("\"processes\":[{") && s.contains("\"type\":\"") {
+        let tree_up = organism_loci(&s).map(|t| !t.is_empty()).unwrap_or(false);
+        if s.contains("\"membrane\"") && s.matches("\"state\":\"loaded\"").count() >= 2 && s.contains("\"digest\":\"verified\"") && tree_up {
             snap = s;
             break;
         }
@@ -84,8 +94,9 @@ fn run_hosts_the_organism_with_iris_and_the_membrane_and_holds_no_state() {
     let compact = snap.replace(' ', "");
     assert!(compact.contains("\"dna\":{"), "{snap}");
     assert!(compact.contains("\"reviews\":[{") && compact.contains("\"state\":\"pending\""), "the status projection carries the pending purpose review: {snap}");
-    assert!(compact.contains("\"type\":\"dna::Dna\"") || compact.contains("\"type\":\"dna::Metabolism\""), "imported loci observed under their author-facing names: {snap}");
-    assert!(!compact.contains("\"type\":\"__lib_"), "no mangled locus type names in the observation: {snap}");
+    let types = organism_loci(&snap).expect("the organism's process in the snapshot");
+    assert!(types.iter().any(|t| t == "dna::Dna" || t == "dna::Metabolism"), "imported loci observed under their author-facing names: {types:?}");
+    assert!(!types.iter().any(|t| t.starts_with("__lib_")), "no mangled locus type names in the observation: {types:?}");
     // an intent through the membrane lands in the organism's Journal
     let before = std::fs::read_to_string(app.join(".hale/dna/journal.jsonl")).unwrap().lines().count();
     let body = r#"{"intent_id":"i1","outcome":"write the changelog","from":"test"}"#;

--- a/crates/hale-cli/tests/model_diff.rs
+++ b/crates/hale-cli/tests/model_diff.rs
@@ -254,6 +254,12 @@ fn contract_effect_and_law_deltas_are_per_entity_set_differences() {
     let b = dump(&dir, "b", &changed);
     let d = diff_json(&a, &b);
     let contracts = rows(&d, "contracts");
+    // a wider payload with the same topology is a CONTRACT change, never "source-only"
+    let widened = BASE.replace("type T { n: Int = 0; }", "type T { n: Int = 0; note: String = \"\"; }");
+    let w = dump(&dir, "w", &widened);
+    let dw = diff_json(&a, &w);
+    assert_eq!(dw["classification"], "contract", "{dw}");
+    assert!(rows(&dw, "contracts").iter().any(|r| r["topic"] == "Evt" && r["facet"] == "shape"), "{dw}");
     let app_params = contracts.iter().find(|r| r["locus"] == "App" && r["facet"] == "params").expect("App params delta");
     assert_eq!(app_params["added"], serde_json::json!(["limit: Int"]));
     assert_eq!(app_params["removed"], serde_json::json!([]));

--- a/crates/hale-codegen/runtime/lotus_arena.c
+++ b/crates/hale-codegen/runtime/lotus_arena.c
@@ -11903,7 +11903,9 @@ lotus_transport_t *lotus_transport_listener_create(const char *path) {
         errno = save;
         return NULL;
     }
-    if (listen(sock, 1) < 0) {
+    /* F.13: several connectors may arrive together (an observer, a
+     * CLI, a peer binary); the serve loop admits them all. */
+    if (listen(sock, 16) < 0) {
         perror("lotus_transport_listener_create: listen");
         int save = errno;
         close(sock);
@@ -15001,6 +15003,10 @@ static lotus_deserialize_fn lotus_bus_find_deserializer(
  * delivered now. The unlocked pend_head read is a fast filter —
  * the flush itself re-checks under the entry lock. */
 static void lotus_bus_early_flush(lotus_bus_remote_entry_t *entry);
+static void lotus_bus_local_dispatch_inbound(lotus_bus_queue_t *queue,
+                                             const char *subject,
+                                             const void *struct_payload,
+                                             size_t struct_size);
 static void lotus_bus_early_flush_for_subject(const char *pattern) {
     for (size_t i = 0; i < g_bus_remote_count; i++) {
         lotus_bus_remote_entry_t *e = g_bus_remote_entries[i];
@@ -15113,8 +15119,8 @@ static void lotus_bus_early_flush(lotus_bus_remote_entry_t *entry) {
                                           (uint64_t)m->len);
         }
         if (lotus_obs_begin_redispatch) lotus_obs_begin_redispatch();
-        lotus_bus_local_dispatch(g_bus_queue_for_remote, entry->subject,
-                                 struct_buf, (size_t)struct_size);
+        lotus_bus_local_dispatch_inbound(g_bus_queue_for_remote, entry->subject,
+                                         struct_buf, (size_t)struct_size);
         if (lotus_obs_end_redispatch) lotus_obs_end_redispatch();
         uint64_t dseq = LOTUS_CTR_BUMP(entry->ctr_msgs_delivered);
         LOTUS_CTR_ADD(entry->ctr_bytes_delivered, m->len);
@@ -15170,20 +15176,197 @@ typedef struct lotus_bus_reader_args {
  * accept). Exits when `closing` is set or accept refuses
  * (teardown shuts the listener down via
  * lotus_bus_transport_interrupt / destroy_all). */
+/* DNA F.12 (GH #529 prep): receive-side key derivation.
+ *
+ * A keyed topic's publish site computes (key_lo, key_hi) from the
+ * payload's `keyed_by` field and routes to `where key == …`
+ * subscribers; a message arriving over a binding carried no key,
+ * so every inbound path dispatched UNKEYED and the keyed dispatch
+ * skipped the filtered subscribers (kind=1) by design — the same
+ * subscription meant "mine only" in-process and "nothing" over a
+ * socket. Codegen now synthesizes one extractor per keyed wire
+ * subject (`__key_extract_*`, the publish site's exact
+ * computation over the DESERIALIZED payload) and registers it at
+ * the main prelude; every inbound path derives the key here and
+ * takes the keyed dispatch. Subjects without an extractor are
+ * unkeyed topics and dispatch as before. */
+typedef void (*lotus_key_extract_fn)(const void *payload,
+                                     uint64_t *key_lo,
+                                     uint64_t *key_hi);
+typedef struct {
+    char                 *subject;   /* owned */
+    lotus_key_extract_fn  fn;
+} lotus_key_extractor_t;
+static lotus_key_extractor_t *g_key_extractors      = NULL;
+static size_t                 g_key_extractor_count = 0;
+static size_t                 g_key_extractor_cap   = 0;
+
+void lotus_bus_register_key_extractor(const char *subject,
+                                      lotus_key_extract_fn fn) {
+    if (!subject || !fn) return;
+    for (size_t i = 0; i < g_key_extractor_count; i++) {
+        if (strcmp(g_key_extractors[i].subject, subject) == 0) {
+            g_key_extractors[i].fn = fn;
+            return;
+        }
+    }
+    if (g_key_extractor_count == g_key_extractor_cap) {
+        size_t nc = g_key_extractor_cap ? g_key_extractor_cap * 2 : 8;
+        lotus_key_extractor_t *grown = (lotus_key_extractor_t *)
+            realloc(g_key_extractors, nc * sizeof(*grown));
+        if (!grown) return;
+        g_key_extractors   = grown;
+        g_key_extractor_cap = nc;
+    }
+    g_key_extractors[g_key_extractor_count].subject = strdup(subject);
+    g_key_extractors[g_key_extractor_count].fn      = fn;
+    g_key_extractor_count++;
+}
+
+static lotus_key_extract_fn lotus_bus_find_key_extractor(const char *subject) {
+    if (!subject) return NULL;
+    for (size_t i = 0; i < g_key_extractor_count; i++) {
+        if (strcmp(g_key_extractors[i].subject, subject) == 0) {
+            return g_key_extractors[i].fn;
+        }
+    }
+    return NULL;
+}
+
+/* Every inbound path (unix serve loop, boot-window flush, UDP
+ * reader, adapter inbound) lands here with STRUCT bytes: derive
+ * the key when the subject is keyed, dispatch keyed; else the
+ * unkeyed local fanout as before. */
+static void lotus_bus_local_dispatch_inbound(lotus_bus_queue_t *queue,
+                                             const char *subject,
+                                             const void *struct_payload,
+                                             size_t struct_size) {
+    lotus_key_extract_fn kx = lotus_bus_find_key_extractor(subject);
+    if (kx) {
+        uint64_t lo = 0, hi = 0;
+        kx(struct_payload, &lo, &hi);
+        lotus_bus_local_dispatch_keyed(queue, subject, struct_payload,
+                                       struct_size, lo, hi);
+        return;
+    }
+    lotus_bus_local_dispatch(queue, subject, struct_payload, struct_size);
+}
+
+/* DNA F.13 (GH #529 prep): a listen binding serves N peers.
+ *
+ * The serve loop used to be accept -> read until EOF -> re-arm:
+ * ONE peer held the socket until it hung up, and a second
+ * connector (an observer holding the membrane, then a CLI
+ * publishing one fact) sat in the backlog with its message never
+ * read. Now the loop polls the listener beside every accepted
+ * peer: connections are admitted as they arrive, each keeps its
+ * own framed seq space (the re-arm's per-peer reset, per peer),
+ * a peer's EOF closes that peer only, and teardown's shutdown of
+ * the listener (or the poll timeout) lets `closing` end the loop.
+ * The transport struct stays the single-connection view the recv
+ * helpers expect: the active peer's fd and seq state are swapped
+ * in around each read. */
+#define LOTUS_UNIX_MAX_PEERS 64
+typedef struct {
+    int      fd;
+    uint64_t recv_seq;
+    uint64_t recv_origin;
+    uint64_t seq_gaps;
+} lotus_unix_peer_t;
+
 static void lotus_bus_unix_serve(lotus_bus_remote_entry_t *entry) {
     lotus_transport_t *t = entry->transport;
     if (!t) return;
     char wire_buf[LOTUS_PAYLOAD_MAX];
     char struct_buf[LOTUS_PAYLOAD_MAX];
+    lotus_unix_peer_t peers[LOTUS_UNIX_MAX_PEERS];
+    int npeers = 0;
+    int warned_full = 0;
+    /* The exit quiesce (lotus_bus_ingress_quiesce) half-closes the
+     * LISTENER and expects the reader to drain every accepted peer
+     * to a true EOF — the kernel hands over queued data before EOF
+     * even after SHUT_RDWR. So a dead listener is not "stop": it is
+     * "admit nobody new, shut the peers down so the silent ones end
+     * too, and leave when the last one has drained". */
+    int listener_down = 0;
     while (!entry->closing) {
-        /* The listener socket was bound at realization, so a
-         * peer's connect-with-retry succeeds as soon as this
-         * binary boots, whether or not this thread has reached
-         * accept yet (m59's no-hang-at-boot property). */
-        if (lotus_transport_listener_accept(t) != 0) break;
-        while (!entry->closing) {
+        struct pollfd pfds[1 + LOTUS_UNIX_MAX_PEERS];
+        pfds[0].fd = listener_down ? -1 : t->listen_fd;   /* -1: poll ignores */
+        pfds[0].events = POLLIN;
+        pfds[0].revents = 0;
+        for (int i = 0; i < npeers; i++) {
+            pfds[1 + i].fd = peers[i].fd;
+            pfds[1 + i].events = POLLIN;
+            pfds[1 + i].revents = 0;
+        }
+        int pr = poll(pfds, (nfds_t)(1 + npeers), 250);
+        if (pr < 0) {
+            if (errno == EINTR) continue;
+            break;
+        }
+        if (entry->closing) break;
+        if (pr == 0) continue;
+        /* new peer(s): the listener socket was bound at
+         * realization, so a peer's connect-with-retry succeeds as
+         * soon as this binary boots (m59's no-hang-at-boot). */
+        if (!listener_down && (pfds[0].revents & (POLLIN | POLLERR | POLLHUP))) {
+            int conn = accept(t->listen_fd, NULL, NULL);
+            if (conn < 0) {
+                if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
+                    /* spurious readiness */
+                } else {
+                    /* listener shut down (exit quiesce or teardown):
+                     * drain what is connected, then leave. */
+                    listener_down = 1;
+                    for (int i = 0; i < npeers; i++) {
+                        shutdown(peers[i].fd, SHUT_RDWR);
+                    }
+                }
+            } else {
+                lotus_set_cloexec(conn);
+                if (npeers < LOTUS_UNIX_MAX_PEERS) {
+                    peers[npeers].fd = conn;
+                    peers[npeers].recv_seq = 0;
+                    peers[npeers].recv_origin = 0;
+                    peers[npeers].seq_gaps = 0;
+                    npeers++;
+                } else {
+                    if (!warned_full) {
+                        fprintf(stderr,
+                                "lotus_bus_unix_serve: %s: %d peers already "
+                                "connected; refusing another\n",
+                                entry->subject ? entry->subject : "?",
+                                LOTUS_UNIX_MAX_PEERS);
+                        warned_full = 1;
+                    }
+                    close(conn);
+                }
+            }
+        }
+        for (int i = 0; i < npeers; i++) {
+            if (entry->closing) break;
+            if (!(pfds[1 + i].revents & (POLLIN | POLLERR | POLLHUP))) continue;
+            /* swap this peer into the transport's single-connection view */
+            t->conn_fd     = peers[i].fd;
+            t->recv_seq    = peers[i].recv_seq;
+            t->recv_origin = peers[i].recv_origin;
+            t->seq_gaps    = peers[i].seq_gaps;
             ssize_t n = lotus_transport_recv(t, wire_buf, sizeof(wire_buf));
-            if (n <= 0) break;     /* peer closed (0) or error (-1) */
+            peers[i].recv_seq    = t->recv_seq;
+            peers[i].recv_origin = t->recv_origin;
+            peers[i].seq_gaps    = t->seq_gaps;
+            if (n <= 0) {
+                /* peer closed (0) or error (-1): close THIS peer only
+                 * (GH #233 step 2's re-arm, per peer). */
+                close(peers[i].fd);
+                t->conn_fd = -1;
+                LOTUS_CTR_BUMP(entry->ctr_rearms);
+                peers[i] = peers[npeers - 1];
+                pfds[1 + i] = pfds[npeers];   /* keep revents aligned with the swap */
+                npeers--;
+                i--;
+                continue;
+            }
 
             /* m60: deserialize wire bytes into struct-layout bytes
              * before handing them to local dispatch. Look up the
@@ -15238,9 +15421,9 @@ static void lotus_bus_unix_serve(lotus_bus_remote_entry_t *entry) {
              * BUS_PUBLISH probe at the top of local_dispatch counts it
              * as a delivery, not a publish. */
             if (lotus_obs_begin_redispatch) lotus_obs_begin_redispatch();
-            lotus_bus_local_dispatch(g_bus_queue_for_remote,
-                                     entry->subject,
-                                     struct_buf, (size_t)struct_size);
+            lotus_bus_local_dispatch_inbound(g_bus_queue_for_remote,
+                                             entry->subject,
+                                             struct_buf, (size_t)struct_size);
             if (lotus_obs_end_redispatch) lotus_obs_end_redispatch();
             uint64_t dseq = LOTUS_CTR_BUMP(entry->ctr_msgs_delivered);
             LOTUS_CTR_ADD(entry->ctr_bytes_delivered, n);
@@ -15272,18 +15455,13 @@ static void lotus_bus_unix_serve(lotus_bus_remote_entry_t *entry) {
                         (uint64_t)n);
                 }
             }
-        }
-        /* GH #233 step 2: re-arm. Close the dead connection and
-         * loop back into accept for the next peer. */
-        if (t->conn_fd >= 0) {
-            close(t->conn_fd);
             t->conn_fd = -1;
-            /* Fresh peer = fresh seq space (a reconnecting
-             * publisher restarts its counter at 1). */
-            t->recv_seq = 0;
-            LOTUS_CTR_BUMP(entry->ctr_rearms);
         }
+        if (listener_down && npeers == 0) break;
     }
+    /* teardown: every peer still connected goes with the loop */
+    for (int i = 0; i < npeers; i++) close(peers[i].fd);
+    t->conn_fd = -1;
 }
 
 /* GH #468 test hook: deterministically stretch the reader's
@@ -15634,9 +15812,9 @@ static void *lotus_bus_udp_reader_thread_main(void *arg) {
         /* iris handoff-4 P15: mark the inbound re-dispatch (delivery,
          * not a publish) so it doesn't inflate the published counter. */
         if (lotus_obs_begin_redispatch) lotus_obs_begin_redispatch();
-        lotus_bus_local_dispatch(g_bus_queue_for_remote,
-                                 args->entry->subject,
-                                 struct_buf, (size_t)struct_size);
+        lotus_bus_local_dispatch_inbound(g_bus_queue_for_remote,
+                                         args->entry->subject,
+                                         struct_buf, (size_t)struct_size);
         if (lotus_obs_end_redispatch) lotus_obs_end_redispatch();
         uint64_t dseq2 = LOTUS_CTR_BUMP(args->entry->ctr_msgs_delivered);
         LOTUS_CTR_ADD(args->entry->ctr_bytes_delivered, n);
@@ -15788,8 +15966,8 @@ static void *lotus_replay_injector_worker(void *arg) {
             lotus_replay_inject_begin(subject, bytes, size, pub_id);
         }
         if (lotus_obs_begin_redispatch) lotus_obs_begin_redispatch();
-        lotus_bus_local_dispatch(g_bus_queue_for_remote, subject,
-                                 struct_buf, (size_t)struct_size);
+        lotus_bus_local_dispatch_inbound(g_bus_queue_for_remote, subject,
+                                         struct_buf, (size_t)struct_size);
         if (lotus_obs_end_redispatch) lotus_obs_end_redispatch();
         if (lotus_replay_note_injected) lotus_replay_note_injected();
         atomic_store_explicit(&w->next_idx, i + 1,

--- a/crates/hale-codegen/src/codegen.rs
+++ b/crates/hale-codegen/src/codegen.rs
@@ -1408,6 +1408,7 @@ pub fn build_executable_with_options(
             .iter()
             .map(|(segs, mangled)| (segs.clone(), mangled.clone()))
             .collect(),
+        key_extractors: BTreeMap::new(),
         bus_state: None,
         shm_ring_subjects: std::collections::BTreeMap::new(),
         routing_key_subjects: std::collections::BTreeMap::new(),
@@ -3608,6 +3609,11 @@ pub(crate) struct Cx<'ctx, 'p> {
     /// (e.g. `"__lib_foo_Y_Bar"`). Consulted by
     /// `Cx::mangled_for_path` after the static stdlib table.
     import_renames: BTreeMap<Vec<String>, String>,
+    /// GH #529 prep (DNA F.12): per keyed wire subject, the synthesized
+    /// `__key_extract_*` fn the runtime calls on a DESERIALIZED inbound
+    /// payload to derive the routing key a listen binding never
+    /// received — the same (key_lo, key_hi) the publish site computes.
+    key_extractors: BTreeMap<String, inkwell::values::FunctionValue<'ctx>>,
     /// Bus state generated when any locus declares a subscribe.
     /// `Some` iff the program contains at least one `bus subscribe`
     /// declaration. Bus storage itself lives in the C runtime
@@ -8713,6 +8719,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // prelude register call + codec_self global store still
         // run later via `emit_bindings_prelude`.
         self.synthesize_codec_thunks_for_main_bindings()?;
+        self.synthesize_key_extractors()?;
 
         // Pass C: lower lifecycle method bodies (birth, run, ...).
         for l in &locus_decls {
@@ -9200,6 +9207,32 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         // become host imports. The browser bus is in-memory / WebSocket-
         // adapter-driven (a later slice), never cross-process sockets.
         if !self.is_wasm {
+            // GH #529 prep (DNA F.12): tell the runtime how to derive a
+            // keyed topic's key from an inbound payload, so a listen
+            // binding delivers to `where key == …` subscribers exactly
+            // as an in-process publish does.
+            let extractors: Vec<(String, inkwell::values::FunctionValue<'ctx>)> =
+                self.key_extractors.iter().map(|(k, v)| (k.clone(), *v)).collect();
+            if !extractors.is_empty() {
+                let reg_fn = self
+                    .module
+                    .get_function("lotus_bus_register_key_extractor")
+                    .expect("lotus_bus_register_key_extractor declared");
+                for (subject, f) in extractors {
+                    let subj_ptr = self
+                        .builder
+                        .build_global_string_ptr(&subject, "lotus.keyx.subject")
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                        .as_pointer_value();
+                    self.builder
+                        .build_call(
+                            reg_fn,
+                            &[subj_ptr.into(), f.as_global_value().as_pointer_value().into()],
+                            "lotus.keyx.register",
+                        )
+                        .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                }
+            }
             let load_cfg_fn = self
                 .module
                 .get_function("lotus_bus_load_config")
@@ -10682,6 +10715,96 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
     /// `emit_codec_binding_register`, which finds the codec_self
     /// global through `codec_thunks` and stores the constructed
     /// instance into it.
+    /// GH #529 prep (DNA F.12): one `__key_extract_<subject>` fn per
+    /// keyed topic — `void(ptr payload, ptr lo_out, ptr hi_out)` —
+    /// computing exactly the (key_lo, key_hi) pair the publish site in
+    /// `bus/dispatch.rs` computes: scalar keys through
+    /// `key_value_to_i64_pair`, String keys as (FNV hash, char*). The
+    /// runtime calls it on a deserialized inbound payload before the
+    /// keyed local dispatch, so a `where key == …` subscriber hears a
+    /// wire delivery. Registered at the main prelude (beside
+    /// `lotus_bus_load_config`).
+    pub(crate) fn synthesize_key_extractors(&mut self) -> Result<(), CodegenError> {
+        let subjects: Vec<(String, RoutingKeySubjectInfo)> = self
+            .routing_key_subjects
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        if subjects.is_empty() {
+            return Ok(());
+        }
+        let saved_block = self.builder.get_insert_block();
+        let ptr_t = self.context.ptr_type(AddressSpace::default());
+        let i64_t = self.context.i64_type();
+        let void_t = self.context.void_type();
+        for (subject, info) in subjects {
+            let Some(payload_struct_info) = self.user_types.get(&info.payload_type_name).cloned() else {
+                continue;
+            };
+            let Some((field_idx, field_ty)) = payload_struct_info.fields.get(&info.keyed_by_field).cloned() else {
+                continue;
+            };
+            let sanitized: String = subject
+                .chars()
+                .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+                .collect();
+            let fn_name = format!("__key_extract_{sanitized}");
+            let fn_ty = void_t.fn_type(&[ptr_t.into(), ptr_t.into(), ptr_t.into()], false);
+            let f = self.module.add_function(&fn_name, fn_ty, None);
+            let bb = self.context.append_basic_block(f, "entry");
+            self.builder.position_at_end(bb);
+            let payload_ptr = f.get_nth_param(0).unwrap().into_pointer_value();
+            let lo_out = f.get_nth_param(1).unwrap().into_pointer_value();
+            let hi_out = f.get_nth_param(2).unwrap().into_pointer_value();
+            let field_slot = self
+                .builder
+                .build_struct_gep(payload_struct_info.struct_ty, payload_ptr, field_idx, "keyx.field.ptr")
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let llvm_field_ty = self.llvm_basic_type(&field_ty);
+            let field_val = self
+                .builder
+                .build_load(llvm_field_ty, field_slot, "keyx.field.load")
+                .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            let (lo, hi) = if matches!(field_ty, CodegenTy::String) {
+                let field_ptr = field_val.into_pointer_value();
+                let hash_fn = self
+                    .module
+                    .get_function("lotus_route_key_hash")
+                    .expect("lotus_route_key_hash declared");
+                let hash = self
+                    .builder
+                    .build_call(hash_fn, &[field_ptr.into()], "keyx.str.hash")
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?
+                    .try_as_basic_value()
+                    .left()
+                    .expect("lotus_route_key_hash returns i64")
+                    .into_int_value();
+                let ptr_int = self
+                    .builder
+                    .build_ptr_to_int(field_ptr, i64_t, "keyx.str.ptr")
+                    .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                (hash, ptr_int)
+            } else {
+                match self.key_value_to_i64_pair(field_val, &field_ty) {
+                    Some(p) => p,
+                    None => {
+                        // not key-eligible: typecheck refuses upstream;
+                        // emit a zero pair rather than a broken module
+                        (i64_t.const_zero(), i64_t.const_zero())
+                    }
+                }
+            };
+            self.builder.build_store(lo_out, lo).map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder.build_store(hi_out, hi).map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.builder.build_return(None).map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+            self.key_extractors.insert(subject, f);
+        }
+        if let Some(bb) = saved_block {
+            self.builder.position_at_end(bb);
+        }
+        Ok(())
+    }
+
     pub(crate) fn synthesize_codec_thunks_for_main_bindings(
         &mut self,
     ) -> Result<(), CodegenError> {

--- a/crates/hale-codegen/src/shared/builtins.rs
+++ b/crates/hale-codegen/src/shared/builtins.rs
@@ -2191,6 +2191,16 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
             None,
         );
 
+        // GH #529 prep (DNA F.12): receive-side key derivation.
+        // declare void @lotus_bus_register_key_extractor(ptr subject, ptr fn)
+        let bus_register_kx_ty =
+            void_t.fn_type(&[ptr_t.into(), ptr_t.into()], false);
+        self.module.add_function(
+            "lotus_bus_register_key_extractor",
+            bus_register_kx_ty,
+            None,
+        );
+
         // F.36 Slice 3 (2026-05-28): codec-binding registration.
         // declare void @lotus_bus_register_codec(ptr subject, ptr self,
         //   ptr encode_fn, ptr decode_fn)

--- a/crates/hale-codegen/tests/binding_keyed_over_wire.rs
+++ b/crates/hale-codegen/tests/binding_keyed_over_wire.rs
@@ -1,0 +1,129 @@
+//! DNA F.12 (GH #529 prep): a keyed subscription hears a wire delivery.
+//!
+//! Remote fanout is unkeyed — the wire carries no key material — so a
+//! `subscribe T as h where key == self.k` subscription behind a listen
+//! binding received nothing: the receive side dispatched unkeyed and the
+//! keyed dispatch skips filtered subscribers by design. Codegen now
+//! synthesizes a per-keyed-topic extractor (the publish site's exact
+//! computation over the deserialized payload) and the runtime derives
+//! the key on every inbound path. Both key kinds: Int and String.
+
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+#[path = "support/transport.rs"]
+mod transport_support;
+
+fn build(name: &str, src: &str) -> std::path::PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(&format!("hale_test_keyedwire_{}", name));
+    build_executable(&program, &bin).expect("build");
+    bin
+}
+
+#[test]
+fn keyed_subscribers_receive_only_their_key_over_a_unix_binding() {
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
+    let sock = format!("{}/hale-f12-{}-{}.sock", std::env::temp_dir().display(), std::process::id(), nanos);
+    let sub_src = format!(
+        r#"
+        type Tick {{ lane: Int = 0; n: Int = 0; }}
+        type Note {{ who: String = ""; n: Int = 0; }}
+        topic Ticks {{ payload: Tick; subject: "f12.ticks"; keyed_by lane; }}
+        topic Notes {{ payload: Note; subject: "f12.notes"; keyed_by who; }}
+        locus Lane {{
+            params {{ lane: Int = 0; seen: Int = 0; }}
+            bus {{ subscribe Ticks as on_tick where key == self.lane; }}
+            fn on_tick(t: Tick) {{
+                self.seen = self.seen + 1;
+                println("lane", self.lane, " got lane=", t.lane, " n=", t.n);
+            }}
+        }}
+        locus Inbox {{
+            params {{ who: String = ""; seen: Int = 0; }}
+            bus {{ subscribe Notes as on_note where key == self.who; }}
+            fn on_note(m: Note) {{
+                self.seen = self.seen + 1;
+                println("inbox ", self.who, " got who=", m.who, " n=", m.n);
+            }}
+        }}
+        main locus App {{
+            params {{
+                a: Lane = Lane {{ lane: 1 }};
+                b: Lane = Lane {{ lane: 2 }};
+                riley: Inbox = Inbox {{ who: "riley" }};
+                sam: Inbox = Inbox {{ who: "sam" }};
+            }}
+            bindings {{
+                Ticks: unix("{sock}.ticks", role: listen);
+                Notes: unix("{sock}.notes", role: listen);
+            }}
+            run() {{
+                let mut waited = 0;
+                while self.a.seen + self.b.seen < 3 || self.riley.seen + self.sam.seen < 2 {{
+                    std::time::sleep(100ms);
+                    waited = waited + 1;
+                    if waited > 150 {{ std::process::exit(3); }}
+                }}
+                std::time::sleep(300ms);
+                println("a=", self.a.seen, " b=", self.b.seen, " riley=", self.riley.seen, " sam=", self.sam.seen);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock = sock
+    );
+    let pub_src = format!(
+        r#"
+        type Tick {{ lane: Int = 0; n: Int = 0; }}
+        type Note {{ who: String = ""; n: Int = 0; }}
+        topic Ticks {{ payload: Tick; subject: "f12.ticks"; keyed_by lane; }}
+        topic Notes {{ payload: Note; subject: "f12.notes"; keyed_by who; }}
+        main locus App {{
+            bus {{ publish Ticks; publish Notes; }}
+            bindings {{
+                Ticks: unix("{sock}.ticks", role: connect);
+                Notes: unix("{sock}.notes", role: connect);
+            }}
+            run() {{
+                Ticks <- Tick {{ lane: 1, n: 10 }};
+                Ticks <- Tick {{ lane: 2, n: 20 }};
+                Ticks <- Tick {{ lane: 1, n: 11 }};
+                Ticks <- Tick {{ lane: 9, n: 99 }};
+                Notes <- Note {{ who: "riley", n: 1 }};
+                Notes <- Note {{ who: "sam", n: 2 }};
+                Notes <- Note {{ who: "nobody", n: 3 }};
+                std::time::sleep(300ms);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock = sock
+    );
+    let sub_bin = build("sub", &sub_src);
+    let pub_bin = build("pub", &pub_src);
+    let sub = Command::new(&sub_bin).stdout(Stdio::piped()).stderr(Stdio::piped()).spawn().expect("spawn subscriber");
+    assert!(transport_support::wait_for_listener(&format!("{sock}.ticks"), std::time::Duration::from_secs(30)));
+    assert!(transport_support::wait_for_listener(&format!("{sock}.notes"), std::time::Duration::from_secs(30)));
+    let p = Command::new(&pub_bin).output().expect("run publisher");
+    assert!(p.status.success(), "publisher: {}", String::from_utf8_lossy(&p.stderr));
+    let out = sub.wait_with_output().expect("subscriber output");
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&pub_bin);
+    let _ = std::fs::remove_file(format!("{sock}.ticks"));
+    let _ = std::fs::remove_file(format!("{sock}.notes"));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "subscriber exit {:?}\nstdout: {stdout}\nstderr: {stderr}", out.status);
+    // Int keys: lane 1 hears its two, lane 2 its one, lane 9 nobody.
+    assert!(stdout.contains("a=2 b=1"), "int-keyed delivery over the wire:\n{stdout}\n{stderr}");
+    assert!(!stdout.contains("n=99"), "an unmatched key reaches no filtered subscriber:\n{stdout}");
+    assert!(stdout.contains("lane1 got lane=1 n=10") && stdout.contains("lane1 got lane=1 n=11") && stdout.contains("lane2 got lane=2 n=20"), "{stdout}");
+    // String keys: hash-gated, then compared by value on the receiver.
+    assert!(stdout.contains("riley=1 sam=1"), "string-keyed delivery over the wire:\n{stdout}\n{stderr}");
+    assert!(!stdout.contains("who=nobody"), "{stdout}");
+}

--- a/crates/hale-codegen/tests/binding_multi_peer.rs
+++ b/crates/hale-codegen/tests/binding_multi_peer.rs
@@ -1,0 +1,127 @@
+//! DNA F.13 (GH #529 prep): a listen binding serves many peers at once.
+//!
+//! The serve loop used to accept ONE peer and read it to EOF before
+//! accepting the next; a second connector sat in the backlog with its
+//! messages unread for as long as the first stayed connected. Now the
+//! listener polls every accepted peer: two publishers connected at the
+//! same time — one long-lived, one that comes and goes — both deliver,
+//! and each keeps its own framed seq space (no gaps).
+
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hale_codegen::build_executable;
+
+#[path = "support/harness.rs"]
+mod harness;
+#[path = "support/transport.rs"]
+mod transport_support;
+
+fn build(name: &str, src: &str) -> std::path::PathBuf {
+    let program = hale_syntax::parse_source(src).expect("parse");
+    let bin = harness::unique_bin(&format!("hale_test_multipeer_{}", name));
+    build_executable(&program, &bin).expect("build");
+    bin
+}
+
+#[test]
+fn two_connected_publishers_both_deliver_to_one_listener() {
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
+    let sock = format!("{}/hale-f13-{}-{}.sock", std::env::temp_dir().display(), std::process::id(), nanos);
+    let sub_src = format!(
+        r#"
+        type T {{ from: Int = 0; n: Int = 0; }}
+        topic Evt {{ payload: T; subject: "f13.evt"; }}
+        locus Sub {{
+            params {{ seen: Int = 0; a: Int = 0; b: Int = 0; }}
+            bus {{ subscribe Evt as on_evt; }}
+            fn on_evt(t: T) {{
+                self.seen = self.seen + 1;
+                if t.from == 1 {{ self.a = self.a + 1; }}
+                if t.from == 2 {{ self.b = self.b + 1; }}
+            }}
+        }}
+        main locus App {{
+            params {{ sub: Sub = Sub {{ }}; }}
+            bindings {{ Evt: unix("{sock}", role: listen); }}
+            run() {{
+                let mut waited = 0;
+                while self.sub.seen < 8 {{
+                    std::time::sleep(100ms);
+                    waited = waited + 1;
+                    if waited > 200 {{
+                        println("timeout seen=", self.sub.seen, " a=", self.sub.a, " b=", self.sub.b);
+                        std::process::exit(3);
+                    }}
+                }}
+                std::time::sleep(300ms);
+                println("seen=", self.sub.seen, " a=", self.sub.a, " b=", self.sub.b);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+        sock = sock
+    );
+    // Publisher 1 stays connected for ~3s, sending slowly; publisher 2
+    // connects while 1 is still attached, sends its four, and leaves.
+    let pub_src = |from: i32, pause: &str, count: i32| {
+        format!(
+            r#"
+        type T {{ from: Int = 0; n: Int = 0; }}
+        topic Evt {{ payload: T; subject: "f13.evt"; }}
+        main locus App {{
+            bus {{ publish Evt; }}
+            bindings {{ Evt: unix("{sock}", role: connect); }}
+            run() {{
+                let mut i = 0;
+                while i < {count} {{
+                    Evt <- T {{ from: {from}, n: i }};
+                    std::time::sleep({pause});
+                    i = i + 1;
+                }}
+                std::time::sleep(300ms);
+            }}
+        }}
+        fn main() {{ App {{ }}; }}
+    "#,
+            sock = sock,
+            from = from,
+            pause = pause,
+            count = count
+        )
+    };
+    let sub_bin = build("sub", &sub_src);
+    let slow_bin = build("slow", &pub_src(1, "600ms", 4));
+    let fast_bin = build("fast", &pub_src(2, "20ms", 4));
+    let sub = Command::new(&sub_bin)
+        .env("LOTUS_UNIX_STREAM", "1")
+        .env("LOTUS_BUS_COUNTERS_DUMP", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn subscriber");
+    assert!(transport_support::wait_for_listener(&sock, std::time::Duration::from_secs(30)));
+    let slow = Command::new(&slow_bin).env("LOTUS_UNIX_STREAM", "1").stdout(Stdio::null()).spawn().expect("slow publisher");
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    // the fast publisher connects WHILE the slow one holds a connection
+    let fast = Command::new(&fast_bin).env("LOTUS_UNIX_STREAM", "1").output().expect("fast publisher");
+    assert!(fast.status.success(), "fast publisher: {}", String::from_utf8_lossy(&fast.stderr));
+    let slow = slow.wait_with_output().expect("slow publisher");
+    assert!(slow.status.success(), "slow publisher: {}", String::from_utf8_lossy(&slow.stderr));
+    let out = sub.wait_with_output().expect("subscriber output");
+    let _ = std::fs::remove_file(&sub_bin);
+    let _ = std::fs::remove_file(&slow_bin);
+    let _ = std::fs::remove_file(&fast_bin);
+    let _ = std::fs::remove_file(&sock);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "subscriber exit {:?}\nstdout: {stdout}\nstderr: {stderr}", out.status);
+    assert!(stdout.contains("seen=8 a=4 b=4"), "both peers delivered while connected together:\n{stdout}\n{stderr}");
+    let line = stderr
+        .lines()
+        .find(|l| l.contains("[bus counters]") && l.contains("subject=f13.evt"))
+        .unwrap_or_else(|| panic!("no counters line.\nstderr: {stderr}"));
+    // The fast peer's EOF is a re-arm; the slow peer may still be
+    // connected when the listener exits (timing), so one or two.
+    assert!(line.contains("delivered=8") && line.contains("seq_gaps=0") && (line.contains("rearms=1") || line.contains("rearms=2")), "per-peer seq spaces, peer EOFs:\n{line}");
+}

--- a/crates/hale-types/src/topology_diff.rs
+++ b/crates/hale-types/src/topology_diff.rs
@@ -728,10 +728,19 @@ pub fn diff(a: &Admitted, b: &Admitted) -> Value {
     let count = |v: &Value, key: &str, val: &str| -> usize {
         v.as_array().map(|r| r.iter().filter(|x| x[key] == val).count()).unwrap_or(0)
     };
+    // `shape_hash` covers the model HALF (sorts, relations, endpoint
+    // identity); payload shapes, params and the other contract facets
+    // ride unhashed. A payload that gained a field with the hash
+    // unmoved is a contract change, not "source-only" — the blind
+    // round's frozen-schema case read as harmless under that label.
+    let contract_changed = contracts.as_array().map(|r| !r.is_empty()).unwrap_or(false)
+        || effects["classes"].as_array().map(|r| !r.is_empty()).unwrap_or(false);
     let classification = if identical {
         "identical"
     } else if shape_changed {
         "model-shape"
+    } else if contract_changed {
+        "contract"
     } else {
         "source-only"
     };
@@ -791,6 +800,7 @@ pub fn render_text(d: &Value) -> String {
         str_of(&d["b"]["shape_hash"])
     ));
     o.push_str("legend: + added  - removed  ~ renamed  > moved  * split/joined  ? ambiguous  ! changed in place\n");
+    o.push_str("classes: identical · source-only (no model or contract change) · contract (a contract or effect moved, shape_hash unmoved) · model-shape\n");
     let mut decl_lines: Vec<String> = Vec::new();
     for r in d["declarations"].as_array().map(|x| x.as_slice()).unwrap_or(&[]) {
         let kind = str_of(&r["kind"]);

--- a/crates/hale-types/src/topology_diff.rs
+++ b/crates/hale-types/src/topology_diff.rs
@@ -272,19 +272,18 @@ fn locus_facets(a: &Admitted, locus: &str, map: &RenameMap) -> BTreeMap<&'static
             .unwrap_or_default(),
     );
     let insts = c["instances"].as_array().cloned().unwrap_or_default();
+    // Ownership and placement as WHO owns / WHERE, not by instance
+    // path: the path is the owner's param name, which the owner's own
+    // params facet already reports — carrying it here made a param
+    // rename echo as two more rows (the kill-test reviewers read them
+    // as noise).
     out.insert(
         "ownership",
-        insts
-            .iter()
-            .map(|i| format!("{} owned by {}", str_of(&i["path"]), i["owner"].as_str().unwrap_or("nobody")))
-            .collect(),
+        insts.iter().map(|i| format!("owned by {}", i["owner"].as_str().unwrap_or("nobody"))).collect(),
     );
     out.insert(
         "placement",
-        insts
-            .iter()
-            .map(|i| format!("{} on {}", str_of(&i["path"]), i["domain"].as_str().unwrap_or("unplaced")))
-            .collect(),
+        insts.iter().map(|i| format!("on {}", i["domain"].as_str().unwrap_or("unplaced"))).collect(),
     );
     out
 }
@@ -544,9 +543,34 @@ fn declarations(a: &Admitted, b: &Admitted) -> (Value, BTreeMap<&'static str, Pa
     (Value::Array(rows), pairings, map)
 }
 
-fn contracts(a: &Admitted, b: &Admitted, loci: &Pairing, map: &RenameMap) -> Value {
+fn topic_row<'a>(art: &'a Admitted, name: &str) -> Option<&'a Value> {
+    art.v["topics"].as_array()?.iter().find(|t| t["name"] == name)
+}
+
+fn contracts(a: &Admitted, b: &Admitted, loci: &Pairing, topics: &Pairing, map: &RenameMap) -> Value {
     let none = RenameMap::new();
     let mut rows: Vec<Value> = Vec::new();
+    // A paired topic whose wire subject or payload shape moved is a
+    // contract change for every locus on it (the kill test's QueueStat
+    // gained a field and the view said nothing).
+    for (na, nb) in &topics.pairs {
+        let (Some(ta), Some(tb)) = (topic_row(a, na), topic_row(b, nb)) else { continue };
+        for facet in ["subject", "shape"] {
+            if ta[facet] != tb[facet] {
+                let mut row = Map::new();
+                row.insert("topic".into(), json!(nb));
+                if na != nb {
+                    row.insert("from".into(), json!(na));
+                }
+                row.insert("facet".into(), json!(facet));
+                row.insert("removed".into(), json!([str_of(&ta[facet])]));
+                row.insert("added".into(), json!([str_of(&tb[facet])]));
+                row.insert("a".into(), site_json(&decl_site(a, na)));
+                row.insert("b".into(), site_json(&decl_site(b, nb)));
+                rows.push(Value::Object(row));
+            }
+        }
+    }
     for (na, nb) in &loci.pairs {
         let fa = locus_facets(a, na, map);
         let fb = locus_facets(b, nb, &none);
@@ -642,7 +666,9 @@ fn law(a: &Admitted, b: &Admitted, claims: &Pairing, map: &RenameMap) -> Value {
             changes.insert("result".into(), json!({"a": ca["result"], "b": cb["result"]}));
         }
         if let (Some(la), Some(lb)) = (law_row(a, na), law_row(b, nb)) {
-            if la["verdict"] != lb["verdict"] {
+            // the typed verdict; only its own row when it differs from
+            // the surface result (they move together almost always)
+            if la["verdict"] != lb["verdict"] && (la["verdict"] != ca["result"] || lb["verdict"] != cb["result"]) {
                 changes.insert("verdict".into(), json!({"a": la["verdict"], "b": lb["verdict"]}));
             }
             if la["family"] != lb["family"] {
@@ -694,7 +720,7 @@ fn law(a: &Admitted, b: &Admitted, claims: &Pairing, map: &RenameMap) -> Value {
 pub fn diff(a: &Admitted, b: &Admitted) -> Value {
     let (decls, pairings, map) = declarations(a, b);
     let empty = Pairing { pairs: Vec::new() };
-    let contracts = contracts(a, b, pairings.get("locus").unwrap_or(&empty), &map);
+    let contracts = contracts(a, b, pairings.get("locus").unwrap_or(&empty), pairings.get("topic").unwrap_or(&empty), &map);
     let effects = effects(a, b, pairings.get("fn").unwrap_or(&empty));
     let law = law(a, b, pairings.get("claim").unwrap_or(&empty), &map);
     let identical = a.artifact_digest == b.artifact_digest;
@@ -744,7 +770,7 @@ pub fn diff(a: &Admitted, b: &Admitted) -> Value {
 
 fn site_text(v: &Value) -> String {
     match (v["unit"].as_str(), v["span"].as_array()) {
-        (Some(u), Some(sp)) if sp.len() == 2 => format!("  ({u}:{}..{})", sp[0], sp[1]),
+        (Some(u), Some(sp)) if sp.len() == 2 => format!("  ({u} bytes {}..{})", sp[0], sp[1]),
         _ => String::new(),
     }
 }
@@ -764,6 +790,7 @@ pub fn render_text(d: &Value) -> String {
         str_of(&d["a"]["shape_hash"]),
         str_of(&d["b"]["shape_hash"])
     ));
+    o.push_str("legend: + added  - removed  ~ renamed  > moved  * split/joined  ? ambiguous  ! changed in place\n");
     let mut decl_lines: Vec<String> = Vec::new();
     for r in d["declarations"].as_array().map(|x| x.as_slice()).unwrap_or(&[]) {
         let kind = str_of(&r["kind"]);
@@ -805,7 +832,11 @@ pub fn render_text(d: &Value) -> String {
             for x in names(&r["added"]) {
                 parts.push(format!("+{x}"));
             }
-            o.push_str(&format!("  ! locus {} {}: {}\n", str_of(&r["locus"]), str_of(&r["facet"]), parts.join("; ")));
+            if r["topic"].is_string() {
+                o.push_str(&format!("  ! topic {} {}: {}\n", str_of(&r["topic"]), str_of(&r["facet"]), parts.join("; ")));
+            } else {
+                o.push_str(&format!("  ! locus {} {}: {}\n", str_of(&r["locus"]), str_of(&r["facet"]), parts.join("; ")));
+            }
         }
     }
     let classes = d["effects"]["classes"].as_array().cloned().unwrap_or_default();

--- a/dna/FRICTION.md
+++ b/dna/FRICTION.md
@@ -395,8 +395,17 @@ and the listening side's wire dispatch skips every entry with a key
 filter, because nobody re-derives the key from the decoded payload.
 The publisher's counters say `sent=1`; the Review stays open.
 
-**Worked around:** the Review subscribes unkeyed and answers only to
-its own `review_id` in the handler. Correct (every Review is a
+**FIXED (GH #529 prep):** codegen synthesizes a per-keyed-topic
+extractor (the publish site's exact computation over the deserialized
+payload) and the runtime derives the key on every inbound path (unix
+serve loop, boot-window flush, UDP reader, adapter inbound), so
+`where key == …` means the same thing on both sides of a socket. The
+Review subscribes keyed again. Test:
+`crates/hale-codegen/tests/binding_keyed_over_wire.rs` (Int and
+String keys).
+
+**Was worked around:** the Review subscribed unkeyed and answered only
+to its own `review_id` in the handler. Correct (every Review is a
 separate locus, so a foreign verdict is a no-op), and cheap at this
 scale, but it is the pattern the keyed topic exists to make
 unnecessary, and it silently diverges from the in-process idiom: the
@@ -422,17 +431,17 @@ are held for its whole run, so a second connector (the membrane
 client) is left in the backlog and its message is never read. The
 publisher's counters say `sent=1`; the organism journals nothing.
 
-**Worked around:** `hale dna run` writes `.hale/dna/iris.port` while
-iris is attached, and `hale dna ask` / `review` publish through
-iris's `/ctl` endpoints in that case — the same declaration on the
-same socket, one hop later. Without iris the client connects
-directly.
+**FIXED (GH #529 prep):** the serve loop polls the listener beside
+every accepted peer (up to 64): connections are admitted as they
+arrive, each keeps its own framed seq space, a peer's EOF closes
+that peer only, and the exit quiesce still drains every connected
+peer to EOF. `hale dna ask` / `review` connect directly beside an
+attached iris; the `iris.port` detour is gone. Test:
+`crates/hale-codegen/tests/binding_multi_peer.rs`.
 
-**Wanted:** a listen binding that serves N peers (poll over accepted
-connections, per-connection seq space as the re-arm already keeps),
-so the fact "who is connected" is not a routing decision every
-client has to make. Until then a second connector should at least
-be refused loudly rather than queued silently.
+**Was worked around:** `hale dna run` wrote `.hale/dna/iris.port`
+while iris was attached and `ask` / `review` published through
+iris's `/ctl` endpoints.
 
 **Compiler bugs fixed in this track:** F.2 (`@unbounded` ignored by the
 hot-path lint), F.6 (release dispatch by child type alone — memory
@@ -452,10 +461,9 @@ are.
 **Recorded, by design:** F.5 (a bus reply reaches a flow child at
 drain, so the retry loop lives with whoever owns the performers).
 
-**Runtime limitations, worked around:** F.12 (keyed subscriptions
-never hear a wire delivery; the membrane Review filters by id in the
-handler), F.13 (a listen binding serves one peer at a time; `hale dna
-ask` goes through iris while iris holds the membrane).
+**Runtime limitations, FIXED:** F.12 (keyed subscriptions now hear
+wire deliveries — receive-side key derivation), F.13 (a listen
+binding serves many peers).
 
 **Things the survey said to verify, now verified:** `adopt` of a
 constitution declared in an imported seed was not needed — the app's

--- a/dna/core/review.hl
+++ b/dna/core/review.hl
@@ -45,24 +45,19 @@ locus Review {
         expose last_refusal: String;
     }
     // GH #527 B6: a verdict crossing the membrane (a human in Iris,
-    // `hale dna review`) arrives on the typed channel and goes through
-    // the same admission as a local one. Nothing about authority or
-    // the TOCTOU pin is relaxed for a remote verdict — the reviewer's
-    // claimed authority is checked here, by the owning locus, never
-    // by the transport.
-    //
-    // Unkeyed on purpose (F.12): the topic is `keyed_by review_id`,
-    // but remote fanout is unkeyed at v0.1 (spec/semantics.md) and a
-    // `where key == self.review_id` subscription never sees a wire
-    // delivery. Every Review hears every verdict and answers only to
-    // its own id — a handful of rows per candidate, never a stream.
+    // `hale dna review`) arrives on the typed channel, keyed to THIS
+    // review, and goes through the same admission as a local one.
+    // Nothing about authority or the TOCTOU pin is relaxed for a
+    // remote verdict — the reviewer's claimed authority is checked
+    // here, by the owning locus, never by the transport. (F.12, fixed:
+    // the receive side of a binding derives the key, so the keyed
+    // idiom means the same thing on both sides of a socket.)
     bus {
-        subscribe ReviewVerdict as on_verdict;
+        subscribe ReviewVerdict as on_verdict where key == self.review_id;
         publish ReviewSettled;
     }
     @unbounded
     fn on_verdict(v: Verdict) {
-        if v.review_id != self.review_id { return; }
         let admitted = self.consider(v);
         if admitted && self.settled {
             ReviewSettled <- ReviewSettlement { review_id: self.review_id, outcome: self.outcome, decided_by: self.decided_by };

--- a/dna/kill-test/WALKTHROUGH.md
+++ b/dna/kill-test/WALKTHROUGH.md
@@ -1,0 +1,75 @@
+# The kill test: is a semantic diff visibly better than a git diff for deciding?
+
+This is the falsification test Track D (GH #529) puts before its
+apply path, following brained's lesson: a one-day test that can stop
+the work, before the work. **If the answer is no, Track D is reordered
+or stopped.** The person answering should not care about Hale.
+
+## The setup
+
+`before/` and `after/` are the same small application — a support
+desk — before and after a proposed change. A candidate (an agent, a
+colleague) describes the change as:
+
+> Tickets can now arrive by email, support engineers get an SLA and can
+> reply to customers, and triage is renamed dispatch.
+
+The reviewer's job is the one Track D asks of a human: **approve,
+revise, or reject the candidate, and say why.** Nothing else.
+
+Run `dna/kill-test/run.sh`. It prints two views of the same change:
+
+- **View A** — the git diff. What every reviewer has today.
+- **View B** — the semantic diff (`hale model diff`): what changed in
+  the *model* of the program — declarations added, removed, renamed,
+  moved; each locus's contract (params, what it publishes and
+  subscribes, supervision, ownership, placement); effects gained or
+  dropped per function; laws added, removed, or whose verdict changed.
+
+`run.sh --iris` also opens the same View B as perspective [4] in
+iris, with the law view on `l`.
+
+## The protocol
+
+1. Give the reviewer View A only. Start a clock. Ask for a verdict
+   and the reasons. Note the time and the reasons verbatim.
+2. Give the reviewer View B (and iris, if they want it). Same
+   question. Note the time and the reasons.
+3. Then reveal what the change actually does to the model (below)
+   and ask which view would have let them see it.
+
+Swap the order for a second reviewer, so the views are not always
+seen second.
+
+## What the change does, which the reviewer has to catch
+
+Five things, of different kinds, chosen because a git diff shows
+each as "some lines changed" and a model diff shows each as what it
+is:
+
+| what | View B row | why it matters to a reviewer |
+|---|---|---|
+| a second publisher of `Tickets` (`EmailIntake`) | `+ locus EmailIntake`, `! claim one_intake: result holds -> violated` | the law `one_intake` is now **violated**; the candidate broke an invariant the team wrote down |
+| `Support` gains the `outbound_email` effect (through `Mailer`) | `! fn Support::on_queue gains … publish`, `+ locus Mailer`, `+ topic Outbound` | a customer-facing side effect appeared where there was none |
+| the Product → Support contract changes | `! locus Support params: +sla_hours: Int`; `QueueStat` gains a field | a parent-facing contract moved |
+| `Triage` becomes `Dispatch` | `~ locus Triage -> Dispatch (renamed; shape unchanged)` | half the git diff is this rename; it changes nothing |
+| a new law `mail_from_support_only` | `+ claim mail_from_support_only … [holds]` | the candidate added law, which needs a different reviewer than code |
+
+## Scoring
+
+Record, per reviewer and per view:
+
+- **time to verdict**;
+- **the verdict** (approve / revise / reject) and **the reasons**;
+- **coverage**: which of the five rows above the reasons mention;
+- **false confidence**: anything asserted that is wrong (e.g. "the
+  rename changes behavior", "no new side effects");
+- **what was missing**: a question the reviewer asked that neither
+  view answered.
+
+The test passes if View B is *visibly* better on coverage and false
+confidence for a reviewer who does not know Hale — not marginally,
+visibly. Time is secondary. If View B only helps someone who already
+reads Hale, or the reviewer's questions are ones neither view
+answers, write that down: it is the finding, and it reorders the
+track.

--- a/dna/kill-test/WALKTHROUGH.md
+++ b/dna/kill-test/WALKTHROUGH.md
@@ -51,7 +51,7 @@ is:
 |---|---|---|
 | a second publisher of `Tickets` (`EmailIntake`) | `+ locus EmailIntake`, `! claim one_intake: result holds -> violated` | the law `one_intake` is now **violated**; the candidate broke an invariant the team wrote down |
 | `Support` gains the `outbound_email` effect (through `Mailer`) | `! fn Support::on_queue gains … publish`, `+ locus Mailer`, `+ topic Outbound` | a customer-facing side effect appeared where there was none |
-| the Product → Support contract changes | `! locus Support params: +sla_hours: Int`; `QueueStat` gains a field | a parent-facing contract moved |
+| the Product → Support contract changes | `! locus Support params: +sla_hours: Int` · `! topic QueueStats shape: -open:i; +open:i;oldest_hours:i` | a parent-facing contract moved |
 | `Triage` becomes `Dispatch` | `~ locus Triage -> Dispatch (renamed; shape unchanged)` | half the git diff is this rename; it changes nothing |
 | a new law `mail_from_support_only` | `+ claim mail_from_support_only … [holds]` | the candidate added law, which needs a different reviewer than code |
 
@@ -66,6 +66,15 @@ Record, per reviewer and per view:
   rename changes behavior", "no new side effects");
 - **what was missing**: a question the reviewer asked that neither
   view answered.
+
+Known limits of View B going in (found by a dry run with model
+reviewers, 2026-09-09): an effect class reached through a bus edge
+(`Support` → `Outbound` → `Mailer`'s `outbound_email`) shows only as
+`gains publish` on the sender, never by the class's name; wire
+*values* (`owner: "triage"` becoming `"dispatch"`) are outside the
+model; and a field that is added but never read looks the same as
+one that is used. Whether those matter to the reviewer's decision is
+part of what the test measures.
 
 The test passes if View B is *visibly* better on coverage and false
 confidence for a reviewer who does not know Hale — not marginally,

--- a/dna/kill-test/WALKTHROUGH.md
+++ b/dna/kill-test/WALKTHROUGH.md
@@ -82,3 +82,41 @@ visibly. Time is secondary. If View B only helps someone who already
 reads Hale, or the reviewer's questions are ones neither view
 answers, write that down: it is the finding, and it reorders the
 track.
+
+## Results so far (2026-09-09)
+
+Two rounds with model reviewers, neither the outsider this test
+wants; recorded here so the human round starts from what is known.
+
+**Round 1 (this walkthrough, two fresh reviewers, opposite order).**
+Both decided from View B in an estimated 2–4 minutes (the law
+flipping to violated is one line) and wrote their revision comments
+from View A in 10–15. View B missed the payload shape change and
+never named `outbound_email`; View A caught everything but could only
+infer the law outcome. Fixed after the round: topic shape rows, no
+rename echo in ownership/placement, a legend, labeled offsets.
+
+**Round 2 (independent, stricter: six cases, two safe controls, a
+Latin square, frozen packets and ground truth, unsafe approvals /
+detections / calibrated holds / completed decisions scored
+separately).** Source and combined views tied on every measure —
+0/4 unsafe approvals, 4/4 detections, 2/2 safe approvals, 6/6
+completed decisions. View B alone: 0/4 unsafe approvals, 2/4
+detections (both law-backed), 4 calibrated holds, 2/6 completed. Its
+two blind spots were pairs whose semantic text was byte-identical:
+a rename versus the same rename plus `+1 → +100` inside a handler
+(behaviour, which a structural diff will never carry), and a frozen
+payload gaining a field versus an inert param (fixed since: the
+shape row).
+
+**What that says.** For small, fully visible changes the semantic
+diff does not beat a complete source diff at *deciding*; it decides
+faster where a law's verdict moved, it summarizes structure, and it
+is honest about what it cannot see — reviewers held rather than
+approved. It is not a standalone approval interface, and Track D's
+review (D4) should render the source diff, the semantic diff and the
+evidence table together, as the issue already says. The human round
+should test that combined view against the source diff alone, on a
+change large enough that the source is not fully readable in one
+sitting — the regime the semantic diff exists for.
+

--- a/dna/kill-test/after/main.hl
+++ b/dna/kill-test/after/main.hl
@@ -1,0 +1,105 @@
+// dna/kill-test — the application AFTER the change (GH #529, the
+// falsification test). The proposal, as a candidate would describe it:
+// "tickets can now arrive by email, support engineers get an SLA and
+// can reply to customers, and triage is renamed dispatch."
+//
+// What that does to the model, which the reviewer has to see:
+//   - EmailIntake is a NEW locus that publishes Tickets (a second
+//     publisher — one_intake's count changes);
+//   - Support GAINS the outbound_email effect through Mailer;
+//   - the Product -> Support contract changes: Support's params gain
+//     sla_hours, and QueueStats gains a field (payload shape);
+//   - Triage becomes Dispatch — same shape, only the name;
+//   - a new claim gates mail behind support_side.
+
+effect outbound_email; // a message leaves for a customer's inbox
+
+type Ticket { id: Int = 0; severity: Int = 0; body: String = ""; }
+type Assignment { ticket: Int = 0; owner: String = ""; }
+type QueueStat { open: Int = 0; oldest_hours: Int = 0; }
+type Mail { to: String = ""; body: String = ""; }
+
+topic Tickets { payload: Ticket; subject: "desk.tickets"; }
+topic Assignments { payload: Assignment; subject: "desk.assignments"; keyed_by ticket; }
+topic QueueStats { payload: QueueStat; subject: "desk.queue"; }
+topic Outbound { payload: Mail; subject: "desk.mail"; }
+
+locus Intake {
+    params { received: Int = 0; }
+    bus { subscribe Tickets as on_ticket; publish Assignments; }
+    fn on_ticket(t: Ticket) {
+        self.received = self.received + 1;
+        Assignments <- Assignment { ticket: t.id, owner: "dispatch" };
+    }
+}
+
+locus EmailIntake {
+    params { polled: Int = 0; }
+    bus { publish Tickets; }
+    fn poll() {
+        self.polled = self.polled + 1;
+        Tickets <- Ticket { id: 100 + self.polled, severity: 1, body: "from mail" };
+    }
+}
+
+locus Dispatch {
+    params { handled: Int = 0; }
+    bus { subscribe Assignments as on_assignment; publish QueueStats; }
+    fn on_assignment(a: Assignment) {
+        self.handled = self.handled + 1;
+        QueueStats <- QueueStat { open: self.handled, oldest_hours: 0 };
+    }
+}
+
+locus Mailer {
+    params { sent: Int = 0; }
+    bus { subscribe Outbound as on_mail; }
+    @effects(is: { outbound_email })
+    fn on_mail(m: Mail) { self.sent = self.sent + 1; }
+}
+
+locus Support {
+    params { engineer: String = "sam"; sla_hours: Int = 8; resolved: Int = 0; }
+    bus { subscribe QueueStats as on_queue; publish Outbound; }
+    fn on_queue(q: QueueStat) {
+        if q.open > 0 {
+            self.resolved = self.resolved + 1;
+            Outbound <- Mail { to: "customer", body: "we are on it" };
+        }
+    }
+}
+
+locus Product {
+    params { watched: Int = 0; }
+    bus { subscribe QueueStats as on_queue; }
+    fn on_queue(q: QueueStat) { self.watched = self.watched + 1; }
+}
+
+group product_side = { Product };
+group support_side = { Support, Dispatch };
+group mail = { Mailer };
+
+main locus Desk {
+    params {
+        intake: Intake = Intake { };
+        email: EmailIntake = EmailIntake { };
+        dispatch: Dispatch = Dispatch { };
+        mailer: Mailer = Mailer { };
+        support: Support = Support { };
+        product: Product = Product { };
+    }
+    bus { publish Tickets; }
+    claims {
+        product_never_emails: forbid reaches(product_side, effects(outbound_email));
+        one_intake: count publishers(topic Tickets) == 1;
+        mail_from_support_only: require publishes(some support_side, topic Outbound);
+    }
+    run() {
+        Tickets <- Ticket { id: 1, severity: 2, body: "login broken" };
+        self.email.poll();
+    }
+}
+
+fn main() {
+    Desk { };
+}

--- a/dna/kill-test/before/main.hl
+++ b/dna/kill-test/before/main.hl
@@ -1,0 +1,66 @@
+// dna/kill-test — the application BEFORE the change (GH #529, the
+// falsification test). A small support desk: tickets come in, get
+// triaged, and land with a support engineer; product engineering
+// watches the queue but never talks to customers directly.
+
+effect outbound_email; // a message leaves for a customer's inbox
+
+type Ticket { id: Int = 0; severity: Int = 0; body: String = ""; }
+type Assignment { ticket: Int = 0; owner: String = ""; }
+type QueueStat { open: Int = 0; }
+
+topic Tickets { payload: Ticket; subject: "desk.tickets"; }
+topic Assignments { payload: Assignment; subject: "desk.assignments"; keyed_by ticket; }
+topic QueueStats { payload: QueueStat; subject: "desk.queue"; }
+
+locus Intake {
+    params { received: Int = 0; }
+    bus { subscribe Tickets as on_ticket; publish Assignments; }
+    fn on_ticket(t: Ticket) {
+        self.received = self.received + 1;
+        Assignments <- Assignment { ticket: t.id, owner: "triage" };
+    }
+}
+
+locus Triage {
+    params { handled: Int = 0; }
+    bus { subscribe Assignments as on_assignment; publish QueueStats; }
+    fn on_assignment(a: Assignment) {
+        self.handled = self.handled + 1;
+        QueueStats <- QueueStat { open: self.handled };
+    }
+}
+
+locus Support {
+    params { engineer: String = "sam"; resolved: Int = 0; }
+    bus { subscribe QueueStats as on_queue; }
+    fn on_queue(q: QueueStat) { if q.open > 0 { self.resolved = self.resolved + 1; } }
+}
+
+locus Product {
+    params { watched: Int = 0; }
+    bus { subscribe QueueStats as on_queue; }
+    fn on_queue(q: QueueStat) { self.watched = self.watched + 1; }
+}
+
+group product_side = { Product };
+group support_side = { Support, Triage };
+
+main locus Desk {
+    params {
+        intake: Intake = Intake { };
+        triage: Triage = Triage { };
+        support: Support = Support { };
+        product: Product = Product { };
+    }
+    bus { publish Tickets; }
+    claims {
+        product_never_emails: forbid reaches(product_side, effects(outbound_email));
+        one_intake: count publishers(topic Tickets) == 1;
+    }
+    run() { Tickets <- Ticket { id: 1, severity: 2, body: "login broken" }; }
+}
+
+fn main() {
+    Desk { };
+}

--- a/dna/kill-test/run.sh
+++ b/dna/kill-test/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# dna/kill-test/run.sh — the falsification test for Track D (GH #529).
+#
+# Produces the two views a reviewer would decide from — the git diff
+# and the semantic diff — over the same change, and (optionally) opens
+# the review view in iris. Read WALKTHROUGH.md first.
+#
+#   dna/kill-test/run.sh            # print both views
+#   dna/kill-test/run.sh --iris     # …and open iris [4] on :8787
+set -euo pipefail
+cd "$(dirname "$0")"
+HALE=${HALE_BIN:-hale}
+out=${KT_OUT:-/tmp/hale-kill-test}
+mkdir -p "$out"
+# The candidate violates a law on purpose; a failing claim still cuts
+# the artifact (the verdict is the thing being recorded).
+"$HALE" check before --dump-topology="$out/before.topology" >/dev/null 2>&1 || true
+"$HALE" check after  --dump-topology="$out/after.topology"  >/dev/null 2>&1 || true
+test -s "$out/before.topology" && test -s "$out/after.topology"
+echo "================ VIEW A: the git diff ================"
+git --no-pager diff --no-index --stat before after || true
+git --no-pager diff --no-index before after || true
+echo
+echo "================ VIEW B: the semantic diff (hale model diff) ================"
+"$HALE" model diff "$out/before.topology" "$out/after.topology" --text
+"$HALE" model diff "$out/before.topology" "$out/after.topology" > "$out/diff.json"
+echo
+echo "artifacts: $out/before.topology $out/after.topology  diff: $out/diff.json"
+if [ "${1:-}" = "--iris" ]; then
+  echo "iris: http://127.0.0.1:${PORT:-8787}/  press 4 for the review view, l for the law"
+  exec "$HALE" iris "${PORT:-8787}" "$out/after.topology" --diff "$out/before.topology" "$out/after.topology"
+fi

--- a/docs/src/services/multi-binary.md
+++ b/docs/src/services/multi-binary.md
@@ -34,6 +34,12 @@ core::Verdict: unix("/tmp/verdicts.sock", role: listen); }` — so a
 library's own declarations are what cross the socket, not copies
 of them.
 
+A listen binding serves any number of connected publishers at once,
+and a `keyed_by` topic keeps its routing across the socket: the
+receiving side derives the key from the payload, so a
+`subscribe T as h where key == self.k` behind a binding hears
+exactly what it would hear in-process.
+
 `bindings { }` is legal only on a `main` locus. The publisher's
 `MatchReady <- info;` and the subscriber's `subscribe MatchReady
 as ...` are *unchanged* — they don't know or care that delivery

--- a/docs/src/systems/dna.md
+++ b/docs/src/systems/dna.md
@@ -171,12 +171,6 @@ your application's. Imported loci are observed under their
 author-facing names (`dna::Dna`, not a mangled symbol), so the
 tower is visible and joins with the artifact.
 
-One thing to know: a unix listen binding serves one peer at a time,
-and iris holds the membrane while it runs (F.13 in
-`dna/FRICTION.md`). `hale dna ask` and `review` notice the attached
-iris (`.hale/dna/iris.port`) and publish through it; without iris
-they connect directly.
-
 ## The membrane
 
 The organism binds two typed topics on unix sockets under

--- a/spec/model.md
+++ b/spec/model.md
@@ -540,9 +540,12 @@ The output is a versioned document (`TOPOLOGY_DIFF_SCHEMA`, now
   `family` changes; claims added and removed with their result;
   `adequacy` changes per family; the overall `verdict` when it
   moved.
-- **`classification`** — `identical` (same `artifact_digest`),
-  `source-only` (same `shape_hash`: comments, moved lines,
-  re-spelt law) or `model-shape`.
+- **`classification`** — `identical` (same `artifact_digest`);
+  `source-only` (same `shape_hash`, no contract or effect rows:
+  comments, moved lines, re-spelt law); `contract` (same
+  `shape_hash`, but a contract facet or an effect set moved — a
+  payload that gained a field, a param added — which the hash does
+  not cover); or `model-shape`.
 
 **Matching is deterministic and names what it compared.** The
 `matching` section of every document states the rules; they are:

--- a/spec/model.md
+++ b/spec/model.md
@@ -525,9 +525,13 @@ The output is a versioned document (`TOPOLOGY_DIFF_SCHEMA`, now
 - **`contracts`** — per paired locus, facet by facet, as set
   differences (`removed` / `added`): `sealed`, `params`, `methods`,
   `publishes`, `subscribes` (with the subscription's queue bound
-  and shed policy), `supervises`, `ownership` and `placement` of
-  its statically exact instances. These facets are read from the
-  artifact's `contracts` section (schema 1.18), the per-locus
+  and shed policy), `supervises`, and the `ownership` (who owns its
+  instances) and `placement` (which thread domains) — by owner and
+  domain, not by instance path, so a param rename does not echo
+  here. Plus, per paired topic, its `subject` and payload `shape`
+  when they moved: a wider payload is a contract change for every
+  locus on the topic. These facets are read from the artifact's
+  `contracts` and `topics` sections (schema 1.18+), the per-locus
   regrouping of facts the model already holds.
 - **`effects`** — per paired fn, classes `gained` / `dropped`; and
   per fn-grained certificate (`lowered` rows keyed by subject and

--- a/spec/runtime.md
+++ b/spec/runtime.md
@@ -1126,7 +1126,13 @@ control plane; the data plane stays in C:
   The transport loci are deliberately NOT pinned: a pinned locus
   runs birth on its spawned thread, which would make realization
   asynchronous; the serve thread belongs to the C data plane.
-- The serve loop (`lotus_bus_unix_serve`) accepts a peer,
+- The serve loop (`lotus_bus_unix_serve`) serves MANY peers
+  (2026-09-09, DNA F.13): it polls the listener beside every
+  accepted connection (up to 64), admits connections as they
+  arrive, keeps a framed seq space per peer, closes only the peer
+  that hangs up, and — once the listener is shut at exit — drains
+  every connected peer to EOF before leaving. Before this it
+  accepted one peer,
   dispatches its messages, and on peer EOF **re-arms** — closes
   the dead connection and loops back into `accept()` for the
   next peer (GH #233 step 2; peer EOF is not connection loss,

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -1907,9 +1907,16 @@ copy of the string (capture-by-value — see "Key stability"
 below), the publish site hashes the payload's `keyed_by` field,
 and only a hash match pays the full string compare, so a
 mismatched key still costs one i64 compare per entry. `StringView`
-and `Bytes` are not key-eligible. Remote fanout stays unkeyed at
-v0.1 for String keys just as for scalars — no key material
-crosses a process boundary.
+and `Bytes` are not key-eligible. Remote fanout is unkeyed for
+String keys just as for scalars — no key material crosses a
+process boundary. The RECEIVE side of a binding derives the key
+instead (2026-09-09, DNA F.12): codegen synthesizes one extractor
+per keyed wire subject, the publish site's exact computation over
+the deserialized payload, and every inbound path (unix serve loop,
+boot-window flush, UDP reader, adapter inbound) dispatches keyed.
+A `where key == …` subscription therefore means the same thing on
+both sides of a socket; before this it received nothing over a
+binding.
 
 **`where key == EXPR` — what EXPR can be.**
 


### PR DESCRIPTION
Follow-up to #558 (the kill test), stacked on it → #557. A dry run of the test's protocol with two model reviewers — not the outsider #529 asks for, so a dry run and a baseline, not the verdict — surfaced four things the semantic view got wrong. Fixed here before a person runs the test.

## The dry run

Two fresh reviewers, no shared context, told they do not know the language and may read only the two view files, one seeing the git diff first and one the semantic diff first. Both:

- **decided from the semantic diff** — `! claim one_intake: result holds -> violated` and `! verdict: clean -> law_failed` gave a reject in an estimated 2–4 minutes, where the git diff left the same reviewers inferring the count change with medium confidence in 10–15;
- **wrote their revision comments from the git diff** — the hard-coded recipient, the per-assignment mail loop, the dead `sla_hours`, the `"triage"` → `"dispatch"` wire value, the "some" clause named "only";
- caught the planted rename as shape-preserving in the semantic view and as mechanical in the git diff;
- named the same things they could not read in the semantic view.

Coverage of the five planted changes: the semantic view missed the `QueueStat` shape change entirely and never named `outbound_email`; the git diff caught everything but could only infer the law outcome. One false confidence from the semantic view: reading a claim's absence from `law:` as "still holds".

## Fixed

- **Topic contract rows.** A persisted topic whose payload `shape` or wire `subject` moved now has a `contracts` row (`! topic QueueStats shape: -open:i; +open:i;oldest_hours:i`). A wider payload is a contract change for every locus on the topic; the view said nothing.
- **No rename echo.** `ownership` and `placement` facets are by owner and thread domain, not by instance path — the path is the owner's param name, which the owner's params facet already reports. The two `Dispatch ownership/placement` rows the reviewers read as noise are gone.
- **A legend** for `+ - ~ > * ? !` in the text view, and source sites labeled `bytes a..b` (both reviewers took them for line numbers).
- **One line per claim change** when result and verdict move together.

## Stated, not fixed

In `WALKTHROUGH.md` as known limits going in: an effect class reached through a bus edge shows only as `gains publish` on the sender, never by the class's name (`outbound_email` never appears — that needs reachable-effect sets per locus in the artifact, not a diff change); wire values are outside the model; an added-but-unread field looks like a used one. Whether those matter to the decision is part of what the human test measures.

`model_diff`, `dna_run`, `dna_status`, `topology_graph_cli`, `iris_cli`, `docs_snippets` green; `hale fmt --check` clean. Spec: `model.md` contracts bullet. CHANGELOG.

Refs #529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
