### PR TITLE
dna: hale dna and hale node exec the host in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ behavior.
 
 ## Unreleased
 
+### `hale dna` and `hale node` exec the host in place
+
+- The shim that resolved the project and started the Hale host waited on it as a child, so a signal to the pid that ran `hale dna run` or `hale node` — a supervisor's, a test's — killed the shim and orphaned the host, which kept ticking; dozens of `host node` agents survived their tests on a workstation and loaded it. The shim now execs the host (and `hale dna ui` its surface) in place: the pid is the host. The fleet test asserts nothing of its own survives its teardown.
+
 ### A vec form owns its elements; `hale run` names a signal (GH #577)
 
 - `@form(vec)`: `get` returns the caller's copy of a heap-bearing element, and `set` / `push` store the vec's own copy whatever arena the value came from. Before, `get` handed back the slot's pointer and `set` passed a pointer already in the arena straight through, so two slots could share one struct and `set`'s retire of the replaced element freed memory the other slot — or a value read earlier — still held: two items swapped through `get` and `set` segfaulted. Scalars and locus refs are unchanged. Test: `tests/hale/form_vec_owned_elements_test.hl`.

--- a/crates/hale-cli/src/dna.rs
+++ b/crates/hale-cli/src/dna.rs
@@ -70,7 +70,12 @@ fn host_exec(verb: &str, dir: &Path, args: &[String]) -> ExitCode {
         let host = crate::iris::ensure_built_in(&cache, hale_dna::HOST_SEED, hale_dna::HOST_BIN, "the host")?;
         let membrane = crate::iris::ensure_built_in(&cache, hale_dna::MEMBRANE_SEED, hale_dna::MEMBRANE_BIN, "the membrane client")?;
         let me = std::env::current_exe().map_err(|e| e.to_string())?;
-        let st = Command::new(&host)
+        // exec in place: the pid that ran `hale dna <verb>` IS the host,
+        // so a signal to it — a supervisor's, a test's — reaches the host
+        // rather than an orphaned child that keeps ticking (dozens of
+        // `host node` processes survived their tests before this)
+        use std::os::unix::process::CommandExt;
+        let e = Command::new(&host)
             .arg(verb)
             .arg(&root)
             .arg(&seed_rel)
@@ -81,9 +86,8 @@ fn host_exec(verb: &str, dir: &Path, args: &[String]) -> ExitCode {
             .env("HALE_BIN", &me)
             .env("HALE_DNA_MEMBRANE", &membrane)
             .env("HALE_DNA_TOOLCHAIN", TOOLCHAIN)
-            .status()
-            .map_err(|e| format!("hale dna {verb}: {e}"))?;
-        Ok(st.code().unwrap_or(1))
+            .exec();
+        Err(format!("hale dna {verb}: {e}"))
     };
     match run() {
         Ok(code) => ExitCode::from(code.clamp(0, 255) as u8),
@@ -750,8 +754,10 @@ fn ui_cmd(args: &[String]) -> ExitCode {
         let bin = crate::iris::ensure_built_in(&cache, hale_dna::UI_SEED, hale_dna::UI_BIN, "the surface")?;
         let me = std::env::current_exe().map_err(|e| e.to_string())?;
         let _ = sync_record(&root);
-        let st = Command::new(&bin).arg(&port).arg(cache.join(hale_dna::UI_HTML.path)).current_dir(&root).env("HALE_BIN", &me).status().map_err(|e| format!("hale dna ui: {e}"))?;
-        Ok(st.code().unwrap_or(1))
+        // exec in place, for the same reason as the host: the pid is the surface
+        use std::os::unix::process::CommandExt;
+        let e = Command::new(&bin).arg(&port).arg(cache.join(hale_dna::UI_HTML.path)).current_dir(&root).env("HALE_BIN", &me).exec();
+        Err(format!("hale dna ui: {e}"))
     };
     match run() {
         Ok(code) => ExitCode::from(code.clamp(0, 255) as u8),

--- a/crates/hale-cli/tests/dna_fleet.rs
+++ b/crates/hale-cli/tests/dna_fleet.rs
@@ -122,6 +122,11 @@ impl Fleet {
             let _ = p.kill();
             let _ = p.wait();
         }
+        // the pid that ran `hale dna run` / `hale node` was the host itself
+        // (it execs in place), so nothing of ours keeps ticking after the kill
+        std::thread::sleep(Duration::from_millis(300));
+        let left = Command::new("pgrep").args(["-f", &format!("host (run|node) {}", self.d.display())]).output().map(|o| String::from_utf8_lossy(&o.stdout).lines().count()).unwrap_or(0);
+        assert_eq!(left, 0, "host processes survived their shim's death");
         for f in ["org.pid", "app.pid"] {
             if let Ok(pid) = std::fs::read_to_string(self.app.join(".hale/dna").join(f)) {
                 let _ = Command::new("kill").args(["-9", pid.trim()]).status();


### PR DESCRIPTION
The shim that resolved the project and started the Hale host (#576) waited on it as a child, so a signal to the pid that ran `hale dna run` / `hale dna dev` / `hale node` — a supervisor's, a test's — killed the shim and orphaned the host, which kept ticking. On this workstation dozens of `host node` agents and `dna/ui` surfaces from earlier test runs were still alive at ~30% CPU each, and a CI job log shows the runner terminating orphaned `ui` processes after a test shard; that load is a plausible part of #578's story.

The shim now execs the host in place (`CommandExt::exec`), and `hale dna ui` its surface: the pid is the process, and a kill reaches it. The fleet test asserts nothing of its own survives its teardown. The DNA suites pass with no process left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)