### PR TITLE
dna: the native Anthropic adapter, and the credential's scheme (GH #583 M2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ behavior.
 - `hale dna models`: the catalog probed — one line per backend with one small request to each that is permitted; the organization is not started and nothing is journaled.
 - `HostedModel` is `OpenAiChat` (`adapter: openai-chat`), named for what it speaks; `FakeModel { fail_after }` refuses after that many calls, for tests that fail an Attempt on cue.
 
+### DNA: the native Anthropic adapter, and the credential's scheme (GH #583 M2)
+
+- `AnthropicMessages`: the Messages API on the same `ModelBackend` seam — `system` beside `messages`, `max_tokens` required (default 4096), the reply's text blocks joined, `anthropic-version` sent, the same evidence and price table as `OpenAiChat`. `init` writes it as the hosted backend when `ANTHROPIC_API_KEY` is present (`claude-opus-5` / `claude-haiku-4-5-20251001`), instead of the compatibility endpoint.
+- `HostedCredential { scheme }`: `bearer` (the default; `Authorization: Bearer`) or `x-api-key`. The sealed credential composes the header for its scheme and takes the adapter's own headers as a separate argument, so no adapter ever holds a header with the material in it.
+
 ### `hale check` refuses a call to a name nothing binds (GH #583, dna/FRICTION.md F.18)
 
 - A bare callee that is not a local binding, a top-level fn, a generic fn or a builtin typed as Unknown and passed `check`, to be refused by `hale build` as `no free fn / generic fn / fn-pointer binding with that name is in scope`. An organization whose gate is `check` applied a candidate naming a router function nobody had written, and found out at expression (rolled back by the window, as designed — but the wrong gate). The checker holds codegen's rule now when a whole seed is checked (`hale check <directory>`, which is what a build compiles and what the organization's gate runs): `call to X: no free fn, generic fn or fn-pointer binding with that name is in scope`, with a did-you-mean over the program's fns. One file checked alone, or a partial program a harness assembles, keeps the permissive reading, since it may call what a sibling file defines. `check_unbound_callee.rs` pins both.

--- a/crates/hale-cli/src/dna.rs
+++ b/crates/hale-cli/src/dna.rs
@@ -608,31 +608,35 @@ fn discover() -> Discovery {
     }
 }
 
