### PR TITLE
compiler: a literal owns a factory result written as its field; check refuses an unbound callee in a seed (GH #583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ behavior.
 
 ## Unreleased
 
+### `hale check` refuses a call to a name nothing binds (GH #583, dna/FRICTION.md F.18)
+
+- A bare callee that is not a local binding, a top-level fn, a generic fn or a builtin typed as Unknown and passed `check`, to be refused by `hale build` as `no free fn / generic fn / fn-pointer binding with that name is in scope`. An organization whose gate is `check` applied a candidate naming a router function nobody had written, and found out at expression (rolled back by the window, as designed — but the wrong gate). The checker holds codegen's rule now when a whole seed is checked (`hale check <directory>`, which is what a build compiles and what the organization's gate runs): `call to X: no free fn, generic fn or fn-pointer binding with that name is in scope`, with a did-you-mean over the program's fns. One file checked alone, or a partial program a harness assembles, keeps the permissive reading, since it may call what a sibling file defines. `check_unbound_callee.rs` pins both.
+
+### A locus literal owns a factory result written as its field (GH #583, dna/FRICTION.md F.17)
+
+- `Router { quick: make("q") }` inside another factory registered `make`'s fresh result as a temporary of the enclosing frame (the GH #402 hook) and dissolved it at that frame's exit while the field — a fat pointer, for an interface-typed slot — still pointed at it: the organization's catalog (`ModelRouter { quick: fast(), deep: frontier() }`) read garbage from its backends under load, first as a corrupted `dir` string, then as a segfault in an interface dispatch. A fresh-factory call written as a locus- or interface-typed field of a literal, explicit or default, is now owned by the literal, the same rule a `let` RHS and an `=` into a locus slot already had. `tests/hale/factory_field_owner_test.hl` pins it; found by recording the M4 fixture, pinpointed with a `LOTUS_ASAN=1` build of the organization.
+
 ### `hale dna` and `hale node` exec the host in place
 
 - The shim that resolved the project and started the Hale host waited on it as a child, so a signal to the pid that ran `hale dna run` or `hale node` — a supervisor's, a test's — killed the shim and orphaned the host, which kept ticking; dozens of `host node` agents survived their tests on a workstation and loaded it. The shim now execs the host (and `hale dna ui` its surface) in place: the pid is the host. The fleet test asserts nothing of its own survives its teardown.

