### PR TITLE
dna: the surface — hale dna ui from the record alone (GH #566 F6, part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ behavior.
 
 ## Unreleased
 
+### DNA: the surface (GH #566 F6)
+
+- `hale dna ui [project] [--port N]`: the DNA surface in a browser, from the record alone — a Hale program (`dna/ui`, embedded in the toolchain beside the core and the membrane client) that answers every request by running one offline verb of `hale dna` in the project root: the status projection, the Board's queue, the pending Reviews and a Review's three views, the fleet, the history, pressure; verdicts, intent and pressure signals from forms go the way the CLI's do (onto the membrane when one is bound here, into the record otherwise). Path segments reaching the CLI are cleaned, so a request cannot name a file or a flag. `hale dna review <id> <verdict> --no-wait` sends a verdict without waiting for the answer. Test: `dna_ui` (no organization anywhere: the page, the API from the record, a verdict from the form landing as a `review.verdict` row in the reviewer's name, an intent, the refusals).
+
 ### DNA: the fleet is the expression (GH #566 F5)
 
 - Fleet plan schema 1.2: an instance may name a `seed` (relative to the plan) instead of an `artifact` — composition cuts the artifact from the seed first — and the `node` that expresses it. `hale fleet check --in <dir>` checks another workspace's declared fleets; `--if-declared` makes a workspace with none a success that says so. `[dna] fleet = "<name>"` in `hale.toml` names the fleet the DNA expresses.

