### PR TITLE
dna: the harness works in an export; the genome is unreachable from it (GH #583 M3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ behavior.
 - `hale dna models`: the catalog probed — one line per backend with one small request to each that is permitted; the organization is not started and nothing is journaled.
 - `HostedModel` is `OpenAiChat` (`adapter: openai-chat`), named for what it speaks; `FakeModel { fail_after }` refuses after that many calls, for tests that fail an Attempt on cue.
 
+### DNA: the harness works in an export; the genome is unreachable from it (GH #583 M3)
+
+- `HarnessModel`: an installed coding harness (`claude`, or `codex` with `output: text`) as a backend that works in place. For a source-editing request the editor exports the Mutation's worktree (a plain directory, never `.git`, never `.hale`), runs the harness there with the whole objective and its own tools on, and imports the export's diff back under the grant: a changed or new file is written through the tools, a deleted one removed, a change outside the grant counted and left behind; `files_changed` is derived from the diff, never from the answer. Then the same fmt, check, retry and assessment as the file-by-file flow. An answer-only call runs in an empty directory of its own. Evidence: one `model.called` row with the harness's own cost summary, `tool_grant: harness @export`, `confinement=<kind>`.
+- `Confinement`: `Bubblewrap` (Linux; the repository and the worktree replaced by empty tmpfs mounts, everything else — the harness's home state, the toolchain, the network — as the operator sees it) or `NoConfinement`; an unavailable confinement refuses the harness unless the org chart's `allow_unconfined` says otherwise. The assembly checks that neither the repository's head nor the worktree's moved during any attempt and fails the Mutation by the record if they did. `effect harness_run` names the reach; `Repository.root()` names what is masked.
+- Discovery writes `harness()` when `claude` (else `codex`) is on `PATH`: the editor's and the agent's quick tier, and every model-backed slot when there is no key.
+- `ModelBackend.works_in_place()`, `ModelRouter.in_place(req)`, `ModelRequest { workspace, mask }`, `SourceEditor.place(worktree, seed, repo)` and `WorktreeTools.remove`.
+
 ### DNA: the native Anthropic adapter, and the credential's scheme (GH #583 M2)
 
 - `AnthropicMessages`: the Messages API on the same `ModelBackend` seam — `system` beside `messages`, `max_tokens` required (default 4096), the reply's text blocks joined, `anthropic-version` sent, the same evidence and price table as `OpenAiChat`. `init` writes it as the hosted backend when `ANTHROPIC_API_KEY` is present (`claude-opus-5` / `claude-haiku-4-5-20251001`), instead of the compatibility endpoint.

--- a/crates/hale-cli/src/dna.rs
+++ b/crates/hale-cli/src/dna.rs
@@ -641,6 +641,17 @@ impl Discovery {
             )
         }
     }
+    /// The harness the catalog writes, when one is on PATH: `claude`
+    /// first, else `codex`.
+    fn harness(&self) -> Option<&'static str> {
+        if self.harnesses.iter().any(|h| h == "claude") {
+            Some("claude")
+        } else if self.harnesses.iter().any(|h| h == "codex") {
+            Some("codex")
+        } else {
+            None
+        }
+    }
     fn summary(&self) -> String {
         let mut parts = Vec::new();
         parts.push(match (self.anthropic, self.openai) {
@@ -673,11 +684,12 @@ impl Discovery {
                 desk,
                 if self.ollama.is_some() { "" } else { ", not found" }
             ),
-            "leader, editor, agent: deep = frontier, quick = fast, private = desk · budget 25.00 USD a day (`hale dna models` probes them)".to_string(),
+            match (self.harness(), self.anthropic || self.openai) {
+                (Some(h), true) => format!("editor, agent: quick = harness ({h}), deep = frontier · leader: deep = frontier, quick = fast · private = desk · budget 25.00 USD a day (`hale dna models` probes them)"),
+                (Some(h), false) => format!("editor, agent, leader: quick = harness ({h}), deep = harness ({h}) · private = desk · budget 25.00 USD a day (`hale dna models` probes them)"),
+                (None, _) => "leader, editor, agent: deep = frontier, quick = fast, private = desk · budget 25.00 USD a day (`hale dna models` probes them)".to_string(),
+            },
         ];
-        for h in &self.harnesses {
-            out.push(format!("found   {h} on PATH; a harness is not a backend in this toolchain yet"));
-        }
         out
     }
 }
