### PR TITLE
codegen: a vec form owns its elements; hale run names a signal (GH #577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ behavior.
 
 ## Unreleased
 
+### A vec form owns its elements; `hale run` names a signal (GH #577)
+
+- `@form(vec)`: `get` returns the caller's copy of a heap-bearing element, and `set` / `push` store the vec's own copy whatever arena the value came from. Before, `get` handed back the slot's pointer and `set` passed a pointer already in the arena straight through, so two slots could share one struct and `set`'s retire of the replaced element freed memory the other slot — or a value read earlier — still held: two items swapped through `get` and `set` segfaulted. Scalars and locus refs are unchanged. Test: `tests/hale/form_vec_owned_elements_test.hl`.
+- `hale run` says when the program was killed by a signal (`hale run: the program was killed by SIGSEGV (signal 11)`) and exits 128 + the signal, where it used to say nothing and exit 1.
+
 ### DNA: the host is Hale (GH #566 F8)
 
 - Everything `hale dna` did beside the compiler that is DNA behaviour — the projections (`status`, `history`, `review`, `board`, `report`, `pressure`, `fleet`), the writers (`ask`, a verdict, `pressure raise`, `sync`, `deploy`, `rollback`, `github sync`), the supervision (`run`, `dev`: the observation window, the fleet's deploy rows and window, the organization's own restarts, crash accounting, the membrane relay, GitHub) and the node agent (`hale node`) — is now `dna/host`, a Hale seed embedded in the toolchain beside the core, the membrane client and the surface, built once into the cache and exec'd by `hale dna` with the project resolved. Some 2,700 lines of Rust in `crates/hale-cli/src/dna.rs` and `node.rs` are gone; the compiler keeps `init` / `new` / `upgrade`, `hale fleet check`, the plan schema and the exec shims. The CLI's text is unchanged and every DNA suite passes against it. Children run detached through `sh` with pid, exit code and log as files, and the host echoes their logs a tick at a time.

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -4698,6 +4698,23 @@ fn compile_and_exec(
     let _ = std::fs::remove_file(&bin);
     match status {
         Ok(s) => {
+            // GH #577: a program killed by a signal says so — a segfault
+            // that printed nothing used to look like `exit 1`
+            use std::os::unix::process::ExitStatusExt;
+            if let Some(sig) = s.signal() {
+                let name = match sig {
+                    libc::SIGSEGV => "SIGSEGV",
+                    libc::SIGABRT => "SIGABRT",
+                    libc::SIGBUS => "SIGBUS",
+                    libc::SIGFPE => "SIGFPE",
+                    libc::SIGILL => "SIGILL",
+                    libc::SIGKILL => "SIGKILL",
+                    libc::SIGTERM => "SIGTERM",
+                    _ => "signal",
+                };
+                eprintln!("hale run: the program was killed by {name} (signal {sig})");
+                return ExitCode::from((128 + sig).clamp(0, 255) as u8);
+            }
             ExitCode::from(s.code().unwrap_or(1).clamp(0, 255) as u8)
         }
         Err(e) => {

--- a/crates/hale-cli/tests/dna_review.rs
+++ b/crates/hale-cli/tests/dna_review.rs
@@ -142,7 +142,20 @@ fn a_mutation_is_rendered_offline_and_decided_through_the_organism() {
     let (ok1, out1) = hale(&["dna", "review", "m1", "approve", "--as", "riley", "--digest", "0000000000000000000000000000000000000000"], &app);
     // the maintainer's verdict on the exact candidate settles it
     let (ok2, out2) = hale(&["dna", "review", "m1", "approve", "--as", "riley", "--comment", "fine"], &app);
-    let (ok3, out3) = hale(&["dna", "status"], &app);
+    // the settle answers first; the apply follows in the organization's
+    // own handler, a moment later on a loaded shard
+    let mut ok3 = false;
+    let mut out3 = String::new();
+    let dl = Instant::now() + Duration::from_secs(60);
+    while Instant::now() < dl {
+        let (o, s) = hale(&["dna", "status"], &app);
+        ok3 = o;
+        out3 = s;
+        if out3.contains("m1 [applied]") || out3.contains("m1 [retained]") {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(300));
+    }
     let (ok4, out4) = hale(&["dna", "history", "m1"], &app);
     finish(&mut host);
     assert!(ok1 && out1.contains("refused the verdict: digest mismatch"), "wrong digest:\n{out1}");

--- a/crates/hale-cli/tests/iris_cli.rs
+++ b/crates/hale-cli/tests/iris_cli.rs
@@ -214,6 +214,10 @@ fn iris_diff_pair_rides_into_the_snapshot() {
             break;
         }
     }
+    if !attempts.is_empty() {
+        // a retried attempt is evidence for GH #578 even when a later one passed
+        eprintln!("iris_diff_pair: retried after a server died before the diff loaded:\n{}", attempts.join("\n"));
+    }
     let json_start = body.find("{\"ts\"").unwrap_or_else(|| panic!("no loaded diff in the snapshot:\n{}", attempts.join("\n")));
     let v: serde_json::Value = serde_json::from_str(&body[json_start..]).expect("snapshot is JSON");
     assert_eq!(v["diff"]["state"], "loaded", "{body}");

--- a/crates/hale-cli/tests/run_reports_signal.rs
+++ b/crates/hale-cli/tests/run_reports_signal.rs
@@ -1,0 +1,29 @@
+//! GH #577 — `hale run` says when the program was killed by a signal,
+//! and exits 128 + the signal, where it used to print nothing and exit
+//! 1. The program here sends itself SIGSEGV through the process API.
+
+use std::process::Command;
+
+const SRC: &str = r#"fn main() {
+    println("about to die");
+    let me = std::process::Child { pid: std::process::pid() };
+    std::process::signal(me, 11) or discard;
+    std::time::sleep(2s);
+    println("still here");
+}
+"#;
+
+#[test]
+fn hale_run_names_the_signal_that_killed_the_program() {
+    let d = std::env::temp_dir().join(format!("hale_run_signal_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).unwrap();
+    std::fs::write(d.join("main.hl"), SRC).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_hale")).args(["run", &d.to_string_lossy()]).output().expect("hale run");
+    let err = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("about to die") && !stdout.contains("still here"), "the program died mid-way:\n{stdout}");
+    assert!(err.contains("killed by SIGSEGV (signal 11)"), "hale run names the signal:\n{err}");
+    assert_eq!(out.status.code(), Some(139), "exit is 128 + the signal");
+    let _ = std::fs::remove_dir_all(&d);
+}

--- a/crates/hale-codegen/src/form/mod.rs
+++ b/crates/hale-codegen/src/form/mod.rs
@@ -99,6 +99,30 @@ use crate::codegen::{
 };
 
 impl<'ctx, 'p> Cx<'ctx, 'p> {
+    /// GH #577: what `get` hands back is OWNED. A vec slot holds a
+    /// pointer to the element (a String's blob, a struct with its
+    /// blobs), and `set` retires the replaced element; a `get` that
+    /// returned that same pointer left the caller holding memory a
+    /// later `set` freed — two items swapped through `get` and `set`
+    /// segfaulted. So a heap-bearing element is deep-copied into the
+    /// caller's current arena on read (the same clone-on-read a
+    /// serialized hashmap does); scalars and locus refs pass through.
+    pub(crate) fn emit_vec_get_owned(
+        &mut self,
+        loaded: BasicValueEnum<'ctx>,
+        elem_ty: &CodegenTy,
+        locus_name: &str,
+    ) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+        if !matches!(elem_ty, CodegenTy::String | CodegenTy::Bytes | CodegenTy::TypeRef(_)) {
+            return Ok(loaded);
+        }
+        let dest = self.current_arena_ptr()?;
+        let _ = locus_name;
+        // always a copy: a child form's arena can be the caller's own,
+        // and a same-arena pass-through would hand the slot's pointer back
+        self.emit_owned_store_copy_ptr(loaded, elem_ty, dest)
+    }
+
     /// v1.x-FORM-2 PR6 (PR5 finale): inline-lower a synthesized
     /// @form(vec) fallible method (get, pop) as-if it were a
     /// fallible-ABI call. The C runtime returns 1=OK / 0=err;
@@ -266,6 +290,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                             &format!("{}.vec.get.bce.elem", locus_name),
                         )
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                    let loaded = self.emit_vec_get_owned(loaded, &elem_ty, locus_name)?;
                     self.builder
                         .build_store(out_val_slot_opt.unwrap(), loaded)
                         .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
@@ -383,6 +408,7 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         &format!("{}.vec.get.elem", locus_name),
                     )
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
+                let loaded = self.emit_vec_get_owned(loaded, &elem_ty, locus_name)?;
                 self.builder
                     .build_store(out_val_slot_opt.unwrap(), loaded)
                     .map_err(|e| CodegenError::LlvmEmit(e.to_string()))?;
@@ -480,12 +506,9 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         CodegenError::LlvmEmit(e.to_string())
                     })?
                     .into_pointer_value();