-/// A hosted backend as the catalog writes it: provider, model, key,
-/// price per 1k tokens in micro-dollars.
+/// A hosted backend as the catalog writes it: the adapter (what the
+/// wire speaks), model, key and its scheme, price per 1k tokens in
+/// micro-dollars.
 struct Hosted {
+    adapter: &'static str, // `dna::OpenAiChat` | `dna::AnthropicMessages`
     model: &'static str,
     endpoint: &'static str,
     env_var: &'static str,
+    scheme: &'static str, // `bearer` | `x-api-key`
     input_micros_per_1k: u32,
     output_micros_per_1k: u32,
 }
 
 impl Discovery {
-    /// The provider the hosted backends speak to: Anthropic when its key
-    /// is present (the strongest models), else OpenAI (its key, or a
-    /// placeholder until one is set).
+    /// The provider the hosted backends speak to: Anthropic's native
+    /// Messages API when its key is present (the strongest models),
+    /// else OpenAI's chat shape (its key, or a placeholder until one is
+    /// set).
     fn hosted(&self) -> (Hosted, Hosted, &'static str) {
         if self.anthropic {
             (
-                Hosted { model: "claude-opus-5", endpoint: "https://api.anthropic.com/v1/chat/completions", env_var: "ANTHROPIC_API_KEY", input_micros_per_1k: 15000, output_micros_per_1k: 75000 },
-                Hosted { model: "claude-haiku-4-5-20251001", endpoint: "https://api.anthropic.com/v1/chat/completions", env_var: "ANTHROPIC_API_KEY", input_micros_per_1k: 1000, output_micros_per_1k: 5000 },
+                Hosted { adapter: "dna::AnthropicMessages", model: "claude-opus-5", endpoint: "https://api.anthropic.com/v1/messages", env_var: "ANTHROPIC_API_KEY", scheme: "x-api-key", input_micros_per_1k: 15000, output_micros_per_1k: 75000 },
+                Hosted { adapter: "dna::AnthropicMessages", model: "claude-haiku-4-5-20251001", endpoint: "https://api.anthropic.com/v1/messages", env_var: "ANTHROPIC_API_KEY", scheme: "x-api-key", input_micros_per_1k: 1000, output_micros_per_1k: 5000 },
                 "ANTHROPIC_API_KEY",
             )
         } else {
             (
-                Hosted { model: "gpt-4o", endpoint: "https://api.openai.com/v1/chat/completions", env_var: "OPENAI_API_KEY", input_micros_per_1k: 2500, output_micros_per_1k: 10000 },
-                Hosted { model: "gpt-4o-mini", endpoint: "https://api.openai.com/v1/chat/completions", env_var: "OPENAI_API_KEY", input_micros_per_1k: 150, output_micros_per_1k: 600 },
+                Hosted { adapter: "dna::OpenAiChat", model: "gpt-4o", endpoint: "https://api.openai.com/v1/chat/completions", env_var: "OPENAI_API_KEY", scheme: "bearer", input_micros_per_1k: 2500, output_micros_per_1k: 10000 },
+                Hosted { adapter: "dna::OpenAiChat", model: "gpt-4o-mini", endpoint: "https://api.openai.com/v1/chat/completions", env_var: "OPENAI_API_KEY", scheme: "bearer", input_micros_per_1k: 150, output_micros_per_1k: 600 },
                 "OPENAI_API_KEY",
             )
         }
@@ -687,8 +691,8 @@ fn models_hl(found: &Discovery) -> String {
     let desk_model = found.ollama.clone().unwrap_or_else(|| "llama3".to_string());
     let hosted = |name: &str, h: &Hosted| {
         format!(
-            "dna::OpenAiChat {{ name: \"{name}\", model: \"{}\", endpoint: \"{}\", credential: dna::HostedCredential {{ env_var: \"{}\" }}, input_micros_per_1k: {}, output_micros_per_1k: {} }}",
-            h.model, h.endpoint, h.env_var, h.input_micros_per_1k, h.output_micros_per_1k
+            "{} {{ name: \"{name}\", model: \"{}\", endpoint: \"{}\", credential: dna::HostedCredential {{ env_var: \"{}\", scheme: \"{}\" }}, input_micros_per_1k: {}, output_micros_per_1k: {} }}",
+            h.adapter, h.model, h.endpoint, h.env_var, h.scheme, h.input_micros_per_1k, h.output_micros_per_1k
         )
     };
     format!(
@@ -707,19 +711,21 @@ import "vendor/dna" as dna;
 
 // ---- backends ------------------------------------------------------
 //
-// A hosted backend speaks the OpenAI chat shape (OpenAI, OpenRouter,
-// vLLM, Anthropic's compatibility endpoint) and presents its key from
-// a sealed locus that never returns it; without the key it is not a
-// permitted backend and the router refuses before the wire. Prices
-// are micro-dollars per 1k tokens, for the evidence and the budget.
+// A hosted backend is `dna::AnthropicMessages` (the native Messages
+// API; the key travels as `x-api-key`) or `dna::OpenAiChat` (the
+// OpenAI chat shape: OpenAI, OpenRouter, vLLM, Ollama; the key as a
+// bearer token). Either presents its key from a sealed locus that
+// never returns it; without the key it is not a permitted backend and
+// the router refuses before the wire. Prices are micro-dollars per
+// 1k tokens, for the evidence and the budget.
 
 // The strongest model: the Leader's decisions, the editor's assessments.
-fn frontier() -> dna::OpenAiChat {{
+fn frontier() -> {adapter} {{
     return {frontier};
 }}
 
 // A fast, cheap model: classification, drafts, retries.
-fn fast() -> dna::OpenAiChat {{
+fn fast() -> {adapter} {{
     return {fast};
 }}
 
@@ -767,6 +773,7 @@ fn probe_catalog() -> String {{
 }}
 "#,
         summary = found.summary(),
+        adapter = frontier.adapter,
         frontier = hosted("deep", &frontier),
         fast = hosted("quick", &fast),
         desk = desk_model,

--- a/crates/hale-cli/tests/dna_models.rs
+++ b/crates/hale-cli/tests/dna_models.rs
@@ -92,7 +92,7 @@ fn init_writes_the_catalog_from_what_the_machine_has_and_the_org_takes_its_route
     assert!(out.contains("leader, editor, agent: deep = frontier, quick = fast, private = desk · budget 25.00 USD a day"), "{out}");
     for needle in [
         "fn frontier() -> dna::OpenAiChat",
-        "model: \"gpt-4o\", endpoint: \"https://api.openai.com/v1/chat/completions\", credential: dna::HostedCredential { env_var: \"OPENAI_API_KEY\" }",
+        "model: \"gpt-4o\", endpoint: \"https://api.openai.com/v1/chat/completions\", credential: dna::HostedCredential { env_var: \"OPENAI_API_KEY\", scheme: \"bearer\" }",
         "fn fast() -> dna::OpenAiChat",
         "fn desk() -> dna::LocalModel",
         "fn leader_models() -> dna::ModelRouter",
@@ -115,16 +115,20 @@ fn init_writes_the_catalog_from_what_the_machine_has_and_the_org_takes_its_route
     let (ok, out) = hale_env(&["build", "dna/org"], &app, &[], &[]);
     assert!(ok, "the organization builds from the catalog: {out}");
 
-    // 2. an Anthropic key: the hosted backends speak to Anthropic's
-    //    compatibility endpoint with the strongest models
+    // 2. an Anthropic key: the hosted backends speak the native Messages
+    //    API, the key as x-api-key, with the strongest models
     let d2 = workdir("anthropic");
     let (ok, out) = hale_env(&["dna", "new", "withkey"], &d2, &[("PATH", &bare_path()), ("ANTHROPIC_API_KEY", "sk-ant-test")], &["OPENAI_API_KEY"]);
     assert!(ok, "{out}");
     let catalog = std::fs::read_to_string(d2.join("withkey/dna/org/models.hl")).unwrap();
     assert!(out.contains("models  found   ANTHROPIC_API_KEY set, no ollama on PATH"), "{out}");
     assert!(out.contains("frontier = claude-opus-5 · fast = claude-haiku-4-5-20251001 (ANTHROPIC_API_KEY)"), "{out}");
-    assert!(catalog.contains("model: \"claude-opus-5\", endpoint: \"https://api.anthropic.com/v1/chat/completions\", credential: dna::HostedCredential { env_var: \"ANTHROPIC_API_KEY\" }, input_micros_per_1k: 15000, output_micros_per_1k: 75000"), "{catalog}");
-    assert!(catalog.contains("model: \"claude-haiku-4-5-20251001\""), "{catalog}");
+    assert!(catalog.contains("fn frontier() -> dna::AnthropicMessages {\n    return dna::AnthropicMessages { name: \"deep\", model: \"claude-opus-5\", endpoint: \"https://api.anthropic.com/v1/messages\", credential: dna::HostedCredential { env_var: \"ANTHROPIC_API_KEY\", scheme: \"x-api-key\" }, input_micros_per_1k: 15000, output_micros_per_1k: 75000 };"), "{catalog}");
+    assert!(catalog.contains("fn fast() -> dna::AnthropicMessages {\n    return dna::AnthropicMessages { name: \"quick\", model: \"claude-haiku-4-5-20251001\""), "{catalog}");
+    assert!(!catalog.contains("-> dna::OpenAiChat"), "no OpenAI backend when Anthropic is chosen:\n{catalog}");
+    // and the organization checks and builds from it
+    let (ok, out) = hale_env(&["check", "--matrix", "."], &d2.join("withkey"), &[], &[]);
+    assert!(ok, "matrix: {out}");
 
     // 3. re-running keeps the catalog the project may have edited
     std::fs::write(d2.join("withkey/dna/org/models.hl"), "// mine\n").unwrap();

--- a/crates/hale-cli/tests/dna_native_suite.rs
+++ b/crates/hale-cli/tests/dna_native_suite.rs
@@ -57,7 +57,8 @@ fn dna_core_verifies_clean() {
 /// A suite that quietly emptied would pass the check above by
 /// running nothing. #526 names eight programs; seven are Hale-native,
 /// #528 adds the hosted-model adapter's, #529 the gateways' and
-/// the source-editing Attempt's, #583 the budget's.
+/// the source-editing Attempt's, #583 the budget's and the Anthropic
+/// adapter's.
 #[test]
 fn dna_fixture_set_is_complete() {
     let dir = repo_root().join("dna/tests");
@@ -73,6 +74,7 @@ fn dna_fixture_set_is_complete() {
     assert_eq!(
         names,
         vec![
+            "anthropic_messages_test.hl",
             "apply_test.hl",
             "assembly_test.hl",
             "budget_test.hl",

--- a/dna/core/models.hl
+++ b/dna/core/models.hl
@@ -263,9 +263,13 @@ fn parse_chat(status: Int, body: String) -> ChatOutcome {
 // A hosted credential: read from the environment at birth, presented
 // on the wire from inside this sealed locus, never returned. The only
 // things that leave are a readiness bit, a fingerprint (a correlation
-// handle over a high-entropy token), and HTTP responses.
+// handle over a high-entropy token), and HTTP responses. The `scheme`
+// says how the wire wants it (GH #583 M2): `bearer` (an
+// `Authorization: Bearer` header: OpenAI and everything that speaks
+// its shape) or `x-api-key` (Anthropic's native API); no adapter
+// composes a header with the material in it.
 @sealed locus HostedCredential {
-    params { env_var: String = "OPENAI_API_KEY"; value: Bytes = b""; }
+    params { env_var: String = "OPENAI_API_KEY"; scheme: String = "bearer"; value: Bytes = b""; }
     birth() {
         if len(self.env_var) > 0 && std::env::var_exists(self.env_var) {
             self.value = std::bytes::from_string(std::env::var(self.env_var));
@@ -278,14 +282,21 @@ fn parse_chat(status: Int, body: String) -> ChatOutcome {
         let h = hex(std::crypto::sha256(self.value));
         return "fp:" + h[0..16];
     }
-    // POST a JSON body with the bearer credential attached HERE.
+    // POST a JSON body with the credential attached HERE, per its
+    // scheme; `extra` is the adapter's own headers (CRLF-terminated
+    // lines, e.g. `anthropic-version`), which never name the material.
     @effects(is: { secret_use, external_model })
-    fn post_json(url: String, body: String) -> std::http::ClientResponse fallible(std::http::HttpError) {
+    fn post_json(url: String, body: String, extra: String) -> std::http::ClientResponse fallible(std::http::HttpError) {
         let u = std::http::parse_url(url) or raise;
+        let presented = if self.scheme == "x-api-key" {
+            "x-api-key: " + std::str::from_bytes(self.value)
+        } else {
+            "Authorization: Bearer " + std::str::from_bytes(self.value)
+        };
         let req = std::http::ClientRequest {
             method: "POST",
             url: u,
-            headers: "Content-Type: application/json\r\nAuthorization: Bearer " + std::str::from_bytes(self.value),
+            headers: "Content-Type: application/json\r\n" + extra + presented,
             body: std::bytes::from_string(body)
         };
         return std::http::request(req) or raise;
@@ -337,9 +348,124 @@ locus OpenAiChat {
         }
         let body = openai_chat_body(self.model, req, self.temperature_milli, self.max_tokens);
         let t0 = std::time::monotonic();
-        let resp = self.credential.post_json(self.endpoint, body) or self.transport_failed(err);
+        let resp = self.credential.post_json(self.endpoint, body, "") or self.transport_failed(err);
         ev.elapsed = to_string(std::time::monotonic() - t0);
         let out = parse_chat(resp.status, std::str::from_bytes(resp.body));
+        ev.ok = out.ok;
+        ev.refused = out.refused;
+        ev.reported_model = out.reported_model;
+        ev.input_tokens = out.input_tokens;
+        ev.output_tokens = out.output_tokens;
+        ev.response_digest = digest_of(out.text);
+        ev.cost_micros = (out.input_tokens * self.input_micros_per_1k + out.output_tokens * self.output_micros_per_1k) / 1000;
+        self.last = ev;
+        ModelCalled <- ev;
+        if !out.ok {
+            return ModelResult { ok: false, backend: self.name, model: self.model, refused: out.refused };
+        }
+        return ModelResult {
+            ok: true, backend: self.name, model: out.reported_model, output: out.text,
+            tokens: out.input_tokens + out.output_tokens, cost_micros: ev.cost_micros
+        };
+    }
+    fn transport_failed(e: std::http::HttpError) -> std::http::ClientResponse {
+        return std::http::ClientResponse { status: 0, body: std::bytes::from_string("{\"error\": {\"message\": " + jq(e.kind + " " + e.detail) + "}}") };
+    }
+}
+
+// ---- the Anthropic adapter (GH #583 M2) --------------------------------
+//
+// The native Messages API: `system` beside `messages`, `max_tokens`
+// required, the reply as content blocks, the key as `x-api-key` with
+// an `anthropic-version`. Same seam, same evidence, same sealed
+// credential as OpenAiChat — the credential's scheme is the only
+// thing that knows how the key travels.
+
+fn anthropic_messages_body(model: String, req: ModelRequest, temperature_milli: Int, max_tokens: Int) -> String {
+    let mut b = "{\"model\": " + jq(model) + ", \"max_tokens\": " + to_string(if max_tokens > 0 { max_tokens } else { 4096 });
+    if len(req.context) > 0 { b = b + ", \"system\": " + jq(req.context); }
+    if temperature_milli >= 0 { b = b + ", \"temperature\": " + to_string(temperature_milli / 1000) + "." + pad3(temperature_milli % 1000); }
+    return b + ", \"messages\": [{\"role\": \"user\", \"content\": " + jq(req.prompt) + "}]}";
+}
+
+// The text blocks of a Messages reply, concatenated; "" when the
+// shape is not a message.
+@unbounded
+fn anthropic_text(body: String) -> String {
+    let content = std::json::find_field_raw(body, "content");
+    if len(content) == 0 { return ""; }
+    let out = std::str::builder_new();
+    let mut it = std::json::array_first(content);
+    while !it.done {
+        let t = std::json::find_string_field(it.element, "text");
+        if len(t) > 0 { std::str::builder_append(out, t); }
+        it = std::json::array_next(it);
+    }
+    return std::str::builder_finish(out);
+}
+
+fn parse_messages(status: Int, body: String) -> ChatOutcome {
+    if status != 200 {
+        let why = std::json::find_string_field(std::json::find_field_raw(body, "error"), "message");
+        return ChatOutcome { status: status, refused: "http " + to_string(status) + " " + why };
+    }
+    let text = anthropic_text(body);
+    if len(text) == 0 { return ChatOutcome { status: status, refused: "no message in the response" }; }
+    let usage = std::json::find_field_raw(body, "usage");
+    return ChatOutcome {
+        ok: true, status: status, text: text,
+        reported_model: std::json::find_string_field(body, "model"),
+        input_tokens: std::json::find_int_field(usage, "input_tokens"),
+        output_tokens: std::json::find_int_field(usage, "output_tokens")
+    };
+}
+
+locus AnthropicMessages {
+    params {
+        name: String = "hosted";
+        adapter: String = "anthropic-messages";
+        endpoint: String = "https://api.anthropic.com/v1/messages";
+        version: String = "2023-06-01"; // the `anthropic-version` header
+        model: String = "claude-sonnet-5";
+        credential: HostedCredential = HostedCredential { env_var: "ANTHROPIC_API_KEY", scheme: "x-api-key" };
+        max_bytes: Int = 800000;
+        temperature_milli: Int = -1; // < 0: the provider's default; 0..1000 sent as 0.000..1.000
+        max_tokens: Int = 4096; // required by the API; a whole-file rewrite needs room
+        // price per 1k tokens, micro-dollars (3 / 15 per M ≈ sonnet)
+        input_micros_per_1k: Int = 3000;
+        output_micros_per_1k: Int = 15000;
+        calls: Int = 0;
+        last: ModelEvidence = ModelEvidence { };
+    }
+    bus { publish ModelCalled; }
+    fn identity() -> String { return self.name; }
+    fn model_name() -> String { return self.model; }
+    fn allows(data_class: String) -> Bool { return data_class != "customer" && self.credential.ready(); }
+    fn capacity_bytes() -> Int { return self.max_bytes; }
+    @effects(is: { external_model })
+    fn complete(req: ModelRequest) -> ModelResult {
+        self.calls = self.calls + 1;
+        let mut ev = ModelEvidence {
+            attempt_id: req.attempt_id, adapter: self.adapter, backend: self.name,
+            endpoint: self.endpoint, credential: self.credential.fingerprint(),
+            requested_model: self.model,
+            params: temperature_param(self.temperature_milli) + " max_tokens=" + to_string(if self.max_tokens > 0 { self.max_tokens } else { 4096 }),
+            prompt_digest: if len(req.prompt_digest) > 0 { req.prompt_digest } else { digest_of(req.prompt) },
+            context_digest: digest_of(req.context),
+            knowledge_bindings: req.knowledge_bindings, tool_grant: req.tool_grant,
+            retry_of: req.retry_of, data_class: req.data_class
+        };
+        if !self.allows(req.data_class) {
+            ev.refused = if self.credential.ready() { "data class " + req.data_class } else { "credential not present" };
+            self.last = ev;
+            ModelCalled <- ev;
+            return ModelResult { ok: false, backend: self.name, model: self.model, refused: ev.refused };
+        }
+        let body = anthropic_messages_body(self.model, req, self.temperature_milli, self.max_tokens);
+        let t0 = std::time::monotonic();
+        let resp = self.credential.post_json(self.endpoint, body, "anthropic-version: " + self.version + "\r\n") or self.transport_failed(err);
+        ev.elapsed = to_string(std::time::monotonic() - t0);
+        let out = parse_messages(resp.status, std::str::from_bytes(resp.body));
         ev.ok = out.ok;
         ev.refused = out.refused;
         ev.reported_model = out.reported_model;

--- a/dna/tests/anthropic_messages_test.hl
+++ b/dna/tests/anthropic_messages_test.hl
@@ -1,0 +1,135 @@
+// dna/tests/anthropic_messages_test.hl — GH #583 M2: the native
+// Anthropic Messages adapter, and the credential's scheme.
+//
+// A fake Messages endpoint in this same program (io pool) insists on
+// `x-api-key` and `anthropic-version`, reads `system` and `messages`,
+// and answers with content blocks and usage. The adapter presents the
+// credential from the sealed locus per its scheme (the test never sees
+// it), records the same evidence OpenAiChat does, refuses customer data
+// and a missing credential before the wire, and reports an API error
+// by its message.
+
+import "../core" as dna;
+
+// The handler is reached through `std::http::Handler`, so what it saw
+// comes back in the reply: the text is "the answer" only for the body
+// the API wants, and names the body otherwise.
+fn body_as_the_api_wants(body: String) -> Bool {
+    return std::str::contains(body, "\"max_tokens\": 64")
+        && std::str::contains(body, "\"system\": \"the diff\"")
+        && std::str::contains(body, "\"messages\": [{\"role\": \"user\", \"content\": \"decide\"}]")
+        && std::str::contains(body, "\"temperature\": 0.200");
+}
+
+locus FakeAnthropic {
+    params { seen: Int = 0; }
+    fn handle(req: std::http::Request) -> std::http::Response {
+        if req.path != "/v1/messages" { return std::http::Response { status: 404, body: "no" }; }
+        if !std::str::contains(req.headers, "x-api-key: ") || std::str::contains(req.headers, "Authorization: Bearer") {
+            return std::http::Response { status: 401, content_type: "application/json", body: "{\"type\": \"error\", \"error\": {\"type\": \"authentication_error\", \"message\": \"x-api-key required\"}}" };
+        }
+        if !std::str::contains(req.headers, "anthropic-version: 2023-06-01") {
+            return std::http::Response { status: 400, content_type: "application/json", body: "{\"type\": \"error\", \"error\": {\"type\": \"invalid_request_error\", \"message\": \"anthropic-version required\"}}" };
+        }
+        self.seen = self.seen + 1;
+        let model = std::json::find_string_field(req.body, "model");
+        if model == "overloaded-model" {
+            return std::http::Response { status: 529, content_type: "application/json", body: "{\"type\": \"error\", \"error\": {\"type\": \"overloaded_error\", \"message\": \"Overloaded\"}}" };
+        }
+        let n = len(req.body) / 4;
+        let second = if body_as_the_api_wants(req.body) { "answer" } else { "unexpected body: " + std::json::escape_string(req.body) };
+        return std::http::Response {
+            status: 200, content_type: "application/json",
+            body: "{\"id\": \"msg_1\", \"type\": \"message\", \"role\": \"assistant\", \"model\": \"" + model + "-20260101\", \"content\": [{\"type\": \"text\", \"text\": \"the \"}, {\"type\": \"text\", \"text\": \"" + second + "\"}], \"stop_reason\": \"end_turn\", \"usage\": {\"input_tokens\": " + to_string(n) + ", \"output_tokens\": 3}}"
+        };
+    }
+}
+
+main locus App {
+    params {
+        srv: std::http::Server = std::http::Server { port: 47392, handler: FakeAnthropic { } };
+        hosted: dna::AnthropicMessages = dna::AnthropicMessages {
+            name: "deep", model: "test-model",
+            endpoint: "http://127.0.0.1:47392/v1/messages",
+            // any present env var stands in for the API key; the server only checks presence
+            credential: dna::HostedCredential { env_var: "HOME", scheme: "x-api-key" },
+            max_tokens: 64, temperature_milli: 200
+        };
+        keyless: dna::AnthropicMessages = dna::AnthropicMessages {
+            name: "deep", model: "test-model",
+            endpoint: "http://127.0.0.1:47392/v1/messages",
+            credential: dna::HostedCredential { env_var: "HALE_DNA_NO_SUCH_KEY_7f3b", scheme: "x-api-key" }
+        };
+        overloaded: dna::AnthropicMessages = dna::AnthropicMessages {
+            name: "deep", model: "overloaded-model",
+            endpoint: "http://127.0.0.1:47392/v1/messages",
+            credential: dna::HostedCredential { env_var: "HOME", scheme: "x-api-key" }
+        };
+        // a bearer credential on the Anthropic wire: the scheme is the
+        // credential's, and the endpoint refuses it
+        wrong_scheme: dna::AnthropicMessages = dna::AnthropicMessages {
+            name: "deep", model: "test-model",
+            endpoint: "http://127.0.0.1:47392/v1/messages",
+            credential: dna::HostedCredential { env_var: "HOME" }
+        };
+        core: dna::Dna = dna::Dna { };
+    }
+    placement { srv: cooperative(pool = io); }
+    run() {
+        std::time::sleep(200ms);
+        // 1. a call: the key travels as x-api-key, the version beside it;
+        //    system and messages as the API wants; blocks joined; usage read
+        let r = self.hosted.complete(dna::ModelRequest {
+            attempt_id: "w1/a0", role: "review", prompt: "decide", context: "the diff",
+            context_bytes: 8, knowledge_bindings: "kb1", data_class: "internal"
+        });
+        std::test::assert(r.ok, "messages call succeeded: " + r.refused);
+        // the blocks joined; and "answer" only for the body the API wants:
+        // max_tokens sent (required), the context as `system`, the prompt
+        // as the user message, the temperature as set
+        std::test::assert_eq_str(r.output, "the answer", "content blocks joined, body as the API wants: " + r.output);
+        std::test::assert_eq_str(r.model, "test-model-20260101", "the model the endpoint REPORTED");
+        std::test::assert(r.tokens > 3, "tokens from usage");
+        let ev = self.hosted.last;
+        std::test::assert_eq_str(ev.adapter, "anthropic-messages", "adapter identity");
+        std::test::assert_eq_str(ev.requested_model, "test-model", "requested model");
+        std::test::assert_eq_str(ev.reported_model, "test-model-20260101", "reported model");
+        std::test::assert(std::str::contains(ev.credential, "fp:"), "credential recorded as a fingerprint, never bytes: " + ev.credential);
+        std::test::assert(std::str::contains(ev.params, "temperature=0.200 max_tokens=64"), "parameters as sent: " + ev.params);
+        std::test::assert(ev.output_tokens == 3, "output tokens from usage");
+        std::test::assert(ev.cost_micros > 0, "cost from the price table");
+        std::test::assert(std::str::contains(ev.response_digest, "sha256:"), "response digest");
+        // 2. customer data never reaches it; no wire call is made
+        let c = self.hosted.complete(dna::ModelRequest { attempt_id: "w1/a1", prompt: "leak?", data_class: "customer" });
+        std::test::assert(!c.ok && std::str::contains(c.refused, "data class customer"), c.refused);
+        std::test::assert_eq_int(self.hosted.calls, 2, "counted, not sent");
+        // 3. no credential: not a permitted backend, refused before the wire
+        std::test::assert(!self.keyless.allows("internal"), "a keyless backend is not permitted");
+        let k = self.keyless.complete(dna::ModelRequest { attempt_id: "w1/a2", prompt: "x" });
+        std::test::assert(std::str::contains(k.refused, "credential not present"), k.refused);
+        // 4. an API error is reported by its message, and is evidence
+        let o = self.overloaded.complete(dna::ModelRequest { attempt_id: "w1/a3", prompt: "x" });
+        std::test::assert(!o.ok && o.refused == "http 529 Overloaded", "the API's message: " + o.refused);
+        std::test::assert(!self.overloaded.last.ok && self.overloaded.last.refused == "http 529 Overloaded", "in the evidence too");
+        // 5. the scheme is the credential's: a bearer credential on this
+        //    wire is refused by the endpoint, and the adapter says so
+        let w = self.wrong_scheme.complete(dna::ModelRequest { attempt_id: "w1/a4", prompt: "x" });
+        std::test::assert(!w.ok && w.refused == "http 401 x-api-key required", "the wrong scheme is the endpoint's refusal: " + w.refused);
+        // 6. every call was journaled by the assembly as model.called evidence
+        std::time::sleep(100ms);
+        let mut n = 0;
+        let mut i = 0;
+        while i < self.core.journal.revision() {
+            if self.core.journal.read(i).kind == "model.called" { n = n + 1; }
+            i = i + 1;
+        }
+        std::test::assert_eq_int(n, 5, "five calls, five evidence rows");
+        let first = self.core.journal.read(0);
+        std::test::assert(std::str::contains(first.body, "\"adapter\": \"anthropic-messages\""), "evidence body: " + first.body);
+        std::test::assert(!std::str::contains(first.body, "decide"), "the prompt itself is never journaled");
+    }
+}
+
+fn main() {
+    App { };
+}

--- a/docs/src/dna/models.md
+++ b/docs/src/dna/models.md
@@ -51,28 +51,33 @@ models  frontier = claude-opus-5 · fast = claude-haiku-4-5-20251001 (ANTHROPIC_
 models  leader, editor, agent: deep = frontier, quick = fast, private = desk · budget 25.00 USD a day (`hale dna models` probes them)
 ```
 
-With `ANTHROPIC_API_KEY` the hosted backends speak to Anthropic's
-OpenAI-compatible endpoint with the strongest models; with
-`OPENAI_API_KEY` alone, to OpenAI; with neither, the catalog still
-names OpenAI with the key's name as a placeholder, the hosted
-backends are simply not permitted until it is set, and every review
-waits for the Board. `ollama` on `PATH` makes its first listed model
+With `ANTHROPIC_API_KEY` the hosted backends are `AnthropicMessages`
+with the strongest models; with `OPENAI_API_KEY` alone, `OpenAiChat`
+to OpenAI; with neither, the catalog still names OpenAI with the
+key's name as a placeholder, the hosted backends are simply not
+permitted until it is set, and every review waits for the Board. `ollama` on `PATH` makes its first listed model
 the desk model. Re-running `init` keeps a catalog you have edited;
 `hale dna upgrade` writes one for an organization from before the
 catalog and tells you what to point at it.
 
-## Three backends
+## Four backends
 
 - **`OpenAiChat`** — a prompt leaves the process for an endpoint
-  speaking the OpenAI chat shape (OpenAI, OpenRouter, vLLM,
-  Anthropic's compatibility endpoint). `complete` carries the
-  `external_model` effect class, so a claim can keep customer data
-  away from it structurally, and the router already refuses
-  `data_class: "customer"` for it. The API key is read from the
-  environment into a **sealed** `HostedCredential` that presents it
-  on the wire and never returns it; without a credential the model
-  is not a permitted backend, and the router refuses before the
-  wire.
+  speaking the OpenAI chat shape (OpenAI, OpenRouter, vLLM, Ollama).
+  `complete` carries the `external_model` effect class, so a claim
+  can keep customer data away from it structurally, and the router
+  already refuses `data_class: "customer"` for it. The API key is
+  read from the environment into a **sealed** `HostedCredential`
+  that presents it on the wire and never returns it; without a
+  credential the model is not a permitted backend, and the router
+  refuses before the wire.
+- **`AnthropicMessages`** — the native Messages API, on the same
+  seam with the same evidence: the context travels as `system`, the
+  prompt as the user message, `max_tokens` is always sent (the API
+  requires it), the reply's text blocks are joined. Its credential
+  has `scheme: "x-api-key"`; the credential, not the adapter, knows
+  how the key is presented — `bearer` for everything OpenAI-shaped —
+  so no adapter ever composes a header with the material in it.
 - **`LocalModel`** — the same wire to a local endpoint: no
   credential, no `external_model`, any data class.
 - **`FakeModel`** — scripted. `answer` (or `answer_file`, or an
@@ -172,4 +177,6 @@ inside it, so no holder can read the key back, and the generated law
 requires it (`credentials_sealed: require sealed(all credentials)`).
 It takes the *name* of a source (`env_var`), never the bytes, and
 loads at birth, so there is no construction site at which anything
-held the material. See [Claims & the law](../claims.md) on `@sealed`.
+held the material. Its `scheme` says how the wire wants the key —
+`bearer` or `x-api-key` — and the credential composes that header
+itself; an adapter hands it only its own headers. See [Claims & the law](../claims.md) on `@sealed`.

--- a/docs/src/dna/reference.md
+++ b/docs/src/dna/reference.md
@@ -134,7 +134,7 @@ last_restart_request, last_observed }`, `intents`, `tasks[]`,
 | `process.hl` | `Task`, `Workflow`, `Step`, `Work`, `Attempt`, `Metabolism` |
 | `work_system.hl` | `WorkSystem`, routing perspectives, the performers |
 | `review.hl` | `Review`, `AutonomyBoundary`, authority ranks |
-| `models.hl` | `ModelRouter`, `OpenAiChat`, `LocalModel`, `FakeModel`, `HostedCredential`, `probe` |
+| `models.hl` | `ModelRouter`, `OpenAiChat`, `AnthropicMessages`, `LocalModel`, `FakeModel`, `HostedCredential` (with its `scheme`), `probe` |
 | `budget.hl` | `BudgetPolicy`, `Budget` (the substrate's one counter) |
 | `knowledge.hl` | semantic memory: ideas, edges, bindings |
 | `workspace.hl` | `IsolatedWorktrees`, `LocalGit`, `MutationGateway` |

--- a/docs/src/dna/shaping.md
+++ b/docs/src/dna/shaping.md
@@ -94,11 +94,13 @@ fn agent_models() -> dna::ModelRouter { return dna::ModelRouter { quick: fast(),
 fn org_budget() -> dna::BudgetPolicy { return dna::BudgetPolicy { window: "day", allowance_micros: 25000000 }; }
 ```
 
-- **Hosted** (`OpenAiChat`) — any endpoint speaking the OpenAI chat
-  shape. The key is named by environment variable and read into a
-  sealed box the rest of the program cannot read back from. Without
-  the key, the backend simply isn't available. Customer-classed data
-  never goes to it.
+- **Hosted** (`OpenAiChat` for any endpoint speaking the OpenAI chat
+  shape, `AnthropicMessages` for Anthropic's native API) — the key
+  is named by environment variable and read into a sealed box the
+  rest of the program cannot read back from, which presents it the
+  way its `scheme` says (`bearer`, or `x-api-key`). Without the key,
+  the backend simply isn't available. Customer-classed data never
+  goes to it.
 - **Local** — the same wire to something on your machine. No key,
   any data.
 - **Scripted** — `dna::FakeModel { answer_file: "…" }` returns a

--- a/spec/dna.md
+++ b/spec/dna.md
@@ -183,14 +183,21 @@ The organization's models are a catalog in source (GH #583 M1):
   every call publishes `ModelCalled`, which the substrate journals as
   `model.called` with the time of the call (`at`). Routers return
   data, never a backend. Adapters: `OpenAiChat` (the OpenAI chat
-  shape: OpenAI, OpenRouter, vLLM, Anthropic's compatibility
-  endpoint; `adapter: openai-chat`; the credential from a sealed
-  `HostedCredential` that names its source and never returns the
-  bytes; `complete` carries `external_model`), `LocalModel` (the same
-  wire to this machine; no credential, no `external_model`, any data
-  class), `FakeModel` (scripted: `answer`, `answer_file`,
-  `answers_dir`, `answer_role`; `fail_after` refuses after that many
-  calls).
+  shape: OpenAI, OpenRouter, vLLM, Ollama; `adapter: openai-chat`),
+  `AnthropicMessages` (the native Messages API: `system` beside
+  `messages`, `max_tokens` required and defaulted to 4096, the reply's
+  text blocks joined, `anthropic-version` sent; `adapter:
+  anthropic-messages`), `LocalModel` (the OpenAI shape to this
+  machine; no credential, no `external_model`, any data class),
+  `FakeModel` (scripted: `answer`, `answer_file`, `answers_dir`,
+  `answer_role`; `fail_after` refuses after that many calls). A hosted
+  adapter's `complete` carries `external_model`; its credential is a
+  sealed `HostedCredential` that names its source (`env_var`) and its
+  `scheme` — `bearer` (an `Authorization: Bearer` header) or
+  `x-api-key` — and never returns the bytes: the credential composes
+  the header, no adapter does. An API error is refused as `http
+  <status> <the API's message>`; a transport failure as `http 0
+  <kind> <detail>`.
 - **The catalog is source.** A backend is a constructor function
   (`frontier()`, `fast()`, `desk()` …); a position's router is a
   function composed from them (`leader_models()`, `editor_models()`,
@@ -202,11 +209,10 @@ The organization's models are a catalog in source (GH #583 M1):
 - **Discovery.** `init` and `new` look at the environment
   (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) and `PATH` (`ollama`, whose
   first listed model becomes the desk model; `claude` and `codex` are
-  reported), write the catalog for what is there (Anthropic's
-  compatibility endpoint with `claude-opus-5` / `claude-haiku-4-5`
-  when its key is present, else OpenAI with `gpt-4o` / `gpt-4o-mini`,
-  a placeholder key when none is set), and print what each position
-  was given. Nothing found is fine: a hosted backend without its key
+  reported), write the catalog for what is there (`AnthropicMessages`
+  with `claude-opus-5` / `claude-haiku-4-5` when its key is present,
+  else `OpenAiChat` with `gpt-4o` / `gpt-4o-mini`, a placeholder key
+  when none is set), and print what each position was given. Nothing found is fine: a hosted backend without its key
   is not permitted, and every Review waits for the Board. `upgrade`
   writes a catalog for an organization that predates it and says what
   to point at it; it never edits the organization's main.


### PR DESCRIPTION
Part of #583 (Phase 4), Track M, M2: the native Anthropic adapter and the credential's scheme. Stacked on #584 (M1).

## What changes

**`AnthropicMessages`.** The Messages API on the same `ModelBackend` seam as `OpenAiChat`: the context travels as `system` beside `messages`, `max_tokens` is always sent (the API requires it; 4096 when unset), the reply's text blocks are joined, `anthropic-version` goes with the request, and the evidence (`adapter: anthropic-messages`) and the price table are the ones every adapter leaves. An API error is refused as `http <status> <the API's message>`; a transport failure as `http 0 <kind> <detail>`.

**`HostedCredential { scheme }`.** `bearer` (the default; `Authorization: Bearer`) or `x-api-key`. The sealed credential composes the header for its scheme and takes the adapter's own headers as a separate argument (`post_json(url, body, extra)`), so no adapter ever holds a header with the material in it. The law's `credentials_sealed` is unchanged.

**Discovery.** With `ANTHROPIC_API_KEY` the catalog's `frontier()` / `fast()` return `dna::AnthropicMessages` (`claude-opus-5` / `claude-haiku-4-5-20251001`, endpoint `https://api.anthropic.com/v1/messages`, `scheme: "x-api-key"`) instead of the compatibility endpoint; the constructor functions name the adapter they return.

## Tests

- `dna/tests/anthropic_messages_test.hl`: a fake Messages endpoint in the same program insists on `x-api-key` and `anthropic-version`, refuses a bearer, reads `system` / `messages` / `max_tokens` / `temperature` (it answers "the answer" only for the body the API wants), answers with content blocks and usage, and overloads on cue. The adapter joins the blocks, reports the model the endpoint named, refuses customer data and a missing credential before the wire, reports the API's error message, and every call is a `model.called` row without the prompt.
- `dna_models.rs`: the Anthropic catalog names the native adapter and the organization checks and builds from it.

Spec (adapters, the scheme, error rendering, discovery), the Book (models, shaping, reference), CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
