### PR TITLE
dna: backends by role — a shell deployment gateway, GitHub as a membrane (GH #566 F4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ behavior.
 
 ## Unreleased
 
+### DNA: backends by role — a shell deployment gateway, GitHub as a membrane (GH #566 F4)
+
+- `Deployment` gains `rollback(base)`; `ShellDeployment { command, seed }` runs `<command> express <candidate> <seed>` on approval and `<command> rollback <base> <seed>` after a bad window or a rejection; the command owns expressing and judging, and its exit code is the observation (`expression.deployed`, then the usual `expression.observed`, `mutation.retained` / `mutation.rolled_back`) with no host asked. Test: `dna/tests/deployment_test.hl` (a scripted command: an approval expresses and retains with nothing asked of a host; a command that fails rolls the genome back and restores the base through the same command).
+- GitHub as a membrane: with `git config dna.github owner/repo` (and `dna.github.board` naming the logins that count as the Board), the host — and `hale dna github sync` — mirrors every pending mutation Review to a pull request (`github.pr`; the candidate pushed to `dna/<id>`, the three views as the body), reads every GitHub review back as a `review.verdict` row in the reviewer's login (once, keyed by login, commit and state), comments the settlement back (`github.commented`) and pushes the genome on approval. Via `gh`; a projection of the record, never the record. Test: `dna_github_membrane` with a fake `gh` on PATH — a pull request opened with the review's body, an APPROVED review by `octocat` becoming `approve by octocat` in the record, the comment back, origin's `main` at the candidate.
+
 ### DNA: the organization evolves (GH #566 F3)
 
 - The `organization` change class edits the organization's own seed: `Mutation.seed`, the editing position confined to it, verification of that seed with its own base artifact, the semantic diff of the organization, a Review that is the Board's. A restart request names the seed; the host answers one for `dna/org` by rebuilding and restarting the organization itself (which records `expression.restarted`), watches the window, and accounts for a crash of the new organization by resetting to the base and restarting the old one.

--- a/crates/hale-cli/src/dna.rs
+++ b/crates/hale-cli/src/dna.rs
@@ -74,6 +74,7 @@ pub fn run(args: &[String]) -> ExitCode {
         Some("board") => report(board(&args[1..])),
         Some("report") => report(file_report(&args[1..])),
         Some("pressure") => report(pressure(&args[1..])),
+        Some("github") => report(github_cmd(&args[1..])),
         Some("review") => report(review(&args[1..])),
         Some("--help") | Some("-h") | None => usage(if args.is_empty() { 2 } else { 0 }),
         Some(other) => {
@@ -100,6 +101,8 @@ fn usage(code: u8) -> ExitCode {
     eprintln!("       hale dna sync [project]      fetch, reconcile and push the record (refs/dna/*) with origin");
     eprintln!("       hale dna board [project]     the Board's queue: what needs its verdict, escalations, proposals, reports");
     eprintln!("       hale dna report [project]    file a report from the record since the last one (report.filed)");
+    eprintln!("       hale dna github sync         mirror pending Reviews to pull requests and read their reviews back as verdicts");
+    eprintln!("                                    (git config dna.github owner/repo; dna.github.board logins,…; needs `gh`)");
     eprintln!("       hale dna pressure [raise <source> <what…>]");
     eprintln!("                                    pressure raised and answered; `raise` publishes one signal on the membrane");
     eprintln!("       hale dna review              the pending Reviews");
@@ -554,6 +557,18 @@ fn run_organism(args: &[String], dev: bool) -> ExitCode {
         }
         if let Err(e) = sync_record(&root) {
             eprintln!("hale dna {verb}: sync: {e}");
+        }
+        // GH #566 F4: GitHub as a membrane — pending Reviews out as pull
+        // requests, their reviews back as verdicts, in the reviewers' names
+        if github_repo(&root).is_some() {
+            match github_sync(&root) {
+                Ok(lines) => {
+                    for l in lines {
+                        eprintln!("hale dna {verb}: github: {l}");
+                    }
+                }
+                Err(e) => eprintln!("hale dna {verb}: github: {e}"),
+            }
         }
         let n = relay_record_membrane(&root, &mut relayed);
         if n > 0 {
@@ -1215,6 +1230,122 @@ fn pressure(args: &[String]) -> Result<Vec<String>, String> {
         out.push(format!("  {:>5}  {:<20} {}  {}", r.seq, r.kind, r.entity, r.body));
     }
     Ok(out)
+}
+
+// ---------------------------------------------------------------
+// GitHub as a membrane (GH #566 F4): a mirror of the record, never the record
+// ---------------------------------------------------------------
+
+/// `git config dna.github` = `owner/repo`. Absent: no GitHub membrane.
+fn github_repo(root: &Path) -> Option<String> {
+    git(root, &["config", "dna.github"]).ok().filter(|s| !s.is_empty())
+}
+
+fn gh(root: &Path, args: &[&str]) -> Result<String, String> {
+    let out = Command::new("gh").args(args).current_dir(root).output().map_err(|e| format!("gh: {e} (is `gh` installed and logged in?)"))?;
+    if !out.status.success() {
+        return Err(format!("gh {}: {}", args.first().unwrap_or(&""), String::from_utf8_lossy(&out.stderr).trim()));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// One pass: every pending mutation Review without a pull request gets
+/// one (its candidate pushed to `dna/<id>`, the three views as the
+/// body); every open pull request's GitHub reviews become
+/// `review.verdict` rows in the reviewer's login (authority `board`
+/// when `dna.github.board` lists the login, else `reviewer`), once
+/// each; every settled Review with a pull request gets the outcome as
+/// a comment, and an approval pushes the genome so GitHub sees the
+/// merge. GitHub is a projection of the record: a review whose head
+/// moved is refused by the Review here and shows as refused there.
+fn github_sync(root: &Path) -> Result<Vec<String>, String> {
+    let repo = github_repo(root).ok_or("no `dna.github` in git config")?;
+    let board: Vec<String> = git(root, &["config", "dna.github.board"]).unwrap_or_default().split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+    let remote = record_remote(root).unwrap_or_else(|| "origin".into());
+    let branch = git(root, &["symbolic-ref", "--short", "HEAD"]).unwrap_or_else(|_| "main".into());
+    let mut out = Vec::new();
+    let st = status_projection(root)?;
+    let s = |v: &Value| v.as_str().unwrap_or("").to_string();
+    let reviews = st["reviews"].as_array().cloned().unwrap_or_default();
+    let rows = read_journal(root)?;
+    let pr_of = |id: &str| -> Option<(u64, String)> {
+        rows.iter().rev().find(|r| r.kind == "github.pr" && r.entity == id).and_then(|r| serde_json::from_str::<Value>(&r.body).ok()).map(|b| (b["number"].as_u64().unwrap_or(0), s(&b["url"])))
+    };
+    // 1. out: a pull request per pending mutation Review
+    for r in reviews.iter().filter(|r| r["state"] == "pending" && r["mutation_id"].is_string()) {
+        let id = s(&r["id"]);
+        if pr_of(&id).is_some() {
+            continue;
+        }
+        let cand = s(&r["candidate_commit"]);
+        let head = format!("dna/{id}");
+        git(root, &["push", "-q", "-f", &remote, &format!("{cand}:refs/heads/{head}")])?;
+        let body = render_review(root, r, false)?.join("
+");
+        let url = gh(root, &["pr", "create", "--repo", &repo, "--base", &branch, "--head", &head, "--title", &s(&r["question"]), "--body", &body])?;
+        let number: u64 = url.rsplit('/').next().and_then(|n| n.trim().parse().ok()).unwrap_or(0);
+        append_journal(root, "github.pr", &id, &serde_json::json!({"number": number, "url": url.trim(), "head": head, "candidate": cand}).to_string())?;
+        out.push(format!("{id}: pull request #{number} opened ({})", url.trim()));
+    }
+    // 2. in: GitHub reviews on open pull requests become verdicts, once each
+    let rows = read_journal(root)?;
+    for r in reviews.iter().filter(|r| r["state"] == "pending" && r["mutation_id"].is_string()) {
+        let id = s(&r["id"]);
+        let Some((number, _)) = pr_of(&id) else { continue };
+        let json = gh(root, &["pr", "view", &number.to_string(), "--repo", &repo, "--json", "state,headRefOid,reviews"])?;
+        let v: Value = serde_json::from_str(&json).map_err(|e| format!("gh pr view: {e}"))?;
+        for rev in v["reviews"].as_array().cloned().unwrap_or_default() {
+            let state = s(&rev["state"]);
+            let verdict = match state.as_str() {
+                "APPROVED" => "approve",
+                "CHANGES_REQUESTED" => "revise",
+                _ => continue,
+            };
+            let login = s(&rev["author"]["login"]);
+            let oid = rev["commit"]["oid"].as_str().map(|s| s.to_string()).unwrap_or_else(|| s(&v["headRefOid"]));
+            let key = format!("{login}@{oid}@{state}");
+            if rows.iter().any(|x| x.kind == "review.verdict" && x.entity == id && x.body.contains(&format!(r#""github":"{key}""#))) {
+                continue;
+            }
+            let authority = if board.iter().any(|b| b == &login) { "board" } else { "reviewer" };
+            let body = serde_json::json!({"review_id": id, "subject_digest": oid, "verdict": verdict, "reviewer": login, "authority": authority, "comment": format!("github review #{number}"), "github": key}).to_string();
+            append_journal(root, "review.verdict", &id, &body)?;
+            out.push(format!("{id}: {verdict} by {login} ({authority}) from pull request #{number}"));
+        }
+    }
+    // 3. back: settlements as comments; an approval pushes the genome
+    let rows = read_journal(root)?;
+    for r in reviews.iter().filter(|r| r["state"] == "settled" && r["mutation_id"].is_string()) {
+        let id = s(&r["id"]);
+        let Some((number, _)) = pr_of(&id) else { continue };
+        if rows.iter().any(|x| x.kind == "github.commented" && x.entity == id) {
+            continue;
+        }
+        let settled = s(&r["settled"]);
+        if settled.starts_with("approve") {
+            let _ = git(root, &["push", "-q", &remote, &format!("{branch}:{branch}")]);
+        }
+        gh(root, &["pr", "comment", &number.to_string(), "--repo", &repo, "--body", &format!("dna: review {id} settled: {settled}")])?;
+        append_journal(root, "github.commented", &id, &format!("#{number}: {settled}"))?;
+        out.push(format!("{id}: pull request #{number} told: {settled}"));
+    }
+    Ok(out)
+}
+
+fn github_cmd(args: &[String]) -> Result<Vec<String>, String> {
+    let (root, _) = project(Path::new("."))?;
+    match args.first().map(|s| s.as_str()) {
+        Some("sync") => {
+            let _ = sync_record(&root);
+            let mut out = github_sync(&root)?;
+            let _ = sync_record(&root);
+            if out.is_empty() {
+                out.push("github: nothing to mirror".into());
+            }
+            Ok(out)
+        }
+        _ => Err("usage: hale dna github sync".into()),
+    }
 }
 
 /// Re-project the Journal into `status.json` (atomically: write beside,

--- a/crates/hale-cli/tests/dna_github_membrane.rs
+++ b/crates/hale-cli/tests/dna_github_membrane.rs
@@ -1,0 +1,180 @@
+//! GH #566 F4 — GitHub as a membrane: a pending Review becomes a pull
+//! request with the three views as its body; a GitHub review becomes a
+//! `review.verdict` row in the reviewer's login with the authority the
+//! project grants that login; the settlement goes back as a comment
+//! and the genome is pushed. `gh` is a fake on PATH here: it logs what
+//! it was asked and answers from files the test writes, so the mapping
+//! runs without the network.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn git(args: &[&str], cwd: &Path) -> String {
+    let out = Command::new("git").args(["-c", "user.name=riley", "-c", "user.email=r@l"]).args(args).current_dir(cwd).output().expect("git");
+    assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn journal(app: &Path) -> Vec<(String, String, String)> {
+    let out = Command::new("git").args(["-C", &app.to_string_lossy(), "show", "refs/dna/journal:journal.jsonl"]).output().unwrap();
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .map(|v| {
+            let s = |k: &str| v[k].as_str().unwrap_or("").to_string();
+            (s("kind"), s("entity"), s("body"))
+        })
+        .collect()
+}
+
+fn wait_for(app: &Path, secs: u64, kind: &str, entity: &str) -> bool {
+    let dl = Instant::now() + Duration::from_secs(secs);
+    while Instant::now() < dl {
+        if journal(app).iter().any(|(k, e, _)| k == kind && e == entity) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(300));
+    }
+    false
+}
+
+const DRIVER: &str = r#"import "vendor/dna" as dna;
+
+fn main() {
+    let cur = std::io::fs::read_file("main.hl") or "";
+    let core = dna::Dna {
+        journal: dna::GitJournal { repo: "." },
+        gateway: dna::MutationGateway {
+            leases: dna::GitLeases { repo: "." },
+            workspaces: dna::IsolatedWorktrees { repo: ".", root: ".hale/dna/worktrees" },
+            repo: dna::LocalGit { repo: "." }
+        },
+        verification: dna::HaleVerification { receipts: dna::GitReceipts { repo: "." }, scratch: ".hale/dna/scratch", repo: ".", seed: "." },
+        editor: dna::SourceEditor {
+            name: "editor",
+            models: dna::ModelRouter {
+                quick: dna::FakeModel { name: "quick", answer: cur + "// documented for the pull request\n" },
+                deep: dna::FakeModel { name: "deep", answer: "docs_coverage +" }
+            }
+        },
+        review_policy: dna::OrgPolicy { },
+        membrane: dna::Board { who: "board" },
+        boundary: dna::AutonomyBoundary { child: "orggh", grant: dna::Grant { child: "orggh", classes: "docs refactor", max_magnitude: 4, review: "pre" } }
+    };
+    println(core.mutate("t0", "docs", "document the entrypoint in main.hl", "main.hl", 1));
+}
+"#;
+
+/// The fake `gh`: logs every invocation; `pr create` prints a URL;
+/// `pr view N` prints `<dir>/pr<N>.json`; `pr comment` logs.
+const FAKE_GH: &str = r#"#!/bin/sh
+dir="$(dirname "$0")"
+echo "$@" >> "$dir/gh.log"
+case "$1 $2" in
+  "pr create") echo "https://github.com/o/r/pull/7" ;;
+  "pr view") cat "$dir/pr$3.json" 2>/dev/null || echo '{"state":"OPEN","headRefOid":"","reviews":[]}' ;;
+  "pr comment") echo "commented" ;;
+  *) echo "fake gh: $*" >&2; exit 1 ;;
+esac
+"#;
+
+#[test]
+fn a_pending_review_becomes_a_pull_request_and_its_review_becomes_the_verdict() {
+    let d = std::env::temp_dir().join(format!("hale_dna_gh_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).unwrap();
+    // the fake gh on PATH
+    let bin = d.join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::write(bin.join("gh"), FAKE_GH).unwrap();
+    let _ = Command::new("chmod").args(["+x", &bin.join("gh").to_string_lossy()]).status();
+    let path = format!("{}:{}", bin.display(), std::env::var("PATH").unwrap_or_default());
+    let hale = |args: &[&str], cwd: &Path| -> (bool, String) {
+        let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+            .args(args)
+            .current_dir(cwd)
+            .env("PATH", &path)
+            .env("HALE_BIN", env!("CARGO_BIN_EXE_hale"))
+            .env("XDG_CACHE_HOME", std::env::temp_dir().join("hale-tests-iris-cache"))
+            .output()
+            .expect("hale");
+        (out.status.success(), format!("{}{}", String::from_utf8_lossy(&out.stdout), String::from_utf8_lossy(&out.stderr)))
+    };
+    let (ok, out) = hale(&["dna", "new", "orggh"], &d);
+    assert!(ok, "{out}");
+    let app: PathBuf = d.join("orggh");
+    let bare = d.join("origin.git");
+    git(&["init", "-q", "--bare", "-b", "main", &bare.to_string_lossy()], &d);
+    git(&["config", "user.name", "riley"], &app);
+    git(&["config", "user.email", "r@l"], &app);
+    git(&["config", "dna.github", "o/r"], &app);
+    git(&["config", "dna.github.board", "octocat,riley"], &app);
+    git(&["add", "-A"], &app);
+    git(&["commit", "-q", "-m", "the app"], &app);
+    git(&["remote", "add", "origin", &bare.to_string_lossy()], &app);
+    git(&["push", "-q", "origin", "main", "refs/dna/*:refs/dna/*"], &app);
+    let base = git(&["rev-parse", "HEAD"], &app);
+    // one Mutation up to its Review, offline
+    std::fs::create_dir_all(app.join("mutate")).unwrap();
+    std::fs::write(app.join("mutate/main.hl"), DRIVER).unwrap();
+    let (ok, out) = hale(&["run", "mutate"], &app);
+    assert!(ok && out.contains("m1: review"), "driver:\n{out}");
+    let cand = journal(&app).iter().find(|(k, e, _)| k == "mutation.candidate" && e == "m1").map(|r| r.2.clone()).expect("candidate");
+
+    // the host mirrors it out, and reads GitHub's review back in
+    let mut host = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(["dna", "run", ".", "--no-iris"])
+        .current_dir(&app)
+        .env("PATH", &path)
+        .env("XDG_CACHE_HOME", std::env::temp_dir().join("hale-tests-iris-cache"))
+        .env("HALE_BIN", env!("CARGO_BIN_EXE_hale"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("hale dna run");
+    let stop = |host: &mut std::process::Child| {
+        let _ = host.kill();
+        let _ = host.wait();
+        for f in ["org.pid", "app.pid"] {
+            if let Ok(pid) = std::fs::read_to_string(app.join(".hale/dna").join(f)) {
+                let _ = Command::new("kill").args(["-9", pid.trim()]).status();
+            }
+        }
+    };
+    let opened = wait_for(&app, 90, "github.pr", "m1");
+    if !opened {
+        stop(&mut host);
+        panic!("no pull request was opened for m1:\n{}", std::fs::read_to_string(bin.join("gh.log")).unwrap_or_default());
+    }
+    // octocat approves on GitHub, at the candidate's head
+    std::fs::write(
+        bin.join("pr7.json"),
+        format!(r#"{{"state":"OPEN","headRefOid":"{cand}","reviews":[{{"author":{{"login":"octocat"}},"state":"APPROVED","commit":{{"oid":"{cand}"}}}}]}}"#),
+    )
+    .unwrap();
+    let settled = wait_for(&app, 90, "review.settled", "m1");
+    let told = wait_for(&app, 60, "github.commented", "m1");
+    std::thread::sleep(Duration::from_secs(1));
+    let rows = journal(&app);
+    let log = std::fs::read_to_string(bin.join("gh.log")).unwrap_or_default();
+    let origin_main = git(&["rev-parse", "main"], &bare);
+    stop(&mut host);
+    let dump: Vec<String> = rows.iter().map(|(k, e, b)| format!("{k} {e} {}", b.chars().take(90).collect::<String>())).collect();
+    let dump = dump.join("\n");
+    assert!(log.contains("pr create --repo o/r --base main --head dna/m1 --title"), "the pull request was opened:\n{log}");
+    assert!(log.contains("source diff (git") && log.contains("evidence ("), "the body is the review's three views:\n{log}");
+    let pr = rows.iter().find(|(k, e, _)| k == "github.pr" && e == "m1").unwrap();
+    assert!(pr.2.contains("\"number\":7") && pr.2.contains("dna/m1"), "{}", pr.2);
+    assert_eq!(git(&["rev-parse", "refs/heads/dna/m1"], &bare), cand, "the candidate is on origin as dna/m1");
+    assert!(settled, "the GitHub review became the verdict and settled:\n{dump}");
+    let verdict = rows.iter().find(|(k, e, _)| k == "review.verdict" && e == "m1").expect("a verdict row");
+    assert!(verdict.2.contains("\"reviewer\":\"octocat\"") && verdict.2.contains("\"authority\":\"board\"") && verdict.2.contains(&format!("\"github\":\"octocat@{cand}@APPROVED\"")), "{}", verdict.2);
+    assert!(rows.iter().any(|(k, e, b)| k == "review.settled" && e == "m1" && b == "approve by octocat"), "{dump}");
+    assert!(rows.iter().filter(|(k, e, _)| k == "review.verdict" && e == "m1").count() == 1, "the same GitHub review is not read twice:\n{dump}");
+    assert!(told && log.contains("pr comment 7 --repo o/r --body dna: review m1 settled: approve by octocat"), "the settlement went back:\n{log}");
+    assert_eq!(origin_main, cand, "an approval pushed the genome, so GitHub sees the merge");
+    assert_ne!(origin_main, base);
+    let _ = std::fs::remove_dir_all(&d);
+}

--- a/crates/hale-cli/tests/dna_native_suite.rs
+++ b/crates/hale-cli/tests/dna_native_suite.rs
@@ -75,6 +75,7 @@ fn dna_fixture_set_is_complete() {
         vec![
             "apply_test.hl",
             "assembly_test.hl",
+            "deployment_test.hl",
             "editing_test.hl",
             "extensions_test.hl",
             "fanout_join_test.hl",

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -2,6 +2,7 @@ crates/hale-cli/tests/check_arg_parsing.rs#0 f428caff9d863411
 crates/hale-cli/tests/debug_info.rs#0 a8a553c534907f76
 crates/hale-cli/tests/dispatch_plan_cli.rs#0 e9ff5fe335d31b65
 crates/hale-cli/tests/dna_apply.rs#0 f2c1228edb650960
+crates/hale-cli/tests/dna_github_membrane.rs#0 f2c1228edb650960
 crates/hale-cli/tests/dna_review.rs#0 f2c1228edb650960
 crates/hale-cli/tests/doc.rs#0 a9238ad19f21c0ec
 crates/hale-cli/tests/effects_manifest.rs#0 0a8481ef56eab005

--- a/dna/core/assembly.hl
+++ b/dna/core/assembly.hl
@@ -101,9 +101,47 @@ locus PostReviewRefactors {
 // ---- deployment gateway (an EFFECT, behind an attributed gate) -----
 
 interface Deployment {
-    fn apply(candidate_digest: String) -> Bool;
+    fn apply(candidate_digest: String) -> Bool; // express the candidate; true when it is up and judged healthy
+    fn rollback(base: String) -> Bool; // express the base again after a bad window or a rejection
     fn kind() -> String;
     fn applied() -> Int;
+}
+
+// A deployment gateway that shells out (GH #566 F4): the command owns
+// expressing and judging. `<command> express <candidate> <seed>` must
+// return 0 once the candidate is up and healthy (it owns the window);
+// `<command> rollback <base> <seed>` restores the base. Everything it
+// does is outside this process — a pipeline, an orchestrator, ssh —
+// and its exit code is the fact the record keeps.
+locus ShellDeployment {
+    params {
+        command: String = "";
+        seed: String = ".";
+        applied_n: Int = 0;
+        rolled_back: Int = 0;
+        last_code: Int = 0;
+        last_output: String = "";
+    }
+    @effects(is: { genome_apply })
+    fn apply(candidate_digest: String) -> Bool {
+        let r = run_tool(self.command + "\nexpress\n" + candidate_digest + "\n" + self.seed);
+        self.last_code = r.code;
+        self.last_output = trim_nl(r.stdout + r.stderr);
+        if r.code != 0 { return false; }
+        self.applied_n = self.applied_n + 1;
+        return true;
+    }
+    @effects(is: { genome_apply })
+    fn rollback(base: String) -> Bool {
+        let r = run_tool(self.command + "\nrollback\n" + base + "\n" + self.seed);
+        self.last_code = r.code;
+        self.last_output = trim_nl(r.stdout + r.stderr);
+        if r.code != 0 { return false; }
+        self.rolled_back = self.rolled_back + 1;
+        return true;
+    }
+    fn kind() -> String { return "shell"; }
+    fn applied() -> Int { return self.applied_n; }
 }
 
 // A deployment that DOES apply (simulated): the one method carries
@@ -112,6 +150,7 @@ locus LocalApplyDeployment {
     params { applied_n: Int = 0; last: String = ""; }
     @effects(is: { genome_apply })
     fn apply(candidate_digest: String) -> Bool { self.applied_n = self.applied_n + 1; self.last = candidate_digest; return true; }
+    fn rollback(base: String) -> Bool { self.last = base; return true; }
     fn kind() -> String { return "local-apply"; }
     fn applied() -> Int { return self.applied_n; }
 }
@@ -120,6 +159,7 @@ locus LocalApplyDeployment {
 locus NoDeployment {
     params { refused: Int = 0; }
     fn apply(candidate_digest: String) -> Bool { self.refused = self.refused + 1; return false; }
+    fn rollback(base: String) -> Bool { return false; }
     fn kind() -> String { return "none"; }
     fn applied() -> Int { return 0; }
 }
@@ -330,6 +370,15 @@ locus Dna {
         let req = self.request_of(mutation_id);
         let fitness = std::json::find_string_field(req, "fitness_signals");
         let seed = std::json::find_string_field(req, "seed");
+        // GH #566 F4: a deployment gateway expresses the candidate itself
+        // and owns the window; its exit is the observation. Without one,
+        // the host is asked to rebuild and restart.
+        if self.deployment.kind() != "none" {
+            let up = self.deployment.apply(candidate);
+            let d = self.journal.append(self.journal.revision(), "expression.deployed", mutation_id, (if up { "expressed " } else { "failed " }) + candidate + " via " + self.deployment.kind());
+            self.on_observed(Observation { mutation_id: mutation_id, outcome: if up { "healthy" } else { "build_failed" }, model_hash: candidate, detail: "deployment " + self.deployment.kind() });
+            return "applied";
+        }
         let x = self.journal.append(self.journal.revision(), "expression.restart_requested", mutation_id, "apply " + candidate + " seed " + seed + " fitness " + fitness);
         self.membrane.notify("restart", mutation_id + " applied as " + candidate + "; rebuild and restart requested");
         return "applied";
@@ -346,6 +395,12 @@ locus Dna {
         if !r.ok {
             let y = self.journal.append(self.journal.revision(), "mutation.failed", mutation_id, "rollback: " + r.refused);
             self.membrane.notify("mutation", mutation_id + " rollback failed: " + r.refused);
+            return;
+        }
+        if self.deployment.kind() != "none" {
+            let back = self.deployment.rollback(base);
+            let d = self.journal.append(self.journal.revision(), "expression.deployed", mutation_id, (if back { "restored " } else { "failed to restore " }) + base + " via " + self.deployment.kind() + " after " + why);
+            self.membrane.notify("restart", mutation_id + " rolled back to " + base + " after " + why + (if back { "" } else { " — the deployment did not restore it" }));
             return;
         }
         self.restarts_requested = self.restarts_requested + 1;

--- a/dna/tests/deployment_test.hl
+++ b/dna/tests/deployment_test.hl
@@ -1,0 +1,107 @@
+// dna/tests/deployment_test.hl — GH #566 F4: the deployment role,
+// filled by a shell gateway.
+//
+// The command owns expressing and judging: `express <candidate>
+// <seed>` returning 0 means the candidate is up and healthy, so the
+// assembly records the deployment and retains the Mutation with no
+// host in the loop; a command that fails means the candidate never
+// expressed, so the genome is rolled back and the base restored
+// through the same command. Everything the command did is outside
+// this process; its exit codes are the facts the record keeps.
+
+import "../core" as dna;
+
+fn toolchain() -> String {
+    if std::env::var_exists("HALE_BIN") { return std::env::var("HALE_BIN"); }
+    return "hale";
+}
+
+fn sh(argv: String) -> dna::RunResult { return dna::run_tool(argv); }
+
+const BASE: String = "type Ping { n: Int = 0; }\ntopic Pings { payload: Ping; subject: \"t.pings\"; }\nlocus A { params { seen: Int = 0; } bus { subscribe Pings as on_ping; } fn on_ping(p: Ping) { self.seen = self.seen + 1; } }\nmain locus App { params { a: A = A { }; } bus { publish Pings; } run() { Pings <- Ping { n: 1 }; } }\nfn main() { App { }; }\n";
+const DOCUMENTED: String = "// A counts pings.\ntype Ping { n: Int = 0; }\ntopic Pings { payload: Ping; subject: \"t.pings\"; }\nlocus A { params { seen: Int = 0; } bus { subscribe Pings as on_ping; } fn on_ping(p: Ping) { self.seen = self.seen + 1; } }\nmain locus App { params { a: A = A { }; } bus { publish Pings; } run() { Pings <- Ping { n: 1 }; } }\nfn main() { App { }; }\n";
+
+main locus App {
+    params {
+        repo: String = "";
+        dna: dna::Dna = dna::Dna { };
+    }
+    bus { publish dna::ReviewVerdict; }
+    @unbounded
+    fn last(kind: String, entity: String) -> String {
+        let mut out = "";
+        let mut i = 0;
+        while i < self.dna.journal.revision() {
+            let e = self.dna.journal.read(i);
+            if e.kind == kind && e.entity == entity { out = e.body; }
+            i = i + 1;
+        }
+        return out;
+    }
+    fn head() -> String { return dna::trim_nl(sh("git\n-C\n" + self.repo + "\nrev-parse\nHEAD").stdout); }
+    fn approve(id: String, digest: String) {
+        dna::ReviewVerdict <- dna::Verdict { review_id: id, subject_digest: digest, verdict: "approve", reviewer: "riley", authority: "board" };
+        std::time::sleep(150ms);
+    }
+    run() {
+        let repo = "/tmp/dna-deploy-" + to_string(std::process::pid());
+        self.repo = repo;
+        std::io::fs::mkdir(repo) or discard;
+        std::io::fs::write_file(repo + "/main.hl", BASE) or discard;
+        std::io::fs::write_file(repo + "/.gitignore", "/.hale/\n") or discard;
+        // the gateway: a script that logs what it was asked and answers as told
+        let script = repo + "/deploy.sh";
+        std::io::fs::write_file(script, "#!/bin/sh\necho \"$1 $2 $3\" >> " + repo + "/deploy.log\nif [ -f " + repo + "/deploy.fail ] && [ \"$1\" = express ]; then echo unhealthy; exit 3; fi\nexit 0\n") or discard;
+        let chmod = sh("chmod\n+x\n" + script);
+        let init = sh("git\n-C\n" + repo + "\ninit\n-q\n-b\nmain");
+        let add = sh("git\n-C\n" + repo + "\nadd\n-A");
+        let c0 = sh("git\n-C\n" + repo + "\n-c\nuser.name=t\n-c\nuser.email=t@local\ncommit\n-q\n-m\nbase");
+        std::test::assert_eq_int(c0.code, 0, "base commit: " + c0.stderr);
+        let base = self.head();
+        self.dna = dna::Dna {
+            journal: dna::GitJournal { repo: repo },
+            gateway: dna::MutationGateway {
+                leases: dna::GitLeases { repo: repo },
+                workspaces: dna::IsolatedWorktrees { repo: repo, root: repo + "/.hale/dna/worktrees" },
+                repo: dna::LocalGit { repo: repo }
+            },
+            verification: dna::HaleVerification { hale_bin: toolchain(), receipts: dna::GitReceipts { repo: repo }, scratch: repo + "/.hale/dna/scratch", repo: repo },
+            editor: dna::SourceEditor {
+                models: dna::ModelRouter { quick: dna::FakeModel { name: "quick", answer: DOCUMENTED, answer_role: "edit" }, deep: dna::FakeModel { name: "deep", answer: "readability +" } },
+                tools: dna::WorktreeTools { hale_bin: toolchain() }
+            },
+            deployment: dna::ShellDeployment { command: script, seed: "." },
+            review_policy: dna::OrgPolicy { },
+            membrane: dna::Board { },
+            boundary: dna::AutonomyBoundary { child: "app", grant: dna::Grant { child: "app", classes: "application", max_magnitude: 40, review: "pre" } }
+        };
+        std::test::assert(std::str::contains(self.dna.status(), "\"deployment\": \"shell\""), self.dna.status());
+
+        // ---- 1. approval expresses through the gateway; its exit is the observation
+        let m1 = self.dna.mutate("t1", "application", "document A in main.hl", "main.hl", 100);
+        std::test::assert_eq_str(m1, "m1: review", m1);
+        let cand1 = self.last("mutation.candidate", "m1");
+        self.approve("m1", cand1);
+        std::test::assert_eq_str(self.head(), cand1, "applied to the genome");
+        std::test::assert(std::str::contains(self.last("expression.deployed", "m1"), "expressed " + cand1 + " via shell"), self.last("expression.deployed", "m1"));
+        std::test::assert(std::str::contains(self.last("expression.observed", "m1"), "healthy"), "the command's exit is the observation: " + self.last("expression.observed", "m1"));
+        std::test::assert(std::str::contains(self.last("mutation.retained", "m1"), cand1), "retained with no host");
+        std::test::assert_eq_str(self.last("expression.restart_requested", "m1"), "", "nothing asked of a host");
+        let log = std::io::fs::read_file(repo + "/deploy.log") or "";
+        std::test::assert(std::str::contains(log, "express " + cand1 + " ."), "the gateway was asked to express the candidate: " + log);
+        std::test::assert_eq_int(self.dna.deployment.applied(), 1, "one expression");
+
+        // ---- 2. a candidate the gateway cannot express is rolled back through it
+        std::io::fs::write_file(repo + "/deploy.fail", "1") or discard;
+        let m2 = self.dna.mutate("t2", "application", "document A in main.hl once more", "main.hl", 200);
+        let cand2 = self.last("mutation.candidate", "m2");
+        self.approve("m2", cand2);
+        std::test::assert(std::str::contains(self.last("expression.deployed", "m2"), "restored " + cand1 + " via shell"), "the base restored through the gateway: " + self.last("expression.deployed", "m2"));
+        std::test::assert_eq_str(self.last("mutation.rolled_back", "m2"), cand1, "rolled back to m2's base");
+        std::test::assert_eq_str(self.head(), cand1, "HEAD is the base again");
+        let log2 = std::io::fs::read_file(repo + "/deploy.log") or "";
+        std::test::assert(std::str::contains(log2, "rollback " + cand1 + " ."), "the gateway restored the base: " + log2);
+        std::test::assert(self.dna.journal.verify_chain(), "chain intact");
+    }
+}
+fn main() { App { }; }

--- a/spec/dna.md
+++ b/spec/dna.md
@@ -67,9 +67,9 @@ Deleting it loses nothing the record holds.
 `mutation.failed`, `effect.requested`, `effect.result`,
 `evidence.<step>`, `evidence.magnitude`, `review.requested`,
 `review.settled`, `review.refused`, `expression.restart_requested`,
-`expression.restarted`, `expression.observed`, `expression.crashed`,
-`pressure.raised`, `pressure.remeasured`, `appendage.proposed`,
-`model.called`. Their bodies are documented in the guide's reference
+`expression.deployed`, `expression.restarted`, `expression.observed`,
+`expression.crashed`, `pressure.raised`, `pressure.remeasured`,
+`appendage.proposed`, `model.called`, `github.pr`, `github.commented`. Their bodies are documented in the guide's reference
 chapter; the set grows by ordinary change, and a reader that meets an
 unknown kind must keep walking.
 
@@ -168,4 +168,33 @@ in all (default 3). Each try is an attempt id (`<work>/a<n>`), so
 every try's model calls are evidence in the record. The result names
 the files changed and the tries taken; a proposal that does not check
 within the bound is a failed Attempt with the last diagnostics.
+
+## Backends by role
+
+The assembly names what fills each role; `hale check` sees the wiring.
+
+- **Record** — `Journal`: `GitJournal` (the branch), `MemJournal` (tests).
+- **Membrane** — where humans see and decide: `Board` /
+  `LocalHumanMembrane` over the unix sockets on one machine; the record
+  itself across clones (`intent.requested`, `review.verdict` rows,
+  relayed by the host); GitHub, mirrored by the host when `git config
+  dna.github` names `owner/repo`: every pending mutation Review becomes
+  a pull request (`github.pr`; the candidate pushed to `dna/<id>`, the
+  three views as the body), every GitHub review on it becomes a
+  `review.verdict` row in the reviewer's login (authority `board` when
+  `dna.github.board` lists the login, else `reviewer`; each review
+  once, keyed by login, commit and state), every settlement goes back
+  as a comment (`github.commented`) and an approval pushes the genome.
+  GitHub is a projection of the record and the record wins: a review
+  whose head moved is refused here and shows as refused there.
+- **Deployment** — `Deployment`: `NoDeployment` (a host expresses:
+  `hale dna dev`), `ShellDeployment { command, seed }` (the command
+  owns expressing and judging: `express <candidate> <seed>` returning 0
+  means up and healthy, `rollback <base> <seed>` restores; the exit
+  code is the observation, `expression.deployed` records it), and
+  `LocalApplyDeployment` (tests). With a gateway wired, an approval
+  expresses and judges in the organization's own handler and no host
+  is asked; without one, `expression.restart_requested` asks the host.
+- **Observation** — for a shell gateway, the command's exit; for a
+  host, the window it watches; for a fleet, F5.
 


### PR DESCRIPTION
Part of #566 (Phase 3, F4). Stacked on #570.

The assembly names what fills each role; `hale check` sees the wiring. This PR fills two roles that Track D left to the host.

**Deployment gateway.** `Deployment` gains `rollback(base)`. `ShellDeployment { command, seed }` runs `<command> express <candidate> <seed>` on an approval and `<command> rollback <base> <seed>` after a bad window or a rejection. The command owns expressing and judging; its exit code is the observation. With a gateway wired, an approval expresses and judges inside the organization's own handler (`expression.deployed`, then the usual `expression.observed` and `mutation.retained` / `mutation.rolled_back`) and no host is asked. Without one, `expression.restart_requested` asks the host as before, which is what `hale dna dev` still does.

**GitHub as a membrane.** With `git config dna.github owner/repo` (and `dna.github.board` naming the logins that count as the Board), the host tick and `hale dna github sync` mirror every pending mutation Review to a pull request (`github.pr`; the candidate pushed to `dna/<id>`, the three views as the body), read every GitHub review back as a `review.verdict` row in the reviewer's login (once, keyed by login, commit and state; authority `board` or `reviewer`), comment the settlement back (`github.commented`) and push the genome on approval. Via `gh`. GitHub is a projection of the record, never the record: a review whose head moved is refused here and shows as refused there.

**Tests.** `dna/tests/deployment_test.hl`: a scripted command; an approval expresses and retains with nothing asked of a host; a failing command rolls the genome back and restores the base through the same command. `dna_github_membrane`: a fake `gh` on PATH logs what it is asked and answers from files the test writes; a pull request is opened with the review's body, an APPROVED review by `octocat` becomes `approve by octocat` in the record, the comment goes back, origin's `main` ends at the candidate.

**Spec.** `spec/dna.md` gains "Backends by role" (record, membrane, deployment, observation) and the new event kinds. CHANGELOG under Unreleased. Corpus baseline regenerated for the harvested driver program.

Suites: `hale test dna` 17 passed; the DNA CLI suites 22 passed; the five harvest binaries and `hale fmt --check .` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
