### PR TITLE
spec: a vec get allocates its copy in the caller's frame; walk with items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ behavior.
 
 ### A vec form owns its elements; `hale run` names a signal (GH #577)
 
-- `@form(vec)`: `get` returns the caller's copy of a heap-bearing element, and `set` / `push` store the vec's own copy whatever arena the value came from. Before, `get` handed back the slot's pointer and `set` passed a pointer already in the arena straight through, so two slots could share one struct and `set`'s retire of the replaced element freed memory the other slot — or a value read earlier — still held: two items swapped through `get` and `set` segfaulted. Scalars and locus refs are unchanged. Test: `tests/hale/form_vec_owned_elements_test.hl`.
+- `@form(vec)`: `get` returns the caller's copy of a heap-bearing element, and `set` / `push` store the vec's own copy whatever arena the value came from. Before, `get` handed back the slot's pointer and `set` passed a pointer already in the arena straight through, so two slots could share one struct and `set`'s retire of the replaced element freed memory the other slot — or a value read earlier — still held: two items swapped through `get` and `set` segfaulted. Scalars and locus refs are unchanged. The copy is an allocation in the caller's arena, freed with the frame (as a hashmap `get` already was); a hot walk uses `for x in v.items`, which visits elements in place. Test: `tests/hale/form_vec_owned_elements_test.hl`.
 - `hale run` says when the program was killed by a signal (`hale run: the program was killed by SIGSEGV (signal 11)`) and exits 128 + the signal, where it used to say nothing and exit 1.
 
 ### DNA: the host is Hale (GH #566 F8)

--- a/spec/forms.md
+++ b/spec/forms.md
@@ -442,6 +442,13 @@ vec.set(i, x)         or noop(err);   # swallow OOB
 > value as before. (Before this, `get` handed back the slot's pointer
 > and a same-arena value passed through `set` uncopied; two items
 > swapped through `get` and `set` segfaulted.)
+>
+> The copy is an allocation in the caller's arena, freed with the
+> frame — the same cost and lifetime as a hashmap `get`. A frame that
+> reads a heap-bearing element millions of times before it returns
+> holds every copy until then; a hot walk uses `for x in v.items`,
+> which visits the elements in place without copying (and must not
+> `set` the vec it walks).
 
 ```hale,fragment
 ```


### PR DESCRIPTION
Follows #580. The ownership rule has a cost the spec should state: a `get` of a heap-bearing element is an allocation in the caller's arena, freed with the frame — the same cost and lifetime a hashmap `get` already had. A frame that reads such an element millions of times before it returns holds every copy until then; a hot walk is `for x in v.items`, which visits the elements in place and must not `set` the vec it walks.

Measured on a 1,000-row vec of `{ Int, String }`: two million `get`s in one `run()` frame grew the process from 3.8 MB to 36 MB; the same two million visits through `items` stayed at 4.9 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)