--- a/crates/hale-cli/src/main.rs
+++ b/crates/hale-cli/src/main.rs
@@ -4218,7 +4218,11 @@ fn run_check_impl_labelled(
     // cost of every `--dump-topology` invocation.
     let allow_unowned =
         std::env::args().any(|a| a == "--allow-unowned-subscriber");
-    let checked = hale_types::check_bundle_opts(&bundle, allow_unowned);
+    // F.18: a whole seed (a directory) is checked to what `build`
+    // accepts — a call to a bare name nothing binds is an error here;
+    // one file of a seed keeps the permissive reading for a sibling's fn
+    let strict_callees = target.is_dir();
+    let checked = hale_types::check_bundle_opts_scoped(&bundle, allow_unowned, strict_callees);
 
     if dump_topology || dump_topology_to.is_some() {
         // The artifact's EXISTENCE means the model is sound.

--- a/crates/hale-cli/tests/check_unbound_callee.rs
+++ b/crates/hale-cli/tests/check_unbound_callee.rs
@@ -1,0 +1,64 @@
+//! GH #583 (dna/FRICTION.md F.18) — `hale check <seed>` refuses a call
+//! to a bare name that nothing binds, the way `hale build` always did.
+//! An organization whose gate is `check` applied a candidate that named
+//! a router function nobody had written, and found out at expression.
+//! The rule is on for a whole seed (a directory) and off for one file,
+//! which may call what a sibling defines.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// `hale check <dir>`: a whole seed, where the rule is on.
+fn check(src: &str, tag: &str) -> (bool, String) {
+    check_as(src, tag, true)
+}
+
+fn check_as(src: &str, tag: &str, whole_seed: bool) -> (bool, String) {
+    let d: PathBuf = std::env::temp_dir().join(format!("hale_check_unbound_{}_{}", std::process::id(), tag));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).unwrap();
+    let f = d.join("main.hl");
+    std::fs::write(&f, src).unwrap();
+    let target = if whole_seed { d.to_string_lossy().to_string() } else { f.to_string_lossy().to_string() };
+    let out = Command::new(env!("CARGO_BIN_EXE_hale")).args(["check", &target]).current_dir(Path::new("/")).output().expect("hale");
+    let text = format!("{}{}", String::from_utf8_lossy(&out.stdout), String::from_utf8_lossy(&out.stderr));
+    let _ = std::fs::remove_dir_all(&d);
+    (out.status.success(), text)
+}
+
+const REFUSAL: &str = "no free fn, generic fn or fn-pointer binding with that name is in scope";
+
+#[test]
+fn a_call_to_nothing_is_refused_in_a_body_a_default_and_an_override() {
+    let body = "locus A { params { n: Int = 0; } fn go() -> Int { return nothing_here(); } }\nmain locus M { params { a: A = A { }; } run() { println(self.a.go()); } }\nfn main() { M { }; }\n";
+    let (ok, out) = check(body, "body");
+    assert!(!ok && out.contains("call to `nothing_here`: ") && out.contains(REFUSAL), "{out}");
+    let default = "locus R { params { k: Int = 1; } }\nlocus A { params { r: R = nothing_here(); } fn go() -> Int { return self.r.k; } }\nmain locus M { params { a: A = A { }; } run() { println(self.a.go()); } }\nfn main() { M { }; }\n";
+    let (ok, out) = check(default, "default");
+    assert!(!ok && out.contains("call to `nothing_here`: "), "{out}");
+    // the organization's shape: a router function the model invented,
+    // beside the one that exists — the hint names it
+    let org = "fn leader_models() -> Int { return 1; }\nfn editor_models() -> Int { return 2; }\nlocus A { params { m: Int = editor_model(); } }\nmain locus M { params { a: A = A { m: leader_models() }; } run() { println(self.a.m); } }\nfn main() { M { }; }\n";
+    let (ok, out) = check(org, "override");
+    assert!(!ok && out.contains("call to `editor_model`: ") && out.contains("did you mean `editor_models`?"), "{out}");
+}
+
+/// One file of a seed may call what a sibling file defines: checked
+/// alone, it keeps the permissive reading (the organization's gate
+/// checks the seed, never one file).
+#[test]
+fn a_single_file_keeps_the_permissive_reading() {
+    let src = "locus A { params { n: Int = 0; } fn go() -> Int { return sibling_helper(); } }\nmain locus M { params { a: A = A { }; } run() { println(self.a.go()); } }\nfn main() { M { }; }\n";
+    let (ok, out) = check_as(src, "single", false);
+    assert!(ok, "a single file is not held to the whole-seed rule: {out}");
+    let (ok, out) = check_as(src, "seed", true);
+    assert!(!ok && out.contains("call to `sibling_helper`: "), "the seed is: {out}");
+}
+
+#[test]
+fn bound_names_still_check() {
+    // a free fn, a fn-pointer local, a builtin, a generic fn, a stdlib path
+    let src = "fn helper(n: Int) -> Int { return n; }\nfn twice<T>(x: T) -> T { return x; }\nmain locus M { run() { let f = helper; println(f(1), \" \", len(\"ab\"), \" \", to_string(twice(3)), \" \", std::str::pad_left(\"a\", 3, \" \"), \" \", abs(0 - 2)); } }\nfn main() { M { }; }\n";
+    let (ok, out) = check(src, "bound");
+    assert!(ok, "{out}");
+}

--- a/crates/hale-codegen/src/locus/instantiation.rs
+++ b/crates/hale-codegen/src/locus/instantiation.rs
@@ -2118,7 +2118,30 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                     let inner_init = self.params_init_initialized.take();
                     self.params_init_initialized =
                         prev_params_init_initialized.clone();
-                    let r = self.lower_expr(expr, scope)?;
+                    // GH #583 (dna/FRICTION.md F.17): a fresh-factory
+                    // call written as a locus- or interface-typed
+                    // FIELD of this literal is owned by the literal —
+                    // `Router { quick: make("q") }` inside another
+                    // factory. Without this the GH #402 hook registered
+                    // the result as a temporary of the enclosing frame
+                    // and dissolved it at that frame's exit while the
+                    // field (a fat pointer, for an interface slot)
+                    // still pointed at it; the organization's catalog
+                    // read garbage from its backends. Same rule as a
+                    // `let` RHS and an `=` into a locus slot: the
+                    // owner of the next call is already decided.
+                    let field_owns_locus_rhs = matches!(expr, Expr::Call { .. })
+                        && matches!(
+                            info.fields.get(fname.as_str()).map(|(_, t)| t),
+                            Some(CodegenTy::LocusRef(_)) | Some(CodegenTy::Interface(_))
+                        );
+                    let prev_sft = self.suppress_fresh_temp;
+                    if field_owns_locus_rhs {
+                        self.suppress_fresh_temp = true;
+                    }
+                    let r = self.lower_expr(expr, scope);
+                    self.suppress_fresh_temp = prev_sft;
+                    let r = r?;
                     self.params_init_initialized = inner_init;
                     self.in_params_default = inner_ipd;
                     self.params_init_self = inner_pis;
@@ -2151,7 +2174,20 @@ impl<'ctx, 'p> LocusInstantiate<'ctx> for Cx<'ctx, 'p> {
                             // method-body current_self.
                             let saved_ipd = self.in_params_default;
                             self.in_params_default = true;
-                            let r = self.lower_expr(e, scope)?;
+                            // the same ownership rule for a default
+                            // that is a factory call (F.17)
+                            let field_owns_locus_rhs = matches!(e, Expr::Call { .. })
+                                && matches!(
+                                    info.fields.get(fname.as_str()).map(|(_, t)| t),
+                                    Some(CodegenTy::LocusRef(_)) | Some(CodegenTy::Interface(_))
+                                );
+                            let prev_sft = self.suppress_fresh_temp;
+                            if field_owns_locus_rhs {
+                                self.suppress_fresh_temp = true;
+                            }
+                            let r = self.lower_expr(e, scope);
+                            self.suppress_fresh_temp = prev_sft;
+                            let r = r?;
                             self.in_params_default = saved_ipd;
                             let owned = !self.instantiating_for_parent_field;
                             self.instantiating_for_parent_field =

--- a/crates/hale-types/src/check.rs
+++ b/crates/hale-types/src/check.rs
@@ -338,6 +338,20 @@ pub fn check_bundle(
     top: &TopScope,
     allow_unowned_subscriber: bool,
 ) -> Vec<Diag> {
+    check_bundle_scoped(bundle, top, allow_unowned_subscriber, false)
+}
+
+/// `strict_callees`: refuse a call to a bare name nothing binds
+/// (dna/FRICTION.md F.18) — the rule `hale build` holds. On only when
+/// the caller checked a WHOLE seed, so a single file of a multi-file
+/// seed, a styleguide snippet or a harness's partial program keeps the
+/// permissive `Unknown` it always had for a sibling's fn.
+pub fn check_bundle_scoped(
+    bundle: &Bundle<'_>,
+    top: &TopScope,
+    allow_unowned_subscriber: bool,
+    strict_callees: bool,
+) -> Vec<Diag> {
     let mut diags = Vec::new();
     let known = collect_known_names(top);
     // WASM plan: the bundle targets wasm if any program declares
@@ -383,6 +397,7 @@ pub fn check_bundle(
             fallible_ctx: None,
             return_ctx: None,
             wasm_target,
+            strict_callees,
             or_value_discarded: false,
             generic_fns,
             generic_types,
@@ -5884,6 +5899,7 @@ struct Checker<'a> {
     /// `target browser_js`. Gates the POSIX-only stdlib (no syscalls in
     /// the browser sandbox) at typecheck — see `wasm_unavailable_stdlib`.
     wasm_target: bool,
+    strict_callees: bool, // F.18: on for a whole seed (`hale check <dir>`), off for a partial program
     /// M3 stage 2 (2026-07-02): true while checking an `or`
     /// expression whose value is discarded (statement position) —
     /// the Substitute arm skips the fallback-vs-success type match.
@@ -11832,6 +11848,47 @@ impl<'a> Checker<'a> {
                     }
                 }
                 let callee_ty = self.check_expr(callee);
+                // GH #583 (dna/FRICTION.md F.18): a bare callee that names
+                // nothing — not a local (a fn-pointer binding), not a
+                // top-level fn, not a generic fn, not a builtin — was
+                // typed Unknown and sailed through `check`, to die in
+                // `hale build` as "no free fn / generic fn / fn-pointer
+                // binding with that name is in scope". An organization
+                // whose gate is `check` applied a candidate that named a
+                // router function nobody had written, and found out at
+                // expression. The checker holds codegen's rule now, for a
+                // WHOLE seed (`strict_callees`); a partial program — one
+                // file of a seed, a snippet — legitimately calls what a
+                // sibling defines and keeps the permissive Unknown. The
+                // builtin list is the set of bare names codegen answers
+                // itself.
+                if let Expr::Ident(id) = callee.as_ref() {
+                    let name = id.name.as_str();
+                    let known = self.locals.lookup(name).is_some()
+                        || self.top.lookup(name).is_some()
+                        || self.generic_fns.contains_key(name)
+                        || BARE_BUILTIN_CALLEES.contains(&name);
+                    if self.strict_callees && !known && matches!(callee_ty, Ty::Unknown) {
+                        let candidates: Vec<&str> = self
+                            .top
+                            .symbols
+                            .iter()
+                            .filter(|(_, sym)| matches!(sym, TopSymbol::Fn(_)))
+                            .map(|(n, _)| n.as_str())
+                            .collect();
+                        let hint = closest_bare_name(name, &candidates)
+                            .map(|h| format!(" — did you mean `{}`?", h))
+                            .unwrap_or_default();
+                        self.diags.push(Diag::ty(
+                            id.span,
+                            format!(
+                                "call to `{}`: no free fn, generic fn or fn-pointer \
+                                 binding with that name is in scope{}",
+                                name, hint
+                            ),
+                        ));
+                    }
+                }
                 let arg_tys: Vec<Ty> = args.iter().map(|a| self.check_expr(a)).collect();
                 // F.20: when a fn param is an interface type, the
                 // arg's locus type must structurally satisfy the
@@ -13899,4 +13956,41 @@ fn locus_has_unsynchronized_state(
         }
     }
     None
+}
+
+/// The bare names codegen answers itself when they resolve to no user
+/// fn (see `lower` in hale-codegen: `len`, `to_string`, the printers,
+/// the numeric trio, the bounded intrinsics, the casts, `__fmt`). A
+/// call to any other unbound bare name is refused by `hale build`, so
+/// the checker refuses it first (dna/FRICTION.md F.18).
+pub(crate) const BARE_BUILTIN_CALLEES: &[&str] = &[
+    "len", "to_string", "hex", "println", "print", "eprintln", "abs", "min", "max",
+    "sum", "prod", "panic", "exit", "push", "at", "set", "count", "clear", "truncate",
+    "Int", "Float", "String", "Bool", "Bytes", "Decimal", "Duration",
+    hale_syntax::parser::FMT_BUILTIN,
+];
+
+/// Nearest name by edit distance, for the "did you mean" hint; `None`
+/// when nothing is within a short distance.
+fn closest_bare_name<'a>(name: &str, candidates: &[&'a str]) -> Option<&'a str> {
+    fn dist(a: &str, b: &str) -> usize {
+        let a: Vec<char> = a.chars().collect();
+        let b: Vec<char> = b.chars().collect();
+        let mut prev: Vec<usize> = (0..=b.len()).collect();
+        for i in 1..=a.len() {
+            let mut cur = vec![i; b.len() + 1];
+            for j in 1..=b.len() {
+                let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+                cur[j] = (prev[j] + 1).min(cur[j - 1] + 1).min(prev[j - 1] + cost);
+            }
+            prev = cur;
+        }
+        prev[b.len()]
+    }
+    candidates
+        .iter()
+        .map(|c| (dist(name, c), *c))
+        .filter(|(d, _)| *d <= 3)
+        .min_by_key(|(d, c)| (*d, c.to_string()))
+        .map(|(_, c)| c)
 }

