### PR TITLE
dna: the dogfood — one real change end to end on hosted models, and what it found (GH #566 F7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ behavior.
 
 ## Unreleased
 
+### DNA: the dogfood (GH #566 F7)
+
+- One real ask end to end on the acceptance chat server under `hale dna dev`, the editor on a hosted quick tier and the Leader on a hosted deep tier (Anthropic's OpenAI-compatible endpoint): the candidate proposed, verified, approved by the Leader with its reasoning, applied, restarted, observed healthy, retained — about 1.2¢ of model calls. What it found, fixed:
+  - a hosted model wraps the file it returns in a code fence however it is asked: the editor now takes the file inside the fence (`unfence`) and asks for plain text; `max_tokens` defaults to 4096 so a whole-file rewrite is not truncated (three 1024-token tries were);
+  - some models refuse `temperature` outright (HTTP 400): the hosted and local adapters send it only when set (`temperature_milli` < 0 is the provider's default; the evidence says `temperature=default`);
+  - the fitness assessor was asked about a change it could not see and answered at length; it now sees the objective and the files as edited, and only well-formed `<signal> <+|->` lines count;
+  - the Leader's reasoning was dropped at settlement: the deciding verdict's comment is now the `review.reasoned` row right after `review.settled` (a person's `--comment` too), rendered as `why:` by `hale dna review <id>` and carried in the status projection;
+  - a Mutation in flight when the organization stopped stayed `located` forever: rehydrate now fails it in the record (`in flight (located) when the organization stopped`) and removes its worktree;
+  - a quick editor rewriting a whole file drops comments it was not asked about (the Leader caught it and revised, with the reason on the record): the editor's prompt now says to change only what the objective requires and keep every other line.
+
 ### DNA: the Book section, written for the organization (GH #566 F6)
 
 - The Book gains a DNA section — a user guide (a governed codebase, getting started, working with it, the organization, operating the fleet, shaping it, what it will and won't do, troubleshooting) and an under-the-hood section (what init makes, the record, the host / the membrane / the nodes, the twelve steps with the record, the Review in detail, apply / express / observe, autonomy, models and credentials, reference) — every transcript from one real session on the demo application. The old single chapter under Systems is replaced; iris's chapter links the new section.

--- a/crates/hale-cli/src/dna.rs
+++ b/crates/hale-cli/src/dna.rs
@@ -1725,6 +1725,11 @@ fn status_projection(root: &Path) -> Result<Value, String> {
                     v["settled"] = Value::String(r.body.clone());
                 }
             }
+            "review.reasoned" => {
+                if let Some(v) = reviews.get_mut(&id) {
+                    v["reasoned"] = Value::String(r.body.clone());
+                }
+            }
             "review.refused" => {
                 if let Some(v) = reviews.get_mut(&id) {
                     if let Some(a) = v["refusals"].as_array_mut() {
@@ -2120,6 +2125,12 @@ fn render_review(root: &Path, r: &Value, iris: bool) -> Result<Vec<String>, Stri
     ];
     for refusal in r["refusals"].as_array().cloned().unwrap_or_default() {
         out.push(format!("  refused a verdict: {}", s(&refusal)));
+    }
+    if let Some(why) = r["reasoned"].as_str() {
+        out.push("  why:".into());
+        for l in why.lines() {
+            out.push(format!("    {l}"));
+        }
     }
     if !r["mutation_id"].is_string() {
         out.push(format!("decide: hale dna review {id} approve|revise|reject|abstain [--as <you>] [--comment <c>]"));

--- a/dna/core/assembly.hl
+++ b/dna/core/assembly.hl
@@ -274,6 +274,11 @@ locus Dna {
             return;
         }
         let x = self.journal.append(self.journal.revision(), "review.settled", r.review_id, r.outcome + " by " + r.decided_by);
+        // the record says why (GH #566 F7): a person's note, or the Leader's
+        // reasoning — the model's answer, not a digest of it
+        if len(r.comment) > 0 {
+            let w = self.journal.append(self.journal.revision(), "review.reasoned", r.review_id, r.comment);
+        }
         // GH #529 D5: a mutation's approval applies exactly the reviewed
         // candidate; a rejection or revision leaves genome and expression
         // untouched and keeps the Mutation in lineage.
@@ -764,6 +769,35 @@ locus Dna {
         }
         self.metabolism.resume(tasks);
         if mutations > self.mutations_minted { self.mutations_minted = mutations; }
+        self.fail_in_flight();
+    }
+    // A Mutation whose last word in the record is `proposed`, `worktree`
+    // or `located` was in flight — an editor mid-attempt — when the
+    // organization stopped (GH #566 F7). Nobody resumes an attempt: it
+    // failed, and the record says so instead of showing it in flight
+    // forever. Bounded by the mutations the record holds.
+    @unbounded
+    fn fail_in_flight() {
+        let n = self.journal.revision();
+        let mut i = 0;
+        while i < n {
+            let e = self.journal.read(i);
+            if e.kind == "mutation.proposed" {
+                let id = e.entity;
+                let mut last = "proposed";
+                let mut k = i + 1;
+                while k < n {
+                    let s = self.journal.read(k);
+                    if s.entity == id && std::str::starts_with(s.kind, "mutation.") { last = s.kind[9..len(s.kind)]; }
+                    k = k + 1;
+                }
+                if last == "proposed" || last == "worktree" || last == "located" {
+                    let x = self.journal.append(self.journal.revision(), "mutation.failed", id, "in flight (" + last + ") when the organization stopped; nothing resumes an attempt");
+                    let y = self.gateway.workspaces.remove(id);
+                }
+            }
+            i = i + 1;
+        }
     }
     fn status() -> String {
         let b = std::json::Builder { };

--- a/dna/core/editing.hl
+++ b/dna/core/editing.hl
@@ -73,6 +73,47 @@ locus WorktreeTools {
 // inside the worktree, format, check; hand back a proposal. Two model
 // calls under one attempt identity (the edit, then the fitness
 // assessment), exactly as AgentPerformer nests its calls.
+// The file inside a model's answer: when the answer carries a fenced
+// block (```lang … ```), the block's body — a preamble before it and a
+// remark after it are commentary, not source. An answer with no fence
+// is the file as given.
+fn unfence(answer: String) -> String {
+    let open = std::str::index_of(answer, "```");
+    if open < 0 { return answer; }
+    let after_open = answer[(open + 3)..len(answer)];
+    let nl = std::str::index_of(after_open, "\n");
+    if nl < 0 { return answer; }
+    let body = after_open[(nl + 1)..len(after_open)];
+    let close = std::str::index_of(body, "\n```");
+    if close < 0 { return body; }
+    return body[0..(close + 1)];
+}
+
+// The well-formed lines of a fitness assessment — `<signal> <+|->`,
+// one per line, nothing else — joined by newlines; commentary is
+// dropped. A signal is one word.
+fn fitness_lines(answer: String) -> String {
+    let mut out = "";
+    let mut line = "";
+    let mut p = 0;
+    let n = len(answer);
+    while p <= n {
+        let ch = if p < n { answer[p..(p + 1)] } else { "\n" };
+        if ch == "\n" {
+            let t = trim_nl(line);
+            let sp = std::str::index_of(t, " ");
+            if sp > 0 && sp == len(t) - 2 && (t[(sp + 1)..len(t)] == "+" || t[(sp + 1)..len(t)] == "-") && !std::str::contains(t[0..sp], "`") {
+                out = out + (if len(out) > 0 { "\n" } else { "" }) + t;
+            }
+            line = "";
+        } else {
+            line = line + ch;
+        }
+        p = p + 1;
+    }
+    return out;
+}
+
 locus SourceEditor {
     params {
         name: String = "editor";
@@ -165,13 +206,15 @@ locus SourceEditor {
         return trim_nl(out);
     }
     // One edit of one file on one try: read, ask, write. The diagnostics
-    // of the previous try, when any, travel in the prompt.
+    // of the previous try, when any, travel in the prompt. A hosted model
+    // wraps a file in a code fence however it is asked (GH #566 F7); the
+    // fence is not the file.
     @unbounded
     fn edit_one(attempt: String, file: String, objective: String, diagnostics: String, data_class: String) -> ModelResult {
         let refused_before = self.tools.refused;
         let current = self.tools.read(file);
         if self.tools.refused > refused_before { return ModelResult { ok: false, refused: self.tools.last_refusal }; }
-        let mut prompt = "Rewrite " + file + " so that: " + objective + "\nReturn the whole file.";
+        let mut prompt = "Rewrite " + file + " so that: " + objective + "\nChange only what the objective requires; keep every other line, comments included, exactly as it is.\nReturn the whole file as plain text: no code fence, no commentary, nothing before the first line of the file or after the last.";
         if len(diagnostics) > 0 { prompt = prompt + "\nThe previous attempt did not check. hale check said:\n" + diagnostics; }
         let edit = self.models.ask(ModelRequest {
             attempt_id: attempt, role: "edit", target: file,
@@ -180,7 +223,7 @@ locus SourceEditor {
             retry_of: if len(diagnostics) > 0 { attempt + ":edit" } else { "" }
         });
         if !edit.ok { return edit; }
-        if !self.tools.edit(file, edit.output) { return ModelResult { ok: false, backend: edit.backend, refused: self.tools.last_refusal }; }
+        if !self.tools.edit(file, unfence(edit.output)) { return ModelResult { ok: false, backend: edit.backend, refused: self.tools.last_refusal }; }
         return edit;
     }
     // Bounded by the attempt cap of the Work that owns this performer
@@ -199,10 +242,12 @@ locus SourceEditor {
         let mut fmt_code = 1;
         let mut check_code = 1;
         let mut done = false;
+        let mut changed = "";
         while tries < self.max_tries && !done {
             let attempt = req.work_id + "/a" + to_string(req.attempt_no + tries);
             let mut rest = files + " ";
             let mut failed = "";
+            changed = "";
             while len(rest) > 0 && len(failed) == 0 {
                 let sp = std::str::index_of(rest, " ");
                 let file = rest[0..sp];
@@ -211,6 +256,7 @@ locus SourceEditor {
                 let e = self.edit_one(attempt, file, req.objective, diagnostics, req.data_class);
                 if !e.ok { failed = "edit of " + file + " refused: " + e.refused; }
                 backends = e.backend;
+                changed = changed + "=== " + file + "\n" + unfence(e.output) + "\n";
             }
             if len(failed) > 0 {
                 return WorkResult { disposition: "failed", narrative: failed, performer: self.name };
@@ -225,10 +271,13 @@ locus SourceEditor {
         let attempt = req.work_id + "/a" + to_string(req.attempt_no + tries - 1);
         // The assessment is the deep tier's (assurance 2): it is what the
         // Review reads, so it is not the quick model's guess.
+        // the assessor sees the change it assesses — the objective and the
+        // files as edited — and only well-formed lines of its answer count
+        // (GH #566 F7: a model with nothing to look at says so, at length)
         let assess = self.models.ask(ModelRequest {
             attempt_id: attempt, role: "assess", assurance: 2,
-            prompt: "Which fitness signals should this change move, and which way? One per line: <signal> <+|->",
-            context: files, context_bytes: len(files) + 64,
+            prompt: "Which fitness signals should this change move, and which way? One per line, nothing else: <signal> <+|->",
+            context: "OBJECTIVE\n" + req.objective + "\n\nFILES AS EDITED\n" + changed, context_bytes: len(changed) + len(req.objective) + 64,
             tool_grant: self.grant(), data_class: req.data_class, retry_of: attempt + ":edit"
         });
         let b = std::json::Builder { };
@@ -236,7 +285,7 @@ locus SourceEditor {
         b.string_field("work_id", req.work_id);
         b.string_field("files_changed", files);
         b.string_field("rationale", req.objective);
-        b.string_field("fitness_signals", if assess.ok { assess.output } else { "" });
+        b.string_field("fitness_signals", if assess.ok { fitness_lines(assess.output) } else { "" });
         b.bool_field("fmt_clean", fmt_code == 0);
         b.bool_field("check_clean", check_code == 0);
         b.int_field("tries", tries);

--- a/dna/core/models.hl
+++ b/dna/core/models.hl
@@ -178,13 +178,20 @@ locus LocalFakeModel {
 // assembly journals it. The prompt's digest, not the prompt, is what
 // the record carries.
 
+fn temperature_param(milli: Int) -> String {
+    if milli < 0 { return "temperature=default"; }
+    return "temperature=" + to_string(milli / 1000) + "." + pad3(milli % 1000);
+}
+
 fn openai_chat_body(model: String, req: ModelRequest, temperature_milli: Int, max_tokens: Int) -> String {
     let mut b = "{\"model\": " + jq(model) + ", \"messages\": [";
     if len(req.context) > 0 {
         b = b + "{\"role\": \"system\", \"content\": " + jq(req.context) + "}, ";
     }
     b = b + "{\"role\": \"user\", \"content\": " + jq(req.prompt) + "}]";
-    b = b + ", \"temperature\": " + to_string(temperature_milli / 1000) + "." + pad3(temperature_milli % 1000);
+    // a provider's default when none is set: some models refuse the
+    // parameter outright (GH #566 F7), and the evidence says which it was
+    if temperature_milli >= 0 { b = b + ", \"temperature\": " + to_string(temperature_milli / 1000) + "." + pad3(temperature_milli % 1000); }
     if max_tokens > 0 { b = b + ", \"max_tokens\": " + to_string(max_tokens); }
     return b + "}";
 }
@@ -282,8 +289,8 @@ locus HostedModel {
         model: String = "gpt-4o-mini";
         credential: HostedCredential = HostedCredential { };
         max_bytes: Int = 400000;
-        temperature_milli: Int = 0;
-        max_tokens: Int = 1024;
+        temperature_milli: Int = -1; // < 0: the provider's default; 0..1000 sent as 0.000..1.000
+        max_tokens: Int = 4096; // a whole-file rewrite needs room; 0 = the provider's default
         // price per 1k tokens, micro-dollars (0.15 / 0.60 per M ≈ gpt-4o-mini)
         input_micros_per_1k: Int = 150;
         output_micros_per_1k: Int = 600;
@@ -305,7 +312,7 @@ locus HostedModel {
             attempt_id: req.attempt_id, adapter: self.adapter, backend: self.name,
             endpoint: self.endpoint, credential: self.credential.fingerprint(),
             requested_model: self.model,
-            params: "temperature=" + to_string(self.temperature_milli / 1000) + "." + pad3(self.temperature_milli % 1000) + " max_tokens=" + to_string(self.max_tokens),
+            params: temperature_param(self.temperature_milli) + " max_tokens=" + to_string(self.max_tokens),
             prompt_digest: if len(req.prompt_digest) > 0 { req.prompt_digest } else { digest_of(req.prompt) },
             context_digest: digest_of(req.context),
             knowledge_bindings: req.knowledge_bindings, tool_grant: req.tool_grant,
@@ -354,8 +361,8 @@ locus LocalModel {
         endpoint: String = "http://127.0.0.1:11434/v1/chat/completions";
         model: String = "llama3";
         max_bytes: Int = 400000;
-        temperature_milli: Int = 0;
-        max_tokens: Int = 1024;
+        temperature_milli: Int = -1; // < 0: the provider's default; 0..1000 sent as 0.000..1.000
+        max_tokens: Int = 4096; // a whole-file rewrite needs room; 0 = the provider's default
         calls: Int = 0;
         last: ModelEvidence = ModelEvidence { };
     }
@@ -369,7 +376,7 @@ locus LocalModel {
         let mut ev = ModelEvidence {
             attempt_id: req.attempt_id, adapter: "local", backend: self.name,
             endpoint: self.endpoint, requested_model: self.model,
-            params: "temperature=" + to_string(self.temperature_milli / 1000) + "." + pad3(self.temperature_milli % 1000) + " max_tokens=" + to_string(self.max_tokens),
+            params: temperature_param(self.temperature_milli) + " max_tokens=" + to_string(self.max_tokens),
             prompt_digest: if len(req.prompt_digest) > 0 { req.prompt_digest } else { digest_of(req.prompt) },
             context_digest: digest_of(req.context),
             knowledge_bindings: req.knowledge_bindings, tool_grant: req.tool_grant,

--- a/dna/core/review.hl
+++ b/dna/core/review.hl
@@ -55,6 +55,7 @@ locus Review {
         settled: Bool = false;
         outcome: String = ""; // "approve" | "revise" | "reject" | ""
         decided_by: String = "";
+        comment: String = ""; // the deciding verdict's comment
         refused: Int = 0; // verdicts refused (wrong digest / authority / independence)
         last_refusal: String = "";
     }
@@ -82,7 +83,7 @@ locus Review {
     fn on_verdict(v: Verdict) {
         let admitted = self.consider(v);
         if admitted && self.settled {
-            ReviewSettled <- ReviewSettlement { review_id: self.review_id, outcome: self.outcome, decided_by: self.decided_by };
+            ReviewSettled <- ReviewSettlement { review_id: self.review_id, outcome: self.outcome, decided_by: self.decided_by, comment: self.comment };
         }
         if !admitted {
             ReviewSettled <- ReviewSettlement { review_id: self.review_id, refusal: self.last_refusal };
@@ -115,6 +116,7 @@ locus Review {
         self.settled = true;
         self.outcome = v.verdict;
         self.decided_by = v.reviewer;
+        self.comment = v.comment;
         return true;
     }
     fn verdict_count() -> Int { return self.verdicts.len(); }

--- a/dna/core/topics.hl
+++ b/dna/core/topics.hl
@@ -67,6 +67,7 @@ type ReviewSettlement {
     outcome: String = ""; // "approve" | "revise" | "reject" | "" when a verdict was refused
     decided_by: String = "";
     refusal: String = ""; // non-empty when a verdict was refused, with the reason
+    comment: String = ""; // the deciding verdict's comment: a person's note, a model's reasoning (GH #566 F7)
 }
 topic ReviewSettled { payload: ReviewSettlement; subject: "dna.review.settled"; }
 

--- a/dna/tests/editing_test.hl
+++ b/dna/tests/editing_test.hl
@@ -54,6 +54,21 @@ main locus App {
         let after = std::io::fs::read_file(root + "/main.hl") or "";
         std::test::assert(std::str::contains(after, "v2"), "the worktree holds the edit");
         std::test::assert_eq_int(self.editor.tools.reads, 1, "one read");
+        // a hosted model's habit: the file inside a fence, with a remark
+        // on each side — the fence is not the file (GH #566 F7)
+        let fenced = dna::SourceEditor {
+            name: "fenced",
+            tools: dna::WorktreeTools { root: root, hale_bin: toolchain() },
+            models: dna::ModelRouter {
+                quick: dna::FakeModel { name: "quick", answer: "Here is the rewritten file:\n\n```hale\nfn main() {\n    println(\"v3\");\n}\n```\n\nI kept the structure.\n" },
+                deep: dna::FakeModel { name: "deep", answer: "Looking at the change, I would expect:\n\nstartup_prints +\nlatency_p99 -\n\nNothing else moves." }
+            }
+        };
+        let r3 = fenced.perform(dna::WorkRequest { work_id: "w3", task_id: "t1", objective: "print v3", target: "main.hl", requires: "edit", attempt_no: 0 });
+        std::test::assert_eq_str(r3.disposition, "done", "a fenced answer is the file inside the fence: " + r3.narrative);
+        let after3 = std::io::fs::read_file(root + "/main.hl") or "";
+        std::test::assert(std::str::contains(after3, "v3") && !std::str::contains(after3, "```") && !std::str::contains(after3, "Here is"), "the worktree holds the file, not the fence or the remarks: " + after3);
+        std::test::assert_eq_str(std::json::find_string_field(r3.result, "fitness_signals"), "startup_prints +\nlatency_p99 -", "only the well-formed signal lines count: " + r3.result);
         std::test::assert_eq_int(self.editor.tools.edits, 1, "one edit");
         std::test::assert_eq_int(self.editor.models.calls, 2, "edit + assess");
 

--- a/dna/tests/hosted_model_test.hl
+++ b/dna/tests/hosted_model_test.hl
@@ -71,6 +71,7 @@ main locus App {
         std::test::assert(std::str::contains(ev.response_digest, "sha256:"), "response digest");
         std::test::assert_eq_str(ev.knowledge_bindings, "kb1 kb2", "knowledge bindings used");
         std::test::assert(std::str::contains(ev.params, "max_tokens=64"), "parameters as sent: " + ev.params);
+        std::test::assert(std::str::contains(ev.params, "temperature=default"), "no temperature unless set — some models refuse the parameter (GH #566 F7): " + ev.params);
         std::test::assert(ev.output_tokens == 3, "output tokens from usage");
         std::test::assert(len(ev.elapsed) > 0, "wall time recorded");
         std::test::assert(ev.cost_micros > 0, "cost from the price table");

--- a/dna/tests/mutation_review_test.hl
+++ b/dna/tests/mutation_review_test.hl
@@ -126,8 +126,20 @@ main locus App {
         // ---- 4. a second mutation stays pending; a new Dna re-births it ----
         let out2 = self.dna.mutate("t2", "feature", "again", "main.hl", 200);
         std::test::assert_eq_str(out2, "m2: review", out2);
+        // a third, still in flight when this organization stops: the next
+        // one fails it in the record rather than showing it located forever
+        let p3 = self.dna.journal.append(self.dna.journal.revision(), "mutation.proposed", "m3", "task t3 feature: never finished (main.hl) at base");
+        let w3 = self.dna.journal.append(self.dna.journal.revision(), "mutation.located", "m3", "main.hl under read edit fmt check");
         let second = dna::Dna { journal: dna::GitJournal { repo: repo } };
         std::test::assert_eq_int(second.rehydrated, 1, "only the pending Review is re-born (m1 settled)");
+        let mut failed3 = "";
+        let mut q = 0;
+        while q < second.journal.revision() {
+            let e = second.journal.read(q);
+            if e.kind == "mutation.failed" && e.entity == "m3" { failed3 = e.body; }
+            q = q + 1;
+        }
+        std::test::assert(std::str::contains(failed3, "in flight (located)"), "the in-flight mutation failed on rehydrate: " + failed3);
         std::test::assert_eq_int(second.reviews_open, 1, "and it is a live child");
         std::test::assert(std::str::contains(second.status(), "\"rehydrated\": 1"), second.status());
     }

--- a/dna/tests/org_test.hl
+++ b/dna/tests/org_test.hl
@@ -133,6 +133,7 @@ main locus Org {
         std::test::assert_eq_str(std::json::find_string_field(req2, "required_authority"), "leader", "the Leader's to decide");
         std::test::assert_eq_int(self.leader.decisions, 1, "one decision");
         std::test::assert_eq_int(self.leader.approved, 1, "approved");
+        std::test::assert(std::str::contains(self.last("review.reasoned", "m2"), "model deep:"), "the Leader's reasoning is in the record: " + self.last("review.reasoned", "m2"));
         std::test::assert_eq_str(self.last("review.settled", "m2"), "approve by leader", "settled by the Leader: " + self.last("review.refused", "m2"));
         std::test::assert_eq_int(self.count_role("review"), 1, "the Leader's decision is a model call with evidence");
         let cand2 = self.last("mutation.candidate", "m2");

--- a/docs/src/dna/organization.md
+++ b/docs/src/dna/organization.md
@@ -44,9 +44,10 @@ review_policy: dna::OrgPolicy { },
 
 A change of a class in the grant and under its size is the Leader's
 to decide. It reads the source diff and the semantic diff with the
-deep model tier, answers `approve`, `revise` or `reject` with a
-comment, and the record has the call: which model, what it cost,
-the digests. The Board can answer first, or overrule nothing — a
+deep model tier, answers `approve`, `revise` or `reject` with its
+reasoning, and the record has both: the call (which model, what it
+cost, the digests) and the reasoning in full (`review.reasoned`,
+rendered as `why:` by `hale dna review <id>`). The Board can answer first, or overrule nothing — a
 settled Review is settled — but it widens or narrows the grant in a
 reviewed commit, and the record shows who did.
 

--- a/docs/src/dna/reference.md
+++ b/docs/src/dna/reference.md
@@ -77,6 +77,7 @@ tree, one JSON object per line: `seq`, `kind`, `entity`, `body`,
 | `review.requested` | `review:<id>` | question, authority, candidate, base, shape, disposition, evidence, magnitude, diff digests, fitness signals |
 | `review.verdict` | `<id>` | a verdict appended from a clone or from GitHub, in the reviewer's name |
 | `review.settled` / `review.refused` | `<id>` | `<verdict> by <reviewer>` / the reason |
+| `review.reasoned` | `<id>` | the deciding verdict's comment: a person's note, or the Leader's reasoning in full |
 | `expression.restart_requested` | `m<n>` | `apply <candidate> seed <s> fitness …` or `rollback <base> seed <s> after …` |
 | `expression.restarted` | `m<n>` | the shape and build the new expression reports |
 | `expression.deployed` | `m<n>` | what a deployment gateway expressed, and its judgement |

--- a/docs/src/dna/review.md
+++ b/docs/src/dna/review.md
@@ -100,7 +100,10 @@ others cannot:
 
 The Leader reads the same three views. Its verdict is a model call
 in the record (`model.called` with the deep tier, the digests of what
-it read, the cost) and a `review.verdict` with `authority: leader`.
+it read, the cost), and its reasoning — the model's answer in full —
+is the `review.reasoned` row right after the settlement, which
+`hale dna review <id>` renders as `why:`. A person's `--comment` lands
+the same way.
 
 The kill test that shaped this — two rounds of reviewers deciding
 from the semantic diff alone, the source diff alone, and both — is

--- a/spec/dna.md
+++ b/spec/dna.md
@@ -70,7 +70,10 @@ Deleting it loses nothing the record holds.
 `expression.deployed`, `expression.restarted`, `expression.observed`,
 `expression.crashed`, `pressure.raised`, `pressure.remeasured`,
 `appendage.proposed`, `model.called`, `github.pr`, `github.commented`,
-`mutation.topology`, `fleet.deploy`, `instance.up`, `instance.exited`. Their bodies are documented in the guide's reference
+`mutation.topology`, `fleet.deploy`, `instance.up`, `instance.exited`,
+`review.reasoned` (the deciding verdict's comment — a person's note or
+the Leader's reasoning — right after `review.settled`; `hale dna
+review <id>` renders it as `why:`). Their bodies are documented in the guide's reference
 chapter; the set grows by ordinary change, and a reader that meets an
 unknown kind must keep walking.
 


### PR DESCRIPTION
Part of #566 (Phase 3, F7). Stacked on #574.

**The run.** The acceptance chat server under `hale dna dev`, the editor on a hosted quick tier and the Leader on a hosted deep tier (Anthropic's OpenAI-compatible endpoint, `HostedModel { endpoint, model, credential }`), the grant widened to `refactor docs application` so the Leader decides an ask:

- `hale dna ask "document the chat server in main.hl: add one comment above the ChatServer locus …"` → candidate, verified (`fmt=0 check=0 verify=0 test=0 diff=0 rollback=0 fleet=0`), `review.settled approve by leader`, applied, `expression restarted … build b1c1366acf5a`, `observed healthy for 5s`, `mutation.retained`. `git log` has the commit with the comment.
- A rename ask (`seen` → `greeted` on a param): the magnitude vector said `contract_change, irreversible, state_migration` → `escalate`, `needs board`; the Board rejected it with a comment because the editor had also dropped the file header. The comment is on the record.
- A docs ask decided by the Leader: `revise by leader`, with the reasoning in full: the diff "also deletes the file-header comment, the rooms-only-path comment, and the rationale comment on the Chat constitution … scope should match description." Fitness signals in the request: `comment_coverage +`, `readability +`.

Model calls for the whole dogfood: about five cents.

**What it found, fixed here.**

- A hosted model wraps the file it returns in a code fence however it is asked (three tries, all `lex error: unterminated time literal` on the fence). The editor takes the file inside the fence (`unfence`), asks for plain text, and `max_tokens` defaults to 4096 so a whole-file rewrite is not truncated at 1024 tokens as those tries were.
- Some models refuse `temperature` outright (`http 400 temperature is deprecated for this model`), which silenced the Leader and the assessor. The hosted and local adapters send it only when set; `temperature_milli < 0` is the provider's default and the evidence says `temperature=default`.
- The fitness assessor was asked about a change it could not see and answered "I don't see the change you're referring to" at length, and that text flowed into the restart request. It now sees the objective and the files as edited, and only well-formed `<signal> <+|->` lines count.
- The deciding verdict's comment was dropped at settlement, so the Leader's reasoning was nowhere in the record. `review.reasoned` follows `review.settled` (a person's `--comment` too); `hale dna review <id>` renders it as `why:`; the status projection carries it.
- A Mutation in flight when the organization stopped stayed `located` forever. Rehydrate fails it in the record (`in flight (located) when the organization stopped; nothing resumes an attempt`) and removes its worktree.
- A quick editor rewriting a whole file drops comments it was not asked about. The prompt now says to change only what the objective requires and keep every other line; the Leader's review is the backstop, and it worked.

**Tests.** The fenced answer and the parsed assessment (`editing_test`), `temperature=default` (`hosted_model_test`), the in-flight mutation failed on rehydrate (`mutation_review_test`), the Leader's reasoning in the record (`org_test`). `hale test dna` 17 passed; the DNA CLI suites 26 passed; harvest binaries and `hale fmt --check .` green.

**Not done here, for the record.** The downstream candidate application, deployed as it actually deploys, is a run only its owner can do; this dogfood used the in-repo acceptance application under `dev`. The fleet path was exercised in CI (#572), not against real nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)