--- a/crates/hale-cli/src/dna.rs
+++ b/crates/hale-cli/src/dna.rs
@@ -1434,15 +1434,8 @@ fn ui_cmd(args: &[String]) -> ExitCode {
     let run = || -> Result<i32, String> {
         let (root, _) = project(&dir)?;
         let cache = hale_iris::materialize().map_err(|e| format!("cannot materialize the toolchain cache: {e}"))?;
-        let bin = cache.join(hale_dna::UI_BIN);
+        let bin = crate::iris::ensure_built_in(&cache, hale_dna::UI_SEED, hale_dna::UI_BIN, "the surface")?;
         let me = std::env::current_exe().map_err(|e| e.to_string())?;
-        if !bin.is_file() {
-            eprintln!("hale dna ui: building the surface ({})", cache.join(hale_dna::UI_SEED).display());
-            let st = Command::new(&me).arg("build").arg(cache.join(hale_dna::UI_SEED)).stdout(std::process::Stdio::null()).status().map_err(|e| e.to_string())?;
-            if !st.success() || !bin.is_file() {
-                return Err("building the DNA surface failed".into());
-            }
-        }
         let _ = sync_record(&root);
         let st = Command::new(&bin).arg(&port).arg(cache.join(hale_dna::UI_HTML.path)).current_dir(&root).env("HALE_BIN", &me).status().map_err(|e| format!("hale dna ui: {e}"))?;
         Ok(st.code().unwrap_or(1))
@@ -1971,34 +1964,7 @@ fn ask(args: &[String]) -> Result<Vec<String>, String> {
 /// attached iris.
 fn publish_on_membrane(root: &Path, kind: &str, body: &str) -> Result<(), String> {
     let cache = hale_iris::materialize().map_err(|e| format!("cannot materialize the toolchain cache: {e}"))?;
-    let bin = cache.join(hale_dna::MEMBRANE_BIN);
-    let me = std::env::current_exe().map_err(|e| e.to_string())?;
-    // One build per cache, under the cache's lock — taken BEFORE the
-    // existence check: the linker creates the output before it is
-    // complete or executable, and two verdicts racing here exec'd a
-    // half-written file (`membrane client: Permission denied`).
-    let lock_path = cache.join(".build.lock");
-    let lock = std::fs::OpenOptions::new().create(true).write(true).open(&lock_path).map_err(|e| format!("cannot open {}: {e}", lock_path.display()))?;
-    {
-        use std::os::unix::io::AsRawFd;
-        // SAFETY: flock on a descriptor we own for the block's lifetime.
-        unsafe {
-            libc::flock(lock.as_raw_fd(), libc::LOCK_EX);
-        }
-        if !bin.is_file() {
-            eprintln!("hale dna: building the membrane client ({})", cache.join(hale_dna::MEMBRANE_SEED).display());
-            let st = Command::new(&me).arg("build").arg(cache.join(hale_dna::MEMBRANE_SEED)).stdout(std::process::Stdio::null()).status().map_err(|e| e.to_string())?;
-            if !st.success() || !bin.is_file() {
-                unsafe {
-                    libc::flock(lock.as_raw_fd(), libc::LOCK_UN);
-                }
-                return Err("building the membrane client failed".into());
-            }
-        }
-        unsafe {
-            libc::flock(lock.as_raw_fd(), libc::LOCK_UN);
-        }
-    }
+    let bin = crate::iris::ensure_built_in(&cache, hale_dna::MEMBRANE_SEED, hale_dna::MEMBRANE_BIN, "the membrane client")?;
     let dna_dir = root.join(".hale/dna");
     let conf = std::env::temp_dir().join(format!("hale-dna-membrane-{}.conf", std::process::id()));
     fs::write(

--- a/crates/hale-cli/src/dna.rs
+++ b/crates/hale-cli/src/dna.rs
@@ -76,6 +76,7 @@ pub fn run(args: &[String]) -> ExitCode {
         Some("pressure") => report(pressure(&args[1..])),
         Some("github") => report(github_cmd(&args[1..])),
         Some("fleet") => report(fleet_cmd(&args[1..])),
+        Some("ui") => ui_cmd(&args[1..]),
         Some("deploy") => report(deploy_cmd(&args[1..], false)),
         Some("rollback") => report(deploy_cmd(&args[1..], true)),
         Some("review") => report(review(&args[1..])),
@@ -112,9 +113,12 @@ fn usage(code: u8) -> ExitCode {
     eprintln!("                                    (`[dna] fleet = \"<name>\"` in hale.toml names the plan; `hale node <name>` runs a node)");
     eprintln!("       hale dna pressure [raise <source> <what…>]");
     eprintln!("                                    pressure raised and answered; `raise` publishes one signal on the membrane");
+    eprintln!("       hale dna ui [project] [--port N]");
+    eprintln!("                                    the DNA surface in a browser, from the record alone: the Board's queue, the Reviews");
+    eprintln!("                                    with their three views, the fleet, the history; verdicts, intent and pressure from forms");
     eprintln!("       hale dna review              the pending Reviews");
     eprintln!("       hale dna review <id> [--iris] render a Review: source diff, semantic diff, evidence (works offline)");
-    eprintln!("       hale dna review <id> approve|revise|reject|abstain [--as <reviewer>] [--authority <a>] [--comment <c>] [--digest <sha>]");
+    eprintln!("       hale dna review <id> approve|revise|reject|abstain [--as <reviewer>] [--authority <a>] [--comment <c>] [--digest <sha>] [--no-wait]");
     eprintln!("                                    send a verdict over the membrane; the Review decides");
     if code == 0 {
         ExitCode::SUCCESS
@@ -1403,6 +1407,55 @@ pub(crate) fn fleet_window(root: &Path, rev: &str, touched: &[String], deploy_se
     }
 }
 
+/// `hale dna ui [project] [--port N]`: the DNA surface in a browser,
+/// from the record alone (GH #566 F6) — a Hale HTTP server over the
+/// offline verbs of `hale dna`, built once into the toolchain cache
+/// beside the core, run in the project root with this toolchain.
+fn ui_cmd(args: &[String]) -> ExitCode {
+    let mut dir = PathBuf::from(".");
+    let mut port = "8790".to_string();
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--port" => match it.next() {
+                Some(p) => port = p.clone(),
+                None => {
+                    eprintln!("hale dna ui: --port needs a value");
+                    return ExitCode::from(2);
+                }
+            },
+            f if f.starts_with("--") => {
+                eprintln!("hale dna ui: unknown flag `{f}`");
+                return ExitCode::from(2);
+            }
+            p => dir = PathBuf::from(p),
+        }
+    }
+    let run = || -> Result<i32, String> {
+        let (root, _) = project(&dir)?;
+        let cache = hale_iris::materialize().map_err(|e| format!("cannot materialize the toolchain cache: {e}"))?;
+        let bin = cache.join(hale_dna::UI_BIN);
+        let me = std::env::current_exe().map_err(|e| e.to_string())?;
+        if !bin.is_file() {
+            eprintln!("hale dna ui: building the surface ({})", cache.join(hale_dna::UI_SEED).display());
+            let st = Command::new(&me).arg("build").arg(cache.join(hale_dna::UI_SEED)).stdout(std::process::Stdio::null()).status().map_err(|e| e.to_string())?;
+            if !st.success() || !bin.is_file() {
+                return Err("building the DNA surface failed".into());
+            }
+        }
+        let _ = sync_record(&root);
+        let st = Command::new(&bin).arg(&port).arg(cache.join(hale_dna::UI_HTML.path)).current_dir(&root).env("HALE_BIN", &me).status().map_err(|e| format!("hale dna ui: {e}"))?;
+        Ok(st.code().unwrap_or(1))
+    };
+    match run() {
+        Ok(code) => ExitCode::from(code.clamp(0, 255) as u8),
+        Err(e) => {
+            eprintln!("hale dna ui: {e}");
+            ExitCode::from(1)
+        }
+    }
+}
+
 /// `hale dna fleet`: what the fleet expresses, from the record — every
 /// instance of the plan, its node, the revision and model hash it last
 /// came up at, whether it is up, and the deploy that asked.
@@ -1984,9 +2037,11 @@ fn review(args: &[String]) -> Result<Vec<String>, String> {
     let mut comment = String::new();
     let mut digest_override: Option<String> = None;
     let mut iris = false;
+    let mut no_wait = false;
     let mut it = args.iter();
     while let Some(a) = it.next() {
         match a.as_str() {
+            "--no-wait" => no_wait = true,
             "--as" => reviewer = it.next().cloned().ok_or("--as needs a reviewer")?,
             "--authority" => authority = it.next().cloned().ok_or("--authority needs a value")?,
             "--comment" => comment = it.next().cloned().ok_or("--comment needs text")?,
@@ -2053,6 +2108,9 @@ fn review(args: &[String]) -> Result<Vec<String>, String> {
         // beside the organism relays it, and the Review answers in the record
         append_journal(&root, "review.verdict", &id, &body)?;
         sync_record(&root)?;
+    }
+    if no_wait {
+        return Ok(vec![format!("verdict {verdict} on {id} by {reviewer} sent {}; the Review answers in the record", if local { "over the membrane" } else { "into the record" })]);
     }
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(if local { 10 } else { 60 });
     loop {
@@ -2359,12 +2417,12 @@ fn pascal(s: &str) -> String {
 
 fn purpose_hl(text: &str) -> String {
     format!(
-        r#"// dna/purpose.hl — the declared purpose (project-owned).
+        r#"// dna/org/purpose.hl — the declared purpose (project-owned).
 //
 // The first governed workflow is the baseline review: the Review
-// named `purpose` in dna/assembly.hl ratifies THIS text (its
-// subject digest is the sha256 of PURPOSE). Change the text and the
-// Review's digest together, or the verdict is refused as stale.
+// named `purpose` ratifies THIS text (its subject digest is the
+// sha256 of PURPOSE). Change the text and the Review's digest
+// together, or the verdict is refused as stale.
 
 const PURPOSE: String = "{}";
 

--- a/crates/hale-cli/src/iris.rs
+++ b/crates/hale-cli/src/iris.rs
@@ -28,9 +28,19 @@ use std::process::{Command, ExitCode, Stdio};
 /// Returns the binary path.
 fn ensure_built(seed: &str, bin: &str) -> Result<(PathBuf, PathBuf), String> {
     let root = hale_iris::materialize().map_err(|e| format!("hale iris: cannot materialize sources: {e}"))?;
+    let bin_path = ensure_built_in(&root, seed, bin, "the observer")?;
+    Ok((root, bin_path))
+}
+
+/// Build `seed` under the materialized cache `root` once, under the
+/// cache's build lock, and return its binary. The DNA's membrane client
+/// and surface share the cache with the observer and build the same
+/// way (GH #566 F7: two commands racing to build one binary exec'd a
+/// half-written file — `Permission denied`).
+pub(crate) fn ensure_built_in(root: &Path, seed: &str, bin: &str, what: &str) -> Result<PathBuf, String> {
     let bin_path = root.join(bin);
     if bin_path.is_file() {
-        return Ok((root, bin_path));
+        return Ok(bin_path);
     }
     // One build per cache, ever: two `hale iris` (or a test shard's
     // five) racing to build the same seed into the same directory
@@ -44,10 +54,10 @@ fn ensure_built(seed: &str, bin: &str) -> Result<(PathBuf, PathBuf), String> {
         .map_err(|e| format!("hale iris: cannot open {}: {e}", lock_path.display()))?;
     let _guard = BuildLock::acquire(&lock);
     if bin_path.is_file() {
-        return Ok((root, bin_path));
+        return Ok(bin_path);
     }
     let me = std::env::current_exe().map_err(|e| format!("hale iris: cannot locate the hale binary: {e}"))?;
-    eprintln!("hale iris: building the observer ({} @ {})", seed, root.display());
+    eprintln!("hale iris: building {what} ({} @ {})", seed, root.display());
     let status = Command::new(&me)
         .arg("build")
         .arg(root.join(seed))
@@ -61,7 +71,7 @@ fn ensure_built(seed: &str, bin: &str) -> Result<(PathBuf, PathBuf), String> {
     if !bin_path.is_file() {
         return Err(format!("hale iris: build produced no binary at {}", bin_path.display()));
     }
-    Ok((root, bin_path))
+    Ok(bin_path)
 }
 
 /// An exclusive advisory lock held for the build; released on drop.

--- a/crates/hale-cli/src/iris.rs
+++ b/crates/hale-cli/src/iris.rs
@@ -39,13 +39,13 @@ fn ensure_built(seed: &str, bin: &str) -> Result<(PathBuf, PathBuf), String> {
 /// half-written file — `Permission denied`).
 pub(crate) fn ensure_built_in(root: &Path, seed: &str, bin: &str, what: &str) -> Result<PathBuf, String> {
     let bin_path = root.join(bin);
-    if bin_path.is_file() {
-        return Ok(bin_path);
-    }
     // One build per cache, ever: two `hale iris` (or a test shard's
     // five) racing to build the same seed into the same directory
     // would trample each other's objects. An exclusive flock on the
     // cache root serializes them; the loser finds the binary built.
+    // The lock is taken BEFORE the existence check: the linker creates
+    // the output before it is complete or executable, and a caller
+    // that saw the file and exec'd it got `Permission denied`.
     let lock_path = root.join(".build.lock");
     let lock = std::fs::OpenOptions::new()
         .create(true)

--- a/crates/hale-cli/tests/dna_ui.rs
+++ b/crates/hale-cli/tests/dna_ui.rs
@@ -1,0 +1,143 @@
+//! GH #566 F6 — `hale dna ui`: the DNA surface from the record alone.
+//! No organization runs here; the page and its API answer from the
+//! record through the CLI's offline verbs, and a verdict from the
+//! form becomes a `review.verdict` row in the record, as the CLI's
+//! would.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn git(args: &[&str], cwd: &Path) -> String {
+    let out = Command::new("git").args(["-c", "user.name=riley", "-c", "user.email=r@l"]).args(args).current_dir(cwd).output().expect("git");
+    assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn http(port: u16, method: &str, path: &str, body: &str) -> Option<String> {
+    let mut s = TcpStream::connect_timeout(&format!("127.0.0.1:{port}").parse().unwrap(), Duration::from_secs(2)).ok()?;
+    let _ = s.set_read_timeout(Some(Duration::from_secs(30)));
+    let req = format!("{method} {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len());
+    s.write_all(req.as_bytes()).ok()?;
+    let mut out = String::new();
+    let _ = s.read_to_string(&mut out);
+    Some(out)
+}
+
+const DRIVER: &str = r#"import "vendor/dna" as dna;
+
+fn main() {
+    let cur = std::io::fs::read_file("main.hl") or "";
+    let core = dna::Dna {
+        journal: dna::GitJournal { repo: "." },
+        gateway: dna::MutationGateway {
+            leases: dna::GitLeases { repo: "." },
+            workspaces: dna::IsolatedWorktrees { repo: ".", root: ".hale/dna/worktrees" },
+            repo: dna::LocalGit { repo: "." }
+        },
+        verification: dna::HaleVerification { receipts: dna::GitReceipts { repo: "." }, scratch: ".hale/dna/scratch", repo: ".", seed: "." },
+        editor: dna::SourceEditor {
+            name: "editor",
+            models: dna::ModelRouter {
+                quick: dna::FakeModel { name: "quick", answer: cur + "// documented for the surface\n" },
+                deep: dna::FakeModel { name: "deep", answer: "docs_coverage +" }
+            }
+        },
+        review_policy: dna::OrgPolicy { },
+        membrane: dna::Board { who: "board" },
+        boundary: dna::AutonomyBoundary { child: "uiapp", grant: dna::Grant { child: "uiapp", classes: "docs refactor", max_magnitude: 4, review: "pre" } }
+    };
+    println(core.mutate("t0", "docs", "document the entrypoint in main.hl", "main.hl", 1));
+}
+"#;
+
+#[test]
+fn the_surface_serves_the_record_and_a_verdict_from_the_form_lands_in_it() {
+    let d = std::env::temp_dir().join(format!("hale_dna_ui_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).unwrap();
+    let cache = std::env::temp_dir().join("hale-tests-iris-cache");
+    let hale = |args: &[&str], cwd: &Path| -> (bool, String) {
+        let out = Command::new(env!("CARGO_BIN_EXE_hale")).args(args).current_dir(cwd).env("HALE_BIN", env!("CARGO_BIN_EXE_hale")).env("XDG_CACHE_HOME", &cache).output().expect("hale");
+        (out.status.success(), format!("{}{}", String::from_utf8_lossy(&out.stdout), String::from_utf8_lossy(&out.stderr)))
+    };
+    let (ok, out) = hale(&["dna", "new", "uiapp"], &d);
+    assert!(ok, "{out}");
+    let app: PathBuf = d.join("uiapp");
+    let bare = d.join("origin.git");
+    git(&["init", "-q", "--bare", "-b", "main", &bare.to_string_lossy()], &d);
+    git(&["config", "user.name", "riley"], &app);
+    git(&["config", "user.email", "r@l"], &app);
+    git(&["add", "-A"], &app);
+    git(&["commit", "-q", "-m", "the app"], &app);
+    git(&["remote", "add", "origin", &bare.to_string_lossy()], &app);
+    git(&["push", "-q", "origin", "main", "refs/dna/*:refs/dna/*"], &app);
+    std::fs::create_dir_all(app.join("mutate")).unwrap();
+    std::fs::write(app.join("mutate/main.hl"), DRIVER).unwrap();
+    let (ok, out) = hale(&["run", "mutate"], &app);
+    assert!(ok && out.contains("m1: review"), "driver:\n{out}");
+    // the surface, with no organization anywhere
+    let port = TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap().port();
+    let mut ui = Command::new(env!("CARGO_BIN_EXE_hale"))
+        .args(["dna", "ui", ".", "--port", &port.to_string()])
+        .current_dir(&app)
+        .env("HALE_BIN", env!("CARGO_BIN_EXE_hale"))
+        .env("XDG_CACHE_HOME", &cache)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("hale dna ui");
+    let dl = Instant::now() + Duration::from_secs(120);
+    let mut page = None;
+    while Instant::now() < dl {
+        if let Some(p) = http(port, "GET", "/", "") {
+            if p.starts_with("HTTP/1.1 200") {
+                page = Some(p);
+                break;
+            }
+        }
+        if let Ok(Some(st)) = ui.try_wait() {
+            panic!("hale dna ui exited early: {st}");
+        }
+        std::thread::sleep(Duration::from_millis(300));
+    }
+    let stop = |ui: &mut std::process::Child| {
+        let _ = ui.kill();
+        let _ = ui.wait();
+    };
+    let Some(page) = page else {
+        stop(&mut ui);
+        panic!("the surface never answered on {port}");
+    };
+    assert!(page.contains("<title>hale dna</title>") && page.contains("/api/status"), "the page");
+    let status = http(port, "GET", "/api/status", "").unwrap_or_default();
+    assert!(status.contains("\"reviews\"") && status.contains("\"m1\"") && status.contains("reading the Journal"), "status from the record:\n{status}");
+    let reviews = http(port, "GET", "/api/reviews", "").unwrap_or_default();
+    assert!(reviews.contains("pending review(s)") && reviews.contains("m1 needs leader"), "{reviews}");
+    let review = http(port, "GET", "/api/review/m1", "").unwrap_or_default();
+    assert!(review.contains("source diff (git") && review.contains("evidence (") && review.contains("documented for the surface"), "the three views:\n{review}");
+    let board = http(port, "GET", "/api/board", "").unwrap_or_default();
+    assert!(board.starts_with("HTTP/1.1 200") && board.contains("purpose") && board.contains("leader: 1 review(s) inside the grant"), "{board}");
+    let fleet = http(port, "GET", "/api/fleet", "").unwrap_or_default();
+    assert!(fleet.contains("no `[dna] fleet"), "no fleet here, said plainly:\n{fleet}");
+    let history = http(port, "GET", "/api/history/m1", "").unwrap_or_default();
+    assert!(history.contains("mutation.candidate"), "{history}");
+    // a path cannot smuggle a flag or a file to the CLI
+    let smuggled = http(port, "GET", "/api/review/--iris", "").unwrap_or_default();
+    assert!(smuggled.contains("no `review.requested` for `-iris`") || smuggled.contains("no `review.requested`"), "{smuggled}");
+    // the verdict form: into the record, in the reviewer's name
+    let answer = http(port, "POST", "/api/verdict", r#"{"id":"m1","verdict":"reject","as":"riley","comment":"not like this"}"#).unwrap_or_default();
+    assert!(answer.contains("verdict reject on m1 by riley sent into the record"), "{answer}");
+    let rows = Command::new("git").args(["-C", &app.to_string_lossy(), "show", "refs/dna/journal:journal.jsonl"]).output().unwrap();
+    let rows = String::from_utf8_lossy(&rows.stdout).to_string();
+    let verdict = rows.lines().find(|l| l.contains("\"kind\":\"review.verdict\"")).unwrap_or_else(|| panic!("a verdict row:\n{rows}"));
+    assert!(verdict.contains("\"author\":\"riley\"") && verdict.contains("reviewer") && verdict.contains("not like this") && verdict.contains("reject"), "{verdict}");
+    let ask = http(port, "POST", "/api/ask", r#"{"outcome":"greet twice","to":""}"#).unwrap_or_default();
+    assert!(ask.contains("requested in the record"), "{ask}");
+    let bad = http(port, "POST", "/api/ask", r#"{"outcome":""}"#).unwrap_or_default();
+    assert!(bad.starts_with("HTTP/1.1 400"), "{bad}");
+    stop(&mut ui);
+    let _ = std::fs::remove_dir_all(&d);
+}

--- a/crates/hale-dna/src/lib.rs
+++ b/crates/hale-dna/src/lib.rs
@@ -57,6 +57,20 @@ pub const MEMBRANE_CLIENT: EmbeddedFile = EmbeddedFile {
 pub const MEMBRANE_SEED: &str = "dna/membrane";
 pub const MEMBRANE_BIN: &str = "dna/membrane/membrane";
 
+/// The DNA surface (`dna/ui`, GH #566 F6): an HTTP server over the
+/// offline verbs of `hale dna`, from the record alone. `hale dna ui`
+/// builds and execs it from the toolchain cache.
+pub const UI_MAIN: EmbeddedFile = EmbeddedFile {
+    path: "dna/ui/main.hl",
+    content: include_str!("../../../dna/ui/main.hl"),
+};
+pub const UI_HTML: EmbeddedFile = EmbeddedFile {
+    path: "dna/ui/index.html",
+    content: include_str!("../../../dna/ui/index.html"),
+};
+pub const UI_SEED: &str = "dna/ui";
+pub const UI_BIN: &str = "dna/ui/ui";
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,5 +95,6 @@ mod tests {
             assert!(!f.content.is_empty(), "{} is empty", f.path);
         }
         assert!(MEMBRANE_CLIENT.content.contains("main locus Client"));
+        assert!(UI_MAIN.content.contains("std::http::Server") && UI_HTML.content.contains("<title>hale dna</title>"));
     }
 }

--- a/crates/hale-iris/src/lib.rs
+++ b/crates/hale-iris/src/lib.rs
@@ -53,6 +53,8 @@ pub fn all_files() -> impl Iterator<Item = (&'static str, &'static str)> {
         .map(|f| (f.path, f.content))
         .chain(hale_dna::FILES.iter().map(|f| (f.path, f.content)))
         .chain(std::iter::once((hale_dna::MEMBRANE_CLIENT.path, hale_dna::MEMBRANE_CLIENT.content)))
+        .chain(std::iter::once((hale_dna::UI_MAIN.path, hale_dna::UI_MAIN.content)))
+        .chain(std::iter::once((hale_dna::UI_HTML.path, hale_dna::UI_HTML.content)))
 }
 
 /// The seed `hale build` compiles for `hale iris` (relative to the root).

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -5,6 +5,7 @@ crates/hale-cli/tests/dna_apply.rs#0 f2c1228edb650960
 crates/hale-cli/tests/dna_fleet.rs#0 f2c1228edb650960
 crates/hale-cli/tests/dna_github_membrane.rs#0 f2c1228edb650960
 crates/hale-cli/tests/dna_review.rs#0 f2c1228edb650960
+crates/hale-cli/tests/dna_ui.rs#0 f2c1228edb650960
 crates/hale-cli/tests/doc.rs#0 a9238ad19f21c0ec
 crates/hale-cli/tests/effects_manifest.rs#0 0a8481ef56eab005
 crates/hale-cli/tests/effects_manifest.rs#1 e91db4ab4aed156e

--- a/dna/ui/index.html
+++ b/dna/ui/index.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>hale dna</title>
+<style>
+  :root { --bg: #fbfaf7; --fg: #1f1d1a; --mute: #6b665e; --line: #e2ddd3; --card: #ffffff; --accent: #2f5d50; --warn: #8a4b1f; }
+  @media (prefers-color-scheme: dark) { :root { --bg: #16150f; --fg: #ece7dc; --mute: #9c968a; --line: #2c2a24; --card: #1e1d17; --accent: #8fc7b4; --warn: #e0a06b; } }
+  body { margin: 0; padding-block: 0; padding-inline: 16px; background: var(--bg); color: var(--fg); font: 14px/1.45 ui-sans-serif, system-ui, sans-serif; }
+  header { display: flex; flex-wrap: wrap; gap: 12px 24px; align-items: baseline; padding: 14px 0; border-bottom: 1px solid var(--line); }
+  header h1 { font-size: 16px; margin: 0; }
+  header .mute { color: var(--mute); }
+  main { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 16px; padding: 16px 0 40px; max-width: 1400px; }
+  @media (max-width: 900px) { main { grid-template-columns: minmax(0, 1fr); } }
+  section { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; min-width: 0; }
+  section.wide { grid-column: 1 / -1; }
+  h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: var(--mute); margin: 0 0 8px; }
+  pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12.5px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; overflow-x: auto; }
+  ul.reviews { list-style: none; margin: 0; padding: 0; }
+  ul.reviews li { padding: 6px 0; border-top: 1px solid var(--line); cursor: pointer; }
+  ul.reviews li:first-child { border-top: 0; }
+  ul.reviews li.open { color: var(--accent); }
+  form { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-top: 10px; }
+  input, select, textarea, button { font: inherit; color: inherit; background: var(--bg); border: 1px solid var(--line); border-radius: 6px; padding: 5px 8px; }
+  textarea { width: 100%; min-height: 56px; }
+  button { cursor: pointer; border-color: var(--accent); }
+  .answer { color: var(--warn); margin-top: 6px; white-space: pre-wrap; }
+  .tag { color: var(--mute); font-size: 12px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>hale dna</h1>
+  <span id="organism" class="mute">reading the record…</span>
+  <span id="journal" class="mute"></span>
+  <span id="expression" class="mute"></span>
+</header>
+<main>
+  <section class="wide">
+    <h2>Board</h2>
+    <pre id="board">…</pre>
+  </section>
+  <section>
+    <h2>Reviews</h2>
+    <ul id="reviews" class="reviews"></ul>
+    <form id="verdict">
+      <span class="tag">verdict on <b id="review-id">—</b></span>
+      <select name="verdict"><option>approve</option><option>revise</option><option>reject</option><option>abstain</option></select>
+      <input name="as" placeholder="as (your name)" size="14">
+      <input name="comment" placeholder="comment" size="28">
+      <button type="submit">send</button>
+    </form>
+    <div id="verdict-answer" class="answer"></div>
+  </section>
+  <section>
+    <h2>Review</h2>
+    <pre id="review">pick a Review</pre>
+  </section>
+  <section>
+    <h2>Fleet</h2>
+    <pre id="fleet">…</pre>
+  </section>
+  <section>
+    <h2>Ask</h2>
+    <form id="ask">
+      <textarea name="outcome" placeholder="what should happen"></textarea>
+      <input name="to" placeholder="to (a locus, optional)" size="18">
+      <button type="submit">offer intent</button>
+    </form>
+    <div id="ask-answer" class="answer"></div>
+    <h2 style="margin-top:14px">Pressure</h2>
+    <form id="pressure">
+      <input name="source" placeholder="source" size="14">
+      <input name="what" placeholder="what it saw" size="30">
+      <button type="submit">raise</button>
+    </form>
+    <div id="pressure-answer" class="answer"></div>
+  </section>
+  <section class="wide">
+    <h2>History</h2>
+    <pre id="history">…</pre>
+  </section>
+</main>
+<script>
+(function () {
+  var $ = function (id) { return document.getElementById(id); };
+  var open = null;
+  function get(path) { return fetch(path, { cache: 'no-store' }).then(function (r) { return r.text(); }); }
+  function post(path, body) {
+    return fetch(path, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }).then(function (r) { return r.text(); });
+  }
+  function refresh() {
+    get('/api/status').then(function (t) {
+      var s; try { s = JSON.parse(t); } catch (e) { $('organism').textContent = t.slice(0, 200); return; }
+      $('organism').textContent = s.organism || '';
+      $('journal').textContent = s.journal ? ('record: ' + s.journal.revision + ' event(s), chain ' + s.journal.chain) : '';
+      var e = s.expression || {};
+      $('expression').textContent = e.current && e.current.shape_hash ? ('expression: ' + String(e.current.shape_hash).slice(0, 12)) : '';
+      var ul = $('reviews'); ul.innerHTML = '';
+      (s.reviews || []).slice().reverse().forEach(function (r) {
+        var li = document.createElement('li');
+        li.textContent = r.id + ' [' + r.state + '] ' + (r.state === 'pending' ? ('needs ' + r.required_authority + ' — ' + r.question) : ('settled ' + (r.settled || '')));
+        if (r.id === open) li.className = 'open';
+        li.onclick = function () { open = r.id; $('review-id').textContent = r.id; showReview(); refresh(); };
+        ul.appendChild(li);
+      });
+      if (!ul.children.length) ul.innerHTML = '<li class="tag">no Reviews in the record</li>';
+    }).catch(function (err) { $('organism').textContent = 'no answer from hale dna ui: ' + err; });
+    get('/api/board').then(function (t) { $('board').textContent = t; });
+    get('/api/fleet').then(function (t) { $('fleet').textContent = t; });
+    get('/api/history').then(function (t) { $('history').textContent = t.split('\n').slice(-40).join('\n'); });
+    if (open) showReview();
+  }
+  function showReview() { get('/api/review/' + encodeURIComponent(open)).then(function (t) { $('review').textContent = t; }); }
+  $('verdict').onsubmit = function (ev) {
+    ev.preventDefault();
+    if (!open) { $('verdict-answer').textContent = 'pick a Review first'; return; }
+    var f = ev.target;
+    post('/api/verdict', { id: open, verdict: f.verdict.value, as: f.as.value, comment: f.comment.value }).then(function (t) { $('verdict-answer').textContent = t; setTimeout(refresh, 1500); });
+  };
+  $('ask').onsubmit = function (ev) {
+    ev.preventDefault();
+    var f = ev.target;
+    post('/api/ask', { outcome: f.outcome.value, to: f.to.value }).then(function (t) { $('ask-answer').textContent = t; f.outcome.value = ''; setTimeout(refresh, 1500); });
+  };
+  $('pressure').onsubmit = function (ev) {
+    ev.preventDefault();
+    var f = ev.target;
+    post('/api/pressure', { source: f.source.value, what: f.what.value }).then(function (t) { $('pressure-answer').textContent = t; setTimeout(refresh, 1500); });
+  };
+  refresh();
+  setInterval(refresh, 4000);
+})();
+</script>
+</body>
+</html>

--- a/dna/ui/main.hl
+++ b/dna/ui/main.hl
@@ -1,0 +1,113 @@
+// dna/ui — `hale dna ui`: the DNA surface, from the record alone
+// (GH #566 F6).
+//
+// A small HTTP server over the offline verbs of `hale dna`. Every
+// request runs one command in the project root and returns what it
+// printed, so the page shows exactly what the CLI shows — the Board's
+// queue, the pending Reviews with their three views, the fleet, the
+// history — with or without an organization up. A verdict or an
+// intent from the page goes the way the CLI's does: onto the membrane
+// when one is bound here, into the record otherwise. Nothing here
+// reads the record itself; nothing here decides.
+//
+//   ui <port> <index.html>      (HALE_BIN names the toolchain; cwd is the project)
+
+fn hale_bin() -> String {
+    if std::env::var_exists("HALE_BIN") { return std::env::var("HALE_BIN"); }
+    return "hale";
+}
+
+// argv as `std::process::run` takes it: newline-separated.
+fn run_failed(e: IoError) -> std::process::ProcessOutput {
+    return std::process::ProcessOutput { code: -1, signal: 0, stdout: "", stderr: e.kind };
+}
+
+fn dna(args: String) -> String {
+    let out = std::process::run(hale_bin() + "\ndna\n" + args) or run_failed(err);
+    if out.code == 0 { return out.stdout; }
+    return out.stdout + out.stderr;
+}
+
+fn text(body: String) -> std::http::Response {
+    return std::http::Response { status: 200, content_type: "text/plain; charset=utf-8", headers: "Cache-Control: no-store", body: body };
+}
+
+// A path segment only: no separators, no flags, so a request cannot
+// name a file or a flag to the CLI.
+fn clean(s: String) -> String {
+    let mut out = "";
+    let mut p = 0;
+    let n = len(s);
+    while p < n {
+        let ch = s[p..(p + 1)];
+        if ch != "/" && ch != "\n" && ch != " " && ch != "\\" && !(p == 0 && ch == "-") { out = out + ch; }
+        p = p + 1;
+    }
+    return out;
+}
+
+locus Ui {
+    params {
+        html: String = "";
+        served: Int = 0;
+    }
+    fn handle(req: std::http::Request) -> std::http::Response {
+        self.served = self.served + 1;
+        let ctx = std::http::build_context(req);
+        if std::http::is_route(ctx, "GET", "/") {
+            let page = std::io::fs::read_file(self.html) or "<h1>hale dna ui: no page at " + self.html + "</h1>";
+            return std::http::Response { status: 200, content_type: "text/html; charset=utf-8", body: page };
+        }
+        if std::http::is_route(ctx, "GET", "/api/status") {
+            return std::http::Response { status: 200, content_type: "application/json", headers: "Cache-Control: no-store", body: dna("status\n--json") };
+        }
+        if std::http::is_route(ctx, "GET", "/api/board") { return text(dna("board")); }
+        if std::http::is_route(ctx, "GET", "/api/fleet") { return text(dna("fleet")); }
+        if std::http::is_route(ctx, "GET", "/api/pressure") { return text(dna("pressure")); }
+        if std::http::is_route(ctx, "GET", "/api/reviews") { return text(dna("review")); }
+        if std::http::is_route(ctx, "GET", "/api/review/:id") {
+            return text(dna("review\n" + clean(std::http::path_param(ctx.params, "id"))));
+        }
+        if std::http::is_route(ctx, "GET", "/api/history") { return text(dna("history")); }
+        if std::http::is_route(ctx, "GET", "/api/history/:entity") {
+            return text(dna("history\n" + clean(std::http::path_param(ctx.params, "entity"))));
+        }
+        // the forms: a verdict, an intent, a pressure signal — each is
+        // the CLI's own verb, sent and not waited for
+        if std::http::is_route(ctx, "POST", "/api/verdict") {
+            let b = req.body;
+            let id = clean(std::json::find_string_field(b, "id"));
+            let verdict = clean(std::json::find_string_field(b, "verdict"));
+            let who = clean(std::json::find_string_field(b, "as"));
+            let comment = std::json::find_string_field(b, "comment");
+            let mut args = "review\n" + id + "\n" + verdict + "\n--no-wait";
+            if len(who) > 0 { args = args + "\n--as\n" + who; }
+            if len(comment) > 0 { args = args + "\n--comment\n" + comment; }
+            return text(dna(args));
+        }
+        if std::http::is_route(ctx, "POST", "/api/ask") {
+            let b = req.body;
+            let outcome = std::json::find_string_field(b, "outcome");
+            let to = clean(std::json::find_string_field(b, "to"));
+            if len(outcome) == 0 { return std::http::Response { status: 400, body: "say what should happen" }; }
+            let mut args = "ask\n--no-wait";
+            if len(to) > 0 { args = args + "\n--to\n" + to; }
+            return text(dna(args + "\n" + outcome));
+        }
+        if std::http::is_route(ctx, "POST", "/api/pressure") {
+            let b = req.body;
+            let source = clean(std::json::find_string_field(b, "source"));
+            let what = std::json::find_string_field(b, "what");
+            if len(source) == 0 || len(what) == 0 { return std::http::Response { status: 400, body: "a source and what it saw" }; }
+            return text(dna("pressure\nraise\n" + source + "\n" + what));
+        }
+        return std::http::Response { status: 404, body: "not found" };
+    }
+}
+
+fn main() {
+    let port = std::str::parse_int(std::env::arg_or(1, "8790")) or 8790;
+    let html = std::env::arg_or(2, "index.html");
+    println("hale dna ui: http://127.0.0.1:", port, "/ (from the record; ctrl-c stops)");
+    std::http::Server { port: port, handler: Ui { html: html } };
+}

--- a/spec/dna.md
+++ b/spec/dna.md
@@ -260,6 +260,29 @@ one arrangement of it:
   record: every instance of the plan, its node, whether it is up, the
   revision and model hash it last came up at, and the last deploy.
 
+## The surface
+
+`hale dna ui [project] [--port N]` serves the DNA surface in a browser
+from the record alone: a Hale program (`dna/ui`, embedded in the
+toolchain like the core and the membrane client, built once into the
+toolchain cache) that answers every request by running one offline
+verb of `hale dna` in the project root and returning what it printed
+— the status projection (`/api/status`), the Board's queue
+(`/api/board`), the pending Reviews and one Review's three views
+(`/api/reviews`, `/api/review/<id>`), the fleet (`/api/fleet`), the
+history (`/api/history[/<entity>]`), pressure (`/api/pressure`). A
+verdict (`POST /api/verdict`), an intent (`POST /api/ask`) and a
+pressure signal (`POST /api/pressure`) are the CLI's own verbs sent
+and not waited for: onto the membrane when one is bound here, into
+the record otherwise, in the name the form gives. A path segment
+reaching the CLI is cleaned of separators and leading dashes, so a
+request cannot name a file or a flag. The surface reads nothing
+itself and decides nothing; with or without an organization up, it
+shows what the CLI shows. `hale dna review <id> <verdict> --no-wait`
+is the same non-blocking verdict from the terminal. Iris stays the
+observer: attached to the organization's process it renders the org
+as the live topology it is.
+
 What is deliberately not here yet: a fleet-level semantic diff (a
 Review's diff is the edited seed's; the deploy row names the instances
 it reaches), pressure raised from services' typed metrics (`hale dna


### PR DESCRIPTION
Part of #566 (Phase 3, F6). Stacked on #572. The docs half of F6 (the Book section and the site page, written for this shape) follows as its own PR.

**`hale dna ui [project] [--port N]`** serves the DNA surface in a browser from the record alone. It is a Hale program (`dna/ui`, embedded in the toolchain beside the core and the membrane client, built once into the toolchain cache) that answers every request by running one offline verb of `hale dna` in the project root and returning what it printed: the status projection, the Board's queue, the pending Reviews and a Review's three views, the fleet, the history, pressure. Verdicts, intent and pressure signals from the page's forms go the way the CLI's do: onto the membrane when one is bound here, into the record otherwise, in the name the form gives. Path segments that reach the CLI are cleaned of separators and leading dashes, so a request cannot name a file or a flag. The surface reads nothing itself and decides nothing; with or without an organization up, it shows what the CLI shows.

`hale dna review <id> <verdict> --no-wait` is the same non-blocking verdict from the terminal. Iris stays the observer: attached to the organization's process under `hale dna run` it renders the org as the live topology it is.

**Test.** `dna_ui`: no organization anywhere; the page, `/api/status` and `/api/review/m1` from the record, the Board's queue, the fleet's plain "no fleet here", a smuggled flag in a path refused, a verdict from the form landing as a `review.verdict` row authored by the reviewer, an intent requested in the record, an empty ask refused.

Spec: "The surface" in `spec/dna.md`. CHANGELOG under Unreleased. Corpus baseline regenerated for the harvested driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)