-                let val = self.emit_cross_arena_store_deep_copy_ptr(
-                    val,
-                    &elem_ty,
-                    dest_arena,
-                    &format!("{}.vec_set", locus_name),
-                )?;
+                // GH #577: the vec owns what it stores — always a copy, so
+                // no two slots share a struct the retire below could free
+                let val = self.emit_owned_store_copy_ptr(val, &elem_ty, dest_arena)?;
                 // FORM-vec hot-path inline (replaces the opaque
                 // lotus_vec_set C call). The vec slot is the inline
                 // struct `{ usize cap, usize len, ptr buf }`. The
@@ -1765,12 +1788,8 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
                         CodegenError::LlvmEmit(e.to_string())
                     })?
                     .into_pointer_value();
-                let arg_val = self.emit_cross_arena_store_deep_copy_ptr(
-                    arg_val,
-                    &slot.elem_ty,
-                    dest_arena,
-                    &format!("{}.vec_push", locus_name),
-                )?;
+                // GH #577: the vec owns what it stores — always a copy (see set)
+                let arg_val = self.emit_owned_store_copy_ptr(arg_val, &slot.elem_ty, dest_arena)?;
                 // Materialize the (now arena-anchored) arg in an
                 // alloca so we can hand its address to
                 // lotus_vec_push. The runtime memcpys elem_size