@@ -689,6 +701,46 @@ impl Discovery {
 fn models_hl(found: &Discovery) -> String {
     let (frontier, fast, _) = found.hosted();
     let desk_model = found.ollama.clone().unwrap_or_else(|| "llama3".to_string());
+    let keyed = found.anthropic || found.openai;
+    let has_harness = found.harness().is_some();
+    // GH #583 M3: an installed harness edits in an export of the worktree
+    // with its own tools; the editor imports the diff under the grant.
+    let harness_section = match found.harness() {
+        Some("codex") => r#"// ---- the harness ---------------------------------------------------
+//
+// `codex` on this machine: run per request with its own tools, in an
+// EXPORT of the worktree (a plain directory, never `.git`) as its cwd;
+// the editor imports what it changed under the grant. The confinement
+// masks the repository from the process (Bubblewrap on Linux); with
+// none available the harness is refused unless `allow_unconfined` says
+// otherwise — that is the org chart's word, and the evidence records
+// which it was. `output: "text"`: codex prints its final message.
+
+fn harness() -> dna::HarnessModel {
+    return dna::HarnessModel { name: "quick", command: "codex", argv: "exec
+--full-auto", output: "text", confinement: dna::Bubblewrap { } };
+}
+
+"#
+        .to_string(),
+        Some(_) => r#"// ---- the harness ---------------------------------------------------
+//
+// `claude` on this machine: run per request with its own tools, in an
+// EXPORT of the worktree (a plain directory, never `.git`) as its cwd;
+// the editor imports what it changed under the grant. The confinement
+// masks the repository from the process (Bubblewrap on Linux); with
+// none available the harness is refused unless `allow_unconfined` says
+// otherwise — that is the org chart's word, and the evidence records
+// which it was.
+
+fn harness() -> dna::HarnessModel {
+    return dna::HarnessModel { name: "quick", command: "claude", confinement: dna::Bubblewrap { } };
+}
+
+"#
+        .to_string(),
+        None => String::new(),
+    };
     let hosted = |name: &str, h: &Hosted| {
         format!(
             "{} {{ name: \"{name}\", model: \"{}\", endpoint: \"{}\", credential: dna::HostedCredential {{ env_var: \"{}\", scheme: \"{}\" }}, input_micros_per_1k: {}, output_micros_per_1k: {} }}",
@@ -735,7 +787,7 @@ fn desk() -> dna::LocalModel {{
     return dna::LocalModel {{ name: "private", endpoint: "http://127.0.0.1:11434/v1/chat/completions", model: "{desk}" }};
 }}
 
-// ---- positions -----------------------------------------------------
+{harness_section}// ---- positions -----------------------------------------------------
 //
 // Each position's router: `deep` decides and assesses, `quick` drafts
 // and classifies, `private` takes what may not leave the machine.
@@ -743,15 +795,15 @@ fn desk() -> dna::LocalModel {{
 // strongest model, the production of candidates on a cheaper one.
 
 fn leader_models() -> dna::ModelRouter {{
-    return dna::ModelRouter {{ quick: fast(), deep: frontier(), private: desk() }};
+    return dna::ModelRouter {{ quick: {leader_quick}, deep: {leader_deep}, private: desk() }};
 }}
 
 fn editor_models() -> dna::ModelRouter {{
-    return dna::ModelRouter {{ quick: fast(), deep: frontier(), private: desk() }};
+    return dna::ModelRouter {{ quick: {editor_quick}, deep: {editor_deep}, private: desk() }};
 }}
 
 fn agent_models() -> dna::ModelRouter {{
-    return dna::ModelRouter {{ quick: fast(), deep: frontier(), private: desk() }};
+    return dna::ModelRouter {{ quick: {editor_quick}, deep: {editor_deep}, private: desk() }};
 }}
 
 // ---- the budget ----------------------------------------------------
@@ -769,7 +821,7 @@ fn org_budget() -> dna::BudgetPolicy {{
 // ---- the probe (`hale dna models`) ---------------------------------
 
 fn probe_catalog() -> String {{
-    return dna::probe("frontier", frontier()) + dna::probe("fast", fast()) + dna::probe("desk", desk());
+    return dna::probe("frontier", frontier()) + dna::probe("fast", fast()) + dna::probe("desk", desk()){probe_harness};
 }}
 "#,
         summary = found.summary(),
@@ -777,6 +829,12 @@ fn probe_catalog() -> String {{
         frontier = hosted("deep", &frontier),
         fast = hosted("quick", &fast),
         desk = desk_model,
+        harness_section = harness_section,
+        leader_quick = if keyed || !has_harness { "fast()" } else { "harness()" },
+        leader_deep = if keyed || !has_harness { "frontier()" } else { "harness()" },
+        editor_quick = if has_harness { "harness()" } else { "fast()" },
+        editor_deep = if keyed || !has_harness { "frontier()" } else { "harness()" },
+        probe_harness = if has_harness { " + dna::probe(\"harness\", harness())" } else { "" },
     )
 }
 

--- a/crates/hale-cli/tests/dna_models.rs
+++ b/crates/hale-cli/tests/dna_models.rs
@@ -138,6 +138,63 @@ fn init_writes_the_catalog_from_what_the_machine_has_and_the_org_takes_its_route
     assert!(!out.contains("models  found"), "no discovery report when the catalog is kept:\n{out}");
 }
 
+/// A stand-in `claude` on PATH: prints the result object `claude -p
+/// --output-format json` prints, with a cost.
+fn fake_claude_dir(tag: &str) -> PathBuf {
+    let bin = workdir(tag).join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let script = "#!/bin/sh\nprintf '{\"type\": \"result\", \"subtype\": \"success\", \"is_error\": false, \"result\": \"ready\", \"total_cost_usd\": 0.002, \"usage\": {\"input_tokens\": 4, \"output_tokens\": 1}}\\n'\n";
+    std::fs::write(bin.join("claude"), script).unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(bin.join("claude"), std::fs::Permissions::from_mode(0o755)).unwrap();
+    bin
+}
+
+#[test]
+fn a_harness_on_path_becomes_the_editors_quick_tier_and_the_probe_runs_it() {
+    let bin = fake_claude_dir("harness");
+    let path = format!("{}:{}", bin.display(), bare_path());
+    let d = workdir("harnessed");
+    // no key: the harness fills every model-backed slot
+    let (ok, out) = hale_env(&["dna", "new", "harnessed"], &d, &[("PATH", &path)], NO_KEYS);
+    assert!(ok, "{out}");
+    let app = d.join("harnessed");
+    let catalog = std::fs::read_to_string(app.join("dna/org/models.hl")).unwrap();
+    assert!(out.contains("models  found   no API key in the environment, no ollama on PATH, claude on PATH"), "{out}");
+    assert!(out.contains("models  editor, agent, leader: quick = harness (claude), deep = harness (claude) · private = desk"), "{out}");
+    assert!(catalog.contains("fn harness() -> dna::HarnessModel {\n    return dna::HarnessModel { name: \"quick\", command: \"claude\", confinement: dna::Bubblewrap { } };"), "{catalog}");
+    assert!(catalog.contains("fn editor_models() -> dna::ModelRouter {\n    return dna::ModelRouter { quick: harness(), deep: harness(), private: desk() };"), "{catalog}");
+    assert!(catalog.contains("fn leader_models() -> dna::ModelRouter {\n    return dna::ModelRouter { quick: harness(), deep: harness(), private: desk() };"), "{catalog}");
+    assert!(catalog.contains("dna::probe(\"harness\", harness())"), "{catalog}");
+    // with a key: the harness is the editor's quick tier, the frontier decides
+    let d2 = workdir("harnessed-keyed");
+    let (ok, out) = hale_env(&["dna", "new", "keyed"], &d2, &[("PATH", &path), ("OPENAI_API_KEY", "sk-test")], &["ANTHROPIC_API_KEY"]);
+    assert!(ok, "{out}");
+    let catalog = std::fs::read_to_string(d2.join("keyed/dna/org/models.hl")).unwrap();
+    assert!(out.contains("models  editor, agent: quick = harness (claude), deep = frontier · leader: deep = frontier, quick = fast · private = desk"), "{out}");
+    assert!(catalog.contains("fn editor_models() -> dna::ModelRouter {\n    return dna::ModelRouter { quick: harness(), deep: frontier(), private: desk() };"), "{catalog}");
+    assert!(catalog.contains("fn leader_models() -> dna::ModelRouter {\n    return dna::ModelRouter { quick: fast(), deep: frontier(), private: desk() };"), "{catalog}");
+    // the organization checks and builds with the harness wired
+    let (ok, out) = hale_env(&["check", "--matrix", "."], &app, &[], &[]);
+    assert!(ok, "matrix: {out}");
+    // the probe runs the harness (an answer-only call in a directory of
+    // its own; the stand-in needs no confinement, so the org chart's
+    // leave is given in the probe's copy of the catalog)
+    let probed = catalog.replace("confinement: dna::Bubblewrap { } };", "confinement: dna::NoConfinement { }, allow_unconfined: true };");
+    std::fs::write(app.join("dna/org/models.hl"), probed).unwrap();
+    let mut c = Command::new(env!("CARGO_BIN_EXE_hale"));
+    c.args(["dna", "models"]).current_dir(&app).env("PATH", &path);
+    for k in NO_KEYS {
+        c.env_remove(k);
+    }
+    let out = c.output().unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(out.status.success(), "{stdout}{}", String::from_utf8_lossy(&out.stderr));
+    let harness_line = stdout.lines().find(|l| l.starts_with("harness ")).unwrap_or_else(|| panic!("a harness line:\n{stdout}"));
+    assert!(harness_line.starts_with("harness     quick     claude                        ok  ") && harness_line.contains("  2000 micro-dollars  \"ready\""), "{stdout}");
+    assert!(stdout.lines().any(|l| l.starts_with("frontier    deep      gpt-4o ") && l.contains("not permitted")), "{stdout}");
+}
+
 #[test]
 fn upgrade_gives_an_older_organization_a_catalog_and_says_what_to_point_at_it() {
     let d = workdir("upgrade");

--- a/crates/hale-cli/tests/dna_native_suite.rs
+++ b/crates/hale-cli/tests/dna_native_suite.rs
@@ -82,6 +82,7 @@ fn dna_fixture_set_is_complete() {
             "editing_test.hl",
             "extensions_test.hl",
             "fanout_join_test.hl",
+            "harness_test.hl",
             "journal_test.hl",
             "knowledge_test.hl",
             "mutation_review_test.hl",

--- a/dna/core/assembly.hl
+++ b/dna/core/assembly.hl
@@ -646,11 +646,15 @@ locus Dna {
         let opened = self.gateway.open(self.journal, id, base, lease.token, now);
         if !opened.ok { return self.mutation_failed(id, "worktree: " + opened.refused); }
         let wt = opened.value;
-        // the grant is the seed this change edits, inside THIS worktree
-        self.editor.confine(if seed == "." || seed == "" { wt } else { wt + "/" + seed });
+        // the grant is the seed this change edits, inside THIS worktree;
+        // the worktree is what a harness's export copies, the repository
+        // what it must never reach (GH #583 M3)
+        self.editor.place(wt, seed, self.gateway.repo.root());
         let mut file = target;
-        if len(file) == 0 {
-            // step 5: the Attempt inspects the listing under its grant
+        // step 5: the Attempt inspects the listing under its grant — unless
+        // its backend works in place (GH #583 M3): a harness finds its own
+        // files, and the import says which it changed
+        if len(file) == 0 && !self.editor.in_place("internal") {
             file = self.editor.locate(objective);
             if len(file) == 0 {
                 let x = self.gateway.remove(self.journal, id, lease.token, now);
@@ -658,9 +662,19 @@ locus Dna {
             }
             let x1 = self.journal.append(self.journal.revision(), "mutation.located", id, file + " under " + self.editor.grant());
         }
+        // GH #583 M3: the genome must not move while an attempt runs —
+        // an editor's process (a harness with tools) could reach it only
+        // around the boundary, and the record says so instead of the
+        // candidate quietly building on a moved base
+        let head_before = self.gateway.head();
+        let wt_before = self.gateway.repo.head(wt);
         let r = self.editor.perform(WorkRequest {
             work_id: id, task_id: task_id, objective: objective, target: file, data_class: "internal"
         });
+        if self.gateway.head() != head_before || self.gateway.repo.head(wt) != wt_before {
+            let x = self.gateway.remove(self.journal, id, lease.token, now);
+            return self.mutation_failed(id, "the genome moved during the attempt (" + head_before + " -> " + self.gateway.head() + "; worktree " + wt_before + " -> " + self.gateway.repo.head(wt) + "): nothing built on it is a candidate");
+        }
         if r.disposition != "done" {
             let x = self.gateway.remove(self.journal, id, lease.token, now);
             return self.mutation_failed(id, "attempt: " + r.narrative);

--- a/dna/core/editing.hl
+++ b/dna/core/editing.hl
@@ -61,6 +61,15 @@ locus WorktreeTools {
         self.refused = self.refused + 1;
         self.last_refusal = "write failed: " + e.kind;
     }
+    // A file the harness deleted in its export (GH #583 M3): removed
+    // inside the grant, refused outside it like any edit.
+    @unbounded
+    fn remove(rel: String) -> Bool {
+        if !self.inside(rel) { self.refused = self.refused + 1; self.last_refusal = "remove outside the worktree: " + rel; return false; }
+        std::io::fs::unlink(self.root + "/" + rel) or discard;
+        self.edits = self.edits + 1;
+        return true;
+    }
     @effects(is: { toolchain_run })
     fn fmt() -> RunResult { return run_tool(self.hale_bin + "\nfmt\n" + self.root); }
     @effects(is: { toolchain_run })
@@ -122,10 +131,29 @@ locus SourceEditor {
         max_tries: Int = 3; // a proposal that does not check is retried with the diagnostics, this many times in all
         attempts: Int = 0;
         last: MutationProposal = MutationProposal { };
+        // GH #583 M3: the harness flow's bearings and counters
+        worktree: String = ""; // the Mutation's worktree (the export copies it)
+        seed: String = ""; // the grant's seed inside it ("" = the whole worktree)
+        repo: String = ""; // the repository: masked from the harness
+        exports: Int = 0;
+        imported: Int = 0; // files brought back from an export under the grant
+        refused_outside: Int = 0; // files the harness changed outside the grant, left behind
+        last_export: String = ""; // the last export's path (removed after the import)
+        last_summary: String = ""; // the harness's one-line answer
     }
     fn kind() -> String { return "agent"; }
     fn identity() -> String { return self.name; }
-    fn confine(root: String) { self.tools.confine(root); }
+    fn confine(root: String) { self.tools.confine(root); self.worktree = root; self.seed = ""; }
+    // Where this Mutation's worktree is, which seed inside it the grant
+    // covers, and the repository it belongs to (GH #583 M3): the export
+    // a harness works in is the whole worktree, the import is only the
+    // grant, and the repository is what the harness must never reach.
+    fn place(worktree: String, seed: String, repo: String) {
+        self.worktree = worktree;
+        self.seed = if seed == "." { "" } else { seed };
+        self.repo = repo;
+        self.tools.confine(if len(self.seed) == 0 { worktree } else { worktree + "/" + self.seed });
+    }
     fn grant() -> String { return "read edit fmt check @" + self.tools.root; }
     // The `.hl` files of the grant's root, newline-separated: what an
     // Attempt may inspect (nothing outside the grant is listed).
@@ -226,12 +254,180 @@ locus SourceEditor {
         if !self.tools.edit(file, unfence(edit.output)) { return ModelResult { ok: false, backend: edit.backend, refused: self.tools.last_refusal }; }
         return edit;
     }
+    // ---- the harness flow (GH #583 M3) --------------------------------
+    // Whether an edit would go to a backend that works in place: then
+    // there is no file to locate first — the harness finds its own.
+    fn in_place(data_class: String) -> Bool {
+        return self.models.in_place(ModelRequest { role: "edit", data_class: data_class });
+    }
+    // An EXPORT of the worktree: a plain directory with the same files,
+    // never `.git` (a worktree's is a pointer into the repository) and
+    // never `.hale`. "" when it cannot be made.
+    fn make_export() -> String {
+        let t = run_tool("mktemp\n-d\n/tmp/hale-dna-export.XXXXXX");
+        let dir = trim_nl(t.stdout);
+        if t.code != 0 || len(dir) == 0 { return ""; }
+        let cp = run_tool("cp\n-r\n" + self.worktree + "/.\n" + dir);
+        if cp.code != 0 { let rm = run_tool("rm\n-rf\n" + dir); return ""; }
+        let strip = run_tool("rm\n-rf\n" + dir + "/.git\n" + dir + "/.hale");
+        self.exports = self.exports + 1;
+        self.last_export = dir;
+        return dir;
+    }
+    // The regular files under `dir`, worktree-relative, one per line;
+    // vendor, .git and .hale are never part of a change.
+    fn listing(dir: String) -> String {
+        // a worktree's `.git` is a FILE (a pointer into the repository), so it is named as well as its tree
+        let r = run_tool("sh\n-c\ncd \"$0\" && find . -type f ! -path \"./vendor/*\" ! -path \"./.git\" ! -path \"./.git/*\" ! -path \"./.hale\" ! -path \"./.hale/*\" | sed \"s|^./||\" | sort\n" + dir);
+        return if r.code == 0 { r.stdout } else { "" };
+    }
+    // The file's path inside the grant, or "" when it lies outside it.
+    fn in_grant(rel: String) -> String {
+        if len(self.seed) == 0 { return rel; }
+        if std::str::starts_with(rel, self.seed + "/") { return rel[(len(self.seed) + 1)..len(rel)]; }
+        return "";
+    }
+    // Bring the export's changes back under the grant: a file that
+    // differs or is new is written through the tools, one that is gone
+    // is removed; a change outside the grant is counted and left behind.
+    // Returns the grant-relative files changed, space-separated.
+    // Bounded by the files of one worktree.
+    @unbounded
+    fn import_from(dir: String) -> String {
+        let mut changed = "";
+        let mut lines = self.listing(dir);
+        while len(lines) > 0 {
+            let nl = std::str::index_of(lines, "\n");
+            let rel = if nl < 0 { lines } else { lines[0..nl] };
+            if nl < 0 { lines = ""; } else { lines = lines[(nl + 1)..len(lines)]; }
+            if len(rel) == 0 { continue; }
+            let after = std::io::fs::read_file(dir + "/" + rel) or "";
+            let before = std::io::fs::read_file(self.worktree + "/" + rel) or "";
+            if after == before { continue; }
+            let g = self.in_grant(rel);
+            if len(g) == 0 { self.refused_outside = self.refused_outside + 1; continue; }
+            if self.tools.edit(g, after) { self.imported = self.imported + 1; changed = changed + g + " "; }
+        }
+        let mut gone = self.listing(self.worktree);
+        while len(gone) > 0 {
+            let nl = std::str::index_of(gone, "\n");
+            let rel = if nl < 0 { gone } else { gone[0..nl] };
+            if nl < 0 { gone = ""; } else { gone = gone[(nl + 1)..len(gone)]; }
+            if len(rel) == 0 || std::io::fs::file_exists(dir + "/" + rel) { continue; }
+            let g = self.in_grant(rel);
+            if len(g) == 0 { self.refused_outside = self.refused_outside + 1; continue; }
+            if self.tools.remove(g) { self.imported = self.imported + 1; changed = changed + g + " "; }
+        }
+        return trim_nl(changed);
+    }
+    // One try of the harness: export, then ask with the export as its
+    // workspace and the repository masked; the caller imports from
+    // `last_export` and removes it.
+    fn harness_try(attempt: String, objective: String, diagnostics: String, data_class: String) -> ModelResult {
+        let dir = self.make_export();
+        if len(dir) == 0 { return ModelResult { ok: false, refused: "cannot export the worktree" }; }
+        let inside = if len(self.seed) == 0 { "." } else { self.seed };
+        let mut prompt = "You are working in a copy of a Hale project: the current directory. Make this change: " + objective
+            + "\nEdit only files under " + inside + ". Run `hale fmt " + inside + "` and `hale check " + inside + "` before you finish, and fix what they report."
+            + "\nReply with one line saying what you changed.";
+        if len(diagnostics) > 0 { prompt = prompt + "\nThe previous attempt did not check. hale check said:\n" + diagnostics; }
+        let r = self.models.ask(ModelRequest {
+            attempt_id: attempt, role: "edit", prompt: prompt, context_bytes: len(prompt),
+            workspace: dir, mask: self.repo + "\n" + self.worktree,
+            tool_grant: "harness @export", data_class: data_class,
+            retry_of: if len(diagnostics) > 0 { attempt + ":edit" } else { "" }
+        });
+        if r.ok { self.last_summary = trim_nl(r.output); }
+        return r;
+    }
+    // The harness flow: the whole objective in one call per try, the
+    // files it changed derived from the export's diff, never from its
+    // answer; then the same fmt, check, retry and assessment as the
+    // file-by-file flow. Bounded by `max_tries`.
+    @unbounded
+    fn perform_in_place(req: WorkRequest) -> WorkResult {
+        let mut tries = 0;
+        let mut diagnostics = "";
+        let mut backends = "";
+        let mut fmt_code = 1;
+        let mut check_code = 1;
+        let mut done = false;
+        let mut files = "";
+        while tries < self.max_tries && !done {
+            let attempt = req.work_id + "/a" + to_string(req.attempt_no + tries);
+            let r = self.harness_try(attempt, req.objective, diagnostics, req.data_class);
+            if !r.ok {
+                let rm = run_tool("rm\n-rf\n" + self.last_export);
+                return WorkResult { disposition: "failed", narrative: "harness refused: " + r.refused, performer: self.name };
+            }
+            backends = r.backend;
+            let brought = self.import_from(self.last_export);
+            let rm = run_tool("rm\n-rf\n" + self.last_export);
+            if len(brought) > 0 { files = brought; }
+            if len(files) == 0 {
+                return WorkResult { disposition: "failed", narrative: "the harness changed nothing under the grant (" + to_string(self.refused_outside) + " change(s) outside it left behind): " + self.last_summary, performer: self.name };
+            }
+            let f = self.tools.fmt();
+            let c = self.tools.check();
+            fmt_code = f.code;
+            check_code = c.code;
+            tries = tries + 1;
+            if c.code == 0 { done = true; } else { diagnostics = trim_nl(c.stderr); }
+        }
+        let attempt = req.work_id + "/a" + to_string(req.attempt_no + tries - 1);
+        let mut changed = "";
+        let mut rest = files + " ";
+        while len(rest) > 0 {
+            let sp = std::str::index_of(rest, " ");
+            let file = rest[0..sp];
+            rest = rest[(sp + 1)..len(rest)];
+            if len(file) == 0 { continue; }
+            changed = changed + "=== " + file + "\n" + self.tools.read(file) + "\n";
+        }
+        let assess = self.models.ask(ModelRequest {
+            attempt_id: attempt, role: "assess", assurance: 2,
+            prompt: "Which fitness signals should this change move, and which way? One per line, nothing else: <signal> <+|->",
+            context: "OBJECTIVE\n" + req.objective + "\n\nFILES AS EDITED\n" + changed, context_bytes: len(changed) + len(req.objective) + 64,
+            tool_grant: self.grant(), data_class: req.data_class, retry_of: attempt + ":edit"
+        });
+        let b = std::json::Builder { };
+        b.begin_object();
+        b.string_field("work_id", req.work_id);
+        b.string_field("files_changed", files);
+        b.string_field("rationale", req.objective);
+        b.string_field("fitness_signals", if assess.ok { fitness_lines(assess.output) } else { "" });
+        b.bool_field("fmt_clean", fmt_code == 0);
+        b.bool_field("check_clean", check_code == 0);
+        b.int_field("tries", tries);
+        b.string_field("check_output", if check_code == 0 { "" } else { diagnostics });
+        b.string_field("summary", self.last_summary);
+        b.int_field("outside_grant", self.refused_outside);
+        b.end_object();
+        self.last = MutationProposal {
+            work_id: req.work_id, files_changed: files, rationale: req.objective,
+            fitness_signals: if assess.ok { assess.output } else { "" },
+            fmt_clean: fmt_code == 0, check_clean: check_code == 0,
+            check_output: if check_code == 0 { "" } else { diagnostics }
+        };
+        return WorkResult {
+            disposition: if check_code == 0 { "done" } else { "failed" },
+            result: b.result(),
+            narrative: if check_code == 0 { "harness proposal checks clean after " + to_string(tries) + " try(ies): " + self.last_summary } else { "harness proposal does not check after " + to_string(tries) + " try(ies): " + diagnostics },
+            evidence: "fmt=" + to_string(fmt_code) + " check=" + to_string(check_code) + " tries=" + to_string(tries) + " backends=" + backends + "," + assess.backend,
+            performer: self.name
+        };
+    }
     // Bounded by the attempt cap of the Work that owns this performer
     // and by `max_tries` (GH #566 F3): a proposal that does not check
     // is tried again with the diagnostics fed back, then fails.
     @unbounded
     fn perform(req: WorkRequest) -> WorkResult {
         self.attempts = self.attempts + 1;
+        // a backend that works in place gets the whole objective and an
+        // export (GH #583 M3); everything else is asked file by file
+        if self.in_place(req.data_class) {
+            return self.perform_in_place(req);
+        }
         let files = if len(req.target) > 0 { req.target } else { self.plan(req.objective) };
         if len(files) == 0 {
             return WorkResult { disposition: "failed", narrative: "no target file in the request", performer: self.name };

--- a/dna/core/models.hl
+++ b/dna/core/models.hl
@@ -818,8 +818,11 @@ locus HarnessModel {
         let mut argv = self.command + "\n" + self.argv;
         if len(self.model) > 0 { argv = argv + "\n--model\n" + self.model; }
         argv = argv + "\n" + prompt;
+        // no boundary available and the org chart allows it: the harness
+        // runs plainly in the workspace, and the evidence says `none`
+        let wrapped = if kind == "none" { "sh\n-c\ncd \"$0\" && exec \"$@\"\n" + cwd + "\n" + argv } else { self.confinement.wrap(argv, cwd, req.mask) };
         let t0 = std::time::monotonic();
-        let r = run_tool(self.confinement.wrap(argv, cwd, req.mask));
+        let r = run_tool(wrapped);
         ev.elapsed = to_string(std::time::monotonic() - t0);
         if len(scratch) > 0 { let rm = run_tool("rm\n-rf\n" + scratch); }
         let out = parse_harness(self.output, r.code, r.stdout, r.stderr);

--- a/dna/core/models.hl
+++ b/dna/core/models.hl
@@ -19,6 +19,8 @@ type ModelRequest {
     knowledge_bindings: String = ""; // ids the context came from, for the evidence
     tool_grant: String = "";
     target: String = ""; // the file the request is about, when it is about one (GH #566 F3)
+    workspace: String = ""; // an EXPORT the backend may work in with its own tools (GH #583 M3); "" = answer only
+    mask: String = ""; // paths the backend's process must not reach, newline-separated (the genome)
     retry_of: String = "";
     data_class: String = "internal";
     needs_tools: Bool = false;
@@ -41,6 +43,10 @@ interface ModelBackend {
     fn model_name() -> String;
     fn allows(data_class: String) -> Bool;
     fn capacity_bytes() -> Int;
+    // True for a backend that edits files in the request's workspace
+    // with its own tools (a harness) rather than answering with text;
+    // the editor exports the worktree for it and imports the diff.
+    fn works_in_place() -> Bool;
     fn complete(req: ModelRequest) -> ModelResult;
 }
 
@@ -101,6 +107,7 @@ locus FakeModel {
     fn model_name() -> String { return self.model; }
     fn allows(data_class: String) -> Bool { return data_class != "customer"; }
     fn capacity_bytes() -> Int { return self.max_bytes; }
+    fn works_in_place() -> Bool { return false; }
     // The scripted answer for a request about a file, by try then by file.
     fn scripted_for(req: ModelRequest) -> String {
         if len(self.answers_dir) == 0 || len(req.target) == 0 || req.role != "edit" { return ""; }
@@ -163,6 +170,7 @@ locus LocalFakeModel {
     fn model_name() -> String { return self.model; }
     fn allows(data_class: String) -> Bool { return true; }
     fn capacity_bytes() -> Int { return self.max_bytes; }
+    fn works_in_place() -> Bool { return false; }
     fn complete(req: ModelRequest) -> ModelResult {
         self.calls = self.calls + 1;
         return fake_answer(self.name, self.model, req, self.max_bytes, self.price_micros);
@@ -327,6 +335,7 @@ locus OpenAiChat {
     // cleanly instead of the wire failing.
     fn allows(data_class: String) -> Bool { return data_class != "customer" && self.credential.ready(); }
     fn capacity_bytes() -> Int { return self.max_bytes; }
+    fn works_in_place() -> Bool { return false; }
     @effects(is: { external_model })
     fn complete(req: ModelRequest) -> ModelResult {
         self.calls = self.calls + 1;
@@ -442,6 +451,7 @@ locus AnthropicMessages {
     fn model_name() -> String { return self.model; }
     fn allows(data_class: String) -> Bool { return data_class != "customer" && self.credential.ready(); }
     fn capacity_bytes() -> Int { return self.max_bytes; }
+    fn works_in_place() -> Bool { return false; }
     @effects(is: { external_model })
     fn complete(req: ModelRequest) -> ModelResult {
         self.calls = self.calls + 1;
@@ -508,6 +518,7 @@ locus LocalModel {
     fn model_name() -> String { return self.model; }
     fn allows(data_class: String) -> Bool { return true; }
     fn capacity_bytes() -> Int { return self.max_bytes; }
+    fn works_in_place() -> Bool { return false; }
     fn complete(req: ModelRequest) -> ModelResult {
         self.calls = self.calls + 1;
         let mut ev = ModelEvidence {
@@ -597,6 +608,18 @@ locus ModelRouter {
         calls: Int = 0;
         last_backend: String = "";
     }
+    // Whether the backend this request would go to works in place (a
+    // harness): the editor asks before it exports a worktree.
+    fn in_place(req: ModelRequest) -> Bool {
+        let quick_ok = self.quick.allows(req.data_class) && self.quick.capacity_bytes() >= req.context_bytes;
+        let deep_ok = self.deep.allows(req.data_class) && self.deep.capacity_bytes() >= req.context_bytes;
+        let private_ok = self.private.allows(req.data_class) && self.private.capacity_bytes() >= req.context_bytes;
+        let cls = self.selection.select(req, quick_ok, deep_ok, private_ok);
+        if cls == "deep" { return self.deep.works_in_place(); }
+        if cls == "private" { return self.private.works_in_place(); }
+        if cls == "" { return false; }
+        return self.quick.works_in_place();
+    }
     // The router returns DATA. Which backend answered is recorded, not hidden.
     fn ask(req: ModelRequest) -> ModelResult {
         let quick_ok = self.quick.allows(req.data_class) && self.quick.capacity_bytes() >= req.context_bytes;
@@ -611,6 +634,211 @@ locus ModelRouter {
         else { self.quick.complete(req) };
         self.spent_micros = self.spent_micros + r.cost_micros;
         return r;
+    }
+}
+
+// ---- the harness adapter (GH #583 M3) ----------------------------------
+//
+// An installed coding harness (`claude`, `codex`) run per request, with
+// its own tools on, in the request's EXPORT of the worktree as its cwd
+// — a plain directory, never `.git`, never `.hale/dna`. The DNA has no
+// opinion about how the work gets done; its law is about reach, and
+// what it guarantees is that the genome is unreachable from the
+// harness process: a `Confinement` masks the repository (Bubblewrap on
+// Linux; `None` is refused unless the org chart allows it), and the
+// editor checks that nothing moved during the call. Outside the genome
+// the harness has exactly the operator's account, which is what
+// running it by hand has. Evidence is one `model.called` row per call
+// with the harness's own cost summary, the grant as `harness @export`,
+// and the confinement kind.
+
+interface Confinement {
+    fn kind() -> String;
+    fn available() -> Bool;
+    // The argv to run so that `argv` executes with `cwd` as its working
+    // directory and none of the `mask` paths (newline-separated) reachable.
+    fn wrap(argv: String, cwd: String, mask: String) -> String;
+}
+
+// No boundary: the process runs as the operator, in `cwd`. Refused by
+// a HarnessModel unless `allow_unconfined` says otherwise.
+locus NoConfinement {
+    params { uses: Int = 0; }
+    fn kind() -> String { return "none"; }
+    fn available() -> Bool { return true; }
+    fn wrap(argv: String, cwd: String, mask: String) -> String {
+        self.uses = self.uses + 1;
+        return "sh\n-c\ncd \"$0\" && exec \"$@\"\n" + cwd + "\n" + argv;
+    }
+}
+
+// Bubblewrap (Linux): the whole filesystem as the operator sees it —
+// the harness's own home state, the toolchain, the network — with
+// every masked path replaced by an empty tmpfs, so the genome does not
+// exist for the process.
+locus Bubblewrap {
+    params { command: String = "bwrap"; uses: Int = 0; }
+    fn kind() -> String { return "bubblewrap"; }
+    fn available() -> Bool {
+        let r = run_tool(self.command + "\n--version");
+        return r.code == 0;
+    }
+    @unbounded
+    fn wrap(argv: String, cwd: String, mask: String) -> String {
+        self.uses = self.uses + 1;
+        let mut out = self.command + "\n--dev-bind\n/\n/\n--die-with-parent";
+        let mut rest = mask;
+        while len(rest) > 0 {
+            let nl = std::str::index_of(rest, "\n");
+            let path = if nl < 0 { rest } else { rest[0..nl] };
+            if len(path) > 0 { out = out + "\n--tmpfs\n" + path; }
+            if nl < 0 { rest = ""; } else { rest = rest[(nl + 1)..len(rest)]; }
+        }
+        return out + "\n--chdir\n" + cwd + "\n--\n" + argv;
+    }
+}
+
+// "0.0123" (dollars, as the harness prints it) -> 12300 micro-dollars.
+fn usd_to_micros(raw: String) -> Int {
+    let t = trim_nl(raw);
+    if len(t) == 0 { return 0; }
+    let dot = std::str::index_of(t, ".");
+    let whole = if dot < 0 { t } else { t[0..dot] };
+    let mut frac = if dot < 0 { "" } else { t[(dot + 1)..len(t)] };
+    while len(frac) < 6 { frac = frac + "0"; }
+    frac = frac[0..6];
+    let w = std::str::parse_int(if len(whole) > 0 { whole } else { "0" }) or 0;
+    let f = std::str::parse_int(frac) or 0;
+    return w * 1000000 + f;
+}
+
+type HarnessOutcome {
+    ok: Bool = false;
+    text: String = "";
+    cost_micros: Int = 0;
+    input_tokens: Int = 0;
+    output_tokens: Int = 0;
+    refused: String = "";
+}
+
+// `claude -p --output-format json` prints one result object:
+// {"type":"result","subtype":"success","is_error":false,"result":"…",
+//  "total_cost_usd":0.0123,"usage":{"input_tokens":N,"output_tokens":M},…}.
+// `text` mode takes stdout as the answer and knows no cost.
+fn parse_harness(output: String, code: Int, stdout: String, stderr: String) -> HarnessOutcome {
+    if code != 0 {
+        let why = trim_nl(if len(stderr) > 0 { stderr } else { stdout });
+        return HarnessOutcome { refused: "exit " + to_string(code) + ": " + first_line(why) };
+    }
+    if output != "json" { return HarnessOutcome { ok: true, text: trim_nl(stdout) }; }
+    let text = std::json::find_string_field(stdout, "result");
+    let usage = std::json::find_field_raw(stdout, "usage");
+    let out = HarnessOutcome {
+        ok: true, text: text,
+        cost_micros: usd_to_micros(std::json::find_field_raw(stdout, "total_cost_usd")),
+        input_tokens: std::json::find_int_field(usage, "input_tokens"),
+        output_tokens: std::json::find_int_field(usage, "output_tokens")
+    };
+    if std::json::find_bool_field(stdout, "is_error") { return HarnessOutcome { refused: "harness error: " + first_line(text), cost_micros: out.cost_micros }; }
+    if len(text) == 0 && len(std::json::find_field_raw(stdout, "result")) == 0 { return HarnessOutcome { refused: "no result object in the harness's output: " + first_line(trim_nl(stdout)) }; }
+    return out;
+}
+
+locus HarnessModel {
+    params {
+        name: String = "quick";
+        adapter: String = "harness";
+        command: String = "claude"; // the harness on PATH
+        // flags before the prompt, newline-separated; the prompt is the
+        // last argument (the `claude -p … <prompt>` shape)
+        argv: String = "-p\n--output-format\njson\n--dangerously-skip-permissions";
+        output: String = "json"; // "json": the result object above; "text": stdout is the answer
+        model: String = ""; // "" = the harness's default; else passed as `--model <model>`
+        confinement: Confinement = Bubblewrap { };
+        allow_unconfined: Bool = false; // the org chart's word: may the harness run with no boundary?
+        max_bytes: Int = 4000000;
+        present: Bool = false;
+        calls: Int = 0;
+        last: ModelEvidence = ModelEvidence { };
+    }
+    bus { publish ModelCalled; }
+    birth() {
+        let r = run_tool("sh\n-c\ncommand -v \"$0\"\n" + self.command);
+        self.present = r.code == 0;
+    }
+    fn identity() -> String { return self.name; }
+    fn model_name() -> String { return if len(self.model) > 0 { self.command + " " + self.model } else { self.command }; }
+    // A harness sends the prompt and whatever it reads to its own
+    // hosted model: customer data never; and nothing without the binary.
+    fn allows(data_class: String) -> Bool { return data_class != "customer" && self.present; }
+    fn capacity_bytes() -> Int { return self.max_bytes; }
+    fn works_in_place() -> Bool { return true; }
+    // A boundary is in force when the confinement is a real one and is
+    // available here; otherwise only the org chart's leave lets it run.
+    fn confined() -> Bool {
+        if self.confinement.kind() == "none" { return self.allow_unconfined; }
+        return self.confinement.available() || self.allow_unconfined;
+    }
+    @effects(is: { external_model, harness_run })
+    fn complete(req: ModelRequest) -> ModelResult {
+        self.calls = self.calls + 1;
+        let kind = if self.confinement.kind() != "none" && self.confinement.available() { self.confinement.kind() } else { "none" };
+        let mut ev = ModelEvidence {
+            attempt_id: req.attempt_id, adapter: self.adapter, backend: self.name,
+            endpoint: self.command, requested_model: self.model_name(),
+            params: "confinement=" + kind + " output=" + self.output,
+            prompt_digest: if len(req.prompt_digest) > 0 { req.prompt_digest } else { digest_of(req.prompt) },
+            context_digest: digest_of(req.context),
+            knowledge_bindings: req.knowledge_bindings,
+            tool_grant: if len(req.workspace) > 0 { "harness @export" } else { "harness" },
+            retry_of: req.retry_of, data_class: req.data_class
+        };
+        if !self.allows(req.data_class) {
+            ev.refused = if self.present { "data class " + req.data_class } else { "harness `" + self.command + "` not on PATH" };
+            self.last = ev;
+            ModelCalled <- ev;
+            return ModelResult { ok: false, backend: self.name, model: self.model_name(), refused: ev.refused };
+        }
+        if !self.confined() {
+            ev.refused = "unconfined harness not allowed (" + self.confinement.kind() + " unavailable; `allow_unconfined` is the org chart's word)";
+            self.last = ev;
+            ModelCalled <- ev;
+            return ModelResult { ok: false, backend: self.name, model: self.model_name(), refused: ev.refused };
+        }
+        // an answer-only request runs in an empty directory of its own:
+        // the harness's tools have nothing to reach there either
+        let mut cwd = req.workspace;
+        let mut scratch = "";
+        if len(cwd) == 0 {
+            let t = run_tool("mktemp\n-d\n/tmp/hale-dna-harness.XXXXXX");
+            scratch = trim_nl(t.stdout);
+            cwd = scratch;
+        }
+        let prompt = if len(req.context) > 0 { req.context + "\n\n" + req.prompt } else { req.prompt };
+        let mut argv = self.command + "\n" + self.argv;
+        if len(self.model) > 0 { argv = argv + "\n--model\n" + self.model; }
+        argv = argv + "\n" + prompt;
+        let t0 = std::time::monotonic();
+        let r = run_tool(self.confinement.wrap(argv, cwd, req.mask));
+        ev.elapsed = to_string(std::time::monotonic() - t0);
+        if len(scratch) > 0 { let rm = run_tool("rm\n-rf\n" + scratch); }
+        let out = parse_harness(self.output, r.code, r.stdout, r.stderr);
+        ev.ok = out.ok;
+        ev.refused = out.refused;
+        ev.reported_model = self.model_name();
+        ev.input_tokens = out.input_tokens;
+        ev.output_tokens = out.output_tokens;
+        ev.cost_micros = out.cost_micros;
+        ev.response_digest = digest_of(out.text);
+        self.last = ev;
+        ModelCalled <- ev;
+        if !out.ok {
+            return ModelResult { ok: false, backend: self.name, model: self.model_name(), refused: out.refused, cost_micros: out.cost_micros };
+        }
+        return ModelResult {
+            ok: true, backend: self.name, model: self.model_name(), output: out.text,
+            tokens: out.input_tokens + out.output_tokens, cost_micros: out.cost_micros
+        };
     }
 }
 

--- a/dna/core/types.hl
+++ b/dna/core/types.hl
@@ -15,6 +15,7 @@ effect journal_io; // the durable journal's own file I/O
 effect worktree_io; // a worktree is created or removed on disk (GH #529 D1)
 effect repo_write; // the repository's history is written (a commit, a merge)
 effect toolchain_run; // the toolchain is run as a subprocess (fmt, check, verify, test, model diff)
+effect harness_run; // an installed coding harness runs as a subprocess with its own tools (GH #583 M3)
 
 // A bounded outcome offered downward (supersystem -> subsystem).
 type Intent {

--- a/dna/core/workspace.hl
+++ b/dna/core/workspace.hl
@@ -111,6 +111,7 @@ locus IsolatedWorktrees {
 // ---- the repository --------------------------------------------------
 
 interface Repository {
+    fn root() -> String; // the repository's path: what a harness must never reach (GH #583 M3)
     fn head(path: String) -> String;
     fn commit_all(path: String, message: String) -> String;
     fn diff(path: String, base: String, candidate: String) -> String;
@@ -131,6 +132,7 @@ locus LocalGit {
         last_error: String = "";
     }
     fn kind() -> String { return "local-git"; }
+    fn root() -> String { return self.repo; }
     fn head(path: String) -> String {
         let r = run_tool("git\n-C\n" + path + "\nrev-parse\nHEAD");
         if r.code != 0 { self.last_error = trim_nl(r.stderr); return ""; }

--- a/dna/tests/harness_test.hl
+++ b/dna/tests/harness_test.hl
@@ -146,7 +146,7 @@ main locus App {
             std::test::assert(std::str::contains(self.dna.editor.last_summary, "genome bytes 0"), "the genome was unreachable from the harness: " + self.dna.editor.last_summary);
         } else {
             std::test::assert(std::str::contains(ev, "confinement=none"), "unconfined by the org chart's leave: " + ev);
-            println("harness_test: bwrap not on PATH here; the mask is not exercised");
+            eprintln("harness_test: bwrap not on PATH here; the mask is not exercised");
         }
         std::test::assert(std::str::contains(std::json::find_string_field(self.last_body(self.dna.journal, "review.requested"), "question"), "note that the harness was here"), "the Review is over the harness's work");
 

--- a/dna/tests/harness_test.hl
+++ b/dna/tests/harness_test.hl
@@ -1,0 +1,202 @@
+// dna/tests/harness_test.hl — GH #583 M3: a harness edits in an EXPORT,
+// the editor imports the diff under the grant, the genome is never
+// reached.
+//
+// A stand-in harness (a shell script) plays `claude -p --output-format
+// json`: it edits the seed's main file in its cwd, leaves a file
+// outside the grant, tries to read the genome by its real path, and
+// prints the result object with a cost. One Dna over a real repository
+// runs a Mutation through it: the candidate carries the harness's
+// edit, the file outside the grant is left behind and counted, the
+// evidence is a `model.called` row with the harness's cost, the export
+// is gone, and the genome was masked when Bubblewrap is here. A
+// harness that moves the genome fails the attempt by the record; an
+// unconfined harness is refused unless the org chart allows it; an
+// answer-only call runs in an empty directory of its own.
+
+import "../core" as dna;
+
+fn toolchain() -> String {
+    if std::env::var_exists("HALE_BIN") { return std::env::var("HALE_BIN"); }
+    return "hale";
+}
+
+fn sh(argv: String) -> dna::RunResult { return dna::run_tool(argv); }
+
+const BASE: String = "type Ping { n: Int = 0; }\ntopic Pings { payload: Ping; subject: \"t.pings\"; }\nlocus A { params { seen: Int = 0; } bus { subscribe Pings as on_ping; } fn on_ping(p: Ping) { self.seen = self.seen + 1; } }\nmain locus App { params { a: A = A { }; } bus { publish Pings; } run() { Pings <- Ping { n: 1 }; } }\nfn main() { App { }; }\n";
+
+// The stand-in: `$1..` are claude's flags, the prompt is last. It
+// reads the genome's path from a file the test wrote, so the result
+// says how many bytes of the genome it could see.
+fn harness_script(genome_file: String) -> String {
+    return "#!/bin/sh\n"
+        + "genome=$(cat " + genome_file + ")\n"
+        + "printf '// touched by the harness\\n' >> app/main.hl\n"
+        + "printf 'left behind\\n' > NOTES.txt\n"
+        + "seen=$(cat \"$genome/app/main.hl\" 2>/dev/null | wc -c | tr -d ' ')\n"
+        + "printf '{\"type\": \"result\", \"subtype\": \"success\", \"is_error\": false, \"result\": \"touched app/main.hl; genome bytes %s\", \"total_cost_usd\": 0.0123, \"usage\": {\"input_tokens\": 10, \"output_tokens\": 5}}\\n' \"$seen\"\n";
+}
+
+// A harness that reaches into the genome and moves it.
+fn mover_script(genome_file: String) -> String {
+    return "#!/bin/sh\n"
+        + "genome=$(cat " + genome_file + ")\n"
+        + "printf '// touched\\n' >> app/main.hl\n"
+        + "git -C \"$genome\" -c user.name=h -c user.email=h@local commit -q --allow-empty -m moved\n"
+        + "printf '{\"type\": \"result\", \"subtype\": \"success\", \"is_error\": false, \"result\": \"moved it\", \"total_cost_usd\": 0.001, \"usage\": {\"input_tokens\": 1, \"output_tokens\": 1}}\\n'\n";
+}
+
+main locus App {
+    params {
+        repo: String = "";
+        dna: dna::Dna = dna::Dna { };
+        again: dna::Dna = dna::Dna { };
+        direct: dna::HarnessModel = dna::HarnessModel { };
+        strict: dna::HarnessModel = dna::HarnessModel { };
+    }
+    @unbounded
+    fn last_body(j: dna::Journal, kind: String) -> String {
+        let mut out = "";
+        let mut i = 0;
+        while i < j.revision() {
+            let e = j.read(i);
+            if e.kind == kind { out = e.body; }
+            i = i + 1;
+        }
+        return out;
+    }
+    @unbounded
+    fn evidence_with(j: dna::Journal, needle: String) -> String {
+        let mut out = "";
+        let mut i = 0;
+        while i < j.revision() {
+            let e = j.read(i);
+            if e.kind == "model.called" && std::str::contains(e.body, needle) { out = e.body; }
+            i = i + 1;
+        }
+        return out;
+    }
+    run() {
+        // ---- the genome: a repository whose seed is `app/`
+        let repo = "/tmp/dna-harness-" + to_string(std::process::pid());
+        let scratch = repo + "-bin";
+        std::io::fs::mkdir(repo) or discard;
+        std::io::fs::mkdir(scratch) or discard;
+        std::io::fs::mkdir(repo + "/app") or discard;
+        std::io::fs::mkdir(repo + "/.hale") or discard;
+        std::io::fs::mkdir(repo + "/.hale/dna") or discard;
+        std::io::fs::write_file(repo + "/hale.toml", "[deps]\n") or discard;
+        std::io::fs::write_file(repo + "/app/main.hl", BASE) or discard;
+        std::io::fs::write_file(repo + "/.gitignore", "/.hale/\n") or discard;
+        std::io::fs::write_file(scratch + "/genome", repo) or discard;
+        std::io::fs::write_file(scratch + "/claude", harness_script(scratch + "/genome")) or discard;
+        std::io::fs::write_file(scratch + "/mover", mover_script(scratch + "/genome")) or discard;
+        let chmod = sh("chmod\n+x\n" + scratch + "/claude\n" + scratch + "/mover");
+        let init = sh("git\n-C\n" + repo + "\ninit\n-q\n-b\nmain");
+        let add = sh("git\n-C\n" + repo + "\nadd\n-A");
+        let c0 = sh("git\n-C\n" + repo + "\n-c\nuser.name=t\n-c\nuser.email=t@local\ncommit\n-q\n-m\nbase");
+        std::test::assert_eq_int(c0.code, 0, "base commit: " + c0.stderr);
+        let cut = sh(toolchain() + "\ncheck\n" + repo + "/app\n--dump-topology=" + repo + "/.hale/dna/baseline.topology");
+        std::test::assert_eq_int(cut.code, 0, "baseline: " + cut.stderr);
+        let bwrap = dna::Bubblewrap { };
+        let masked = bwrap.available();
+
+        // ---- 1. a Mutation through the harness
+        self.dna = dna::Dna {
+            journal: dna::GitJournal { repo: repo },
+            gateway: dna::MutationGateway {
+                workspaces: dna::IsolatedWorktrees { repo: repo, root: repo + "/.hale/dna/worktrees", base_exec_digest: "exec:base" },
+                repo: dna::LocalGit { repo: repo }
+            },
+            verification: dna::HaleVerification { hale_bin: toolchain(), receipts: dna::GitReceipts { repo: repo }, scratch: repo + "/.hale/dna/scratch", repo: repo, seed: "app" },
+            editor: dna::SourceEditor {
+                name: "editor",
+                models: dna::ModelRouter {
+                    // the quick tier is the harness; Bubblewrap when this machine has it, else none by the org chart's leave
+                    quick: dna::HarnessModel { name: "quick", command: scratch + "/claude", confinement: dna::Bubblewrap { }, allow_unconfined: true },
+                    deep: dna::FakeModel { name: "deep", answer: "pings_seen +" }
+                },
+                tools: dna::WorktreeTools { hale_bin: toolchain() }
+            },
+            boundary: dna::AutonomyBoundary { child: "app", grant: dna::Grant { child: "app", classes: "docs refactor", max_magnitude: 8, review: "pre" } },
+            genome_seed: "app"
+        };
+        let out = self.dna.mutate("t1", "docs", "note that the harness was here", "", 1);
+        std::test::assert(std::str::contains(out, ": review"), "the harness's candidate reaches its Review: " + out);
+        std::time::sleep(100ms);
+        // the candidate carries the harness's edit, and only the grant's files
+        let cand = std::json::find_string_field(self.last_body(self.dna.journal, "review.requested"), "candidate_commit");
+        let shown = sh("git\n-C\n" + repo + "\nshow\n" + cand + ":app/main.hl");
+        std::test::assert(std::str::contains(shown.stdout, "// touched by the harness"), "the edit is in the candidate: " + shown.stdout);
+        let notes = sh("git\n-C\n" + repo + "\nshow\n" + cand + ":NOTES.txt");
+        std::test::assert(notes.code != 0, "the file outside the grant was left behind");
+        std::test::assert_eq_int(self.dna.editor.refused_outside, 1, "and counted");
+        std::test::assert_eq_int(self.dna.editor.imported, 1, "one file imported");
+        std::test::assert_eq_int(self.dna.editor.exports, 1, "one export");
+        std::test::assert(!std::io::fs::file_exists(self.dna.editor.last_export), "the export is gone: " + self.dna.editor.last_export);
+        // the evidence: adapter, cost from the harness's own summary, the grant, the confinement
+        let ev = self.evidence_with(self.dna.journal, "\"adapter\": \"harness\"");
+        std::test::assert(len(ev) > 0, "a model.called row for the harness call");
+        std::test::assert(std::str::contains(ev, "\"cost_micros\": 12300"), "cost from the harness's summary: " + ev);
+        std::test::assert(std::str::contains(ev, "\"tool_grant\": \"harness @export\""), "the grant is the export: " + ev);
+        std::test::assert(std::str::contains(ev, "\"input_tokens\": 10"), "usage from the summary: " + ev);
+        std::test::assert(std::str::contains(ev, "\"endpoint\": \"" + scratch + "/claude\""), "the harness named: " + ev);
+        if masked {
+            std::test::assert(std::str::contains(ev, "confinement=bubblewrap"), "confined: " + ev);
+            std::test::assert(std::str::contains(self.dna.editor.last_summary, "genome bytes 0"), "the genome was unreachable from the harness: " + self.dna.editor.last_summary);
+        } else {
+            std::test::assert(std::str::contains(ev, "confinement=none"), "unconfined by the org chart's leave: " + ev);
+            println("harness_test: bwrap not on PATH here; the mask is not exercised");
+        }
+        std::test::assert(std::str::contains(std::json::find_string_field(self.last_body(self.dna.journal, "review.requested"), "question"), "note that the harness was here"), "the Review is over the harness's work");
+
+        // ---- 2. a harness that moves the genome fails the attempt by the record
+        self.again = dna::Dna {
+            journal: dna::GitJournal { repo: repo },
+            gateway: dna::MutationGateway {
+                workspaces: dna::IsolatedWorktrees { repo: repo, root: repo + "/.hale/dna/worktrees", base_exec_digest: "exec:base" },
+                repo: dna::LocalGit { repo: repo }
+            },
+            verification: dna::HaleVerification { hale_bin: toolchain(), receipts: dna::GitReceipts { repo: repo }, scratch: repo + "/.hale/dna/scratch", repo: repo, seed: "app" },
+            editor: dna::SourceEditor {
+                name: "editor",
+                models: dna::ModelRouter {
+                    quick: dna::HarnessModel { name: "quick", command: scratch + "/mover", confinement: dna::NoConfinement { }, allow_unconfined: true },
+                    deep: dna::FakeModel { name: "deep", answer: "pings_seen +" }
+                },
+                tools: dna::WorktreeTools { hale_bin: toolchain() }
+            },
+            boundary: dna::AutonomyBoundary { child: "app", grant: dna::Grant { child: "app", classes: "docs refactor", max_magnitude: 8, review: "pre" } },
+            genome_seed: "app"
+        };
+        let moved = self.again.mutate("t2", "docs", "move it", "", 2);
+        std::test::assert(std::str::contains(moved, "the genome moved during the attempt"), "refused by the record: " + moved);
+        std::test::assert(std::str::contains(self.last_body(self.again.journal, "mutation.failed"), "the genome moved during the attempt"), "journaled: " + self.last_body(self.again.journal, "mutation.failed"));
+
+        // ---- 3. unconfined is refused unless the org chart allows it
+        self.strict = dna::HarnessModel { name: "quick", command: scratch + "/claude", confinement: dna::NoConfinement { } };
+        std::test::assert(self.strict.allows("internal"), "the binary is present");
+        let s = self.strict.complete(dna::ModelRequest { attempt_id: "x/a0", prompt: "hello" });
+        std::test::assert(!s.ok && std::str::contains(s.refused, "unconfined harness not allowed"), s.refused);
+        std::test::assert(!self.strict.allows("customer"), "customer data never goes to a harness");
+        let absent = dna::HarnessModel { name: "quick", command: "/no/such/harness-7f3c", allow_unconfined: true };
+        std::test::assert(!absent.allows("internal"), "a harness that is not there is not permitted");
+
+        // ---- 4. an answer-only call runs in an empty directory of its own
+        self.direct = dna::HarnessModel { name: "deep", command: scratch + "/claude", confinement: dna::NoConfinement { }, allow_unconfined: true };
+        let d = self.direct.complete(dna::ModelRequest { attempt_id: "r/review", role: "review", prompt: "decide", context: "the diff" });
+        std::test::assert(d.ok, "answered: " + d.refused);
+        std::test::assert(std::str::starts_with(d.output, "touched app/main.hl"), "the result text is the answer: " + d.output);
+        std::test::assert_eq_int(d.cost_micros, 12300, "cost from the summary");
+        std::test::assert_eq_str(self.direct.last.tool_grant, "harness", "no export: no grant");
+        std::test::assert(!std::io::fs::file_exists(repo + "/NOTES.txt"), "its scratch was not the repository");
+
+        // the money arithmetic
+        std::test::assert_eq_int(dna::usd_to_micros("0.0123"), 12300, "0.0123 USD");
+        std::test::assert_eq_int(dna::usd_to_micros("1.5"), 1500000, "1.5 USD");
+        std::test::assert_eq_int(dna::usd_to_micros("0"), 0, "0 USD");
+        std::test::assert_eq_int(dna::usd_to_micros("0.00000049"), 0, "below a micro-dollar");
+    }
+}
+
+fn main() { App { }; }

--- a/docs/src/dna/models.md
+++ b/docs/src/dna/models.md
@@ -46,9 +46,9 @@ for what is there, then says so:
 
 ```text
 created …/chat/dna/org/models.hl
-models  found   ANTHROPIC_API_KEY set, ollama on PATH (llama3)
+models  found   ANTHROPIC_API_KEY set, ollama on PATH (llama3), claude on PATH
 models  frontier = claude-opus-5 · fast = claude-haiku-4-5-20251001 (ANTHROPIC_API_KEY) · desk = llama3 (ollama at 127.0.0.1:11434)
-models  leader, editor, agent: deep = frontier, quick = fast, private = desk · budget 25.00 USD a day (`hale dna models` probes them)
+models  editor, agent: quick = harness (claude), deep = frontier · leader: deep = frontier, quick = fast · private = desk · budget 25.00 USD a day (`hale dna models` probes them)
 ```
 
 With `ANTHROPIC_API_KEY` the hosted backends are `AnthropicMessages`
@@ -56,11 +56,14 @@ with the strongest models; with `OPENAI_API_KEY` alone, `OpenAiChat`
 to OpenAI; with neither, the catalog still names OpenAI with the
 key's name as a placeholder, the hosted backends are simply not
 permitted until it is set, and every review waits for the Board. `ollama` on `PATH` makes its first listed model
-the desk model. Re-running `init` keeps a catalog you have edited;
+the desk model. `claude` (else `codex`) on `PATH` becomes
+`harness()`: the editor's and the agent's quick tier, and with no key
+at all every model-backed slot, so a laptop with a harness and no key
+still edits, reviews and decides. Re-running `init` keeps a catalog you have edited;
 `hale dna upgrade` writes one for an organization from before the
 catalog and tells you what to point at it.
 
-## Four backends
+## Five backends
 
 - **`OpenAiChat`** — a prompt leaves the process for an endpoint
   speaking the OpenAI chat shape (OpenAI, OpenRouter, vLLM, Ollama).
@@ -78,6 +81,12 @@ catalog and tells you what to point at it.
   has `scheme: "x-api-key"`; the credential, not the adapter, knows
   how the key is presented — `bearer` for everything OpenAI-shaped —
   so no adapter ever composes a header with the material in it.
+- **`HarnessModel`** — an installed coding harness (`claude`, or
+  `codex` with `output: "text"`), run per request with its own tools
+  on. It does not answer with a file: it *works in place*, and the
+  editor treats it accordingly (below). Customer-classed data never
+  goes to it, and it is not a permitted backend when the binary is
+  not on `PATH`.
 - **`LocalModel`** — the same wire to a local endpoint: no
   credential, no `external_model`, any data class.
 - **`FakeModel`** — scripted. `answer` (or `answer_file`, or an
@@ -88,6 +97,49 @@ catalog and tells you what to point at it.
   rehearse a session before spending money. It leaves the same
   evidence a hosted call does, with `adapter: fake`.
 
+## The harness works in an export
+
+The DNA has no opinion about how a change gets made; its law is
+about reach. So a harness runs with all its tools, but in an
+**export** of the Mutation's worktree: a plain directory with the
+same files and no `.git`, no `.hale`. The editor gives it the whole
+objective in one prompt, waits, and then imports the export's diff
+back under the grant — a changed or new file is written through the
+same tools a chat model's edit goes through, a deleted one is
+removed, and anything the harness touched outside the grant is
+counted and left behind. `files_changed` comes from that diff, never
+from what the harness said. Then the usual fmt, check, a retry with
+the diagnostics in the next prompt, and the assessment.
+
+The export is a boundary on what DNA accepts, not a sandbox: a
+process whose working directory is the export can still reach
+whatever your account can. What DNA guarantees is narrower and
+enforced: **the genome is unreachable from the harness process.**
+That is a `Confinement`:
+
+```hale,fragment
+fn harness() -> dna::HarnessModel {
+    return dna::HarnessModel { name: "quick", command: "claude", confinement: dna::Bubblewrap { } };
+}
+```
+
+`Bubblewrap` (Linux) runs the harness with the filesystem as you see
+it — its own settings and login, the toolchain, the network — and
+the repository and the worktree replaced by empty mounts, so the
+genome does not exist for it. With no confinement available the
+harness is refused, unless you say `allow_unconfined: true`; the
+evidence records which it was (`confinement=bubblewrap`,
+`confinement=none`). And on every platform the organization checks
+that neither the repository's head nor the worktree's moved while an
+attempt ran, and fails the Mutation by the record if they did. Outside
+the genome the harness has exactly your account, which is what
+running it by hand has.
+
+Evidence is one `model.called` row per call, with the harness's own
+cost summary, `tool_grant: harness @export`, and the confinement.
+The Leader can use a harness too: an answer-only call runs in an
+empty directory of its own.
+
 ## Probing the catalog
 
 ```text
@@ -97,6 +149,7 @@ backend     slot      model                         answer
 frontier    deep      claude-opus-5                 ok  1.2s  1230 micro-dollars  "ready"
 fast        quick     claude-haiku-4-5-20251001     ok  412ms  38 micro-dollars  "Ready."
 desk        private   llama3                        refused: http 0 connect connection refused
+harness     quick     claude                        ok  6.1s  4100 micro-dollars  "ready"
 ```
 
 One line per backend the catalog names, one small request to each

--- a/docs/src/dna/reference.md
+++ b/docs/src/dna/reference.md
@@ -134,7 +134,7 @@ last_restart_request, last_observed }`, `intents`, `tasks[]`,
 | `process.hl` | `Task`, `Workflow`, `Step`, `Work`, `Attempt`, `Metabolism` |
 | `work_system.hl` | `WorkSystem`, routing perspectives, the performers |
 | `review.hl` | `Review`, `AutonomyBoundary`, authority ranks |
-| `models.hl` | `ModelRouter`, `OpenAiChat`, `AnthropicMessages`, `LocalModel`, `FakeModel`, `HostedCredential` (with its `scheme`), `probe` |
+| `models.hl` | `ModelRouter`, `OpenAiChat`, `AnthropicMessages`, `HarnessModel`, `LocalModel`, `FakeModel`, `HostedCredential` (with its `scheme`), `Confinement` (`Bubblewrap`, `NoConfinement`), `probe` |
 | `budget.hl` | `BudgetPolicy`, `Budget` (the substrate's one counter) |
 | `knowledge.hl` | semantic memory: ideas, edges, bindings |
 | `workspace.hl` | `IsolatedWorktrees`, `LocalGit`, `MutationGateway` |

--- a/docs/src/dna/shaping.md
+++ b/docs/src/dna/shaping.md
@@ -101,6 +101,11 @@ fn org_budget() -> dna::BudgetPolicy { return dna::BudgetPolicy { window: "day",
   way its `scheme` says (`bearer`, or `x-api-key`). Without the key,
   the backend simply isn't available. Customer-classed data never
   goes to it.
+- **Harness** (`HarnessModel`) — `claude` or `codex` on your
+  machine, run with its own tools in an export of the worktree, the
+  repository masked from it; the editor imports what it changed
+  under the grant. [Models and credentials](./models.md) has the
+  boundary.
 - **Local** — the same wire to something on your machine. No key,
   any data.
 - **Scripted** — `dna::FakeModel { answer_file: "…" }` returns a

--- a/spec/dna.md
+++ b/spec/dna.md
@@ -198,6 +198,42 @@ The organization's models are a catalog in source (GH #583 M1):
   the header, no adapter does. An API error is refused as `http
   <status> <the API's message>`; a transport failure as `http 0
   <kind> <detail>`.
+- **The harness.** `HarnessModel` runs an installed coding harness
+  (`command: claude`, or `codex` with `output: text`) per request with
+  its own tools on, as a backend that `works_in_place`: for a
+  source-editing request the editor makes an EXPORT of the Mutation's
+  worktree (a plain directory with the same files, never `.git`, never
+  `.hale`), runs the harness with the export as its cwd and the whole
+  objective as its prompt, and imports the export's diff back under
+  the grant — a file that differs or is new is written through the
+  tools, one that is gone is removed, a change outside the grant is
+  counted (`outside_grant`) and left behind; `files_changed` is
+  derived from that diff, never from the harness's answer. Then the
+  same fmt, check, retry (the diagnostics in the next prompt) and
+  assessment as the file-by-file flow. An answer-only request (a
+  review) runs in an empty directory of its own. `complete` carries
+  `external_model` and `harness_run`; evidence is one `model.called`
+  row per call with the harness's own cost summary
+  (`total_cost_usd`, `usage`), `tool_grant: harness @export`, and
+  `confinement=<kind>` in `params`.
+- **The boundary is stated exactly.** The export is not a sandbox: a
+  process whose cwd is the export can still reach whatever the
+  operator's account can. What DNA guarantees is that *the genome is
+  unreachable from the harness process*. A `Confinement` (`kind`,
+  `available`, `wrap(argv, cwd, mask)`) supplies it: `Bubblewrap`
+  (Linux: the filesystem as the operator sees it — the harness's own
+  home state, the toolchain, the network — with the repository and
+  the worktree replaced by empty tmpfs mounts, `--die-with-parent`)
+  or `NoConfinement`. A harness whose confinement is unavailable is
+  refused (`unconfined harness not allowed`) unless the org chart's
+  `allow_unconfined` says otherwise; the evidence records which it
+  was. On every platform the assembly also checks that the
+  repository's head and the worktree's head did not move during the
+  attempt and fails the Mutation (`mutation.failed`: `the genome
+  moved during the attempt`) if they did: not a boundary, but a
+  bypass becomes a loud refusal. Outside the genome the harness has
+  exactly the operator's account, which is what running it by hand
+  has. The `Repository` interface names its `root` for the mask.
 - **The catalog is source.** A backend is a constructor function
   (`frontier()`, `fast()`, `desk()` …); a position's router is a
   function composed from them (`leader_models()`, `editor_models()`,
@@ -208,11 +244,14 @@ The organization's models are a catalog in source (GH #583 M1):
   boundary.
 - **Discovery.** `init` and `new` look at the environment
   (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) and `PATH` (`ollama`, whose
-  first listed model becomes the desk model; `claude` and `codex` are
-  reported), write the catalog for what is there (`AnthropicMessages`
-  with `claude-opus-5` / `claude-haiku-4-5` when its key is present,
-  else `OpenAiChat` with `gpt-4o` / `gpt-4o-mini`, a placeholder key
-  when none is set), and print what each position was given. Nothing found is fine: a hosted backend without its key
+  first listed model becomes the desk model; `claude`, else `codex`,
+  becomes `harness()`), write the catalog for what is there
+  (`AnthropicMessages` with `claude-opus-5` / `claude-haiku-4-5` when
+  its key is present, else `OpenAiChat` with `gpt-4o` /
+  `gpt-4o-mini`, a placeholder key when none is set; with a harness
+  the editor's and the agent's `quick` tier is the harness, and with
+  no key every model-backed slot is), and print what each position
+  was given. Nothing found is fine: a hosted backend without its key
   is not permitted, and every Review waits for the Board. `upgrade`
   writes a catalog for an organization that predates it and says what
   to point at it; it never edits the organization's main.


### PR DESCRIPTION
Part of #583 (Phase 4), Track M, M3: the harness backend, the export, `Confinement`. Stacked on #585 (M2).

## What changes

**`HarnessModel`.** An installed coding harness (`command: "claude"`, or `codex` with `output: "text"`) run per request with its own tools on, as a backend that `works_in_place`. For a source-editing request the editor makes an **export** of the Mutation's worktree (a plain directory with the same files, never `.git`, never `.hale`), runs the harness there with the whole objective as its prompt, and imports the export's diff back under the grant: a changed or new file is written through the same tools a chat model's edit goes through, a deleted one is removed, a change outside the grant is counted (`outside_grant`) and left behind. `files_changed` is derived from that diff, never from the harness's answer. Then the same fmt, check, retry (diagnostics in the next prompt) and assessment as the file-by-file flow. An answer-only request (a review) runs in an empty directory of its own. Evidence is one `model.called` row per call with the harness's own cost summary (`total_cost_usd`, `usage`), `tool_grant: harness @export`, and `confinement=<kind>` in `params`.

**The boundary, stated exactly.** The export decides what DNA accepts; it is not a sandbox. What DNA guarantees is that *the genome is unreachable from the harness process*: a `Confinement` (`kind`, `available`, `wrap(argv, cwd, mask)`) supplies it — `Bubblewrap` on Linux (the filesystem as the operator sees it: the harness's own home state, the toolchain, the network; the repository and the worktree replaced by empty tmpfs mounts; `--die-with-parent`) or `NoConfinement`, which is refused unless the org chart's `allow_unconfined` says otherwise. The evidence records which it was. On every platform the assembly also checks that neither the repository's head nor the worktree's moved during any attempt and fails the Mutation by the record (`mutation.failed`: `the genome moved during the attempt`) if they did: not a boundary, but a bypass becomes a loud refusal. Outside the genome the harness has exactly the operator's account, which is what running it by hand has. `effect harness_run` names the reach; `Repository.root()` names what is masked.

**Discovery.** `claude` (else `codex`) on `PATH` becomes `harness()`: the editor's and the agent's quick tier, and every model-backed slot when there is no key, so a laptop with a harness and no key still edits, reviews and decides. The probe runs it too.

**Seams.** `ModelBackend.works_in_place()`, `ModelRouter.in_place(req)`, `ModelRequest { workspace, mask }`, `SourceEditor.place(worktree, seed, repo)` (the assembly's call; `confine` still works for tests), `WorktreeTools.remove`. The assembly skips locating a file first when the editor's backend works in place.

## Tests

- `dna/tests/harness_test.hl`: a stand-in harness (a shell script playing `claude -p --output-format json`) edits the seed's main file in its export, leaves a file outside the grant, tries to read the genome by its real path, and prints the result object with a cost. One Dna over a real repository runs a Mutation through it: the candidate carries the edit, the stray file is left behind and counted, the evidence has `cost_micros: 12300`, `tool_grant: harness @export` and the confinement, the export is gone, and under Bubblewrap the harness read **zero bytes** of the genome (the mask is exercised where `bwrap` is present; reported as skipped otherwise). A harness that commits to the genome fails the attempt by the record. An unconfined harness is refused without the org chart's leave; a harness that is not on PATH is not permitted; customer data never goes to one. An answer-only call runs in a directory of its own and never touches the repository.
- `dna_models.rs`: a stand-in `claude` on PATH becomes `harness()`; with no key every slot is the harness, with a key the editor's quick tier only; the organization checks with it wired; `hale dna models` runs the harness and shows its cost.

Spec (the harness, the boundary, discovery), the Book (models: "The harness works in an export"; shaping; reference), CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
