### PR TITLE
dna: the fleet is the expression — plan seeds and nodes, hale node, deploy rows, the window over every touched instance (GH #566 F5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ behavior.
 
 ## Unreleased
 
+### DNA: the fleet is the expression (GH #566 F5)
+
+- Fleet plan schema 1.2: an instance may name a `seed` (relative to the plan) instead of an `artifact` — composition cuts the artifact from the seed first — and the `node` that expresses it. `hale fleet check --in <dir>` checks another workspace's declared fleets; `--if-declared` makes a workspace with none a success that says so. `[dna] fleet = "<name>"` in `hale.toml` names the fleet the DNA expresses.
+- Verification runs the fleet on every candidate (`evidence.fleet`, `fleet_clean`): a change that breaks a fleet claim is `mutation.deny` with the witness in the receipt; a candidate whose diff names a plan or the manifest is re-classed `topology` (`mutation.topology`) and goes to the Board. The steps string gains `fleet=<code>`.
+- `hale node <name> [--repo <clone>] [--fleet <name>] [--tick <ms>]`: the agent that expresses a plan's instances on one machine from the record — reads the latest `fleet.deploy`, fetches the revision (`refs/dna/revisions/<rev>`), builds and restarts the instances it touches, and reports `instance.up` (node, instance, revision, model hash, build, pid) and `instance.exited` (code) in the node's name. It decides nothing.
+- Under `hale dna run` with `[dna] fleet` set, the host answers an application's restart request with a `fleet.deploy` row (revision, seed, the instances touched, reason) and watches the window over every touched instance: all up at the revision and none exited is `healthy`; one exited is `expression.crashed` naming the instance and its node, and the organization's rollback is another deploy row every node answers. `hale dna deploy <revision>`, `hale dna rollback <mutation>` write the same rows by hand; `hale dna fleet` renders what the fleet expresses.
+- Tests: `dna_fleet` (two node clones, an API with two instances; an approval redeploys both, both report one model hash, retained; killing one inside the window rolls both back to the base with `instance api-1 on edge-2 exited` in the record), `fleet_seed_instances` (schema 1.2 composition, `--in`/`--if-declared`, the refusals). Spec: `spec/dna.md` "The fleet", `spec/verification.md` schema 1.2; Book: multi-binary chapter.
+
 ### DNA: backends by role — a shell deployment gateway, GitHub as a membrane (GH #566 F4)
 
 - `Deployment` gains `rollback(base)`; `ShellDeployment { command, seed }` runs `<command> express <candidate> <seed>` on approval and `<command> rollback <base> <seed>` after a bad window or a rejection; the command owns expressing and judging, and its exit code is the observation (`expression.deployed`, then the usual `expression.observed`, `mutation.retained` / `mutation.rolled_back`) with no host asked. Test: `dna/tests/deployment_test.hl` (a scripted command: an approval expresses and retains with nothing asked of a host; a command that fails rolls the genome back and restores the base through the same command).

--- a/crates/hale-cli/src/dna.rs
+++ b/crates/hale-cli/src/dna.rs
@@ -75,6 +75,9 @@ pub fn run(args: &[String]) -> ExitCode {
         Some("report") => report(file_report(&args[1..])),
         Some("pressure") => report(pressure(&args[1..])),
         Some("github") => report(github_cmd(&args[1..])),
+        Some("fleet") => report(fleet_cmd(&args[1..])),
+        Some("deploy") => report(deploy_cmd(&args[1..], false)),
+        Some("rollback") => report(deploy_cmd(&args[1..], true)),
         Some("review") => report(review(&args[1..])),
         Some("--help") | Some("-h") | None => usage(if args.is_empty() { 2 } else { 0 }),
         Some(other) => {
@@ -103,6 +106,10 @@ fn usage(code: u8) -> ExitCode {
     eprintln!("       hale dna report [project]    file a report from the record since the last one (report.filed)");
     eprintln!("       hale dna github sync         mirror pending Reviews to pull requests and read their reviews back as verdicts");
     eprintln!("                                    (git config dna.github owner/repo; dna.github.board logins,…; needs `gh`)");
+    eprintln!("       hale dna fleet [project]     what the fleet expresses: every instance, its node, revision, model hash, state");
+    eprintln!("       hale dna deploy <revision>   express a genome revision through the fleet's nodes (fleet.deploy)");
+    eprintln!("       hale dna rollback <mutation> express the base a Mutation was applied on, again");
+    eprintln!("                                    (`[dna] fleet = \"<name>\"` in hale.toml names the plan; `hale node <name>` runs a node)");
     eprintln!("       hale dna pressure [raise <source> <what…>]");
     eprintln!("                                    pressure raised and answered; `raise` publishes one signal on the membrane");
     eprintln!("       hale dna review              the pending Reviews");
@@ -541,6 +548,19 @@ fn run_organism(args: &[String], dev: bool) -> ExitCode {
     let mut handled: BTreeSet<u64> = BTreeSet::new();
     let mut relayed: BTreeSet<u64> = BTreeSet::new();
     let mut app_gone_reported = false;
+    // GH #566 F5: under `run`, the fleet `[dna] fleet` names is the
+    // expression — this host deploys through the record and watches the
+    // window over every instance the change touches
+    let fleet = match crate::pkg::read_dna_fleet(&root.join("hale.toml")) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("hale dna {verb}: {e}");
+            None
+        }
+    };
+    if let Some((name, plan)) = &fleet {
+        eprintln!("hale dna {verb}: the fleet `{name}` ({}) is the expression; `hale node <name>` runs its nodes", plan.display());
+    }
     let code = loop {
         match org.try_wait() {
             Ok(Some(st)) => break st.code().unwrap_or(1),
@@ -581,7 +601,51 @@ fn run_organism(args: &[String], dev: bool) -> ExitCode {
             let rollback = body.starts_with("rollback ");
             let seed_named = body.split(" seed ").nth(1).and_then(|r| r.split(' ').next()).unwrap_or("").to_string();
             if !dev && seed_named != ORG_SEED {
-                eprintln!("hale dna run: {id} requests a restart ({body}); no expression is under this host — `hale dna dev`, or a deployment gateway, expresses it");
+                let Some((fname, plan)) = &fleet else {
+                    eprintln!("hale dna run: {id} requests a restart ({body}); no expression is under this host — `hale dna dev`, a fleet (`[dna] fleet`), or a deployment gateway expresses it");
+                    continue;
+                };
+                let rollback = body.starts_with("rollback ");
+                let rev = body.split(' ').nth(1).unwrap_or("").to_string();
+                eprintln!("hale dna run: {id} requests a restart ({body}); deploying to the fleet `{fname}`");
+                let deployed = fleet_deploy(&root, fname, plan, &rev, &seed_named, &id, if rollback { "rollback" } else { "apply" });
+                let (deploy_seq, touched) = match deployed {
+                    Ok(x) => x,
+                    Err(e) => {
+                        eprintln!("hale dna run: {id}: the fleet does not deploy: {e}");
+                        if !rollback {
+                            let body = serde_json::json!({"mutation_id": id, "outcome": "build_failed", "model_hash": "", "detail": format!("fleet: {e}")}).to_string();
+                            let _ = publish_on_membrane(&root, "observed", &body);
+                        }
+                        continue;
+                    }
+                };
+                eprintln!("hale dna run: {id}: fleet.deploy {} {} touching {}", if rollback { "rollback to" } else { "apply" }, short(&rev), touched.join(" "));
+                if rollback {
+                    continue;
+                }
+                // the window over every touched instance: each comes up at
+                // the revision, then none exits for the window
+                let outcome = fleet_window(&root, &rev, &touched, deploy_seq, 180, observe_secs, &status_path);
+                let body = match outcome {
+                    FleetOutcome::Healthy(shape) => {
+                        eprintln!("hale dna run: {id}: {} instance(s) observed healthy for {observe_secs}s as {shape}", touched.len());
+                        serde_json::json!({"mutation_id": id, "outcome": "healthy", "model_hash": shape, "detail": format!("{} instance(s) up for {observe_secs}s", touched.len())}).to_string()
+                    }
+                    FleetOutcome::Crashed { instance, node, code, shape } => {
+                        eprintln!("hale dna run: {id}: instance {instance} on {node} exited ({code}) inside the observation window");
+                        let _ = append_journal(&root, "expression.crashed", &id, &format!("instance {instance} on {node} exited {code} in the observation window"));
+                        serde_json::json!({"mutation_id": id, "outcome": "crashed", "model_hash": shape, "detail": format!("instance {instance} on {node} exited {code} in the observation window")}).to_string()
+                    }
+                    FleetOutcome::NeverUp(missing) => {
+                        eprintln!("hale dna run: {id}: never expressed by {}", missing.join(" "));
+                        let _ = append_journal(&root, "expression.crashed", &id, &format!("never expressed: {}", missing.join(" ")));
+                        serde_json::json!({"mutation_id": id, "outcome": "build_failed", "model_hash": "", "detail": format!("never expressed by {}", missing.join(" "))}).to_string()
+                    }
+                };
+                if let Err(e) = publish_on_membrane(&root, "observed", &body) {
+                    eprintln!("hale dna run: could not report on the membrane: {e}");
+                }
                 continue;
             }
             eprintln!("hale dna {verb}: {id} requests a restart ({body})");
@@ -820,7 +884,7 @@ fn launch_iris(me: &Path, port: &str, current: &Path, diff_from: Option<PathBuf>
 }
 
 /// SIGTERM, a grace period, then SIGKILL; the exit is reaped.
-fn terminate(organism: &mut std::process::Child) {
+pub(crate) fn terminate(organism: &mut std::process::Child) {
     unsafe {
         libc::kill(organism.id() as i32, libc::SIGTERM);
     }
@@ -852,7 +916,7 @@ fn pending_restart(root: &Path, handled: &BTreeSet<u64>) -> Option<(u64, String,
     out
 }
 
-fn shape_of(artifact: &Path) -> String {
+pub(crate) fn shape_of(artifact: &Path) -> String {
     fs::read_to_string(artifact)
         .ok()
         .and_then(|t| serde_json::from_str::<Value>(&t).ok())
@@ -863,7 +927,7 @@ fn shape_of(artifact: &Path) -> String {
 /// Append one event to the Journal from the host — only while the
 /// organism is NOT running (the Journal has one writer at a time; the
 /// organism's in-memory projection would go stale otherwise).
-fn git(root: &Path, args: &[&str]) -> Result<String, String> {
+pub(crate) fn git(root: &Path, args: &[&str]) -> Result<String, String> {
     let out = Command::new("git").arg("-C").arg(root).args(args).output().map_err(|e| format!("git: {e}"))?;
     if !out.status.success() {
         return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
@@ -892,7 +956,7 @@ fn append_journal(root: &Path, kind: &str, entity: &str, body: &str) -> Result<(
     append_journal_as(root, kind, entity, body, None)
 }
 
-fn append_journal_as(root: &Path, kind: &str, entity: &str, body: &str, author: Option<&str>) -> Result<(), String> {
+pub(crate) fn append_journal_as(root: &Path, kind: &str, entity: &str, body: &str, author: Option<&str>) -> Result<(), String> {
     let dna_dir = root.join(".hale/dna");
     fs::create_dir_all(&dna_dir).map_err(|e| e.to_string())?;
     let pid = std::process::id();
@@ -963,7 +1027,7 @@ fn receipt_read(root: &Path, digest: &str) -> Option<String> {
 const REMOTE_TRACK: &str = "refs/dna/remote/journal";
 
 /// The remote the record syncs with, when the repository has one.
-fn record_remote(root: &Path) -> Option<String> {
+pub(crate) fn record_remote(root: &Path) -> Option<String> {
     let name = git(root, &["config", "dna.remote"]).ok().filter(|s| !s.is_empty()).unwrap_or_else(|| "origin".into());
     git(root, &["remote", "get-url", &name]).ok().map(|_| name)
 }
@@ -973,7 +1037,7 @@ fn record_remote(root: &Path) -> Option<String> {
 /// re-appended on top of the remote's head (their bodies and authors
 /// unchanged; their seq is their new position) and pushed. Receipts
 /// travel both ways by refspec. Returns a one-line summary.
-fn sync_record(root: &Path) -> Result<String, String> {
+pub(crate) fn sync_record(root: &Path) -> Result<String, String> {
     let Some(remote) = record_remote(root) else {
         return Ok("no remote: the record is local".into());
     };
@@ -1233,6 +1297,173 @@ fn pressure(args: &[String]) -> Result<Vec<String>, String> {
 }
 
 // ---------------------------------------------------------------
+// The fleet as the expression (GH #566 F5): `fleet.deploy` rows out,
+// `instance.up` / `instance.exited` rows back from the nodes
+// ---------------------------------------------------------------
+
+/// Fold `.` and `..` out of a path without touching the filesystem, so
+/// a plan's `seed` (relative to the plan) and a mutation's seed
+/// (relative to the root) compare as the same directory.
+pub(crate) fn normalize(p: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for c in p.components() {
+        match c {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// The plan as it is at `rev`, parsed; `plan` is its path under `root`.
+pub(crate) fn plan_at(root: &Path, plan: &Path, rev: &str) -> Result<crate::fleet::FleetPlan, String> {
+    let rel = plan.strip_prefix(root).unwrap_or(plan).to_string_lossy().to_string();
+    let text = git(root, &["show", &format!("{rev}:{rel}")]).map_err(|e| format!("no plan {rel} at {}: {e}", short(rev)))?;
+    let p: crate::fleet::FleetPlan = serde_json::from_str(&text).map_err(|e| format!("{rel} at {}: {e}", short(rev)))?;
+    Ok(p)
+}
+
+/// The instances a change to `seed` touches: every instance a node
+/// expresses whose seed is that directory; every one when the seed is
+/// "" (an operator's deploy, a rollback of the whole genome).
+pub(crate) fn touched_by(root: &Path, plan_path: &Path, plan: &crate::fleet::FleetPlan, seed: &str) -> Vec<String> {
+    let plan_dir = plan_path.parent().unwrap_or(root);
+    let want = if seed.is_empty() { None } else { Some(normalize(&root.join(seed))) };
+    plan.instances
+        .iter()
+        .filter(|i| i.node.is_some())
+        .filter(|i| match (&want, &i.seed) {
+            (None, _) => true,
+            (Some(w), Some(s)) => &normalize(&plan_dir.join(s)) == w,
+            (Some(_), None) => false,
+        })
+        .map(|i| i.id.clone())
+        .collect()
+}
+
+/// Ask the fleet to express `rev`: the revision pushed where every node
+/// fetches from (`refs/dna/revisions/<rev>`), then one `fleet.deploy` row
+/// — plan, revision, seed, the touched instances, why. Returns the row's
+/// seq and the touched instances.
+pub(crate) fn fleet_deploy(root: &Path, fleet: &str, plan_path: &Path, rev: &str, seed: &str, entity: &str, reason: &str) -> Result<(u64, Vec<String>), String> {
+    let rev = git(root, &["rev-parse", "--verify", &format!("{rev}^{{commit}}")])?;
+    let plan = plan_at(root, plan_path, &rev)?;
+    let touched = touched_by(root, plan_path, &plan, seed);
+    if let Some(remote) = record_remote(root) {
+        git(root, &["push", "-q", "-f", &remote, &format!("{rev}:refs/dna/revisions/{rev}")])?;
+    }
+    let body = serde_json::json!({"plan": fleet, "revision": rev, "seed": seed, "touched": touched, "reason": reason}).to_string();
+    append_journal(root, "fleet.deploy", entity, &body)?;
+    let _ = sync_record(root);
+    let seq = read_journal(root)?.iter().rev().find(|r| r.kind == "fleet.deploy" && r.entity == entity).map(|r| r.seq).unwrap_or(0);
+    Ok((seq, touched))
+}
+
+pub(crate) enum FleetOutcome {
+    Healthy(String),
+    Crashed { instance: String, node: String, code: i64, shape: String },
+    NeverUp(Vec<String>),
+}
+
+/// The window over the touched instances: every one reports `instance.up`
+/// at `rev` after the deploy row (within `settle_secs`), then none reports
+/// `instance.exited` for `observe_secs`. The shape is what the instances
+/// report; a crash names the instance and its node.
+pub(crate) fn fleet_window(root: &Path, rev: &str, touched: &[String], deploy_seq: u64, settle_secs: u64, observe_secs: u64, status_path: &Path) -> FleetOutcome {
+    let settle = std::time::Instant::now() + std::time::Duration::from_secs(settle_secs);
+    let mut all_up_at: Option<std::time::Instant> = None;
+    let mut shape = String::new();
+    loop {
+        let _ = sync_record(root);
+        write_status(root, status_path);
+        let rows = read_journal(root).unwrap_or_default();
+        let after: Vec<(&Row, Value)> = rows.iter().filter(|r| r.seq > deploy_seq && r.kind.starts_with("instance.")).map(|r| (r, serde_json::from_str::<Value>(&r.body).unwrap_or(Value::Null))).collect();
+        let at_rev = |b: &Value| b["revision"].as_str() == Some(rev);
+        for (r, b) in &after {
+            if r.kind == "instance.exited" && at_rev(b) && touched.contains(&r.entity) {
+                return FleetOutcome::Crashed { instance: r.entity.clone(), node: b["node"].as_str().unwrap_or("?").to_string(), code: b["code"].as_i64().unwrap_or(-1), shape: shape.clone() };
+            }
+        }
+        let missing: Vec<String> = touched.iter().filter(|t| !after.iter().any(|(r, b)| r.kind == "instance.up" && &r.entity == *t && at_rev(b))).cloned().collect();
+        if missing.is_empty() {
+            if shape.is_empty() {
+                shape = after.iter().find(|(r, b)| r.kind == "instance.up" && at_rev(b)).and_then(|(_, b)| b["model_hash"].as_str().map(|s| s.to_string())).unwrap_or_default();
+            }
+            let since = *all_up_at.get_or_insert_with(std::time::Instant::now);
+            if since.elapsed() >= std::time::Duration::from_secs(observe_secs) {
+                return FleetOutcome::Healthy(shape);
+            }
+        } else if std::time::Instant::now() > settle {
+            return FleetOutcome::NeverUp(missing);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+}
+
+/// `hale dna fleet`: what the fleet expresses, from the record — every
+/// instance of the plan, its node, the revision and model hash it last
+/// came up at, whether it is up, and the deploy that asked.
+fn fleet_cmd(args: &[String]) -> Result<Vec<String>, String> {
+    let dir = args.first().map(PathBuf::from).unwrap_or_else(|| PathBuf::from("."));
+    let (root, _) = project(&dir)?;
+    let _ = sync_record(&root);
+    let Some((name, plan_path)) = crate::pkg::read_dna_fleet(&root.join("hale.toml"))? else {
+        return Err("no `[dna] fleet = \"<name>\"` in hale.toml: the DNA expresses no fleet here".into());
+    };
+    let plan = crate::fleet::read_plan(&plan_path).map_err(|e| e.join("\n"))?;
+    let rows = read_journal(&root)?;
+    let mut out = vec![format!("fleet {name} ({})", plan_path.strip_prefix(&root).unwrap_or(&plan_path).display())];
+    if let Some(d) = rows.iter().rev().find(|r| r.kind == "fleet.deploy") {
+        let b: Value = serde_json::from_str(&d.body).unwrap_or_default();
+        out.push(format!("last deploy: {} {} ({}) touching {} — {}", b["reason"].as_str().unwrap_or("?"), short(b["revision"].as_str().unwrap_or("")), d.entity, b["touched"].as_array().map(|a| a.len()).unwrap_or(0), b["seed"].as_str().filter(|s| !s.is_empty()).unwrap_or("the whole genome")));
+    } else {
+        out.push("no deploy yet: `hale dna deploy <revision>`".into());
+    }
+    for i in &plan.instances {
+        let last = rows.iter().rev().find(|r| r.kind.starts_with("instance.") && r.entity == i.id);
+        let line = match last {
+            None => format!("  {:<12} {:<10} never expressed", i.id, i.node.as_deref().unwrap_or("-")),
+            Some(r) => {
+                let b: Value = serde_json::from_str(&r.body).unwrap_or_default();
+                let state = if r.kind == "instance.up" { "up".to_string() } else { format!("exited {}", b["code"].as_i64().unwrap_or(-1)) };
+                format!("  {:<12} {:<10} {:<8} rev {} model {}", i.id, b["node"].as_str().unwrap_or(i.node.as_deref().unwrap_or("-")), state, short(b["revision"].as_str().unwrap_or("")), b["model_hash"].as_str().map(short).unwrap_or_default())
+            }
+        };
+        out.push(line);
+    }
+    Ok(out)
+}
+
+/// `hale dna deploy <revision>` / `hale dna rollback <mutation>`: an
+/// operator's deploy row, the same row an approval writes.
+fn deploy_cmd(args: &[String], rollback: bool) -> Result<Vec<String>, String> {
+    let verb = if rollback { "rollback" } else { "deploy" };
+    let Some(what) = args.first() else {
+        return Err(format!("usage: hale dna {verb} <{}>", if rollback { "mutation id" } else { "revision" }));
+    };
+    let (root, _) = project(Path::new("."))?;
+    let _ = sync_record(&root);
+    let Some((name, plan_path)) = crate::pkg::read_dna_fleet(&root.join("hale.toml"))? else {
+        return Err("no `[dna] fleet = \"<name>\"` in hale.toml: the DNA expresses no fleet here".into());
+    };
+    let (rev, entity, reason) = if rollback {
+        let base = base_of(&root, what);
+        if base.is_empty() {
+            return Err(format!("{what}: no Review in the record names its base"));
+        }
+        (base, what.clone(), format!("rollback {what} by operator"))
+    } else {
+        let rev = git(&root, &["rev-parse", "--verify", &format!("{what}^{{commit}}")])?;
+        (rev.clone(), short(&rev), "deploy by operator".to_string())
+    };
+    let (seq, touched) = fleet_deploy(&root, &name, &plan_path, &rev, "", &entity, &reason)?;
+    Ok(vec![format!("fleet.deploy #{seq}: {name} at {} touching {}", short(&rev), if touched.is_empty() { "no instance (none has a node)".to_string() } else { touched.join(" ") })])
+}
+
+// ---------------------------------------------------------------
 // GitHub as a membrane (GH #566 F4): a mirror of the record, never the record
 // ---------------------------------------------------------------
 
@@ -1367,14 +1598,14 @@ fn write_status(root: &Path, path: &Path) {
 // ---------------------------------------------------------------
 
 #[derive(Clone)]
-struct Row {
-    seq: u64,
-    kind: String,
-    entity: String,
-    body: String,
+pub(crate) struct Row {
+    pub(crate) seq: u64,
+    pub(crate) kind: String,
+    pub(crate) entity: String,
+    pub(crate) body: String,
 }
 
-fn read_journal(root: &Path) -> Result<Vec<Row>, String> {
+pub(crate) fn read_journal(root: &Path) -> Result<Vec<Row>, String> {
     let Some(_) = record_head(root) else {
         return Err(format!("no record at {RECORD_REF} in {} (run `hale dna init`)", root.display()));
     };
@@ -1820,7 +2051,7 @@ fn review(args: &[String]) -> Result<Vec<String>, String> {
     }
 }
 
-fn short(sha: &str) -> String {
+pub(crate) fn short(sha: &str) -> String {
     sha.chars().take(12).collect()
 }
 

--- a/crates/hale-cli/src/dna.rs
+++ b/crates/hale-cli/src/dna.rs
@@ -1920,11 +1920,30 @@ fn publish_on_membrane(root: &Path, kind: &str, body: &str) -> Result<(), String
     let cache = hale_iris::materialize().map_err(|e| format!("cannot materialize the toolchain cache: {e}"))?;
     let bin = cache.join(hale_dna::MEMBRANE_BIN);
     let me = std::env::current_exe().map_err(|e| e.to_string())?;
-    if !bin.is_file() {
-        eprintln!("hale dna: building the membrane client ({})", cache.join(hale_dna::MEMBRANE_SEED).display());
-        let st = Command::new(&me).arg("build").arg(cache.join(hale_dna::MEMBRANE_SEED)).stdout(std::process::Stdio::null()).status().map_err(|e| e.to_string())?;
-        if !st.success() || !bin.is_file() {
-            return Err("building the membrane client failed".into());
+    // One build per cache, under the cache's lock — taken BEFORE the
+    // existence check: the linker creates the output before it is
+    // complete or executable, and two verdicts racing here exec'd a
+    // half-written file (`membrane client: Permission denied`).
+    let lock_path = cache.join(".build.lock");
+    let lock = std::fs::OpenOptions::new().create(true).write(true).open(&lock_path).map_err(|e| format!("cannot open {}: {e}", lock_path.display()))?;
+    {
+        use std::os::unix::io::AsRawFd;
+        // SAFETY: flock on a descriptor we own for the block's lifetime.
+        unsafe {
+            libc::flock(lock.as_raw_fd(), libc::LOCK_EX);
+        }
+        if !bin.is_file() {
+            eprintln!("hale dna: building the membrane client ({})", cache.join(hale_dna::MEMBRANE_SEED).display());
+            let st = Command::new(&me).arg("build").arg(cache.join(hale_dna::MEMBRANE_SEED)).stdout(std::process::Stdio::null()).status().map_err(|e| e.to_string())?;
+            if !st.success() || !bin.is_file() {
+                unsafe {
+                    libc::flock(lock.as_raw_fd(), libc::LOCK_UN);
+                }
+                return Err("building the membrane client failed".into());
+            }
+        }
+        unsafe {
+            libc::flock(lock.as_raw_fd(), libc::LOCK_UN);
         }
     }
     let dna_dir = root.join(".hale/dna");

--- a/crates/hale-cli/src/fleet.rs
+++ b/crates/hale-cli/src/fleet.rs
@@ -40,7 +40,7 @@ pub const FLEET_PLAN_SCHEMA: &str = "1.1";
 /// Plan schemas this build reads. Equality was right when there was
 /// one; a set keeps "your plan is newer than your compiler" a real
 /// refusal without making every older plan one too.
-const READABLE_PLAN_SCHEMAS: [&str; 2] = ["1.0", "1.1"];
+const READABLE_PLAN_SCHEMAS: [&str; 3] = ["1.0", "1.1", "1.2"];
 
 /// An exact, finite deployment. Autoscaling ranges and wildcard
 /// discovery are elaborator INPUTS, not sealed-plan contents: a
@@ -145,10 +145,24 @@ pub struct InstanceSpec {
     /// witnesses, several instances of one artifact — needs the
     /// distinction.
     pub id: String,
-    /// Path to a topology artifact, relative to the plan file.
+    /// Path to a topology artifact, relative to the plan file. Empty
+    /// when `seed` names where to cut it from (schema 1.2).
+    #[serde(default)]
     pub artifact: String,
     #[serde(default)]
     pub labels: Vec<String>,
+    /// GH #566 F5 (schema 1.2): the seed this instance is built from,
+    /// relative to the plan file. With no `artifact`, composition cuts
+    /// the artifact from the seed first (`hale check --dump-topology`)
+    /// — the plan then describes the workspace's own services, and a
+    /// DNA candidate is checked as the fleet it would deploy.
+    #[serde(default)]
+    pub seed: Option<String>,
+    /// GH #566 F5 (schema 1.2): the node that expresses this instance
+    /// (`hale node <name>`). An instance with no node is expressed by
+    /// whoever runs it by hand.
+    #[serde(default)]
+    pub node: Option<String>,
     /// GH #408 Phase 7 (`attest`): path to this instance's built
     /// executable, relative to the plan file. The artifact certifies
     /// the model; this row is what lets a deployment answer for the
@@ -234,12 +248,19 @@ pub fn compose(
             ));
             continue;
         }
-        match load_artifact(&base.join(&inst.artifact), trust) {
+        let artifact = match artifact_of(base, &plan.name, inst) {
+            Ok(p) => p,
+            Err(e) => {
+                errs.push(format!("instance `{}`: {}", inst.id, e));
+                continue;
+            }
+        };
+        match load_artifact(&artifact, trust) {
             Ok((model, sha256, signed_by)) => comps.push(Component {
                 id: inst.id.clone(),
                 labels: inst.labels.clone(),
                 model,
-                path: base.join(&inst.artifact),
+                path: artifact,
                 sha256,
                 signed_by,
             }),
@@ -1379,7 +1400,40 @@ pub fn attest(plan_path: &Path) -> Result<String, Vec<String>> {
     }
 }
 
-fn read_plan(p: &Path) -> Result<FleetPlan, Vec<String>> {
+/// Where an instance's artifact is: the plan's `artifact` path, or —
+/// with a `seed` and no artifact (schema 1.2) — cut now from the seed
+/// into `.hale/fleet/<plan>/<id>.topology.json` beside the plan, so
+/// the composition reads what the seed IS at this revision. A seed
+/// that does not check is an instance with no admissible artifact.
+fn artifact_of(base: &Path, plan_name: &str, inst: &InstanceSpec) -> Result<PathBuf, String> {
+    if !inst.artifact.is_empty() {
+        return Ok(base.join(&inst.artifact));
+    }
+    let Some(seed) = inst.seed.as_deref() else {
+        return Err("no `artifact` and no `seed`: an instance names one or the other".into());
+    };
+    let out = base.join(".hale/fleet").join(plan_name).join(format!("{}.topology.json", inst.id));
+    if let Some(d) = out.parent() {
+        std::fs::create_dir_all(d).map_err(|e| format!("mkdir {}: {e}", d.display()))?;
+    }
+    let me = std::env::current_exe().map_err(|e| e.to_string())?;
+    let r = std::process::Command::new(me)
+        .arg("check")
+        .arg(base.join(seed))
+        .arg(format!("--dump-topology={}", out.display()))
+        .output()
+        .map_err(|e| format!("hale check {seed}: {e}"))?;
+    if !r.status.success() {
+        return Err(format!(
+            "seed `{seed}` does not check, so it has no artifact to compose:\n{}{}",
+            String::from_utf8_lossy(&r.stdout).trim(),
+            String::from_utf8_lossy(&r.stderr).trim()
+        ));
+    }
+    Ok(out)
+}
+
+pub fn read_plan(p: &Path) -> Result<FleetPlan, Vec<String>> {
     let src = std::fs::read_to_string(p)
         .map_err(|e| vec![format!("read {}: {}", p.display(), e)])?;
     let plan: FleetPlan = serde_json::from_str(&src)

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -30,6 +30,7 @@ use hale_lsp as lsp;
 mod fleet;
 mod dna;
 mod iris;
+mod node;
 mod mcp;
 mod pkg;
 mod replay;
@@ -67,6 +68,11 @@ fn main() -> ExitCode {
     // application as ordinary Hale source.
     if cmd == "dna" {
         return dna::run(&args[2..]);
+    }
+    // GH #566 F5: `hale node <name>` — the agent that expresses a fleet
+    // plan's instances on one machine, from the record.
+    if cmd == "node" {
+        return node::run(&args[2..]);
     }
     if cmd == "--list-targets" || cmd == "targets" {
         let host = hale_codegen::target::TargetSpec::host();
@@ -2692,9 +2698,10 @@ fn file_of_span(
 /// environment is law bound to an entrypoint. A workspace declares
 /// both, and `production` in one need not mean `production` in the
 /// other.
-fn run_fleet_all() -> ExitCode {
-    let cwd =
-        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+fn run_fleet_all(from: Option<&Path>, if_declared: bool) -> ExitCode {
+    let cwd = from
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
     let mut dir = cwd.canonicalize().unwrap_or(cwd);
     let manifest = loop {
         let m = dir.join("hale.toml");
@@ -2707,6 +2714,10 @@ fn run_fleet_all() -> ExitCode {
         }
     };
     let Some(manifest) = manifest else {
+        if if_declared {
+            println!("no hale.toml at or above {}: no fleets declared", dir.display());
+            return ExitCode::SUCCESS;
+        }
         eprintln!(
             "`hale fleet check` with no plan checks every fleet in \
              `[fleets]`, and no `hale.toml` was found at or above the \
@@ -2739,6 +2750,10 @@ fn run_fleet_all() -> ExitCode {
         }
     };
     if fleets.is_empty() {
+        if if_declared {
+            println!("{} declares no [fleets]", manifest.display());
+            return ExitCode::SUCCESS;
+        }
         eprintln!(
             "{} declares no `[fleets]`. Add `<name> = \"<plan path>\"` \
              entries, or name a plan explicitly — reporting success for \
@@ -2874,6 +2889,12 @@ fn run_fleet(rest: &[String]) -> ExitCode {
     // given, exactly like `[fleet_trust]` in the manifest.
     let mut args: Vec<&String> = Vec::new();
     let mut trust_paths: Vec<PathBuf> = Vec::new();
+    // GH #566 F5: `--in <dir>` checks the fleets a workspace elsewhere
+    // declares (a DNA candidate's worktree); `--if-declared` makes a
+    // workspace with no fleets a success that says so, for a
+    // verification step that runs on every workspace.
+    let mut from: Option<PathBuf> = None;
+    let mut if_declared = false;
     let mut it = rest.iter();
     while let Some(a) = it.next() {
         if a == "--trust" {
@@ -2884,6 +2905,16 @@ fn run_fleet(rest: &[String]) -> ExitCode {
                     return ExitCode::from(2);
                 }
             }
+        } else if a == "--in" {
+            match it.next() {
+                Some(d) => from = Some(PathBuf::from(d)),
+                None => {
+                    eprintln!("--in needs a directory");
+                    return ExitCode::from(2);
+                }
+            }
+        } else if a == "--if-declared" {
+            if_declared = true;
         } else {
             args.push(a);
         }
@@ -2905,7 +2936,7 @@ fn run_fleet(rest: &[String]) -> ExitCode {
             );
             return ExitCode::from(2);
         }
-        return run_fleet_all();
+        return run_fleet_all(from.as_deref(), if_declared);
     }
     let (sub, plan) = match (sub, plan) {
         (Some("check"), Some(p)) | (Some("dump"), Some(p)) => {
@@ -2913,7 +2944,8 @@ fn run_fleet(rest: &[String]) -> ExitCode {
         }
         _ => {
             eprintln!("hale fleet check [plan.json]   compose and check");
-            eprintln!("                                (no plan: every fleet in [fleets])");
+            eprintln!("                                (no plan: every fleet in [fleets];");
+            eprintln!("                                 --in <dir> another workspace's, --if-declared: none is ok)");
             eprintln!("hale fleet dump  <plan.json>    write the fleet artifact");
             eprintln!("hale fleet attest <plan.json>   binaries match the plan's sha256 rows");
             eprintln!("hale fleet keygen <prefix>      ES256 keypair for signing");

--- a/crates/hale-cli/src/node.rs
+++ b/crates/hale-cli/src/node.rs
@@ -1,0 +1,212 @@
+//! GH #566 F5 — `hale node <name>`: the agent that expresses, on one
+//! machine, the instances a fleet plan assigns to that node.
+//!
+//! A node owns a clone of the governed repository and nothing else.
+//! Every tick it syncs the record, reads the latest `fleet.deploy`
+//! row, and — when that names a revision it does not express yet —
+//! fetches the revision (`refs/dna/revisions/<rev>`, pushed by whoever
+//! deployed), checks it out, and for each of its instances the deploy
+//! touches (or that is not running) cuts the artifact, builds the
+//! seed, restarts the process, and appends `instance.up` in the node's
+//! name: node, instance, revision, model hash, build digest, pid. An
+//! instance that exits appends `instance.exited` with its code. That
+//! is the expression identity per instance: reported by the node that
+//! expresses it, joined to the plan by instance id, judged by the host
+//! beside the organization over the window.
+//!
+//! The node never decides anything. It expresses what the record says
+//! and reports what it sees.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use serde_json::Value;
+
+use crate::dna::{append_journal_as, git, normalize, read_journal, record_remote, shape_of, short, sync_record, terminate};
+
+struct Running {
+    child: std::process::Child,
+    revision: String,
+}
+
+pub fn run(args: &[String]) -> ExitCode {
+    let mut name: Option<String> = None;
+    let mut repo = PathBuf::from(".");
+    let mut fleet: Option<String> = None;
+    let mut tick_ms: u64 = 1000;
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--repo" => match it.next() {
+                Some(r) => repo = PathBuf::from(r),
+                None => return usage("--repo needs a directory"),
+            },
+            "--fleet" => match it.next() {
+                Some(f) => fleet = Some(f.clone()),
+                None => return usage("--fleet needs a name"),
+            },
+            "--tick" => match it.next().and_then(|v| v.parse::<u64>().ok()) {
+                Some(n) => tick_ms = n.max(100),
+                None => return usage("--tick needs milliseconds"),
+            },
+            f if f.starts_with("--") => return usage(&format!("unknown flag `{f}`")),
+            n => name = Some(n.to_string()),
+        }
+    }
+    let Some(name) = name else { return usage("a node has a name") };
+    let root = match repo.canonicalize() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("hale node {name}: {}: {e}", repo.display());
+            return ExitCode::from(2);
+        }
+    };
+    if git(&root, &["rev-parse", "--git-dir"]).is_err() {
+        eprintln!("hale node {name}: {} is not a git clone of the governed repository", root.display());
+        return ExitCode::from(2);
+    }
+    let me = match std::env::current_exe() {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("hale node {name}: {e}");
+            return ExitCode::from(1);
+        }
+    };
+    let node_dir = root.join(".hale/node").join(&name);
+    let _ = fs::create_dir_all(&node_dir);
+    let author = format!("node/{name}");
+    eprintln!("hale node {name}: expressing from {} (record via {})", root.display(), record_remote(&root).unwrap_or_else(|| "no remote".into()));
+    let mut running: BTreeMap<String, Running> = BTreeMap::new();
+    let mut expressed_seq: u64 = 0;
+    loop {
+        if let Err(e) = sync_record(&root) {
+            eprintln!("hale node {name}: sync: {e}");
+        }
+        // what exited since the last tick
+        let mut gone: Vec<String> = Vec::new();
+        for (id, r) in running.iter_mut() {
+            if let Ok(Some(st)) = r.child.try_wait() {
+                let code = st.code().unwrap_or(-1);
+                eprintln!("hale node {name}: instance {id} exited ({code})");
+                let body = serde_json::json!({"node": name, "instance": id, "revision": r.revision, "code": code}).to_string();
+                let _ = append_journal_as(&root, "instance.exited", id, &body, Some(&author));
+                let _ = fs::remove_file(node_dir.join(format!("{id}.pid")));
+                gone.push(id.clone());
+            }
+        }
+        for id in &gone {
+            running.remove(id);
+        }
+        if !gone.is_empty() {
+            let _ = sync_record(&root);
+        }
+        // the latest deploy for our fleet
+        let rows = read_journal(&root).unwrap_or_default();
+        let deploy = rows.iter().rev().find(|r| r.kind == "fleet.deploy").and_then(|r| serde_json::from_str::<Value>(&r.body).ok().map(|b| (r.seq, b))).filter(|(_, b)| fleet.as_deref().map(|f| b["plan"].as_str() == Some(f)).unwrap_or(true));
+        if let Some((seq, body)) = deploy {
+            if seq != expressed_seq {
+                match express(&me, &root, &name, &node_dir, &author, &body, &mut running) {
+                    Ok(n) => {
+                        expressed_seq = seq;
+                        eprintln!("hale node {name}: fleet.deploy #{seq} expressed ({n} instance(s) started)");
+                        let _ = sync_record(&root);
+                    }
+                    Err(e) => eprintln!("hale node {name}: fleet.deploy #{seq}: {e} (retrying next tick)"),
+                }
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(tick_ms));
+    }
+}
+
+fn usage(why: &str) -> ExitCode {
+    eprintln!("hale node: {why}");
+    eprintln!("usage: hale node <name> [--repo <clone>] [--fleet <name>] [--tick <ms>]");
+    eprintln!("       run the instances a fleet plan assigns to node <name>, from the record;");
+    eprintln!("       the clone's `origin` (or `dna.remote`) is where the record and revisions come from");
+    ExitCode::from(2)
+}
+
+/// Express one deploy row: the revision checked out, every instance of
+/// this node the deploy touches (or that is not up) rebuilt and
+/// restarted at it. Returns how many were started.
+fn express(me: &Path, root: &Path, node: &str, node_dir: &Path, author: &str, deploy: &Value, running: &mut BTreeMap<String, Running>) -> Result<usize, String> {
+    let rev = deploy["revision"].as_str().unwrap_or("").to_string();
+    if rev.is_empty() {
+        return Err("a deploy with no revision".into());
+    }
+    if let Some(remote) = record_remote(root) {
+        let _ = git(root, &["fetch", "-q", &remote, "+refs/dna/revisions/*:refs/dna/revisions/*"]);
+    }
+    git(root, &["rev-parse", "--verify", &format!("{rev}^{{commit}}")]).map_err(|_| format!("revision {} is not here yet", short(&rev)))?;
+    git(root, &["checkout", "-q", "--detach", &rev])?;
+    let plan_name = deploy["plan"].as_str().unwrap_or("");
+    let plan_path = match crate::pkg::read_dna_fleet(&root.join("hale.toml"))? {
+        Some((n, p)) if n == plan_name || plan_name.is_empty() => p,
+        _ => {
+            let fleets = crate::pkg::read_fleets(&root.join("hale.toml"))?;
+            match fleets.get(plan_name) {
+                Some(rel) => root.join(rel),
+                None => return Err(format!("no fleet `{plan_name}` in hale.toml at {}", short(&rev))),
+            }
+        }
+    };
+    let plan = crate::fleet::read_plan(&plan_path).map_err(|e| e.join("; "))?;
+    let plan_dir = plan_path.parent().unwrap_or(root).to_path_buf();
+    let touched: Vec<String> = deploy["touched"].as_array().map(|a| a.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect()).unwrap_or_default();
+    let mut started = 0;
+    for inst in plan.instances.iter().filter(|i| i.node.as_deref() == Some(node)) {
+        let up = running.get(&inst.id).map(|r| r.revision == rev).unwrap_or(false);
+        if up && !touched.contains(&inst.id) {
+            continue;
+        }
+        let Some(seed) = inst.seed.as_deref() else {
+            eprintln!("hale node {node}: instance {} has no seed to build; skipped", inst.id);
+            continue;
+        };
+        let seed_dir = normalize(&plan_dir.join(seed));
+        let artifact = node_dir.join(format!("{}.topology", inst.id));
+        let bin = build(me, &seed_dir, &artifact).map_err(|e| format!("instance {}: {e}", inst.id))?;
+        let shape = shape_of(&artifact);
+        let build_digest = crate::sign::sha256_file(&bin).map(|d| d[..12].to_string()).unwrap_or_default();
+        if let Some(mut old) = running.remove(&inst.id) {
+            terminate(&mut old.child);
+        }
+        let child = Command::new(&bin)
+            .current_dir(root)
+            .env("LOTUS_OBS", "1")
+            .env("HALE_BIN", me)
+            .env("HALE_DNA_NODE", node)
+            .env("HALE_DNA_INSTANCE", &inst.id)
+            .env("HALE_DNA_EXPRESSION", format!("{shape} build {build_digest}"))
+            .spawn()
+            .map_err(|e| format!("instance {}: cannot start {}: {e}", inst.id, bin.display()))?;
+        let _ = fs::write(node_dir.join(format!("{}.pid", inst.id)), child.id().to_string());
+        let body = serde_json::json!({"node": node, "instance": inst.id, "revision": rev, "model_hash": shape, "build": build_digest, "pid": child.id()}).to_string();
+        append_journal_as(root, "instance.up", &inst.id, &body, Some(author))?;
+        eprintln!("hale node {node}: instance {} up (pid {}) at {} as {}", inst.id, child.id(), short(&rev), short(&shape));
+        running.insert(inst.id.clone(), Running { child, revision: rev.clone() });
+        started += 1;
+    }
+    Ok(started)
+}
+
+/// Cut the artifact and build the seed; the binary.
+fn build(me: &Path, seed: &Path, artifact: &Path) -> Result<PathBuf, String> {
+    let st = Command::new(me).arg("check").arg(seed).arg(format!("--dump-topology={}", artifact.display())).stdout(std::process::Stdio::null()).status();
+    if !matches!(st, Ok(s) if s.success()) {
+        return Err(format!("`hale check {}` failed; nothing runs that does not pass", seed.display()));
+    }
+    let st = Command::new(me).arg("build").arg(seed).stdout(std::process::Stdio::null()).status();
+    if !matches!(st, Ok(s) if s.success()) {
+        return Err(format!("`hale build {}` failed", seed.display()));
+    }
+    let bin_name = seed.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_else(|| "app".into());
+    let bin = seed.join(&bin_name);
+    if !bin.is_file() {
+        return Err(format!("no binary at {}", bin.display()));
+    }
+    Ok(bin)
+}

--- a/crates/hale-cli/src/pkg.rs
+++ b/crates/hale-cli/src/pkg.rs
@@ -99,6 +99,35 @@ pub struct Manifest {
     /// which is the pre-Phase-7 meaning of a composition, unchanged.
     #[serde(default)]
     pub fleet_trust: FleetTrust,
+    /// GH #566 F5: `[dna] fleet = "production"` — which declared fleet
+    /// the DNA expresses. Named, not inferred: a workspace usually
+    /// declares more than one arrangement, and the one an approval
+    /// redeploys must be a choice somebody made.
+    #[serde(default)]
+    pub dna: DnaManifest,
+}
+
+/// The `[dna]` section.
+#[derive(Deserialize, Default, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct DnaManifest {
+    pub fleet: Option<String>,
+}
+
+/// GH #566 F5: the fleet the DNA expresses — its name and plan path
+/// (relative to the manifest), when `[dna] fleet` names one.
+pub fn read_dna_fleet(manifest: &Path) -> Result<Option<(String, PathBuf)>, String> {
+    if !manifest.exists() {
+        return Ok(None);
+    }
+    let src = fs::read_to_string(manifest).map_err(|e| format!("read {}: {}", manifest.display(), e))?;
+    let m: Manifest = toml::from_str(&src).map_err(|e| format!("parse {}: {}", manifest.display(), e))?;
+    let Some(name) = m.dna.fleet else { return Ok(None) };
+    let Some(rel) = m.fleets.get(&name) else {
+        return Err(format!("{}: `[dna] fleet = \"{name}\"` names no entry of `[fleets]`", manifest.display()));
+    };
+    let base = manifest.parent().unwrap_or(Path::new("."));
+    Ok(Some((name, base.join(rel))))
 }
 
 /// The `[fleet_trust]` section.

--- a/crates/hale-cli/tests/dna_apply.rs
+++ b/crates/hale-cli/tests/dna_apply.rs
@@ -138,7 +138,9 @@ fn approval_applies_the_pinned_candidate_and_the_host_restarts_and_observes() {
     }
     // the organism applies, the host restarts, the window passes, the report lands
     let dl = Instant::now() + Duration::from_secs(120);
-    while Instant::now() < dl && !has(&journal(&app), "mutation.retained", "m1") {
+    // retained, and the worktree dissolved right after it — two rows,
+    // a tick apart under load
+    while Instant::now() < dl && !journal(&app).iter().any(|(k, e, b)| k == "mutation.worktree" && e == "m1" && b == "removed") {
         std::thread::sleep(Duration::from_millis(300));
     }
     let rows = journal(&app);

--- a/crates/hale-cli/tests/dna_fleet.rs
+++ b/crates/hale-cli/tests/dna_fleet.rs
@@ -93,16 +93,29 @@ impl Fleet {
         (out.status.success(), format!("{}{}", String::from_utf8_lossy(&out.stdout), String::from_utf8_lossy(&out.stderr)))
     }
     fn spawn(&mut self, args: &[&str], cwd: &Path) {
+        // stderr to a file per process, shown when the test fails
+        let log = std::fs::File::create(self.d.join(format!("{}.stderr", args.iter().take(2).map(|a| a.replace('/', "_")).collect::<Vec<_>>().join("-")))).unwrap();
         let c = Command::new(env!("CARGO_BIN_EXE_hale"))
             .args(args)
             .current_dir(cwd)
             .env("HALE_BIN", env!("CARGO_BIN_EXE_hale"))
             .env("XDG_CACHE_HOME", std::env::temp_dir().join("hale-tests-iris-cache"))
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stderr(log)
             .spawn()
             .expect("spawn");
         self.procs.push(c);
+    }
+    fn logs(&self) -> String {
+        let mut out = String::new();
+        if let Ok(rd) = std::fs::read_dir(&self.d) {
+            for f in rd.flatten() {
+                if f.path().extension().map(|x| x == "stderr").unwrap_or(false) {
+                    out.push_str(&format!("--- {}\n{}\n", f.file_name().to_string_lossy(), std::fs::read_to_string(f.path()).unwrap_or_default()));
+                }
+            }
+        }
+        out
     }
     fn stop(&mut self) {
         for p in self.procs.iter_mut() {
@@ -185,11 +198,12 @@ fn bring_up(tag: &str) -> Fleet {
     }
     assert!(out.contains("touching api-0 api-1"), "{out}");
     let base = f.base.clone();
-    let up = wait_row(&app, 90, |(_, k, e, b)| k == "instance.up" && e == "api-0" && b.contains(&base)) && wait_row(&app, 90, |(_, k, e, b)| k == "instance.up" && e == "api-1" && b.contains(&base));
+    let up = wait_row(&app, 180, |(_, k, e, b)| k == "instance.up" && e == "api-0" && b.contains(&base)) && wait_row(&app, 180, |(_, k, e, b)| k == "instance.up" && e == "api-1" && b.contains(&base));
     if !up {
         let dump = dump(&app);
+        let logs = f.logs();
         f.stop();
-        panic!("the base was not expressed by both nodes:\n{dump}");
+        panic!("the base was not expressed by both nodes:\n{dump}\n{logs}");
     }
     f
 }

--- a/crates/hale-cli/tests/dna_fleet.rs
+++ b/crates/hale-cli/tests/dna_fleet.rs
@@ -1,0 +1,270 @@
+//! GH #566 F5 — the fleet is the expression. Two nodes, each a clone of
+//! the governed repository, run one instance of the API each from the
+//! record (`hale node`); the host beside the organization deploys an
+//! approved candidate to them (`fleet.deploy`), watches the window over
+//! both instances (`instance.up` / `instance.exited`), and the
+//! organization retains or rolls back. Killing one instance inside the
+//! window rolls the whole fleet back, with the instance named.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn git(args: &[&str], cwd: &Path) -> String {
+    let out = Command::new("git").args(["-c", "user.name=riley", "-c", "user.email=r@l"]).args(args).current_dir(cwd).output().expect("git");
+    assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn journal(app: &Path) -> Vec<(u64, String, String, String)> {
+    let out = Command::new("git").args(["-C", &app.to_string_lossy(), "show", "refs/dna/journal:journal.jsonl"]).output().unwrap();
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .map(|v| {
+            let s = |k: &str| v[k].as_str().unwrap_or("").to_string();
+            (v["seq"].as_u64().unwrap_or(0), s("kind"), s("entity"), s("body"))
+        })
+        .collect()
+}
+
+fn wait_row(app: &Path, secs: u64, pred: impl Fn(&(u64, String, String, String)) -> bool) -> bool {
+    let dl = Instant::now() + Duration::from_secs(secs);
+    while Instant::now() < dl {
+        if journal(app).iter().any(&pred) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(300));
+    }
+    false
+}
+
+fn dump(app: &Path) -> String {
+    journal(app).iter().map(|(q, k, e, b)| format!("{q} {k} {e} {}", b.chars().take(110).collect::<String>())).collect::<Vec<_>>().join("\n")
+}
+
+const DRIVER: &str = r#"import "vendor/dna" as dna;
+
+fn main() {
+    let cur = std::io::fs::read_file("main.hl") or "";
+    let core = dna::Dna {
+        journal: dna::GitJournal { repo: "." },
+        gateway: dna::MutationGateway {
+            leases: dna::GitLeases { repo: "." },
+            workspaces: dna::IsolatedWorktrees { repo: ".", root: ".hale/dna/worktrees" },
+            repo: dna::LocalGit { repo: "." }
+        },
+        verification: dna::HaleVerification { receipts: dna::GitReceipts { repo: "." }, scratch: ".hale/dna/scratch", repo: ".", seed: "." },
+        editor: dna::SourceEditor {
+            name: "editor",
+            models: dna::ModelRouter {
+                quick: dna::FakeModel { name: "quick", answer: cur + "// documented for the fleet\n" },
+                deep: dna::FakeModel { name: "deep", answer: "docs_coverage +" }
+            }
+        },
+        review_policy: dna::OrgPolicy { },
+        membrane: dna::Board { who: "board" },
+        boundary: dna::AutonomyBoundary { child: "fleetapp", grant: dna::Grant { child: "fleetapp", classes: "docs refactor", max_magnitude: 4, review: "pre" } }
+    };
+    println(core.mutate("t0", "docs", "document the entrypoint in main.hl", "main.hl", 1));
+}
+"#;
+
+struct Fleet {
+    d: PathBuf,
+    app: PathBuf,
+    bare: PathBuf,
+    edges: Vec<PathBuf>,
+    procs: Vec<std::process::Child>,
+    base: String,
+    cand: String,
+}
+
+impl Fleet {
+    fn hale(&self, args: &[&str], cwd: &Path) -> (bool, String) {
+        let out = Command::new(env!("CARGO_BIN_EXE_hale"))
+            .args(args)
+            .current_dir(cwd)
+            .env("HALE_BIN", env!("CARGO_BIN_EXE_hale"))
+            .env("XDG_CACHE_HOME", std::env::temp_dir().join("hale-tests-iris-cache"))
+            .output()
+            .expect("hale");
+        (out.status.success(), format!("{}{}", String::from_utf8_lossy(&out.stdout), String::from_utf8_lossy(&out.stderr)))
+    }
+    fn spawn(&mut self, args: &[&str], cwd: &Path) {
+        let c = Command::new(env!("CARGO_BIN_EXE_hale"))
+            .args(args)
+            .current_dir(cwd)
+            .env("HALE_BIN", env!("CARGO_BIN_EXE_hale"))
+            .env("XDG_CACHE_HOME", std::env::temp_dir().join("hale-tests-iris-cache"))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn");
+        self.procs.push(c);
+    }
+    fn stop(&mut self) {
+        for p in self.procs.iter_mut() {
+            let _ = p.kill();
+            let _ = p.wait();
+        }
+        for f in ["org.pid", "app.pid"] {
+            if let Ok(pid) = std::fs::read_to_string(self.app.join(".hale/dna").join(f)) {
+                let _ = Command::new("kill").args(["-9", pid.trim()]).status();
+            }
+        }
+        for (i, e) in self.edges.iter().enumerate() {
+            let nd = e.join(".hale/node").join(format!("edge-{}", i + 1));
+            if let Ok(rd) = std::fs::read_dir(&nd) {
+                for f in rd.flatten() {
+                    if f.path().extension().map(|x| x == "pid").unwrap_or(false) {
+                        if let Ok(pid) = std::fs::read_to_string(f.path()) {
+                            let _ = Command::new("kill").args(["-9", pid.trim()]).status();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// An application with its DNA, a plan of two API instances on two
+/// nodes, an origin, two node clones, and one Mutation waiting for its
+/// Review; then the organization, the two nodes, and the base deployed.
+fn bring_up(tag: &str) -> Fleet {
+    let d = std::env::temp_dir().join(format!("hale_dna_fleet_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).unwrap();
+    let mut f = Fleet { d: d.clone(), app: d.join("fleetapp"), bare: d.join("origin.git"), edges: vec![d.join("edge-1"), d.join("edge-2")], procs: vec![], base: String::new(), cand: String::new() };
+    let (ok, out) = f.hale(&["dna", "new", "fleetapp"], &d);
+    assert!(ok, "{out}");
+    let app = f.app.clone();
+    std::fs::write(
+        app.join("fleet.plan.json"),
+        r#"{"schema":"1.2","name":"production","instances":[
+  {"id":"api-0","seed":".","node":"edge-1","labels":["api"]},
+  {"id":"api-1","seed":".","node":"edge-2","labels":["api"]}]}
+"#,
+    )
+    .unwrap();
+    let mut manifest = std::fs::read_to_string(app.join("hale.toml")).unwrap();
+    manifest.push_str("\n[fleets]\nproduction = \"fleet.plan.json\"\n\n[dna]\nfleet = \"production\"\n");
+    std::fs::write(app.join("hale.toml"), manifest).unwrap();
+    git(&["init", "-q", "--bare", "-b", "main", &f.bare.to_string_lossy()], &d);
+    git(&["config", "user.name", "riley"], &app);
+    git(&["config", "user.email", "r@l"], &app);
+    git(&["add", "-A"], &app);
+    git(&["commit", "-q", "-m", "the app and its fleet"], &app);
+    git(&["remote", "add", "origin", &f.bare.to_string_lossy()], &app);
+    git(&["push", "-q", "origin", "main", "refs/dna/*:refs/dna/*"], &app);
+    f.base = git(&["rev-parse", "HEAD"], &app);
+    for e in &f.edges {
+        git(&["clone", "-q", &f.bare.to_string_lossy(), &e.to_string_lossy()], &d);
+    }
+    // one Mutation up to its Review, offline
+    std::fs::create_dir_all(app.join("mutate")).unwrap();
+    std::fs::write(app.join("mutate/main.hl"), DRIVER).unwrap();
+    let (ok, out) = f.hale(&["run", "mutate"], &app);
+    assert!(ok && out.contains("m1: review"), "driver:\n{out}");
+    f.cand = journal(&app).iter().find(|(_, k, e, _)| k == "mutation.candidate" && e == "m1").map(|r| r.3.clone()).expect("candidate");
+    // the organization, then the nodes, then the base deployed
+    f.spawn(&["dna", "run", ".", "--no-iris", "--observe", "4"], &app);
+    let edges = f.edges.clone();
+    for (i, e) in edges.iter().enumerate() {
+        f.spawn(&["node", &format!("edge-{}", i + 1), "--repo", &e.to_string_lossy(), "--tick", "300"], &d);
+    }
+    let dl = Instant::now() + Duration::from_secs(60);
+    while !app.join(".hale/dna/org.pid").exists() && Instant::now() < dl {
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    let (ok, out) = f.hale(&["dna", "deploy", "HEAD"], &app);
+    if !ok {
+        f.stop();
+        panic!("deploy: {out}");
+    }
+    assert!(out.contains("touching api-0 api-1"), "{out}");
+    let base = f.base.clone();
+    let up = wait_row(&app, 90, |(_, k, e, b)| k == "instance.up" && e == "api-0" && b.contains(&base)) && wait_row(&app, 90, |(_, k, e, b)| k == "instance.up" && e == "api-1" && b.contains(&base));
+    if !up {
+        let dump = dump(&app);
+        f.stop();
+        panic!("the base was not expressed by both nodes:\n{dump}");
+    }
+    f
+}
+
+#[test]
+fn an_approval_redeploys_both_instances_and_the_window_retains() {
+    let mut f = bring_up("ok");
+    let app = f.app.clone();
+    let cand = f.cand.clone();
+    let (ok, out) = f.hale(&["dna", "review", "m1", "approve", "--as", "riley"], &app);
+    if !ok {
+        f.stop();
+        panic!("approve: {out}");
+    }
+    let retained = wait_row(&app, 150, |(_, k, e, _)| k == "mutation.retained" && e == "m1");
+    let rows = journal(&app);
+    let fleet_out = f.hale(&["dna", "fleet"], &app).1;
+    let dump = dump(&app);
+    f.stop();
+    assert!(retained, "the candidate was retained:\n{dump}");
+    let deploy = rows.iter().find(|(_, k, e, b)| k == "fleet.deploy" && e == "m1" && b.contains("\"reason\":\"apply\"")).expect("the apply's deploy row");
+    assert!(deploy.3.contains(&cand) && deploy.3.contains("\"touched\":[\"api-0\",\"api-1\"]"), "{}", deploy.3);
+    let ups: Vec<&(u64, String, String, String)> = rows.iter().filter(|(q, k, _, b)| *q > deploy.0 && k == "instance.up" && b.contains(&cand)).collect();
+    assert_eq!(ups.len(), 2, "both instances came up at the candidate:\n{dump}");
+    let hash = |b: &str| serde_json::from_str::<serde_json::Value>(b).unwrap()["model_hash"].as_str().unwrap().to_string();
+    assert_eq!(hash(&ups[0].3), hash(&ups[1].3), "both report the same model hash");
+    assert!(ups.iter().any(|r| r.3.contains("\"node\":\"edge-1\"")) && ups.iter().any(|r| r.3.contains("\"node\":\"edge-2\"")), "one per node");
+    let observed = rows.iter().find(|(_, k, e, _)| k == "expression.observed" && e == "m1").expect("observed");
+    assert!(observed.3.starts_with(&format!("healthy {} 2 instance(s) up", hash(&ups[0].3))), "{}", observed.3);
+    assert!(fleet_out.contains("api-0") && fleet_out.contains("edge-2") && fleet_out.matches(" up ").count() == 2, "hale dna fleet shows both up:\n{fleet_out}");
+    assert_eq!(git(&["rev-parse", "HEAD"], &f.edges[0]), cand, "edge-1 checked out the candidate");
+    let _ = std::fs::remove_dir_all(&f.d);
+}
+
+#[test]
+fn an_instance_killed_inside_the_window_rolls_the_fleet_back_by_name() {
+    let mut f = bring_up("kill");
+    let app = f.app.clone();
+    let cand = f.cand.clone();
+    let base = f.base.clone();
+    let (ok, out) = f.hale(&["dna", "review", "m1", "approve", "--as", "riley"], &app);
+    if !ok {
+        f.stop();
+        panic!("approve: {out}");
+    }
+    // api-1 comes up at the candidate on edge-2; kill it inside the window
+    let c = cand.clone();
+    if !wait_row(&app, 120, |(_, k, e, b)| k == "instance.up" && e == "api-1" && b.contains(&c)) {
+        let dump = dump(&app);
+        f.stop();
+        panic!("api-1 never came up at the candidate:\n{dump}");
+    }
+    let pid = std::fs::read_to_string(f.edges[1].join(".hale/node/edge-2/api-1.pid")).expect("api-1's pid");
+    let _ = Command::new("kill").args(["-9", pid.trim()]).status();
+    let rolled = wait_row(&app, 120, |(_, k, e, _)| k == "mutation.rolled_back" && e == "m1");
+    // the rollback deploy brings both back to the base, after the row
+    let rolled = rolled && wait_row(&app, 60, |(_, k, e, b)| k == "fleet.deploy" && e == "m1" && b.contains("\"reason\":\"rollback\""));
+    let rb_seq = journal(&app).iter().find(|(_, k, e, b)| k == "fleet.deploy" && e == "m1" && b.contains("\"reason\":\"rollback\"")).map(|r| r.0).unwrap_or(u64::MAX);
+    let b = base.clone();
+    let back = rolled
+        && wait_row(&app, 120, |(q, k, e, body)| *q > rb_seq && k == "instance.up" && e == "api-0" && body.contains(&b))
+        && wait_row(&app, 120, |(q, k, e, body)| *q > rb_seq && k == "instance.up" && e == "api-1" && body.contains(&b));
+    let rows = journal(&app);
+    let dump = dump(&app);
+    f.stop();
+    assert!(rolled, "the organization rolled back:\n{dump}");
+    let crashed = rows.iter().find(|(_, k, e, _)| k == "expression.crashed" && e == "m1").expect("the crash is in the record");
+    assert!(crashed.3.contains("instance api-1 on edge-2 exited"), "{}", crashed.3);
+    let observed = rows.iter().find(|(_, k, e, b)| k == "expression.observed" && e == "m1" && b.starts_with("crashed")).expect("observed crashed");
+    assert!(observed.3.contains("instance api-1 on edge-2"), "{}", observed.3);
+    let rb = rows.iter().find(|(_, k, e, b)| k == "fleet.deploy" && e == "m1" && b.contains("\"reason\":\"rollback\"")).expect("the rollback's deploy row");
+    assert!(rb.3.contains(&base) && rb.3.contains("\"touched\":[\"api-0\",\"api-1\"]"), "{}", rb.3);
+    let ups_base_after: Vec<_> = rows.iter().filter(|(q, k, _, b)| *q > rb.0 && k == "instance.up" && b.contains(&base)).collect();
+    assert!(back && ups_base_after.len() == 2, "both instances came back at the base after the rollback:\n{dump}");
+    assert_eq!(git(&["rev-parse", "HEAD"], &f.edges[1]), base, "edge-2 is back at the base");
+    assert!(rows.iter().any(|(_, k, e, _)| k == "mutation.retained" && e == "m1") == false, "nothing was retained:\n{dump}");
+    let _ = std::fs::remove_dir_all(&f.d);
+}

--- a/crates/hale-cli/tests/dna_membrane.rs
+++ b/crates/hale-cli/tests/dna_membrane.rs
@@ -204,7 +204,16 @@ fn verdict_and_intent_cross_the_membrane_and_the_organism_decides() {
 
     // 4. a malformed request never becomes a publish.
     let r = post(port, "/ctl/review", r#"{"verdict":"approve"}"#);
-    let snap = http(port, "GET /snapshot HTTP/1.0\r\nHost: x\r\n\r\n");
+    // the counters land on the fusion loop's next snapshot tick
+    let mut snap = String::new();
+    let dl = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < dl {
+        snap = http(port, "GET /snapshot HTTP/1.0\r\nHost: x\r\n\r\n");
+        if snap.contains("\"verdicts\":2") && snap.contains("\"intents\":1") {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
     finish(&mut organism, &mut iris);
     let transcript = lines.lock().unwrap().join("\n");
     assert!(born, "task born via the membrane:\n{transcript}");

--- a/crates/hale-cli/tests/dna_review.rs
+++ b/crates/hale-cli/tests/dna_review.rs
@@ -96,7 +96,7 @@ fn a_mutation_is_rendered_offline_and_decided_through_the_organism() {
         "+// tuned: the entrypoint is documented here",
         "semantic diff (hale model diff",
         "classification: source-only",
-        "evidence (fmt=0 check=0 verify=0 test=0 diff=0 rollback=0):",
+        "evidence (fmt=0 check=0 verify=0 test=0 diff=0 rollback=0 fleet=0):",
         "rollback   yes    0",
         "base       yes    0",
         "check      yes    0",

--- a/crates/hale-cli/tests/fleet_seed_instances.rs
+++ b/crates/hale-cli/tests/fleet_seed_instances.rs
@@ -1,0 +1,62 @@
+//! GH #566 F5 — plan schema 1.2: an instance may name a `seed` instead
+//! of an `artifact`, and composition cuts the artifact from the seed
+//! first; `hale fleet check --in <dir> --if-declared` is the
+//! verification step's spelling, a success that says so when the
+//! workspace declares no fleet.
+
+use std::path::Path;
+use std::process::Command;
+
+fn hale(args: &[&str], cwd: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_hale")).args(args).current_dir(cwd).output().expect("hale");
+    (out.status.success(), format!("{}{}", String::from_utf8_lossy(&out.stdout), String::from_utf8_lossy(&out.stderr)))
+}
+
+const SVC: &str = r#"topic Tick { payload: Int; subject: "svc.tick"; }
+locus Svc {
+    params { n: Int = 0; }
+    fn bump() { self.n = self.n + 1; }
+}
+fn main() {
+    let s = Svc { };
+    s.bump();
+    println("svc ", s.n);
+}
+"#;
+
+#[test]
+fn an_instance_with_a_seed_composes_from_the_artifact_cut_from_it() {
+    let d = std::env::temp_dir().join(format!("hale_fleet_seed_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(d.join("svc")).unwrap();
+    std::fs::write(d.join("svc/main.hl"), SVC).unwrap();
+    std::fs::write(
+        d.join("prod.plan.json"),
+        r#"{"schema":"1.2","name":"prod","instances":[
+  {"id":"svc-0","seed":"svc","node":"edge-1","labels":["svc"]},
+  {"id":"svc-1","seed":"svc","node":"edge-2","labels":["svc"]}]}"#,
+    )
+    .unwrap();
+    let (ok, out) = hale(&["fleet", "check", "prod.plan.json"], &d);
+    assert!(ok, "a plan of seeds composes:\n{out}");
+    assert!(d.join(".hale/fleet/prod/svc-0.topology.json").is_file() && d.join(".hale/fleet/prod/svc-1.topology.json").is_file(), "the artifacts were cut beside the plan");
+    // the workspace's fleets, from elsewhere, and none declared is a
+    // success that says so
+    std::fs::write(d.join("hale.toml"), "[deps]\n[fleets]\nprod = \"prod.plan.json\"\n").unwrap();
+    let (ok, out) = hale(&["fleet", "check", "--in", &d.to_string_lossy(), "--if-declared"], Path::new("/"));
+    assert!(ok && out.contains("fleet `prod`") && out.contains("ok:"), "{out}");
+    std::fs::write(d.join("hale.toml"), "[deps]\n").unwrap();
+    let (ok, out) = hale(&["fleet", "check", "--in", &d.to_string_lossy(), "--if-declared"], Path::new("/"));
+    assert!(ok && out.contains("declares no [fleets]"), "{out}");
+    let (ok, out) = hale(&["fleet", "check", "--in", &d.to_string_lossy()], Path::new("/"));
+    assert!(!ok && out.contains("declares no `[fleets]`"), "without --if-declared, none is still the refusal:\n{out}");
+    // neither an artifact nor a seed is a plan that cannot be formed
+    std::fs::write(d.join("bad.plan.json"), r#"{"schema":"1.2","name":"bad","instances":[{"id":"x-0","node":"edge-1"}]}"#).unwrap();
+    let (ok, out) = hale(&["fleet", "check", "bad.plan.json"], &d);
+    assert!(!ok && out.contains("no `artifact` and no `seed`"), "{out}");
+    // a seed that does not check has no artifact to compose
+    std::fs::write(d.join("svc/main.hl"), "fn main() { let x: Int = \"no\"; }\n").unwrap();
+    let (ok, out) = hale(&["fleet", "check", "prod.plan.json"], &d);
+    assert!(!ok && out.contains("does not check, so it has no artifact"), "{out}");
+    let _ = std::fs::remove_dir_all(&d);
+}

--- a/crates/hale-cli/tests/iris_cli.rs
+++ b/crates/hale-cli/tests/iris_cli.rs
@@ -5,7 +5,7 @@
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -38,6 +38,48 @@ fn free_port() -> u16 {
     TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap().port()
 }
 
+/// Start `hale iris <port> <args…>` on a free port and wait until it
+/// accepts connections. A port picked with bind(0) and released can be
+/// taken again before fuse-hl binds it — under a loaded shard, by an
+/// ephemeral source port of another test's connection — and a server
+/// that failed its bind exits at birth, which a poll loop with a
+/// silent stderr waits 300 s for. So: stderr captured, an early exit
+/// retried on a fresh port, and the failure named.
+fn spawn_iris(cache: &Path, args: &[&str]) -> (std::process::Child, u16) {
+    let mut last = String::new();
+    for _ in 0..4 {
+        let port = free_port();
+        let log = cache.join(format!("iris-{port}.stderr"));
+        let mut child = Command::new(env!("CARGO_BIN_EXE_hale"))
+            .args(["iris", &port.to_string()])
+            .args(args)
+            .env("XDG_CACHE_HOME", cache)
+            .stdout(Stdio::null())
+            .stderr(std::fs::File::create(&log).unwrap())
+            .spawn()
+            .expect("spawn hale iris");
+        let deadline = Instant::now() + Duration::from_secs(240);
+        loop {
+            if let Ok(Some(st)) = child.try_wait() {
+                last = format!("hale iris exited {st} before serving on {port}:\n{}", std::fs::read_to_string(&log).unwrap_or_default());
+                break;
+            }
+            if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                return (child, port);
+            }
+            if Instant::now() > deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                last = format!("hale iris did not accept on {port} within 240s:\n{}", std::fs::read_to_string(&log).unwrap_or_default());
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        eprintln!("{last}; retrying on another port");
+    }
+    panic!("{last}");
+}
+
 #[test]
 fn iris_materializes_builds_once_and_serves_a_snapshot() {
     let cache = cache_root();
@@ -62,14 +104,7 @@ fn iris_materializes_builds_once_and_serves_a_snapshot() {
     assert!(!err.contains("building the observer"), "second launch must not rebuild: {err}");
 
     // Launch and fetch /snapshot.
-    let port = free_port();
-    let mut child = Command::new(env!("CARGO_BIN_EXE_hale"))
-        .args(["iris", &port.to_string()])
-        .env("XDG_CACHE_HOME", &cache)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn hale iris");
+    let (mut child, port) = spawn_iris(&cache, &[]);
     let deadline = Instant::now() + Duration::from_secs(300);
     let mut body = String::new();
     while Instant::now() < deadline {
@@ -127,16 +162,7 @@ fn iris_diff_pair_rides_into_the_snapshot() {
         assert!(art.is_file(), "artifact {name}: {}", String::from_utf8_lossy(&out.stderr));
         artifacts.push(art);
     }
-    let port = free_port();
-    let mut child = Command::new(env!("CARGO_BIN_EXE_hale"))
-        .args(["iris", &port.to_string(), "--diff"])
-        .arg(&artifacts[0])
-        .arg(&artifacts[1])
-        .env("XDG_CACHE_HOME", &cache)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn hale iris --diff");
+    let (mut child, port) = spawn_iris(&cache, &["--diff", &artifacts[0].to_string_lossy(), &artifacts[1].to_string_lossy()]);
     let deadline = Instant::now() + Duration::from_secs(300);
     let mut body = String::new();
     while Instant::now() < deadline {

--- a/crates/hale-cli/tests/iris_cli.rs
+++ b/crates/hale-cli/tests/iris_cli.rs
@@ -38,13 +38,14 @@ fn free_port() -> u16 {
     TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap().port()
 }
 
-/// Start `hale iris <port> <args…>` on a free port and wait until it
-/// accepts connections. A port picked with bind(0) and released can be
-/// taken again before fuse-hl binds it — under a loaded shard, by an
-/// ephemeral source port of another test's connection — and a server
-/// that failed its bind exits at birth, which a poll loop with a
-/// silent stderr waits 300 s for. So: stderr captured, an early exit
-/// retried on a fresh port, and the failure named.
+/// Start `hale iris <port> <args…>` on a free port and wait until OUR
+/// server says it is listening. A port picked with bind(0) and released
+/// can be taken before fuse-hl binds it — under a loaded shard, by
+/// another test's server — and then a connect to the port succeeds
+/// against a stranger whose snapshot never loads our diff, which a poll
+/// loop waits 300 s for. So: stderr captured, the ready line
+/// (`fuse-hl: listening`) awaited from our own child, an early exit or
+/// a silent child retried on a fresh port, and the failure named.
 fn spawn_iris(cache: &Path, args: &[&str]) -> (std::process::Child, u16) {
     let mut last = String::new();
     for _ in 0..4 {
@@ -64,7 +65,8 @@ fn spawn_iris(cache: &Path, args: &[&str]) -> (std::process::Child, u16) {
                 last = format!("hale iris exited {st} before serving on {port}:\n{}", std::fs::read_to_string(&log).unwrap_or_default());
                 break;
             }
-            if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            let said = std::fs::read_to_string(&log).unwrap_or_default();
+            if said.contains("fuse-hl: listening") && TcpStream::connect(("127.0.0.1", port)).is_ok() {
                 return (child, port);
             }
             if Instant::now() > deadline {

--- a/crates/hale-cli/tests/iris_cli.rs
+++ b/crates/hale-cli/tests/iris_cli.rs
@@ -187,7 +187,19 @@ fn iris_diff_pair_rides_into_the_snapshot() {
     }
     let _ = child.kill();
     let _ = child.wait();
-    let json_start = body.find("{\"ts\"").expect("snapshot body");
+    let json_start = body.find("{\"ts\"").unwrap_or_else(|| {
+        // the last snapshot seen and what the server said, for a failure
+        // a loaded shard produces and a workstation never does
+        let last = TcpStream::connect(("127.0.0.1", port)).ok().and_then(|mut s| {
+            let _ = s.set_read_timeout(Some(Duration::from_secs(3)));
+            let _ = s.write_all(b"GET /snapshot HTTP/1.0\r\nHost: x\r\n\r\n");
+            let mut b = String::new();
+            let _ = s.read_to_string(&mut b);
+            Some(b)
+        });
+        let log = std::fs::read_to_string(cache.join(format!("iris-{port}.stderr"))).unwrap_or_default();
+        panic!("no loaded diff in the snapshot within 300s\nlast snapshot: {last:?}\nserver log:\n{log}");
+    });
     let v: serde_json::Value = serde_json::from_str(&body[json_start..]).expect("snapshot is JSON");
     assert_eq!(v["diff"]["state"], "loaded", "{body}");
     let doc = &v["diff"]["document"];

--- a/crates/hale-cli/tests/iris_cli.rs
+++ b/crates/hale-cli/tests/iris_cli.rs
@@ -51,12 +51,16 @@ fn spawn_iris(cache: &Path, args: &[&str]) -> (std::process::Child, u16) {
     for _ in 0..4 {
         let port = free_port();
         let log = cache.join(format!("iris-{port}.stderr"));
+        // both streams into one log: the ready line is printed, the
+        // build banner and a bind failure are eprinted
+        let out = std::fs::File::create(&log).unwrap();
+        let err = out.try_clone().unwrap();
         let mut child = Command::new(env!("CARGO_BIN_EXE_hale"))
             .args(["iris", &port.to_string()])
             .args(args)
             .env("XDG_CACHE_HOME", cache)
-            .stdout(Stdio::null())
-            .stderr(std::fs::File::create(&log).unwrap())
+            .stdout(out)
+            .stderr(err)
             .spawn()
             .expect("spawn hale iris");
         let deadline = Instant::now() + Duration::from_secs(240);

--- a/crates/hale-cli/tests/iris_cli.rs
+++ b/crates/hale-cli/tests/iris_cli.rs
@@ -55,10 +55,16 @@ fn spawn_iris(cache: &Path, args: &[&str]) -> (std::process::Child, u16) {
         // build banner and a bind failure are eprinted
         let out = std::fs::File::create(&log).unwrap();
         let err = out.try_clone().unwrap();
+        // a private registry: this iris discovers no other test's observed
+        // processes, whose segments come and go under it on a loaded
+        // shard — what it serves here needs none of them
+        let runtime = cache.join(format!("iris-{port}-runtime"));
+        let _ = std::fs::create_dir_all(&runtime);
         let mut child = Command::new(env!("CARGO_BIN_EXE_hale"))
             .args(["iris", &port.to_string()])
             .args(args)
             .env("XDG_CACHE_HOME", cache)
+            .env("XDG_RUNTIME_DIR", &runtime)
             .stdout(out)
             .stderr(err)
             .spawn()
@@ -185,6 +191,7 @@ fn iris_diff_pair_rides_into_the_snapshot() {
         }
         std::thread::sleep(Duration::from_millis(250));
     }
+    let exited = child.try_wait().ok().flatten().map(|st| format!("{st}")).unwrap_or_else(|| "still running".into());
     let _ = child.kill();
     let _ = child.wait();
     let json_start = body.find("{\"ts\"").unwrap_or_else(|| {
@@ -198,7 +205,7 @@ fn iris_diff_pair_rides_into_the_snapshot() {
             Some(b)
         });
         let log = std::fs::read_to_string(cache.join(format!("iris-{port}.stderr"))).unwrap_or_default();
-        panic!("no loaded diff in the snapshot within 300s\nlast snapshot: {last:?}\nserver log:\n{log}");
+        panic!("no loaded diff in the snapshot within 300s (server {exited})\nlast snapshot: {last:?}\nserver log:\n{log}");
     });
     let v: serde_json::Value = serde_json::from_str(&body[json_start..]).expect("snapshot is JSON");
     assert_eq!(v["diff"]["state"], "loaded", "{body}");

--- a/crates/hale-iris/src/lib.rs
+++ b/crates/hale-iris/src/lib.rs
@@ -110,9 +110,19 @@ pub fn materialize_into(root: &Path) -> io::Result<()> {
         if let Some(parent) = p.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let tmp = p.with_extension("tmp-materialize");
+        // a tmp name per writer: two commands materializing one cache at
+        // once renamed the same tmp, and the loser's rename found nothing
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let tmp = p.with_extension(format!("tmp-materialize-{}-{}", std::process::id(), SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)));
         std::fs::write(&tmp, content)?;
-        std::fs::rename(&tmp, &p)?;
+        if let Err(e) = std::fs::rename(&tmp, &p) {
+            let _ = std::fs::remove_file(&tmp);
+            // the other writer won with the same bytes: fine
+            if std::fs::read_to_string(&p).map(|now| now == content).unwrap_or(false) {
+                continue;
+            }
+            return Err(e);
+        }
     }
     Ok(())
 }
@@ -129,6 +139,28 @@ pub fn materialize() -> io::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Several commands materialize one cache at once on a fresh
+    /// machine (a host, two nodes and a CLI in one test): every writer
+    /// must succeed, and the files must be whole.
+    #[test]
+    fn concurrent_materialization_never_fails_a_writer() {
+        let dir = std::env::temp_dir().join(format!("hale-iris-materialize-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let d = dir.clone();
+                std::thread::spawn(move || materialize_into(&d))
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap().expect("a writer lost the race and failed");
+        }
+        for (path, content) in all_files() {
+            assert_eq!(std::fs::read_to_string(dir.join(path)).unwrap(), content, "{path} is whole");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn every_embedded_file_is_nonempty_and_unique() {

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -2,6 +2,7 @@ crates/hale-cli/tests/check_arg_parsing.rs#0 f428caff9d863411
 crates/hale-cli/tests/debug_info.rs#0 a8a553c534907f76
 crates/hale-cli/tests/dispatch_plan_cli.rs#0 e9ff5fe335d31b65
 crates/hale-cli/tests/dna_apply.rs#0 f2c1228edb650960
+crates/hale-cli/tests/dna_fleet.rs#0 f2c1228edb650960
 crates/hale-cli/tests/dna_github_membrane.rs#0 f2c1228edb650960
 crates/hale-cli/tests/dna_review.rs#0 f2c1228edb650960
 crates/hale-cli/tests/doc.rs#0 a9238ad19f21c0ec
@@ -64,6 +65,7 @@ crates/hale-cli/tests/fleet_compose.rs#9 44748ce6a81cc054
 crates/hale-cli/tests/fleet_cross_tier.rs#5 74534bdd47d17023
 crates/hale-cli/tests/fleet_model_soundness.rs#2 096bf948a953c55c
 crates/hale-cli/tests/fleet_model_soundness.rs#3 0307e1dae8efcf77
+crates/hale-cli/tests/fleet_seed_instances.rs#0 bc7076df25d5111b
 crates/hale-cli/tests/fleet_sign.rs#0 c4804249b5a05260
 crates/hale-cli/tests/law_selection_reaches_the_artifact.rs#2 eee350907cf202be
 crates/hale-cli/tests/lsp.rs#0 3533bcfd7c9f71d5

--- a/dna/core/assembly.hl
+++ b/dna/core/assembly.hl
@@ -642,7 +642,25 @@ locus Dna {
             let x = self.journal.append(self.journal.revision(), "mutation.deny", id, "candidate does not check (" + report.steps + ")");
             return id + ": denied: candidate does not check";
         }
-        let d = self.review_mutation(m, report, self.editor.identity());
+        // GH #566 F5: a change to one service that breaks a claim the fleet
+        // makes over all of them is denied with the witness in the evidence
+        if !report.evidence.fleet_clean {
+            let x = self.journal.append(self.journal.revision(), "mutation.deny", id, "candidate breaks the fleet (" + report.steps + ")");
+            return id + ": denied: candidate breaks the fleet";
+        }
+        // a candidate that names a plan or the manifest changes the fleet's
+        // shape: it is a topology mutation whatever it was asked as
+        let mut reviewed = m;
+        if report.evidence.topology_changed && m.change_class != "topology" {
+            reviewed = Mutation {
+                id: m.id, task_id: m.task_id, base_commit: m.base_commit, worktree: m.worktree,
+                candidate_commit: m.candidate_commit, candidate_digest: m.candidate_digest,
+                change_class: "topology", seed: m.seed, rationale: m.rationale,
+                fitness_signals: m.fitness_signals, disposition: m.disposition
+            };
+            let y = self.journal.append(self.journal.revision(), "mutation.topology", id, "names a plan or the manifest: the fleet's shape changes, the Board decides");
+        }
+        let d = self.review_mutation(reviewed, report, self.editor.identity());
         return id + ": " + d;
     }
     fn mutation_failed(id: String, why: String) -> String {

--- a/dna/core/types.hl
+++ b/dna/core/types.hl
@@ -94,6 +94,8 @@ type Evidence {
     replay_ok: Bool = false;
     independent_reviews: Int = 0;
     rollback_rehearsed: Bool = false;
+    fleet_clean: Bool = true; // every fleet the workspace declares composes and holds its claims with the candidate's artifacts (GH #566 F5); true when it declares none
+    topology_changed: Bool = false; // the candidate names a plan or the manifest: the change is the fleet's shape, not one service's source
 }
 
 // The disposition of a proposed change (#521): release inside an

--- a/dna/core/verification.hl
+++ b/dna/core/verification.hl
@@ -22,7 +22,7 @@ type VerificationReport {
     candidate_shape: String = ""; // the candidate artifact's shape hash ("" when it did not check)
     evidence: Evidence = Evidence { };
     magnitude: Magnitude = Magnitude { };
-    steps: String = ""; // "fmt=0 check=0 verify=0 test=0 diff=0"
+    steps: String = ""; // "fmt=0 check=0 verify=0 test=0 diff=0 rollback=0 fleet=0"
     candidate_topology: String = ""; // path
     diff_json: String = ""; // receipt digest ("" when there was no candidate artifact)
     diff_text: String = ""; // receipt digest
@@ -120,6 +120,26 @@ fn resolve_toolchain(given: String) -> String {
     return "hale";
 }
 
+// Does a `git diff --name-only` name the fleet's shape — a plan
+// (`*.plan.json`) or the manifest (`hale.toml`)? Such a change is a
+// `topology` mutation whatever it was asked as (GH #566 F5).
+fn names_topology(names: String) -> Bool {
+    let mut line = "";
+    let mut p = 0;
+    let n = len(names);
+    while p < n {
+        let ch = names[p..(p + 1)];
+        if ch == "\n" {
+            if std::str::contains(line, ".plan.json") || line == "hale.toml" { return true; }
+            line = "";
+        } else {
+            line = line + ch;
+        }
+        p = p + 1;
+    }
+    return std::str::contains(line, ".plan.json") || line == "hale.toml";
+}
+
 fn magnitude_json(m: Magnitude) -> String {
     let b = std::json::Builder { };
     b.begin_object();
@@ -208,6 +228,15 @@ locus HaleVerification {
         let verify = self.record(j, cand, m.id, "verify", run_tool(self.hale_bin + "\nverify\n" + wt + "\n--json"));
         let tests = run_tool(self.hale_bin + "\ntest\n" + wt);
         let test = self.record(j, cand, m.id, "test", tests);
+        // the fleet (GH #566 F5): every arrangement the workspace declares,
+        // composed from the candidate's own artifacts; a workspace that
+        // declares none passes and says so
+        let fleet = self.record(j, cand, m.id, "fleet", run_tool(self.hale_bin + "\nfleet\ncheck\n--in\n" + m.worktree + "\n--if-declared"));
+        let mut topology = false;
+        if len(m.base_commit) > 0 {
+            let names = run_tool("git\n-C\n" + m.worktree + "\ndiff\n--name-only\n" + m.base_commit + "\n" + cand);
+            topology = names_topology(names.stdout);
+        }
         let mut replay_ok = false;
         if len(self.recording) > 0 {
             let rp = self.record(j, cand, m.id, "replay", run_tool(self.hale_bin + "\nreplay\n" + self.recording + "\n" + wt + "\n--feed"));
@@ -243,16 +272,16 @@ locus HaleVerification {
         // a project with no tests has no test evidence, only an exit code
         let tested = test == 0 && std::str::contains(tests.stdout, ", 0 failed");
         self.last = self.assemble(m.id, cand, shape,
-            Evidence { check_clean: check == 0, verify_clean: verify == 0, tests_pass: tested, replay_ok: replay_ok, rollback_rehearsed: rehearsed == 0 },
-            mag, fmt, check, verify, test, diff, rehearsed, if check == 0 { topo } else { "" }, diff_json, diff_text);
+            Evidence { check_clean: check == 0, verify_clean: verify == 0, tests_pass: tested, replay_ok: replay_ok, rollback_rehearsed: rehearsed == 0, fleet_clean: fleet == 0, topology_changed: topology },
+            mag, fmt, check, verify, test, diff, rehearsed, fleet, if check == 0 { topo } else { "" }, diff_json, diff_text);
         return self.last;
     }
     // One report per run; bounded by the runs a Review asks for.
     @unbounded
-    fn assemble(id: String, cand: String, shape: String, e: Evidence, mag: Magnitude, fmt: Int, check: Int, verify: Int, test: Int, diff: Int, rehearsed: Int, topo: String, diff_json: String, diff_text: String) -> VerificationReport {
+    fn assemble(id: String, cand: String, shape: String, e: Evidence, mag: Magnitude, fmt: Int, check: Int, verify: Int, test: Int, diff: Int, rehearsed: Int, fleet: Int, topo: String, diff_json: String, diff_text: String) -> VerificationReport {
         return VerificationReport {
             mutation_id: id, candidate: cand, candidate_shape: shape, evidence: e, magnitude: mag,
-            steps: "fmt=" + to_string(fmt) + " check=" + to_string(check) + " verify=" + to_string(verify) + " test=" + to_string(test) + " diff=" + to_string(diff) + " rollback=" + to_string(rehearsed),
+            steps: "fmt=" + to_string(fmt) + " check=" + to_string(check) + " verify=" + to_string(verify) + " test=" + to_string(test) + " diff=" + to_string(diff) + " rollback=" + to_string(rehearsed) + " fleet=" + to_string(fleet),
             candidate_topology: topo, diff_json: diff_json, diff_text: diff_text
         };
     }

--- a/dna/tests/mutation_review_test.hl
+++ b/dna/tests/mutation_review_test.hl
@@ -94,7 +94,7 @@ main locus App {
         std::test::assert_eq_str(std::json::find_string_field(requested, "mutation_id"), "m1", "the request names the mutation");
         std::test::assert_eq_str(std::json::find_string_field(requested, "disposition"), "review", "effects widened: a hard boundary, so review: " + requested);
         std::test::assert(std::str::contains(requested, "\"external_blast\": 2"), "the magnitude travels with the request: " + requested);
-        std::test::assert_eq_int(evidence, 8, "eight receipts: base fmt check verify test rollback diff magnitude");
+        std::test::assert_eq_int(evidence, 9, "nine receipts: base fmt check verify test fleet rollback diff magnitude");
         std::test::assert(self.dna.journal.verify_chain(), "chain intact");
 
         // ---- 2. a verdict naming another digest is refused BY THE REVIEW ---

--- a/dna/tests/verification_test.hl
+++ b/dna/tests/verification_test.hl
@@ -52,7 +52,7 @@ main locus App {
 
         // ---- a candidate that checks ---------------------------------------
         let r = self.v.verify(self.journal, dna::Mutation { id: "m1", worktree: root + "/wt", candidate_commit: "cand1" }, root + "/baseline.topology");
-        std::test::assert_eq_str(r.steps, "fmt=0 check=0 verify=0 test=0 diff=0 rollback=-1", "every step ran clean (no base commit: no rehearsal): " + r.steps);
+        std::test::assert_eq_str(r.steps, "fmt=0 check=0 verify=0 test=0 diff=0 rollback=-1 fleet=0", "every step ran clean (no base commit: no rehearsal): " + r.steps);
         std::test::assert(r.evidence.check_clean && r.evidence.verify_clean, "check and verify evidence");
         std::test::assert(!r.evidence.tests_pass, "no tests is no test evidence");
         std::test::assert(!r.evidence.replay_ok, "no recording is no replay evidence");
@@ -85,7 +85,7 @@ main locus App {
             if std::str::contains(e.kind, "evidence.") { evidence_events = evidence_events + 1; }
             i = i + 1;
         }
-        std::test::assert_eq_int(evidence_events, 6, "fmt check verify test diff magnitude");
+        std::test::assert_eq_int(evidence_events, 7, "fmt check verify test fleet diff magnitude");
         std::test::assert(self.journal.verify_chain(), "chain intact");
 
         // ---- a candidate that does not check ------------------------------

--- a/docs/src/services/multi-binary.md
+++ b/docs/src/services/multi-binary.md
@@ -234,6 +234,19 @@ Why an *instance* rather than an application: `oms` is a program,
 `oms-0` is a process. Cardinality, witnesses, and running two copies
 of one binary all need the distinction.
 
+When the services live in the same workspace, an instance can name
+the **seed** it is built from instead of a committed artifact (schema
+1.2), and the node that runs it:
+
+```json
+{"id": "oms-0", "seed": "apps/oms", "node": "edge-1", "labels": ["oms"]}
+```
+
+`hale fleet check` cuts the artifact from the seed first, so the plan
+is checked against what the source is right now. The `node` is for
+the DNA (`hale node <name>` expresses the plan's instances on that
+machine; see the DNA chapters), and composition ignores it.
+
 Why artifacts rather than source: merging the programs would invent
 edges that no deployed route creates (an unbound topic is in-process
 by default), erase routes that exist only in config, and turn

--- a/spec/dna.md
+++ b/spec/dna.md
@@ -69,7 +69,8 @@ Deleting it loses nothing the record holds.
 `review.settled`, `review.refused`, `expression.restart_requested`,
 `expression.deployed`, `expression.restarted`, `expression.observed`,
 `expression.crashed`, `pressure.raised`, `pressure.remeasured`,
-`appendage.proposed`, `model.called`, `github.pr`, `github.commented`. Their bodies are documented in the guide's reference
+`appendage.proposed`, `model.called`, `github.pr`, `github.commented`,
+`mutation.topology`, `fleet.deploy`, `instance.up`, `instance.exited`. Their bodies are documented in the guide's reference
 chapter; the set grows by ordinary change, and a reader that meets an
 unknown kind must keep walking.
 
@@ -196,5 +197,72 @@ The assembly names what fills each role; `hale check` sees the wiring.
   expresses and judges in the organization's own handler and no host
   is asked; without one, `expression.restart_requested` asks the host.
 - **Observation** — for a shell gateway, the command's exit; for a
-  host, the window it watches; for a fleet, F5.
+  host, the window it watches; for a fleet, what its nodes report
+  (below).
+
+## The fleet
+
+The genome's topology is the fleet plan Hale already checks
+(`spec/verification.md`, "Fleet composition"), and the DNA expresses
+one arrangement of it:
+
+- **The plan describes the workspace's own services.** Plan schema
+  1.2 lets an instance name a `seed` (relative to the plan) instead
+  of an `artifact`; composition cuts the artifact from the seed first,
+  so a candidate is checked as the fleet it would deploy. An instance
+  may name the `node` that expresses it. `[dna] fleet = "<name>"` in
+  `hale.toml` names which entry of `[fleets]` the DNA expresses.
+- **The fleet is evidence.** Verification runs `hale fleet check --in
+  <worktree> --if-declared` on every candidate (`evidence.fleet`;
+  `fleet_clean`, true when the workspace declares no fleet). A change
+  to one service that breaks a claim the fleet makes over all of them
+  is `mutation.deny` ("candidate breaks the fleet") with the witness
+  in the receipt. A candidate whose diff names a plan (`*.plan.json`)
+  or the manifest (`hale.toml`) changes the fleet's shape: it is
+  re-classed `topology` (`mutation.topology`) whatever it was asked
+  as, and `OrgPolicy` sends it to the Board.
+- **A deploy is a row.** `fleet.deploy` (entity: the Mutation, or the
+  short revision for an operator's deploy) carries the plan name, the
+  revision, the seed the change edits (`""` for the whole genome), the
+  instances touched — every instance with a node whose seed is that
+  directory — and the reason (`apply`, `rollback`, or the operator's).
+  The revision is pushed to `refs/dna/revisions/<rev>` on the record's
+  remote first, so every node can fetch it. Under `hale dna run` with
+  `[dna] fleet` set, the host answers an application's
+  `expression.restart_requested` with a deploy row; `hale dna deploy
+  <revision>` and `hale dna rollback <mutation>` write the same row by
+  hand. A rollback's row asks for the base; nothing is watched.
+- **A node expresses.** `hale node <name> [--repo <clone>] [--fleet
+  <name>] [--tick <ms>]` runs in a clone of the governed repository.
+  Every tick it syncs the record and reads the latest `fleet.deploy`;
+  when that names a revision it does not express, it fetches the
+  revision, checks it out, and for each instance the plan assigns to
+  the node that the deploy touches (or that is not up) cuts the
+  artifact, builds the seed, restarts the process (cwd the clone,
+  `LOTUS_OBS=1`, `HALE_DNA_NODE`, `HALE_DNA_INSTANCE`,
+  `HALE_DNA_EXPRESSION`) and appends `instance.up` as `node/<name>`:
+  node, instance, revision, model hash, build digest, pid. An instance
+  that exits appends `instance.exited` with its code. The expression
+  identity per instance is therefore reported by the node that
+  expresses it and joined to the plan by instance id. The node decides
+  nothing. `.hale/node/<name>/<instance>.pid` is the only local state.
+- **The window is over every touched instance.** After an apply's
+  deploy row the host waits for every touched instance's `instance.up`
+  at the revision (180 s to settle), then for the observation window
+  with no `instance.exited` at the revision among them. All up and
+  none exited: `Observation healthy` with the model hash the instances
+  reported. One exited: `expression.crashed` naming the instance and
+  its node, `Observation crashed` with the same detail, and the
+  organization rolls back — a rollback deploy row touching the same
+  instances, which every node answers. Never up: `expression.crashed`
+  "never expressed by …" and `Observation build_failed`.
+- **`hale dna fleet`** renders what the fleet expresses from the
+  record: every instance of the plan, its node, whether it is up, the
+  revision and model hash it last came up at, and the last deploy.
+
+What is deliberately not here yet: a fleet-level semantic diff (a
+Review's diff is the edited seed's; the deploy row names the instances
+it reaches), pressure raised from services' typed metrics (`hale dna
+pressure raise` is the spelling; nothing raises it for a node), and
+the organization as an instance of its own plan.
 

--- a/spec/verification.md
+++ b/spec/verification.md
@@ -1032,6 +1032,21 @@ A repository usually has more than one, and checking whichever one
 somebody remembered to name is the same partial-coverage problem
 `--matrix` solves for entrypoints. Every fleet runs even when an
 earlier one fails, and the exit status is the worst of them.
+`--in <dir>` checks the fleets another workspace declares (a
+candidate's worktree); `--if-declared` makes a workspace that declares
+none a success that says so, for a step that runs on every workspace.
+
+**Schema 1.2 (GH #566 F5): seeds and nodes.** An instance may name a
+`seed` — a directory relative to the plan — instead of an `artifact`;
+composition then cuts the artifact from the seed first (`hale check
+<seed> --dump-topology`, into `.hale/fleet/<plan>/<id>.topology.json`
+beside the plan), so the plan can describe the workspace's own
+services and a change is checked as the fleet it would deploy. A seed
+that does not check is an instance with no admissible artifact; an
+instance with neither is a plan that cannot be formed. An instance may
+also name the `node` that expresses it (`hale node <name>`,
+`spec/dna.md`); composition ignores it. `[dna] fleet = "<name>"` in
+`hale.toml` names which declared fleet the DNA expresses.
 
 `[fleets]` and `[environments]` are **separate axes** and a workspace
 may declare both. An environment binds law to an ENTRYPOINT at the


### PR DESCRIPTION
Part of #566 (Phase 3, F5). Stacked on #571.

The genome's topology is the fleet plan Hale already checks, and the DNA expresses one arrangement of it. Nothing about the process runs inside the services.

**Plan schema 1.2.** An instance may name a `seed` (relative to the plan) instead of an `artifact`; composition cuts the artifact from the seed first, so a candidate is checked as the fleet it would deploy. An instance may name the `node` that expresses it. `hale fleet check --in <dir>` checks another workspace's declared fleets and `--if-declared` makes a workspace with none a success that says so. `[dna] fleet = "<name>"` in `hale.toml` names the fleet the DNA expresses.

**The fleet is evidence.** Verification runs the fleet on every candidate (`evidence.fleet`, `fleet_clean`). A change to one service that breaks a claim the fleet makes over all of them is `mutation.deny` with the witness in the receipt. A candidate whose diff names a plan or the manifest is re-classed `topology` (`mutation.topology`) whatever it was asked as, and `OrgPolicy` sends it to the Board.

**`hale node <name>`** runs in a clone of the governed repository. Every tick it syncs the record, reads the latest `fleet.deploy`, and when that names a revision it does not express, fetches it (`refs/dna/revisions/<rev>`), checks it out, builds and restarts the instances the plan assigns to the node that the deploy touches, and reports `instance.up` (node, instance, revision, model hash, build digest, pid) and `instance.exited` (code) in its own name. The expression identity per instance is reported by the node that expresses it and joined to the plan by instance id. The node decides nothing.

**Deploy rows and the window.** Under `hale dna run` with a fleet named, the host answers an application's restart request with a `fleet.deploy` row (plan, revision, seed, the instances touched, reason) and watches the window over every touched instance: all up at the revision and none exited is `healthy` with the model hash they reported; one exited is `expression.crashed` naming the instance and its node, `Observation crashed`, and the organization's rollback is another deploy row every node answers. `hale dna deploy <revision>` and `hale dna rollback <mutation>` write the same rows by hand. `hale dna fleet` renders what the fleet expresses from the record.

**Tests.** `dna_fleet`: two node clones of one origin, an API with two instances; an approval redeploys both, both report one model hash, the window retains, edge-1 is at the candidate. Killing api-1 inside the window: `expression.crashed` says `instance api-1 on edge-2 exited`, the organization rolls back, the rollback deploy row touches both, both come back at the base, edge-2 is at the base, nothing retained. `fleet_seed_instances`: schema 1.2 composition, `--in` / `--if-declared`, the refusals (no artifact and no seed; a seed that does not check).

**Not in this PR, said in the spec.** A fleet-level semantic diff (a Review's diff is the edited seed's; the deploy row names the instances it reaches), pressure raised from services' typed metrics, and the organization as an instance of its own plan.

Spec: `spec/dna.md` "The fleet" and the event kinds; `spec/verification.md` schema 1.2. Book: the multi-binary chapter. CHANGELOG under Unreleased. Corpus baseline regenerated for the harvested drivers.

Suites: `hale test dna` 17 passed; the DNA CLI suites 24 passed; the fleet suites 57 passed; the five harvest binaries and `hale fmt --check .` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