--- a/crates/hale-types/src/lib.rs
+++ b/crates/hale-types/src/lib.rs
@@ -144,8 +144,19 @@ pub fn check_bundle_opts(
     bundle: &Bundle<'_>,
     allow_unowned_subscriber: bool,
 ) -> Vec<Diag> {
+    check_bundle_opts_scoped(bundle, allow_unowned_subscriber, false)
+}
+
+/// The same check with the F.18 rule on: a call to a bare name nothing
+/// binds is an error, as `hale build` would say. The CLI passes `true`
+/// when it checked a whole seed (a directory), never for one file.
+pub fn check_bundle_opts_scoped(
+    bundle: &Bundle<'_>,
+    allow_unowned_subscriber: bool,
+    strict_callees: bool,
+) -> Vec<Diag> {
     let (top, mut diags) = resolve::build_top_scope(bundle);
-    diags.extend(check::check_bundle(bundle, &top, allow_unowned_subscriber));
+    diags.extend(check::check_bundle_scoped(bundle, &top, allow_unowned_subscriber, strict_callees));
     // GH #476 Change 9 (review): claim VERDICTS are judged over the
     // canonical model, and a model is a description of a CHECKED
     // program — `derive_application_model` says so, and ends with a

--- a/dna/FRICTION.md
+++ b/dna/FRICTION.md
@@ -353,6 +353,109 @@ precise answer without the concrete type; filed as a follow-up.
 
 ---
 
+## F.17 — a String computed in a fn and passed to a locus constructor in another fn that returns the locus dangles under the organization
+
+**Tag:** `factory-result-in-literal-field-dissolved-by-frame`
+**Severity:** SOUNDNESS (a silently corrupted param, then a segfault),
+seen 2026-09-11 while recording the M4 fixture (GH #583).
+**Status:** FIXED in the compiler the same day (see the resolution
+below); the by-name params stay as design.
+
+The fixture's catalog wrote
+
+```hale
+fn tape_dir() -> String { return std::env::var("HALE_DNA_TAPE_DIR"); }
+fn frontier() -> dna::RecordedModel {
+    return dna::RecordedModel { name: "deep", dir: tape_dir(), inner: dna::AnthropicMessages { … } };
+}
+fn editor_models() -> dna::ModelRouter { return dna::ModelRouter { deep: frontier(), … }; }
+```
+
+and the generated organization's main took `models: editor_models()`
+as a param default. Under `hale dna run`, in the editor's second model
+call of a Mutation (from the assembly's `on_work_requested` handler),
+`self.dir` of the `deep` RecordedModel read as
+`/home/riley/code/hale-la��?��d`: the first bytes intact, the tail
+overwritten. The `quick` model, built the same way, still read its
+`dir` whole at that point. The computed String lived in the frame of
+`frontier()` (or of `tape_dir()`), was stored by the constructor as a
+param of a locus that outlived that frame, and the region was reused
+under the handler's allocation pressure. A literal in the same slot
+(`dir: "…"`) is static and never dangles, which is why every other
+catalog function is unaffected.
+
+Not reproduced on the main thread: a minimal program building the
+same shape (`fn computed() -> String`, `fn make() -> Box { return Box
+{ s: computed() } }`, `params { a: Box = make(); }`) and churning
+300 KB of strings afterwards reads the param intact. The organization
+adds the handler thread, the off-thread bus and much more allocation
+before the read; the minimal reproducer needs one of those.
+
+**Workaround in the core (kept as design):** a locus that needs a
+value from the environment names its SOURCE and reads it at birth,
+into its own region — `RecordedModel { dir_env, mode_env }`, the same
+shape as `HostedCredential { env_var }`. A catalog function computes
+no string.
+
+**Resolution (2026-09-11):** the string was the first symptom, not
+the cause. A `LOTUS_ASAN=1` build of the organization faulted in
+`RecordedModel.allows` on `self.inner`, and a minimal program
+reproduced it on the main thread: `Router { quick: make("q") }`
+inside another factory. The GH #402 hook registered `make`'s fresh
+result as a temporary of `make_router`'s frame and dissolved it at
+that frame's exit, while the field — a fat pointer, for an
+interface-typed slot — still pointed at it; the strings the dissolved
+locus carried went with it. The fix (crates/hale-codegen
+`locus/instantiation.rs`): a fresh-factory call written as a locus- or
+interface-typed field of a literal, explicit or default, is owned by
+the literal — the same one-shot suppression a `let` RHS and an `=`
+into a locus slot already had. `tests/hale/factory_field_owner_test.hl`
+pins the shape. Every catalog written by M1 (`ModelRouter { quick:
+fast(), deep: frontier() }`) had this hole; nothing ran those routers
+under a live organization until the fixture did.
+
+---
+
+## F.18 — `hale check` accepted a call to a function nobody wrote
+
+**Tag:** `unbound-bare-callee-passes-check`
+**Severity:** SOUNDNESS of the organization's gate, seen 2026-09-11
+while recording the M4 fixture (GH #583).
+**Status:** FIXED in the checker the same day.
+
+Under pressure from the worker the organization proposed a
+supervisor position; the model wrote
+
+```hale
+fulfilment: dna::Leader = dna::Leader { name: "fulfilment", models: fulfilment_models(), … };
+```
+
+with no `fulfilment_models` anywhere. `hale check dna/org` said
+`ok: 4 file(s) typechecked` — the candidate's `check_clean` held, the
+Board approved it, the gateway applied it — and `hale build dna/org`
+refused it at expression: `call to fulfilment_models: no free fn /
+generic fn / fn-pointer binding with that name is in scope`. The
+window judged `build_failed` and rolled the organization back to its
+base, which is the machinery working; but the gate that should have
+refused the candidate before anyone reviewed it is `check`, and it
+had no opinion. Minimal: `fn go() -> Int { return nothing_here(); }`
+typechecks. An unresolved bare identifier types as Unknown, and a
+call on Unknown is permissive.
+
+**Fix:** the checker holds codegen's rule for a bare callee when a
+WHOLE seed is checked (`hale check <directory>`, the organization's
+gate): a name that is not a local binding, a top-level fn, a generic
+fn or one of the builtins codegen answers itself is `call to X: no
+free fn, generic fn or fn-pointer binding with that name is in
+scope`, with a did-you-mean over the program's fns. One file of a
+seed, a styleguide snippet or a harness's partial program keeps the
+permissive reading — it may call what a sibling defines — which CI's
+corpus checks proved on the first try. Unresolved identifiers in
+other positions stay permissive (that is a wider change); the call is
+the shape a model invents.
+
+---
+
 ## Requests and bugs, summarized (2026-09-05)
 
 Eleven entries. What the fixtures established, against #521's prediction

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -970,7 +970,12 @@ This is the same principle as the no-locus-return rule on methods
 (`fn get() -> SomeLocus` is rejected): **a locus is structure, not
 a value to hand around.** Ordinary `let`-bound loci — including
 factory results — are unaffected; they are owned by the binding
-that names them.
+that names them. A factory result written as a locus- or
+interface-typed **field of a locus literal** — `Router { quick:
+make("q") }`, in a body, a default, or another factory — is owned
+by that literal: the literal is the construction site, so this is
+not the ambiguous store above, and the frame that made the call
+does not reclaim the result at its exit (dna/FRICTION.md F.17).
 
 ## Mode invocation
 

--- a/spec/types.md
+++ b/spec/types.md
@@ -576,6 +576,23 @@ function within the locus's scope. Lifecycle methods (`birth`,
 `accept`, etc.) are not regular `fn`s — they have their own
 syntax and don't take `self` (it's implicit).
 
+### Calls to bare names
+
+A call whose callee is a bare identifier must name something: a
+local binding (a fn pointer), a free `fn`, a generic `fn`, or one of
+the builtins the compiler answers itself (`len`, `to_string`, `hex`,
+the printers, `abs` / `min` / `max`, the `bounded` intrinsics, the
+casts). When a **whole seed** is checked (`hale check <directory>`,
+which is what a build compiles and what the organization's gate
+runs), any other bare callee is a type error — `call to X: no free
+fn, generic fn or fn-pointer binding with that name is in scope`,
+with a did-you-mean over the program's fns — rather than an
+`Unknown` that `hale build` refuses later. One file checked alone,
+or a partial program a harness assembles, keeps the permissive
+reading: it may call what a sibling file defines. Unresolved
+identifiers in other positions remain permissive (dna/FRICTION.md
+F.18).
+
 ## Contract subsumption
 
 For two contracts `C1` and `C2`, `C1 ⊆ C2` iff every entry in

--- a/tests/hale/factory_field_owner_test.hl
+++ b/tests/hale/factory_field_owner_test.hl
@@ -1,0 +1,62 @@
+// GH #583 (dna/FRICTION.md F.17) — a fresh-factory call written as a
+// locus- or interface-typed FIELD of a locus literal inside another
+// factory is owned by the literal. `Router { quick: make("q") }` used
+// to register `make`'s result as a temporary of `make_router`'s frame
+// and dissolve it at that frame's exit while the field — a fat pointer,
+// for an interface slot — still pointed at it: the organization's
+// catalog read garbage from its backends. The same shape as a `let`
+// RHS and an `=` into a locus slot: the owner of the call is decided.
+
+interface Backend { fn name() -> String; fn cap() -> Int; }
+
+locus Inner {
+    params { n: String = "inner"; max: Int = 7; }
+    fn name() -> String { return self.n; }
+    fn cap() -> Int { return self.max; }
+}
+
+locus Wrap {
+    params { label: String = "w"; inner: Backend = Inner { n: "default" }; }
+    fn name() -> String { return self.label + ":" + self.inner.name(); }
+    fn cap() -> Int { return self.inner.cap(); }
+}
+
+locus Router {
+    params { quick: Backend = Inner { }; deep: Backend = Inner { }; }
+    fn who() -> String { return self.quick.name() + "/" + self.deep.name() + " " + to_string(self.quick.cap() + self.deep.cap()); }
+}
+
+fn make(label: String) -> Wrap {
+    return Wrap { label: label, inner: Inner { n: "from-" + label, max: 3 } };
+}
+
+// factory inside factory: the fields own what `make` hands back
+fn make_router() -> Router {
+    return Router { quick: make("q"), deep: make("d") };
+}
+
+locus Holder { params { r: Router = make_router(); } }
+
+fn churn(n: Int) -> String {
+    let mut s = "";
+    let mut i = 0;
+    while i < n { s = s + "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz" + to_string(i); i = i + 1; }
+    return s;
+}
+
+main locus App {
+    params { h: Holder = Holder { }; }
+    run() {
+        let mut i = 0;
+        while i < 100 {
+            let j = churn(400);
+            std::test::assert_eq_str(self.h.r.who(), "q:from-q/d:from-d 6", "the backends survive the factory frames, under churn");
+            i = i + 1;
+        }
+        // the same shape as a param default of a literal, not a factory
+        let direct = Router { quick: make("x"), deep: make("y") };
+        std::test::assert_eq_str(direct.who(), "x:from-x/y:from-y 6", "a literal in a body owns its factory fields too");
+    }
+}
+
+fn main() { App { }; }


### PR DESCRIPTION
The two compiler holes the Phase 4 fixture (#583) found under a live organization, moved to the bottom of the chain so every PR in it is sound against its base. Recorded as dna/FRICTION.md F.17 and F.18.

**F.17 — a locus literal owns a factory result written as its field.** `Router { quick: make("q") }` inside another factory registered `make`'s fresh result as a temporary of the enclosing frame (the GH #402 hook) and dissolved it at that frame's exit while the field, a fat pointer for an interface-typed slot, still pointed at it. The organization's catalog (`ModelRouter { quick: fast(), deep: frontier() }`, #584) read garbage from its backends under a live organization: first a corrupted string, then a segfault in an interface dispatch, pinpointed with a `LOTUS_ASAN=1` build of the organization. A fresh-factory call written as a locus- or interface-typed field of a literal, explicit or default, is now owned by the literal, the same one-shot suppression a `let` RHS and an `=` into a locus slot already had. `tests/hale/factory_field_owner_test.hl` pins the shape; spec/semantics.md says it.

**F.18 — `hale check <seed>` refuses a call to a name nothing binds.** A bare callee that is not a local binding, a top-level fn, a generic fn or a builtin typed as Unknown and passed `check`, to be refused by `hale build` (`no free fn / generic fn / fn-pointer binding with that name is in scope`). An organization whose gate is `check` applied a candidate naming a router function the model invented, and found out at expression: rolled back by the window, as designed, but the wrong gate. The checker holds codegen's rule now **when a whole seed is checked** (`hale check <directory>`, which is what a build compiles and what the organization's gate runs). One file of a multi-file seed, a styleguide snippet or a harness's partial program keeps the permissive reading, since it may call what a sibling defines; CI's corpus checks proved that scoping was needed on the first try. `check_unbound_callee.rs` pins both sides; spec/types.md says it.

Verified here: the whole workspace's harnesses (`examples`, `codegen_fixtures_typecheck`, `styleguide_snippets`, `corpus_check_build_agreement` under ASan with `--ignored`), the hale-native suite, the harvest binaries with the baseline regenerated, and fmt.

The chain: this → #584 (M1) → #585 → #586 → #587 → #588 → #589 → #590 → #591. Merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