--- a/crates/hale-codegen/src/locus/return_path.rs
+++ b/crates/hale-codegen/src/locus/return_path.rs
@@ -130,6 +130,28 @@ impl<'ctx, 'p> Cx<'ctx, 'p> {
         Ok(phi.as_basic_value())
     }
 
+    /// GH #577: a store that always OWNS. `emit_cross_arena_store_deep_copy_ptr`
+    /// passes a pointer through when it already lives in `dest_arena`;
+    /// for a container whose `set` retires the replaced element that
+    /// pass-through let two slots share one struct (a value read from
+    /// the same vec, or one value pushed twice), and retiring one freed
+    /// the other's. A vec's elements are the vec's: a heap-bearing value
+    /// is copied into `dest_arena` on every push and set, whatever
+    /// arena it came from; scalars and locus refs pass through.
+    pub(crate) fn emit_owned_store_copy_ptr(
+        &mut self,
+        value: BasicValueEnum<'ctx>,
+        ty: &CodegenTy,
+        dest_arena: PointerValue<'ctx>,
+    ) -> Result<BasicValueEnum<'ctx>, CodegenError> {
+        match ty {
+            CodegenTy::String | CodegenTy::Bytes | CodegenTy::TypeRef(_) | CodegenTy::Tuple(_) | CodegenTy::Array(_, _) => {
+                self.emit_return_value_deep_copy(value, ty, dest_arena)
+            }
+            _ => Ok(value),
+        }
+    }
+
     pub(crate) fn emit_return_value_deep_copy(
         &mut self,
         value: BasicValueEnum<'ctx>,

--- a/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
+++ b/crates/hale-types/tests/fixtures/topology_shape_baseline.txt
@@ -95,6 +95,7 @@ crates/hale-cli/tests/replay_cli.rs#6 ca2f585ef8f64e58
 crates/hale-cli/tests/replay_cli.rs#7 78922a4aa4ea28c6
 crates/hale-cli/tests/replay_cli.rs#8 ff3b32fa4150221e
 crates/hale-cli/tests/replay_cli.rs#9 e4c2a028e4502903
+crates/hale-cli/tests/run_reports_signal.rs#0 14adc3b285b22ece
 crates/hale-cli/tests/source_map.rs#0 183856ff8794bd36
 crates/hale-cli/tests/source_map.rs#1 049ab7929fcc5890
 crates/hale-cli/tests/test_ffi_pickup.rs#1 865d341109268295

--- a/dna/FRICTION.md
+++ b/dna/FRICTION.md
@@ -566,3 +566,7 @@ sorts an id list built by string insertion.
 
 Two frictions in one: the aliasing, and the silence — a segfault in
 a `hale run` program prints nothing, not even that it died by signal.
+
+**FIXED** (GH #577): a vec form owns its elements — `get` returns the
+caller's copy and `set` / `push` store the vec's copy, whatever arena
+the value came from — and `hale run` reports a death by signal.

--- a/spec/forms.md
+++ b/spec/forms.md
@@ -429,11 +429,19 @@ vec.set(i, x)         or noop(err);   # swallow OOB
 > freelist immediately, and the deep-copy allocation consults that
 > freelist — steady-state `set` churn ping-pongs between reused
 > blocks instead of growing the arena (~33 B/set and a
-> progressively slower containment walk, pre-fix). Single-owner
-> caveat: a value obtained from `.get` is invalidated by a later
-> `set` to the same slot — holding a get result across a mutation
-> of its slot is out of contract (the same single-owner rule the
-> hashmap forms document).
+> progressively slower containment walk, pre-fix).
+>
+> **The vec owns its elements (GH #577).** `get` returns the
+> CALLER's copy of a heap-bearing element (a String, Bytes, a
+> struct with such fields), allocated in the caller's current arena;
+> `set` and `push` store the VEC's own copy, whatever arena the value
+> came from — a value read from the same vec, or one value pushed
+> twice, never leaves two slots sharing one struct. So a `get` result
+> stays whole across a later `set` of its slot, and the retire above
+> frees only what the vec held. Scalars and locus refs are copied by
+> value as before. (Before this, `get` handed back the slot's pointer
+> and a same-arena value passed through `set` uncopied; two items
+> swapped through `get` and `set` segfaulted.)
 
 ```hale,fragment
 ```

--- a/tests/hale/form_vec_owned_elements_test.hl
+++ b/tests/hale/form_vec_owned_elements_test.hl
@@ -1,0 +1,57 @@
+// GH #577 — a vec form owns its elements: what `get` returns is the
+// caller's copy, what `set` and `push` store is the vec's copy. Two
+// items swapped through `get` and `set` used to segfault: `get` handed
+// back the slot's pointer and `set` retired the replaced element's
+// strings under it.
+
+type Row { id: String = ""; state: String = "pending"; note: String = ""; }
+@form(vec)
+locus Rows { capacity { heap items of Row; } }
+
+locus Keeper {
+    params { rows: Rows = Rows { }; }
+    fn swap() {
+        self.rows.push(Row { id: "purpose", note: "first" });
+        self.rows.push(Row { id: "m1", note: "second" });
+        let a = self.rows.get(0) or Row { };
+        let b = self.rows.get(1) or Row { };
+        self.rows.set(0, b) or discard;
+        self.rows.set(1, a) or discard;
+    }
+    fn touch() {
+        let mut r = self.rows.get(0) or Row { };
+        r.state = "settled";
+        self.rows.set(0, r) or discard;
+    }
+    fn twice() {
+        let v = Row { id: "shared", note: "one value, two slots" };
+        self.rows.push(v);
+        self.rows.push(v);
+        self.rows.set(2, Row { id: "replaced", note: "the other slot must survive" }) or discard;
+    }
+}
+
+fn main() {
+    let k = Keeper { };
+    k.swap();
+    let r0 = k.rows.get(0) or Row { };
+    let r1 = k.rows.get(1) or Row { };
+    std::test::assert_eq_str(r0.id, "m1", "swapped: slot 0 is m1");
+    std::test::assert_eq_str(r0.note, "second", "slot 0 carries m1's note");
+    std::test::assert_eq_str(r1.id, "purpose", "swapped: slot 1 is purpose");
+    std::test::assert_eq_str(r1.note, "first", "slot 1 carries purpose's note");
+    k.touch();
+    let t0 = k.rows.get(0) or Row { };
+    std::test::assert_eq_str(t0.state, "settled", "read-modify-write lands");
+    std::test::assert_eq_str(t0.note, "second", "and keeps the other fields");
+    // a copy from `get` outlives a `set` of its slot
+    let before = k.rows.get(1) or Row { };
+    k.rows.set(1, Row { id: "new", note: "n" }) or discard;
+    std::test::assert_eq_str(before.id, "purpose", "the copy read before the set is still whole");
+    std::test::assert_eq_str(before.note, "first", "including its strings");
+    k.twice();
+    let s3 = k.rows.get(3) or Row { };
+    std::test::assert_eq_str(s3.id, "shared", "one value pushed twice: the other slot survives a set");
+    std::test::assert_eq_str(s3.note, "one value, two slots", "with its strings");
+    std::test::assert_eq_int(k.rows.len(), 4, "four rows");
+}


### PR DESCRIPTION
Closes #577.

**The bug.** A vec slot holds a pointer to its element. `get` handed that pointer back, and the store path's deep copy passed a pointer already in the arena straight through, so two slots could share one struct (a value read from the same vec and written back elsewhere, or one value pushed twice). `set` retires the replaced element's strings and block, so the other holder — the other slot, or a value read earlier — was left on freed memory. Two items swapped through `get` and `set` segfaulted; a read-modify-write of one slot only worked because old and new were the same pointer.

**The rule.** The vec owns its elements: `get` returns the caller's copy of a heap-bearing element (allocated in the caller's current arena), and `set` / `push` store the vec's own copy whatever arena the value came from. Scalars and locus refs are unchanged. `spec/forms.md` states it and drops the single-owner caveat on `get` results.

**`hale run`** now says `hale run: the program was killed by SIGSEGV (signal 11)` and exits 128 + the signal, where it printed nothing and exited 1.

**Tests.** `tests/hale/form_vec_owned_elements_test.hl` (the swap, a read-modify-write, a copy outliving a `set` of its slot, one value pushed twice surviving a `set`); `run_reports_signal` (a program that sends itself SIGSEGV). The codegen crate's 1339 tests, the DNA and native suites and the harvest binaries pass. Also in this PR: the iris diff test prints a retried attempt's log even when a later attempt passed, as evidence for #578.

**Cost.** A `get` of a struct-with-strings or String element now copies; scalar vecs are untouched. The bench suite lives in its own repository and was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)